### PR TITLE
feat(@formatjs/intl-getcanonicallocales): expose polyfill-force variant

### DIFF
--- a/packages/intl-getcanonicallocales/polyfill-force.ts
+++ b/packages/intl-getcanonicallocales/polyfill-force.ts
@@ -1,0 +1,20 @@
+import {getCanonicalLocales} from './'
+if (typeof Intl === 'undefined') {
+  if (typeof window !== 'undefined') {
+    Object.defineProperty(window, 'Intl', {
+      value: {},
+    })
+    // @ts-ignore we don't include @types/node so global isn't a thing
+  } else if (typeof global !== 'undefined') {
+    // @ts-ignore we don't include @types/node so global isn't a thing
+    Object.defineProperty(global, 'Intl', {
+      value: {},
+    })
+  }
+}
+Object.defineProperty(Intl, 'getCanonicalLocales', {
+  value: getCanonicalLocales,
+  writable: true,
+  enumerable: false,
+  configurable: true,
+})

--- a/website/docs/polyfills/intl-getcanonicallocales.md
+++ b/website/docs/polyfills/intl-getcanonicallocales.md
@@ -62,6 +62,8 @@ async function polyfill() {
   if (shouldPolyfill()) {
     await import('@formatjs/intl-getcanonicallocales/polyfill')
   }
+  // Alternatively, force the polyfill regardless of support
+  await import('@formatjs/intl-getcanonicallocales/polyfill-force')
 }
 ```
 


### PR DESCRIPTION
This is done to match what is available in other polyfills like `Intl.NumberFormat` and `Intl.PluralRules`, which is helpful to force the polyfill to be applied.