### PR TITLE
feat(eslint-plugin-formatjs): allow scoping settings to formatjs

### DIFF
--- a/packages/eslint-plugin-formatjs/rules/blocklist-elements.ts
+++ b/packages/eslint-plugin-formatjs/rules/blocklist-elements.ts
@@ -1,5 +1,5 @@
 import {Rule} from 'eslint'
-import {extractMessages} from '../util'
+import {extractMessages, getSettings} from '../util'
 import {
   parse,
   isPluralElement,
@@ -78,7 +78,8 @@ function verifyAst(blocklist: Element[], ast: MessageFormatElement[]) {
 }
 
 function checkNode(context: Rule.RuleContext, node: TSESTree.Node) {
-  const msgs = extractMessages(node, context.settings)
+  const settings = getSettings(context)
+  const msgs = extractMessages(node, settings)
   if (!msgs.length) {
     return
   }
@@ -100,7 +101,7 @@ function checkNode(context: Rule.RuleContext, node: TSESTree.Node) {
       verifyAst(
         context.options[0],
         parse(defaultMessage, {
-          ignoreTag: context.settings.ignoreTag,
+          ignoreTag: settings.ignoreTag,
         })
       )
     } catch (e) {

--- a/packages/eslint-plugin-formatjs/rules/enforce-default-message.ts
+++ b/packages/eslint-plugin-formatjs/rules/enforce-default-message.ts
@@ -1,9 +1,9 @@
 import {Rule} from 'eslint'
-import {extractMessages} from '../util'
+import {extractMessages, getSettings} from '../util'
 import {TSESTree} from '@typescript-eslint/typescript-estree'
 
 function checkNode(context: Rule.RuleContext, node: TSESTree.Node) {
-  const msgs = extractMessages(node, context.settings)
+  const msgs = extractMessages(node, getSettings(context))
   const {
     options: [type],
   } = context

--- a/packages/eslint-plugin-formatjs/rules/enforce-description.ts
+++ b/packages/eslint-plugin-formatjs/rules/enforce-description.ts
@@ -1,9 +1,9 @@
 import {Rule} from 'eslint'
-import {extractMessages} from '../util'
+import {extractMessages, getSettings} from '../util'
 import {TSESTree} from '@typescript-eslint/typescript-estree'
 
 function checkNode(context: Rule.RuleContext, node: TSESTree.Node) {
-  const msgs = extractMessages(node, context.settings)
+  const msgs = extractMessages(node, getSettings(context))
   const {
     options: [type],
   } = context

--- a/packages/eslint-plugin-formatjs/rules/enforce-id.ts
+++ b/packages/eslint-plugin-formatjs/rules/enforce-id.ts
@@ -1,5 +1,5 @@
 import {Rule} from 'eslint'
-import {extractMessages} from '../util'
+import {extractMessages, getSettings} from '../util'
 import {TSESTree} from '@typescript-eslint/typescript-estree'
 import {interpolateName} from '@formatjs/ts-transformer'
 
@@ -13,7 +13,7 @@ function checkNode(
   node: TSESTree.Node,
   {idInterpolationPattern, idWhitelistRegexps}: Opts
 ) {
-  const msgs = extractMessages(node, context.settings)
+  const msgs = extractMessages(node, getSettings(context))
   for (const [
     {
       message: {defaultMessage, description, id},

--- a/packages/eslint-plugin-formatjs/rules/enforce-placeholders.ts
+++ b/packages/eslint-plugin-formatjs/rules/enforce-placeholders.ts
@@ -1,6 +1,6 @@
 import {Rule} from 'eslint'
 import {TSESTree} from '@typescript-eslint/typescript-estree'
-import {extractMessages} from '../util'
+import {extractMessages, getSettings} from '../util'
 import {
   parse,
   isPluralElement,
@@ -75,9 +75,10 @@ function verifyAst(
 }
 
 function checkNode(context: Rule.RuleContext, node: TSESTree.Node) {
+  const settings = getSettings(context)
   const msgs = extractMessages(node, {
     excludeMessageDeclCalls: true,
-    ...context.settings,
+    ...settings,
   })
   const {
     options: [opt],
@@ -96,7 +97,7 @@ function checkNode(context: Rule.RuleContext, node: TSESTree.Node) {
     try {
       verifyAst(
         parse(defaultMessage, {
-          ignoreTag: context.settings.ignoreTag,
+          ignoreTag: settings.ignoreTag,
         }),
         values,
         ignoreList

--- a/packages/eslint-plugin-formatjs/rules/enforce-plural-rules.ts
+++ b/packages/eslint-plugin-formatjs/rules/enforce-plural-rules.ts
@@ -1,6 +1,6 @@
 import {Rule} from 'eslint'
 import {TSESTree} from '@typescript-eslint/typescript-estree'
-import {extractMessages} from '../util'
+import {extractMessages, getSettings} from '../util'
 import {
   parse,
   isPluralElement,
@@ -48,7 +48,8 @@ function verifyAst(
 }
 
 function checkNode(context: Rule.RuleContext, node: TSESTree.Node) {
-  const msgs = extractMessages(node, context.settings)
+  const settings = getSettings(context)
+  const msgs = extractMessages(node, settings)
   if (!msgs.length) {
     return
   }
@@ -70,7 +71,7 @@ function checkNode(context: Rule.RuleContext, node: TSESTree.Node) {
       verifyAst(
         context.options[0],
         parse(defaultMessage, {
-          ignoreTag: context.settings.ignoreTag,
+          ignoreTag: settings.ignoreTag,
         })
       )
     } catch (e) {

--- a/packages/eslint-plugin-formatjs/rules/no-camel-case.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-camel-case.ts
@@ -6,7 +6,7 @@ import {
   MessageFormatElement,
   isArgumentElement,
 } from '@formatjs/icu-messageformat-parser'
-import {extractMessages} from '../util'
+import {extractMessages, getSettings} from '../util'
 
 const CAMEL_CASE_REGEX = /[A-Z]/
 
@@ -35,7 +35,8 @@ function verifyAst(ast: MessageFormatElement[]) {
 }
 
 function checkNode(context: Rule.RuleContext, node: TSESTree.Node) {
-  const msgs = extractMessages(node, context.settings)
+  const settings = getSettings(context)
+  const msgs = extractMessages(node, settings)
 
   for (const [
     {
@@ -49,7 +50,7 @@ function checkNode(context: Rule.RuleContext, node: TSESTree.Node) {
     try {
       verifyAst(
         parse(defaultMessage, {
-          ignoreTag: context.settings.ignoreTag,
+          ignoreTag: settings.ignoreTag,
         })
       )
     } catch (e) {

--- a/packages/eslint-plugin-formatjs/rules/no-complex-selectors.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-complex-selectors.ts
@@ -1,6 +1,6 @@
 import {Rule} from 'eslint'
 import {TSESTree} from '@typescript-eslint/typescript-estree'
-import {extractMessages} from '../util'
+import {extractMessages, getSettings} from '../util'
 import {
   parse,
   isPluralElement,
@@ -26,7 +26,8 @@ function calculateComplexity(ast: MessageFormatElement[]): number {
 }
 
 function checkNode(context: Rule.RuleContext, node: TSESTree.Node) {
-  const msgs = extractMessages(node, context.settings)
+  const settings = getSettings(context)
+  const msgs = extractMessages(node, settings)
   if (!msgs.length) {
     return
   }
@@ -49,7 +50,7 @@ function checkNode(context: Rule.RuleContext, node: TSESTree.Node) {
     let ast: MessageFormatElement[]
     try {
       ast = parse(defaultMessage, {
-        ignoreTag: context.settings.ignoreTag,
+        ignoreTag: settings.ignoreTag,
       })
     } catch (e) {
       context.report({

--- a/packages/eslint-plugin-formatjs/rules/no-emoji.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-emoji.ts
@@ -1,11 +1,11 @@
 import {Rule} from 'eslint'
 import {TSESTree} from '@typescript-eslint/typescript-estree'
-import {extractMessages} from '../util'
+import {extractMessages, getSettings} from '../util'
 import emojiRegex from 'emoji-regex'
 const EMOJI_REGEX: RegExp = (emojiRegex as any)()
 
 function checkNode(context: Rule.RuleContext, node: TSESTree.Node) {
-  const msgs = extractMessages(node, context.settings)
+  const msgs = extractMessages(node, getSettings(context))
 
   for (const [
     {

--- a/packages/eslint-plugin-formatjs/rules/no-id.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-id.ts
@@ -1,5 +1,5 @@
 import {Rule, SourceCode} from 'eslint'
-import {extractMessages} from '../util'
+import {extractMessages, getSettings} from '../util'
 import {TSESTree} from '@typescript-eslint/typescript-estree'
 import * as ESTree from 'estree'
 
@@ -10,7 +10,7 @@ function isComment(
 }
 
 function checkNode(context: Rule.RuleContext, node: TSESTree.Node) {
-  const msgs = extractMessages(node, context.settings)
+  const msgs = extractMessages(node, getSettings(context))
   for (const [{idPropNode}] of msgs) {
     if (idPropNode) {
       context.report({

--- a/packages/eslint-plugin-formatjs/rules/no-invalid-icu.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-invalid-icu.ts
@@ -1,10 +1,11 @@
 import {Rule} from 'eslint'
 import {TSESTree} from '@typescript-eslint/typescript-estree'
 import {parse} from '@formatjs/icu-messageformat-parser'
-import {extractMessages} from '../util'
+import {extractMessages, getSettings} from '../util'
 
 function checkNode(context: Rule.RuleContext, node: TSESTree.Node) {
-  const msgs = extractMessages(node as any, context.settings)
+  const settings = getSettings(context)
+  const msgs = extractMessages(node, settings)
 
   if (!msgs.length) {
     return
@@ -22,7 +23,7 @@ function checkNode(context: Rule.RuleContext, node: TSESTree.Node) {
 
     try {
       parse(defaultMessage, {
-        ignoreTag: context.settings['ignoreTag'],
+        ignoreTag: settings.ignoreTag,
       })
     } catch (e) {
       const msg = e instanceof Error ? e.message : e

--- a/packages/eslint-plugin-formatjs/rules/no-multiple-plurals.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-multiple-plurals.ts
@@ -1,6 +1,6 @@
 import {Rule} from 'eslint'
 import {TSESTree} from '@typescript-eslint/typescript-estree'
-import {extractMessages} from '../util'
+import {extractMessages, getSettings} from '../util'
 import {
   parse,
   isPluralElement,
@@ -27,7 +27,8 @@ function verifyAst(ast: MessageFormatElement[], pluralCount = {count: 0}) {
 }
 
 function checkNode(context: Rule.RuleContext, node: TSESTree.Node) {
-  const msgs = extractMessages(node, context.settings)
+  const settings = getSettings(context)
+  const msgs = extractMessages(node, settings)
 
   for (const [
     {
@@ -41,7 +42,7 @@ function checkNode(context: Rule.RuleContext, node: TSESTree.Node) {
     try {
       verifyAst(
         parse(defaultMessage, {
-          ignoreTag: context.settings.ignoreTag,
+          ignoreTag: settings.ignoreTag,
         })
       )
     } catch (e) {

--- a/packages/eslint-plugin-formatjs/rules/no-multiple-whitespaces.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-multiple-whitespaces.ts
@@ -6,7 +6,7 @@ import {
 } from '@formatjs/icu-messageformat-parser'
 import {TSESTree} from '@typescript-eslint/typescript-estree'
 import {Rule} from 'eslint'
-import {extractMessages} from '../util'
+import {extractMessages, getSettings} from '../util'
 
 function isAstValid(ast: MessageFormatElement[]): boolean {
   for (const element of ast) {
@@ -94,7 +94,7 @@ function trimMultiWhitespaces(
 }
 
 function checkNode(context: Rule.RuleContext, node: TSESTree.Node) {
-  const msgs = extractMessages(node, context.settings)
+  const msgs = extractMessages(node, getSettings(context))
 
   for (const [
     {

--- a/packages/eslint-plugin-formatjs/rules/no-offset.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-offset.ts
@@ -1,6 +1,6 @@
 import {Rule} from 'eslint'
 import {TSESTree} from '@typescript-eslint/typescript-estree'
-import {extractMessages} from '../util'
+import {extractMessages, getSettings} from '../util'
 import {
   parse,
   isPluralElement,
@@ -26,7 +26,8 @@ function verifyAst(ast: MessageFormatElement[]) {
 }
 
 function checkNode(context: Rule.RuleContext, node: TSESTree.Node) {
-  const msgs = extractMessages(node, context.settings)
+  const settings = getSettings(context)
+  const msgs = extractMessages(node, settings)
 
   for (const [
     {
@@ -40,7 +41,7 @@ function checkNode(context: Rule.RuleContext, node: TSESTree.Node) {
     try {
       verifyAst(
         parse(defaultMessage, {
-          ignoreTag: context.settings.ignoreTag,
+          ignoreTag: settings.ignoreTag,
         })
       )
     } catch (e) {

--- a/packages/eslint-plugin-formatjs/tests/blocklist-elements.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/blocklist-elements.test.ts
@@ -18,7 +18,9 @@ ruleTester.run('blocklist-elements', blocklistElements, {
   })`,
       options: [['selectordinal']],
       settings: {
-        ignoreTag: true,
+        formatjs: {
+          ignoreTag: true,
+        },
       },
     },
     {
@@ -28,7 +30,9 @@ ruleTester.run('blocklist-elements', blocklistElements, {
   })`,
       options: [['selectordinal']],
       settings: {
-        additionalFunctionNames: ['$t'],
+        formatjs: {
+          additionalFunctionNames: ['$t'],
+        },
       },
     },
     dynamicMessage,
@@ -57,7 +61,9 @@ ruleTester.run('blocklist-elements', blocklistElements, {
               })`,
       options: [['selectordinal']],
       settings: {
-        additionalFunctionNames: ['$t'],
+        formatjs: {
+          additionalFunctionNames: ['$t'],
+        },
       },
       errors: [
         {

--- a/packages/eslint-plugin-formatjs/util.ts
+++ b/packages/eslint-plugin-formatjs/util.ts
@@ -1,3 +1,4 @@
+import {Rule} from 'eslint'
 import {TSESTree} from '@typescript-eslint/typescript-estree'
 
 export interface MessageDescriptor {
@@ -23,6 +24,10 @@ export interface MessageDescriptorNodeInfo {
   descriptionNode?: TSESTree.Property['value'] | TSESTree.JSXAttribute['value']
   idValueNode?: TSESTree.Property['value'] | TSESTree.JSXAttribute['value']
   idPropNode?: TSESTree.Property | TSESTree.JSXAttribute
+}
+
+export function getSettings({settings}: Rule.RuleContext): Settings {
+  return settings.formatjs ?? settings
 }
 
 function isStringLiteral(node: TSESTree.Node): node is TSESTree.StringLiteral {

--- a/website/docs/tooling/linter.md
+++ b/website/docs/tooling/linter.md
@@ -96,11 +96,11 @@ This will check against `intl.formatMessage`, `$formatMessage` function calls in
 
 These settings are applied globally to all formatjs rules once specified. See [Shared Settings](https://eslint.org/docs/user-guide/configuring/configuration-files#adding-shared-settings) for more details on how to set them.
 
-### `additionalFunctionNames`
+### `formatjs.additionalFunctionNames`
 
 Similar to [babel-plugin-formatjs](./babel-plugin.md#additionalfunctionnames) & [@formatjs/ts-transformer](./ts-transformer.md#additionalfunctionnames), this allows you to specify additional function names to check besides `formatMessage` & `$formatMessage`.
 
-### `additionalComponentNames`
+### `formatjs.additionalComponentNames`
 
 Similar to [babel-plugin-formatjs](./babel-plugin.md#additionalcomponentnames) & [@formatjs/ts-transformer](./ts-transformer.md#additionalcomponentnames), this allows you to specify additional component names to check besides `FormattedMessage`.
 


### PR DESCRIPTION
The previous shared settings format (#2967, #2998) gave no indication that the settings belong to `formatjs` rules as opposed to other unrelated rules:

```json
{
  "plugins": ["formatjs", "unrelated-plugin"],
  "settings": {
    "additionalFunctionNames": ["$t"]
  },
  "rules": …
}
```

Support a clearer format that does:

```json
{
  "plugins": ["formatjs", "unrelated-plugin"],
  "settings": {
    "formatjs": {
       "additionalFunctionNames": ["$t"]
    }
  },
  "rules": …
}
```

The old format is still supported for compatibility.