### PR TITLE
Fixed typo

### DIFF
--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -305,7 +305,7 @@ yarn add -D @formatjs/ts-transformer
 
 Take a look at [`ts-jest` guide](https://kulshekhar.github.io/ts-jest/docs/getting-started/options/astTransformers) on how to incorporate custom AST Transformers.
 
-### `ttypescript`
+### `typescript`
 
 <Tabs
 groupId="npm"


### PR DESCRIPTION
`ttypescript` --> `typescript`