### PR TITLE
Allow `--format default` in CLI and updated documentation

### DIFF
--- a/packages/cli-lib/src/formatters/index.ts
+++ b/packages/cli-lib/src/formatters/index.ts
@@ -35,6 +35,8 @@ export async function resolveBuiltinFormatter(
       return lokalise
     case 'crowdin':
       return crowdin
+    case 'default':
+      return defaultFormatter
   }
   try {
     // eslint-disable-next-line import/dynamic-import-chunkname

--- a/website/docs/getting-started/application-workflow.md
+++ b/website/docs/getting-started/application-workflow.md
@@ -18,16 +18,21 @@ This guide will give you an idea of how to work with both types of tools.
 projectRoot
 |-- src
 |   |-- App.js
+|   |-- lang
+|      |-- fr.json
+|      |-- de.json
 |-- extracted
 |   |-- en.json
-|-- lang
-|   |-- fr.json
-|   |-- de.json
 |-- package.json
 |-- .eslintrc.js
 ```
 
-The extracted translation files live in the `extracted` folder since they have a different internal structure (e.g. they contain additional information like the comments). The translation files produced during the translation process are stored in the `lang` folder.
+In this scenario, the default messages are extracted from your source code into the `extracted` folder. The translation editor treats this file as read only because it would be overwritten with the next extraction run. 
+
+The translated messages are stored in the `lang` folder for a direct import into your application. This has the advantage that your app updates automatically with each save in the editor. The translations in this folder have the simple format.
+
+It's also possible to compile the translation files. This requires an additional step in which the files are parsed and stored with some additional information. The files are a bit bigger but speed up you application startup if you have many translations.
+
 
 ### The workflow
 

--- a/website/docs/getting-started/message-extraction.md
+++ b/website/docs/getting-started/message-extraction.md
@@ -298,7 +298,7 @@ We also provide several [builtin formatters](../tooling/cli.md#builtin-formatter
 
 | TMS                                                                                        | `--format`  |
 | ------------------------------------------------------------------------------------------ | ----------- |
-| [BabelEdit](https://www.codeandweb.com/babeledit/format-js)                                | `simple`    |
+| [BabelEdit](https://www.codeandweb.com/babeledit/format-js)                                | `default`   |
 | [Crowdin Chrome JSON](https://support.crowdin.com/file-formats/chrome-json/)               | `crowdin`   |
 | [Lingohub](https://lingohub.com/developers/resource-files/json-localization/)              | `simple`    |
 | [Localize's Simple JSON](https://developers.localizejs.com/docs/simple-json-import-export) | `simple`    |

--- a/website/docs/tooling/cli.md
+++ b/website/docs/tooling/cli.md
@@ -406,7 +406,7 @@ We provide the following built-in formatters to integrate with 3rd party TMSes:
 
 | TMS                                                                                        | `--format`  |
 | ------------------------------------------------------------------------------------------ | ----------- |
-| [BabelEdit](https://www.codeandweb.com/babeledit/format-js)                                | `simple`    |
+| [BabelEdit](https://www.codeandweb.com/babeledit/format-js)                                | `default`   |
 | [Crowdin Chrome JSON](https://support.crowdin.com/file-formats/chrome-json/)               | `crowdin`   |
 | [Lingohub](https://lingohub.com/developers/resource-files/json-localization/)              | `simple`    |
 | [Localize's Simple JSON](https://developers.localizejs.com/docs/simple-json-import-export) | `simple`    |


### PR DESCRIPTION
Changes:

- Updated the documentation with a better explanation of a purely local workflow.
- Updated extraction documentation: BabelEdit supports the `default` format - including comments - this is better than using `simple`
- Adde support for `--format default` to the CLI to make it consistent with the other extraction tools. Specifying `--format default` in the current version of the CLI tool tries to read the `default` format from the current directory.
