### PR TITLE
fix(@formatjs/fast-memoize): correct Cache.get return type

### DIFF
--- a/packages/fast-memoize/index.ts
+++ b/packages/fast-memoize/index.ts
@@ -13,7 +13,7 @@ interface CacheCreateFunc<K, V> {
 }
 
 interface DefaultCache<K, V> {
-  get(key: K): V
+  get(key: K): V | undefined
   set(key: K, value: V): void
 }
 


### PR DESCRIPTION
Hello 👋

A tiny fix to correct Cache.get type, as it's an object lookup on unknown key it can return undefined

Thanks