### PR TITLE
docs: grammar updates to define messages docs

### DIFF
--- a/website/docs/intl.md
+++ b/website/docs/intl.md
@@ -532,7 +532,7 @@ function defineMessages(
 function defineMessage(messageDescriptor: MessageDescriptor): MessageDescriptor
 ```
 
-These functions is exported by the `@formatjs/intl` package and is simply a _hook_ for our CLI & babel/TS plugin to use when compiling default messages defined in JavaScript source files. This function simply returns the Message Descriptor map object that's passed-in.
+These functions are exported by the `@formatjs/intl` package and are simply a _hook_ for our CLI & babel/TS plugin to use when compiling default messages defined in JavaScript source files. This function simply returns the Message Descriptor map object that's passed-in.
 
 ```ts
 import {defineMessages, defineMessage} from '@formatjs/intl'

--- a/website/docs/react-intl/api.md
+++ b/website/docs/react-intl/api.md
@@ -612,7 +612,7 @@ function defineMessages(
 function defineMessage(messageDescriptor: MessageDescriptor): MessageDescriptor
 ```
 
-These functions is exported by the `react-intl` package and is simply a _hook_ for our CLI & babel/TS plugin to use when compiling default messages defined in JavaScript source files. This function simply returns the Message Descriptor map object that's passed-in.
+These functions are exported by the `react-intl` package and are simply a _hook_ for our CLI & babel/TS plugin to use when compiling default messages defined in JavaScript source files. This function simply returns the Message Descriptor map object that's passed-in.
 
 ```ts
 import {defineMessages, defineMessage} from 'react-intl'


### PR DESCRIPTION
Noticed when reading docs an incorrect usage of `is` instead of `are`. This is my first PR so sorry if I missed anything in the contributing guidelines.