### PR TITLE
fix(@formatjs/cli-lib): fix incorrect xx-HA generation

### DIFF
--- a/packages/cli-lib/src/pseudo_locale.ts
+++ b/packages/cli-lib/src/pseudo_locale.ts
@@ -42,12 +42,12 @@ export function generateXXHA(
   msg: string | MessageFormatElement[]
 ): MessageFormatElement[] {
   const ast = typeof msg === 'string' ? parse(msg) : msg
-  const firstChunk = ast.shift()
+  const [firstChunk, ...rest] = ast
   if (firstChunk && isLiteralElement(firstChunk)) {
     firstChunk.value = '[javascript]' + firstChunk.value
-    return [firstChunk, ...ast]
+    return [firstChunk, ...rest]
   }
-  return [{type: TYPE.literal, value: '[javascript]'}, ...ast]
+  return [{type: TYPE.literal, value: '[javascript]'}, ...rest]
 }
 
 const ASCII = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'

--- a/packages/cli-lib/tests/unit/__snapshots__/pseudo_locale.test.ts.snap
+++ b/packages/cli-lib/tests/unit/__snapshots__/pseudo_locale.test.ts.snap
@@ -1,5 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`pseudo-locale: en-HA works with message that does not contain literal element 1`] = `
+Array [
+  Object {
+    "type": 1,
+    "value": "foo",
+  },
+  Object {
+    "type": 0,
+    "value": "SSSSSSSSSSSSSSSSSSSSSSSSS",
+  },
+]
+`;
+
+exports[`pseudo-locale: xx-LS works with message that does not contain literal element 1`] = `
+Array [
+  Object {
+    "type": 1,
+    "value": "foo",
+  },
+  Object {
+    "type": 0,
+    "value": "SSSSSSSSSSSSSSSSSSSSSSSSS",
+  },
+]
+`;
+
 exports[`pseudo-locale: xx-LS works with messages that ends with a tag 1`] = `
 Array [
   Object {

--- a/packages/cli-lib/tests/unit/pseudo_locale.test.ts
+++ b/packages/cli-lib/tests/unit/pseudo_locale.test.ts
@@ -1,7 +1,17 @@
 import {generateXXLS} from '../../src/pseudo_locale'
 
-describe.only('pseudo-locale: xx-LS', () => {
+describe('pseudo-locale: xx-LS', () => {
   it('works with messages that ends with a tag', () => {
     expect(generateXXLS('Foo <a>bar</a>')).toMatchSnapshot()
+  })
+
+  it('works with message that does not contain literal element', () => {
+    expect(generateXXLS('{foo}')).toMatchSnapshot()
+  })
+})
+
+describe('pseudo-locale: en-HA', () => {
+  it('works with message that does not contain literal element', () => {
+    expect(generateXXLS('{foo}')).toMatchSnapshot()
   })
 })


### PR DESCRIPTION
This PR fixes the issue where if `xx-HA` transform is applied to a string that does not start with a literal element, its first element will be incorrectly replaced by the generated prefix literal element.