### PR TITLE
feat(@formatjs/fast-memoize): remove unused Cache.has

### DIFF
--- a/packages/fast-memoize/index.ts
+++ b/packages/fast-memoize/index.ts
@@ -15,7 +15,6 @@ interface CacheCreateFunc<K, V> {
 interface DefaultCache<K, V> {
   get(key: K): V
   set(key: K, value: V): void
-  has(key: K): boolean
 }
 
 export type Serializer = (args: any[]) => string
@@ -166,10 +165,6 @@ const serializerDefault: Serializer = function (): string {
 
 function ObjectWithoutPrototypeCache(this: any) {
   this.cache = Object.create(null) as Record<string, any>
-}
-
-ObjectWithoutPrototypeCache.prototype.has = function (key: string) {
-  return key in this.cache
 }
 
 ObjectWithoutPrototypeCache.prototype.get = function (key: string) {

--- a/packages/intl-messageformat/src/core.ts
+++ b/packages/intl-messageformat/src/core.ts
@@ -68,9 +68,6 @@ function createFastMemoizeCache<V>(store: Record<string, V>): Cache<string, V> {
   return {
     create() {
       return {
-        has(key) {
-          return key in store
-        },
         get(key) {
           return store[key]
         },

--- a/packages/intl/src/utils.ts
+++ b/packages/intl/src/utils.ts
@@ -67,9 +67,6 @@ function createFastMemoizeCache<V>(store: Record<string, V>): Cache<string, V> {
   return {
     create() {
       return {
-        has(key) {
-          return key in store
-        },
         get(key) {
           return store[key]
         },


### PR DESCRIPTION
Hello, 

Just noticed that Cache.has is never used in fast-memoize and would force to have a useless method in custom cache

This is a tiny PR to remove it :)

Thanks 