### PR TITLE
feat(intl-messageformat-parser): Add 'ignoreTag' option

### DIFF
--- a/packages/intl-messageformat-parser/src/parser.pegjs
+++ b/packages/intl-messageformat-parser/src/parser.pegjs
@@ -25,8 +25,8 @@ See the accompanying LICENSE file for terms.
         }: {}
     }
 
-    function noTagSupport() {
-        return options && options.noTagSupport;
+    function ignoreTag() {
+        return options && options.ignoreTag;
     }
 }
 
@@ -275,11 +275,11 @@ quotedString = "'" escapedChar:escapedChar quotedChars:$("''" / [^'])* "'"? {
 
 unquotedString = $(x:. &{
     return (
-        (noTagSupport() || x !== '<') &&
+        (ignoreTag() || x !== '<') &&
         x !== '{' &&
         !(isInPluralOption() && x === '#') &&
         !(isNestedMessageText() && x === '}') &&
-        !(!noTagSupport() && isNestedMessageText() && x === '>')
+        !(!ignoreTag() && isNestedMessageText() && x === '>')
     );
 } / '\n')
 

--- a/packages/intl-messageformat-parser/src/parser.pegjs
+++ b/packages/intl-messageformat-parser/src/parser.pegjs
@@ -24,6 +24,10 @@ See the accompanying LICENSE file for terms.
             location: location()
         }: {}
     }
+
+    function noTagSupport() {
+        return options && options.noTagSupport;
+    }
 }
 
 start
