### PR TITLE
docs: minor cleanup

### DIFF
--- a/website/docs/react-intl.md
+++ b/website/docs/react-intl.md
@@ -57,13 +57,6 @@ If you're using `react-intl` in React Native, make sure your runtime has built-i
 
 If you cannot use the Intl variant of JSC (e.g on iOS), follow the instructions in [Runtime Requirements](#runtime-requirements) to polyfill those APIs accordingly.
 
-## Experimental Intl Features
-
-FormatJS also provides types & polyfill for the following Intl API proposals:
-
-- NumberFormat: [polyfill](polyfills/intl-numberformat.md) & [spec](https://tc39.es/ecma402/)
-- DisplayNames: [polyfill](polyfills/intl-displaynames.md) & [spec](https://tc39.es/proposal-intl-displaynames/)
-
 ## The `react-intl` Package
 
 Install the [`react-intl` npm package](https://www.npmjs.com/package/react-intl) via npm:

--- a/website/docs/react-intl.md
+++ b/website/docs/react-intl.md
@@ -30,10 +30,6 @@ If you need to support older browsers, we recommend you do the following:
 
 5. If you need `Intl.DisplayNames`, include this [polyfill](polyfills/intl-displaynames.md) in your build along with individual CLDR data for each locale you support.
 
-### Browser
-
-We officially support IE11 along with 2 most recent versions of Edge, Chrome & Firefox.
-
 ### Node.js
 
 #### full-icu


### PR DESCRIPTION
- removed the "We officially support IE11 along with 2 most recent versions of Edge, Chrome & Firefox." sentence because it's missing a reference to Safari, and it duplicates a similar sentence on line 12: https://github.com/formatjs/formatjs/blob/main/website/docs/react-intl.md?plain=1#L12
- removed "Experimental Intl Features" section now that the two referenced Intl APIs have been standardised and are discussed above in the polyfill section