### PR TITLE
fix(@formatjs/ts-transformer): move typescript & tslib to peerDependencies

### DIFF
--- a/packages/ts-transformer/package.json
+++ b/packages/ts-transformer/package.json
@@ -17,12 +17,16 @@
     "react-intl"
   ],
   "dependencies": {
-    "intl-messageformat-parser": "6.3.2",
+    "intl-messageformat-parser": "6.3.2"
+  },
+  "devDependencies": {
     "tslib": "^2.0.1",
     "typescript": "^4.0"
   },
   "peerDependencies": {
-    "ts-jest": "^26.4.0"
+    "ts-jest": "^26.4.0",
+    "tslib": "^2.0.1",
+    "typescript": "^4.0"
   },
   "peerDependenciesMeta": {
     "ts-jest": {


### PR DESCRIPTION
If AST is created from one version of typescript then your visitor which is using another typescript will have different constants for the node kinds and types. They have the same names but in runtime have different instances/values.

More details in https://github.com/formatjs/formatjs/issues/2620