### PR TITLE
fix(react-intl): named esm exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "benchmark": "^2.1.4",
         "chalk": "^4.0.0",
         "chokidar": "^3.4.2",
+        "cjs-module-lexer": "^1.2.2",
         "classnames": "^2.2.6",
         "cldr-core": "39",
         "cldr-dates-full": "39",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "benchmark": "^2.1.4",
     "chalk": "^4.0.0",
     "chokidar": "^3.4.2",
+    "cjs-module-lexer": "^1.2.2",
     "classnames": "^2.2.6",
     "cldr-core": "39",
     "cldr-dates-full": "39",

--- a/packages/react-intl/BUILD
+++ b/packages/react-intl/BUILD
@@ -53,7 +53,9 @@ TESTS = glob([
 TEST_DEPS = SRC_DEPS + [
     "@npm//@testing-library/jest-dom",
     "@npm//@testing-library/react",
+    "@npm//cjs-module-lexer",
     "@npm//react-dom",
+    "@npm//typescript",
     "//packages/ecma402-abstract:types",
     "//packages/icu-messageformat-parser:types",
     "//packages/intl-displaynames:types",

--- a/packages/react-intl/index.ts
+++ b/packages/react-intl/index.ts
@@ -16,6 +16,32 @@ import {
 import {IntlListFormatOptions} from '@formatjs/intl-listformat'
 import {DisplayNamesOptions} from '@formatjs/intl-displaynames'
 import {NumberFormatOptions} from '@formatjs/ecma402-abstract'
+import injectIntl, {
+  Provider as RawIntlProvider,
+  Context as IntlContext,
+  WithIntlProps,
+  WrappedComponentProps,
+} from './src/components/injectIntl'
+import useIntl from './src/components/useIntl'
+import IntlProvider, {createIntl} from './src/components/provider'
+import FormattedRelativeTime from './src/components/relative'
+import FormattedPlural from './src/components/plural'
+import FormattedMessage from './src/components/message'
+import FormattedDateTimeRange from './src/components/dateTimeRange'
+export {
+  FormattedDateTimeRange,
+  FormattedMessage,
+  FormattedPlural,
+  FormattedRelativeTime,
+  IntlContext,
+  IntlProvider,
+  RawIntlProvider,
+  WithIntlProps,
+  WrappedComponentProps,
+  createIntl,
+  injectIntl,
+  useIntl,
+}
 export {IntlConfig, ResolvedIntlConfig, IntlShape} from './src/types'
 export {
   createIntlCache,
@@ -51,15 +77,6 @@ export function defineMessages<
 export function defineMessage<T extends MessageDescriptor>(msg: T): T {
   return msg
 }
-export {
-  default as injectIntl,
-  Provider as RawIntlProvider,
-  Context as IntlContext,
-  WithIntlProps,
-  WrappedComponentProps,
-} from './src/components/injectIntl'
-export {default as useIntl} from './src/components/useIntl'
-export {default as IntlProvider, createIntl} from './src/components/provider'
 // IMPORTANT: Explicit here to prevent api-extractor from outputing `import('./src/types').CustomFormatConfig`
 export const FormattedDate: React.FC<
   Intl.DateTimeFormatOptions &
@@ -107,8 +124,4 @@ export {
   FormattedNumberParts,
   FormattedListParts,
 } from './src/components/createFormattedComponent'
-export {default as FormattedRelativeTime} from './src/components/relative'
-export {default as FormattedPlural} from './src/components/plural'
-export {default as FormattedMessage} from './src/components/message'
-export {default as FormattedDateTimeRange} from './src/components/dateTimeRange'
 export type {MessageFormatElement} from '@formatjs/icu-messageformat-parser'

--- a/packages/react-intl/tests/unit/components/message.tsx
+++ b/packages/react-intl/tests/unit/components/message.tsx
@@ -1,12 +1,10 @@
 import * as React from 'react'
 import FormattedMessage from '../../../src/components/message'
-import IntlProvider, {
-  IntlConfig,
-  createIntl,
-} from '../../../src/components/provider'
+import IntlProvider, {createIntl} from '../../../src/components/provider'
 import {mountFormattedComponentWithProvider} from '../testUtils'
 import {IntlShape} from '../../../'
 import {render} from '@testing-library/react'
+import type {IntlConfig} from '../../../src/types'
 
 const mountWithProvider = mountFormattedComponentWithProvider(FormattedMessage)
 

--- a/packages/react-intl/tests/unit/components/provider.tsx
+++ b/packages/react-intl/tests/unit/components/provider.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react'
-import IntlProvider, {IntlConfig} from '../../../src/components/provider'
+import IntlProvider from '../../../src/components/provider'
 import withIntl from '../../../src/components/injectIntl'
 import {render} from '@testing-library/react'
 import {FormattedDate, FormattedMessage} from '../../../'
+import type {IntlConfig} from '../../../src/types'
 
 describe('<IntlProvider>', () => {
   const now = Date.now()

--- a/packages/react-intl/tests/unit/components/relative.tsx
+++ b/packages/react-intl/tests/unit/components/relative.tsx
@@ -4,7 +4,7 @@ import FormattedRelativeTime from '../../../src/components/relative'
 import {createIntl} from '../../../src/components/provider'
 import {IntlShape} from '../../../src/types'
 import {mountFormattedComponentWithProvider} from '../testUtils'
-import {IntlConfig} from '../../../src/components/provider'
+import type {IntlConfig} from '../../../src/types'
 import {render, act} from '@testing-library/react'
 
 jest.useFakeTimers()

--- a/packages/react-intl/tests/unit/react-intl.ts
+++ b/packages/react-intl/tests/unit/react-intl.ts
@@ -1,4 +1,8 @@
 import * as ReactIntl from '../../'
+import * as ts from 'typescript'
+import fs from 'fs'
+import lexer from 'cjs-module-lexer'
+import path from 'path'
 
 describe('react-intl', () => {
   describe('exports', () => {
@@ -62,6 +66,23 @@ describe('react-intl', () => {
       it('exports `FormattedDisplayNames`', () => {
         expect(typeof ReactIntl.FormattedDisplayName).toBe('function')
       })
+    })
+  })
+  describe('static analysis of named exports ', () => {
+    // Parse dist file for statically analyzable named exports
+    const filePath = path.resolve(__dirname, '..', '..', 'index.ts')
+    const source = fs.readFileSync(filePath, 'utf8')
+    const {outputText} = ts.transpileModule(source, {
+      compilerOptions: {
+        esModuleInterop: true,
+        module: ts.ModuleKind.CommonJS,
+      },
+    })
+    const parsed = lexer.parse(outputText)
+    const keys = Object.keys(ReactIntl)
+
+    it.each(keys)('has named export "%s"', key => {
+      expect(parsed.exports).toContain(key)
     })
   })
 })

--- a/packages/react-intl/tests/unit/testUtils.tsx
+++ b/packages/react-intl/tests/unit/testUtils.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
-import Provider, {IntlConfig} from '../../src/components/provider'
+import Provider from '../../src/components/provider'
 import {render} from '@testing-library/react'
+import type {IntlConfig} from '../../src/types'
 
 export function mountFormattedComponentWithProvider<P>(
   Comp: React.ComponentType<P>


### PR DESCRIPTION
[v5.8.0](https://github.com/formatjs/formatjs/releases/tag/react-intl@5.8.0) introduced a bug where some of the named exports such as `injectIntl` are no longer statically analyzable by [cjs-module-lexer](https://github.com/nodejs/cjs-module-lexer), breaking the named export for es modules.

```js
// index.mjs
import { injectIntl } from 'react-intl';
         ^^^^^^^^^^
```

> SyntaxError: Named export 'injectIntl' not found. The requested module 'react-intl' is a CommonJS module, which may not support all module.exports as named exports.

-----

The root cause is because of a change in Typescript between versions [3.9.7](https://www.typescriptlang.org/play?module=1&ts=3.9.7#code/KYDwDg9gTgLgBAbzgE2AMwIYFcA28MDOcAlgHYBWwAxjAJKkw5wC+caUEAtnAOQB0AejQQIPANxA) and [4.0.5](https://www.typescriptlang.org/play?module=1&ts=4.0.5#code/KYDwDg9gTgLgBAbzgE2AMwIYFcA28MDOcAlgHYBWwAxjAJKkw5wC+caUEAtnAOQB0AejQQIPANxA) where the added `__importDefault` function call no longer matches the static analysis lexer ([docs](https://github.com/nodejs/node/tree/master/deps/cjs-module-lexer#getter-exports-parsing)) due to the potential for side effects.

```diff
  Object.defineProperty(exports, "injectIntl", {
    enumerable: true,
    get: function () {
-     return injectIntl_1.default;                  // v5.7.2
+     return __importDefault(injectIntl_1).default; // v5.8.0
    }
  });

```

There has been some back and fourth between the Typescript folks and the author of the lexer
- https://github.com/microsoft/TypeScript/issues/45813
- https://github.com/nodejs/cjs-module-lexer/issues/63

with the tl;dr being that the lexer will not be updated since it would effectively cause module loading to work differently in different versions of node and it's better to just be consistent.

-----

The fix here is to remove any `export { default as ... ` from index.js, separating the import and export so that the export is once again statically analyzable.

This is still tree shakable, so we won't pull `injectIntl` into all code using react-intl or anything like that.

A reasonable test for this might look like this, though I'm not sure exactly how to work this into the build system. I'm having some issues with the bazel setup y'all have here `no such package '@npm//ts-node': npm_install failed` but I'll see if I can debug those and shoehorn this test in (or something similar).

```js
const reactIntl = require('react-intl');
const lexer = require('cjs-module-lexer');
const fs = require('fs');

const filePath = require.resolve('react-intl');
const content = fs.readFileSync(filePath, 'utf8');
const parsed = lexer.parse(content);

it.each(Object.keys(reactIntl))('should have a named esm export "%s"', name => {
  expect(parsed.exports).toContain(name);
});
```

```
 FAIL  ./index.test.js
  ✓ should have a named esm export "createIntlCache" (3 ms)
  ✓ should have a named esm export "MessageDescriptor" (1 ms)
  ✓ should have a named esm export "IntlCache"
  ✓ should have a named esm export "Formatters"
  ✓ should have a named esm export "IntlFormatters" (1 ms)
  ✓ should have a named esm export "FormatDisplayNameOptions"
  ✓ should have a named esm export "FormatListOptions" (1 ms)
  ✓ should have a named esm export "FormatPluralOptions" (1 ms)
  ✓ should have a named esm export "FormatRelativeTimeOptions"
  ✓ should have a named esm export "FormatNumberOptions" (1 ms)
  ✓ should have a named esm export "FormatDateOptions" (1 ms)
  ✓ should have a named esm export "CustomFormatConfig" (1 ms)
  ✓ should have a named esm export "CustomFormats"
  ✓ should have a named esm export "UnsupportedFormatterError" (1 ms)
  ✓ should have a named esm export "InvalidConfigError"
  ✓ should have a named esm export "MissingDataError"
  ✓ should have a named esm export "MessageFormatError"
  ✓ should have a named esm export "MissingTranslationError" (1 ms)
  ✓ should have a named esm export "ReactIntlErrorCode" (1 ms)
  ✓ should have a named esm export "ReactIntlError"
  ✓ should have a named esm export "defineMessages"
  ✓ should have a named esm export "defineMessage"
  ✕ should have a named esm export "injectIntl" (7 ms)
  ✓ should have a named esm export "RawIntlProvider"
  ✓ should have a named esm export "IntlContext" (1 ms)
  ✕ should have a named esm export "useIntl" (1 ms)
  ✕ should have a named esm export "IntlProvider" (2 ms)
  ✓ should have a named esm export "createIntl" (1 ms)
  ✓ should have a named esm export "FormattedDate" (1 ms)
  ✓ should have a named esm export "FormattedTime" (1 ms)
  ✓ should have a named esm export "FormattedNumber" (1 ms)
  ✓ should have a named esm export "FormattedList" (1 ms)
  ✓ should have a named esm export "FormattedDisplayName"
  ✓ should have a named esm export "FormattedDateParts" (1 ms)
  ✓ should have a named esm export "FormattedTimeParts" (1 ms)
  ✓ should have a named esm export "FormattedNumberParts"
  ✓ should have a named esm export "FormattedListParts" (1 ms)
  ✕ should have a named esm export "FormattedRelativeTime" (1 ms)
  ✕ should have a named esm export "FormattedPlural"
  ✕ should have a named esm export "FormattedMessage" (1 ms)
  ✕ should have a named esm export "FormattedDateTimeRange" (1 ms)
```