### PR TITLE
docs: fix link to CLI docs in api.md docs

### DIFF
--- a/website/docs/react-intl/api.md
+++ b/website/docs/react-intl/api.md
@@ -474,7 +474,7 @@ type MessageDescriptor = {
 ```
 
 :::info Extracting Message Descriptor
-You can extract inline-declared messages from source files using [our CLI](http://localhost:3000/docs/getting-started/message-extraction).
+You can extract inline-declared messages from source files using [our CLI](../getting-started/message-extraction).
 :::
 
 ### Message Formatting Fallbacks

--- a/website/docs/react-intl/api.md
+++ b/website/docs/react-intl/api.md
@@ -474,7 +474,7 @@ type MessageDescriptor = {
 ```
 
 :::info Extracting Message Descriptor
-You can extract inline-declared messages from source files using [our CLI](../getting-started/message-extraction).
+You can extract inline-declared messages from source files using [our CLI](../getting-started/message-extraction.md).
 :::
 
 ### Message Formatting Fallbacks


### PR DESCRIPTION
It had a localhost URL, now pointed to the correct one.