### PR TITLE
fix(@formatjs/intl): fix type checker errors with TypeScript 4.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "ts-jest": "28",
     "ts-loader": "^9.1.2",
     "ts-node": "^10.8",
+    "tsd": "^0.24.1",
     "tslib": "2.4.0",
     "typescript": "^4.7",
     "unidiff": "^1.0.2",

--- a/packages/intl/BUILD
+++ b/packages/intl/BUILD
@@ -1,8 +1,10 @@
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_js//npm/private:npm_package.bzl", "npm_package")
+load("@npm//:tsd/package_json.bzl", tsd_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:index.bzl", "check_format", "package_json_test", "ts_compile")
 load("//tools:jest.bzl", "jest_test")
+load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 
 npm_link_all_packages(name = "node_modules")
 
@@ -76,4 +78,32 @@ check_format(
 package_json_test(
     name = "package_json_test",
     deps = SRC_DEPS,
+)
+
+# TODO: make this a macro that paramtrizes on `.test-d.ts` files.
+copy_to_directory(
+    name = "global_type_overrides_test_files",
+    srcs = [
+        ":%s" % PACKAGE_NAME,
+        "tests/global_type_overrides.test-d.ts"
+    ],
+    out = "type_test_files",
+    # Remove the prefix so the package directory merges with the test file directory.
+    replace_prefixes = dict([
+        ("%s" % PACKAGE_NAME, "")
+    ])
+)
+
+tsd_bin.tsd_test(
+    name = "global_type_overrides_test",
+    data = [
+        "//:node_modules/tsd",
+        ":global_type_overrides_test_files",
+        "tsconfig.json",
+    ] + SRC_DEPS,
+    args = [
+        "--files",
+        "tests/**/*.test-d.ts"
+    ],
+    chdir = "packages/%s/type_test_files" % PACKAGE_NAME
 )

--- a/packages/intl/src/types.ts
+++ b/packages/intl/src/types.ts
@@ -23,6 +23,9 @@ import {
 import {DEFAULT_INTL_CONFIG} from './utils'
 import {NumberFormatOptions} from '@formatjs/ecma402-abstract'
 
+// Note: FormatjsIntl is defined as a global namespace so the library user can
+// override the default types of Message.ids (e.g. as string literal unions from extracted strings)
+// or IntlConfig.locale (e.g. to a list of supported locales).
 declare global {
   namespace FormatjsIntl {
     interface Message {}
@@ -31,12 +34,14 @@ declare global {
   }
 }
 
-type MessageIds = FormatjsIntl.Message extends {ids: string}
-  ? FormatjsIntl.Message['ids']
-  : string
+// NOTE: workaround the TypeScript 4.9 bug: https://github.com/formatjs/formatjs/issues/3910
+type _Message = FormatjsIntl.Message
+type MessageIds = _Message extends {ids: string} ? _Message['ids'] : string
 
-type Locale = FormatjsIntl.IntlConfig extends {locale: string}
-  ? FormatjsIntl.IntlConfig['locale']
+// NOTE: workaround the TypeScript 4.9 bug: https://github.com/formatjs/formatjs/issues/3910
+type _IntlConfig = FormatjsIntl.IntlConfig
+type Locale = _IntlConfig extends {locale: string}
+  ? _IntlConfig['locale']
   : string
 
 export type OnErrorFn = (

--- a/packages/intl/tests/global_type_overrides.test-d.ts
+++ b/packages/intl/tests/global_type_overrides.test-d.ts
@@ -1,0 +1,18 @@
+import {expectType} from 'tsd'
+import {MessageDescriptor, ResolvedIntlConfig} from '../src/types'
+
+// Example type overrides
+declare global {
+  namespace FormatjsIntl {
+    interface Message {
+      ids: 'a' | 'b'
+    }
+    interface IntlConfig {
+      locale: 'en-US' | 'zh-CN'
+    }
+  }
+}
+
+// Check that the type overrides actually work.
+expectType<'a' | 'b'>(null as any as NonNullable<MessageDescriptor['id']>)
+expectType<'en-US' | 'zh-CN'>(null as any as ResolvedIntlConfig['locale'])

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,7 @@ importers:
       ts-jest: '28'
       ts-loader: ^9.1.2
       ts-node: ^10.8
+      tsd: ^0.24.1
       tslib: 2.4.0
       typescript: ^4.7
       unidiff: ^1.0.2
@@ -205,6 +206,7 @@ importers:
       ts-jest: 28.0.8_gagsrpfcf57grbi77unje5kuni
       ts-loader: 9.3.1_3o2jfq6vfqxns3sz6wn2nnc3ei
       ts-node: 10.8.1_x2utdhayajzrh747hktprshhby
+      tsd: 0.24.1
       tslib: 2.4.0
       typescript: 4.7.4
       unidiff: 1.0.2
@@ -6362,6 +6364,10 @@ packages:
     resolution: {integrity: sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==}
     dev: true
 
+  /@tsd/typescript/4.8.4:
+    resolution: {integrity: sha512-WMFNVstwWGyDuZP2LGPRZ+kPHxZLmhO+2ormstDvnXiyoBPtW1qq9XhhrkI4NVtxgs+2ZiUTl9AG7nNIRq/uCg==}
+    dev: true
+
   /@types/aria-query/4.2.2:
     resolution: {integrity: sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==}
     dev: true
@@ -6452,6 +6458,13 @@ packages:
     dependencies:
       '@types/eslint': 8.4.3
       '@types/estree': 1.0.0
+    dev: true
+
+  /@types/eslint/7.29.0:
+    resolution: {integrity: sha512-VNcvioYDH8/FxaeTKkM4/TiTwt6pBV9E3OfGmvaw8tPl0rrHCJ4Ll15HRT+pMiFAf/MLQvAzC+6RzUMEL9Ceng==}
+    dependencies:
+      '@types/estree': 1.0.0
+      '@types/json-schema': 7.0.11
     dev: true
 
   /@types/eslint/8.4.3:
@@ -10188,6 +10201,24 @@ packages:
       - utf-8-validate
     dev: true
 
+  /eslint-formatter-pretty/4.1.0:
+    resolution: {integrity: sha512-IsUTtGxF1hrH6lMWiSl1WbGaiP01eT6kzywdY1U+zLc0MP+nwEnUiS9UI8IaOTUhTeQJLlCEWIbXINBH4YJbBQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      '@types/eslint': 7.29.0
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      eslint-rule-docs: 1.1.235
+      log-symbols: 4.1.0
+      plur: 4.0.0
+      string-width: 4.2.3
+      supports-hyperlinks: 2.2.0
+    dev: true
+
+  /eslint-rule-docs/1.1.235:
+    resolution: {integrity: sha512-+TQ+x4JdTnDoFEXXb3fDvfGOwnyNV7duH8fXWTPD1ieaBmB8omj7Gw/pMBBu4uI2uJCCU8APDaQJzWuXnTsH4A==}
+    dev: true
+
   /eslint-scope/5.1.1:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
     engines: {node: '>=8.0.0'}
@@ -11950,6 +11981,11 @@ packages:
   /ipaddr.js/2.0.1:
     resolution: {integrity: sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng==}
     engines: {node: '>= 10'}
+    dev: true
+
+  /irregular-plurals/3.3.0:
+    resolution: {integrity: sha512-MVBLKUTangM3EfRPFROhmWQQKRDsrgI83J8GS3jXy+OwYqiR2/aoWndYQ5416jLE3uaGgLH7ncme3X9y09gZ3g==}
+    engines: {node: '>=8'}
     dev: true
 
   /is-alphabetical/1.0.4:
@@ -14132,6 +14168,24 @@ packages:
       yargs-parser: 20.2.9
     dev: true
 
+  /meow/9.0.0:
+    resolution: {integrity: sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      '@types/minimist': 1.2.2
+      camelcase-keys: 6.2.2
+      decamelize: 1.2.0
+      decamelize-keys: 1.1.0
+      hard-rejection: 2.1.0
+      minimist-options: 4.1.0
+      normalize-package-data: 3.0.3
+      read-pkg-up: 7.0.1
+      redent: 3.0.0
+      trim-newlines: 3.0.1
+      type-fest: 0.18.1
+      yargs-parser: 20.2.9
+    dev: true
+
   /merge-descriptors/1.0.1:
     resolution: {integrity: sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==}
     dev: true
@@ -15261,6 +15315,13 @@ packages:
 
   /platform/1.3.6:
     resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
+    dev: true
+
+  /plur/4.0.0:
+    resolution: {integrity: sha512-4UGewrYgqDFw9vV6zNV+ADmPAUAfJPKtGvb/VdpQAx25X5f3xXdGdyOEVFwkl8Hl/tl7+xbeHqSEM+D5/TirUg==}
+    engines: {node: '>=10'}
+    dependencies:
+      irregular-plurals: 3.3.0
     dev: true
 
   /pnpm/7.9.3:
@@ -18047,6 +18108,19 @@ packages:
       typescript: 4.7.4
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    dev: true
+
+  /tsd/0.24.1:
+    resolution: {integrity: sha512-sD+s81/2aM4RRhimCDttd4xpBNbUFWnoMSHk/o8kC8Ek23jljeRNWjsxFJmOmYLuLTN9swRt1b6iXfUXTcTiIA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
+    dependencies:
+      '@tsd/typescript': 4.8.4
+      eslint-formatter-pretty: 4.1.0
+      globby: 11.1.0
+      meow: 9.0.0
+      path-exists: 4.0.0
+      read-pkg-up: 7.0.1
     dev: true
 
   /tslib/1.14.1:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,6 +27,9 @@
     "jsx": "react"
   },
   "exclude": [
-    "packages/react-intl/example-sandboxes"
+    "packages/react-intl/example-sandboxes",
+    // Exclude any tsd tests because they can mess with normal
+    // type checking in editors.
+    "**/*.test-d.ts"
   ]
 }


### PR DESCRIPTION
Supersedes #3912
Fixes #3905
Fixes #3910

This PR fixes the type checking issue of `MessageIds` and `Locale` under TypeScript 4.9.

It may be a TypeScript bug, because this does not work:

```ts
type MessageIds = FormatjsIntl.Message extends {ids: string}
  ? FormatjsIntl.Message['ids']
  : string
```

But this works:

```ts
type _Message = FormatjsIntl.Message
type MessageIds = _Message extends {ids: string}
  ? _Message['ids']
  : string
```

🤷 The only difference is aliasing the type from the namespace.

---

I also added a `tsd` test to verify that the global type override works as expected.