### PR TITLE
fix(@formatjs/cli): fix calling extract programmatically without idInterpolationPattern

### DIFF
--- a/packages/cli/src/extract.ts
+++ b/packages/cli/src/extract.ts
@@ -90,7 +90,6 @@ function processFile(
 ) {
   let messages: ExtractedMessageDescriptor[] = [];
   let meta: Record<string, string> | undefined;
-  const {onMetaExtracted, onMsgExtracted} = opts;
 
   opts = {
     ...opts,
@@ -102,13 +101,9 @@ function processFile(
         }));
       }
       messages = messages.concat(msgs);
-
-      if (onMsgExtracted) onMsgExtracted(_, msgs);
     },
     onMetaExtracted(_, m) {
       meta = m;
-
-      if (onMetaExtracted) onMetaExtracted(_, m);
     },
   };
 

--- a/packages/cli/src/extract.ts
+++ b/packages/cli/src/extract.ts
@@ -90,7 +90,7 @@ function processFile(
 ) {
   let messages: ExtractedMessageDescriptor[] = [];
   let meta: Record<string, string> | undefined;
-  const { onMetaExtracted, onMsgExtracted } = opts;
+  const {onMetaExtracted, onMsgExtracted} = opts;
 
   opts = {
     ...opts,


### PR DESCRIPTION
Currently when calling the `extract` function from `@formats/cli` it will not return any results if `idInterpolationPattern` is not set, because neither the `onMsgExtracted`, nor the `onMetaExtracted` callbacks get initialized. 

This PR ensures the default behavior for these callbacks always runs.