### PR TITLE
docs: add currency example to FormattedNumber documentation

### DIFF
--- a/website/docs/react-intl/components.md
+++ b/website/docs/react-intl/components.md
@@ -343,6 +343,16 @@ By default `<FormattedNumber>` will render the formatted number into a `React.Fr
 <FormattedNumber value={1000} />
 ```
 
+**Example Formatting Currency Values**
+
+```tsx live
+<FormattedNumber
+  value={1000}
+  style="currency"
+  currency="USD"
+/>
+```
+
 **Formatting Number using `unit`**
 
 Currently this is part of ES2020 [NumberFormat](https://tc39.es/ecma402/#numberformat-objects).


### PR DESCRIPTION
### Summary

Adds an explicit currency-related example to the `FormattedNumber` component documentation.

### Discussion

I know [the documentation references the `Intl.NumberFormat` APIs as part of the `FormattedNumber` documentation](https://github.com/formatjs/formatjs/blob/main/website/docs/react-intl/components.md#formattednumber) but maybe it'd be easier to understand how to use `FormattedNumber` with currency values if an explicit example existed.

Feel free to change the title of the example code-block.