### PR TITLE
fix(@formatjs/cli): add string_format:icu config to smartling formatter

### DIFF
--- a/packages/cli/src/formatters/smartling.ts
+++ b/packages/cli/src/formatters/smartling.ts
@@ -9,6 +9,7 @@ export interface SmartlingDirectives {
     }
   ];
   variants_enabled: boolean;
+  string_format: string;
   [k: string]: any;
 }
 
@@ -33,6 +34,7 @@ export const format: FormatFn<SmartlingJson> = msgs => {
         },
       ],
       variants_enabled: true,
+      string_format: 'icu',
     },
   } as any;
   for (const [id, msg] of Object.entries(msgs)) {

--- a/packages/cli/tests/extract/__snapshots__/integration.test.ts.snap
+++ b/packages/cli/tests/extract/__snapshots__/integration.test.ts.snap
@@ -580,6 +580,7 @@ Object {
   "stderr": "",
   "stdout": "{
   \\"smartling\\": {
+    \\"string_format\\": \\"icu\\",
     \\"translate_paths\\": [
       {
         \\"instruction\\": \\"*/description\\",


### PR DESCRIPTION
fixes #2526