### PR TITLE
fix(IntlProvider): Add explicit types for children

### DIFF
--- a/src/components/provider.tsx
+++ b/src/components/provider.tsx
@@ -165,7 +165,7 @@ export function createIntl(
 }
 
 export default class IntlProvider extends React.PureComponent<
-  OptionalIntlConfig,
+  React.PropsWithChildren<OptionalIntlConfig>,
   State
 > {
   static displayName = 'IntlProvider';


### PR DESCRIPTION
We plan to remove implicit `children` from `React.FunctionComponent` and `React.Component`. `IntlProvider` currently implements `children` without declaring them in its props interface.

Found this when running tests in the DefinitelyTyped repository. Unclear yet whether this affects latest versions. Would appreciated an out-of-band release of 3.x so that we don't have to inline types in the DefinitelyTyped repository.