### PR TITLE
docs: correct example for intl-datetimeformat

### DIFF
--- a/website/docs/polyfills/intl-datetimeformat.md
+++ b/website/docs/polyfills/intl-datetimeformat.md
@@ -93,7 +93,7 @@ async function polyfill(locale: string) {
         )
         break
     }
-    await Promise.all(polyfills)
+    await Promise.all(dataPolyfills)
   }
 }
 ```


### PR DESCRIPTION
Fixes the Dynamic import + capability detection example to not have an error in it.