### PR TITLE
fix(@formatjs/intl-datetimeformat): methods return "Invalid Date" ins…

### DIFF
--- a/packages/intl-datetimeformat/polyfill.ts
+++ b/packages/intl-datetimeformat/polyfill.ts
@@ -14,7 +14,11 @@ if (shouldPolyfill()) {
       locales?: string | string[],
       options?: Intl.DateTimeFormatOptions
     ) {
-      return _toLocaleString(this, locales, options)
+      try {
+        return _toLocaleString(this, locales, options)
+      } catch (error) {
+        return 'Invalid Date'
+      }
     },
   })
   defineProperty(Date.prototype, 'toLocaleDateString', {
@@ -22,7 +26,11 @@ if (shouldPolyfill()) {
       locales?: string | string[],
       options?: Intl.DateTimeFormatOptions
     ) {
-      return _toLocaleDateString(this, locales, options)
+      try {
+        return _toLocaleDateString(this, locales, options)
+      } catch (error) {
+        return 'Invalid Date'
+      }
     },
   })
   defineProperty(Date.prototype, 'toLocaleTimeString', {
@@ -30,7 +38,11 @@ if (shouldPolyfill()) {
       locales?: string | string[],
       options?: Intl.DateTimeFormatOptions
     ) {
-      return _toLocaleTimeString(this, locales, options)
+      try {
+        return _toLocaleTimeString(this, locales, options)
+      } catch (error) {
+        return 'Invalid Date'
+      }
     },
   })
 }

--- a/packages/intl-datetimeformat/tests/index.test.ts
+++ b/packages/intl-datetimeformat/tests/index.test.ts
@@ -313,4 +313,16 @@ describe('Intl.DateTimeFormat', function () {
       '5/19/2021, 5:00 AM – 6/19/2021, 1:00 PM'
     )
   })
+  it('toLocaleString returns "Invalid Date", GH #3508', function () {
+    const date1 = new Date('')
+    expect(() => date1.toLocaleString('en-US')).toBe('Invalid Date')
+  })
+  it('toLocaleTimeString returns "Invalid Date", GH #3508', function () {
+    const date1 = new Date('')
+    expect(() => date1.toLocaleTimeString('en-US')).toBe('Invalid Date')
+  })
+  it('toLocaleDateString returns "Invalid Date", GH #3508', function () {
+    const date1 = new Date('')
+    expect(() => date1.toLocaleDateString('en-US')).toBe('Invalid Date')
+  })
 })


### PR DESCRIPTION
…tead of throwing

Fixes #3508

Sadly, I am not able to properly set up bazel on my work machine, so I'm contributing a bit blind here. If necessary I'm going to try to verify the fix on my private computer.