### PR TITLE
perf(@formatjs/ecma402-abstract): cache NumberFormat instances for 20x speed-up when formatting dates

### DIFF
--- a/packages/ecma402-abstract/DateTimeFormat/FormatDateTimePattern.ts
+++ b/packages/ecma402-abstract/DateTimeFormat/FormatDateTimePattern.ts
@@ -50,6 +50,27 @@ export interface FormatDateTimePatternImplDetails {
   getDefaultTimeZone(): string
 }
 
+const numberFormatsCache = new Map<
+  string,
+  [Intl.NumberFormat, Intl.NumberFormat]
+>()
+
+function getNumberFormatsForLocale(locale: string) {
+  const cache = numberFormatsCache.get(locale)
+  if (cache) return cache
+
+  const nfOptions = Object.create(null)
+  nfOptions.useGrouping = false
+
+  const nf = new Intl.NumberFormat(locale, nfOptions)
+  const nf2Options = Object.create(null)
+  nf2Options.minimumIntegerDigits = 2
+  nf2Options.useGrouping = false
+  const nf2 = new Intl.NumberFormat(locale, nf2Options)
+  numberFormatsCache.set(locale, [nf, nf2])
+  return [nf, nf2]
+}
+
 /**
  * https://tc39.es/ecma402/#sec-partitiondatetimepattern
  * @param dtf
@@ -72,16 +93,7 @@ export function FormatDateTimePattern(
   const dataLocale = internalSlots.dataLocale
   const dataLocaleData = localeData[dataLocale]
   /** IMPL END */
-
-  const locale = internalSlots.locale
-  const nfOptions = Object.create(null)
-  nfOptions.useGrouping = false
-
-  const nf = new Intl.NumberFormat(locale, nfOptions)
-  const nf2Options = Object.create(null)
-  nf2Options.minimumIntegerDigits = 2
-  nf2Options.useGrouping = false
-  const nf2 = new Intl.NumberFormat(locale, nf2Options)
+  const [nf, nf2] = getNumberFormatsForLocale(internalSlots.locale)
   const tm = ToLocalTime(
     x,
     // @ts-ignore


### PR DESCRIPTION
Fixes #2807 
Fixes #2813 

It appears that creating `new Intl.NumberFormat` instances is extremely slow. Caching them by locale key seems safe, and this dramatically increases performance.

Before:
```
format (polyfill) x 15,193 ops/sec ±2.86% (87 runs sampled)
format (native) x 551,023 ops/sec ±4.01% (83 runs sampled)
```

After:
```
format (polyfill) x 326,105 ops/sec ±0.42% (98 runs sampled)
format (native) x 643,658 ops/sec ±0.62% (93 runs sampled)
```

cc @longlho 