### PR TITLE
feat(@formatjs/intl): allow formatList & FormattedList to take in readonly array

### DIFF
--- a/packages/intl/src/list.ts
+++ b/packages/intl/src/list.ts
@@ -24,7 +24,7 @@ export function formatList(
     onError: OnErrorFn
   },
   getListFormat: Formatters['getListFormat'],
-  values: Array<string>,
+  values: ReadonlyArray<string>,
   options: Parameters<IntlFormatters['formatList']>[1]
 ): string
 export function formatList<T>(
@@ -61,7 +61,7 @@ export function formatListToParts<T>(
     onError: OnErrorFn
   },
   getListFormat: Formatters['getListFormat'],
-  values: Array<string>,
+  values: ReadonlyArray<string>,
   options: Parameters<IntlFormatters['formatList']>[1]
 ): Part[]
 export function formatListToParts<T>(

--- a/packages/intl/src/types.ts
+++ b/packages/intl/src/types.ts
@@ -137,12 +137,12 @@ export interface IntlFormatters<T = any, R = T> {
     values?: Record<string, PrimitiveType | T | FormatXMLElementFn<T, R>>,
     opts?: IntlMessageFormatOptions
   ): R
-  formatList(values: Array<string>, opts?: FormatListOptions): string
+  formatList(values: ReadonlyArray<string>, opts?: FormatListOptions): string
   formatList(
-    values: Array<string | T>,
+    values: ReadonlyArray<string | T>,
     opts?: FormatListOptions
   ): T | string | Array<string | T>
-  formatListToParts(values: Array<string | T>, opts?: FormatListOptions): Part[]
+  formatListToParts(values: ReadonlyArray<string | T>, opts?: FormatListOptions): Part[]
   formatDisplayName(
     value: Parameters<DisplayNames['of']>[0],
     opts: FormatDisplayNameOptions

--- a/packages/intl/src/types.ts
+++ b/packages/intl/src/types.ts
@@ -142,7 +142,10 @@ export interface IntlFormatters<T = any, R = T> {
     values: ReadonlyArray<string | T>,
     opts?: FormatListOptions
   ): T | string | Array<string | T>
-  formatListToParts(values: ReadonlyArray<string | T>, opts?: FormatListOptions): Part[]
+  formatListToParts(
+    values: ReadonlyArray<string | T>,
+    opts?: FormatListOptions
+  ): Part[]
   formatDisplayName(
     value: Parameters<DisplayNames['of']>[0],
     opts: FormatDisplayNameOptions

--- a/packages/react-intl/index.ts
+++ b/packages/react-intl/index.ts
@@ -84,7 +84,7 @@ export const FormattedNumber: React.FC<
 > = createFormattedComponent('formatNumber')
 export const FormattedList: React.FC<
   IntlListFormatOptions & {
-    value: React.ReactNode[]
+    value: readonly React.ReactNode[]
   }
 > = createFormattedComponent('formatList')
 export const FormattedDisplayName: React.FC<


### PR DESCRIPTION
We've got readonly arrays of values we want to pass directly to `<FormattedList />`, but we can't at the moment because of the types requiring mutable arrays. I'd hope the arrays aren't actually mutated, so the readonly subset of `Array` should be allowed.