### PR TITLE
chore(docs): add notes on how to get setup locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,17 @@ You can sign-up using this [invitation link](https://join.slack.com/t/formatjs/s
 
 Development is currently being done against the latest Node LTS. This repository leverages [Lerna][] for package management.
 
+To setup locally:
+
+```sh
+> lerna bootstrap
+> yarn build
+> yarn test
+```
+
 Releases can be done with the following steps:
 
-```js
+```sh
 > lerna publish
 ```
 


### PR DESCRIPTION
Hi! It wasn't clear to me how to get this codebase setup locally to contribute.

This adds a note to the main README on how to install, build and test the codebase so that someone new to the project can contribute easier.

If there's a better way to get setup, or a better place to put information like this, I'm happy to make changes to this PR!