### PR TITLE
fix(@formatjs/cli-lib): fix incorrect en-LS generation that may drop the last chunk

### DIFF
--- a/packages/cli-lib/src/pseudo_locale.ts
+++ b/packages/cli-lib/src/pseudo_locale.ts
@@ -12,10 +12,10 @@ export function generateXXLS(
   msg: string | MessageFormatElement[]
 ): MessageFormatElement[] {
   const ast = typeof msg === 'string' ? parse(msg) : msg
-  const lastChunk = ast.pop()
+  const lastChunk = ast[ast.length - 1]
   if (lastChunk && isLiteralElement(lastChunk)) {
     lastChunk.value += 'SSSSSSSSSSSSSSSSSSSSSSSSS'
-    return [...ast, lastChunk]
+    return ast
   }
   return [...ast, {type: TYPE.literal, value: 'SSSSSSSSSSSSSSSSSSSSSSSSS'}]
 }

--- a/packages/cli-lib/tests/unit/__snapshots__/pseudo_locale.test.ts.snap
+++ b/packages/cli-lib/tests/unit/__snapshots__/pseudo_locale.test.ts.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`pseudo-locale: xx-LS works with messages that ends with a tag 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "Foo ",
+  },
+  Object {
+    "children": Array [
+      Object {
+        "type": 0,
+        "value": "bar",
+      },
+    ],
+    "type": 8,
+    "value": "a",
+  },
+  Object {
+    "type": 0,
+    "value": "SSSSSSSSSSSSSSSSSSSSSSSSS",
+  },
+]
+`;

--- a/packages/cli-lib/tests/unit/pseudo_locale.test.ts
+++ b/packages/cli-lib/tests/unit/pseudo_locale.test.ts
@@ -1,0 +1,7 @@
+import {generateXXLS} from '../../src/pseudo_locale'
+
+describe.only('pseudo-locale: xx-LS', () => {
+  it('works with messages that ends with a tag', () => {
+    expect(generateXXLS('Foo <a>bar</a>')).toMatchSnapshot()
+  })
+})

--- a/packages/cli/integration-tests/compile/__snapshots__/integration.test.ts.snap
+++ b/packages/cli/integration-tests/compile/__snapshots__/integration.test.ts.snap
@@ -1010,6 +1010,30 @@ Object {
       \\"value\\": \\"I have \\"
     },
     {
+      \\"offset\\": 0,
+      \\"options\\": {
+        \\"one\\": {
+          \\"value\\": [
+            {
+              \\"type\\": 0,
+              \\"value\\": \\"a dog\\"
+            }
+          ]
+        },
+        \\"other\\": {
+          \\"value\\": [
+            {
+              \\"type\\": 0,
+              \\"value\\": \\"many dogs\\"
+            }
+          ]
+        }
+      },
+      \\"pluralType\\": \\"cardinal\\",
+      \\"type\\": 6,
+      \\"value\\": \\"count\\"
+    },
+    {
       \\"type\\": 0,
       \\"value\\": \\"SSSSSSSSSSSSSSSSSSSSSSSSS\\"
     }
@@ -1018,6 +1042,36 @@ Object {
     {
       \\"type\\": 0,
       \\"value\\": \\"I have \\"
+    },
+    {
+      \\"offset\\": 0,
+      \\"options\\": {
+        \\"one\\": {
+          \\"value\\": [
+            {
+              \\"children\\": [
+                {
+                  \\"type\\": 0,
+                  \\"value\\": \\"a dog\\"
+                }
+              ],
+              \\"type\\": 8,
+              \\"value\\": \\"b\\"
+            }
+          ]
+        },
+        \\"other\\": {
+          \\"value\\": [
+            {
+              \\"type\\": 0,
+              \\"value\\": \\"many dogs\\"
+            }
+          ]
+        }
+      },
+      \\"pluralType\\": \\"cardinal\\",
+      \\"type\\": 6,
+      \\"value\\": \\"count\\"
     },
     {
       \\"type\\": 0,
@@ -1030,6 +1084,46 @@ Object {
       \\"value\\": \\"I have \\"
     },
     {
+      \\"offset\\": 0,
+      \\"options\\": {
+        \\"one\\": {
+          \\"value\\": [
+            {
+              \\"children\\": [
+                {
+                  \\"type\\": 0,
+                  \\"value\\": \\"a \\"
+                },
+                {
+                  \\"children\\": [
+                    {
+                      \\"type\\": 0,
+                      \\"value\\": \\"dog\\"
+                    }
+                  ],
+                  \\"type\\": 8,
+                  \\"value\\": \\"i\\"
+                }
+              ],
+              \\"type\\": 8,
+              \\"value\\": \\"b\\"
+            }
+          ]
+        },
+        \\"other\\": {
+          \\"value\\": [
+            {
+              \\"type\\": 0,
+              \\"value\\": \\"many dogs\\"
+            }
+          ]
+        }
+      },
+      \\"pluralType\\": \\"cardinal\\",
+      \\"type\\": 6,
+      \\"value\\": \\"count\\"
+    },
+    {
       \\"type\\": 0,
       \\"value\\": \\"SSSSSSSSSSSSSSSSSSSSSSSSS\\"
     }
@@ -1038,6 +1132,10 @@ Object {
     {
       \\"type\\": 0,
       \\"value\\": \\"my name is \\"
+    },
+    {
+      \\"type\\": 1,
+      \\"value\\": \\"name\\"
     },
     {
       \\"type\\": 0,


### PR DESCRIPTION
This PR fixes the bug in the `en-LS` pseudo-locale generation, where if the last chunk of the message is not a literal element, we erroneously drop the last chunk and replace it with the synthesized `SSSSSSSSSSSSSSSSSSSSSSSSS` literal element.