### PR TITLE
chore: use tslib for all packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "ts-jest": "^26.4.0",
     "ts-node": "^9.0.0",
     "ts-pegjs": "^0.2.6",
-    "tslib": "^2.0.0",
+    "tslib": "^2.0.1",
     "typescript": "4"
   },
   "eslintConfig": {

--- a/packages/babel-plugin-react-intl/package.json
+++ b/packages/babel-plugin-react-intl/package.json
@@ -18,7 +18,8 @@
     "@types/babel__core": "^7.1.7",
     "@types/schema-utils": "^2.4.0",
     "intl-messageformat-parser": "^6.0.7",
-    "schema-utils": "^2.6.6"
+    "schema-utils": "^2.6.6",
+    "tslib": "^2.0.1"
   },
   "keywords": [
     "babel-plugin",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,7 +44,8 @@
     "json-stable-stringify": "^1.0.1",
     "lodash": "^4.17.15",
     "loud-rejection": "^2.2.0",
-    "typescript": "^4.0"
+    "typescript": "^4.0",
+    "tslib": "^2.0.1"
   },
   "bugs": {
     "url": "https://github.com/formatjs/formatjs/issues"

--- a/packages/ecma402-abstract/BUILD
+++ b/packages/ecma402-abstract/BUILD
@@ -77,6 +77,7 @@ generate_src_file(
         "@npm//@types/node",
         "@npm//fs-extra",
         "@npm//minimist",
+        "@npm//tslib",
     ],
 )
 

--- a/packages/ecma402-abstract/package.json
+++ b/packages/ecma402-abstract/package.json
@@ -13,6 +13,9 @@
     "ecma262",
     "format"
   ],
+  "dependencies": {
+    "tslib": "^2.0.1"
+  },
   "author": "Long Ho <holevietlong@gmail.com",
   "bugs": {
     "url": "https://github.com/formatjs/formatjs/issues"

--- a/packages/eslint-plugin-formatjs/package.json
+++ b/packages/eslint-plugin-formatjs/package.json
@@ -26,7 +26,8 @@
     "@types/estree": "^0.0.45",
     "@typescript-eslint/typescript-estree": "^3.6.0",
     "emoji-regex": "^9.0.0",
-    "intl-messageformat-parser": "^6.0.7"
+    "intl-messageformat-parser": "^6.0.7",
+    "tslib": "^2.0.1"
   },
   "peerDependencies": {
     "eslint": "^7.0.0"

--- a/packages/intl-datetimeformat/BUILD
+++ b/packages/intl-datetimeformat/BUILD
@@ -97,6 +97,7 @@ CLDR_DEPS = [
     "@npm//fs-extra",
     "@npm//fast-glob",
     "@npm//minimist",
+    "@npm//tslib",
 ]
 
 ts_node(
@@ -124,6 +125,7 @@ ts_node(
         "@npm//fast-glob",
         "@npm//fs-extra",
         "@npm//minimist",
+        "@npm//tslib",
     ],
     output_dir = True,
 )
@@ -191,6 +193,7 @@ generate_src_file(
         "@npm//@types/node",
         "@npm//fs-extra",
         "@npm//minimist",
+        "@npm//tslib",
         "@tzdata//:backward",
     ],
 )
@@ -219,6 +222,7 @@ generate_src_file(
         "@npm//fs-extra",
         "@npm//json-stable-stringify",
         "@npm//minimist",
+        "@npm//tslib",
         "@tzdata//:zdumps",
     ],
 )
@@ -249,6 +253,7 @@ ts_node(
         "@npm//fs-extra",
         "@npm//json-stable-stringify",
         "@npm//minimist",
+        "@npm//tslib",
         "@tzdata//:zdumps",
     ],
 )
@@ -279,6 +284,7 @@ ts_node(
         "@npm//fs-extra",
         "@npm//json-stable-stringify",
         "@npm//minimist",
+        "@npm//tslib",
         "@tzdata//:zdumps",
     ],
 )

