### PR TITLE
Improve browser bundling with Browserify/Webpack

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,10 +5,11 @@
 var oldReact = global.React;
 global.React = require('react');
 
-// Add all locale data to `ReactIntlMixin`.
+// Add all locale data to `ReactIntlMixin`. This module will be ignored when
+// bundling for the browser with Browserify/Webpack.
 require('./lib/locales');
 
-exports = module.exports = require('./lib/mixin').default;
+exports = module.exports = require('./lib/main').default;
 Object.defineProperty(exports, 'default', {value: exports});
 
 // Put back `global.React` to how it was.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
   },
   "main": "index.js",
   "jsnext:main": "src/main.js",
+  "browser": {
+    "./lib/locales": false,
+    "./lib/locales.js": false
+  },
   "dependencies": {
     "intl-format-cache": "2.0.2",
     "intl-messageformat": "1.0.1",


### PR DESCRIPTION
This adds a `"browser"` field to the `package.json` file to hint to both Browserify and Webpack that they should _not_ include the data for all locales (just English) when bundling for the browser.
