### PR TITLE
feat(babel-plugin-formatjs): skip message extraction if defaultMessage isn't provided

### DIFF
--- a/packages/babel-plugin-formatjs/tests/__snapshots__/index.test.ts.snap
+++ b/packages/babel-plugin-formatjs/tests/__snapshots__/index.test.ts.snap
@@ -1162,6 +1162,30 @@ export default class Foo extends Component {
 }
 `;
 
+exports[`skipExtractionFormattedMessage 1`] = `
+Object {
+  "code": "import React, { Component } from 'react';
+import { FormattedMessage } from 'react-intl';
+
+function nonStaticId() {
+  return 'baz';
+}
+
+export default class Foo extends Component {
+  render() {
+    return /*#__PURE__*/React.createElement(FormattedMessage, {
+      id: \\"foo.bar.\\".concat(nonStaticId())
+    });
+  }
+
+}",
+  "data": Object {
+    "messages": Array [],
+    "meta": Object {},
+  },
+}
+`;
+
 exports[`templateLiteral 1`] = `
 Object {
   "code": "import React, { Component } from 'react';

--- a/packages/babel-plugin-formatjs/tests/fixtures/skipExtractionFormattedMessage.js
+++ b/packages/babel-plugin-formatjs/tests/fixtures/skipExtractionFormattedMessage.js
@@ -1,0 +1,12 @@
+import React, {Component} from 'react'
+import {FormattedMessage} from 'react-intl'
+
+function nonStaticId() {
+  return 'baz'
+}
+
+export default class Foo extends Component {
+  render() {
+    return <FormattedMessage id={`foo.bar.${nonStaticId()}`} />
+  }
+}

--- a/packages/babel-plugin-formatjs/tests/index.test.ts
+++ b/packages/babel-plugin-formatjs/tests/index.test.ts
@@ -183,6 +183,10 @@ test('Properly throws parse errors', () => {
   ).toThrow('SyntaxError: MALFORMED_ARGUMENT')
 })
 
+test('skipExtractionFormattedMessage', function () {
+  transformAndCheck('skipExtractionFormattedMessage')
+})
+
 let cacheBust = 1
 
 function transform(

--- a/packages/babel-plugin-formatjs/visitors/jsx-opening-element.ts
+++ b/packages/babel-plugin-formatjs/visitors/jsx-opening-element.ts
@@ -61,7 +61,7 @@ export const visitor: VisitNodeFunction<
   // write `<FormattedMessage {...descriptor} />`, because it will be
   // skipped here and extracted elsewhere. The descriptor will
   // be extracted only (storeMessage) if a `defaultMessage` prop.
-  if (!descriptorPath.id && !descriptorPath.defaultMessage) {
+  if (!descriptorPath.defaultMessage) {
     return
   }
 


### PR DESCRIPTION
fix #2910