### PR TITLE
Added entry point for browser bundles

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,18 @@
+// Entry point for browser bundles.
+
+/* jshint node:true */
+'use strict';
+
+// Expose `React` as a global, because the ReactIntlMixin assumes it's global.
+var oldReact = global.React;
+global.React = require('react');
+
+exports = module.exports = require('./lib/mixin').default;
+Object.defineProperty(exports, 'default', {value: exports});
+
+// Put back `global.React` to how it was.
+if (oldReact) {
+    global.React = oldReact;
+} else {
+    delete global.React;
+}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "main": "index.js",
   "jsnext:main": "src/main.js",
+  "browser": "browser.js",
   "dependencies": {
     "intl-format-cache": "2.0.1",
     "intl-messageformat": "1.0.1",


### PR DESCRIPTION
The code is the same as in the `index.js` file, but without the `require('./lib/locales')` line, which caused the inclusion of the locale data on the bundle.
