### PR TITLE
docs: add Localize as TMS

### DIFF
--- a/website/docs/getting-started/message-extraction.md
+++ b/website/docs/getting-started/message-extraction.md
@@ -306,3 +306,4 @@ We also provide several [builtin formatters](../tooling/cli.md#builtin-formatter
 | [Lokalise Structured JSON](https://docs.lokalise.com/en/articles/3229161-structured-json) | `lokalise`  |
 | [SimpleLocalize JSON](https://simplelocalize.io/docs/file-formats/simplelocalize-json/)   | `simple`    |
 | [POEditor Key-Value JSON](https://poeditor.com/localization/files/key-value-json)         | `simple`    |
+| [Localize's Simple JSON](https://developers.localizejs.com/docs/simple-json-import-export)| `simple`    |

--- a/website/docs/tooling/cli.md
+++ b/website/docs/tooling/cli.md
@@ -415,6 +415,7 @@ We provide the following built-in formatters to integrate with 3rd party TMSes:
 | [locize](https://docs.locize.com/integration/supported-formats#json-nested)               | `simple`    |
 | [SimpleLocalize](https://simplelocalize.io/docs/integrations/format-js-cli/)              | `simple`    |
 | [POEditor Key-Value JSON](https://poeditor.com/localization/files/key-value-json)         | `simple`    |
+| [Localize's Simple JSON](https://developers.localizejs.com/docs/simple-json-import-export)| `simple`    |
 
 :::caution
 The `format`s of `extract` & `compile` have to be the same, which means if you `extract --format smartling`, you have to `compile --format smartling` as well & vice versa.


### PR DESCRIPTION
This change adds [Localize](https://localizejs.com) as a TMS using a simple file format for message extraction.