### PR TITLE
fix(@formatjs/intl-datetimeformat): Add missing formatRange feature detection

### DIFF
--- a/packages/intl-datetimeformat/should-polyfill.ts
+++ b/packages/intl-datetimeformat/should-polyfill.ts
@@ -36,6 +36,7 @@ export function shouldPolyfill() {
   return (
     !('DateTimeFormat' in Intl) ||
     !('formatToParts' in Intl.DateTimeFormat.prototype) ||
+    !('formatRange' in Intl.DateTimeFormat.prototype) ||
     hasChromeLt71Bug() ||
     hasUnthrownDateTimeStyleBug() ||
     !supportsDateStyle()


### PR DESCRIPTION
Currently importing intl-datetimeformat using the instructions at https://formatjs.io/docs/polyfills/intl-datetimeformat/ does not polyfill formatRange on at least Firefox 81. The issue is fixed by adding a check for "formatRange" in shouldPolyfill function.