### PR TITLE
fix(eslint-plugin-formatjs): fix missing error when missing placeholder used inside tag

### DIFF
--- a/packages/eslint-plugin-formatjs/rules/enforce-placeholders.ts
+++ b/packages/eslint-plugin-formatjs/rules/enforce-placeholders.ts
@@ -8,6 +8,7 @@ import {
   isLiteralElement,
   isSelectElement,
   isPoundElement,
+  isTagElement,
 } from '@formatjs/icu-messageformat-parser'
 
 class PlaceholderEnforcement extends Error {
@@ -65,6 +66,10 @@ function verifyAst(
       for (const selector of Object.keys(el.options)) {
         verifyAst(el.options[selector].value, values, ignoreList)
       }
+    }
+
+    if (isTagElement(el)) {
+      verifyAst(el.children, values, ignoreList)
     }
   }
 }

--- a/packages/eslint-plugin-formatjs/tests/enforce-placeholders.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/enforce-placeholders.test.ts
@@ -143,6 +143,16 @@ ruleTester.run('enforce-placeholders', enforcePlaceholders, {
     },
     {
       code: `
+        import {FormattedMessage} from 'react-intl'
+        const a = <FormattedMessage defaultMessage="Hello <bold>{name}</bold>" values={{ bold: (msg) => <strong>{msg}</strong> }} />`,
+      errors: [
+        {
+          message: 'Missing value for placeholder "name"',
+        },
+      ],
+    },
+    {
+      code: `
         intl.formatMessage({
           defaultMessage: '{count, plural, one {<a>#</a>} other {# more}}',
           description: 'asd'


### PR DESCRIPTION
Fixes https://github.com/formatjs/formatjs/issues/3309