### PR TITLE
fix(@formatjs/intl-datetimeformat): update tz process script to keep the latest abbreviated entry

### DIFF
--- a/packages/intl-datetimeformat/BUILD
+++ b/packages/intl-datetimeformat/BUILD
@@ -227,7 +227,7 @@ generate_src_file(
     ],
 )
 
-# "ts-node scripts/process-zdump --polyfill --output dist/add-all-tz.js --input data.zdump"
+# "ts-node scripts/process-zdump --polyfill --output dist/add-all-tz.js data.zdump"
 # add-all-tz
 ts_node(
     name = "add-all-tz",

--- a/packages/intl-datetimeformat/scripts/process-zdump.ts
+++ b/packages/intl-datetimeformat/scripts/process-zdump.ts
@@ -335,13 +335,16 @@ function processZone(
       zones[zone] = [['', abbrvIndex, offsetIndex, +dst]];
     } else {
       const lastEntry = zones[zone][zones[zone].length - 1];
+      const entry: ZoneData = [
+        utTimeToSeconds(utTime),
+        abbrvIndex,
+        offsetIndex,
+        +dst,
+      ];
       if (lastEntry[1] !== abbrvIndex) {
-        zones[zone].push([
-          utTimeToSeconds(utTime),
-          abbrvIndex,
-          offsetIndex,
-          +dst,
-        ]);
+        zones[zone].push(entry);
+      } else {
+        zones[zone][zones[zone].length - 1] = entry;
       }
     }
   }


### PR DESCRIPTION
Fixes the cause of #2190 

The problem is that only the most recent abbreviated timezone is kept for a given timezone. The PR changes it such that it is the most recent instead. It seem like not taking historical time zones into consideration could prove problematic in some cases. Thats beyond the scope of this PR though.

The timezone generation process seems to have changed. From what I can make out, `process-zdump.ts` processes `data.zdump` to produce `dist/add-all-tz.js`. However, I can't find `data.zdump` in the most recent source and I don't know how to generate it. I've restored `data.zdump` from the git history it and produced my own updated timezone data. I'll submit a separate with the updated data. 

