### PR TITLE
fix(@formatjs/cli): only compare stringified descriptions

### DIFF
--- a/packages/cli/src/extract.ts
+++ b/packages/cli/src/extract.ts
@@ -222,7 +222,7 @@ ${JSON.stringify(message, undefined, 2)}`
       if (extractedMessages.has(id)) {
         const existing = extractedMessages.get(id)!
         if (
-          description !== existing.description ||
+          stringify(description) !== stringify(existing.description) ||
           defaultMessage !== existing.defaultMessage
         ) {
           const error = new Error(


### PR DESCRIPTION
Since descriptions can be objects we need to stringify the values whenever doing direct comparisons. Stable stringify can handle string params therefore we do not need to check the type of description.