### PR TITLE
Change default value for `idInterpolationPattern` to `[sha512:contenthash:base64:6]` in order to avoid hash collisions happening with `[contenthash:5]`

### DIFF
--- a/packages/babel-plugin-formatjs/CHANGELOG.md
+++ b/packages/babel-plugin-formatjs/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 10.0.0 (https://github.com/formatjs/formatjs/compare/babel-plugin-formatjs@9.2.5...babel-plugin-formatjs@10.0.0) (2021-03-25)
+
+Change default value for `idInterpolationPattern` to `[sha512:contenthash:base64:6]` in order to avoid hash collisions happening with `[contenthash:5]`
+
 ## [9.2.5](https://github.com/formatjs/formatjs/compare/babel-plugin-formatjs@9.2.4...babel-plugin-formatjs@9.2.5) (2021-03-15)
 
 **Note:** Version bump only for package babel-plugin-formatjs

--- a/packages/babel-plugin-formatjs/utils.ts
+++ b/packages/babel-plugin-formatjs/utils.ts
@@ -78,7 +78,7 @@ export function evaluateMessageDescriptor(
   descriptorPath: MessageDescriptorPath,
   isJSXSource = false,
   filename: string | undefined,
-  idInterpolationPattern = '[contenthash:5]',
+  idInterpolationPattern = '[sha512:contenthash:base64:6]',
   overrideIdFn?: Options['overrideIdFn'],
   preserveWhitespace?: Options['preserveWhitespace']
 ) {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [4.0.0](https://github.com/formatjs/formatjs/compare/@formatjs/cli@3.2.0...@formatjs/cli@4.0.0) (2021-03-25)
+
+Change default value for `--id-interpolation-pattern` to `[sha512:contenthash:base64:6]` in order to avoid hash collisions happening with `[contenthash:5]`
+
 # [3.2.0](https://github.com/formatjs/formatjs/compare/@formatjs/cli@3.1.6...@formatjs/cli@3.2.0) (2021-03-15)
 
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -54,10 +54,10 @@ This is especially useful to convert from our extracted format to a TMS-specific
     .option(
       '--id-interpolation-pattern <pattern>',
       `If certain message descriptors don't have id, this \`pattern\` will be used to automatically
-generate IDs for them. Default to \`[contenthash:5]\` where \`contenthash\` is the hash of
+generate IDs for them. Default to \`[sha512:contenthash:base64:6]\` where \`contenthash\` is the hash of
 \`defaultMessage\` and \`description\`.
 See https://github.com/webpack/loader-utils#interpolatename for sample patterns`,
-      '[contenthash:5]'
+      '[sha512:contenthash:base64:6]'
     )
     .option(
       '--extract-source-location',

--- a/packages/cli/tests/extract/__snapshots__/integration.test.ts.snap
+++ b/packages/cli/tests/extract/__snapshots__/integration.test.ts.snap
@@ -215,7 +215,7 @@ Options:
   --id-interpolation-pattern <pattern>                  If certain message descriptors don't have id, this \`pattern\` will be used to automatically
   generate IDs for them. Default to \`[contenthash:5]\` where \`contenthash\` is the hash of
   \`defaultMessage\` and \`description\`.
-  See https://github.com/webpack/loader-utils#interpolatename for sample patterns (default: \\"[contenthash:5]\\")
+  See https://github.com/webpack/loader-utils#interpolatename for sample patterns (default: \\"[sha512:contenthash:base64:6]\\")
   --extract-source-location                             Whether the metadata about the location of the message in the source file should be 
   extracted. If \`true\`, then \`file\`, \`start\`, and \`end\` fields will exist for each 
   extracted message descriptors. (default: false)

--- a/packages/cli/tests/extract/__snapshots__/integration.test.ts.snap
+++ b/packages/cli/tests/extract/__snapshots__/integration.test.ts.snap
@@ -213,7 +213,7 @@ Options:
   --out-file <path>                                     The target file path where the plugin will output an aggregated 
   \`.json\` file of all the translations from the \`files\` supplied.
   --id-interpolation-pattern <pattern>                  If certain message descriptors don't have id, this \`pattern\` will be used to automatically
-  generate IDs for them. Default to \`[contenthash:5]\` where \`contenthash\` is the hash of
+  generate IDs for them. Default to \`[sha512:contenthash:base64:6]\` where \`contenthash\` is the hash of
   \`defaultMessage\` and \`description\`.
   See https://github.com/webpack/loader-utils#interpolatename for sample patterns (default: \\"[sha512:contenthash:base64:6]\\")
   --extract-source-location                             Whether the metadata about the location of the message in the source file should be 

--- a/translated/es-ES/website/docs/tooling/cli.md
+++ b/translated/es-ES/website/docs/tooling/cli.md
@@ -116,7 +116,7 @@ The target file path where the plugin will output an aggregated `.json` file of 
 
 ### `--id-interpolation-pattern [pattern]`
 
-If certain message descriptors don't have id, this `pattern` will be used to automaticallygenerate IDs for them. Default to `[contenthash:5]`. See https://github.com/webpack/loader-utils#interpolatename for sample patterns
+If certain message descriptors don't have id, this `pattern` will be used to automaticallygenerate IDs for them. Default to `[sha512:contenthash:base64:6]`. See https://github.com/webpack/loader-utils#interpolatename for sample patterns
 
 ### `--extract-source-location`
 

--- a/translated/fr-FR/website/docs/tooling/cli.md
+++ b/translated/fr-FR/website/docs/tooling/cli.md
@@ -116,7 +116,7 @@ The target file path where the plugin will output an aggregated `.json` file of 
 
 ### `--id-interpolation-pattern [pattern]`
 
-If certain message descriptors don't have id, this `pattern` will be used to automaticallygenerate IDs for them. Default to `[contenthash:5]`. See https://github.com/webpack/loader-utils#interpolatename for sample patterns
+If certain message descriptors don't have id, this `pattern` will be used to automaticallygenerate IDs for them. Default to `[sha512:contenthash:base64:6]`. See https://github.com/webpack/loader-utils#interpolatename for sample patterns
 
 ### `--extract-source-location`
 

--- a/translated/ja-JP/website/docs/tooling/cli.md
+++ b/translated/ja-JP/website/docs/tooling/cli.md
@@ -116,7 +116,7 @@ The target file path where the plugin will output an aggregated `.json` file of 
 
 ### `--id-interpolation-pattern [pattern]`
 
-If certain message descriptors don't have id, this `pattern` will be used to automaticallygenerate IDs for them. Default to `[contenthash:5]`. See https://github.com/webpack/loader-utils#interpolatename for sample patterns
+If certain message descriptors don't have id, this `pattern` will be used to automaticallygenerate IDs for them. Default to `[sha512:contenthash:base64:6]`. See https://github.com/webpack/loader-utils#interpolatename for sample patterns
 
 ### `--extract-source-location`
 

--- a/translated/pt-PT/website/docs/tooling/cli.md
+++ b/translated/pt-PT/website/docs/tooling/cli.md
@@ -116,7 +116,7 @@ The target file path where the plugin will output an aggregated `.json` file of 
 
 ### `--id-interpolation-pattern [pattern]`
 
-If certain message descriptors don't have id, this `pattern` will be used to automaticallygenerate IDs for them. Default to `[contenthash:5]`. See https://github.com/webpack/loader-utils#interpolatename for sample patterns
+If certain message descriptors don't have id, this `pattern` will be used to automaticallygenerate IDs for them. Default to `[sha512:contenthash:base64:6]`. See https://github.com/webpack/loader-utils#interpolatename for sample patterns
 
 ### `--extract-source-location`
 

--- a/translated/zh-CN/website/docs/tooling/cli.md
+++ b/translated/zh-CN/website/docs/tooling/cli.md
@@ -116,7 +116,7 @@ The target file path where the plugin will output an aggregated `.json` file of 
 
 ### `--id-interpolation-pattern [pattern]`
 
-If certain message descriptors don't have id, this `pattern` will be used to automaticallygenerate IDs for them. Default to `[contenthash:5]`. See https://github.com/webpack/loader-utils#interpolatename for sample patterns
+If certain message descriptors don't have id, this `pattern` will be used to automaticallygenerate IDs for them. Default to `[sha512:contenthash:base64:6]`. See https://github.com/webpack/loader-utils#interpolatename for sample patterns
 
 ### `--extract-source-location`
 

--- a/translated/zh-TW/website/docs/tooling/cli.md
+++ b/translated/zh-TW/website/docs/tooling/cli.md
@@ -116,7 +116,7 @@ The target file path where the plugin will output an aggregated `.json` file of 
 
 ### `--id-interpolation-pattern [pattern]`
 
-If certain message descriptors don't have id, this `pattern` will be used to automaticallygenerate IDs for them. Default to `[contenthash:5]`. See https://github.com/webpack/loader-utils#interpolatename for sample patterns
+If certain message descriptors don't have id, this `pattern` will be used to automaticallygenerate IDs for them. Default to `[sha512:contenthash:base64:6]`. See https://github.com/webpack/loader-utils#interpolatename for sample patterns
 
 ### `--extract-source-location`
 

--- a/website/docs/tooling/cli.md
+++ b/website/docs/tooling/cli.md
@@ -120,7 +120,7 @@ The target file path where the plugin will output an aggregated `.json` file of 
 
 ### `--id-interpolation-pattern [pattern]`
 
-If certain message descriptors don't have id, this `pattern` will be used to automaticallygenerate IDs for them. Default to `[contenthash:5]`. See https://github.com/webpack/loader-utils#interpolatename for sample patterns
+If certain message descriptors don't have id, this `pattern` will be used to automaticallygenerate IDs for them. Default to `[sha512:contenthash:base64:6]`. See https://github.com/webpack/loader-utils#interpolatename for sample patterns
 
 ### `--extract-source-location`
 


### PR DESCRIPTION
Closes #2750