### PR TITLE
fix(@formatjs/intl-getcanonicallocales): add peerDependenciesMeta field

### DIFF
--- a/packages/intl-getcanonicallocales/package.json
+++ b/packages/intl-getcanonicallocales/package.json
@@ -29,5 +29,10 @@
   },
   "peerDependencies": {
     "@types/node": "14 || 16 || 17"
+  },
+  "peerDependenciesMeta": {
+    "@types/node": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
yarn complains in a project, where `@formatjs/intl-locale` is used, that the requested peerDependency "@types/node" from `@formatjs/intl-getcanonicallocales` is not provided:

> @formatjs/intl-locale@npm:2.4.45 doesn't provide @types/node (p02c46), requested by @formatjs/intl-getcanonicallocales.

This change makes the installation of the peerDependency optional.

Resources:

- https://yarnpkg.com/configuration/manifest#peerDependenciesMeta
- https://docs.npmjs.com/cli/v7/configuring-npm/package-json#peerdependenciesmeta