### PR TITLE
chore: upgrade unsupported Ubuntu 21.10 image to 22.04

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -188,7 +188,7 @@ lerna(
 # First thing, apt install build-essential
 download_pkgs(
     name = "build_essential_pkgs",
-    image_tar = "@ubuntu2110//image",
+    image_tar = "@ubuntu2204//image",
     packages = [
         "build-essential",
     ],
@@ -196,7 +196,7 @@ download_pkgs(
 
 install_pkgs(
     name = "ubuntu_build_essential_image",
-    image_tar = "@ubuntu2110//image",
+    image_tar = "@ubuntu2204//image",
     installables_tar = ":build_essential_pkgs.tar",
     output_image_name = "ubuntu_build_essential_image",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -184,10 +184,10 @@ load(
 )
 
 container_pull(
-    name = "ubuntu2110",
+    name = "ubuntu2204",
     architecture = "amd64",
-    digest = "sha256:d0b4808a158b42b6efb3ae93abb567b1cb6ee097221813c0315390de0fa320b9",
+    digest = "sha256:42ba2dfce475de1113d55602d40af18415897167d47c2045ec7b6d9746ff148f",
     registry = "index.docker.io",
     repository = "library/ubuntu",
-    tag = "21.10",
+    tag = "22.04",
 )


### PR DESCRIPTION
CI is failing because Ubuntu 21.10 is no longer supported. Attempt to upgrade it to Ubuntu 22.04.