### PR TITLE
Fix `--pseudo-locale` help link

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -166,7 +166,7 @@ for more information`
     )
     .option(
       '--pseudo-locale <pseudoLocale>',
-      `Whether to generate pseudo-locale files. See http://localhost:3000/docs/tooling/cli#--pseudo-locale-pseudolocale for possible values. 
+      `Whether to generate pseudo-locale files. See https://formatjs.io/docs/tooling/cli#--pseudo-locale-pseudolocale for possible values. 
 "--ast" is required for this to work.`
     )
     .action(async (filePattern: string, opts: CompileCLIOpts) => {


### PR DESCRIPTION
When using `formatjs compile --help` the `--pseudo-locale` option description contains a wrong link.