### PR TITLE
docs: fix typo in Advanced Usage examples

### DIFF
--- a/website/docs/guides/advanced-usage.md
+++ b/website/docs/guides/advanced-usage.md
@@ -30,7 +30,7 @@ module.exports = {
   //...
   resolve: {
     alias: {
-      'intl-messageformat-parser': 'intl-messageformatp-parser/no-parser',
+      'intl-messageformat-parser': 'intl-messageformat-parser/no-parser',
     },
   },
 }
@@ -46,7 +46,7 @@ module.exports = {
   plugins: [
     alias({
       entries: {
-        'intl-messageformat-parser': 'intl-messageformatp-parser/no-parser',
+        'intl-messageformat-parser': 'intl-messageformat-parser/no-parser',
       },
     }),
   ],


### PR DESCRIPTION
I went to update my webpack config using the example here and noticed a typo. This fixes it!