### PR TITLE
feat(vue-intl): follow Vue.js 3 plugin conventions

### DIFF
--- a/packages/vue-intl/index.ts
+++ b/packages/vue-intl/index.ts
@@ -1,6 +1,5 @@
 import {MessageDescriptor} from '@formatjs/intl'
-import {plugin} from './plugin'
-export default plugin
+export * from './plugin'
 export * from './provider'
 export {
   IntlShape,

--- a/packages/vue-intl/plugin.ts
+++ b/packages/vue-intl/plugin.ts
@@ -1,12 +1,12 @@
-import {createIntl, IntlConfig} from '@formatjs/intl'
+import {createIntl as _createIntl, IntlConfig} from '@formatjs/intl'
 import Vue from 'vue'
 
-export const plugin: Vue.Plugin = {
-  install: (app, options: IntlConfig) => {
+export const createIntl = (options: IntlConfig): Vue.Plugin => ({
+  install(app) {
     if (!options) {
       throw new Error('Missing `options` for vue-intl plugin')
     }
-    const intl = createIntl(options)
+    const intl = _createIntl(options)
 
     app.config.globalProperties.$intl = intl
     app.config.globalProperties.$formatMessage = intl.formatMessage
@@ -19,4 +19,4 @@ export const plugin: Vue.Plugin = {
 
     app.provide('intl', intl)
   },
-}
+})

--- a/packages/vue-intl/tests/index.test.ts
+++ b/packages/vue-intl/tests/index.test.ts
@@ -1,7 +1,7 @@
 import {defineComponent, h} from 'vue'
-import VueIntl, {provideIntl, useIntl} from '../index'
+import {createIntl, provideIntl, useIntl} from '../index'
 import {mount} from '@vue/test-utils'
-import {createIntl} from '@formatjs/intl'
+import {createIntl as rawCreateIntl} from '@formatjs/intl'
 
 const Translations = defineComponent({
   template: `
@@ -44,7 +44,7 @@ const Descendant = {
 const Ancestor = {
   setup() {
     provideIntl(
-      createIntl({
+      rawCreateIntl({
         locale: 'en',
         defaultLocale: 'en',
         messages: {
@@ -77,16 +77,13 @@ test('basic', function () {
   const wrapper = mount(Translations, {
     global: {
       plugins: [
-        [
-          VueIntl,
-          {
-            locale: 'en',
-            defaultLocale: 'en',
-            messages: {
-              foo: 'Foo',
-            },
+        createIntl({
+          locale: 'en',
+          defaultLocale: 'en',
+          messages: {
+            foo: 'Foo',
           },
-        ],
+        }),
       ],
     },
   })
@@ -98,16 +95,13 @@ test('injected', function () {
   const wrapper = mount(Injected, {
     global: {
       plugins: [
-        [
-          VueIntl,
-          {
-            locale: 'en',
-            defaultLocale: 'en',
-            messages: {
-              foo: 'Injected',
-            },
+        createIntl({
+          locale: 'en',
+          defaultLocale: 'en',
+          messages: {
+            foo: 'Injected',
           },
-        ],
+        }),
       ],
     },
   })

--- a/website/docs/vue-intl.md
+++ b/website/docs/vue-intl.md
@@ -38,16 +38,18 @@ yarn add -S vue-intl
 Initialize `VueIntl` plugin with the same `IntlConfig` documented in [@formatjs/intl](./intl.md#IntlShape).
 
 ```tsx
-import VueIntl from 'vue-intl'
+import {createIntl} from 'vue-intl'
 
 const app = createApp(App)
-app.use(VueIntl, {
-  locale: 'en',
-  defaultLocale: 'en',
-  messages: {
-    foo: 'bar',
-  },
-})
+app.use(
+  createIntl({
+    locale: 'en',
+    defaultLocale: 'en',
+    messages: {
+      foo: 'bar',
+    },
+  })
+)
 ```
 
 From there you can use our APIs in 2 ways:


### PR DESCRIPTION
This is the general idea. Since I'm not able to build the project locally, it's difficult to test it properly.

- I wasn't sure how to name the `createIntl` import alias. I just used a leading underscore, but let me know if you'd prefer something else.
- I had to disable the pre-commit hook in order to commit the changes.

https://github.com/formatjs/formatjs/discussions/2889