### PR TITLE
fix(@formatjs/icu-messageformat-parser): fix object null check (#3849)

### DIFF
--- a/packages/icu-messageformat-parser/manipulator.ts
+++ b/packages/icu-messageformat-parser/manipulator.ts
@@ -10,7 +10,7 @@ function cloneDeep<T>(obj: T): T {
     // @ts-expect-error meh
     return [...obj.map(cloneDeep)]
   }
-  if (typeof obj === 'object') {
+  if (obj !== null && typeof obj === 'object') {
     // @ts-expect-error meh
     return Object.keys(obj).reduce((cloned, k) => {
       // @ts-expect-error meh

--- a/packages/icu-messageformat-parser/tests/manipulator.test.ts
+++ b/packages/icu-messageformat-parser/tests/manipulator.test.ts
@@ -49,3 +49,15 @@ test('should hoist plural & select and tag', function () {
     )
   ).toMatchSnapshot()
 })
+
+test('should hoist 1 plural with number', function () {
+  expect(
+    printAST(
+      hoistSelectors(
+        parse(
+          '{count, plural, one {{count, number} cat} other {{count, number} cats}}'
+        )
+      )
+    )
+  ).toBe('{count,plural,one{{count, number} cat} other{{count, number} cats}}')
+})


### PR DESCRIPTION
Calling the `Object.keys(null)` will throw the error. It gets called because `typeof null` is `object`.