### PR TITLE
feat(eslint-plugin-formatjs): add `idWhitelist` option to `enforce-id` rule

### DIFF
--- a/packages/eslint-plugin-formatjs/rules/enforce-id.ts
+++ b/packages/eslint-plugin-formatjs/rules/enforce-id.ts
@@ -3,11 +3,18 @@ import {extractMessages} from '../util'
 import {TSESTree} from '@typescript-eslint/typescript-estree'
 import {interpolateName} from '@formatjs/ts-transformer'
 
-function checkNode(context: Rule.RuleContext, node: TSESTree.Node) {
+interface Opts {
+  idInterpolationPattern: string
+  idWhitelistRegexps?: RegExp[]
+  idWhitelistErrorMsg?: string
+}
+
+function checkNode(
+  context: Rule.RuleContext,
+  node: TSESTree.Node,
+  {idInterpolationPattern, idWhitelistRegexps, idWhitelistErrorMsg}: Opts
+) {
   const msgs = extractMessages(node, context.settings)
-  const {options} = context
-  const [opt = {}] = options
-  const {idInterpolationPattern} = opt
   for (const [
     {
       message: {defaultMessage, description, id},
@@ -33,6 +40,15 @@ function checkNode(context: Rule.RuleContext, node: TSESTree.Node) {
           message: `description must be a string literal to calculate generated IDs`,
         })
       } else {
+        if (
+          idWhitelistRegexps &&
+          id &&
+          idWhitelistRegexps.some((r: RegExp) => r.test(id))
+        ) {
+          // messageId is whitelisted so skip interpolation id check
+          return
+        }
+
         const correctId = interpolateName(
           {
             resourcePath: context.getFilename(),
@@ -47,7 +63,9 @@ function checkNode(context: Rule.RuleContext, node: TSESTree.Node) {
         if (id !== correctId) {
           context.report({
             node: node as any,
-            message: `"id" does not match with hash pattern ${idInterpolationPattern}.
+            message: `"id" does not match with hash pattern ${idInterpolationPattern}${
+              idWhitelistErrorMsg ?? ''
+            }.
 Expected: ${correctId}
 Actual: ${id}`,
             fix(fixer) {
@@ -98,6 +116,16 @@ export default {
         properties: {
           idInterpolationPattern: {
             type: 'string',
+            description:
+              'Pattern to verify ID against. Recommended value: [sha512:contenthash:base64:6]',
+          },
+          idWhitelist: {
+            type: 'array',
+            description:
+              "An array of strings with regular expressions. This array allows whitelist custom ids for messages. For example '`\\\\.`' allows any id which has dot; `'^payment_.*'` - allows any custom id which has prefix `payment_`. Be aware that any backslash \\ provided via string must be escaped with an additional backslash.",
+            items: {
+              type: 'string',
+            },
           },
         },
         required: ['idInterpolationPattern'],
@@ -106,8 +134,22 @@ export default {
     ],
   },
   create(context) {
+    const tmp = context?.options?.[0]
+    const opts = {
+      idInterpolationPattern: tmp?.idInterpolationPattern,
+    } as Opts
+    if (Array.isArray(tmp?.idWhitelist)) {
+      const {idWhitelist} = tmp
+      opts.idWhitelistRegexps = idWhitelist.map(
+        (str: string) => new RegExp(str, 'i')
+      )
+      opts.idWhitelistErrorMsg = ` or does not match whitelisted patterns ["${idWhitelist.join(
+        '", "'
+      )}"]`
+    }
+
     const callExpressionVisitor = (node: TSESTree.Node) =>
-      checkNode(context, node)
+      checkNode(context, node, opts)
 
     if (context.parserServices.defineTemplateBodyVisitor) {
       return context.parserServices.defineTemplateBodyVisitor(
@@ -120,7 +162,8 @@ export default {
       )
     }
     return {
-      JSXOpeningElement: (node: TSESTree.Node) => checkNode(context, node),
+      JSXOpeningElement: (node: TSESTree.Node) =>
+        checkNode(context, node, opts),
       CallExpression: callExpressionVisitor,
     }
   },

--- a/packages/eslint-plugin-formatjs/tests/enforce-id.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/enforce-id.test.ts
@@ -196,7 +196,7 @@ defineMessages({ example: { defaultMessage: 'example2', id: 'payment_string' } }
 intl.formatMessage({defaultMessage: '{count, plural, one {#} other {# more}}', description: 'asd'})`,
       errors: [
         {
-          message: `"id" does not match with hash pattern [sha512:contenthash:base64:6] or does not match whitelisted patterns ["\\.", "^payment_.*"].
+          message: `"id" does not match with hash pattern [sha512:contenthash:base64:6] or whitelisted patterns ["/\\./i", "/^payment_.*/i"].
 Expected: j9qhn+
 Actual: undefined`,
         },

--- a/packages/eslint-plugin-formatjs/tests/enforce-id.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/enforce-id.test.ts
@@ -173,3 +173,37 @@ defineMessages({ example: { defaultMessage: 'example', id: 'O7Eu2j' } })`,
     },
   ],
 })
+
+const optionsWithWhitelist = [
+  {
+    idInterpolationPattern: '[sha512:contenthash:base64:6]',
+    idWhitelist: ['\\.', '^payment_.*'],
+  },
+]
+ruleTester.run('enforce-id', enforceId, {
+  valid: [
+    {
+      options: optionsWithWhitelist,
+      code: `
+import { defineMessages } from 'react-intl'
+defineMessages({ example: { defaultMessage: 'example1', id: 'my.custom.id' } })
+defineMessages({ example: { defaultMessage: 'example2', id: 'payment_string' } })`,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+intl.formatMessage({defaultMessage: '{count, plural, one {#} other {# more}}', description: 'asd'})`,
+      errors: [
+        {
+          message: `"id" does not match with hash pattern [sha512:contenthash:base64:6] or does not match whitelisted patterns ["\\.", "^payment_.*"].
+Expected: j9qhn+
+Actual: undefined`,
+        },
+      ],
+      options: optionsWithWhitelist,
+      output: `
+intl.formatMessage({defaultMessage: '{count, plural, one {#} other {# more}}', id: 'j9qhn+', description: 'asd'})`,
+    },
+  ],
+})

--- a/website/docs/tooling/linter.md
+++ b/website/docs/tooling/linter.md
@@ -502,6 +502,7 @@ const messages = defineMessages({
 ```
 
 - `idInterpolationPattern`: Pattern to verify ID against
+- `idWhitelist`: An array of strings with regular expressions. This array allows whitelist custom ids for messages. For example '`\\.`' allows any id which has dot; `'^payment_.*'` - allows any custom id which has prefix `payment_`. Be aware that any backslash \ provided via string must be escaped with an additional backslash.
 
 ### `no-id`
 


### PR DESCRIPTION
`enforce-id` rule is quite good but it does not allow to pass custom message ids. This PR adds `idWhitelist` option with an array of regexps as strings. And if the checker gets an id that matches one of provided regexp then it bypasses its check to interpolation pattern.

For example, I want to add for some widget custom message ids eg. `payment_***` or allow custom names with dots 'component.key1' and it can be done via following config:
```
'formatjs/enforce-id': [
  'error',
  {
    idInterpolationPattern: '[sha512:contenthash:base64:6]',
    idWhitelist: ['\\.', '^payment_.*'],
  },
],
```

These changes are backward compatible and do not introduce any breaking changes.