### PR TITLE
fix(@formatjs/cli): bump fast-glob to 3.2.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "core-js": "^3.6.5",
         "emoji-regex": "^9.2.0",
         "eslint": "^7.4.0",
-        "fast-glob": "^3.2.4",
+        "fast-glob": "^3.2.7",
         "fs-extra": "10",
         "hoist-non-react-statics": "^3.3.2",
         "http-server": "^0.12.3",
@@ -13948,9 +13948,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.6.tgz",
-      "integrity": "sha512-GnLuqj/pvQ7pX8/L4J84nijv6sAnlwvSDpMkJi9i7nPmPxGtRPkBSStfvDW5l6nMdX9VWe+pkKWFTgD+vF2QSQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
+      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -43134,9 +43134,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.6.tgz",
-      "integrity": "sha512-GnLuqj/pvQ7pX8/L4J84nijv6sAnlwvSDpMkJi9i7nPmPxGtRPkBSStfvDW5l6nMdX9VWe+pkKWFTgD+vF2QSQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
+      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -52618,6 +52618,7 @@
         "chalk": "^4.1.0",
         "find-up": "^5.0.0",
         "mkdirp": "^1.0.4",
+        "postcss": "^8.2.4",
         "strip-json-comments": "^3.1.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "core-js": "^3.6.5",
     "emoji-regex": "^9.2.0",
     "eslint": "^7.4.0",
-    "fast-glob": "^3.2.4",
+    "fast-glob": "^3.2.7",
     "fs-extra": "10",
     "hoist-non-react-statics": "^3.3.2",
     "http-server": "^0.12.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,7 +40,7 @@
     "@vue/compiler-sfc": "^3.0.5",
     "chalk": "^4.0.0",
     "commander": "8",
-    "fast-glob": "^3.2.4",
+    "fast-glob": "^3.2.7",
     "fs-extra": "^9.0.0",
     "json-stable-stringify": "^1.0.1",
     "lodash": "^4.17.15",


### PR DESCRIPTION
fixes #3027