### PR TITLE
docs: update docs' hero colors

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -252,7 +252,9 @@ function Home() {
           <h1 className="hero__title">
             <img src={useBaseUrl('/img/logo-header.svg')} />
           </h1>
-          <p className="hero__subtitle">{siteConfig.tagline}</p>
+          <p className={cx('hero__subtitle', styles.heroSubtitle)}>
+            {siteConfig.tagline}
+          </p>
           <Demo />
           <div className={styles.buttons}>
             <Link

--- a/website/src/pages/styles.module.css
+++ b/website/src/pages/styles.module.css
@@ -30,10 +30,22 @@
   }
 }
 
+.heroSubtitle {
+  color: var(--ifm-color-white);
+}
+
 .buttons {
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+.getStarted:global(.button.button--outline.button--secondary):not(:hover) {
+  color: var(--ifm-color-white);
+}
+
+.getStarted:global(.button.button--outline.button--secondary):hover {
+  color: var(--ifm-color-gray-900);
 }
 
 .features {


### PR DESCRIPTION
Hi, this is updating some of the hero's text and button colors to make them better readable in light/dark mode.

![docs-hero-color-changes](https://user-images.githubusercontent.com/27507295/94938412-14e28e80-04d1-11eb-87d6-1626dfec1415.gif)

I was first also planning to update some of the link code block colors (e.g. https://formatjs.io/docs/getting-started/installation#minimal-application where the text color is white on white background), however, the local build is somehow different to the deployed one when it comes to some of these colors. I wasn't able to reproduce this so far and I'm not really sure what's going on there, so I left that part as is for now.
