### PR TITLE
feat(intl-messageformat): generate modern web bundle as intl-messageformat.esm.js

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -29,6 +29,13 @@ ts_config(
     deps = ["//:tsconfig.json"],
 )
 
+ts_config(
+    name = "tsconfig.esm.esnext",
+    src = "tsconfig.esm.esnext.json",
+    visibility = ["//:__subpackages__"],
+    deps = ["//:tsconfig.json"],
+)
+
 # We run this centrally so it doesn't spawn
 # multiple browser sessions which overwhelms SauceLabs
 KARMA_TESTS = [

--- a/package-lock.json
+++ b/package-lock.json
@@ -52618,6 +52618,7 @@
         "chalk": "^4.1.0",
         "find-up": "^5.0.0",
         "mkdirp": "^1.0.4",
+        "postcss": "^8.2.4",
         "strip-json-comments": "^3.1.1"
       }
     },

--- a/packages/intl-messageformat/BUILD
+++ b/packages/intl-messageformat/BUILD
@@ -13,6 +13,7 @@ pkg_npm(
         "README.md",
     ],
     deps = [
+        "%s.esm.js" % PACKAGE_NAME,
         "%s.iife.js" % PACKAGE_NAME,
         ":dist",
     ],
@@ -48,6 +49,7 @@ ts_compile(
     package_name = PACKAGE_NAME,
     srcs = SRCS,
     skip_esm = False,
+    skip_esm_esnext = False,
     deps = SRC_DEPS,
 )
 
@@ -68,6 +70,19 @@ esbuild(
     target = "es5",
     deps = [
         ":dist-esm",
+    ] + SRC_DEPS,
+)
+
+esbuild(
+    name = "%s.esm" % PACKAGE_NAME,
+    args = [
+        "--global-name=IntlMessageFormat",
+    ],
+    entry_point = "lib_esnext/index.js",
+    format = "esm",
+    target = "esnext",
+    deps = [
+        ":dist-esm-esnext",
     ] + SRC_DEPS,
 )
 

--- a/tools/index.bzl
+++ b/tools/index.bzl
@@ -42,7 +42,7 @@ BUILDIFIER_WARNINGS = [
     "unused-variable",
 ]
 
-def ts_compile(name, srcs, deps, package_name = None, skip_esm = True):
+def ts_compile(name, srcs, deps, package_name = None, skip_esm = True, skip_esm_esnext = True):
     """Compile TS with prefilled args.
 
     Args:
@@ -51,6 +51,7 @@ def ts_compile(name, srcs, deps, package_name = None, skip_esm = True):
         deps: deps
         package_name: name from package.json
         skip_esm: skip building ESM bundle
+        skip_esm_esnext: skip building the ESM ESNext bundle
     """
     deps = deps + ["@npm//tslib"]
     ts_config(
@@ -74,6 +75,16 @@ def ts_compile(name, srcs, deps, package_name = None, skip_esm = True):
             declaration_map = True,
             out_dir = "lib",
             tsconfig = "//:tsconfig.esm",
+            deps = deps,
+        )
+    if not skip_esm_esnext:
+        ts_project(
+            name = "%s-esm-esnext" % name,
+            srcs = srcs,
+            declaration = True,
+            declaration_map = True,
+            out_dir = "lib_esnext",
+            tsconfig = "//:tsconfig.esm.esnext",
             deps = deps,
         )
 

--- a/tsconfig.esm.esnext.json
+++ b/tsconfig.esm.esnext.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "target": "esnext"
+  }
+}


### PR DESCRIPTION
The DevTools team is currently using an outdated version of `intl-messageformat`. Unfortunately, our build system is not able to consume the iife bundle in a way that works for us, stopping us from upgrading and refactoring the way we use `intl-messageformat`.

I was hoping we could use this PR as a starting point for discussing how to ship a modern web bundle version of `intl-messageformat`. Must have for us would be ESM, the target ES version is not as important (the PR uses ESNext for now).