### PR TITLE
fix(react-intl): add generic constraint to defineMessage for better intellisense experience

### DIFF
--- a/packages/react-intl/index.ts
+++ b/packages/react-intl/index.ts
@@ -51,7 +51,7 @@ export function defineMessages<
   return msgs
 }
 
-export function defineMessage<T>(msg: T): T {
+export function defineMessage<T extends MessageDescriptor>(msg: T): T {
   return msg
 }
 export {


### PR DESCRIPTION
Currently, when writing:
```ts
const message = defineMessage({ defaultMessage: 'Some message' });
```
There is no autocomplete presented for the thing passed to `defineMessage`.

That only happens if you either are passing it to something that already expected a `MessageDescriptor` such as `intl.formatMessage`, or type the variable explicitly, such as:
```ts
const message: MessageDescriptor = defineMessage(...);
```

I don't know if there's any specific reason why you typed it the way it was, but if not, then I would suggest that this gives a better developer experience.