### PR TITLE
docs: fix ts-transformer example link

### DIFF
--- a/website/docs/tooling/ts-transformer.md
+++ b/website/docs/tooling/ts-transformer.md
@@ -200,4 +200,4 @@ Callback that gets triggered whenever a message is encountered.
 
 Callback that gets triggered whenever a `pragme` meta is encountered.
 
-Take a look at [`compile.ts`](https://github.com/formatjs/formatjs/blob/master/packages/ts-transformer/compile.ts) for example in integration.
+Take a look at [`compile.ts`](https://github.com/formatjs/formatjs/blob/main/packages/ts-transformer/examples/compile.ts) for example in integration.


### PR DESCRIPTION
Current documentation leads to 404. This Pull request fixes the link