### PR TITLE
fix(eslint-plugin-formatjs): actually add no-literal-string-in-jsx to the plugin registry

### DIFF
--- a/packages/eslint-plugin-formatjs/index.ts
+++ b/packages/eslint-plugin-formatjs/index.ts
@@ -11,6 +11,7 @@ import noId from './rules/no-id'
 import noMultiplePlurals from './rules/no-multiple-plurals'
 import noMultipleWhitespaces from './rules/no-multiple-whitespaces'
 import noOffset from './rules/no-offset'
+import noLiteralStringInJsx from './rules/no-literal-string-in-jsx'
 const plugin = {
   rules: {
     'blocklist-elements': blocklistElements,
@@ -23,6 +24,7 @@ const plugin = {
     'no-complex-selectors': noComplexSelectors,
     'no-emoji': noEmoji,
     'no-id': noId,
+    'no-literal-string-in-jsx': noLiteralStringInJsx,
     'no-multiple-plurals': noMultiplePlurals,
     'no-multiple-whitespaces': noMultipleWhitespaces,
     'no-offset': noOffset,


### PR DESCRIPTION
This fix make `no-literal-string-in-jsx` rule available by exporting the rule from `index.ts`.
