### PR TITLE
fix(@formatjs/intl-localematcher): Correct path to main file for @formatjs/intl-localematcher

### DIFF
--- a/packages/intl-localematcher/package.json
+++ b/packages/intl-localematcher/package.json
@@ -14,7 +14,7 @@
   "author": "Long Ho <holevietlong@gmail.com>",
   "homepage": "https://github.com/formatjs/formatjs#readme",
   "license": "MIT",
-  "main": "index.umd.js",
+  "main": "index.js",
   "types": "index.d.ts",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Currently it links to a non-existent file name `index.umd.js`
Here is a link showing the published files of this package, which shows that no file named `index.umd.js` exists -- https://unpkg.com/browse/@formatjs/intl-localematcher@0.2.16/