### PR TITLE
Rename method from `intl*` to `format*`

### DIFF
--- a/example/src/components.js
+++ b/example/src/components.js
@@ -8,13 +8,13 @@ var Another = React.createClass({
     return <div>
       <h2>Instance #{this.props.foo}</h2>
       <h3>date helper with custom formatters:</h3>
-      {this.intlDate(new Date(), "time-style")}
+      {this.formatDate(new Date(), "time-style")}
 
       <h3>number helper with custom formatters:</h3>
-      {this.intlNumber(600, "eur")}
+      {this.formatNumber(600, "eur")}
 
       <h3>message helper:</h3>
-      {this.intlMessage(this.getIntlMessage('SHORT'), {
+      {this.formatMessage(this.getIntlMessage('SHORT'), {
         product: 'apples',
         price: 2000.15,
         deadline: new Date(),
@@ -58,32 +58,32 @@ var Container = global.Container = React.createClass({
   },
   render: function () {
     return <div>
-        <h1>`intlDate` helper</h1>
+        <h1>`formatDate` helper</h1>
 
         <h3>date helper:</h3>
-        {this.intlDate(this.props.someTimestamp)}
+        {this.formatDate(this.props.someTimestamp)}
         <h3>date helper with formatters:</h3>
-        {this.intlDate(this.props.someTimestamp, { hour: 'numeric', minute: 'numeric' })}
+        {this.formatDate(this.props.someTimestamp, { hour: 'numeric', minute: 'numeric' })}
         <h3>date helper with custom formatters:</h3>
-        {this.intlDate(this.props.someTimestamp, "time-style")}
+        {this.formatDate(this.props.someTimestamp, "time-style")}
 
         <hr/>
 
-        <h1>`intlNumber` helper</h1>
+        <h1>`formatNumber` helper</h1>
 
         <h3>number helper:</h3>
-        {this.intlNumber(400)}
+        {this.formatNumber(400)}
         <h3>number helper with formatters:</h3>
-        {this.intlNumber(400, { style: 'percent' })}
+        {this.formatNumber(400, { style: 'percent' })}
         <h3>number helper with custom formatters:</h3>
-        {this.intlNumber(400, "eur")}
+        {this.formatNumber(400, "eur")}
 
         <hr/>
 
-        <h1>`intlMessage` helper</h1>
+        <h1>`formatMessage` helper</h1>
 
         <h3>message helper:</h3>
-        {this.intlMessage(this.getIntlMessage('LONG'), {
+        {this.formatMessage(this.getIntlMessage('LONG'), {
           product: 'oranges',
           price: 40000.004,
           deadline: this.props.someTimestamp,

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -9,36 +9,20 @@ import {
 
 // -----------------------------------------------------------------------------
 
+var typesSpec = {
+    locales: React.PropTypes.oneOfType([
+        React.PropTypes.string,
+        React.PropTypes.array
+    ]),
+
+    formats : React.PropTypes.object,
+    messages: React.PropTypes.object
+};
+
 export default {
-    contextTypes: {
-        locales: React.PropTypes.oneOfType([
-            React.PropTypes.string,
-            React.PropTypes.array
-        ]),
-
-        formats : React.PropTypes.object,
-        messages: React.PropTypes.object
-    },
-
-    childContextTypes: {
-        locales: React.PropTypes.oneOfType([
-            React.PropTypes.string,
-            React.PropTypes.array
-        ]),
-
-        formats : React.PropTypes.object,
-        messages: React.PropTypes.object
-    },
-
-    propsTypes: {
-        locales: React.PropTypes.oneOfType([
-            React.PropTypes.string,
-            React.PropTypes.array
-        ]),
-
-        formats : React.PropTypes.object,
-        messages: React.PropTypes.object
-    },
+    propsTypes       : typesSpec,
+    contextTypes     : typesSpec,
+    childContextTypes: typesSpec,
 
     getChildContext: function () {
         var childContext = Object.create(this.context);
@@ -58,7 +42,7 @@ export default {
         return childContext;
     },
 
-    intlDate: function (date, options) {
+    formatDate: function (date, options) {
         var locales = this.props.locales || this.context.locales,
             formats = this.props.formats || this.context.formats;
 
@@ -80,10 +64,11 @@ export default {
         return getDateTimeFormat(locales, options).format(date);
     },
 
-    intlTime: function (date, options) {
+    formatTime: function (date, options) {
         var formats = this.props.formats || this.context.formats;
 
-        // Lookup named format on `formats.time` before delegating to intlDate.
+        // Lookup named format on `formats.time` before delegating to
+        // `formatDate()`.
         if (options && typeof options === 'string') {
             try {
                 options = formats.time[options];
@@ -92,10 +77,10 @@ export default {
             }
         }
 
-        return this.intlDate(date, options);
+        return this.formatDate(date, options);
     },
 
-    intlNumber: function (num, options) {
+    formatNumber: function (num, options) {
         var locales = this.props.locales || this.context.locales,
             formats = this.props.formats || this.context.formats;
 
@@ -114,7 +99,7 @@ export default {
         return getNumberFormat(locales, options).format(num);
     },
 
-    intlMessage: function (message, values) {
+    formatMessage: function (message, values) {
         var locales = this.props.locales || this.context.locales,
             formats = this.props.formats || this.context.formats;
 


### PR DESCRIPTION
These method names now make more sense, see #8 for details.
