### PR TITLE
docs: add subsection with demo script

### DIFF
--- a/website/docs/tooling/cli.md
+++ b/website/docs/tooling/cli.md
@@ -219,6 +219,89 @@ Given the English message `my name is {name}`
 | `xx-HA` | `[javascript]my name is {name}`              |
 | `en-XA` | `ṁẏ ńâṁè íś {name}`                          |
 
+## Extraction and compilation with a single script
+
+In some environments you may want to simply extract your messages to a file ready for use with react-intl without using an intermediary extracted message file format. This could be useful for quickly and easily creating the file for the original language that uses the default messages. This could also be useful if you use a Translation Management System (TMS) that is best suited to working with the compiled files. Keep in mind that the compiled file does not contain message descriptions so it is harder to work with for translators. Ideally you want to find or write a custom formatter you can use to extract messages into a file format that works with your TMS.
+
+In order to achieve extraction and compilation in a single script, you can simply set up a script for that in `package.json` like in this example:
+
+```json
+"scripts": {
+  "extract": "formatjs extract",
+  "compile": "formatjs compile",
+  "extract-compile": "formatjs extract 'src/**/*.ts*' --out-file temp.json --flatten --id-interpolation-pattern '[sha512:contenthash:base64:6]' && formatjs compile 'temp.json' --out-file lang/en.json && rm temp.json"
+}
+```
+
+### Breakdown of the script
+
+The `extract-compile` example script consists of three operations performed one after the other.
+
+```sh
+formatjs extract 'src/**/*.ts*' --out-file temp.json --flatten --id-interpolation-pattern '[sha512:contenthash:base64:6]'
+```
+
+The first script extracts messages from all typescript files that are located in subfolders of `src`. You may need to ignore certain files that could trigger errors or warnings in the script, such as `--ignore myFolder/myFile.ts`
+
+```sh
+formatjs compile 'temp.json' --out-file lang/en.json
+```
+
+The second script compiles the messages from `temp.json` into the file `lang/en.json`. This file is ready to be consumed by react-intl.
+
+```sh
+rm temp.json
+```
+
+The last script deletes the `temp.json` extracted file. Feel free remove this from the script if you wish to keep this file around.
+
+### The resulting files
+
+Here you can see the difference between the extracted (using the default formatter) and the compiled file formats. In the script above, `temp.json` is the extracted file and `en.json` is the compiled file.
+<Tabs
+groupId="json"
+defaultValue="extracted"
+values={[
+{label: 'Extracted messages', value: 'extracted'},
+{label: 'Compiled messages', value: 'compiled'},
+]}>
+<TabItem value="extracted">
+
+```json
+{
+  "hak27d": {
+    "defaultMessage": "Control Panel",
+    "description": "title of control panel section"
+  },
+  "haqsd": {
+    "defaultMessage": "Delete user {name}",
+    "description": "delete button"
+  },
+  "19hjs": {
+    "defaultMessage": "New Password",
+    "description": "placeholder text"
+  },
+  "explicit-id": {
+    "defaultMessage": "Confirm Password",
+    "description": "placeholder text"
+  }
+}
+```
+
+</TabItem>
+<TabItem value="compiled">
+```json
+{
+  "hak27d": "Control Panel",
+  "haqsd": "Delete user {name}",
+  "19hjs": "New Password",
+  "explicit-id": "Confirm Password"
+}
+```
+
+</TabItem>
+</Tabs>
+
 ## Folder Compilation
 
 Batch compile a folder with extracted files from `formatjs extract` to a folder containing react-intl consumable JSON files. This also does ICU message verification. See [Message Distribution](../getting-started/message-distribution.md) for more details.


### PR DESCRIPTION
**Background:**
In a project where I used `@formatjs/cli`, I found it useful to have a script where I extracted and compiled the messages in a single script. I just needed the final, compiled output in a `en.json` file.

In case this could be useful to others I have written a section demonstrating this usage of the cli. I took care to explain why it could be a bad idea to do this (losing message descriptions which are useful to translators) so that users won't end up doing something they don't really want.

In the subsection there's also a little `<Tabs>` group which demonstrates the output file format of these two scripts. I used the example messages from [docs/Extraction](https://formatjs.io/docs/getting-started/message-extraction) for consistency.

I'll admit it could be considered somewhat of a corner case scenario and not worthy of documentation here. I'm totally open to gutting this subsection and maybe putting the file format examples in the sections for Extraction and Compilation, respectively. 

**Changes:** 
- docs: (@tooling/cli) add subsection with demo `extract-compile` script with explanation and contextual information