### PR TITLE
feat(@formatjs/ts-transformer): add support for string literals within curly braces for JSX component props

### DIFF
--- a/packages/ts-transformer/src/transform.ts
+++ b/packages/ts-transformer/src/transform.ts
@@ -219,13 +219,35 @@ function extractMessageDescriptor(
 
   properties.forEach(prop => {
     const {name} = prop;
-    const initializer =
+    const initializer:
+      | typescript.Expression
+      | typescript.JsxExpression
+      | undefined =
       ts.isPropertyAssignment(prop) || ts.isJsxAttribute(prop)
         ? prop.initializer
         : undefined;
+
     if (name && ts.isIdentifier(name) && initializer) {
+      // <FormattedMessage foo={'barbaz'} />
+      if (
+        ts.isJsxExpression(initializer) &&
+        initializer.expression &&
+        ts.isStringLiteral(initializer.expression)
+      ) {
+        switch (name.text) {
+          case 'id':
+            msg.id = initializer.expression.text;
+            break;
+          case 'defaultMessage':
+            msg.defaultMessage = initializer.expression.text;
+            break;
+          case 'description':
+            msg.description = initializer.expression.text;
+            break;
+        }
+      }
       // {id: 'id'}
-      if (ts.isStringLiteral(initializer)) {
+      else if (ts.isStringLiteral(initializer)) {
         switch (name.text) {
           case 'id':
             msg.id = initializer.text;

--- a/packages/ts-transformer/tests/__snapshots__/index.test.ts.snap
+++ b/packages/ts-transformer/tests/__snapshots__/index.test.ts.snap
@@ -34,12 +34,20 @@ export default class Foo extends Component {
         <FormattedMessage id=\\"foo.bar.baz\\" defaultMessage=\\"Hello World! {foo, number}\\" values={{
                 foo: 1,
             }}/>
+        <FormattedMessage id=\\"foo.bar.baz\\" defaultMessage=\\"Hello World! {foo, number}\\" values={{
+                foo: 1,
+            }}/>
       </p>);
     }
 }
 ",
   "meta": Object {},
   "msgs": Array [
+    Object {
+      "defaultMessage": "Hello World! {foo, number}",
+      "description": "The default message.",
+      "id": "foo.bar.baz",
+    },
     Object {
       "defaultMessage": "Hello World! {foo, number}",
       "description": "The default message.",

--- a/packages/ts-transformer/tests/fixtures/FormattedMessage.tsx
+++ b/packages/ts-transformer/tests/fixtures/FormattedMessage.tsx
@@ -21,6 +21,14 @@ export default class Foo extends Component {
             foo: 1,
           }}
         />
+        <FormattedMessage
+          id="foo.bar.baz"
+          defaultMessage={'Hello World! {foo, number}'}
+          description="The default message."
+          values={{
+            foo: 1,
+          }}
+        />
       </p>
     );
   }


### PR DESCRIPTION
As discussed in https://github.com/formatjs/formatjs/issues/2614 there is not currently support for string literal props wrapped by curly braces. While I do agree that it is likely better code-style to remove unnecessary curly braces, I believe this should be an addition to the repo for the following reasons:

1. Curly brace wrapped string literals are valid javascript, and therefore should be supported
2. eslint specifically cannot auto-fix all instances of this issue, causing a potentially unexpected failure case for developers relying on its no curly braces rule (https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-curly-brace-presence.md#edge-cases)
3. By the nature of the formatjs project, many use cases will involve large scale conversions of entire repositories (and often entire organizations). In these situations it is very easy to miss specific cases, and the failure case here is quite severe at runtime, therefore, it should be avoided in an expected way if possible.
4. I do not believe libraries should be prescriptive of code style where they are used (one could just as easily require curly braces everywhere with the eslint rule from (2) which would make using formatjs impossible until changed).