### PR TITLE
Allowing full stops and nested argument values

### DIFF
--- a/packages/intl-messageformat-parser/src/parser.ts
+++ b/packages/intl-messageformat-parser/src/parser.ts
@@ -384,7 +384,7 @@ function peg$parse(input: string, options?: IParseOptions) {
   const peg$c79 = /^[\t-\r \x85\xA0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000]/;
   const peg$c80 = peg$classExpectation([["\t", "\r"], " ", "\x85", "\xA0", "\u1680", ["\u2000", "\u200A"], "\u2028", "\u2029", "\u202F", "\u205F", "\u3000"], false, false);
   const peg$c81 = peg$otherExpectation("syntax pattern");
-  const peg$c82 = /^[!-\/:-@[-\^`{-~\xA1-\xA7\xA9\xAB\xAC\xAE\xB0\xB1\xB6\xBB\xBF\xD7\xF7\u2010-\u2027\u2030-\u203E\u2041-\u2053\u2055-\u205E\u2190-\u245F\u2500-\u2775\u2794-\u2BFF\u2E00-\u2E7F\u3001-\u3003\u3008-\u3020\u3030\uFD3E\uFD3F\uFE45\uFE46]/;
+  const peg$c82 = /^(?!\.)[!-\/:-@[-\^`{-~\xA1-\xA7\xA9\xAB\xAC\xAE\xB0\xB1\xB6\xBB\xBF\xD7\xF7\u2010-\u2027\u2030-\u203E\u2041-\u2053\u2055-\u205E\u2190-\u245F\u2500-\u2775\u2794-\u2BFF\u2E00-\u2E7F\u3001-\u3003\u3008-\u3020\u3030\uFD3E\uFD3F\uFE45\uFE46]/;
   const peg$c83 = peg$classExpectation([["!", "/"], [":", "@"], ["[", "^"], "`", ["{", "~"], ["\xA1", "\xA7"], "\xA9", "\xAB", "\xAC", "\xAE", "\xB0", "\xB1", "\xB6", "\xBB", "\xBF", "\xD7", "\xF7", ["\u2010", "\u2027"], ["\u2030", "\u203E"], ["\u2041", "\u2053"], ["\u2055", "\u205E"], ["\u2190", "\u245F"], ["\u2500", "\u2775"], ["\u2794", "\u2BFF"], ["\u2E00", "\u2E7F"], ["\u3001", "\u3003"], ["\u3008", "\u3020"], "\u3030", "\uFD3E", "\uFD3F", "\uFE45", "\uFE46"], false, false);
   const peg$c84 = peg$otherExpectation("optional whitespace");
   const peg$c85 = peg$otherExpectation("number");

--- a/packages/intl-messageformat/tests/index.test.ts
+++ b/packages/intl-messageformat/tests/index.test.ts
@@ -465,6 +465,84 @@ describe('IntlMessageFormat', function () {
         expect(msg.format({ST1ATE: state})).toBe(state);
       });
     });
+
+    describe('a nested object', function () {
+      const user = {
+        name: 'FormatJS',
+        loggedIn: false,
+        friends: 0,
+        nullable: null,
+        notifications: 1,
+      };
+
+      it('should properly replace arguments in string', function () {
+        const mf = new IntlMessageFormat('Hey {user.name}!');
+        const message = mf.format({user});
+
+        expect(message).toBe('Hey FormatJS!');
+      });
+
+      it('should properly replace booleans', function () {
+        const mf = new IntlMessageFormat('{user.loggedIn}');
+        const message = mf.format({user});
+
+        expect(message).toBe('');
+      });
+
+      it('should properly replace numbers', function () {
+        const mf = new IntlMessageFormat(
+          'You have {user.friends} friends online.'
+        );
+        const message = mf.format({user});
+
+        expect(message).toBe('You have 0 friends online.');
+      });
+
+      it('should properly replace nulls', function () {
+        const mf = new IntlMessageFormat('{user.nullable}');
+        const message = mf.format({user});
+
+        expect(message).toBe('');
+      });
+
+      it('should fail on missing value', function () {
+        const mf = new IntlMessageFormat('{user.unknown}');
+
+        function formatWithMissingValue() {
+          return mf.format({user});
+        }
+
+        expect(formatWithMissingValue).toThrow(
+          Error(
+            'The intl string context variable "user.unknown" was not provided to the string "{user.unknown}"'
+          )
+        );
+      });
+
+      it('should properly format', function () {
+        const mf = new IntlMessageFormat(
+          `You have {user.notifications, plural,
+                      =0 {no notifications.}
+                      =1 {one notification.}
+                      other {# notifications.}
+                    }`
+        );
+
+        const message = mf.format({user});
+
+        expect(message).toBe('You have one notification.');
+      });
+
+      it('should properly replace multiple values', function () {
+        const mf = new IntlMessageFormat(
+          'Hey, {user.name}. You have {user.friends} friends online.'
+        );
+
+        const message = mf.format({user});
+
+        expect(message).toBe('Hey, FormatJS. You have 0 friends online.');
+      });
+    });
   });
 
   describe('selectordinal arguments', function () {


### PR DESCRIPTION
This PR aims to allow for nested argument values. Currently formatjs allows for a single word to be entered as the variable name within a formatted string. This work is to attempt to introduce the ability to reference a variable from within an object passed into the values property.

A usage example:
```typescript
const user = { name: "FormatJS" };
const formatter = new IntlMessageFormat("Hey, {user.name}!");
const message = formatter.format({ user }); // Hey, FormatJS!
```