### PR TITLE
Fix asynchronous process.stdout.write in CLI

### DIFF
--- a/packages/cli/src/compile.ts
+++ b/packages/cli/src/compile.ts
@@ -1,7 +1,7 @@
 import {parse, MessageFormatElement} from '@formatjs/icu-messageformat-parser'
 import {outputFile, readJSON} from 'fs-extra'
 import stringify from 'json-stable-stringify'
-import {debug, warn} from './console_utils'
+import {debug, warn, writeStdout} from './console_utils'
 import {resolveBuiltinFormatter, Formatter} from './formatters'
 import {
   generateXXAC,
@@ -136,6 +136,6 @@ export default async function compileAndWrite(
     debug('Writing output file:', outFile)
     return outputFile(outFile, serializedResult)
   }
-  process.stdout.write(serializedResult)
-  process.stdout.write('\n')
+  await writeStdout(serializedResult)
+  await writeStdout('\n')
 }

--- a/packages/cli/src/extract.ts
+++ b/packages/cli/src/extract.ts
@@ -1,6 +1,5 @@
-import {warn, getStdinAsString, debug} from './console_utils'
+import {warn, getStdinAsString, debug, writeStdout} from './console_utils'
 import {readFile, outputFile} from 'fs-extra'
-import {promisify} from 'util';
 import {
   interpolateName,
   Opts,
@@ -266,7 +265,5 @@ export default async function extractAndWrite(
     debug('Writing output file:', outFile)
     return outputFile(outFile, serializedResult)
   }
-  await promisify(process.stdout.write.bind(process.stdout))(
-    serializedResult
-  )
+  await writeStdout(serializedResult)
 }

--- a/packages/cli/src/extract.ts
+++ b/packages/cli/src/extract.ts
@@ -1,5 +1,6 @@
 import {warn, getStdinAsString, debug} from './console_utils'
 import {readFile, outputFile} from 'fs-extra'
+import {promisify} from 'util';
 import {
   interpolateName,
   Opts,
@@ -265,5 +266,7 @@ export default async function extractAndWrite(
     debug('Writing output file:', outFile)
     return outputFile(outFile, serializedResult)
   }
-  process.stdout.write(serializedResult)
+  await promisify(process.stdout.write.bind(process.stdout))(
+    serializedResult
+  )
 }

--- a/packages/ts-transformer/src/console_utils.ts
+++ b/packages/ts-transformer/src/console_utils.ts
@@ -13,20 +13,20 @@ function label(level: keyof typeof LEVEL_COLORS, message: string) {
   )}] ${message}`
 }
 
-export function debug(message: string, ...args: any[]): void {
+export async function debug(message: string, ...args: any[]) {
   if (process.env.LOG_LEVEL !== 'debug') {
     return
   }
-  process.stderr.write(format(label('debug', message), ...args))
-  process.stderr.write('\n')
+  console.error(format(label('debug', message), ...args))
+  console.error('\n')
 }
 
 export function warn(message: string, ...args: any[]): void {
-  process.stderr.write(format(label('warn', message), ...args))
-  process.stderr.write('\n')
+  console.error(format(label('warn', message), ...args))
+  console.error('\n')
 }
 
 export function error(message: string, ...args: any[]): void {
-  process.stderr.write(format(label('error', message), ...args))
-  process.stderr.write('\n')
+  console.error(format(label('error', message), ...args))
+  console.error('\n')
 }


### PR DESCRIPTION
`process.stdout.write` can be async :: https://nodejs.org/api/process.html#process_a_note_on_process_i_o

When it's async then `process.exit(0)` can be called after first chunk has been sent to stdout.
https://github.com/formatjs/formatjs/blob/852da9d79246e5b0c4b8c3295fa3ed7a8a479f30/packages/cli/src/cli.ts#L151

It can be reproduced on MacOS or Linux with `child_process`.
```
child_process.spawn(
    './node_modules/.bin/formatjs',
    ['extract', '--ignore=**/*.d.ts', '**/*.{ts,tsx}'],
    {
      preferLocal: true,
      encoding: 'utf8'
    }
  ).stdout.on('data', (d) => console.log('CHUNK\n==============\n', d.toString()))
```

There is only one chunk will sended because `process.stdout.write` is async. If the output is large, it will be broken.

But last argument `writable.write` is callback. So this bug can be fixed with `util.promisify`. 