### PR TITLE
feat(eslint-plugin-formatjs): capture literals in the conditional expression

### DIFF
--- a/packages/eslint-plugin-formatjs/rules/no-literal-string-in-jsx.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-literal-string-in-jsx.ts
@@ -150,6 +150,9 @@ const rule: Rule.RuleModule = {
       } else if (node.type === 'BinaryExpression' && node.operator === '+') {
         checkJSXExpression(node.left)
         checkJSXExpression(node.right)
+      } else if (node.type === 'ConditionalExpression') {
+        checkJSXExpression(node.consequent)
+        checkJSXExpression(node.alternate)
       }
     }
 

--- a/packages/eslint-plugin-formatjs/tests/no-literal-string-in-jsx.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/no-literal-string-in-jsx.test.ts
@@ -15,6 +15,16 @@ ruleTester.run('no-literal-string-in-jsx', noLiteralStringInJsx, {
     {
       code: '<div>{f("message")}</div>',
     },
+    // Conditional expression
+    {
+      code: '<div>{a ? b : c}</div>',
+    },
+    {
+      code: '<div>{"a" ? b : c}</div>',
+    },
+    {
+      code: '<div aria-label={a ? b : c} />',
+    },
     // Excluded built-in img alt attribute check
     {
       code: '<img alt="alt" />',
@@ -220,6 +230,25 @@ ruleTester.run('no-literal-string-in-jsx', noLiteralStringInJsx, {
         {message: 'Cannot have untranslated text in JSX'},
         {message: 'Cannot have untranslated text in JSX'},
       ],
+    },
+    // Conditional expression
+    {
+      code: '<div>{a ? "b" : "c"}</div>',
+      errors: [
+        {message: 'Cannot have untranslated text in JSX'},
+        {message: 'Cannot have untranslated text in JSX'},
+      ],
+    },
+    {
+      code: '<div aria-label={a ? "b" : "c"} />',
+      errors: [
+        {message: 'Cannot have untranslated text in JSX'},
+        {message: 'Cannot have untranslated text in JSX'},
+      ],
+    },
+    {
+      code: '<div aria-label={a ? b ? "c" : d : e} />',
+      errors: [{message: 'Cannot have untranslated text in JSX'}],
     },
   ],
 })


### PR DESCRIPTION
This PR enhances the `no-literal-string-in-jsx` rule to capture the literals appearing in branches of conditional expression. So if you have code like this:

```tsx
<div>
    {a ? 'b' : 'c'}
</div>
```

The linter will be able to capture `'b'` and `'c'` as violations.