### PR TITLE
feat(intl-messageformat): support more parse options in constructor

### DIFF
--- a/packages/icu-messageformat-parser/index.ts
+++ b/packages/icu-messageformat-parser/index.ts
@@ -54,6 +54,7 @@ export function parse(message: string, opts: ParserOptions = {}) {
   }
   return result.val
 }
+export {ParserOptions}
 export * from './types'
 // only for testing
 export const _Parser = Parser

--- a/packages/intl-messageformat/src/core.ts
+++ b/packages/intl-messageformat/src/core.ts
@@ -4,7 +4,11 @@ Copyrights licensed under the New BSD License.
 See the accompanying LICENSE file for terms.
 */
 
-import {parse, MessageFormatElement} from '@formatjs/icu-messageformat-parser'
+import {
+  parse,
+  MessageFormatElement,
+  ParserOptions,
+} from '@formatjs/icu-messageformat-parser'
 import memoize, {Cache, strategies} from '@formatjs/fast-memoize'
 import {
   FormatterCache,
@@ -53,15 +57,8 @@ function mergeConfigs(
   )
 }
 
-export interface Options {
+export interface Options extends Omit<ParserOptions, 'locale'> {
   formatters?: Formatters
-  /**
-   * Whether to treat HTML/XML tags as string literal
-   * instead of parsing them as tag token.
-   * When this is false we only allow simple tags without
-   * any attributes
-   */
-  ignoreTag?: boolean
 }
 
 function createFastMemoizeCache<V>(
@@ -133,9 +130,10 @@ export class IntlMessageFormat {
           'IntlMessageFormat.__parse must be set to process `message` of type `string`'
         )
       }
+      const {formatters, ...parseOpts} = opts || {}
       // Parse string messages into an AST.
       this.ast = IntlMessageFormat.__parse(message, {
-        ignoreTag: opts?.ignoreTag,
+        ...parseOpts,
         locale: this.resolvedLocale,
       })
     } else {

--- a/packages/intl-messageformat/tests/index.test.ts
+++ b/packages/intl-messageformat/tests/index.test.ts
@@ -473,15 +473,17 @@ describe('IntlMessageFormat', function () {
     const msg = '{variable, select, a {A} b {B} c {C}}'
 
     it('should throw by default', function () {
-      expect(() => IntlMessageFormat.__parse!(msg)).toThrow(
-        /MISSING_OTHER_CLAUSE/
-      )
+      expect(() => {
+        new IntlMessageFormat(msg, 'en')
+      }).toThrow(/MISSING_OTHER_CLAUSE/)
     })
 
     it('should not throw when requiresOtherClause is false', function () {
-      expect(() =>
-        IntlMessageFormat.__parse!(msg, {requiresOtherClause: false})
-      ).not.toThrow()
+      expect(() => {
+        new IntlMessageFormat(msg, 'en', undefined, {
+          requiresOtherClause: false,
+        })
+      }).not.toThrow()
     })
   })
 

--- a/packages/intl-messageformat/tests/index.test.ts
+++ b/packages/intl-messageformat/tests/index.test.ts
@@ -469,6 +469,22 @@ describe('IntlMessageFormat', function () {
     })
   })
 
+  describe('select message without other clause', function () {
+    const msg = '{variable, select, a {A} b {B} c {C}}'
+
+    it('should throw by default', function () {
+      expect(() => IntlMessageFormat.__parse!(msg)).toThrow(
+        /MISSING_OTHER_CLAUSE/
+      )
+    })
+
+    it('should not throw when requiresOtherClause is false', function () {
+      expect(() =>
+        IntlMessageFormat.__parse!(msg, {requiresOtherClause: false})
+      ).not.toThrow()
+    })
+  })
+
   describe('selectordinal arguments', function () {
     const msg =
       'This is my {year, selectordinal, one{#st} two{#nd} few{#rd} other{#th}} birthday.'


### PR DESCRIPTION
Currently, only the `ignoreTag` option from the Parser is supported by the `IntlMessageFormat` constructor. The others are not "available". In my scenario, we'd like to turn off the `requiresOtherClause` while we migrate some projects and we bumped into this limitation.

Our current workaround is to use `patch-package` to modify the library and I'm opening this PR in case the maintainers are open to supporting all of the other options from the constructor.

If you want to limit them to specific properties or prefer to explicitly pass each one instead of spreading them, let me know and I can update the PR or feel free to update it too.

Best regards.