### PR TITLE
Make Pragma regex more whitespace tolerant

### DIFF
--- a/packages/ts-transformer/src/transform.ts
+++ b/packages/ts-transformer/src/transform.ts
@@ -735,8 +735,8 @@ export function transformWithTs(ts: TypeScript, opts: Opts) {
     typescript.SourceFile
   > = ctx => {
     return (sf: typescript.SourceFile) => {
-      const pragmaResult = PRAGMA_REGEX.exec(sf.text)
-      if (pragmaResult) {
+      const pragmaResults = sf.text.matchAll(PRAGMA_REGEX)
+      for(const pragmaResult of pragmaResults) {
         debug('Pragma found', pragmaResult)
         const [, pragma, kvString] = pragmaResult
         if (pragma === opts.pragma) {

--- a/packages/ts-transformer/src/transform.ts
+++ b/packages/ts-transformer/src/transform.ts
@@ -707,7 +707,7 @@ function extractMessagesFromCallExpression(
   return node
 }
 
-const PRAGMA_REGEX = /^\/\/ @([^\s]*) (.*)$/m
+const PRAGMA_REGEX = /^\s*\/\/ @([^\s]*) (.*)$/m
 
 function getVisitor(
   ts: TypeScript,

--- a/packages/ts-transformer/src/transform.ts
+++ b/packages/ts-transformer/src/transform.ts
@@ -740,7 +740,7 @@ export function transformWithTs(ts: TypeScript, opts: Opts) {
         debug('Pragma found', pragmaResult)
         const [, pragma, kvString] = pragmaResult
         if (pragma === opts.pragma) {
-          const kvs = kvString.trim().split(' ')
+          const kvs = kvString.split(' ').filter(Boolean)
           const result: Record<string, string> = {}
           for (const kv of kvs) {
             const [k, v] = kv.split(':')

--- a/packages/ts-transformer/src/transform.ts
+++ b/packages/ts-transformer/src/transform.ts
@@ -707,7 +707,7 @@ function extractMessagesFromCallExpression(
   return node
 }
 
-const PRAGMA_REGEX = /^\s*\/\/ @([^\s]*) (.*)$/m
+const PRAGMA_REGEX = /^\s*\/\/\s*@([^\s]*)\s+(.*)$/m
 
 function getVisitor(
   ts: TypeScript,
@@ -740,7 +740,7 @@ export function transformWithTs(ts: TypeScript, opts: Opts) {
         debug('Pragma found', pragmaResult)
         const [, pragma, kvString] = pragmaResult
         if (pragma === opts.pragma) {
-          const kvs = kvString.split(' ')
+          const kvs = kvString.trim().split(' ')
           const result: Record<string, string> = {}
           for (const kv of kvs) {
             const [k, v] = kv.split(':')


### PR DESCRIPTION
Currently the `PRAGMA_REGEX` assumes that the line starts with the comment `// @intl-meta something` which makes comments with whitespace before not matching.

Also it can be easy for engineers to miss if they have extra whitespace inside the comment, so making the regex and parsing bit more tolerant will reduce number of issues that can happen by that (and are hard to spot)

```ts
// this one always worked
// @intl-meta key:value

// following pragmas where not detected but are now
//@intl-meta key:value
//       @intl-meta key:value
      // @intl-meta key:value

// also following pragma were not parsed properly because it produced { "key": "value", "key2": "value2", "": undefined }
// @intl-meta key:value   key2:value2
```

our use-case that gets unblocked by this
```ts
const Component = () => {
  // this is fixed by this PR (notice the whitespace before comment)
  // @intl-meta key:value
  return <FormattedMessage defaultMessage="something" />
}
```