### PR TITLE
fix(eslint-plugin-formatjs): remove deprecated @types/emoji-regex 9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
         "@types/babel__core": "^7.1.7",
         "@types/babel__helper-plugin-utils": "^7.10.0",
         "@types/benchmark": "^2.1.0",
-        "@types/emoji-regex": "9",
         "@types/eslint": "^7.2.0",
         "@types/estree": "^0.0.50",
         "@types/fs-extra": "^9.0.1",
@@ -6359,16 +6358,6 @@
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
       "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==",
       "dev": true
-    },
-    "node_modules/@types/emoji-regex": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/@types/emoji-regex/-/emoji-regex-9.2.0.tgz",
-      "integrity": "sha512-Q2BaUWiokKV2ZWk15twerRiNIex/VOGIz3pAgPMk6JZAeuGT9oAm/kA2Ri9InUtPc84bY0UQZzn/Pd2yUd33Ig==",
-      "deprecated": "This is a stub types definition. emoji-regex provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "emoji-regex": "*"
-      }
     },
     "node_modules/@types/eslint": {
       "version": "7.28.0",
@@ -37197,15 +37186,6 @@
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
       "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==",
       "dev": true
-    },
-    "@types/emoji-regex": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/@types/emoji-regex/-/emoji-regex-9.2.0.tgz",
-      "integrity": "sha512-Q2BaUWiokKV2ZWk15twerRiNIex/VOGIz3pAgPMk6JZAeuGT9oAm/kA2Ri9InUtPc84bY0UQZzn/Pd2yUd33Ig==",
-      "dev": true,
-      "requires": {
-        "emoji-regex": "*"
-      }
     },
     "@types/eslint": {
       "version": "7.28.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -52921,6 +52921,7 @@
         "chalk": "^4.1.0",
         "find-up": "^5.0.0",
         "mkdirp": "^1.0.4",
+        "postcss": "^8.2.4",
         "strip-json-comments": "^3.1.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "@types/babel__core": "^7.1.7",
     "@types/babel__helper-plugin-utils": "^7.10.0",
     "@types/benchmark": "^2.1.0",
-    "@types/emoji-regex": "9",
     "@types/eslint": "^7.2.0",
     "@types/estree": "^0.0.50",
     "@types/fs-extra": "^9.0.1",

--- a/packages/eslint-plugin-formatjs/BUILD
+++ b/packages/eslint-plugin-formatjs/BUILD
@@ -34,7 +34,6 @@ SRCS = glob(["rules/*.ts"]) + [
 ]
 
 SRC_DEPS = [
-    "@npm//@types/emoji-regex",
     "@npm//@types/eslint",
     "@npm//@typescript-eslint/typescript-estree",
     "@npm//emoji-regex",

--- a/packages/eslint-plugin-formatjs/package.json
+++ b/packages/eslint-plugin-formatjs/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "@formatjs/icu-messageformat-parser": "2.0.11",
     "@formatjs/ts-transformer": "3.4.10",
-    "@types/emoji-regex": "9",
     "@types/eslint": "^7.2.0",
     "@typescript-eslint/typescript-estree": "^4.11.0",
     "emoji-regex": "^9.2.0",


### PR DESCRIPTION
Fixes `npm WARN deprecated @types/emoji-regex@9.2.0: This is a stub types definition. emoji-regex provides its own type definitions, so you do not need this installed.`