--- a/packages/intl-datetimeformat/package.json
+++ b/packages/intl-datetimeformat/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/formatjs/formatjs#readme",
   "dependencies": {
-    "@formatjs/ecma402-abstract": "^1.2.2"
+    "@formatjs/ecma402-abstract": "^1.2.2",
+    "tslib": "^2.0.1"
   }
 }

--- a/packages/intl-displaynames/BUILD
+++ b/packages/intl-displaynames/BUILD
@@ -91,6 +91,7 @@ CLDR_DEPS = [
     "@npm//fs-extra",
     "@npm//fast-glob",
     "@npm//minimist",
+    "@npm//tslib",
 ]
 
 ts_node(
@@ -115,6 +116,7 @@ ts_node(
         "@npm//fast-glob",
         "@npm//fs-extra",
         "@npm//minimist",
+        "@npm//tslib",
     ],
     output_dir = True,
 )

--- a/packages/intl-displaynames/package.json
+++ b/packages/intl-displaynames/package.json
@@ -21,7 +21,8 @@
     "url": "git+https://github.com/formatjs/formatjs.git"
   },
   "dependencies": {
-    "@formatjs/ecma402-abstract": "^1.2.2"
+    "@formatjs/ecma402-abstract": "^1.2.2",
+    "tslib": "^2.0.1"
   },
   "bugs": {
     "url": "https://github.com/formatjs/formatjs/issues"

--- a/packages/intl-getcanonicallocales/BUILD
+++ b/packages/intl-getcanonicallocales/BUILD
@@ -79,6 +79,7 @@ generate_src_file(
         "@npm//cldr-core",
         "@npm//fs-extra",
         "@npm//minimist",
+        "@npm//tslib",
     ],
 )
 

--- a/packages/intl-getcanonicallocales/package.json
+++ b/packages/intl-getcanonicallocales/package.json
@@ -25,6 +25,7 @@
     "url": "https://github.com/formatjs/formatjs/issues"
   },
   "dependencies": {
-    "cldr-core": "36.0.0"
+    "cldr-core": "36.0.0",
+    "tslib": "^2.0.1"
   }
 }

--- a/packages/intl-listformat/BUILD
+++ b/packages/intl-listformat/BUILD
@@ -96,6 +96,7 @@ CLDR_DEPS = [
     "@npm//fs-extra",
     "@npm//fast-glob",
     "@npm//minimist",
+    "@npm//tslib",
 ]
 
 ts_node(
@@ -121,6 +122,7 @@ ts_node(
         "@npm//fs-extra",
         "@npm//lodash",
         "@npm//minimist",
+        "@npm//tslib",
     ],
     output_dir = True,
 )

--- a/packages/intl-listformat/package.json
+++ b/packages/intl-listformat/package.json
@@ -19,7 +19,8 @@
     "url": "git@github.com:formatjs/formatjs.git"
   },
   "dependencies": {
-    "@formatjs/ecma402-abstract": "^1.2.2"
+    "@formatjs/ecma402-abstract": "^1.2.2",
+    "tslib": "^2.0.1"
   },
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/intl-locale/package.json
+++ b/packages/intl-locale/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@formatjs/ecma402-abstract": "^1.2.2",
     "@formatjs/intl-getcanonicallocales": "^1.4.5",
-    "cldr-core": "^36.0.0"
+    "cldr-core": "^36.0.0",
+    "tslib": "^2.0.1"
   }
 }

--- a/packages/intl-messageformat-parser/BUILD
+++ b/packages/intl-messageformat-parser/BUILD
@@ -66,6 +66,7 @@ nodejs_binary(
         "@npm//minimist",
         "@npm//pegjs",
         "@npm//ts-pegjs",
+        "@npm//tslib",
     ],
     entry_point = "tools/build.js",
 )

--- a/packages/intl-messageformat-parser/package.json
+++ b/packages/intl-messageformat-parser/package.json
@@ -35,7 +35,8 @@
     "url": "https://github.com/formatjs/formatjs/issues"
   },
   "dependencies": {
-    "@formatjs/ecma402-abstract": "^1.2.2"
+    "@formatjs/ecma402-abstract": "^1.2.2",
+    "tslib": "^2.0.1"
   },
   "homepage": "https://github.com/formatjs/formatjs",
   "gitHead": "8b0baec8eda5002715cf893274fe59782fc2d371"

