### PR TITLE
feat(@formatjs/ts-transformer): allow to override user defined message id via `overrideIdFn` as function

### DIFF
--- a/packages/ts-transformer/src/transform.ts
+++ b/packages/ts-transformer/src/transform.ts
@@ -164,18 +164,20 @@ function extractMessageDescriptor(
   if (!msg.defaultMessage && !msg.id) {
     return;
   }
-  if (!msg.id && msg.defaultMessage && overrideIdFn) {
+  if (msg.defaultMessage && overrideIdFn) {
     switch (typeof overrideIdFn) {
       case 'string':
-        msg.id = interpolateName(
-          {sourcePath: sf.fileName} as any,
-          overrideIdFn,
-          {
-            content: msg.description
-              ? `${msg.defaultMessage}#${msg.description}`
-              : msg.defaultMessage,
-          }
-        );
+        if (!msg.id) {
+          msg.id = interpolateName(
+            {sourcePath: sf.fileName} as any,
+            overrideIdFn,
+            {
+              content: msg.description
+                ? `${msg.defaultMessage}#${msg.description}`
+                : msg.defaultMessage,
+            }
+          );
+        }
         break;
       case 'function':
         msg.id = overrideIdFn(

--- a/packages/ts-transformer/tests/__snapshots__/index.test.ts.snap
+++ b/packages/ts-transformer/tests/__snapshots__/index.test.ts.snap
@@ -453,11 +453,11 @@ Object {
 import { defineMessages, FormattedMessage, defineMessage } from 'react-intl';
 const msgs = defineMessages({
     header: {
-        id: \\"foo.bar.baz\\",
+        id: \\"HELLO.foo.bar.baz.12.string\\",
         defaultMessage: \\"Hello World!\\"
     },
     content: {
-        id: \\"foo.bar.biff\\",
+        id: \\"HELLO.foo.bar.biff.12.undefined\\",
         defaultMessage: \\"Hello Nurse!\\"
     }
 });
@@ -488,7 +488,7 @@ export default class Foo extends Component {
         <p>
           <FormattedMessage {...msgs.content}/>
         </p>
-        <FormattedMessage id=\\"foo.bar.zoo\\" defaultMessage=\\"Hello World! {abc}\\" values={{ abc: 2 }}/>
+        <FormattedMessage id=\\"HELLO.foo.bar.zoo.18.undefined\\" defaultMessage=\\"Hello World! {abc}\\" values={{ abc: 2 }}/>
         <FormattedMessage id=\\"HELLO..18.undefined\\" defaultMessage=\\"Hello World! {abc}\\" values={{ abc: 2 }}/>
       </div>);
     }
@@ -499,11 +499,11 @@ export default class Foo extends Component {
     Object {
       "defaultMessage": "Hello World!",
       "description": "The default message",
-      "id": "foo.bar.baz",
+      "id": "HELLO.foo.bar.baz.12.string",
     },
     Object {
       "defaultMessage": "Hello Nurse!",
-      "id": "foo.bar.biff",
+      "id": "HELLO.foo.bar.biff.12.undefined",
     },
     Object {
       "defaultMessage": "defineMessage",
@@ -527,7 +527,7 @@ export default class Foo extends Component {
     },
     Object {
       "defaultMessage": "Hello World! {abc}",
-      "id": "foo.bar.zoo",
+      "id": "HELLO.foo.bar.zoo.18.undefined",
     },
     Object {
       "defaultMessage": "Hello World! {abc}",


### PR DESCRIPTION
This PR introduces the following logic:
1) overrideIdFn is a string
  - if msg.id is defined leave it unchanged
  - if msg.id is empty then use interpolateName with provided template
2) overrideIdFn is a function
  - pass msg.id to function as first arg. Allow to user decide what to do with id - it may be empty or contain already defined value