### PR TITLE
Remove global `React` lookup during runtime

### DIFF
--- a/src/components/date.js
+++ b/src/components/date.js
@@ -1,5 +1,7 @@
-/* global React */
-/* jslint esnext:true */
+/* jshint esnext:true */
+
+// TODO: Use `import React from "react";` when external modules are supported.
+import React from '../react';
 
 import IntlMixin from '../mixin';
 

--- a/src/components/html-message.js
+++ b/src/components/html-message.js
@@ -1,5 +1,7 @@
-/* global React */
-/* jslint esnext:true */
+/* jshint esnext:true */
+
+// TODO: Use `import React from "react";` when external modules are supported.
+import React from '../react';
 
 import escape from '../escape';
 import IntlMixin from '../mixin';

--- a/src/components/message.js
+++ b/src/components/message.js
@@ -1,5 +1,7 @@
-/* global React */
-/* jslint esnext:true */
+/* jshint esnext:true */
+
+// TODO: Use `import React from "react";` when external modules are supported.
+import React from '../react';
 
 import IntlMixin from '../mixin';
 

--- a/src/components/number.js
+++ b/src/components/number.js
@@ -1,5 +1,7 @@
-/* global React */
-/* jslint esnext:true */
+/* jshint esnext:true */
+
+// TODO: Use `import React from "react";` when external modules are supported.
+import React from '../react';
 
 import IntlMixin from '../mixin';
 

--- a/src/components/relative.js
+++ b/src/components/relative.js
@@ -1,5 +1,7 @@
-/* global React */
-/* jslint esnext:true */
+/* jshint esnext:true */
+
+// TODO: Use `import React from "react";` when external modules are supported.
+import React from '../react';
 
 import IntlMixin from '../mixin';
 

--- a/src/components/time.js
+++ b/src/components/time.js
@@ -1,5 +1,7 @@
-/* global React */
-/* jslint esnext:true */
+/* jshint esnext:true */
+
+// TODO: Use `import React from "react";` when external modules are supported.
+import React from '../react';
 
 import IntlMixin from '../mixin';
 

--- a/src/escape.js
+++ b/src/escape.js
@@ -1,4 +1,4 @@
-/* jslint esnext:true */
+/* jshint esnext:true */
 
 /*
 HTML escaping implementation is the same as React's (on purpose.) Therefore, it

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-/* jslint esnext: true */
+/* jshint esnext: true */
 
 import {
     Mixin,

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -1,5 +1,7 @@
-/* global React */
-/* jslint esnext:true */
+/* jshint esnext:true */
+
+// TODO: Use `import React from "react";` when external modules are supported.
+import React from './react';
 
 import IntlMessageFormat from 'intl-messageformat';
 import IntlRelativeFormat from 'intl-relativeformat';

--- a/src/react-intl.js
+++ b/src/react-intl.js
@@ -1,4 +1,4 @@
-/* jslint esnext: true */
+/* jshint esnext: true */
 
 import IntlMessageFormat from 'intl-messageformat';
 import IntlRelativeFormat from 'intl-relativeformat';

--- a/src/react.js
+++ b/src/react.js
@@ -1,0 +1,7 @@
+/* global React */
+/* jshint esnext:true */
+
+// TODO: Remove the global `React` binding lookup once the ES6 Module Transpiler
+// supports external modules. This is a hack for now that provides the local
+// modules a referece to React.
+export default React;


### PR DESCRIPTION
This removes the global `React` lookup that was happening within the React Intl Components' `render()` methods. A new local `react` module has been created to provide the reference to the `React` object.

**Note:** This is a temp solution, the real fix we want is to update the ES6 Module Transpiler to poperly deal with external, non ES6 modules.

Closes #47
