### PR TITLE
feat(intl-messageformat): allow module augmentation for custom formats

### DIFF
--- a/packages/intl-messageformat/src/formatters.ts
+++ b/packages/intl-messageformat/src/formatters.ts
@@ -22,10 +22,22 @@ import {
   InvalidValueTypeError,
 } from './error'
 
+declare global {
+  namespace FormatjsIntl {
+    interface Message {}
+    interface IntlConfig {}
+    interface Formats {}
+  }
+}
+
+type Format<Source = string> = Source extends keyof FormatjsIntl.Formats
+  ? FormatjsIntl.Formats[Source]
+  : string
+
 export interface Formats {
-  number: Record<string, NumberFormatOptions>
-  date: Record<string, Intl.DateTimeFormatOptions>
-  time: Record<string, Intl.DateTimeFormatOptions>
+  number: Record<Format<'number'>, NumberFormatOptions>
+  date: Record<Format<'date'>, Intl.DateTimeFormatOptions>
+  time: Record<Format<'time'>, Intl.DateTimeFormatOptions>
 }
 
 export interface FormatterCache {

--- a/packages/intl/src/types.ts
+++ b/packages/intl/src/types.ts
@@ -27,6 +27,7 @@ declare global {
   namespace FormatjsIntl {
     interface Message {}
     interface IntlConfig {}
+    interface Formats {}
   }
 }
 
@@ -74,22 +75,24 @@ export interface CustomFormats extends Partial<Formats> {
   relative?: Record<string, Intl.RelativeTimeFormatOptions>
 }
 
-export interface CustomFormatConfig {
-  format?: string
+export interface CustomFormatConfig<Source = string> {
+  format?: Source extends keyof FormatjsIntl.Formats
+    ? FormatjsIntl.Formats[Source]
+    : string
 }
 
 export type FormatDateOptions = Omit<
   Intl.DateTimeFormatOptions,
   'localeMatcher'
 > &
-  CustomFormatConfig
+  CustomFormatConfig<'date'>
 export type FormatNumberOptions = Omit<NumberFormatOptions, 'localeMatcher'> &
-  CustomFormatConfig
+  CustomFormatConfig<'number'>
 export type FormatRelativeTimeOptions = Omit<
   Intl.RelativeTimeFormatOptions,
   'localeMatcher'
 > &
-  CustomFormatConfig
+  CustomFormatConfig<'time'>
 export type FormatPluralOptions = Omit<
   Intl.PluralRulesOptions,
   'localeMatcher'


### PR DESCRIPTION
## Motivation
I already opened an issue, as a feature request, to allow module augmentation for custom formats. This issue was moved to discussions https://github.com/formatjs/formatjs/discussions/2764.

Proposed changes allows the user to do the following:

```tsx
// This can be done on any file of the project.
import '@formatjs/intl';

declare global {
    namespace FormatjsIntl {
        interface Formats {
            number: 'custom_format_1' | 'custom_format_2';
            date: 'custom_date_1' ;
        }
    }
}

```

Which makes intellisense to know about our user defined formatters. Actually Typescript forces you to use one of them:

![image](https://user-images.githubusercontent.com/44379989/171387640-36f53c77-d36d-4d2a-8f88-74cad4368d4d.png)
![image](https://user-images.githubusercontent.com/44379989/171213474-c5e4cb58-d962-42b3-8fd4-abb576ac9cdc.png)

The changes made in intl-messageformat package provide type safety for the custom formats defined in the IntlProvider configuration:

![image](https://user-images.githubusercontent.com/44379989/171386476-847b0e78-6144-4797-81f1-0b5dadd92447.png)

If no augmentation is made by the user, everything is like it used to be, every format name is valid for both provider props and format function calls.

If this change is accepted, the feature could be extended to react-intl Components which also reads from these formats.