### PR TITLE
Handle missing ICU data bug

### DIFF
--- a/packages/intl-displaynames/polyfill.ts
+++ b/packages/intl-displaynames/polyfill.ts
@@ -12,7 +12,18 @@ declare global {
   }
 }
 
-if (!Intl.DisplayNames) {
+/**
+ * https://bugs.chromium.org/p/chromium/issues/detail?id=1097432
+ */
+function hasMissingICUBug() {
+  if (Intl.DisplayNames) {
+    const regionNames = new Intl.DisplayNames(['en'], { type: 'region' });
+    return regionNames.of('CA') === 'CA'
+  }
+  return false;
+}
+
+if (!Intl.DisplayNames || hasMissingICUBug()) {
   Object.defineProperty(Intl, 'DisplayNames', {
     value: DisplayNames,
     enumerable: false,

--- a/packages/intl-displaynames/polyfill.ts
+++ b/packages/intl-displaynames/polyfill.ts
@@ -17,8 +17,8 @@ declare global {
  */
 function hasMissingICUBug() {
   if (Intl.DisplayNames) {
-    const regionNames = new Intl.DisplayNames(['en'], { type: 'region' });
-    return regionNames.of('CA') === 'CA'
+    const regionNames = new Intl.DisplayNames(['en'], {type: 'region'});
+    return regionNames.of('CA') === 'CA';
   }
   return false;
 }


### PR DESCRIPTION
Better handle https://github.com/formatjs/formatjs/issues/1879 when browser doesn't include full ICU data where the prototype function exists. 