### PR TITLE
fix(@formatjs/fast-memoize): fixed fast-memoize package license information

### DIFF
--- a/packages/fast-memoize/package.json
+++ b/packages/fast-memoize/package.json
@@ -18,7 +18,7 @@
     "i18n"
   ],
   "author": "Long Ho <holevietlong@gmail.com>",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/formatjs/formatjs/issues"
   },


### PR DESCRIPTION
fix #3299