### PR TITLE
fix(@formatjs/cli-lib): only compare stringified descriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 .cache
 .bazelrc.user
 *.log
+.idea

--- a/packages/cli-lib/src/extract.ts
+++ b/packages/cli-lib/src/extract.ts
@@ -222,7 +222,7 @@ ${JSON.stringify(message, undefined, 2)}`
       if (extractedMessages.has(id)) {
         const existing = extractedMessages.get(id)!
         if (
-          description !== existing.description ||
+          stringify(description) !== stringify(existing.description) ||
           defaultMessage !== existing.defaultMessage
         ) {
           const error = new Error(

--- a/packages/cli-lib/tests/integration/extract/__snapshots__/integration.test.ts.snap
+++ b/packages/cli-lib/tests/integration/extract/__snapshots__/integration.test.ts.snap
@@ -408,6 +408,25 @@ Object {
 }
 `;
 
+exports[`non duplicated descriptors does not throw 1`] = `
+Object {
+  "stderr": "",
+  "stdout": "",
+}
+`;
+
+exports[`non duplicated descriptors does not throw 2`] = `
+Object {
+  "foo": Object {
+    "defaultMessage": "Foo",
+    "description": Object {
+      "maxCharacterCount": 2,
+      "text": "Bar",
+    },
+  },
+}
+`;
+
 exports[`pragma 1`] = `
 Object {
   "stderr": "",

--- a/packages/cli-lib/tests/integration/extract/integration.test.ts
+++ b/packages/cli-lib/tests/integration/extract/integration.test.ts
@@ -200,6 +200,18 @@ test('duplicated descriptor ids throws', async () => {
   }).rejects.toThrowError('Duplicate message id: "foo"')
 }, 20000)
 
+test('non duplicated descriptors does not throw', async () => {
+  await expect(
+      exec(
+          `${BIN_PATH} extract --throws '${join(__dirname, 'nonDuplicated/*.tsx')}' --out-file ${ARTIFACT_PATH}/nonDuplicated/actual.json`
+      )
+  ).resolves.toMatchSnapshot()
+
+  expect(
+      await readJSON(join(ARTIFACT_PATH, 'nonDuplicated/actual.json'))
+  ).toMatchSnapshot()
+}, 20000)
+
 test('invalid syntax should throw', async () => {
   expect(async () => {
     await exec(

--- a/packages/cli-lib/tests/integration/extract/nonDuplicated/file1.tsx
+++ b/packages/cli-lib/tests/integration/extract/nonDuplicated/file1.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import {FormattedMessage} from 'react-intl'
+
+export function Foo() {
+  return (
+    <p>
+        <FormattedMessage id="foo" defaultMessage="Foo" description={{maxCharacterCount: 2, text: 'Bar'}}/>
+    </p>
+  )
+}

--- a/packages/cli-lib/tests/integration/extract/nonDuplicated/file2.tsx
+++ b/packages/cli-lib/tests/integration/extract/nonDuplicated/file2.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import {FormattedMessage} from 'react-intl'
+
+export function Bar() {
+  return (
+    <p>
+        <FormattedMessage id="foo" defaultMessage="Foo" description={{text: 'Bar', maxCharacterCount: 2}}/>
+    </p>
+  )
+}


### PR DESCRIPTION
Since descriptions can be objects we need to stringify the values whenever doing direct comparisons. Stable stringify can handle string params therefore we do not need to check the type of description.