### PR TITLE
fix(react-intl): createIntl now correctly sets fallbackOnEmptyString

### DIFF
--- a/packages/react-intl/src/components/provider.tsx
+++ b/packages/react-intl/src/components/provider.tsx
@@ -140,6 +140,7 @@ export const createIntl: CreateIntlFn<
       {
         locale: coreIntl.locale,
         timeZone: coreIntl.timeZone,
+        fallbackOnEmptyString: coreIntl.fallbackOnEmptyString,
         formats: coreIntl.formats,
         defaultLocale: coreIntl.defaultLocale,
         defaultFormats: coreIntl.defaultFormats,


### PR DESCRIPTION
Currently `createIntl` does not set `fallbackOnEmptyString`, causing the fallback procedure to be always triggered even when `fallbackOnEmptyString` is set to `false`. This pull request fixes this bug.