### PR TITLE
fix(@formatjs/intl): update IntlFormatters.formatNumber value type

### DIFF
--- a/packages/intl-numberformat/src/types.ts
+++ b/packages/intl-numberformat/src/types.ts
@@ -12,7 +12,7 @@ import {
 export interface NumberFormat {
   resolvedOptions(): ResolvedNumberFormatOptions
   formatToParts(x: number): NumberFormatPart[]
-  format(x: number): string
+  format(x: number | string): string
   formatRange(start: number, end: number): string
   formatRangeToParts(start: number, end: number): NumberRangeToParts[]
 }

--- a/packages/intl/src/number.ts
+++ b/packages/intl/src/number.ts
@@ -67,7 +67,9 @@ export function formatNumber(
   options: Parameters<IntlFormatters['formatNumber']>[1] = {}
 ): string {
   try {
-    return getFormatter(config, getNumberFormat, options).format(value)
+    return getFormatter(config, getNumberFormat, options).format(
+      value as number
+    )
   } catch (e) {
     config.onError(
       new IntlError(IntlErrorCode.FORMAT_ERROR, 'Error formatting number.', e)

--- a/packages/intl/src/types.ts
+++ b/packages/intl/src/types.ts
@@ -145,7 +145,7 @@ export interface IntlFormatters<TBase = unknown> {
     opts?: FormatRelativeTimeOptions
   ): string
   formatNumber(
-    value: Parameters<Intl.NumberFormat['format']>[0],
+    value: Parameters<Intl.NumberFormat['format']>[0] | string,
     opts?: FormatNumberOptions
   ): string
   formatNumberToParts(

--- a/packages/react-intl/index.ts
+++ b/packages/react-intl/index.ts
@@ -95,7 +95,7 @@ export const FormattedTime: React.FC<
 export const FormattedNumber: React.FC<
   Omit<NumberFormatOptions, 'localeMatcher'> &
     CustomFormatConfig<'number'> & {
-      value: number
+      value: number | string
       children?(formattedNumber: string): React.ReactElement | null
     }
 > = createFormattedComponent('formatNumber')

--- a/website/docs/intl.md
+++ b/website/docs/intl.md
@@ -100,7 +100,7 @@ interface IntlFormatters {
     unit?: FormattableUnit,
     opts?: FormatRelativeTimeOptions
   ): string
-  formatNumber(value: number, opts?: FormatNumberOptions): string
+  formatNumber(value: number | string, opts?: FormatNumberOptions): string
   formatNumberToParts(
     value: number,
     opts?: FormatNumberOptions

--- a/website/docs/react-intl/api.md
+++ b/website/docs/react-intl/api.md
@@ -156,7 +156,7 @@ interface IntlFormatters {
     unit?: FormattableUnit,
     opts?: FormatRelativeTimeOptions
   ): string
-  formatNumber(value: number, opts?: FormatNumberOptions): string
+  formatNumber(value: number | string, opts?: stringOptions): string
   formatNumberToParts(
     value: number,
     opts?: FormatNumberOptions


### PR DESCRIPTION
I opened #3949 because I noticed a TS error was being thrown when passing a `string` type value to `formatNumber`, which I don't believe should be raised since `Intl.FormatNumber.prototype.format` does support string values as indicated [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/format#parameters)

Please let me know if there's anything I've missed! Apologies if I've jumped the gun on creating a PR prior to having my issue triaged 🙏🏻  