### PR TITLE
fix(react-intl): update typescript types for FormattedDate and FormattedTime explicitly add children

### DIFF
--- a/packages/react-intl/index.ts
+++ b/packages/react-intl/index.ts
@@ -82,12 +82,14 @@ export const FormattedDate: React.FC<
   Intl.DateTimeFormatOptions &
     CustomFormatConfig & {
       value: string | number | Date | undefined
+      children?(formattedDate: string): React.ReactElement | null
     }
 > = createFormattedComponent('formatDate')
 export const FormattedTime: React.FC<
   Intl.DateTimeFormatOptions &
     CustomFormatConfig & {
       value: string | number | Date | undefined
+      children?(formattedTime: string): React.ReactElement | null
     }
 > = createFormattedComponent('formatTime')
 // @ts-ignore issue w/ TS Intl types


### PR DESCRIPTION
I added the missing children prop explicitly to the FormattedDate and FormattedTime types

Testcases ran successfully