### PR TITLE
fix(ts-transformer): fix file name in LoaderContext passed to interpolateName

### DIFF
--- a/packages/ts-transformer/src/transform.ts
+++ b/packages/ts-transformer/src/transform.ts
@@ -248,7 +248,7 @@ function extractMessageDescriptor(
       case 'string':
         if (!msg.id) {
           msg.id = interpolateName(
-            {sourcePath: sf.fileName} as any,
+            {resourcePath: sf.fileName} as any,
             overrideIdFn,
             {
               content: msg.description


### PR DESCRIPTION
I tried to use the following ID interpolation pattern as `overrideIdFn` in the `ts-transformer`: `[name]:[contenthash:5]`. However, in the generated output all the IDs looked like this: `file-a1b2c` instead of e.g. `MyComponent-a1b2c`.

Seems like LoaderContext passed to interpolateName has the file name set as `sourcePath`, whereas interpolateName expects `resourcePath`? This PR changes calling code from `sourcePath` to the latter.

Did not add test case for this yet, figuring those out right now.