### PR TITLE
docs: fix language in Intl MessageFormat example

### DIFF
--- a/website/docs/intl-messageformat.md
+++ b/website/docs/intl-messageformat.md
@@ -56,7 +56,7 @@ new IntlMessageFormat(
       =1 {tiene una foto.}
       other {tiene # fotos.}
     }`,
-  'en-US'
+  'es-ES'
 ).format({numPhotos: 1000})
 ```
 


### PR DESCRIPTION
Updated language from "en-US" to "es-ES" in the Intl MessageFormat example as the text is in Spanish.