### PR TITLE
fix(@formatjs/ts-transformer): update package.json to allow ts-jest 28 in peer dependencies

### DIFF
--- a/packages/ts-transformer/package.json
+++ b/packages/ts-transformer/package.json
@@ -26,7 +26,7 @@
     "typescript": "^4.5"
   },
   "peerDependencies": {
-    "ts-jest": "27"
+    "ts-jest": "27 || 28"
   },
   "peerDependenciesMeta": {
     "ts-jest": {


### PR DESCRIPTION
Fix #3629

Updated the `package.json` file to add `|| 28` for the `ts-jest` in the peer dependencies block since 28 is the latest version