### PR TITLE
fix(@formatjs/cli-lib): formatter path on Windows

### DIFF
--- a/packages/cli-lib/src/formatters/index.ts
+++ b/packages/cli-lib/src/formatters/index.ts
@@ -38,7 +38,7 @@ export async function resolveBuiltinFormatter(
   }
   try {
     // eslint-disable-next-line import/dynamic-import-chunkname
-    return import(pathToFileURL(resolve(process.cwd(), format)))
+    return import(pathToFileURL(resolve(process.cwd(), format)).href)
   } catch (e) {
     console.error(`Cannot resolve formatter ${format}`)
     throw e

--- a/packages/cli-lib/src/formatters/index.ts
+++ b/packages/cli-lib/src/formatters/index.ts
@@ -7,6 +7,7 @@ import * as lokalise from './lokalise'
 import * as crowdin from './crowdin'
 import {Comparator} from 'json-stable-stringify'
 import {resolve} from 'path'
+import {pathToFileURL} from 'url'
 
 export interface Formatter {
   format: FormatFn
@@ -37,7 +38,7 @@ export async function resolveBuiltinFormatter(
   }
   try {
     // eslint-disable-next-line import/dynamic-import-chunkname
-    return import(resolve(process.cwd(), format))
+    return import(pathToFileURL(resolve(process.cwd(), format)))
   } catch (e) {
     console.error(`Cannot resolve formatter ${format}`)
     throw e


### PR DESCRIPTION
This PR fixes #3645 – Formatter paths didn't work in Windows as `path.resolve()` returns path starting `C:` but the `import` statement expects `file://`.
I have worked around this issue by using `pathToFileURL` method the same way as in the [Vue CLI](https://github.com/vuejs/vue-cli/blob/dev/packages/@vue/cli-service/lib/util/loadFileConfig.js#L28). 

More info can be found in [my comment in the issue thread](https://github.com/formatjs/formatjs/issues/3645#issuecomment-1202857537). 