### PR TITLE
docs: fixed formatting comment

### DIFF
--- a/website/docs/react-intl/api.md
+++ b/website/docs/react-intl/api.md
@@ -227,7 +227,7 @@ This function will return a formatted date string, but it differs from [`formatD
 It expects a `value` which can be parsed as a date (i.e., `isFinite(new Date(value))`), and accepts `options` that conform to `DateTimeFormatOptions`.
 
 ```tsx live
-intl.formatTime(Date.now()) // "4:03 PM"
+intl.formatTime(Date.now()) /* "4:03 PM" */
 ```
 
 ## formatDateTimeRange


### PR DESCRIPTION
The tsx live code block was invalid, probably due to the line comment. Converting to block comment should fix the issue.
Current live version:
![image](https://user-images.githubusercontent.com/17480022/102076618-439daf00-3e08-11eb-8d0b-26ad6073e5ed.png)

After modification:
![image](https://user-images.githubusercontent.com/17480022/102076670-5912d900-3e08-11eb-855f-b45d16a783e4.png)
