### PR TITLE
fix(@formatjs/intl-displaynames): fix polyfill typing and use ponyfill in tests

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const {sync: globSync} = require('glob');
 const FILES = globSync('./packages/*/tests-karma/*.js');
 

--- a/packages/intl-displaynames/src/polyfill.ts
+++ b/packages/intl-displaynames/src/polyfill.ts
@@ -1,9 +1,14 @@
-import {DisplayNames} from '.';
+import {DisplayNames, DisplayNamesOptions} from '.';
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace Intl {
-    const DisplayNames: DisplayNames;
+    const DisplayNames: {
+      new (
+        locales?: string | string[],
+        options?: DisplayNamesOptions
+      ): DisplayNames;
+    };
   }
 }
 

--- a/packages/intl-displaynames/tests/index.test.ts
+++ b/packages/intl-displaynames/tests/index.test.ts
@@ -1,43 +1,42 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import '@formatjs/intl-getcanonicallocales/polyfill';
-import '../src/polyfill';
-import '../dist/locale-data/zh';
-import '../dist/locale-data/en';
-import type {DisplayNames} from '../src';
-const PolyfilledDisplayNames = (Intl as any)
-  .DisplayNames as typeof DisplayNames;
+import {DisplayNames} from '../src';
+
+DisplayNames.__addLocaleData(
+  require('../dist/locale-data/en.json'),
+  require('../dist/locale-data/zh.json')
+);
+
 describe('.of()', () => {
   it('accepts case-insensitive language code with region subtag', () => {
-    expect(
-      new PolyfilledDisplayNames('zh', {type: 'language'}).of('zh-hANs-sG')
-    ).toBe('简体中文（新加坡）');
+    expect(new DisplayNames('zh', {type: 'language'}).of('zh-hANs-sG')).toBe(
+      '简体中文（新加坡）'
+    );
   });
 
   it('accepts case-insensitive currency code', () => {
     expect(
-      new PolyfilledDisplayNames('en-US', {type: 'currency', style: 'long'}).of(
-        'cNy'
-      )
+      new DisplayNames('en-US', {type: 'currency', style: 'long'}).of('cNy')
     ).toBe('Chinese Yuan');
   });
 
   it('preserves unrecognized region subtag in language code when fallback option is code', () => {
-    expect(
-      new PolyfilledDisplayNames('zh', {fallback: 'code'}).of('zh-Hans-Xy')
-    ).toBe('简体中文（XY）');
+    expect(new DisplayNames('zh', {fallback: 'code'}).of('zh-Hans-Xy')).toBe(
+      '简体中文（XY）'
+    );
   });
 
   describe('with fallback set to "none"', () => {
     it('returns undefined when called with language code that has unrecognized region subtag', () => {
-      expect(
-        new PolyfilledDisplayNames('zh', {fallback: 'none'}).of('zh-Hans-XY')
-      ).toBe(undefined);
+      expect(new DisplayNames('zh', {fallback: 'none'}).of('zh-Hans-XY')).toBe(
+        undefined
+      );
     });
 
     it('returns undefined when called with language code that valid region subtag but invalid language subtag', () => {
-      expect(
-        new PolyfilledDisplayNames('zh', {fallback: 'none'}).of('xx-CN')
-      ).toBe(undefined);
+      expect(new DisplayNames('zh', {fallback: 'none'}).of('xx-CN')).toBe(
+        undefined
+      );
     });
   });
 });


### PR DESCRIPTION
- Fixed polyfill typing of `Intl.DisplayNames`.
- Always use ponyfill in `Intl.DisplayNames` tests to ensure consistency across browsers.