### PR TITLE
feat(@formatjs/intl-locale): add static read-only polyfilled property

### DIFF
--- a/packages/intl-locale/index.ts
+++ b/packages/intl-locale/index.ts
@@ -504,6 +504,7 @@ export class Locale {
   }
 
   static relevantExtensionKeys = RELEVANT_EXTENSION_KEYS
+  public static readonly polyfilled = true
 }
 
 try {

--- a/packages/intl-locale/tests/index.test.ts
+++ b/packages/intl-locale/tests/index.test.ts
@@ -15,4 +15,7 @@ describe('intl-locale', () => {
   it('und-x-private', function () {
     expect(new Locale('und-x-private').toString()).toBe('und-x-private')
   })
+  it('has static polyfilled property', function () {
+    expect(Locale.polyfilled).toBe(true)
+  })
 })

--- a/website/docs/polyfills/intl-locale.md
+++ b/website/docs/polyfills/intl-locale.md
@@ -66,6 +66,8 @@ async function polyfill() {
   if (shouldPolyfill()) {
     await import('@formatjs/intl-locale/polyfill')
   }
+  // Alternatively, force the polyfill regardless of support
+  await import('@formatjs/intl-locale/polyfill-force')
 }
 ```
 


### PR DESCRIPTION
This is done to match what is available in other polyfills like `Intl.NumberFormat` and `Intl.PluralRules`, where is helpful to know if the polyfill has been applied or not.

Let me know if you think this should not be a `feat` but something else.