### PR TITLE
docs(tooling/cli): add npm/yarn command to script demonstrations

### DIFF
--- a/website/docs/tooling/cli.md
+++ b/website/docs/tooling/cli.md
@@ -91,7 +91,7 @@ values={[
 <TabItem value="npm">
 
 ```sh
-npm run formatjs extract --help
+npm run extract --help
 # Usage: formatjs extract [options] [files...]
 
 # Extract string messages from React components that use react-intl.
@@ -101,14 +101,14 @@ npm run formatjs extract --help
 For example:
 
 ```sh
-npm run formatjs extract "src/**/*.{ts,tsx,vue}" --out-file lang.json
+npm run extract "src/**/*.{ts,tsx,vue}" --out-file lang.json
 ```
 
 </TabItem>
 <TabItem value="yarn">
 
 ```sh
-yarn formatjs extract --help
+yarn extract --help
 # Usage: formatjs extract [options] [files...]
 
 # Extract string messages from React components that use react-intl.
@@ -118,7 +118,7 @@ yarn formatjs extract --help
 For example:
 
 ```sh
-yarn formatjs extract "src/**/*.{ts,tsx,vue}" --out-file lang.json
+yarn extract "src/**/*.{ts,tsx,vue}" --out-file lang.json
 ```
 
 </TabItem>
@@ -219,14 +219,14 @@ values={[
 <TabItem value="npm">
 
 ```sh
-npm run formatjs compile --help
+npm run compile --help
 ```
 
 </TabItem>
 <TabItem value="yarn">
 
 ```sh
-yarn formatjs compile --help
+yarn compile --help
 ```
 
 </TabItem>

--- a/website/docs/tooling/cli.md
+++ b/website/docs/tooling/cli.md
@@ -81,8 +81,17 @@ function Comp(props) {
 
 ## Extraction
 
+<Tabs
+groupId="npm"
+defaultValue="npm"
+values={[
+{label: 'npm', value: 'npm'},
+{label: 'yarn', value: 'yarn'},
+]}>
+<TabItem value="npm">
+
 ```sh
-formatjs extract --help
+npm formatjs extract --help
 # Usage: formatjs extract [options] [files...]
 
 # Extract string messages from React components that use react-intl.
@@ -92,8 +101,28 @@ formatjs extract --help
 For example:
 
 ```sh
-formatjs extract "src/**/*.{ts,tsx,vue}" --out-file lang.json
+npm formatjs extract "src/**/*.{ts,tsx,vue}" --out-file lang.json
 ```
+
+</TabItem>
+<TabItem value="yarn">
+
+```sh
+yarn formatjs extract --help
+# Usage: formatjs extract [options] [files...]
+
+# Extract string messages from React components that use react-intl.
+# The input language is expected to be TypeScript or ES2017 with JSX.
+```
+
+For example:
+
+```sh
+yarn formatjs extract "src/**/*.{ts,tsx,vue}" --out-file lang.json
+```
+
+</TabItem>
+</Tabs>
 
 :::caution
 You should always quote (`"` or `'`) your glob pattern (like `"src/**/*"`) to avoid auto shell expansion of those glob, which varies depending on your shell (`zsh` vs `fish` vs `bash`).
@@ -180,9 +209,28 @@ sentences are not translator-friendly.
 Compile extracted file from `formatjs extract` to a react-intl consumable
 JSON file. This also does ICU message verification. See [Message Distribution](../getting-started/message-distribution.md) for more details.
 
+<Tabs
+groupId="npm"
+defaultValue="npm"
+values={[
+{label: 'npm', value: 'npm'},
+{label: 'yarn', value: 'yarn'},
+]}>
+<TabItem value="npm">
+
 ```sh
-formatjs compile --help
+npm formatjs compile --help
 ```
+
+</TabItem>
+<TabItem value="yarn">
+
+```sh
+yarn formatjs compile --help
+```
+
+</TabItem>
+</Tabs>
 
 ### `--format [path]`
 
@@ -223,9 +271,28 @@ Given the English message `my name is {name}`
 
 Batch compile a folder with extracted files from `formatjs extract` to a folder containing react-intl consumable JSON files. This also does ICU message verification. See [Message Distribution](../getting-started/message-distribution.md) for more details.
 
+<Tabs
+groupId="npm"
+defaultValue="npm"
+values={[
+{label: 'npm', value: 'npm'},
+{label: 'yarn', value: 'yarn'},
+]}>
+<TabItem value="npm">
+
 ```sh
-formatjs compile-folder [options] <folder> <outFolder>
+npm formatjs compile-folder [options] <folder> <outFolder>
 ```
+
+</TabItem>
+<TabItem value="yarn">
+
+```sh
+yarn formatjs compile-folder [options] <folder> <outFolder>
+```
+
+</TabItem>
+</Tabs>
 
 Folder structure should be in the form of `<folder>/<locale>.json` and the output would be `<outFolder>/<locale>.json`.
 

--- a/website/docs/tooling/cli.md
+++ b/website/docs/tooling/cli.md
@@ -91,7 +91,7 @@ values={[
 <TabItem value="npm">
 
 ```sh
-npm formatjs extract --help
+npm run formatjs extract --help
 # Usage: formatjs extract [options] [files...]
 
 # Extract string messages from React components that use react-intl.
@@ -101,7 +101,7 @@ npm formatjs extract --help
 For example:
 
 ```sh
-npm formatjs extract "src/**/*.{ts,tsx,vue}" --out-file lang.json
+npm run formatjs extract "src/**/*.{ts,tsx,vue}" --out-file lang.json
 ```
 
 </TabItem>
@@ -219,7 +219,7 @@ values={[
 <TabItem value="npm">
 
 ```sh
-npm formatjs compile --help
+npm run formatjs compile --help
 ```
 
 </TabItem>
@@ -281,7 +281,7 @@ values={[
 <TabItem value="npm">
 
 ```sh
-npm formatjs compile-folder [options] <folder> <outFolder>
+npm run formatjs compile-folder [options] <folder> <outFolder>
 ```
 
 </TabItem>


### PR DESCRIPTION
Background: issue #2992 (closed due to inactivity, sorry).
Changes:
- Add `npm`/`yarn` to run commands in [tooling/cli](https://formatjs.io/docs/tooling/cli) docs (this change is consistent with other docs pages such as [Message Extraction](https://formatjs.io/docs/getting-started/message-extraction)
- All instances of this are wrapped in `<Tab>`s with the same groupId as the one at the beginning to that the user can select npm/yarn once and see the correct one displayed throughout the page (as is the case in other docs pages)