### PR TITLE
Update compile.ts

### DIFF
--- a/packages/cli/src/compile.ts
+++ b/packages/cli/src/compile.ts
@@ -55,7 +55,7 @@ Message from ${compiled[id]}: ${inputFile}
       }
       messages[id] = compiled[id];
       try {
-        const msgAst = parse(compiled[id]);
+        const msgAst = parse(compiled[id] || '');
         messageAsts[id] = msgAst;
       } catch (e) {
         console.error(


### PR DESCRIPTION
Fix an error from the parser with `null` and `undefined` values.
Personally I use null values for the still untranslated values, my IDE colors them differently and it's easier to notice.