### PR TITLE
feat(@formatjs/cli): add `--skip-errors` to skip messages with errors when compiling

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -168,6 +168,10 @@ If this is not provided, result will be printed to stdout`
 for more information`
     )
     .option(
+      '--skip-errors',
+      `Whether to continue compiling messages after encountering an error. Any keys with errors will not be included in the output file.`
+    )
+    .option(
       '--pseudo-locale <pseudoLocale>',
       `Whether to generate pseudo-locale files. See https://formatjs.io/docs/tooling/cli#--pseudo-locale-pseudolocale for possible values. 
 "--ast" is required for this to work.`

--- a/packages/cli/tests/compile/__snapshots__/integration.test.ts.snap
+++ b/packages/cli/tests/compile/__snapshots__/integration.test.ts.snap
@@ -89,6 +89,9 @@ Options:
   --ast                           Whether to compile to AST. See
                                   https://formatjs.io/docs/guides/advanced-usage#pre-parsing-messages
                                   for more information
+  --skip-errors                   Whether to continue compiling messages after
+                                  encountering an error. Any keys with errors
+                                  will not be included in the output file.
   --pseudo-locale <pseudoLocale>  Whether to generate pseudo-locale files. See
                                   https://formatjs.io/docs/tooling/cli#--pseudo-locale-pseudolocale
                                   for possible values.
@@ -322,6 +325,18 @@ Object {
   "a1d12": "I have {count, plural, one{a dog} other{many dogs}}",
   "a1dd2": "my name is {name}",
   "ashd2": "a message",
+}
+`;
+
+exports[`skipped malformed ICU message json 1`] = `
+Object {
+  "stderr": "Error validating message \\"my name is {name\\" with ID \\"a1dd2\\" in file \\"/private/var/tmp/_bazel_paulsalvatore/7e27ede63a999511abb8d01522822ce0/execroot/formatjs/bazel-out/darwin-fastbuild/bin/packages/cli/integration.update.sh.runfiles/formatjs/packages/cli/tests/compile/lang/malformed-messages.json\\"
+",
+  "stdout": "{
+  \\"a1d12\\": \\"I have {count, plural, one{a dog} other{many dogs}}\\",
+  \\"ashd2\\": \\"a message\\"
+}
+",
 }
 `;
 

--- a/packages/cli/tests/compile/__snapshots__/integration.test.ts.snap
+++ b/packages/cli/tests/compile/__snapshots__/integration.test.ts.snap
@@ -330,8 +330,7 @@ Object {
 
 exports[`skipped malformed ICU message json 1`] = `
 Object {
-  "stderr": "Error validating message \\"my name is {name\\" with ID \\"a1dd2\\" in file \\"/private/var/tmp/_bazel_paulsalvatore/7e27ede63a999511abb8d01522822ce0/execroot/formatjs/bazel-out/darwin-fastbuild/bin/packages/cli/integration.update.sh.runfiles/formatjs/packages/cli/tests/compile/lang/malformed-messages.json\\"
-",
+  "stderr": StringMatching /\\^Error validating message "my name is \\{name" with ID "a1dd2" in file \\.\\*\\\\/packages\\\\/cli\\\\/tests\\\\/compile\\\\/lang\\\\/malformed-messages\\.json/,
   "stdout": "{
   \\"a1d12\\": \\"I have {count, plural, one{a dog} other{many dogs}}\\",
   \\"ashd2\\": \\"a message\\"

--- a/packages/cli/tests/compile/integration.test.ts
+++ b/packages/cli/tests/compile/integration.test.ts
@@ -140,6 +140,17 @@ test('malformed ICU message json', async () => {
   ).rejects.toThrowError('SyntaxError: Expected "," but end of input found.')
 }, 20000)
 
+test('skipped malformed ICU message json', async () => {
+  await expect(
+    exec(
+      `${BIN_PATH} compile  --skip-errors ${join(
+        __dirname,
+        'lang/malformed-messages.json'
+      )}`
+    )
+  ).resolves.toMatchSnapshot()
+}, 20000)
+
 test('AST', async () => {
   await expect(
     exec(`${BIN_PATH} compile --ast ${join(__dirname, 'lang/en.json')}`)

--- a/packages/cli/tests/compile/integration.test.ts
+++ b/packages/cli/tests/compile/integration.test.ts
@@ -148,7 +148,11 @@ test('skipped malformed ICU message json', async () => {
         'lang/malformed-messages.json'
       )}`
     )
-  ).resolves.toMatchSnapshot()
+  ).resolves.toMatchSnapshot({
+    stderr: expect.stringMatching(
+      /^Error validating message "my name is {name" with ID "a1dd2" in file .*\/packages\/cli\/tests\/compile\/lang\/malformed-messages.json/
+    ),
+  } as Partial<any>)
 }, 20000)
 
 test('AST', async () => {

--- a/website/docs/tooling/cli.md
+++ b/website/docs/tooling/cli.md
@@ -226,6 +226,10 @@ This is especially useful to convert from a TMS-specific format back to react-in
 
 Whether to compile message into AST instead of just string. See [Advanced Usage](../guides/advanced-usage.md)
 
+### `--skip-errors`
+
+Whether to continue compiling messages after encountering an error parsing one of them. Any keys with errors will not be included in the output file.
+
 ## Builtin Formatters
 
 We provide the following built-in formatters to integrate with 3rd party TMSes:


### PR DESCRIPTION
Gives the option to continue compiling files through the CLI command when encountering a line that cannot be properly parsed. This helps with unblocking compilation when translations need to be updated.

I chose to continue to console.error the message since it makes diagnosing incorrect translations easier, I can see an argument for this being completely ignored though.