### PR TITLE
feat(@formatjs/cli): add a check for duplicated keys in different files

### DIFF
--- a/packages/cli/tests/extract/integration_tests/__snapshots__/index.test.ts.snap
+++ b/packages/cli/tests/extract/integration_tests/__snapshots__/index.test.ts.snap
@@ -244,6 +244,15 @@ Options:
 "
 `;
 
+exports[`duplicated descriptor ids shows warning 1`] = `
+Array [
+  Object {
+    "defaultMessage": "Bar",
+    "id": "foo",
+  },
+]
+`;
+
 exports[`ignore -> stdout 1`] = `
 Array [
   Object {

--- a/packages/cli/tests/extract/integration_tests/duplicated/file1.tsx
+++ b/packages/cli/tests/extract/integration_tests/duplicated/file1.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import {FormattedMessage} from 'react-intl';
+
+export function Foo() {
+  return (
+    <p>
+      <FormattedMessage id="foo" defaultMessage="Foo" />
+    </p>
+  );
+}

--- a/packages/cli/tests/extract/integration_tests/duplicated/file2.tsx
+++ b/packages/cli/tests/extract/integration_tests/duplicated/file2.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import {FormattedMessage} from 'react-intl';
+
+export function Bar() {
+  return (
+    <p>
+      <FormattedMessage id="foo" defaultMessage="Bar" />
+    </p>
+  );
+}

--- a/packages/cli/tests/extract/integration_tests/index.test.ts
+++ b/packages/cli/tests/extract/integration_tests/index.test.ts
@@ -97,3 +97,19 @@ test('ignore -> stdout', async () => {
   expect(JSON.parse(jsResult.stdout)).toMatchSnapshot();
   expect(jsResult.stderr).toBe('');
 }, 20000);
+
+test('duplicated descriptor ids shows warning', async () => {
+  const {stderr, stdout} = await exec(
+    `${BIN_PATH} extract ${path.join(__dirname, 'duplicated/*.tsx')}`
+  );
+  expect(JSON.parse(stdout)).toMatchSnapshot();
+  expect(stderr).toContain('Duplicate message id: "foo"');
+}, 20000);
+
+test('duplicated descriptor ids throws', async () => {
+  expect(async () => {
+    await exec(
+      `${BIN_PATH} extract --throws ${path.join(__dirname, 'duplicated/*.tsx')}`
+    );
+  }).rejects.toThrowError('Duplicate message id: "foo"');
+}, 20000);


### PR DESCRIPTION
This would close #1707
Adding the warning @shadiabuhilal mentioned should probably go as a different PR. I would also put those warnings behind a new cli flag.

Not sure what kind of version bump this will require as this will break ci builds that are now passing.