### PR TITLE
feat(eslint-plugin-formatjs): add no-invalid-icu eslint rule

### DIFF
--- a/packages/eslint-plugin-formatjs/index.ts
+++ b/packages/eslint-plugin-formatjs/index.ts
@@ -3,6 +3,7 @@ import enforceDefaultMessage from './rules/enforce-default-message'
 import enforceDescription from './rules/enforce-description'
 import enforceId from './rules/enforce-id'
 import enforcePlaceholders from './rules/enforce-placeholders'
+import noInvalidICU from './rules/no-invalid-icu'
 import enforcePluralRules from './rules/enforce-plural-rules'
 import noCamelCase from './rules/no-camel-case'
 import noComplexSelectors from './rules/no-complex-selectors'
@@ -27,6 +28,7 @@ const plugin = {
     'no-literal-string-in-jsx': noLiteralStringInJsx,
     'no-multiple-plurals': noMultiplePlurals,
     'no-multiple-whitespaces': noMultipleWhitespaces,
+    'no-invalid-icu': noInvalidICU,
     'no-offset': noOffset,
   },
 }

--- a/packages/eslint-plugin-formatjs/rules/no-invalid-icu.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-invalid-icu.ts
@@ -1,0 +1,68 @@
+import {Rule} from 'eslint'
+import {TSESTree} from '@typescript-eslint/typescript-estree'
+import {parse} from '@formatjs/icu-messageformat-parser'
+import {extractMessages} from '../util'
+
+function checkNode(context: Rule.RuleContext, node: TSESTree.Node) {
+  const msgs = extractMessages(node as any, context.settings)
+
+  if (!msgs.length) {
+    return
+  }
+
+  for (const [
+    {
+      message: {defaultMessage},
+      messageNode,
+    },
+  ] of msgs) {
+    if (!defaultMessage || !messageNode) {
+      continue
+    }
+
+    try {
+      parse(defaultMessage, {
+        ignoreTag: context.settings['ignoreTag'],
+      })
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : e
+      context.report({
+        node: messageNode as any,
+        message: `Error parsing ICU string: ${msg}`,
+      })
+    }
+  }
+}
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: `Make sure ICU messages are formatted correctly with no bad select statements, plurals, etc.`,
+      category: 'Errors',
+      recommended: true,
+    },
+    fixable: 'code',
+  },
+  create(context) {
+    const callExpressionVisitor = (node: TSESTree.Node) =>
+      checkNode(context, node)
+
+    if (context.parserServices.defineTemplateBodyVisitor) {
+      return context.parserServices.defineTemplateBodyVisitor(
+        {
+          CallExpression: callExpressionVisitor,
+        },
+        {
+          CallExpression: callExpressionVisitor,
+        }
+      )
+    }
+    return {
+      JSXOpeningElement: (node: TSESTree.Node) => checkNode(context, node),
+      CallExpression: callExpressionVisitor,
+    }
+  },
+}
+
+export default rule

