### PR TITLE
fix(eslint-plugin-formatjs): adding $t, an alternative to formatMessage

### DIFF
--- a/packages/eslint-plugin-formatjs/tests/enforce-placeholders.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/enforce-placeholders.test.ts
@@ -166,5 +166,17 @@ ruleTester.run('enforce-placeholders', enforcePlaceholders, {
         },
       ],
     },
+    {
+      code: `
+      {$t({ 
+        defaultMessage: "My name is {name}" 
+      })}
+      `,
+      errors: [
+        {
+          message: 'Missing value for placeholder "name"',
+        },
+      ]
+    }
   ],
 })

--- a/packages/eslint-plugin-formatjs/util.ts
+++ b/packages/eslint-plugin-formatjs/util.ts
@@ -7,7 +7,7 @@ export interface MessageDescriptor {
   description?: string | object
 }
 
-const FORMAT_FUNCTION_NAMES = new Set(['$formatMessage', 'formatMessage'])
+const FORMAT_FUNCTION_NAMES = new Set(['$formatMessage', 'formatMessage', '$t'])
 const COMPONENT_NAMES = new Set(['FormattedMessage'])
 const DECLARATION_FUNCTION_NAMES = new Set(['defineMessage'])
 


### PR DESCRIPTION
This is to address #3930

Eslint should catch the error when placeholder is not used when using $t which seems to have been added here:
https://github.com/formatjs/formatjs/commit/a0ab2d431b0bb714fd9173b7492190fa006c88be

# How did I test?

`pnpm bazel test //packages/eslint-plugin-formatjs:unit-enforce-placeholders`