### PR TITLE
fix(3652) use double-quotes for description if applicable

### DIFF
--- a/packages/eslint-plugin-formatjs/rules/enforce-id.ts
+++ b/packages/eslint-plugin-formatjs/rules/enforce-id.ts
@@ -92,9 +92,10 @@ Actual: ${id}`,
                   ` id="${correctId}"`
                 )
               }
+              const quote = defaultMessage.indexOf('\'') === -1 ? "'" : '"';
               return fixer.replaceText(
                 messagePropNode as any,
-                `defaultMessage: '${defaultMessage}', id: '${correctId}'`
+                `defaultMessage: ${quote}${defaultMessage}${quote}, id: '${correctId}'`
               )
             },
           })

--- a/packages/eslint-plugin-formatjs/rules/enforce-id.ts
+++ b/packages/eslint-plugin-formatjs/rules/enforce-id.ts
@@ -95,7 +95,7 @@ Actual: ${id}`,
               const quote = defaultMessage.indexOf('\'') === -1 ? "'" : '"';
               return fixer.replaceText(
                 messagePropNode as any,
-                `defaultMessage: ${quote}${defaultMessage}${quote}, id: '${correctId}'`
+                `defaultMessage: '${defaultMessage.split(`'`).join(`\\'`)}', id: '${correctId}'`
               )
             },
           })

--- a/packages/eslint-plugin-formatjs/rules/enforce-id.ts
+++ b/packages/eslint-plugin-formatjs/rules/enforce-id.ts
@@ -92,7 +92,6 @@ Actual: ${id}`,
                   ` id="${correctId}"`
                 )
               }
-              const quote = defaultMessage.indexOf('\'') === -1 ? "'" : '"';
               return fixer.replaceText(
                 messagePropNode as any,
                 `defaultMessage: '${defaultMessage.split(`'`).join(`\\'`)}', id: '${correctId}'`


### PR DESCRIPTION
To address causing parse error if default message has single quote 
see https://github.com/formatjs/formatjs/issues/3652 for more

