### PR TITLE
fix(react-intl): support union component prop types in `injectIntl`

### DIFF
--- a/packages/react-intl/src/components/injectIntl.tsx
+++ b/packages/react-intl/src/components/injectIntl.tsx
@@ -27,7 +27,22 @@ export type WrappedComponentProps<IntlPropName extends string = 'intl'> = {
   [k in IntlPropName]: IntlShape
 }
 
-export type WithIntlProps<P> = Omit<P, keyof WrappedComponentProps> & {
+/**
+ * Utility type to help deal with the fact that `Omit` doesn't play well with unions:
+ * - https://github.com/microsoft/TypeScript/issues/31501
+ * - https://github.com/microsoft/TypeScript/issues/28339
+ *
+ * @example
+ *      DistributedOmit<X | Y, K>  -->  Omit<X, K> | Omit<Y, K>
+ */
+export type DistributedOmit<T, K extends PropertyKey> = T extends unknown
+  ? Omit<T, K>
+  : never
+
+export type WithIntlProps<P> = DistributedOmit<
+  P,
+  keyof WrappedComponentProps
+> & {
   forwardedRef?: React.Ref<any>
 }
 

--- a/packages/react-intl/tests/unit/react-intl.tsx
+++ b/packages/react-intl/tests/unit/react-intl.tsx
@@ -110,5 +110,23 @@ describe('react-intl', () => {
       // This test only need to pass the type checking.
       ;<Test />
     })
+
+    it('injectIntl works with union prop types', () => {
+      type TestProps = {intl: ReactIntl.IntlShape; base: string} & (
+        | {type: 'a'; text: string}
+        | {type: 'b'; value: number}
+      )
+
+      class _Test extends React.Component<TestProps> {
+        render() {
+          return null
+        }
+      }
+
+      const Test = ReactIntl.injectIntl(_Test)
+
+      // This test only need to pass the type checking.
+      ;<Test base="base" type="a" text="text" />
+    })
   })
 })


### PR DESCRIPTION
This PR fixes the issue where if the React component props type is an union of objects, the return type of `injectIntl` will not correctly respect the union types. The fix is to apply the omit of the `intl` prop distributively.

Example:

```tsx
type TestProps = {intl: ReactIntl.IntlShape; base: string} & (
  | {type: 'a'; text: string}
  | {type: 'b'; value: number}
)

class _Test extends React.Component<TestProps> {
  render() {
    return null
  }
}

const Test = ReactIntl.injectIntl(_Test)

// Now the component props are correctly typed as the discriminated union.
;<Test base="base" type="a" text="text" />
```