### PR TITLE
fix(@formatjs/intl): support isolatedModules

### DIFF
--- a/packages/intl/src/error.ts
+++ b/packages/intl/src/error.ts
@@ -1,6 +1,6 @@
 import {MessageDescriptor} from './types';
 
-export const enum IntlErrorCode {
+export enum IntlErrorCode {
   FORMAT_ERROR = 'FORMAT_ERROR',
   UNSUPPORTED_FORMATTER = 'UNSUPPORTED_FORMATTER',
   INVALID_CONFIG = 'INVALID_CONFIG',


### PR DESCRIPTION
Fix "Cannot access ambient const enums when the '--isolatedModules' flag is provided.ts(2748)"