### PR TITLE
fix(@formatjs/cli): remove unnecessary type definition

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,7 +35,6 @@
     "@formatjs/ts-transformer": "3.3.4",
     "@types/json-stable-stringify": "^1.0.32",
     "@types/lodash": "^4.14.150",
-    "@types/loud-rejection": "^2.0.0",
     "@types/node": "14",
     "@vue/compiler-core": "^3.0.0",
     "@vue/compiler-sfc": "^3.0.5",


### PR DESCRIPTION
`loud-rejection` now provides it's own type definitions. This was causing the following warning when installing `@formatjs/cli`.
```
@types/loud-rejection@2.0.0: This is a stub types definition. loud-rejection provides its own type definitions, so you do not need this installed.
```