--- a/packages/eslint-plugin-formatjs/tests/no-invalid-icu.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/no-invalid-icu.test.ts
@@ -1,0 +1,104 @@
+import noMalformedICU from '../rules/no-invalid-icu'
+import {ruleTester} from './util'
+import {dynamicMessage, noMatch, spreadJsx, emptyFnCall} from './fixtures'
+
+ruleTester.run('no-invalid-icu', noMalformedICU, {
+  valid: [
+    `intl.formatMessage({
+      defaultMessage: '{count, plural, one {#} other {# more}}',
+      description: 'asd'
+  }, {count: 1})`,
+    `intl.formatMessage({
+    defaultMessage: '{count, plural, one {#} other {# more}}',
+    description: 'asd'
+  }, {'count': 1})`,
+    `import {FormattedMessage} from 'react-intl'
+  const a = <FormattedMessage
+  defaultMessage="{count, plural, one {#} other {# more}}"
+  values={{ count: 1}} />
+        `,
+    `import {FormattedMessage} from 'react-intl'
+  const a = <FormattedMessage
+  defaultMessage="{count, plural, one {#} other {# more}} {bar}"
+  values={{ 'count': 1, bar: 2}} />
+        `,
+    `import {defineMessages, _} from 'react-intl'
+  defineMessages({
+    foo: {
+      defaultMessage: '{count, plural, one {#} other {# more}}',
+      description: 'asd'
+    }
+  })
+  defineMessage({
+    defaultMessage: '{count, plural, one {#} other {# more}}',
+    description: 'asd'
+  })
+  `,
+    `
+  intl.formatMessage({
+    defaultMessage: '{count, plural, one {<a>#</a>} other {# more}}',
+    description: 'asd'
+  }, {
+    count: 1,
+    a: (...chunks) => <a>{chunks}</a>
+  })
+  `,
+    `
+  intl.formatMessage({
+    defaultMessage: '{count, plural, one {<a>#</a>} other {# more}}',
+    description: 'asd'
+  }, {
+    ...foo,
+    count: 1,
+    a: (...chunks) => <a>{chunks}</a>
+  })
+  `,
+    dynamicMessage,
+    noMatch,
+    spreadJsx,
+    emptyFnCall,
+    {
+      code: `
+        intl.formatMessage({
+          defaultMessage: '{count, plural, one {#} other {# more}}',
+          description: 'asd'
+      })`,
+      options: [{ignoreList: ['count']}],
+    },
+    {
+      code: `
+        intl.formatMessage({
+          defaultMessage: '<b>foo</b>',
+          description: 'asd'
+      })`,
+      options: [{ignoreList: ['b']}],
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        intl.formatMessage({
+          defaultMessage: '{count, plural, oe {#} other {# more}}',
+          description: 'asd'
+      })`,
+      errors: [
+        {
+          message: 'Error parsing ICU string: EXPECT_SELECT_ARGUMENT_OPTIONS',
+        },
+      ],
+    },
+
+    {
+      code: `
+        intl.formatMessage({
+          defaultMessage: "{aDifferentKey, plur {#} other {# more}}" },
+          { count: 1 }
+        )`,
+      errors: [
+        {
+          message: 'Error parsing ICU string: INVALID_ARGUMENT_TYPE',
+        },
+      ],
+    },
+  ],
+})

--- a/packages/eslint-plugin-formatjs/tests/no-invalid-icu.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/no-invalid-icu.test.ts
@@ -78,12 +78,14 @@ ruleTester.run('no-invalid-icu', noMalformedICU, {
     {
       code: `
         intl.formatMessage({
-          defaultMessage: '{count, plural, oe {#} other {# more}}',
+          defaultMessage: '{count, plural, {#} other {# more}}',
           description: 'asd'
-      })`,
+        }, {
+          count: 1
+        })`,
       errors: [
         {
-          message: 'Error parsing ICU string: EXPECT_SELECT_ARGUMENT_OPTIONS',
+          message: 'Error parsing ICU string: EXPECT_PLURAL_ARGUMENT_SELECTOR',
         },
       ],
     },

--- a/website/docs/tooling/linter.md
+++ b/website/docs/tooling/linter.md
@@ -592,6 +592,25 @@ const messages = defineMessages({
 - `idInterpolationPattern`: Pattern to verify ID against
 - `idWhitelist`: An array of strings with regular expressions. This array allows allowlist custom ids for messages. For example '`\\.`' allows any id which has dot; `'^payment_.*'` - allows any custom id which has prefix `payment_`. Be aware that any backslash \ provided via string must be escaped with an additional backslash.
 
+### `no-invalid-icu`
+
+This bans strings inside `defaultMessage` that are syntactically invalid.
+
+#### Why
+
+It's easy to miss strings that look correct to you as a developer but which are actually syntactically invalid ICU strings. For instance, the following would cause an eslint error:
+
+```typescript
+formatMessage(
+  {
+    defaultMessage: '{count, plural one {#} other {# more}}', //Missing a comma!
+  },
+  {
+    count: 1,
+  }
+)
+```
+
 ### `no-id`
 
 This bans explicit ID in `MessageDescriptor`.


### PR DESCRIPTION
Adds a handy eslint check. I couldn't get the repo to build locally so I couldn't test things locally. You're doing a great work here with this library but I think the contributing instructions need some beefing up: https://github.com/formatjs/formatjs/blob/main/CONTRIBUTING.md#development

Only 8 tests out of the whole test suite ran after doing those instructions. And I am not familiar with Bazel and how to test just a small subset of tests. 

Please let me know what else I can do. Thanks!