### PR TITLE
fix(@formatjs/eslint-plugin-formatjs): handle ICU message syntax error in no-complex-selectors rule

### DIFF
--- a/packages/eslint-plugin-formatjs/rules/no-complex-selectors.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-complex-selectors.ts
@@ -45,11 +45,21 @@ function checkNode(context: Rule.RuleContext, node: TSESTree.Node) {
     if (!defaultMessage || !messageNode) {
       continue
     }
-    const hoistedAst = hoistSelectors(
-      parse(defaultMessage, {
+
+    let ast: MessageFormatElement[]
+    try {
+      ast = parse(defaultMessage, {
         ignoreTag: context.settings.ignoreTag,
       })
-    )
+    } catch (e) {
+      context.report({
+        node: messageNode as any,
+        message: e instanceof Error ? e.message : String(e),
+      })
+      return
+    }
+
+    const hoistedAst = hoistSelectors(ast)
     const complexity = calculateComplexity(hoistedAst)
     if (complexity > config.limit) {
       context.report({

--- a/packages/eslint-plugin-formatjs/tests/no-complex-selectors.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/no-complex-selectors.test.ts
@@ -26,6 +26,17 @@ ruleTester.run('no-complex-selectors', noComplexSelectors, {
     },
   ],
   invalid: [
+    // Syntax error
+    {
+      code: `
+        import {defineMessage} from 'react-intl'
+        defineMessage({
+            defaultMessage: '{'
+        })
+      `,
+      options: [{limit: 1}],
+      errors: [{message: 'EXPECT_ARGUMENT_CLOSING_BRACE'}],
+    },
     {
       code: `
               import {defineMessage} from 'react-intl'


### PR DESCRIPTION
This PR handles the parser thrown error in no-complex-selectors rule, so that eslint won't crash with incomplete message (e.g. when writing the message in the editor).