### PR TITLE
fix(@formatjs/intl): fix missing properties in type inference

### DIFF
--- a/packages/intl/src/types.ts
+++ b/packages/intl/src/types.ts
@@ -25,8 +25,8 @@ import {NumberFormatOptions} from '@formatjs/ecma402-abstract'
 
 declare global {
   namespace FormatjsIntl {
-    interface Message {}
-    interface IntlConfig {}
+    interface Message { ids?: string }
+    interface IntlConfig { locale?: string }
     interface Formats {}
   }
 }


### PR DESCRIPTION
Typescript 4.9 doesn't like empty interfaces to infer non-existing files.

This commit introduces default values as optional properties to appease Typescript.

---

Fixes: #3905 
Fixes: #3910