### PR TITLE
fix(@formatjs/cli): use `readJSONSync` instead of `require`

### DIFF
--- a/packages/cli/src/compile.ts
+++ b/packages/cli/src/compile.ts
@@ -1,6 +1,6 @@
 import {parse, MessageFormatElement} from 'intl-messageformat-parser';
 import {MessageDescriptor} from '@formatjs/ts-transformer';
-import {outputJSONSync,readJSONSync} from 'fs-extra';
+import {outputJSONSync, readJSONSync} from 'fs-extra';
 export interface CompileCLIOpts extends Opts {
   outFile?: string;
 }
@@ -12,10 +12,9 @@ export default function compile(
   outFile?: string,
   {ast}: Opts = {}
 ) {
-  const messages: Record<
-    string,
-    Omit<MessageDescriptor, 'id'>
-  > = readJSONSync(inputFile);
+  const messages: Record<string, Omit<MessageDescriptor, 'id'>> = readJSONSync(
+    inputFile
+  );
   const results: Record<string, string | MessageFormatElement[]> = {};
   for (const [id, {defaultMessage = ''}] of Object.entries(messages)) {
     // Parse so we can verify that the message is not malformed

--- a/packages/cli/src/compile.ts
+++ b/packages/cli/src/compile.ts
@@ -1,6 +1,6 @@
 import {parse, MessageFormatElement} from 'intl-messageformat-parser';
 import {MessageDescriptor} from '@formatjs/ts-transformer';
-import {outputJSONSync} from 'fs-extra';
+import {outputJSONSync,readJSONSync} from 'fs-extra';
 export interface CompileCLIOpts extends Opts {
   outFile?: string;
 }
@@ -15,7 +15,7 @@ export default function compile(
   const messages: Record<
     string,
     Omit<MessageDescriptor, 'id'>
-  > = require(inputFile);
+  > = readJSONSync(inputFile);
   const results: Record<string, string | MessageFormatElement[]> = {};
   for (const [id, {defaultMessage = ''}] of Object.entries(messages)) {
     // Parse so we can verify that the message is not malformed


### PR DESCRIPTION
Tested this out as per the documentation here - https://formatjs.io/docs/getting-started/message-distribution - but every time I ran the command I got

```
Error: Cannot find module './lang/en.json'
Require stack:
- /Users/adamjenkins/Documents/GitHub/web-client/node_modules/@formatjs/cli/src/compile.js
- /Users/adamjenkins/Documents/GitHub/web-client/node_modules/@formatjs/cli/src/cli.js
- /Users/adamjenkins/Documents/GitHub/web-client/node_modules/@formatjs/cli/bin/formatjs
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:966:15)
    at Function.Module._load (internal/modules/cjs/loader.js:842:27)
    at Module.require (internal/modules/cjs/loader.js:1026:19)
    at require (internal/modules/cjs/helpers.js:72:18)
    at Object.compile [as default] (/Users/adamjenkins/Documents/GitHub/web-client/node_modules/@formatjs/cli/src/compile.js:7:20)
    at Command.<anonymous> (/Users/adamjenkins/Documents/GitHub/web-client/node_modules/@formatjs/cli/src/cli.js:156:41)
    at Command.listener [as _actionHandler] (/Users/adamjenkins/Documents/GitHub/web-client/node_modules/@formatjs/cli/node_modules/commander/index.js:413:31)
    at Command._parseCommand (/Users/adamjenkins/Documents/GitHub/web-client/node_modules/@formatjs/cli/node_modules/commander/index.js:914:14)
    at Command._dispatchSubcommand (/Users/adamjenkins/Documents/GitHub/web-client/node_modules/@formatjs/cli/node_modules/commander/index.js:865:18)
    at Command._parseCommand (/Users/adamjenkins/Documents/GitHub/web-client/node_modules/@formatjs/cli/node_modules/commander/index.js:882:12)
adamjenkins@MacBook-Pro web-client % npx formatjs compile ./lang/en.json --out-file compiled-lang/en.json
```

When I changed it to use readJSONSync (because the cli already uses fs-extra so why not) it worked like a charm. I didn't see a bug report, is anybody else experiencing this issue?