### PR TITLE
fix(babel-plugin-formatjs): support entire module import

### DIFF
--- a/packages/babel-plugin-formatjs/index.ts
+++ b/packages/babel-plugin-formatjs/index.ts
@@ -24,8 +24,14 @@ export default declare<Options, PluginObj>((api, options) => {
   componentNames.add('FormattedMessage')
   const functionNames = new Set<string>(options.additionalFunctionNames)
   functionNames.add('formatMessage')
+  functionNames.add('defineMessage')
+  functionNames.add('defineMessages')
+
   // Vue
   functionNames.add('$formatMessage')
+  functionNames.add('$defineMessage')
+  functionNames.add('$defineMessages')
+
   return {
     inherits: babelPluginSyntaxJsx,
     pre() {

--- a/packages/babel-plugin-formatjs/tests/__snapshots__/index.test.ts.snap
+++ b/packages/babel-plugin-formatjs/tests/__snapshots__/index.test.ts.snap
@@ -723,7 +723,7 @@ export default injectIntl(Foo);",
 exports[`idInterpolationPattern 1`] = `
 Object {
   "code": "import React, { Component } from 'react';
-import { defineMessages, FormattedMessage } from 'react-intl';
+import intl, { defineMessages, FormattedMessage } from 'react-intl';
 var msgs = defineMessages({
   header: {
     id: \\"fixtures.idInterpolationPattern.4d1460\\",
@@ -734,9 +734,13 @@ var msgs = defineMessages({
     defaultMessage: \\"Hello Nurse!\\"
   }
 });
+var soloMessage = intl.defineMessage({
+  id: \\"fixtures.idInterpolationPattern.412ecb\\",
+  defaultMessage: \\"no-id\\"
+});
 export default class Foo extends Component {
   render() {
-    return /*#__PURE__*/React.createElement(\\"div\\", null, /*#__PURE__*/React.createElement(\\"h1\\", null, /*#__PURE__*/React.createElement(FormattedMessage, msgs.header)), /*#__PURE__*/React.createElement(\\"p\\", null, /*#__PURE__*/React.createElement(FormattedMessage, msgs.content)), /*#__PURE__*/React.createElement(FormattedMessage, {
+    return /*#__PURE__*/React.createElement(\\"div\\", null, /*#__PURE__*/React.createElement(\\"h1\\", null, /*#__PURE__*/React.createElement(FormattedMessage, msgs.header)), /*#__PURE__*/React.createElement(\\"p\\", null, /*#__PURE__*/React.createElement(intl.FormattedMessage, msgs.content)), /*#__PURE__*/React.createElement(FormattedMessage, {
       id: \\"fixtures.idInterpolationPattern.36a8c8\\",
       defaultMessage: \\"Hello World!\\"
     }), /*#__PURE__*/React.createElement(FormattedMessage, {
@@ -762,6 +766,11 @@ export default class Foo extends Component {
         "id": "foo.bar.biff",
       },
       Object {
+        "defaultMessage": "no-id",
+        "description": "message without an id",
+        "id": "fixtures.idInterpolationPattern.412ecb",
+      },
+      Object {
         "defaultMessage": "Hello World!",
         "description": "Something for the translator. Another description",
         "id": "fixtures.idInterpolationPattern.36a8c8",
@@ -780,7 +789,7 @@ export default class Foo extends Component {
 exports[`idInterpolationPattern default 1`] = `
 Object {
   "code": "import React, { Component } from 'react';
-import { defineMessages, FormattedMessage } from 'react-intl';
+import intl, { defineMessages, FormattedMessage } from 'react-intl';
 var msgs = defineMessages({
   header: {
     id: \\"TRRgnX\\",
@@ -791,9 +800,13 @@ var msgs = defineMessages({
     defaultMessage: \\"Hello Nurse!\\"
   }
 });
+var soloMessage = intl.defineMessage({
+  id: \\"QS7LNM\\",
+  defaultMessage: \\"no-id\\"
+});
 export default class Foo extends Component {
   render() {
-    return /*#__PURE__*/React.createElement(\\"div\\", null, /*#__PURE__*/React.createElement(\\"h1\\", null, /*#__PURE__*/React.createElement(FormattedMessage, msgs.header)), /*#__PURE__*/React.createElement(\\"p\\", null, /*#__PURE__*/React.createElement(FormattedMessage, msgs.content)), /*#__PURE__*/React.createElement(FormattedMessage, {
+    return /*#__PURE__*/React.createElement(\\"div\\", null, /*#__PURE__*/React.createElement(\\"h1\\", null, /*#__PURE__*/React.createElement(FormattedMessage, msgs.header)), /*#__PURE__*/React.createElement(\\"p\\", null, /*#__PURE__*/React.createElement(intl.FormattedMessage, msgs.content)), /*#__PURE__*/React.createElement(FormattedMessage, {
       id: \\"NqjIBK\\",
       defaultMessage: \\"Hello World!\\"
     }), /*#__PURE__*/React.createElement(FormattedMessage, {
@@ -817,6 +830,11 @@ export default class Foo extends Component {
           "text": "Something for the translator.",
         },
         "id": "foo.bar.biff",
+      },
+      Object {
+        "defaultMessage": "no-id",
+        "description": "message without an id",
+        "id": "QS7LNM",
       },
       Object {
         "defaultMessage": "Hello World!",

--- a/packages/babel-plugin-formatjs/tests/fixtures/idInterpolationPattern.js
+++ b/packages/babel-plugin-formatjs/tests/fixtures/idInterpolationPattern.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react'
-import {defineMessages, FormattedMessage} from 'react-intl'
+import intl, {defineMessages, FormattedMessage} from 'react-intl'
 
 const msgs = defineMessages({
   header: {
@@ -16,6 +16,11 @@ const msgs = defineMessages({
   },
 })
 
+const soloMessage = intl.defineMessage({
+  defaultMessage: 'no-id',
+  description: 'message without an id'
+})
+
 export default class Foo extends Component {
   render() {
     return (
@@ -24,7 +29,7 @@ export default class Foo extends Component {
           <FormattedMessage {...msgs.header} />
         </h1>
         <p>
-          <FormattedMessage {...msgs.content} />
+          <intl.FormattedMessage {...msgs.content} />
         </p>
         <FormattedMessage
           defaultMessage="Hello World!"

--- a/packages/babel-plugin-formatjs/visitors/call-expression.ts
+++ b/packages/babel-plugin-formatjs/visitors/call-expression.ts
@@ -24,7 +24,7 @@ function assertObjectExpression(
   }
 }
 
-function isFormatMessageCall(
+function isValidCall(
   callee: NodePath<t.Expression | t.V8IntrinsicIdentifier | t.MemberExpression>,
   functionNames: string[]
 ) {
@@ -196,10 +196,7 @@ export const visitor: VisitNodeFunction<PluginPass & State, t.CallExpression> =
             .forEach(processMessageObject)
         }
       }
-    }
-
-    // Check that this is `intl.formatMessage` call
-    if (isFormatMessageCall(callee, functionNames)) {
+    } else if (isValidCall(callee, functionNames)) {
       const messageDescriptor = args[0]
       if (messageDescriptor.isObjectExpression()) {
         processMessageObject(messageDescriptor)

--- a/packages/babel-plugin-formatjs/visitors/jsx-opening-element.ts
+++ b/packages/babel-plugin-formatjs/visitors/jsx-opening-element.ts
@@ -13,6 +13,14 @@ import {
   wasExtracted,
 } from '../utils'
 
+function isValidJSXElement(path: NodePath<any>, name: string) {
+  return (
+    path.isJSXIdentifier({name}) ||
+    (path.isJSXMemberExpression() &&
+      path.get('property').isJSXIdentifier({name}))
+  )
+}
+
 export const visitor: VisitNodeFunction<
   PluginPass & State,
   t.JSXOpeningElement
@@ -40,7 +48,7 @@ export const visitor: VisitNodeFunction<
 
   const name = path.get('name')
 
-  if (!componentNames.find(n => name.isJSXIdentifier({name: n}))) {
+  if (!componentNames.find(n => isValidJSXElement(name, n))) {
     return
   }
 


### PR DESCRIPTION
# Support entire module import

The plugin does not detect usages of `defineMessage`, `defineMessages` or `FormattedMessage` when importing the entire module via

```ts
import * as intl from 'react-intl';
// or 
import intl from 'react-intl';

// and then using any of the API methods
intl.defineMessage({
  msg: {
    defaultMessage: 'hello world'
  }
})

```

The problem is the plugin assumes usages are going to be of the AST type `Identifier` but under this import method it could be also a `MemberExpression`, this PR fixes that.

