### PR TITLE
feat(eslint-plugin-formatjs): capture literals in the logical expression

### DIFF
--- a/packages/eslint-plugin-formatjs/rules/no-literal-string-in-jsx.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-literal-string-in-jsx.ts
@@ -153,6 +153,9 @@ const rule: Rule.RuleModule = {
       } else if (node.type === 'ConditionalExpression') {
         checkJSXExpression(node.consequent)
         checkJSXExpression(node.alternate)
+      } else if (node.type === 'LogicalExpression') {
+        checkJSXExpression(node.left)
+        checkJSXExpression(node.right)
       }
     }
 

--- a/packages/eslint-plugin-formatjs/tests/no-literal-string-in-jsx.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/no-literal-string-in-jsx.test.ts
@@ -25,6 +25,16 @@ ruleTester.run('no-literal-string-in-jsx', noLiteralStringInJsx, {
     {
       code: '<div aria-label={a ? b : c} />',
     },
+    // Logical expression
+    {
+      code: '<div>{a && b}</div>',
+    },
+    {
+      code: '<div>{a || b}</div>',
+    },
+    {
+      code: '<div>{a ?? b}</div>',
+    },
     // Excluded built-in img alt attribute check
     {
       code: '<img alt="alt" />',
@@ -249,6 +259,30 @@ ruleTester.run('no-literal-string-in-jsx', noLiteralStringInJsx, {
     {
       code: '<div aria-label={a ? b ? "c" : d : e} />',
       errors: [{message: 'Cannot have untranslated text in JSX'}],
+    },
+    // Logical expression
+    {
+      code: '<div>{a && "a"}</div>',
+      errors: [{message: 'Cannot have untranslated text in JSX'}],
+    },
+    {
+      code: '<div>{"a" && a}</div>',
+      errors: [{message: 'Cannot have untranslated text in JSX'}],
+    },
+    {
+      code: '<div>{a || "a"}</div>',
+      errors: [{message: 'Cannot have untranslated text in JSX'}],
+    },
+    {
+      code: '<div>{a ?? "a"}</div>',
+      errors: [{message: 'Cannot have untranslated text in JSX'}],
+    },
+    {
+      code: '<div>{a && "b" ?? "c"}</div>',
+      errors: [
+        {message: 'Cannot have untranslated text in JSX'},
+        {message: 'Cannot have untranslated text in JSX'},
+      ],
     },
   ],
 })


### PR DESCRIPTION
Enhance `no-string-literal-in-jsx` to capture string literals appearing in the logical expression, so the following code:

```tsx
<div>
    {a && "b"}
</div>
```

is consider a violation.