### PR TITLE
fix(react-intl): change minimum react 16 version to 16.6.0, fix #3587

### DIFF
--- a/packages/react-intl/package.json
+++ b/packages/react-intl/package.json
@@ -140,7 +140,7 @@
     "tslib": "2.4.0"
   },
   "peerDependencies": {
-    "react": "^16.3.0 || 17 || 18",
+    "react": "^16.6.0 || 17 || 18",
     "typescript": "^4.5"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
fix #3587 

This is the version that introduced `memo` and thus is the minimum version necessary to run react-intl on React 16.