### PR TITLE
feat!(@formatjs/eslint-plugin-formatjs): no-multiple-whitespaces now allows whitespaces in non-literals

### DIFF
--- a/packages/eslint-plugin-formatjs/tests/no-multiple-whitespaces.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/no-multiple-whitespaces.test.ts
@@ -32,6 +32,7 @@ ruleTester.run('no-multiple-whitespaces', noMultipleWhitespaces, {
           message: 'Multiple consecutive whitespaces are not allowed',
         },
       ],
+      output: `import {defineMessage} from 'react-intl';defineMessage({defaultMessage: "a {placeHolder}"})`,
     },
     {
       code: "<FormattedMessage defaultMessage='a   thing'/>",
@@ -40,6 +41,7 @@ ruleTester.run('no-multiple-whitespaces', noMultipleWhitespaces, {
           message: 'Multiple consecutive whitespaces are not allowed',
         },
       ],
+      output: `<FormattedMessage defaultMessage="a thing"/>`,
     },
     {
       code: `
@@ -52,12 +54,17 @@ ruleTester.run('no-multiple-whitespaces', noMultipleWhitespaces, {
           message: 'Multiple consecutive whitespaces are not allowed',
         },
       ],
+      output: `
+              import {defineMessage} from 'react-intl'
+              defineMessage({
+                  defaultMessage: "a {placeHolder}"
+              })`,
     },
     {
       code: `
         import {defineMessage} from 'react-intl'
         defineMessage({
-          defaultMessage: \`{a, select,
+          defaultMessage: \`hello     {a, select,
             b {{c, plural, one {  d} other { #}}}
             other {e}
           }\`
@@ -68,6 +75,26 @@ ruleTester.run('no-multiple-whitespaces', noMultipleWhitespaces, {
           message: 'Multiple consecutive whitespaces are not allowed',
         },
       ],
+      output: `
+        import {defineMessage} from 'react-intl'
+        defineMessage({
+          defaultMessage: \`hello {a, select,
+            b {{c, plural, one { d} other { #}}}
+            other {e}
+          }\`
+        })
+      `,
+    },
+    // Backslash escapes in the template literals
+    {
+      code: "import {defineMessage} from 'react-intl';defineMessage({defaultMessage: `a\\\\  \\`  {placeHolder}`})",
+      errors: [
+        {
+          message: 'Multiple consecutive whitespaces are not allowed',
+        },
+      ],
+      output:
+        "import {defineMessage} from 'react-intl';defineMessage({defaultMessage: `a\\\\ \\` {placeHolder}`})",
     },
   ],
 })

--- a/packages/eslint-plugin-formatjs/tests/no-multiple-whitespaces.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/no-multiple-whitespaces.test.ts
@@ -4,14 +4,24 @@ import {dynamicMessage, noMatch, spreadJsx, emptyFnCall} from './fixtures'
 ruleTester.run('no-multiple-whitespaces', noMultipleWhitespaces, {
   valid: [
     `import {defineMessage} from 'react-intl'
-  defineMessage({
-      defaultMessage: 'a {placeholder}',
-      description: 'asd'
-  })`,
+    defineMessage({
+        defaultMessage: 'a {placeholder}',
+        description: 'asd'
+    })`,
     dynamicMessage,
     noMatch,
     spreadJsx,
     emptyFnCall,
+    `
+      import {defineMessage} from 'react-intl'
+      defineMessage({
+        defaultMessage: \`a {
+          b, select,
+            c {d}
+            other {e}
+        }\`
+      })
+    `,
   ],
   invalid: [
     {
@@ -22,8 +32,6 @@ ruleTester.run('no-multiple-whitespaces', noMultipleWhitespaces, {
           message: 'Multiple consecutive whitespaces are not allowed',
         },
       ],
-      output:
-        "import {defineMessage} from 'react-intl';defineMessage({defaultMessage: 'a {placeHolder}'})",
     },
     {
       code: "<FormattedMessage defaultMessage='a   thing'/>",
@@ -32,7 +40,6 @@ ruleTester.run('no-multiple-whitespaces', noMultipleWhitespaces, {
           message: 'Multiple consecutive whitespaces are not allowed',
         },
       ],
-      output: "<FormattedMessage defaultMessage='a thing'/>",
     },
     {
       code: `
@@ -45,11 +52,22 @@ ruleTester.run('no-multiple-whitespaces', noMultipleWhitespaces, {
           message: 'Multiple consecutive whitespaces are not allowed',
         },
       ],
-      output: `
-              import {defineMessage} from 'react-intl'
-              defineMessage({
-                  defaultMessage: 'a {placeHolder}'
-              })`,
+    },
+    {
+      code: `
+        import {defineMessage} from 'react-intl'
+        defineMessage({
+          defaultMessage: \`{a, select,
+            b {{c, plural, one {  d} other { #}}}
+            other {e}
+          }\`
+        })
+      `,
+      errors: [
+        {
+          message: 'Multiple consecutive whitespaces are not allowed',
+        },
+      ],
     },
   ],
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -42,29 +42,29 @@
     "paths": {
       "@formatjs/*": [
         // k8 is 64-bit GNU/Linux output location, darwin is macOS.
-        "bazel-out/k8-fastbuild/bin/packages/*",
-        "bazel-out/darwin-fastbuild/bin/packages/*",
-        "bazel-out/darwin_arm64-fastbuild/bin/packages/*",
+        "dist/out/k8-fastbuild/bin/packages/*",
+        "dist/out/darwin-fastbuild/bin/packages/*",
+        "dist/out/darwin_arm64-fastbuild/bin/packages/*",
       ],
       "intl-messageformat": [
-        "bazel-out/k8-fastbuild/bin/packages/intl-messageformat",
-        "bazel-out/darwin-fastbuild/bin/packages/intl-messageformat",
-        "bazel-out/darwin_arm64-fastbuild/bin/packages/intl-messageformat",
+        "dist/out/k8-fastbuild/bin/packages/intl-messageformat",
+        "dist/out/darwin-fastbuild/bin/packages/intl-messageformat",
+        "dist/out/darwin_arm64-fastbuild/bin/packages/intl-messageformat",
       ],
       "babel-plugin-formatjs": [
-        "bazel-out/k8-fastbuild/bin/packages/babel-plugin-formatjs",
-        "bazel-out/darwin-fastbuild/bin/packages/babel-plugin-formatjs",
-        "bazel-out/darwin_arm64-fastbuild/bin/packages/babel-plugin-formatjs",
+        "dist/out/k8-fastbuild/bin/packages/babel-plugin-formatjs",
+        "dist/out/darwin-fastbuild/bin/packages/babel-plugin-formatjs",
+        "dist/out/darwin_arm64-fastbuild/bin/packages/babel-plugin-formatjs",
       ],
       "eslint-plugin-formatjs": [
-        "bazel-out/k8-fastbuild/bin/packages/eslint-plugin-formatjs",
-        "bazel-out/darwin-fastbuild/bin/packages/eslint-plugin-formatjs",
-        "bazel-out/darwin_arm64-fastbuild/bin/packages/eslint-plugin-formatjs",
+        "dist/out/k8-fastbuild/bin/packages/eslint-plugin-formatjs",
+        "dist/out/darwin-fastbuild/bin/packages/eslint-plugin-formatjs",
+        "dist/out/darwin_arm64-fastbuild/bin/packages/eslint-plugin-formatjs",
       ],
       "react-intl": [
-        "bazel-out/k8-fastbuild/bin/packages/react-intl",
-        "bazel-out/darwin-fastbuild/bin/packages/react-intl",
-        "bazel-out/darwin_arm64-fastbuild/bin/packages/react-intl",
+        "dist/out/k8-fastbuild/bin/packages/react-intl",
+        "dist/out/darwin-fastbuild/bin/packages/react-intl",
+        "dist/out/darwin_arm64-fastbuild/bin/packages/react-intl",
       ]
     }
   }


### PR DESCRIPTION
BREAKING CHANGE: no-multiple-whitespaces now allows whitespaces in non-literals of the ICU message.

Sometimes it is nice to have line breaks and padding in the mesages for readability, so long as they does not affect the literal parts of the message:

```tsx
defineMessages({
    defaultMessage: `{foo, select,
        a {b}
        other {c}
    }`
});
```

This PR parses the mesage and traverse the AST. It will only report consecutive whitespaces in the `TYPE.literal` message parts. This PR also removes the autofix since it is non-trivial to implement.