--- a/packages/intl-messageformat/package.json
+++ b/packages/intl-messageformat/package.json
@@ -32,7 +32,8 @@
   "types": "index.d.ts",
   "dependencies": {
     "fast-memoize": "^2.5.2",
-    "intl-messageformat-parser": "^6.0.7"
+    "intl-messageformat-parser": "^6.0.7",
+    "tslib": "^2.0.1"
   },
   "sideEffects": false,
   "homepage": "https://github.com/formatjs/formatjs",

--- a/packages/intl-numberformat/BUILD
+++ b/packages/intl-numberformat/BUILD
@@ -118,6 +118,7 @@ CLDR_DEPS = [
     "@npm//fast-glob",
     "@npm//fs-extra",
     "@npm//minimist",
+    "@npm//tslib",
     "//:tsconfig.json",
     "scripts/cldr.ts",
 ]
@@ -149,6 +150,7 @@ ts_node(
         "@npm//fs-extra",
         "@npm//lodash",
         "@npm//minimist",
+        "@npm//tslib",
     ],
     output_dir = True,
     visibility = [
@@ -230,6 +232,7 @@ generate_src_file(
         "@npm//fs-extra",
         "@npm//lodash",
         "@npm//minimist",
+        "@npm//tslib",
     ],
 )
 
@@ -258,6 +261,7 @@ generate_src_file(
         "@npm//fs-extra",
         "@npm//lodash",
         "@npm//minimist",
+        "@npm//tslib",
     ],
 )
 
@@ -280,6 +284,7 @@ generate_src_file(
         "@npm//@types/node",
         "@npm//fs-extra",
         "@npm//minimist",
+        "@npm//tslib",
     ],
 )
 

--- a/packages/intl-numberformat/package.json
+++ b/packages/intl-numberformat/package.json
@@ -22,7 +22,8 @@
     "url": "git+https://github.com/formatjs/formatjs.git"
   },
   "dependencies": {
-    "@formatjs/ecma402-abstract": "^1.2.2"
+    "@formatjs/ecma402-abstract": "^1.2.2",
+    "tslib": "^2.0.1"
   },
   "bugs": {
     "url": "https://github.com/formatjs/formatjs/issues"

--- a/packages/intl-pluralrules/BUILD
+++ b/packages/intl-pluralrules/BUILD
@@ -89,6 +89,7 @@ CLDR_DEPS = [
     "@npm//fs-extra",
     "@npm//fast-glob",
     "@npm//minimist",
+    "@npm//tslib",
 ]
 
 ts_node(
@@ -112,6 +113,7 @@ ts_node(
         "@npm//make-plural-compiler",
         "@npm//minimist",
         "@npm//serialize-javascript",
+        "@npm//tslib",
     ],
     output_dir = True,
 )

--- a/packages/intl-pluralrules/package.json
+++ b/packages/intl-pluralrules/package.json
@@ -20,7 +20,8 @@
     "url": "git+https://github.com/formatjs/formatjs.git"
   },
   "dependencies": {
-    "@formatjs/ecma402-abstract": "^1.2.2"
+    "@formatjs/ecma402-abstract": "^1.2.2",
+    "tslib": "^2.0.1"
   },
   "bugs": {
     "url": "https://github.com/formatjs/formatjs/issues"

--- a/packages/intl-relativetimeformat/BUILD
+++ b/packages/intl-relativetimeformat/BUILD
@@ -94,6 +94,7 @@ CLDR_DEPS = [
     "@npm//fs-extra",
     "@npm//fast-glob",
     "@npm//minimist",
+    "@npm//tslib",
 ]
 
 ts_node(
@@ -118,6 +119,7 @@ ts_node(
         "@npm//fast-glob",
         "@npm//fs-extra",
         "@npm//minimist",
+        "@npm//tslib",
     ],
     output_dir = True,
 )

--- a/packages/intl-relativetimeformat/package.json
+++ b/packages/intl-relativetimeformat/package.json
@@ -20,7 +20,8 @@
     "url": "git@github.com:formatjs/formatjs.git"
   },
   "dependencies": {
-    "@formatjs/ecma402-abstract": "^1.2.2"
+    "@formatjs/ecma402-abstract": "^1.2.2",
+    "tslib": "^2.0.1"
   },
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/intl/package.json
+++ b/packages/intl/package.json
@@ -35,6 +35,7 @@
     "@formatjs/intl-relativetimeformat": "^7.2.7",
     "fast-memoize": "^2.5.2",
     "intl-messageformat": "^9.3.8",
