### PR TITLE
docs: use example.com as example URL

### DIFF
--- a/website/docs/react-intl/components.md
+++ b/website/docs/react-intl/components.md
@@ -643,7 +643,7 @@ By allowing embedding XML tag we want to make sure contextual information is not
   defaultMessage="To buy a shoe, <a>visit our website</a> and <cta>buy a shoe</cta>"
   values={{
     a: chunks => (
-      <a class="external_link" target="_blank" href="https://www.shoe.com/">
+      <a class="external_link" target="_blank" href="https://www.example.com/shoe">
         {chunks}
       </a>
     ),
@@ -662,7 +662,7 @@ Since rich text formatting allows embedding `ReactElement`, in function as the c
   defaultMessage="To buy a shoe, <a>visit our website</a> and <cta>buy a shoe</cta>"
   values={{
     a: chunks => (
-      <a class="external_link" target="_blank" href="https://www.shoe.com/">
+      <a class="external_link" target="_blank" href="https://www.example.com/shoe">
         {chunks}
       </a>
     ),

--- a/website/docs/react-intl/components.md
+++ b/website/docs/react-intl/components.md
@@ -643,7 +643,11 @@ By allowing embedding XML tag we want to make sure contextual information is not
   defaultMessage="To buy a shoe, <a>visit our website</a> and <cta>buy a shoe</cta>"
   values={{
     a: chunks => (
-      <a class="external_link" target="_blank" href="https://www.example.com/shoe">
+      <a
+        class="external_link"
+        target="_blank"
+        href="https://www.example.com/shoe"
+      >
         {chunks}
       </a>
     ),
@@ -662,7 +666,11 @@ Since rich text formatting allows embedding `ReactElement`, in function as the c
   defaultMessage="To buy a shoe, <a>visit our website</a> and <cta>buy a shoe</cta>"
   values={{
     a: chunks => (
-      <a class="external_link" target="_blank" href="https://www.example.com/shoe">
+      <a
+        class="external_link"
+        target="_blank"
+        href="https://www.example.com/shoe"
+      >
         {chunks}
       </a>
     ),


### PR DESCRIPTION
You should always use example.com as an example domain. shoe.com seems to point to some generic parked domain page (which could feasibly change to something undesirable if the domain was bought by a bad actor).