### PR TITLE
fix(@formatjs/swc-plugin): Pass filename to `overrideIdFn`

### DIFF
--- a/packages/swc-plugin/src/transform.ts
+++ b/packages/swc-plugin/src/transform.ts
@@ -452,7 +452,12 @@ function extractMessageDescriptor(
         }
         break
       case 'function':
-        msg.id = overrideIdFn(msg.id, msg.defaultMessage, msg.description)
+        msg.id = overrideIdFn(
+          msg.id,
+          msg.defaultMessage,
+          msg.description,
+          filename
+        )
         break
     }
   }

--- a/website/docs/tooling/swc-plugin.md
+++ b/website/docs/tooling/swc-plugin.md
@@ -70,7 +70,7 @@ const output = await transform(input, {
 
 ### **`overrideIdFn`**
 
-A function with the signature `(id: string, defaultMessage: string, description: string|object) => string` which allows you to override the ID both in the extracted javascript and messages.
+A function with the signature `(id: string, defaultMessage: string, description?: string|object, filePath: string) => string` which allows you to override the ID both in the extracted javascript and messages.
 
 Alternatively, `overrideIdFn` can be a template string, which is used only if the message ID is empty.
 


### PR DESCRIPTION
The `overrideIdFn` in the swc-plugin should be passing in the file path as the 4th argument to match how the babel plugin [works](https://github.com/formatjs/formatjs/blob/d6f33d92f64ba304d435fe766bcc2d8dc8f252aa/packages/babel-plugin-formatjs/utils.ts#L107).

I can't get the local bazel env setup to work properly on my mac for some reason, so I can't verify/update/add tests yet. Was hoping to use the CI to check