### PR TITLE
feat(@formatjs/intl-relativetimeformat): update shouldPolyfill for Intl.RelativeTimeFormat

### DIFF
--- a/packages/intl-relativetimeformat/should-polyfill.ts
+++ b/packages/intl-relativetimeformat/should-polyfill.ts
@@ -11,12 +11,21 @@ function supportedLocalesOf(locale?: string | string[]) {
 
 function hasResolvedOptionsNumberingSystem(locale?: string | string[]) {
   try {
-    return ('numberingSystem' in (new Intl.RelativeTimeFormat(locale || "en", { numeric: "auto" }).resolvedOptions()));
+    return (
+      'numberingSystem' in
+      new Intl.RelativeTimeFormat(locale || 'en', {
+        numeric: 'auto',
+      }).resolvedOptions()
+    )
   } catch (_) {
-    return false;
+    return false
   }
 }
 
 export function shouldPolyfill(locale?: string | string[]) {
-  return !('RelativeTimeFormat' in Intl) || !supportedLocalesOf(locale) || !hasResolvedOptionsNumberingSystem(locale);
+  return (
+    !('RelativeTimeFormat' in Intl) ||
+    !supportedLocalesOf(locale) ||
+    !hasResolvedOptionsNumberingSystem(locale)
+  )
 }

--- a/packages/intl-relativetimeformat/should-polyfill.ts
+++ b/packages/intl-relativetimeformat/should-polyfill.ts
@@ -9,6 +9,14 @@ function supportedLocalesOf(locale?: string | string[]) {
   )
 }
 
+function hasResolvedOptionsNumberingSystem(locale?: string | string[]) {
+  try {
+    return ('numberingSystem' in (new Intl.RelativeTimeFormat(locale || "en", { numeric: "auto" }).resolvedOptions()));
+  } catch (_) {
+    return false;
+  }
+}
+
 export function shouldPolyfill(locale?: string | string[]) {
-  return !('RelativeTimeFormat' in Intl) || !supportedLocalesOf(locale)
+  return !('RelativeTimeFormat' in Intl) || !supportedLocalesOf(locale) || !hasResolvedOptionsNumberingSystem(locale);
 }


### PR DESCRIPTION
see [docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat#browser_compatibility)

<img width="1061" alt="Screenshot 2021-08-29 at 11 04 57" src="https://user-images.githubusercontent.com/11521496/131244985-d4f591ac-76c0-4f4d-a0ee-c63983f9bdc3.png">
