### PR TITLE
fix(intl-messageformat): throw when a value is `undefined` or `null`

### DIFF
--- a/packages/intl-messageformat/src/formatters.ts
+++ b/packages/intl-messageformat/src/formatters.ts
@@ -136,7 +136,7 @@ export function formatToParts<T>(
     const {value: varName} = el
 
     // Enforce that all required values are provided by the caller.
-    if (!(values && varName in values)) {
+    if (!(values && values[varName] != null)) {
       throw new MissingValueError(varName, originalMessage)
     }
 

--- a/packages/intl-messageformat/tests/index.test.ts
+++ b/packages/intl-messageformat/tests/index.test.ts
@@ -123,14 +123,9 @@ describe('IntlMessageFormat', function () {
       expect(output).toBe('I am 0 years old.')
     })
 
-    it('should ignore false, null, and undefined', function () {
-      const mf = new IntlMessageFormat('{a}{b}{c}')
-      const output = mf.format({
-        a: false,
-        b: null,
-        c: undefined,
-      })
-
+    it('should ignore false', function () {
+      const mf = new IntlMessageFormat('{a}')
+      const output = mf.format({a: false})
       expect(output).toBe('')
     })
   })
@@ -778,6 +773,14 @@ describe('IntlMessageFormat', function () {
         minimumFractionDigits: 5,
         maximumFractionDigits: 5,
       }).format(0.1234567)
+    )
+  })
+
+  it('throws when a date argument is `undefined`', () => {
+    const msg = 'Today is {time, date, long}'
+    const mf = new IntlMessageFormat(msg, 'en')
+    expect(() => mf.format({time: undefined})).toThrow(
+      'The intl string context variable "time" was not provided to the string "Today is {time, date, long}"'
     )
   })
 


### PR DESCRIPTION
Fixes #3249

Currently the behaviour is the same for all kinds of arguments. I stumbled upon this with a date argument where I was a bit surprised that the default of the current date is used. I guess it's open to debate if this behaviour should be consistent across all value types, or if it would make sense to only use it for use cases like dates.