### PR TITLE
feat(@formatjs/ts-transformer): add optional img proper to MessageDescriptor

### DIFF
--- a/packages/babel-plugin-formatjs/tests/fixtures/FormattedMessage.js
+++ b/packages/babel-plugin-formatjs/tests/fixtures/FormattedMessage.js
@@ -6,6 +6,7 @@ export default class Foo extends Component {
     return (
       <FormattedMessage
         id="foo.bar.baz"
+        img="https://foo.com"
         defaultMessage="Hello World!"
         description="The default message."
       />

--- a/packages/babel-plugin-formatjs/visitors/call-expression.ts
+++ b/packages/babel-plugin-formatjs/visitors/call-expression.ts
@@ -158,6 +158,17 @@ export const visitor: VisitNodeFunction<PluginPass & State, t.CallExpression> =
         })
         ?.remove()
 
+      // Remove img
+      properties
+        .find(prop => {
+          const keyProp = prop.get('key')
+          return (
+            keyProp.isIdentifier({name: 'img'}) ||
+            keyProp.isStringLiteral({value: 'img'})
+          )
+        })
+        ?.remove()
+
       // Pre-parse or remove defaultMessage
       if (defaultMessageProp) {
         if (removeDefaultMessage) {

--- a/packages/babel-plugin-formatjs/visitors/jsx-opening-element.ts
+++ b/packages/babel-plugin-formatjs/visitors/jsx-opening-element.ts
@@ -88,6 +88,7 @@ export const visitor: VisitNodeFunction<
 
   let idAttr: NodePath<t.JSXAttribute> | undefined
   let descriptionAttr: NodePath<t.JSXAttribute> | undefined
+  let imgAttr: NodePath<t.JSXAttribute> | undefined
   let defaultMessageAttr: NodePath<t.JSXAttribute> | undefined
   const firstAttr = attributes[0]
   for (const attr of attributes) {
@@ -99,6 +100,9 @@ export const visitor: VisitNodeFunction<
     ) {
       case 'description':
         descriptionAttr = attr
+        break
+      case 'img':
+        imgAttr = attr
         break
       case 'defaultMessage':
         defaultMessageAttr = attr
@@ -122,6 +126,10 @@ export const visitor: VisitNodeFunction<
 
   if (descriptionAttr) {
     descriptionAttr.remove()
+  }
+
+  if (imgAttr) {
+    imgAttr.remove()
   }
 
   if (defaultMessageAttr) {

--- a/packages/ts-transformer/src/transform.ts
+++ b/packages/ts-transformer/src/transform.ts
@@ -20,6 +20,7 @@ const MESSAGE_DESC_KEYS: Array<keyof MessageDescriptor> = [
   'id',
   'defaultMessage',
   'description',
+  'img'
 ]
 
 type TypeScript = typeof typescript
@@ -259,6 +260,9 @@ function extractMessageDescriptor(
           case 'description':
             msg.description = initializer.expression.text
             break
+          case 'img':
+            msg.img = initializer.expression.text
+            break
         }
       }
       // {id: 'id'}
@@ -272,6 +276,9 @@ function extractMessageDescriptor(
             break
           case 'description':
             msg.description = initializer.text
+            break
+          case 'img':
+            msg.img = initializer.text
             break
         }
       }
@@ -287,6 +294,9 @@ function extractMessageDescriptor(
           case 'description':
             msg.description = initializer.text
             break
+          case 'img':
+            msg.img = initializer.text
+            break
         }
       } else if (ts.isJsxExpression(initializer) && initializer.expression) {
         // <FormattedMessage foo={`bar`} />
@@ -301,6 +311,9 @@ function extractMessageDescriptor(
               break
             case 'description':
               msg.description = expression.text
+              break
+            case 'img':
+              msg.img = expression.text
               break
           }
         }
@@ -319,6 +332,9 @@ function extractMessageDescriptor(
               case 'description':
                 msg.description = result
                 break
+              case 'img':
+                msg.img = result
+                break
             }
           }
         }
@@ -336,6 +352,9 @@ function extractMessageDescriptor(
               break
             case 'description':
               msg.description = result
+              break
+            case 'img':
+              msg.img = result
               break
           }
         }

--- a/packages/ts-transformer/src/types.ts
+++ b/packages/ts-transformer/src/types.ts
@@ -2,6 +2,7 @@ export interface MessageDescriptor {
   id: string
   description?: string
   defaultMessage?: string
+  img?: string
   file?: string
   start?: number
   end?: number

--- a/packages/ts-transformer/tests/fixtures/FormattedMessage.tsx
+++ b/packages/ts-transformer/tests/fixtures/FormattedMessage.tsx
@@ -29,6 +29,15 @@ export default class Foo extends Component {
             foo: 1,
           }}
         />
+        <FormattedMessage
+          id="foo.bar.baz"
+          img="https://foo.com"
+          defaultMessage="Hello World! {foo, number}"
+          description="The default message."
+          values={{
+            foo: 1,
+          }}
+        />
       </p>
     )
   }

--- a/website/docs/tooling/babel-plugin.md
+++ b/website/docs/tooling/babel-plugin.md
@@ -6,7 +6,7 @@ title: babel-plugin-formatjs
 Process string messages for translation from modules that use react-intl, specifically:
 
 - Parse and verify that messages are ICU-compliant w/o any syntax issues.
-- Remove `description` from message descriptor to save bytes since it isn't used at runtime.
+- Remove `description` and `img` from message descriptor to save bytes since it isn't used at runtime.
 - Option to remove `defaultMessage` from message descriptor to save bytes since it isn't used at runtime.
 - Automatically inject message ID based on specific pattern.
 

--- a/website/docs/tooling/ts-transformer.md
+++ b/website/docs/tooling/ts-transformer.md
@@ -8,7 +8,7 @@ title: ts-transformer
 Process string messages for translation from modules that use react-intl, specifically:
 
 - Parse and verify that messages are ICU-compliant w/o any syntax issues.
-- Remove `description` from message descriptor to save bytes since it isn't used at runtime.
+- Remove `description` and `img` from message descriptor to save bytes since it isn't used at runtime.
 - Option to remove `defaultMessage` from message descriptor to save bytes since it isn't used at runtime.
 - Automatically inject message ID based on specific pattern.
 


### PR DESCRIPTION
As discussed in https://github.com/formatjs/formatjs/discussions/3363

The goal of this PR is to provide an optional `img` prop to MessageDescriptor which can serve as a way to provide context images for strings.

An alternative to adding this prop would be to add a `metadata` object field, this would be less opinionated about what information can get stored onto a message, and allows greater flexibility when writing transformers.
