### PR TITLE
docs: injectIntl is not used in the example code snippet

### DIFF
--- a/website/docs/react-intl.md
+++ b/website/docs/react-intl.md
@@ -165,7 +165,7 @@ Here's an example using `<IntlProvider>`, `<Formatted*>` components, and the imp
 ```tsx
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {injectIntl, IntlProvider, FormattedRelative, useIntl} from 'react-intl';
+import {IntlProvider, FormattedRelative, useIntl} from 'react-intl';
 
 const MS_IN_DAY = 1e3 * 3600 * 24
 


### PR DESCRIPTION
injectIntl is not used in the example code snippet