### PR TITLE
docs: fix document link typo

### DIFF
--- a/website/docs/react-intl.md
+++ b/website/docs/react-intl.md
@@ -216,7 +216,7 @@ Assuming `navigator.language` is `"en-us"`:
 </div>
 ```
 
-**See:** The [**API docs**][api] and [**Component docs**][components] for more details.
+**See:** The [**API docs**](react-intl/api.md) and [**Component docs**](react-intl/components.md) for more details.
 
 # ESM Build
 


### PR DESCRIPTION
Add links to unlinked document