### PR TITLE
fix(react-intl): add children typing to injectIntl

### DIFF
--- a/packages/react-intl/src/components/injectIntl.tsx
+++ b/packages/react-intl/src/components/injectIntl.tsx
@@ -37,8 +37,10 @@ export type WithIntlProps<P> = Omit<P, keyof WrappedComponentProps> & {
   forwardedRef?: React.Ref<any>;
 };
 
+// TODO: type hoisted static methods.
+// Non ref forwarding overload
 export default function injectIntl<
-  IntlPropName extends string,
+  IntlPropName extends string = 'intl',
   P extends WrappedComponentProps<IntlPropName> = WrappedComponentProps<any>
 >(
   WrappedComponent: React.ComponentType<P>,
@@ -46,6 +48,7 @@ export default function injectIntl<
 ): React.FC<WithIntlProps<P>> & {
   WrappedComponent: React.ComponentType<P>;
 };
+// Ref forwarding overload.
 export default function injectIntl<
   IntlPropName extends string = 'intl',
   P extends WrappedComponentProps<IntlPropName> = WrappedComponentProps<any>,
@@ -54,7 +57,8 @@ export default function injectIntl<
   WrappedComponent: React.ComponentType<P>,
   options?: Opts<IntlPropName, true>
 ): React.ForwardRefExoticComponent<
-  React.PropsWithoutRef<WithIntlProps<P>> & React.RefAttributes<T>
+  React.PropsWithoutRef<WithIntlProps<React.PropsWithChildren<P>>> &
+    React.RefAttributes<T>
 > & {
   WrappedComponent: React.ComponentType<P>;
 };


### PR DESCRIPTION
Fixes #1704.

This diff adds `children` type to the returning component type of the `injectIntl`, for the forward ref overload. By default, `React.FC` correctly types `children`, but this is not the case for `React.ForwardRefExoticComponent`. Simply adding the `children` type to the props for that overload fixes the type check issue.