### PR TITLE
docs: add --ignore='**/*.d.ts' for extract documentation

### DIFF
--- a/website/docs/getting-started/message-extraction.md
+++ b/website/docs/getting-started/message-extraction.md
@@ -57,14 +57,14 @@ values={[
 <TabItem value="npm">
 
 ```sh
-npm run extract -- 'src/**/*.ts*' --out-file lang/en.json --id-interpolation-pattern '[sha512:contenthash:base64:6]'
+npm run extract -- 'src/**/*.ts*' --ignore='**/*.d.ts' --out-file lang/en.json --id-interpolation-pattern '[sha512:contenthash:base64:6]'
 ```
 
 </TabItem>
 <TabItem value="yarn">
 
 ```sh
-yarn extract 'src/**/*.ts*' --out-file lang/en.json --id-interpolation-pattern '[sha512:contenthash:base64:6]'
+yarn extract 'src/**/*.ts*' --ignore='**/*.d.ts' --out-file lang/en.json --id-interpolation-pattern '[sha512:contenthash:base64:6]'
 ```
 
 </TabItem>


### PR DESCRIPTION
Since extract doesn't support `d.ts` files it would be helpful to include `--ignore='**/*.d.ts'` in the documentation. I can add `src/` if you'd like or just leave it as `**`. Thanks!