@@ -271,11 +275,11 @@ quotedString = "'" escapedChar:escapedChar quotedChars:$("''" / [^'])* "'"? {
 
 unquotedString = $(x:. &{
     return (
-        x !== '<' &&
+        (noTagSupport() || x !== '<') &&
         x !== '{' &&
         !(isInPluralOption() && x === '#') &&
         !(isNestedMessageText() && x === '}') &&
-        !(isNestedMessageText() && x === '>')
+        !(!noTagSupport() && isNestedMessageText() && x === '>')
     );
 } / '\n')
 

--- a/packages/intl-messageformat-parser/test/__snapshots__/tag.test.ts.snap
+++ b/packages/intl-messageformat-parser/test/__snapshots__/tag.test.ts.snap
@@ -35,7 +35,7 @@ Array [
 ]
 `;
 
-exports[`mismatched tag with noTagSupport 1`] = `
+exports[`mismatched tag with ignoreTag 1`] = `
 Array [
   Object {
     "type": 0,
@@ -73,7 +73,7 @@ Array [
 ]
 `;
 
-exports[`nested tag with noTagSupport 1`] = `
+exports[`nested tag with ignoreTag 1`] = `
 Array [
   Object {
     "type": 0,
@@ -127,7 +127,7 @@ Array [
 ]
 `;
 
-exports[`self-closing tag with noTagSupport 1`] = `
+exports[`self-closing tag with ignoreTag 1`] = `
 Array [
   Object {
     "type": 0,
@@ -198,7 +198,7 @@ Array [
 ]
 `;
 
-exports[`tag in plural with noTagSupport 1`] = `
+exports[`tag in plural with ignoreTag 1`] = `
 Array [
   Object {
     "type": 0,
@@ -277,7 +277,7 @@ Array [
 ]
 `;
 
-exports[`tag with dash with noTagSupport 1`] = `
+exports[`tag with dash with ignoreTag 1`] = `
 Array [
   Object {
     "type": 0,
@@ -318,7 +318,7 @@ Array [
 ]
 `;
 
-exports[`tag with number arg with noTagSupport 1`] = `
+exports[`tag with number arg with ignoreTag 1`] = `
 Array [
   Object {
     "type": 0,
@@ -382,7 +382,7 @@ Array [
 ]
 `;
 
-exports[`tag with rich arg with noTagSupport 1`] = `
+exports[`tag with rich arg with ignoreTag 1`] = `
 Array [
   Object {
     "type": 0,

--- a/packages/intl-messageformat-parser/test/__snapshots__/tag.test.ts.snap
+++ b/packages/intl-messageformat-parser/test/__snapshots__/tag.test.ts.snap
@@ -35,6 +35,15 @@ Array [
 ]
 `;
 
+exports[`mismatched tag with noTagSupport 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "this is <a>mismatch</b>",
+  },
+]
+`;
+
 exports[`nested tag 1`] = `
 Array [
   Object {
@@ -60,6 +69,23 @@ Array [
     ],
     "type": 8,
     "value": "a",
+  },
+]
+`;
+
+exports[`nested tag with noTagSupport 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "this is <a>nested <b>",
+  },
+  Object {
+    "type": 1,
+    "value": "placeholder",
+  },
+  Object {
+    "type": 0,
+    "value": "</b></a>",
   },
 ]
 `;
@@ -97,6 +123,23 @@ Array [
     ],
     "type": 8,
     "value": "a",
+  },
+]
+`;
+
+exports[`self-closing tag with noTagSupport 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "this is <br/> <a>nested <b>",
+  },
+  Object {
+    "type": 1,
+    "value": "placeholder",
+  },
+  Object {
+    "type": 0,
+    "value": "</b></a>",
   },
 ]
 `;
@@ -155,6 +198,48 @@ Array [
 ]
 `;
 
+exports[`tag in plural with noTagSupport 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "You have ",
+  },
+  Object {
+    "offset": 0,
+    "options": Object {
+      "=1": Object {
+        "location": undefined,
+        "value": Array [
+          Object {
+            "type": 0,
+            "value": "<b>1</b> Message",
+          },
+        ],
+      },
+      "other": Object {
+        "location": undefined,
+        "value": Array [
+          Object {
+            "type": 0,
+            "value": "<b>",
+          },
+          Object {
+            "type": 7,
+          },
+          Object {
+            "type": 0,
+            "value": "</b> Messages",
+          },
+        ],
+      },
+    },
+    "pluralType": "cardinal",
+    "type": 6,
+    "value": "count",
+  },
+]
+`;
+
 exports[`tag with dash 1`] = `
 Array [
   Object {
@@ -192,6 +277,23 @@ Array [
 ]
 `;
 
+exports[`tag with dash with noTagSupport 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "this is <br/> <dash-tag>nested <b>",
+  },
+  Object {
+    "type": 1,
+    "value": "placeholder",
+  },
+  Object {
+    "type": 0,
+    "value": "</b></dash-tag>",
+  },
+]
+`;
+
 exports[`tag with number arg 1`] = `
 Array [
   Object {
@@ -212,6 +314,24 @@ Array [
   Object {
     "type": 0,
     "value": " cats.",
+  },
+]
+`;
+
+exports[`tag with number arg with noTagSupport 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "I have <foo>",
+  },
+  Object {
+    "style": null,
+    "type": 2,
+    "value": "numCats",
+  },
+  Object {
+    "type": 0,
+    "value": "</foo> cats.",
   },
 ]
 `;
@@ -258,6 +378,32 @@ Array [
   Object {
     "type": 0,
     "value": " cats.",
+  },
+]
+`;
+
+exports[`tag with rich arg with noTagSupport 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "I <b>have</b> <foo>",
+  },
+  Object {
+    "style": null,
+    "type": 2,
+    "value": "numCats",
+  },
+  Object {
+    "type": 0,
+    "value": " some string ",
+  },
+  Object {
+    "type": 1,
+    "value": "placeholder",
+  },
+  Object {
+    "type": 0,
+    "value": "</foo> cats.",
   },
 ]
 `;

--- a/packages/intl-messageformat-parser/test/tag.test.ts
+++ b/packages/intl-messageformat-parser/test/tag.test.ts
@@ -6,9 +6,9 @@ test('tag with number arg', () => {
   ).toMatchSnapshot();
 });
 
-test('tag with number arg with noTagSupport', () => {
+test('tag with number arg with ignoreTag', () => {
   expect(
-    pegParse('I have <foo>{numCats, number}</foo> cats.', {noTagSupport: true})
+    pegParse('I have <foo>{numCats, number}</foo> cats.', {ignoreTag: true})
   ).toMatchSnapshot();
 });
 
@@ -20,11 +20,11 @@ test('tag with rich arg', () => {
   ).toMatchSnapshot();
 });
 
-test('tag with rich arg with noTagSupport', () => {
+test('tag with rich arg with ignoreTag', () => {
   expect(
     pegParse(
       'I <b>have</b> <foo>{numCats, number} some string {placeholder}</foo> cats.',
-      {noTagSupport: true}
+      {ignoreTag: true}
     )
   ).toMatchSnapshot();
 });
@@ -47,9 +47,9 @@ test('mismatched tag', function () {
   expect(() => pegParse('this is <a>mismatch</b>')).toThrowError(/Mismatch/);
 });
 
-test('mismatched tag with noTagSupport', function () {
+test('mismatched tag with ignoreTag', function () {
   expect(
-    pegParse('this is <a>mismatch</b>', {noTagSupport: true})
+    pegParse('this is <a>mismatch</b>', {ignoreTag: true})
   ).toMatchSnapshot();
 });
 
@@ -59,9 +59,9 @@ test('nested tag', function () {
   ).toMatchSnapshot();
 });
 
-test('nested tag with noTagSupport', function () {
+test('nested tag with ignoreTag', function () {
   expect(
-    pegParse('this is <a>nested <b>{placeholder}</b></a>', {noTagSupport: true})
+    pegParse('this is <a>nested <b>{placeholder}</b></a>', {ignoreTag: true})
   ).toMatchSnapshot();
 });
 
@@ -73,11 +73,11 @@ test('tag in plural', function () {
   ).toMatchSnapshot();
 });
 
-test('tag in plural with noTagSupport', function () {
+test('tag in plural with ignoreTag', function () {
   expect(
     pegParse(
       'You have {count, plural, =1 {<b>1</b> Message} other {<b>#</b> Messages}}',
-      {noTagSupport: true}
+      {ignoreTag: true}
     )
   ).toMatchSnapshot();
 });
@@ -88,10 +88,10 @@ test('self-closing tag', function () {
   ).toMatchSnapshot();
 });
 
-test('self-closing tag with noTagSupport', function () {
+test('self-closing tag with ignoreTag', function () {
   expect(
     pegParse('this is <br/> <a>nested <b>{placeholder}</b></a>', {
-      noTagSupport: true,
+      ignoreTag: true,
     })
   ).toMatchSnapshot();
 });
@@ -102,10 +102,10 @@ test('tag with dash', function () {
   ).toMatchSnapshot();
 });
 
-test('tag with dash with noTagSupport', function () {
+test('tag with dash with ignoreTag', function () {
   expect(
     pegParse('this is <br/> <dash-tag>nested <b>{placeholder}</b></dash-tag>', {
-      noTagSupport: true,
+      ignoreTag: true,
     })
   ).toMatchSnapshot();
 });

--- a/packages/intl-messageformat-parser/test/tag.test.ts
+++ b/packages/intl-messageformat-parser/test/tag.test.ts
@@ -6,10 +6,25 @@ test('tag with number arg', () => {
   ).toMatchSnapshot();
 });
 
+test('tag with number arg with noTagSupport', () => {
+  expect(
+    pegParse('I have <foo>{numCats, number}</foo> cats.', {noTagSupport: true})
+  ).toMatchSnapshot();
+});
+
 test('tag with rich arg', () => {
   expect(
     pegParse(
       'I <b>have</b> <foo>{numCats, number} some string {placeholder}</foo> cats.'
+    )
+  ).toMatchSnapshot();
+});
+
+test('tag with rich arg with noTagSupport', () => {
+  expect(
+    pegParse(
+      'I <b>have</b> <foo>{numCats, number} some string {placeholder}</foo> cats.',
+      {noTagSupport: true}
     )
   ).toMatchSnapshot();
 });
@@ -32,9 +47,21 @@ test('mismatched tag', function () {
   expect(() => pegParse('this is <a>mismatch</b>')).toThrowError(/Mismatch/);
 });
 
+test('mismatched tag with noTagSupport', function () {
+  expect(
+    pegParse('this is <a>mismatch</b>', {noTagSupport: true})
+  ).toMatchSnapshot();
+});
+
 test('nested tag', function () {
   expect(
     pegParse('this is <a>nested <b>{placeholder}</b></a>')
+  ).toMatchSnapshot();
+});
+
+test('nested tag with noTagSupport', function () {
+  expect(
+    pegParse('this is <a>nested <b>{placeholder}</b></a>', {noTagSupport: true})
   ).toMatchSnapshot();
 });
 
@@ -46,14 +73,39 @@ test('tag in plural', function () {
   ).toMatchSnapshot();
 });
 
+test('tag in plural with noTagSupport', function () {
+  expect(
+    pegParse(
+      'You have {count, plural, =1 {<b>1</b> Message} other {<b>#</b> Messages}}',
+      {noTagSupport: true}
+    )
+  ).toMatchSnapshot();
+});
+
 test('self-closing tag', function () {
   expect(
     pegParse('this is <br/> <a>nested <b>{placeholder}</b></a>')
   ).toMatchSnapshot();
 });
 
+test('self-closing tag with noTagSupport', function () {
+  expect(
+    pegParse('this is <br/> <a>nested <b>{placeholder}</b></a>', {
+      noTagSupport: true,
+    })
+  ).toMatchSnapshot();
+});
+
 test('tag with dash', function () {
   expect(
     pegParse('this is <br/> <dash-tag>nested <b>{placeholder}</b></dash-tag>')
+  ).toMatchSnapshot();
+});
+
+test('tag with dash with noTagSupport', function () {
+  expect(
+    pegParse('this is <br/> <dash-tag>nested <b>{placeholder}</b></dash-tag>', {
+      noTagSupport: true,
+    })
   ).toMatchSnapshot();
 });


### PR DESCRIPTION
The option may be used by projects that wish to treat angle bracket characters like regular messages characters that do not require escaping. Setting this option would mean opting out of the tag feature, as the parser will never create a node with type "tag" (8)

See issue #1648 and issue #1693