### PR TITLE
Change FormattedNumberParts to expect ReactChild instead of ReactElement

### DIFF
--- a/packages/react-intl/src/components/createFormattedComponent.tsx
+++ b/packages/react-intl/src/components/createFormattedComponent.tsx
@@ -38,7 +38,7 @@ export const FormattedNumberParts: React.FC<
   Formatter['formatNumber'] & {
     value: Parameters<IntlShape['formatNumber']>[0]
 
-    children(val: Intl.NumberFormatPart[]): React.ReactElement | null
+    children(val: Intl.NumberFormatPart[]): React.ReactChild | null
   }
 > = props => {
   const intl = useIntl()


### PR DESCRIPTION
ReactElement expects a component, while `ReactChild = ReactElement | ReactText`, which is more correct type for `children`. My exact use case:

```
<FormattedNumberParts value={0} currency={currency} style="currency" currencyDisplay="narrowSymbol">
    {(parts): string => parts.find(p => p.type === 'currency')?.value}
</FormattedNumberParts>
```

This is a valid output, but not allowed in the current type.