### PR TITLE
fix(@formatjs/icu-messageformat-parser): check "yu" regex option support with full regex

### DIFF
--- a/packages/icu-messageformat-parser/parser.ts
+++ b/packages/icu-messageformat-parser/parser.ts
@@ -92,7 +92,7 @@ const isSafeInteger = hasNativeIsSafeInteger
 // IE11 does not support y and u.
 let REGEX_SUPPORTS_U_AND_Y = true
 try {
-  RE('', 'yu')
+  RE('([^\\p{White_Space}\\p{Pattern_Syntax}]*)', 'yu')
 } catch (_) {
   REGEX_SUPPORTS_U_AND_Y = false
 }


### PR DESCRIPTION
Fixes https://github.com/formatjs/formatjs/issues/2766