### PR TITLE
fix: #3652 eslint enforce-id, append correct id

### DIFF
--- a/packages/eslint-plugin-formatjs/rules/enforce-id.ts
+++ b/packages/eslint-plugin-formatjs/rules/enforce-id.ts
@@ -92,9 +92,9 @@ Actual: ${id}`,
                   ` id="${correctId}"`
                 )
               }
-              return fixer.replaceText(
+              return fixer.insertTextAfter(
                 messagePropNode as any,
-                `defaultMessage: '${defaultMessage}', id: '${correctId}'`
+                `, id: '${correctId}'`
               )
             },
           })

--- a/packages/eslint-plugin-formatjs/tests/enforce-id.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/enforce-id.test.ts
@@ -205,5 +205,19 @@ Actual: undefined`,
       output: `
 intl.formatMessage({defaultMessage: '{count, plural, one {#} other {# more}}', id: 'j9qhn+', description: 'asd'})`,
     },
+    {
+      code: `
+intl.formatMessage({defaultMessage: "{count, plural, one {#} other {# more}}", description: "asd"})`,
+      errors: [
+        {
+          message: `"id" does not match with hash pattern [sha512:contenthash:base64:6] or allowlisted patterns ["/\\./i", "/^payment_.*/i"].
+Expected: j9qhn+
+Actual: undefined`,
+        },
+      ],
+      options: optionsWithWhitelist,
+      output: `
+intl.formatMessage({defaultMessage: "{count, plural, one {#} other {# more}}", id: 'j9qhn+', description: "asd"})`,
+    },
   ],
 })


### PR DESCRIPTION
#### Fixes https://github.com/formatjs/formatjs/issues/3652
**enforce-id** assumes `intl.formatMessage` object uses single quotes. As a result if there is any unescaped quotes it will cause a syntax error. This change appends the new id and keeps the original format of defaultMessage.
New test added to cover double-quote case.

<img width="934" alt="image" src="https://user-images.githubusercontent.com/3076448/188260483-64ad797d-06dc-44d3-bae0-7f79ef509981.png">
