### PR TITLE
feat(@formatjs/intl,react-intl): move IntlFormatter type parameters to methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@lerna-lite/cli": "^1.10.0",
     "@lerna-lite/list": "^1.10.0",
     "@testing-library/jest-dom": "^5.11.5",
-    "@testing-library/react": "^12.0.0",
+    "@testing-library/react": "^13.4.0",
     "@types/babel__core": "^7.1.7",
     "@types/babel__helper-plugin-utils": "^7.10.0",
     "@types/babel__traverse": "^7.1.7",

--- a/packages/intl-messageformat/src/formatters.ts
+++ b/packages/intl-messageformat/src/formatters.ts
@@ -306,6 +306,6 @@ Try polyfilling it using "@formatjs/intl-pluralrules"
   return mergeLiteral(result)
 }
 
-export type FormatXMLElementFn<T, R = string | T | Array<string | T>> = (
+export type FormatXMLElementFn<T, R = string | T | (string | T)[]> = (
   parts: Array<string | T>
 ) => R

--- a/packages/intl/src/list.ts
+++ b/packages/intl/src/list.ts
@@ -32,7 +32,7 @@ export function formatList<T>(
     onError: OnErrorFn
   },
   getListFormat: Formatters['getListFormat'],
-  values: Parameters<IntlFormatters['formatList']>[0],
+  values: ReadonlyArray<string>,
   options: Parameters<IntlFormatters['formatList']>[1] = {}
 ): Array<T | string> | T | string {
   const results = formatListToParts(

--- a/packages/intl/src/list.ts
+++ b/packages/intl/src/list.ts
@@ -32,7 +32,7 @@ export function formatList<T>(
     onError: OnErrorFn
   },
   getListFormat: Formatters['getListFormat'],
-  values: ReadonlyArray<string>,
+  values: ReadonlyArray<string | T>,
   options: Parameters<IntlFormatters['formatList']>[1] = {}
 ): Array<T | string> | T | string {
   const results = formatListToParts(
@@ -60,7 +60,7 @@ export function formatListToParts<T>(
     onError: OnErrorFn
   },
   getListFormat: Formatters['getListFormat'],
-  values: ReadonlyArray<string>,
+  values: ReadonlyArray<string | T>,
   options: Parameters<IntlFormatters['formatList']>[1]
 ): Part[]
 export function formatListToParts<T>(

--- a/packages/intl/src/types.ts
+++ b/packages/intl/src/types.ts
@@ -106,7 +106,11 @@ export type FormatDisplayNameOptions = Omit<
   'localeMatcher'
 >
 
-export interface IntlFormatters<T = any, R = T> {
+/**
+ * `TBase` is the type constraints of the rich text element in the formatted output.
+ * For example, with React, `TBase` should be `React.ReactNode`.
+ */
+export interface IntlFormatters<TBase = unknown> {
   formatDateTimeRange(
     from: Parameters<DateTimeFormat['formatRange']>[0],
     to: Parameters<DateTimeFormat['formatRange']>[1],
@@ -150,27 +154,27 @@ export interface IntlFormatters<T = any, R = T> {
     values?: Record<string, PrimitiveType | FormatXMLElementFn<string, string>>,
     opts?: IntlMessageFormatOptions
   ): string
-  formatMessage(
+  formatMessage<T extends TBase>(
     descriptor: MessageDescriptor,
-    values?: Record<string, PrimitiveType | T | FormatXMLElementFn<T, R>>,
+    values?: Record<string, PrimitiveType | T | FormatXMLElementFn<T>>,
     opts?: IntlMessageFormatOptions
-  ): R
+  ): string | T | (T | string)[]
   $t(
     descriptor: MessageDescriptor,
     values?: Record<string, PrimitiveType | FormatXMLElementFn<string, string>>,
     opts?: IntlMessageFormatOptions
   ): string
-  $t(
+  $t<T extends TBase>(
     descriptor: MessageDescriptor,
-    values?: Record<string, PrimitiveType | T | FormatXMLElementFn<T, R>>,
+    values?: Record<string, PrimitiveType | T | FormatXMLElementFn<T>>,
     opts?: IntlMessageFormatOptions
-  ): R
+  ): string | T | (T | string)[]
   formatList(values: ReadonlyArray<string>, opts?: FormatListOptions): string
-  formatList(
+  formatList<T extends TBase>(
     values: ReadonlyArray<string | T>,
     opts?: FormatListOptions
-  ): T | string | Array<string | T>
-  formatListToParts(
+  ): T | string | (string | T)[]
+  formatListToParts<T extends TBase>(
     values: ReadonlyArray<string | T>,
     opts?: FormatListOptions
   ): Part[]
@@ -207,7 +211,7 @@ export interface Formatters {
 
 export interface IntlShape<T = string>
   extends ResolvedIntlConfig<T>,
-    IntlFormatters {
+    IntlFormatters<T> {
   formatters: Formatters
 }
 

--- a/packages/react-intl/index.ts
+++ b/packages/react-intl/index.ts
@@ -99,6 +99,7 @@ export const FormattedNumber: React.FC<
       value: number | bigint
     }
 > = createFormattedComponent('formatNumber')
+// @ts-ignore issue w/ TS Intl types
 export const FormattedList: React.FC<
   IntlListFormatOptions & {
     value: readonly React.ReactNode[]

--- a/packages/react-intl/index.ts
+++ b/packages/react-intl/index.ts
@@ -92,14 +92,12 @@ export const FormattedTime: React.FC<
       children?(formattedTime: string): React.ReactElement | null
     }
 > = createFormattedComponent('formatTime')
-// @ts-ignore issue w/ TS Intl types
 export const FormattedNumber: React.FC<
   NumberFormatOptions &
     CustomFormatConfig & {
       value: number | bigint
     }
 > = createFormattedComponent('formatNumber')
-// @ts-ignore issue w/ TS Intl types
 export const FormattedList: React.FC<
   IntlListFormatOptions & {
     value: readonly React.ReactNode[]

--- a/packages/react-intl/tests/unit/components/message.tsx
+++ b/packages/react-intl/tests/unit/components/message.tsx
@@ -123,7 +123,9 @@ describe('<FormattedMessage>', () => {
       defaultMessage: 'Hello, World!',
     }
 
-    const H1: React.FC = ({children}) => <h1 data-testid="h1">{children}</h1>
+    const H1: React.FC<{children: React.ReactNode[]}> = ({children}) => (
+      <h1 data-testid="h1">{children}</h1>
+    )
     const {getByTestId} = mountWithProvider(
       {...descriptor, tagName: H1},
       providerProps
@@ -196,7 +198,7 @@ describe('<FormattedMessage>', () => {
           defaultMessage: 'Hello, <b>{name}</b>!',
           values: {
             name: 'Jest',
-            b: (name: string) => <b data-testid="b">{name}</b>,
+            b: (name: React.ReactNode[]) => <b data-testid="b">{name}</b>,
           },
         },
         providerProps
@@ -253,7 +255,7 @@ describe('<FormattedMessage>', () => {
           values: {
             name: 'Jest',
             b: (chunks: any[]) => <b>{chunks}</b>,
-            i: (msg: string) => <i>{msg}</i>,
+            i: (msg: React.ReactNode[]) => <i>{msg}</i>,
           },
         },
         providerProps
@@ -269,7 +271,7 @@ describe('<FormattedMessage>', () => {
           values: {
             name: 'Jest',
             b: (chunks: any) => <b>{chunks}</b>,
-            i: (msg: string) => <i>{msg}</i>,
+            i: (msg: React.ReactNode[]) => <i>{msg}</i>,
           },
         },
         providerProps

--- a/packages/react-intl/tests/unit/components/message.tsx
+++ b/packages/react-intl/tests/unit/components/message.tsx
@@ -198,7 +198,7 @@ describe('<FormattedMessage>', () => {
           defaultMessage: 'Hello, <b>{name}</b>!',
           values: {
             name: 'Jest',
-            b: (name: React.ReactNode[]) => <b data-testid="b">{name}</b>,
+            b: name => <b data-testid="b">{name}</b>,
           },
         },
         providerProps
@@ -254,8 +254,8 @@ describe('<FormattedMessage>', () => {
           defaultMessage: 'Hello, <b>{name}<i>!</i></b>',
           values: {
             name: 'Jest',
-            b: (chunks: any[]) => <b>{chunks}</b>,
-            i: (msg: React.ReactNode[]) => <i>{msg}</i>,
+            b: chunks => <b>{chunks}</b>,
+            i: msg => <i>{msg}</i>,
           },
         },
         providerProps
@@ -271,7 +271,7 @@ describe('<FormattedMessage>', () => {
           values: {
             name: 'Jest',
             b: (chunks: any) => <b>{chunks}</b>,
-            i: (msg: React.ReactNode[]) => <i>{msg}</i>,
+            i: msg => <i>{msg}</i>,
           },
         },
         providerProps

--- a/packages/react-intl/tests/unit/react-intl.tsx
+++ b/packages/react-intl/tests/unit/react-intl.tsx
@@ -1,4 +1,5 @@
-import * as ReactIntl from '../../'
+import * as React from 'react'
+import * as ReactIntl from '../..'
 import * as ts from 'typescript'
 import fs from 'fs'
 import lexer from 'cjs-module-lexer'
@@ -83,6 +84,31 @@ describe('react-intl', () => {
 
     it.each(keys)('has named export "%s"', key => {
       expect(parsed.exports).toContain(key)
+    })
+  })
+
+  describe('types', () => {
+    // https://github.com/formatjs/formatjs/issues/3856
+    it('works with react18 typing', () => {
+      function Test() {
+        const messages = ReactIntl.defineMessages({
+          greeting: {
+            id: 'app.greeting',
+            defaultMessage: 'Hello, <bold>{name}</bold>!',
+            description: 'Greeting to welcome the user to the app',
+          },
+        })
+
+        const intl = ReactIntl.useIntl()
+
+        return intl.formatMessage(messages.greeting, {
+          name: 'Eric',
+          bold: str => <b>{str}</b>,
+        })
+      }
+
+      // This test only need to pass the type checking.
+      ;<Test />
     })
   })
 })

--- a/packages/ts-transformer/integration-tests/integration/ts-jest.test.tsx
+++ b/packages/ts-transformer/integration-tests/integration/ts-jest.test.tsx
@@ -26,7 +26,7 @@ describe('ts-jest transformer', function () {
   })
   it('Comp', function () {
     expect(ReactDOMServer.renderToString(<Component />)).toEqual(
-      '<span data-reactroot="">lQsqfv<!-- --> - <!-- -->[{&quot;type&quot;:0,&quot;value&quot;:&quot;test message&quot;}]<!-- --> - <!-- --> <!-- -->- <!-- -->fooo</span>'
+      '<span>lQsqfv<!-- --> - <!-- -->[{&quot;type&quot;:0,&quot;value&quot;:&quot;test message&quot;}]<!-- --> - <!-- --> <!-- -->- <!-- -->fooo</span>'
     )
   })
 })

--- a/packages/vue-intl/index.ts
+++ b/packages/vue-intl/index.ts
@@ -1,4 +1,7 @@
-import {MessageDescriptor} from '@formatjs/intl'
+import {
+  IntlFormatters as CoreIntlFormatters,
+  MessageDescriptor,
+} from '@formatjs/intl'
 export * from './plugin'
 export * from './provider'
 export {intlKey} from './injection-key'
@@ -10,7 +13,6 @@ export {
   MessageDescriptor,
   IntlCache,
   Formatters,
-  IntlFormatters,
   FormatDisplayNameOptions,
   FormatListOptions,
   FormatPluralOptions,
@@ -27,6 +29,10 @@ export {
   IntlErrorCode,
   IntlError,
 } from '@formatjs/intl'
+import {VNode} from 'vue'
+
+export type IntlFormatters = CoreIntlFormatters<VNode>
+
 export function defineMessages<
   K extends keyof any,
   T = MessageDescriptor,

--- a/packages/vue-intl/provider.ts
+++ b/packages/vue-intl/provider.ts
@@ -1,13 +1,13 @@
 import {IntlShape} from '@formatjs/intl'
-import {inject, provide} from 'vue'
+import {inject, provide, VNode} from 'vue'
 import {intlKey} from './injection-key'
 
-export function provideIntl(intl: IntlShape<string>) {
+export function provideIntl(intl: IntlShape<VNode>) {
   provide(intlKey, intl)
 }
 
 export function useIntl() {
-  const intl = inject<IntlShape<string>>(intlKey)
+  const intl = inject<IntlShape<VNode>>(intlKey)
   if (!intl) {
     throw new Error(
       `An intl object was not injected. Install the plugin or use provideIntl.`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,7 +30,7 @@ importers:
       '@lerna-lite/cli': ^1.10.0
       '@lerna-lite/list': ^1.10.0
       '@testing-library/jest-dom': ^5.11.5
-      '@testing-library/react': ^12.0.0
+      '@testing-library/react': ^13.4.0
       '@types/babel__core': ^7.1.7
       '@types/babel__helper-plugin-utils': ^7.10.0
       '@types/babel__traverse': ^7.1.7
@@ -130,7 +130,7 @@ importers:
       '@lerna-lite/cli': 1.10.0
       '@lerna-lite/list': 1.10.0
       '@testing-library/jest-dom': 5.16.4
-      '@testing-library/react': 12.1.5_sfoxds7t5ydpegc3knd667wn6m
+      '@testing-library/react': 13.4.0_biqbaboplfbrettd7655fr4n2y
       '@types/babel__core': 7.1.19
       '@types/babel__helper-plugin-utils': 7.10.0
       '@types/babel__traverse': 7.17.1
@@ -196,8 +196,8 @@ importers:
       picomatch: 2.3.1
       pnpm: 7.9.3
       prettier: 2.7.1
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
       regenerate: 1.4.2
       rimraf: 3.0.2
       serialize-javascript: 6.0.0
@@ -5885,7 +5885,7 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@babel/code-frame': 7.18.6
-      '@babel/runtime': 7.18.3
+      '@babel/runtime': 7.18.9
       '@types/aria-query': 4.2.2
       aria-query: 5.0.0
       chalk: 4.1.2
@@ -5909,18 +5909,18 @@ packages:
       redent: 3.0.0
     dev: true
 
-  /@testing-library/react/12.1.5_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-OfTXCJUFgjd/digLUuPxa0+/3ZxsQmE7ub9kcbW/wi96Bh3o/p5vrETcBGfP17NWPGqeYYl5LTRpwyGoMC4ysg==}
+  /@testing-library/react/13.4.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-sXOGON+WNTh3MLE9rve97ftaZukN3oNf2KjDy7YTx6hcTO2uuLHuCGynMDhFwGw/jYf4OJ2Qk0i4i79qMNNkyw==}
     engines: {node: '>=12'}
     peerDependencies:
-      react: <18.0.0
-      react-dom: <18.0.0
+      react: ^18.0.0
+      react-dom: ^18.0.0
     dependencies:
-      '@babel/runtime': 7.18.3
+      '@babel/runtime': 7.18.9
       '@testing-library/dom': 8.14.0
-      '@types/react-dom': 17.0.17
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
+      '@types/react-dom': 18.0.5
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
     dev: true
 
   /@tootallnate/once/2.0.0:
@@ -6248,12 +6248,6 @@ packages:
     resolution: {integrity: sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==}
     dev: true
 
-  /@types/react-dom/17.0.17:
-    resolution: {integrity: sha512-VjnqEmqGnasQKV0CWLevqMTXBYG9GbwuE6x3VetERLh0cq2LTptFE73MrQi2S7GkKXCf2GgwItB/melLnxfnsg==}
-    dependencies:
-      '@types/react': 17.0.47
-    dev: true
-
   /@types/react-dom/18.0.5:
     resolution: {integrity: sha512-OWPWTUrY/NIrjsAPkAk1wW9LZeIjSvkXRhclsFO8CZcZGCOg2G0YZy4ft+rOyYxy8B7ui5iZzi9OkDebZ7/QSA==}
     dependencies:
@@ -6281,14 +6275,6 @@ packages:
     dependencies:
       '@types/history': 4.7.11
       '@types/react': 18.0.14
-    dev: true
-
-  /@types/react/17.0.47:
-    resolution: {integrity: sha512-mk0BL8zBinf2ozNr3qPnlu1oyVTYq+4V7WA76RgxUAtf0Em/Wbid38KN6n4abEkvO4xMTBWmnP1FtQzgkEiJoA==}
-    dependencies:
-      '@types/prop-types': 15.7.5
-      '@types/scheduler': 0.16.2
-      csstype: 3.1.0
     dev: true
 
   /@types/react/18.0.14:
@@ -14822,6 +14808,16 @@ packages:
       scheduler: 0.20.2
     dev: true
 
+  /react-dom/18.2.0_react@18.2.0:
+    resolution: {integrity: sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==}
+    peerDependencies:
+      react: ^18.2.0
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.2.0
+      scheduler: 0.23.0
+    dev: true
+
   /react-error-overlay/6.0.11:
     resolution: {integrity: sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==}
     dev: true
@@ -14981,6 +14977,13 @@ packages:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
+    dev: true
+
+  /react/18.2.0:
+    resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      loose-envify: 1.4.0
     dev: true
 
   /read-package-json-fast/2.0.3:
@@ -15498,6 +15501,12 @@ packages:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
+    dev: true
+
+  /scheduler/0.23.0:
+    resolution: {integrity: sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==}
+    dependencies:
+      loose-envify: 1.4.0
     dev: true
 
   /schema-utils/2.7.0:


### PR DESCRIPTION
Fixes #3856
Fixes #3707

1. Now `IntlFormatters` only take one type parameter `TBase`, which is the type constraint of the rich text element. For React, this will be `React.ReactNode`, requiring the rich text element to extend from `React.ReactNode`.
2. `formatMessage`, `$t`, and `formatList` now types the type parameter `T`, which must satisfy `T extends TBase`. Doing so makes the formatter typing parametric to the callsite, which is more accurate than instantiating the type parameter on the `IntlFormatters` or its subtypes.