-    "intl-messageformat-parser": "^6.0.7"
+    "intl-messageformat-parser": "^6.0.7",
+    "tslib": "^2.0.1"
   }
 }

--- a/packages/react-intl/package.json
+++ b/packages/react-intl/package.json
@@ -138,7 +138,8 @@
     "hoist-non-react-statics": "^3.3.2",
     "intl-messageformat": "^9.3.8",
     "intl-messageformat-parser": "^6.0.7",
-    "shallow-equal": "^1.2.1"
+    "shallow-equal": "^1.2.1",
+    "tslib": "^2.0.1"
   },
   "peerDependencies": {
     "react": "^16.3.0",

--- a/packages/react-intl/rollup.config.js
+++ b/packages/react-intl/rollup.config.js
@@ -21,5 +21,11 @@ export default {
     }),
     commonjs(),
   ],
+  // UMD fallback for `react` is the global variable `React`.
   external: ['react'],
+  output: {
+    globals: {
+      react: 'React',
+    },
+  },
 };

--- a/packages/ts-transformer/package.json
+++ b/packages/ts-transformer/package.json
@@ -18,7 +18,8 @@
   ],
   "dependencies": {
     "intl-messageformat-parser": "^6.0.7",
-    "typescript": "^4.0"
+    "typescript": "^4.0",
+    "tslib": "^2.0.1"
   },
   "peerDependencies": {
     "ts-jest": "^26.4.0"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,5 +14,11 @@ export default {
     }),
     commonjs(),
   ],
+  // UMD fallback for `react` is the global variable `React`.
   external: ['react'],
+  output: {
+    globals: {
+      react: 'React',
+    },
+  },
 };

--- a/tools/index.bzl
+++ b/tools/index.bzl
@@ -17,6 +17,8 @@ def ts_compile(name, srcs, deps, package_name = None, skip_esm = True):
         package_name: name from package.json
         skip_esm: skip building ESM bundle
     """
+    deps = deps + ["@npm//tslib"]
+
     ts_project(
         name = "%s-base" % name,
         srcs = srcs,
@@ -98,6 +100,7 @@ def bundle_karma_tests(name, srcs, tests, data = [], deps = [], rollup_deps = []
             "@npm//@jest/transform",
             "@npm//ts-jest",
             "@npm//@types/jest",
+            "@npm//tslib",
         ],
     )
 
@@ -115,6 +118,7 @@ def bundle_karma_tests(name, srcs, tests, data = [], deps = [], rollup_deps = []
                 "@npm//@rollup/plugin-commonjs",
                 "@npm//@rollup/plugin-replace",
                 "@npm//@rollup/plugin-json",
+                "@npm//tslib",
             ] + deps + rollup_deps,
         )
 

--- a/tools/jest.bzl
+++ b/tools/jest.bzl
@@ -30,6 +30,7 @@ def jest_test(name, srcs, deps, size = "medium", jest_config = "//:jest.config.j
         "@npm//@jest/transform",
         "@npm//ts-jest",
         "@npm//@types/jest",
+        "@npm//tslib",
         "//:tsconfig.json",
         "//tools:jest-reporter.js",
     ]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "noFallthroughCasesInSwitch": true,
     "declarationMap": true,
     "jsx": "react",
+    "importHelpers": true,
     "paths": {
       "@formatjs/*": [
         // k8 is 64-bit GNU/Linux output location, darwin is macOS.

--- a/yarn.lock
+++ b/yarn.lock
@@ -12399,7 +12399,7 @@ tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
 
-tslib@^2.0.0:
+tslib@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
   integrity sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==


### PR DESCRIPTION
Suppress Rollup warnings as described in #1715. Rollup will correctly resolve to the ESM version tslib.