### PR TITLE
docs: Link directly to the `react-intl` docs

### DIFF
--- a/packages/react-intl/README.md
+++ b/packages/react-intl/README.md
@@ -1,3 +1,3 @@
 # React Intl
 
-We've migrated the docs to https://formatjs.io.
+We've migrated the docs to https://formatjs.io/docs/react-intl.


### PR DESCRIPTION
I was quite confused when landing on `formatjs.io` for the first time; `react-intl` isn't listed in the default state of the side bar (all collapsed) nor mentioned on the "Getting Started" page linked from the homepage.

Updating this link ensures folks finding the package via `npm` will be sent to the correct page. It also mirrors the `homepage` value in `package.json`.