### PR TITLE
docs(eslint-plugin-formatjs): Update url for rule no-multiple-whitespaces

### DIFF
--- a/packages/eslint-plugin-formatjs/rules/no-multiple-whitespaces.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-multiple-whitespaces.ts
@@ -37,7 +37,7 @@ const rule: Rule.RuleModule = {
   meta: {
     type: 'problem',
     docs: {
-      description: 'Disallow emojis in message',
+      description: 'Prevents usage of multiple consecutive whitespaces in message',
       category: 'Errors',
       recommended: false,
       url: 'https://formatjs.io/docs/tooling/linter#no-multiple-whitespaces',

--- a/packages/eslint-plugin-formatjs/rules/no-multiple-whitespaces.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-multiple-whitespaces.ts
@@ -37,7 +37,8 @@ const rule: Rule.RuleModule = {
   meta: {
     type: 'problem',
     docs: {
-      description: 'Prevents usage of multiple consecutive whitespaces in message',
+      description:
+        'Prevents usage of multiple consecutive whitespaces in message',
       category: 'Errors',
       recommended: false,
       url: 'https://formatjs.io/docs/tooling/linter#no-multiple-whitespaces',

--- a/packages/eslint-plugin-formatjs/rules/no-multiple-whitespaces.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-multiple-whitespaces.ts
@@ -40,7 +40,7 @@ const rule: Rule.RuleModule = {
       description: 'Disallow emojis in message',
       category: 'Errors',
       recommended: false,
-      url: 'https://formatjs.io/docs/tooling/linter#no-emoji',
+      url: 'https://formatjs.io/docs/tooling/linter#no-multiple-whitespaces',
     },
     fixable: 'whitespace',
   },


### PR DESCRIPTION
The description and url for eslint rule `no-multiple-whitespaces` incorrect points to `no-emoji` doc