### PR TITLE
fix(@formatjs/intl-displaynames): skip Android icu bug detection for polyfill

### DIFF
--- a/packages/intl-displaynames/polyfill.ts
+++ b/packages/intl-displaynames/polyfill.ts
@@ -8,6 +8,8 @@ declare global {
         locales?: string | string[],
         options?: DisplayNamesOptions
       ): DisplayNames;
+
+      readonly polyfilled?: true;
     };
   }
 }

--- a/packages/intl-displaynames/should-polyfill.ts
+++ b/packages/intl-displaynames/should-polyfill.ts
@@ -2,7 +2,7 @@
  * https://bugs.chromium.org/p/chromium/issues/detail?id=1097432
  */
 function hasMissingICUBug() {
-  if (Intl.DisplayNames) {
+  if (Intl.DisplayNames && !Intl.DisplayNames.polyfilled) {
     const regionNames = new Intl.DisplayNames(['en'], {type: 'region'});
     return regionNames.of('CA') === 'CA';
   }


### PR DESCRIPTION
The Android ICU issue (https://bugs.chromium.org/p/chromium/issues/detail?id=1097432) can
only occur for the native implementation anyways. Also, running the check on the polyfill
fails if the 'en' locale data has not been loaded for the polyfill.