### PR TITLE
feat!(@formatjs/cli-lib): repurpose en-XB for bidi pseudo locale

### DIFF
--- a/packages/cli-lib/src/pseudo_locale.ts
+++ b/packages/cli-lib/src/pseudo_locale.ts
@@ -6,7 +6,25 @@ import {
   isPluralElement,
   isSelectElement,
   isTagElement,
+  LiteralElement,
 } from '@formatjs/icu-messageformat-parser'
+
+function forEachLiteralElement(
+  ast: MessageFormatElement[],
+  fn: (el: LiteralElement) => void
+): void {
+  ast.forEach(el => {
+    if (isLiteralElement(el)) {
+      fn(el)
+    } else if (isPluralElement(el) || isSelectElement(el)) {
+      for (const opt of Object.values(el.options)) {
+        forEachLiteralElement(opt.value, fn)
+      }
+    } else if (isTagElement(el)) {
+      forEachLiteralElement(el.children, fn)
+    }
+  })
+}
 
 export function generateXXLS(
   msg: string | MessageFormatElement[]
@@ -24,16 +42,8 @@ export function generateXXAC(
   msg: string | MessageFormatElement[]
 ): MessageFormatElement[] {
   const ast = typeof msg === 'string' ? parse(msg) : msg
-  ast.forEach(el => {
-    if (isLiteralElement(el)) {
-      el.value = el.value.toUpperCase()
-    } else if (isPluralElement(el) || isSelectElement(el)) {
-      for (const opt of Object.values(el.options)) {
-        generateXXAC(opt.value)
-      }
-    } else if (isTagElement(el)) {
-      generateXXAC(el.children)
-    }
+  forEachLiteralElement(ast, el => {
+    el.value = el.value.toUpperCase()
   })
   return ast
 }
@@ -50,64 +60,104 @@ export function generateXXHA(
   return [{type: TYPE.literal, value: '[javascript]'}, ...ast]
 }
 
-const ASCII = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
-const ACCENTED_ASCII = 'âḃćḋèḟĝḫíĵǩĺṁńŏṗɋŕśṭůṿẘẋẏẓḀḂḈḊḔḞḠḢḬĴḴĻḾŊÕṔɊŔṠṮŨṼẄẌŸƵ'
+type _TupleOf<T, N extends number, R extends unknown[]> = R['length'] extends N
+  ? R
+  : _TupleOf<T, N, [T, ...R]>
 
+type Tuple<T, N extends number> = N extends N
+  ? number extends N
+    ? T[]
+    : _TupleOf<T, N, []>
+  : never
+
+type PseudoLocaleTransformMap = {
+  caps: Tuple<number, 26>
+  small: Tuple<number, 26>
+}
+
+const ACCENTED_MAP: PseudoLocaleTransformMap = {
+  // ȦƁƇḒḖƑƓĦĪĴĶĿḾȠǾƤɊŘŞŦŬṼẆẊẎẐ
+  // prettier-ignore
+  "caps": [550, 385, 391, 7698, 7702, 401, 403, 294, 298, 308, 310, 319, 7742, 544, 510, 420, 586, 344, 350, 358, 364, 7804, 7814, 7818, 7822, 7824],
+  // ȧƀƈḓḗƒɠħīĵķŀḿƞǿƥɋřşŧŭṽẇẋẏẑ
+  // prettier-ignore
+  "small": [551, 384, 392, 7699, 7703, 402, 608, 295, 299, 309, 311, 320, 7743, 414, 511, 421, 587, 345, 351, 359, 365, 7805, 7815, 7819, 7823, 7825],
+}
+
+const FLIPPED_MAP: PseudoLocaleTransformMap = {
+  // ∀ԐↃᗡƎℲ⅁HIſӼ⅂WNOԀÒᴚS⊥∩ɅMX⅄Z
+  // prettier-ignore
+  "caps": [8704, 1296, 8579, 5601, 398, 8498, 8513, 72, 73, 383, 1276, 8514, 87, 78, 79, 1280, 210, 7450, 83, 8869, 8745, 581, 77, 88, 8516, 90],
+  // ɐqɔpǝɟƃɥıɾʞʅɯuodbɹsʇnʌʍxʎz
+  // prettier-ignore
+  "small": [592, 113, 596, 112, 477, 607, 387, 613, 305, 638, 670, 645, 623, 117, 111, 100, 98, 633, 115, 647, 110, 652, 653, 120, 654, 122],
+}
+
+/**
+ * Based on: https://hg.mozilla.org/mozilla-central/file/a1f74e8c8fb72390d22054d6b00c28b1a32f6c43/intl/l10n/L10nRegistry.jsm#l425
+ */
+function transformString(
+  map: PseudoLocaleTransformMap,
+  elongate = false,
+  msg: string
+) {
+  return msg.replace(/[a-z]/gi, ch => {
+    const cc = ch.charCodeAt(0)
+    if (cc >= 97 && cc <= 122) {
+      const newChar = String.fromCodePoint(map.small[cc - 97])
+      // duplicate "a", "e", "o" and "u" to emulate ~30% longer text
+      if (elongate && (cc === 97 || cc === 101 || cc === 111 || cc === 117)) {
+        return newChar + newChar
+      }
+      return newChar
+    }
+    if (cc >= 65 && cc <= 90) {
+      return String.fromCodePoint(map.caps[cc - 65])
+    }
+    return ch
+  })
+}
+
+/**
+ * accented - Ȧȧƈƈḗḗƞŧḗḗḓ Ḗḗƞɠŀīīşħ
+ * --------------------------------
+ *
+ * This locale replaces all Latin characters with their accented equivalents, and duplicates some
+ * vowels to create roughly 30% longer strings. Strings are wrapped in markers (square brackets),
+ * which help with detecting truncation.
+ */
 export function generateENXA(
   msg: string | MessageFormatElement[]
 ): MessageFormatElement[] {
   const ast = typeof msg === 'string' ? parse(msg) : msg
-  ast.forEach(el => {
-    if (isLiteralElement(el)) {
-      el.value = el.value
-        .split('')
-        .map(c => {
-          const i = ASCII.indexOf(c)
-          if (i < 0) {
-            return c
-          }
-          return ACCENTED_ASCII[i]
-        })
-        .join('')
-    } else if (isPluralElement(el) || isSelectElement(el)) {
-      for (const opt of Object.values(el.options)) {
-        generateENXA(opt.value)
-      }
-    } else if (isTagElement(el)) {
-      generateENXA(el.children)
-    }
+  forEachLiteralElement(ast, el => {
+    el.value = transformString(ACCENTED_MAP, true, el.value)
   })
-  return ast
+  return [
+    {type: TYPE.literal, value: '['},
+    ...ast,
+    {type: TYPE.literal, value: ']'},
+  ]
 }
 
+/**
+ * bidi - ɥsıʅƃuƎ ıpıԐ
+ * -------------------
+ *
+ * This strategy replaces all Latin characters with their 180 degree rotated versions and enforces
+ * right to left text flow using Unicode UAX#9 Explicit Directional Embeddings. In this mode, the UI
+ * directionality will also be set to right-to-left.
+ */
 export function generateENXB(
   msg: string | MessageFormatElement[]
 ): MessageFormatElement[] {
   const ast = typeof msg === 'string' ? parse(msg) : msg
-  ast.forEach(el => {
-    if (isLiteralElement(el)) {
-      const pseudoString = el.value
-        .split('')
-        .map((c, index) => {
-          const i = ASCII.indexOf(c)
-          const canPad = (index + 1) % 3 === 0
-
-          if (i < 0) {
-            return c
-          }
-
-          return canPad ? ACCENTED_ASCII[i].repeat(3) : ACCENTED_ASCII[i]
-        })
-        .join('')
-
-      el.value = `[!! ${pseudoString} !!]`
-    } else if (isPluralElement(el) || isSelectElement(el)) {
-      for (const opt of Object.values(el.options)) {
-        generateENXB(opt.value)
-      }
-    } else if (isTagElement(el)) {
-      generateENXB(el.children)
-    }
+  forEachLiteralElement(ast, el => {
+    el.value = transformString(FLIPPED_MAP, false, el.value)
   })
-  return ast
+  return [
+    {type: TYPE.literal, value: '\u202e'},
+    ...ast,
+    {type: TYPE.literal, value: '\u202c'},
+  ]
 }

--- a/packages/cli-lib/tests/unit/__snapshots__/pseudo_locale.test.ts.snap
+++ b/packages/cli-lib/tests/unit/__snapshots__/pseudo_locale.test.ts.snap
@@ -1,6 +1,141 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`pseudo-locale: en-HA works with a message that starts with a literal element 1`] = `
+exports[`pseudo-locale en-AC works with a message that has a plural element 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "FOO ",
+  },
+  Object {
+    "offset": 0,
+    "options": Object {
+      "=1": Object {
+        "value": Array [
+          Object {
+            "type": 0,
+            "value": "1 BAR",
+          },
+        ],
+      },
+      "other": Object {
+        "value": Array [
+          Object {
+            "type": 7,
+          },
+          Object {
+            "type": 0,
+            "value": " BARS",
+          },
+        ],
+      },
+    },
+    "pluralType": "cardinal",
+    "type": 6,
+    "value": "bar",
+  },
+]
+`;
+
+exports[`pseudo-locale en-AC works with a message that starts with a literal element 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "FOO ",
+  },
+  Object {
+    "type": 1,
+    "value": "bar",
+  },
+]
+`;
+
+exports[`pseudo-locale en-AC works with a string literal 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "FIND HELP ONLINE",
+  },
+]
+`;
+
+exports[`pseudo-locale en-AC works with message that does not contain a literal element 1`] = `
+Array [
+  Object {
+    "type": 1,
+    "value": "foo",
+  },
+]
+`;
+
+exports[`pseudo-locale en-AC works with message that does not start with a literal element 1`] = `
+Array [
+  Object {
+    "type": 1,
+    "value": "foo",
+  },
+  Object {
+    "type": 0,
+    "value": " BAR",
+  },
+]
+`;
+
+exports[`pseudo-locale en-AC works with messages that ends with a tag 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "FOO ",
+  },
+  Object {
+    "children": Array [
+      Object {
+        "type": 0,
+        "value": "BAR",
+      },
+    ],
+    "type": 8,
+    "value": "a",
+  },
+]
+`;
+
+exports[`pseudo-locale en-HA works with a message that has a plural element 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "[javascript]foo ",
+  },
+  Object {
+    "offset": 0,
+    "options": Object {
+      "=1": Object {
+        "value": Array [
+          Object {
+            "type": 0,
+            "value": "1 bar",
+          },
+        ],
+      },
+      "other": Object {
+        "value": Array [
+          Object {
+            "type": 7,
+          },
+          Object {
+            "type": 0,
+            "value": " bars",
+          },
+        ],
+      },
+    },
+    "pluralType": "cardinal",
+    "type": 6,
+    "value": "bar",
+  },
+]
+`;
+
+exports[`pseudo-locale en-HA works with a message that starts with a literal element 1`] = `
 Array [
   Object {
     "type": 0,
@@ -13,7 +148,29 @@ Array [
 ]
 `;
 
-exports[`pseudo-locale: en-HA works with message that does not start with a literal element 1`] = `
+exports[`pseudo-locale en-HA works with a string literal 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "[javascript]Find Help Online",
+  },
+]
+`;
+
+exports[`pseudo-locale en-HA works with message that does not contain a literal element 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "[javascript]",
+  },
+  Object {
+    "type": 1,
+    "value": "foo",
+  },
+]
+`;
+
+exports[`pseudo-locale en-HA works with message that does not start with a literal element 1`] = `
 Array [
   Object {
     "type": 0,
@@ -30,7 +187,105 @@ Array [
 ]
 `;
 
-exports[`pseudo-locale: xx-LS works with message that does not contain literal element 1`] = `
+exports[`pseudo-locale en-HA works with messages that ends with a tag 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "[javascript]Foo ",
+  },
+  Object {
+    "children": Array [
+      Object {
+        "type": 0,
+        "value": "bar",
+      },
+    ],
+    "type": 8,
+    "value": "a",
+  },
+]
+`;
+
+exports[`pseudo-locale en-LS works with a message that has a plural element 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "foo ",
+  },
+  Object {
+    "offset": 0,
+    "options": Object {
+      "=1": Object {
+        "value": Array [
+          Object {
+            "type": 0,
+            "value": "1 bar",
+          },
+        ],
+      },
+      "other": Object {
+        "value": Array [
+          Object {
+            "type": 7,
+          },
+          Object {
+            "type": 0,
+            "value": " bars",
+          },
+        ],
+      },
+    },
+    "pluralType": "cardinal",
+    "type": 6,
+    "value": "bar",
+  },
+  Object {
+    "type": 0,
+    "value": "SSSSSSSSSSSSSSSSSSSSSSSSS",
+  },
+]
+`;
+
+exports[`pseudo-locale en-LS works with a message that starts with a literal element 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "foo ",
+  },
+  Object {
+    "type": 1,
+    "value": "bar",
+  },
+  Object {
+    "type": 0,
+    "value": "SSSSSSSSSSSSSSSSSSSSSSSSS",
+  },
+]
+`;
+
+exports[`pseudo-locale en-LS works with a string literal 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "Find Help OnlineSSSSSSSSSSSSSSSSSSSSSSSSS",
+  },
+]
+`;
+
+exports[`pseudo-locale en-LS works with message that does not contain a literal element 1`] = `
+Array [
+  Object {
+    "type": 1,
+    "value": "foo",
+  },
+  Object {
+    "type": 0,
+    "value": "SSSSSSSSSSSSSSSSSSSSSSSSS",
+  },
+]
+`;
+
+exports[`pseudo-locale en-LS works with message that does not start with a literal element 1`] = `
 Array [
   Object {
     "type": 1,
@@ -43,7 +298,7 @@ Array [
 ]
 `;
 
-exports[`pseudo-locale: xx-LS works with messages that ends with a tag 1`] = `
+exports[`pseudo-locale en-LS works with messages that ends with a tag 1`] = `
 Array [
   Object {
     "type": 0,
@@ -62,6 +317,300 @@ Array [
   Object {
     "type": 0,
     "value": "SSSSSSSSSSSSSSSSSSSSSSSSS",
+  },
+]
+`;
+
+exports[`pseudo-locale en-XA works with a message that has a plural element 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "[",
+  },
+  Object {
+    "type": 0,
+    "value": "ƒǿǿǿǿ ",
+  },
+  Object {
+    "offset": 0,
+    "options": Object {
+      "=1": Object {
+        "value": Array [
+          Object {
+            "type": 0,
+            "value": "1 ƀȧȧř",
+          },
+        ],
+      },
+      "other": Object {
+        "value": Array [
+          Object {
+            "type": 7,
+          },
+          Object {
+            "type": 0,
+            "value": " ƀȧȧřş",
+          },
+        ],
+      },
+    },
+    "pluralType": "cardinal",
+    "type": 6,
+    "value": "bar",
+  },
+  Object {
+    "type": 0,
+    "value": "]",
+  },
+]
+`;
+
+exports[`pseudo-locale en-XA works with a message that starts with a literal element 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "[",
+  },
+  Object {
+    "type": 0,
+    "value": "ƒǿǿǿǿ ",
+  },
+  Object {
+    "type": 1,
+    "value": "bar",
+  },
+  Object {
+    "type": 0,
+    "value": "]",
+  },
+]
+`;
+
+exports[`pseudo-locale en-XA works with a string literal 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "[",
+  },
+  Object {
+    "type": 0,
+    "value": "Ƒīƞḓ Ħḗḗŀƥ Ǿƞŀīƞḗḗ",
+  },
+  Object {
+    "type": 0,
+    "value": "]",
+  },
+]
+`;
+
+exports[`pseudo-locale en-XA works with message that does not contain a literal element 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "[",
+  },
+  Object {
+    "type": 1,
+    "value": "foo",
+  },
+  Object {
+    "type": 0,
+    "value": "]",
+  },
+]
+`;
+
+exports[`pseudo-locale en-XA works with message that does not start with a literal element 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "[",
+  },
+  Object {
+    "type": 1,
+    "value": "foo",
+  },
+  Object {
+    "type": 0,
+    "value": " ƀȧȧř",
+  },
+  Object {
+    "type": 0,
+    "value": "]",
+  },
+]
+`;
+
+exports[`pseudo-locale en-XA works with messages that ends with a tag 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "[",
+  },
+  Object {
+    "type": 0,
+    "value": "Ƒǿǿǿǿ ",
+  },
+  Object {
+    "children": Array [
+      Object {
+        "type": 0,
+        "value": "ƀȧȧř",
+      },
+    ],
+    "type": 8,
+    "value": "a",
+  },
+  Object {
+    "type": 0,
+    "value": "]",
+  },
+]
+`;
+
+exports[`pseudo-locale en-XB works with a message that has a plural element 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "‮",
+  },
+  Object {
+    "type": 0,
+    "value": "ɟoo ",
+  },
+  Object {
+    "offset": 0,
+    "options": Object {
+      "=1": Object {
+        "value": Array [
+          Object {
+            "type": 0,
+            "value": "1 qɐɹ",
+          },
+        ],
+      },
+      "other": Object {
+        "value": Array [
+          Object {
+            "type": 7,
+          },
+          Object {
+            "type": 0,
+            "value": " qɐɹs",
+          },
+        ],
+      },
+    },
+    "pluralType": "cardinal",
+    "type": 6,
+    "value": "bar",
+  },
+  Object {
+    "type": 0,
+    "value": "‬",
+  },
+]
+`;
+
+exports[`pseudo-locale en-XB works with a message that starts with a literal element 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "‮",
+  },
+  Object {
+    "type": 0,
+    "value": "ɟoo ",
+  },
+  Object {
+    "type": 1,
+    "value": "bar",
+  },
+  Object {
+    "type": 0,
+    "value": "‬",
+  },
+]
+`;
+
+exports[`pseudo-locale en-XB works with a string literal 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "‮",
+  },
+  Object {
+    "type": 0,
+    "value": "Ⅎıup Hǝʅd Ouʅıuǝ",
+  },
+  Object {
+    "type": 0,
+    "value": "‬",
+  },
+]
+`;
+
+exports[`pseudo-locale en-XB works with message that does not contain a literal element 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "‮",
+  },
+  Object {
+    "type": 1,
+    "value": "foo",
+  },
+  Object {
+    "type": 0,
+    "value": "‬",
+  },
+]
+`;
+
+exports[`pseudo-locale en-XB works with message that does not start with a literal element 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "‮",
+  },
+  Object {
+    "type": 1,
+    "value": "foo",
+  },
+  Object {
+    "type": 0,
+    "value": " qɐɹ",
+  },
+  Object {
+    "type": 0,
+    "value": "‬",
+  },
+]
+`;
+
+exports[`pseudo-locale en-XB works with messages that ends with a tag 1`] = `
+Array [
+  Object {
+    "type": 0,
+    "value": "‮",
+  },
+  Object {
+    "type": 0,
+    "value": "Ⅎoo ",
+  },
+  Object {
+    "children": Array [
+      Object {
+        "type": 0,
+        "value": "qɐɹ",
+      },
+    ],
+    "type": 8,
+    "value": "a",
+  },
+  Object {
+    "type": 0,
+    "value": "‬",
   },
 ]
 `;

--- a/packages/cli-lib/tests/unit/pseudo_locale.test.ts
+++ b/packages/cli-lib/tests/unit/pseudo_locale.test.ts
@@ -1,21 +1,45 @@
-import {generateXXHA, generateXXLS} from '../../src/pseudo_locale'
+import {
+  generateXXAC,
+  generateXXHA,
+  generateXXLS,
+  generateENXA,
+  generateENXB,
+} from '../../src/pseudo_locale'
 
-describe('pseudo-locale: xx-LS', () => {
-  it('works with messages that ends with a tag', () => {
-    expect(generateXXLS('Foo <a>bar</a>')).toMatchSnapshot()
-  })
+const pseudoLocales = [
+  {name: 'en-LS', generate: generateXXLS},
+  {name: 'en-AC', generate: generateXXAC},
+  {name: 'en-HA', generate: generateXXHA},
+  {name: 'en-XA', generate: generateENXA},
+  {name: 'en-XB', generate: generateENXB},
+]
 
-  it('works with message that does not contain literal element', () => {
-    expect(generateXXLS('{foo} bar')).toMatchSnapshot()
-  })
-})
+for (const {name, generate} of pseudoLocales) {
+  describe(`pseudo-locale ${name}`, () => {
+    it('works with a string literal', () => {
+      expect(generate('Find Help Online')).toMatchSnapshot()
+    })
 
-describe('pseudo-locale: en-HA', () => {
-  it('works with message that does not start with a literal element', () => {
-    expect(generateXXHA('{foo} bar')).toMatchSnapshot()
-  })
+    it('works with message that does not start with a literal element', () => {
+      expect(generate('{foo} bar')).toMatchSnapshot()
+    })
 
-  it('works with a message that starts with a literal element', () => {
-    expect(generateXXHA('foo {bar}')).toMatchSnapshot()
+    it('works with a message that starts with a literal element', () => {
+      expect(generate('foo {bar}')).toMatchSnapshot()
+    })
+
+    it('works with a message that has a plural element', () => {
+      expect(
+        generate('foo {bar, plural, =1 {1 bar} other {# bars}}')
+      ).toMatchSnapshot()
+    })
+
+    it('works with messages that ends with a tag', () => {
+      expect(generate('Foo <a>bar</a>')).toMatchSnapshot()
+    })
+
+    it('works with message that does not contain a literal element', () => {
+      expect(generate('{foo}')).toMatchSnapshot()
+    })
   })
-})
+}

--- a/website/docs/tooling/cli.md
+++ b/website/docs/tooling/cli.md
@@ -265,7 +265,8 @@ Given the English message `my name is {name}`
 | `xx-LS` | `my name is {name}SSSSSSSSSSSSSSSSSSSSSSSSS` |
 | `xx-AC` | `MY NAME IS {name}`                          |
 | `xx-HA` | `[javascript]my name is {name}`              |
-| `en-XA` | `ṁẏ ńâṁè íś {name}`                          |
+| `en-XA` | `[ḿẏ ƞȧȧḿḗḗ īş {name}]`                      |
+| `en-XB` | `‮ɯʎ uɐɯǝ ıs {name}‬`                        |
 
 ## Extraction and compilation with a single script
 


### PR DESCRIPTION
BREAKING CHANGE: `en-XA` is a pseudo locale for accented and lengthned English with markers, and `en-XB` is now a bidi pseudo locale.

Prior to this change, `en-XB` (introduced by #2708) is the accented and lengthened pseudo locale. But according to the [TR35](http://unicode.org/reports/tr35/), `XB` is conventionally reversed to indicate derived testing locale with forced RTL English, whereas `XA` is the derived testing locale with English + added accents and lengthened.

This PR aims to respect the convention by repurposing the pre-existing `en-XA` to derive both accents and lengthened English testing locale, and have `en-XB` be a bidi testing locale with flipped English character with RTL text direction.

The implementation is larged based on the prior art by [Netflix](https://netflixtechblog.com/pseudo-localization-netflix-12fff76fbcbe) and [Firefox](https://hg.mozilla.org/mozreview/gecko/rev/a96cf6ff334617c3d51e325ece5f27eaa0fefac9#index_header).