### PR TITLE
feat(react-intl): add onWarn

### DIFF
--- a/packages/intl/src/create-intl.ts
+++ b/packages/intl/src/create-intl.ts
@@ -34,10 +34,11 @@ function messagesContainString(
 
 function verifyConfigMessages<T = string>(config: IntlConfig<T>) {
   if (
+    config.onWarn &&
     config.defaultRichTextElements &&
     messagesContainString(config.messages || {})
   ) {
-    console.warn(`[@formatjs/intl] "defaultRichTextElements" was specified but "message" was not pre-compiled. 
+    config.onWarn(`[@formatjs/intl] "defaultRichTextElements" was specified but "message" was not pre-compiled. 
 Please consider using "@formatjs/cli" to pre-compile your messages for performance.
 For more details see https://formatjs.io/docs/getting-started/message-distribution`)
   }

--- a/packages/intl/src/types.ts
+++ b/packages/intl/src/types.ts
@@ -48,6 +48,8 @@ export type OnErrorFn = (
     | FormatError
 ) => void
 
+export type OnWarnFn = (warning: string) => void
+
 /**
  * Config for intl object.
  * Generic type T is the type of potential rich text element. For example:
@@ -65,6 +67,7 @@ export interface ResolvedIntlConfig<T = string> {
   defaultFormats: CustomFormats
   defaultRichTextElements?: Record<string, FormatXMLElementFn<T>>
   onError: OnErrorFn
+  onWarn?: OnWarnFn
 }
 
 export interface CustomFormats extends Partial<Formats> {

--- a/packages/intl/src/utils.ts
+++ b/packages/intl/src/utils.ts
@@ -3,6 +3,7 @@ import {
   CustomFormats,
   Formatters,
   OnErrorFn,
+  OnWarnFn,
   ResolvedIntlConfig,
 } from './types'
 import {IntlMessageFormat} from 'intl-messageformat'
@@ -33,6 +34,13 @@ const defaultErrorHandler: OnErrorFn = error => {
   }
 }
 
+const defaultWarnHandler: OnWarnFn = (warning: string) => {
+  // @ts-ignore just so we don't need to declare dep on @types/node
+  if (process.env.NODE_ENV !== 'production') {
+    console.warn(warning)
+  }
+}
+
 export const DEFAULT_INTL_CONFIG: Pick<
   ResolvedIntlConfig<any>,
   | 'fallbackOnEmptyString'
@@ -42,6 +50,7 @@ export const DEFAULT_INTL_CONFIG: Pick<
   | 'defaultLocale'
   | 'defaultFormats'
   | 'onError'
+  | 'onWarn'
 > = {
   formats: {},
   messages: {},
@@ -53,6 +62,7 @@ export const DEFAULT_INTL_CONFIG: Pick<
   fallbackOnEmptyString: true,
 
   onError: defaultErrorHandler,
+  onWarn: defaultWarnHandler,
 }
 
 export function createIntlCache(): IntlCache {

--- a/packages/intl/tests/create-intl.test.ts
+++ b/packages/intl/tests/create-intl.test.ts
@@ -14,13 +14,47 @@ test('createIntl', function () {
   ).toBe('bar')
 })
 
-test('verify config', function () {
-  const warnFn = jest.spyOn(console, 'warn')
-  expect(warnFn).not.toHaveBeenCalled()
+test('should warn when defaultRichTextElements is used with messages', function () {
+  const onWarn = jest.fn()
   createIntl({
     locale: 'en',
-    messages: {},
+    messages: {
+      foo: 'bar',
+    },
+    defaultRichTextElements: {},
+    onWarn,
+  })
+  expect(onWarn).toHaveBeenCalledWith(
+    expect.stringContaining(
+      `defaultRichTextElements" was specified but "message" was not pre-compiled.`
+    )
+  )
+})
+
+test('should not warn when defaultRichTextElements is not used', function () {
+  const onWarn = jest.fn()
+  createIntl({
+    locale: 'en',
+    messages: {
+      foo: 'bar',
+    },
+    onWarn,
+  })
+  expect(onWarn).not.toHaveBeenCalled()
+})
+
+test('should use the default warn handler when none is passed', function () {
+  const warnFn = jest.spyOn(console, 'warn')
+  createIntl({
+    locale: 'en',
+    messages: {
+      foo: 'bar',
+    },
     defaultRichTextElements: {},
   })
-  expect(warnFn).not.toHaveBeenCalled()
+  expect(warnFn).toHaveBeenCalledWith(
+    expect.stringContaining(
+      `defaultRichTextElements" was specified but "message" was not pre-compiled.`
+    )
+  )
 })

--- a/packages/react-intl/src/components/provider.tsx
+++ b/packages/react-intl/src/components/provider.tsx
@@ -57,6 +57,7 @@ function processIntlConfig<P extends IntlConfig = IntlConfig>(
     defaultLocale: config.defaultLocale,
     defaultFormats: config.defaultFormats,
     onError: config.onError,
+    onWarn: config.onWarn,
     wrapRichTextChunksInFragment: config.wrapRichTextChunksInFragment,
     defaultRichTextElements: config.defaultRichTextElements,
   }


### PR DESCRIPTION
Adds onWarn so we can prevent the console warning when IntlProvider is used with with defaultRichTextElements 

fix https://github.com/formatjs/formatjs/issues/3454