### PR TITLE
docs(polyfills): clarify that dependent locales must be specified individually

### DIFF
--- a/website/docs/polyfills/intl-datetimeformat.md
+++ b/website/docs/polyfills/intl-datetimeformat.md
@@ -55,7 +55,7 @@ This package requires the following capabilities:
 
 - [`Intl.getCanonicalLocales`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/getCanonicalLocales) or [polyfill](intl-getcanonicallocales.md)
 - [`Intl.Locale`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale) or [polyfill](intl-locale.md).
-- [`Intl.NumberFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat)
+- [`Intl.NumberFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat) or [polyfill](intl-numberformat.md).
 
 ## Usage
 

--- a/website/docs/polyfills/intl-datetimeformat.md
+++ b/website/docs/polyfills/intl-datetimeformat.md
@@ -61,11 +61,11 @@ This package requires the following capabilities:
 
 ### Via polyfill.io
 
-You can use [polyfill.io URL Builder](https://polyfill.io/v3/url-builder/) to create a polyfill script tag for `Intl.DateTimeFormat`. By default the created URL does not come with any locale data. In order to add locale data, append `Intl.DateTimeFormat.~locale.<locale>` to your list of features. For example:
+You can use [polyfill.io URL Builder](https://polyfill.io/v3/url-builder/) to create a polyfill script tag for `Intl.DateTimeFormat`. By default the created URL does not come with any locale data. In order to add locale data, append `Intl.DateTimeFormat.~locale.<locale>`, as well as locale data for any required polyfills, to your list of features. For example:
 
 ```html
 <!-- Polyfill Intl.DateTimeFormat, its dependencies & `en` locale data -->
-<script src="https://polyfill.io/v3/polyfill.min.js?features=Intl.DateTimeFormat,Intl.DateTimeFormat.~locale.en"></script>
+<script src="https://polyfill.io/v3/polyfill.min.js?features=Intl.DateTimeFormat,Intl.DateTimeFormat.~locale.en,Intl.NumberFormat.~locale.en"></script>
 ```
 
 ### Simple

--- a/website/docs/polyfills/intl-numberformat.md
+++ b/website/docs/polyfills/intl-numberformat.md
@@ -45,7 +45,7 @@ This package requires the following capabilities:
 
 - [`Intl.getCanonicalLocales`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/getCanonicalLocales) or [polyfill](intl-getcanonicallocales.md)
 - [`Intl.Locale`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale) or [polyfill](intl-locale.md).
-- [`Intl.PluralRules`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/PluralRules)
+- [`Intl.PluralRules`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/PluralRules) or [polyfill](intl-pluralrules.md).
 
 ## Features
 

--- a/website/docs/polyfills/intl-numberformat.md
+++ b/website/docs/polyfills/intl-numberformat.md
@@ -55,11 +55,18 @@ Everything in the ES2020 Internationalization API spec (https://tc39.es/ecma402)
 
 ### Via polyfill.io
 
-You can use [polyfill.io URL Builder](https://polyfill.io/v3/url-builder/) to create a polyfill script tag for `Intl.NumberFormat`. By default the created URL does not come with any locale data. In order to add locale data, append `Intl.NumberFormat.~locale.<locale>` to your list of features. For example:
+You can use [polyfill.io URL Builder](https://polyfill.io/v3/url-builder/) to create a polyfill script tag for `Intl.NumberFormat`. By default the created URL does not come with any locale data. In order to add locale data, append `Intl.NumberFormat.~locale.<locale>`, as well as locale data for any required polyfills, to your list of features. For example:
 
 ```html
 <!-- Polyfill Intl.NumberFormat, its dependencies & `en` locale data -->
 <script src="https://polyfill.io/v3/polyfill.min.js?features=Intl.NumberFormat,Intl.NumberFormat.~locale.en"></script>
+```
+
+Or if `Intl.PluralRules` needs to be polyfilled as well:
+
+```html
+<!-- Polyfill Intl.NumberFormat, its dependencies & `en` locale data -->
+<script src="https://polyfill.io/v3/polyfill.min.js?features=Intl.NumberFormat,Intl.NumberFormat.~locale.en,Intl.PluralRules.~locale.en"></script>
 ```
 
 ### Simple


### PR DESCRIPTION
Also adds polyfill as alternative for `Intl.NumberFormat` and `Intl.PluralRules` as required capabilities.

As more general feedback, the experience of using `polyfill.io` wasn't all that great. using the suggested `<script>` snippet I got cryptic errors such as `Missing locale for` without it specifying what locale was missing, because `foundLocale` was an empty string, as well as `TypeError: 'P.localeData[e].fn' is undefined`. I had to walk through the code to figure out that the root causes were that `NumberFormat.availableLocales` and `PluralRules.availableLocales`, respectively, were empty.

Furthermore, there doesn't seem to be any list of available locales, and they also differ for each polyfill (e.g. `Intl.PluralRules` only has `en`, not `en-GB`. `en-US` etc.). I also couldn't find them on GitHub, so I went to `jsdelivr.com` to be able to browse the npm packages online.

Once everything's set up it works great though! but getting there was a bit more of an adventure than I would have liked. I'm hoping this PR will help others avoid some of the adventure at least, but the other problems need a bit more than just documentation I think.