### PR TITLE
fix(react-intl): add children prop type to IntlProvider

### DIFF
--- a/packages/react-intl/src/components/provider.tsx
+++ b/packages/react-intl/src/components/provider.tsx
@@ -165,7 +165,9 @@ export function createIntl(
 }
 
 export default class IntlProvider extends React.PureComponent<
-  OptionalIntlConfig,
+  // Exporting children props so it is composable with other HOCs.
+  // See: https://github.com/formatjs/formatjs/issues/1697
+  React.PropsWithChildren<OptionalIntlConfig>,
   State
 > {
   static displayName = 'IntlProvider';


### PR DESCRIPTION
Fixes #1697