### PR TITLE
getChildContext() should only return its own props

### DIFF
--- a/src/mixin.js
+++ b/src/mixin.js
@@ -25,7 +25,11 @@ export default {
     childContextTypes: typesSpec,
 
     getChildContext: function () {
-        var childContext = Object.create(this.context);
+        var childContext = {
+            locales: this.context.locales,
+            formats: this.context.formats,
+            messages: this.context.messages
+        };
 
         if (this.props.locales) {
             childContext.locales = this.props.locales;


### PR DESCRIPTION
i understand you want to extend the context with the props passed in from the root component but when "cloning" this.context (l.28) you will capture context variables defined by other compositeComponents.

so if that happens react will [throw](https://github.com/facebook/react/blob/90d1aeb1c3612b8d9b3cccc1f0c78ba0db3506ac/src/core/ReactCompositeComponent.js#L950) because some of the variables captured in your child context don't belong to your component/mixin i.e they're not defined in the propTypes.

you don't need to worry about shadowing/overriding the context because react will merge (see [here](https://github.com/facebook/react/blob/90d1aeb1c3612b8d9b3cccc1f0c78ba0db3506ac/src/core/ReactCompositeComponent.js#L176) or [there](https://github.com/facebook/react/blob/90d1aeb1c3612b8d9b3cccc1f0c78ba0db3506ac/src/core/ReactCompositeComponent.js#L956)) the objects return from each different compositeComponent.

i don't know much about react internals so i don't know if thats the best way to solve this but it works okay for me. maybe react peoples can help...
