### PR TITLE
feat(eslint-plugin-formatjs): new linter rules `prefer-formatted-message`and`prefer-pound-in-plural`

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,9 +82,8 @@
     "cldr-localenames-full": "40",
     "cldr-misc-full": "40",
     "cldr-numbers-full": "40",
-    "cldr-units-full": "40",
     "cldr-segments-full": "40",
-    "regexpu-core": "^5.2.2",
+    "cldr-units-full": "40",
     "clsx": "1",
     "commander": "8",
     "core-js": "^3.6.5",
@@ -114,6 +113,7 @@
     "react": "^16.6.0 || 17 || 18",
     "react-dom": "^16.6.0 || 17 || 18",
     "regenerate": "^1.4.2",
+    "regexpu-core": "^5.2.2",
     "rimraf": "^3.0.2",
     "serialize-javascript": "^6.0.0",
     "test262-harness": "10",
@@ -123,8 +123,8 @@
     "tsd": "^0.24.1",
     "tslib": "^2.4.0",
     "typescript": "4.9.3",
-    "unidiff": "^1.0.2",
     "unicode-emoji-utils": "^1.1.1",
+    "unidiff": "^1.0.2",
     "vue": "^3.2.45",
     "vue-class-component": "^8.0.0-rc.1",
     "vue-eslint-parser": "^7.3.0",
@@ -167,5 +167,8 @@
       "@commitlint/rules@17.0.0": "patches/@commitlint__rules@17.0.0.patch"
     }
   },
-  "author": "Seth Bertalotto <sbertal@verizonmedia.com>"
+  "author": "Seth Bertalotto <sbertal@verizonmedia.com>",
+  "dependencies": {
+    "magic-string": "^0.29.0"
+  }
 }

--- a/packages/eslint-plugin-formatjs/BUILD
+++ b/packages/eslint-plugin-formatjs/BUILD
@@ -32,6 +32,7 @@ SRC_DEPS = [
     "//:node_modules/@types/picomatch",
     "//:node_modules/@typescript-eslint/typescript-estree",
     "//:node_modules/eslint",
+    "//:node_modules/magic-string",
     "//:node_modules/picomatch",
     "//:node_modules/typescript",
     "//:node_modules/unicode-emoji-utils",

--- a/packages/eslint-plugin-formatjs/index.ts
+++ b/packages/eslint-plugin-formatjs/index.ts
@@ -14,6 +14,7 @@ import noMultipleWhitespaces from './rules/no-multiple-whitespaces'
 import noOffset from './rules/no-offset'
 import noLiteralStringInJsx from './rules/no-literal-string-in-jsx'
 import noUselessMessage from './rules/no-useless-message'
+import preferFormattedMessage from './rules/prefer-formatted-message'
 
 const plugin = {
   rules: {
@@ -33,6 +34,7 @@ const plugin = {
     'no-multiple-whitespaces': noMultipleWhitespaces,
     'no-offset': noOffset,
     'no-useless-message': noUselessMessage,
+    'prefer-formatted-message': preferFormattedMessage,
   },
 }
 

--- a/packages/eslint-plugin-formatjs/index.ts
+++ b/packages/eslint-plugin-formatjs/index.ts
@@ -15,6 +15,7 @@ import noOffset from './rules/no-offset'
 import noLiteralStringInJsx from './rules/no-literal-string-in-jsx'
 import noUselessMessage from './rules/no-useless-message'
 import preferFormattedMessage from './rules/prefer-formatted-message'
+import preferPoundInPlural from './rules/prefer-pound-in-plural'
 
 const plugin = {
   rules: {
@@ -35,6 +36,7 @@ const plugin = {
     'no-offset': noOffset,
     'no-useless-message': noUselessMessage,
     'prefer-formatted-message': preferFormattedMessage,
+    'prefer-pound-in-plural': preferPoundInPlural,
   },
 }
 

--- a/packages/eslint-plugin-formatjs/package.json
+++ b/packages/eslint-plugin-formatjs/package.json
@@ -26,6 +26,7 @@
     "@types/picomatch": "^2.3.0",
     "@typescript-eslint/typescript-estree": "5.45.0",
     "emoji-regex": "^10.2.1",
+    "magic-string": "^0.29.0",
     "picomatch": "^2.3.1",
     "tslib": "2.4.0",
     "typescript": "^4.7",

--- a/packages/eslint-plugin-formatjs/rules/prefer-formatted-message.ts
+++ b/packages/eslint-plugin-formatjs/rules/prefer-formatted-message.ts
@@ -1,0 +1,62 @@
+import type {Rule} from 'eslint'
+import {TSESTree} from '@typescript-eslint/typescript-estree'
+import {extractMessageDescriptor, isIntlFormatMessageCall} from '../util'
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Prefer `FormattedMessage` component over `intl.formatMessage` if applicable.',
+      category: 'Errors',
+      recommended: false,
+      url: 'https://formatjs.io/docs/tooling/linter#prefer-formatted-message',
+    },
+    fixable: 'code',
+    schema: [],
+  },
+  // TODO: Vue support
+  create(context) {
+    return {
+      JSXElement: (node: TSESTree.JSXElement) => {
+        node.children.forEach(child => {
+          if (
+            child.type === 'JSXExpressionContainer' &&
+            isIntlFormatMessageCall(child.expression)
+          ) {
+            context.report({
+              node: node as any,
+              message:
+                'Prefer `FormattedMessage` over `intl.formatMessage` in the JSX expression',
+              fix(fixer) {
+                const args0 = child.expression.arguments[0]
+                const args1 = child.expression.arguments[1]
+
+                // We can't really analyze spread element
+                if (!args0 || args0.type === 'SpreadElement') {
+                  return []
+                }
+
+                const descriptor = extractMessageDescriptor(args0)
+                if (!descriptor) {
+                  return []
+                }
+
+                const {message, idValueNode} = descriptor
+
+                return [
+                  fixer.replaceText(
+                    child as any,
+                    `<FormattedMessage id="${id}" defaultMessage="${msg}" description="${desc}" values={${values}} />`
+                  ),
+                ]
+              },
+            })
+          }
+        })
+      },
+    } as any
+  },
+}
+
+export default rule

--- a/packages/eslint-plugin-formatjs/rules/prefer-formatted-message.ts
+++ b/packages/eslint-plugin-formatjs/rules/prefer-formatted-message.ts
@@ -1,6 +1,6 @@
 import type {Rule} from 'eslint'
 import {TSESTree} from '@typescript-eslint/typescript-estree'
-import {extractMessageDescriptor, isIntlFormatMessageCall} from '../util'
+import {isIntlFormatMessageCall} from '../util'
 
 const rule: Rule.RuleModule = {
   meta: {
@@ -8,12 +8,13 @@ const rule: Rule.RuleModule = {
     docs: {
       description:
         'Prefer `FormattedMessage` component over `intl.formatMessage` if applicable.',
-      category: 'Errors',
       recommended: false,
       url: 'https://formatjs.io/docs/tooling/linter#prefer-formatted-message',
     },
-    fixable: 'code',
-    schema: [],
+    messages: {
+      jsxChildren:
+        'Prefer `FormattedMessage` over `intl.formatMessage` in the JSX children expression.',
+    },
   },
   // TODO: Vue support
   create(context) {
@@ -21,38 +22,15 @@ const rule: Rule.RuleModule = {
       JSXElement: (node: TSESTree.JSXElement) => {
         node.children.forEach(child => {
           if (
-            child.type === 'JSXExpressionContainer' &&
-            isIntlFormatMessageCall(child.expression)
+            child.type !== 'JSXExpressionContainer' ||
+            !isIntlFormatMessageCall(child.expression)
           ) {
-            context.report({
-              node: node as any,
-              message:
-                'Prefer `FormattedMessage` over `intl.formatMessage` in the JSX expression',
-              fix(fixer) {
-                const args0 = child.expression.arguments[0]
-                const args1 = child.expression.arguments[1]
-
-                // We can't really analyze spread element
-                if (!args0 || args0.type === 'SpreadElement') {
-                  return []
-                }
-
-                const descriptor = extractMessageDescriptor(args0)
-                if (!descriptor) {
-                  return []
-                }
-
-                const {message, idValueNode} = descriptor
-
-                return [
-                  fixer.replaceText(
-                    child as any,
-                    `<FormattedMessage id="${id}" defaultMessage="${msg}" description="${desc}" values={${values}} />`
-                  ),
-                ]
-              },
-            })
+            return
           }
+          context.report({
+            node: node as any,
+            messageId: 'jsxChildren',
+          })
         })
       },
     } as any

--- a/packages/eslint-plugin-formatjs/rules/prefer-pound-in-plural.ts
+++ b/packages/eslint-plugin-formatjs/rules/prefer-pound-in-plural.ts
@@ -1,0 +1,250 @@
+import {
+  MessageFormatElement,
+  parse,
+  PluralElement,
+  TYPE,
+} from '@formatjs/icu-messageformat-parser'
+import {TSESTree} from '@typescript-eslint/typescript-estree'
+import type {Rule} from 'eslint'
+import {extractMessages, getSettings, patchMessage} from '../util'
+import MagicString from 'magic-string'
+
+function verifyAst(
+  context: Rule.RuleContext,
+  messageNode: TSESTree.Node,
+  ast: MessageFormatElement[]
+): void {
+  type MessagePatch =
+    | {type: 'remove'; start: number; end: number}
+    | {type: 'prependLeft'; index: number; content: string}
+    | {type: 'update'; start: number; end: number; content: string}
+
+  const patches: MessagePatch[] = []
+
+  _verifyAst(ast)
+
+  if (patches.length > 0) {
+    const patchedMessage = patchMessage(messageNode, ast, content => {
+      return patches
+        .reduce((magicString, patch) => {
+          switch (patch.type) {
+            case 'prependLeft':
+              return magicString.prependLeft(patch.index, patch.content)
+            case 'remove':
+              return magicString.remove(patch.start, patch.end)
+            case 'update':
+              return magicString.update(patch.start, patch.end, patch.content)
+          }
+        }, new MagicString(content))
+        .toString()
+    })
+
+    context.report({
+      node: messageNode as any,
+      messageId: 'preferPoundInPlurals',
+      fix:
+        patchedMessage !== null
+          ? fixer => fixer.replaceText(messageNode as any, patchedMessage)
+          : null,
+    })
+  }
+
+  function _verifyAst(ast: ReadonlyArray<MessageFormatElement>) {
+    for (let i = 0; i < ast.length; i++) {
+      const current = ast[i]
+      switch (current.type) {
+        case TYPE.argument:
+        case TYPE.number: {
+          // Applicable to only plain argument or number argument without any style
+          if (current.type === TYPE.number && current.style) {
+            break
+          }
+
+          const next = ast[i + 1] as MessageFormatElement | undefined
+          const nextNext = ast[i + 2] as MessageFormatElement | undefined
+
+          if (
+            next &&
+            nextNext &&
+            next.type === TYPE.literal &&
+            next.value === ' ' &&
+            nextNext.type === TYPE.plural &&
+            nextNext.value === current.value
+          ) {
+            // `{A} {A, plural, one {B} other {Bs}}` => `{A, plural, one {# B} other {# Bs}}`
+            _removeRangeAndPrependPluralClauses(
+              current.location!.start.offset,
+              next.location!.end.offset,
+              nextNext,
+              '# '
+            )
+          } else if (
+            next &&
+            next.type === TYPE.plural &&
+            next.value === current.value
+          ) {
+            // `{A}{A, plural, one {B} other {Bs}}` => `{A, plural, one {#B} other {#Bs}}`
+            _removeRangeAndPrependPluralClauses(
+              current.location!.start.offset,
+              current.location!.end.offset,
+              next,
+              '#'
+            )
+          }
+          break
+        }
+        case TYPE.plural: {
+          // `{A, plural, one {{A} B} other {{A} Bs}}` => `{A, plural, one {# B} other {# Bs}}`
+          const name = current.value
+          for (const {value} of Object.values(current.options)) {
+            _replacementArgumentWithPound(name, value)
+          }
+          break
+        }
+        case TYPE.select: {
+          for (const {value} of Object.values(current.options)) {
+            _verifyAst(value)
+          }
+          break
+        }
+        case TYPE.tag:
+          _verifyAst(current.children)
+          break
+        default:
+          break
+      }
+    }
+  }
+
+  // Replace plain argument of number argument w/o style option that matches
+  // the name with a pound sign.
+  function _replacementArgumentWithPound(
+    name: string,
+    ast: MessageFormatElement[]
+  ) {
+    for (const element of ast) {
+      switch (element.type) {
+        case TYPE.argument:
+        case TYPE.number: {
+          if (
+            element.value === name &&
+            // Either plain argument or number argument without any style
+            (element.type !== TYPE.number || !element.style)
+          ) {
+            patches.push({
+              type: 'update',
+              start: element.location!.start.offset,
+              end: element.location!.end.offset,
+              content: '#',
+            })
+          }
+          break
+        }
+        case TYPE.tag: {
+          _replacementArgumentWithPound(name, element.children)
+          break
+        }
+        case TYPE.select: {
+          for (const {value} of Object.values(element.options)) {
+            _replacementArgumentWithPound(name, value)
+          }
+          break
+        }
+        default:
+          break
+      }
+    }
+  }
+
+  // Helper to remove a certain text range and then prepend the specified text to
+  // each plural clause.
+  function _removeRangeAndPrependPluralClauses(
+    rangeToRemoveStart: number,
+    rangeToRemoveEnd: number,
+    pluralElement: PluralElement,
+    prependText: string
+  ) {
+    // Delete both the `{A}` and ` `
+    patches.push({
+      type: 'remove',
+      start: rangeToRemoveStart,
+      end: rangeToRemoveEnd,
+    })
+    // Insert `# ` to the beginning of every option clause
+    for (const {location} of Object.values(pluralElement.options)) {
+      // location marks the entire clause with the surrounding braces
+      patches.push({
+        type: 'prependLeft',
+        index: location!.start.offset + 1,
+        content: prependText,
+      })
+    }
+  }
+}
+
+function checkNode(context: Rule.RuleContext, node: TSESTree.Node) {
+  const msgs = extractMessages(node, getSettings(context))
+
+  for (const [
+    {
+      message: {defaultMessage},
+      messageNode,
+    },
+  ] of msgs) {
+    if (!defaultMessage || !messageNode) {
+      continue
+    }
+
+    let ast: MessageFormatElement[]
+    try {
+      ast = parse(defaultMessage, {captureLocation: true})
+    } catch (e) {
+      context.report({
+        node: messageNode as any,
+        message: e instanceof Error ? e.message : String(e),
+      })
+      return
+    }
+
+    verifyAst(context, messageNode, ast)
+  }
+}
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Prefer using # to reference the count in the plural argument.',
+      recommended: false,
+      url: 'https://formatjs.io/docs/tooling/linter#prefer-pound-in-plurals',
+    },
+    messages: {
+      preferPoundInPlurals:
+        'Prefer using # to reference the count in the plural argument instead of repeating the argument.',
+    },
+    fixable: 'code',
+  },
+  // TODO: Vue support
+  create(context) {
+    const callExpressionVisitor = (node: TSESTree.Node) =>
+      checkNode(context, node)
+
+    if (context.parserServices.defineTemplateBodyVisitor) {
+      return context.parserServices.defineTemplateBodyVisitor(
+        {
+          CallExpression: callExpressionVisitor,
+        },
+        {
+          CallExpression: callExpressionVisitor,
+        }
+      )
+    }
+    return {
+      JSXOpeningElement: (node: TSESTree.Node) => checkNode(context, node),
+      CallExpression: callExpressionVisitor,
+    }
+  },
+}
+
+export default rule

--- a/packages/eslint-plugin-formatjs/tests/no-multiple-whitespaces.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/no-multiple-whitespaces.test.ts
@@ -99,5 +99,11 @@ ruleTester.run('no-multiple-whitespaces', noMultipleWhitespaces, {
       output:
         "import {defineMessage} from 'react-intl';defineMessage({defaultMessage: `a\\\\ \\` {placeHolder}`})",
     },
+    {
+      code: "import {defineMessage} from 'react-intl';defineMessage({defaultMessage: `<em>a  b</em>`})",
+      errors: [{message: 'Multiple consecutive whitespaces are not allowed'}],
+      output:
+        "import {defineMessage} from 'react-intl';defineMessage({defaultMessage: `<em>a b</em>`})",
+    },
   ],
 })

--- a/packages/eslint-plugin-formatjs/tests/prefer-formatted-message.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/prefer-formatted-message.test.ts
@@ -1,0 +1,69 @@
+import preferFormattedMessage from '../rules/prefer-formatted-message'
+import {ruleTester} from './util'
+import {
+  dynamicMessage,
+  noMatch,
+  spreadJsx,
+  emptyFnCall,
+  defineMessage,
+} from './fixtures'
+
+ruleTester.run('prefer-formatted-message', preferFormattedMessage, {
+  valid: [
+    defineMessage,
+    dynamicMessage,
+    noMatch,
+    spreadJsx,
+    emptyFnCall,
+    {
+      code: `
+      <div>
+        <FormattedMessage defaultMessage="test" />
+      </div>
+      `,
+    },
+    {
+      code: `<img src="/example.png" alt={intl.formatMessage({defaultMessage: 'test'})} />`,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+      <div>
+        {intl.formatMessage({
+          defaultMessage: 'test',
+        })}
+      </div>
+      `,
+      errors: [
+        {
+          message:
+            'Prefer `FormattedMessage` over `intl.formatMessage` in the JSX children expression.',
+        },
+      ],
+    },
+    {
+      code: `
+      <div>
+        {intl.formatMessage({
+          defaultMessage: 'hello',
+        })}
+        {' '}
+        {intl.formatMessage({
+          defaultMessage: 'world',
+        })}
+      </div>
+      `,
+      errors: [
+        {
+          message:
+            'Prefer `FormattedMessage` over `intl.formatMessage` in the JSX children expression.',
+        },
+        {
+          message:
+            'Prefer `FormattedMessage` over `intl.formatMessage` in the JSX children expression.',
+        },
+      ],
+    },
+  ],
+})

--- a/packages/eslint-plugin-formatjs/tests/prefer-pound-in-plural.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/prefer-pound-in-plural.test.ts
@@ -1,0 +1,304 @@
+import preferPoundInPlural from '../rules/prefer-pound-in-plural'
+import {ruleTester} from './util'
+import {
+  dynamicMessage,
+  noMatch,
+  spreadJsx,
+  emptyFnCall,
+  defineMessage,
+} from './fixtures'
+
+ruleTester.run('no-multiple-whitespaces', preferPoundInPlural, {
+  valid: [
+    defineMessage,
+    dynamicMessage,
+    noMatch,
+    spreadJsx,
+    emptyFnCall,
+    `
+      import {defineMessage} from 'react-intl'
+      defineMessage({
+        defaultMessage: \`I have {
+          count, plural,
+            one {an apple}
+            other {# apples}
+        }.\`
+      })
+    `,
+    `
+      import {defineMessage} from 'react-intl'
+      defineMessage({
+        defaultMessage: \`I have {
+          count, plural,
+            one {an apple}
+            other {some apples}
+        }.\`
+      })
+    `,
+    // Ignore number argument with style option
+    `
+      import {defineMessage} from 'react-intl'
+      defineMessage({
+        defaultMessage: \`I have {count, number, integer} {
+          count, plural,
+            one {apple}
+            other {apples}
+        }.\`
+      })
+    `,
+    `
+      import {defineMessage} from 'react-intl'
+      defineMessage({
+        defaultMessage: \`I have {
+          count, plural,
+            one {{count, number, integer} apple}
+            other {{count, number, integer} apples}
+        }.\`
+      })
+    `,
+    // Does not reach into nested plural argument
+    `
+      import {defineMessage} from 'react-intl'
+      defineMessage({
+        defaultMessage: \`I have {
+          appleCount, plural,
+            one {{
+              pearCount, plural,
+                one {an apple and a pear}
+                other {an apple and # pears}
+            }}
+            other {{
+              pearCount, plural,
+                one {{appleCount} apple and a pear}
+                other {{appleCount} apple and # pears}
+            }}
+        }.\`
+      })
+    `,
+    // Checks the matching argument name
+    `
+      import {defineMessage} from 'react-intl'
+      defineMessage({
+        defaultMessage: \`I have {meh} {
+          count, plural,
+            one {apple}
+            other {apples}
+        }.\`
+      })
+    `,
+    `
+      import {defineMessage} from 'react-intl'
+      defineMessage({
+        defaultMessage: \`I have {
+          count, plural,
+            one {{meh} apple}
+            other {{meh} apples}
+        }.\`
+      })
+    `,
+  ],
+  invalid: [
+    // Sink the argument preceding the plural argument as `#` into the plural clauses.
+    {
+      code: `
+        import {defineMessage} from 'react-intl'
+        defineMessage({
+          defaultMessage: \`I have {count} {
+            count, plural,
+              one {apple}
+              other {apples}
+          }.\`
+        })
+      `,
+      errors: [{messageId: 'preferPoundInPlurals'}],
+      output: `
+        import {defineMessage} from 'react-intl'
+        defineMessage({
+          defaultMessage: \`I have {
+            count, plural,
+              one {# apple}
+              other {# apples}
+          }.\`
+        })
+      `,
+    },
+    {
+      code: `
+        import {defineMessage} from 'react-intl'
+        defineMessage({
+          defaultMessage: \`I have {count, number} {
+            count, plural,
+              one {apple}
+              other {apples}
+          }.\`
+        })
+      `,
+      errors: [{messageId: 'preferPoundInPlurals'}],
+      output: `
+        import {defineMessage} from 'react-intl'
+        defineMessage({
+          defaultMessage: \`I have {
+            count, plural,
+              one {# apple}
+              other {# apples}
+          }.\`
+        })
+      `,
+    },
+    // Replace the argument in the plural clause with `#` if applicable.
+    {
+      code: `
+        import {defineMessage} from 'react-intl'
+        defineMessage({
+          defaultMessage: \`I have {
+            count, plural,
+              one {{count} apple}
+              other {{count} apples}
+          }.\`
+        })
+      `,
+      errors: [{messageId: 'preferPoundInPlurals'}],
+      output: `
+        import {defineMessage} from 'react-intl'
+        defineMessage({
+          defaultMessage: \`I have {
+            count, plural,
+              one {# apple}
+              other {# apples}
+          }.\`
+        })
+      `,
+    },
+    {
+      code: `
+        import {defineMessage} from 'react-intl'
+        defineMessage({
+          defaultMessage: \`I have {
+            count, plural,
+              one {{count, number} apple}
+              other {{count, number} apples}
+          }.\`
+        })
+      `,
+      errors: [{messageId: 'preferPoundInPlurals'}],
+      output: `
+        import {defineMessage} from 'react-intl'
+        defineMessage({
+          defaultMessage: \`I have {
+            count, plural,
+              one {# apple}
+              other {# apples}
+          }.\`
+        })
+      `,
+    },
+    // Empty clause
+    {
+      code: `
+        import {defineMessage} from 'react-intl'
+        defineMessage({
+          defaultMessage: \`I have {count} {
+            count, plural,
+              one {apple}
+              other {}
+          }.\`
+        })
+      `,
+      errors: [{messageId: 'preferPoundInPlurals'}],
+      output: `
+        import {defineMessage} from 'react-intl'
+        defineMessage({
+          defaultMessage: \`I have {
+            count, plural,
+              one {# apple}
+              other {# }
+          }.\`
+        })
+      `,
+    },
+    // Complex example with tags and select argument
+    {
+      code: `
+        import {defineMessage} from 'react-intl'
+        defineMessage({
+          defaultMessage: \`I have {
+            count, plural,
+              one {<b>{count}</b> apple}
+              other {{
+                hasPears, select,
+                  true {<b>{count}</b> apples and some pears}
+                  other {<b>{count}</b> apples}
+              }}
+          }.\`
+        })
+      `,
+      errors: [{messageId: 'preferPoundInPlurals'}],
+      output: `
+        import {defineMessage} from 'react-intl'
+        defineMessage({
+          defaultMessage: \`I have {
+            count, plural,
+              one {<b>#</b> apple}
+              other {{
+                hasPears, select,
+                  true {<b>#</b> apples and some pears}
+                  other {<b>#</b> apples}
+              }}
+          }.\`
+        })
+      `,
+    },
+    // Select ordinal
+    {
+      code: `
+        import {defineMessage} from 'react-intl'
+        defineMessage({
+          defaultMessage: \`I won the {ranking}{
+            ranking, selectordinal,
+              one {st}
+              two {nd}
+              few {rd}
+              other {th}
+          } place.\`
+        })
+      `,
+      errors: [{messageId: 'preferPoundInPlurals'}],
+      output: `
+        import {defineMessage} from 'react-intl'
+        defineMessage({
+          defaultMessage: \`I won the {
+            ranking, selectordinal,
+              one {#st}
+              two {#nd}
+              few {#rd}
+              other {#th}
+          } place.\`
+        })
+      `,
+    },
+    // Two cases together
+    {
+      code: `
+        import {defineMessage} from 'react-intl'
+        defineMessage({
+          defaultMessage: \`I have {count} {
+            count, plural,
+              one {{count} apple}
+              other {{count} apples}
+          }.\`
+        })
+      `,
+      errors: [{messageId: 'preferPoundInPlurals'}],
+      output: `
+        import {defineMessage} from 'react-intl'
+        defineMessage({
+          defaultMessage: \`I have {
+            count, plural,
+              one {# # apple}
+              other {# # apples}
+          }.\`
+        })
+      `,
+    },
+  ],
+})

--- a/packages/eslint-plugin-formatjs/util.ts
+++ b/packages/eslint-plugin-formatjs/util.ts
@@ -1,5 +1,6 @@
 import {Rule} from 'eslint'
 import {TSESTree} from '@typescript-eslint/typescript-estree'
+import {MessageFormatElement} from '@formatjs/icu-messageformat-parser'
 
 export interface MessageDescriptor {
   id?: string
@@ -306,4 +307,37 @@ export function extractMessages(
     }
   }
   return []
+}
+
+/**
+ * Apply changes to the ICU message in code. The return value can be used in
+ * `fixer.replaceText(messageNode, <return value>)`. If the return value is null,
+ * it means that the patch cannot be applied.
+ */
+export function patchMessage(
+  messageNode: TSESTree.Node,
+  ast: MessageFormatElement[],
+  patcher: (messageContent: string, ast: MessageFormatElement[]) => string
+): string | null {
+  if (
+    messageNode.type === 'Literal' &&
+    messageNode.value &&
+    typeof messageNode.value === 'string'
+  ) {
+    return JSON.stringify(patcher(messageNode.value as string, ast))
+  } else if (
+    messageNode.type === 'TemplateLiteral' &&
+    messageNode.quasis.length === 1 &&
+    messageNode.expressions.length === 0
+  ) {
+    return (
+      '`' +
+      patcher(messageNode.quasis[0].value.cooked, ast)
+        .replace(/\\/g, '\\\\')
+        .replace(/`/g, '\\`') +
+      '`'
+    )
+  }
+
+  return null
 }

--- a/packages/eslint-plugin-formatjs/util.ts
+++ b/packages/eslint-plugin-formatjs/util.ts
@@ -58,7 +58,9 @@ function staticallyEvaluateStringConcat(
   return ['', false]
 }
 
-function isIntlFormatMessageCall(node: TSESTree.Node) {
+export function isIntlFormatMessageCall(
+  node: TSESTree.Node
+): node is TSESTree.CallExpression {
   return (
     node.type === 'CallExpression' &&
     node.callee.type === 'MemberExpression' &&
@@ -90,7 +92,7 @@ function isMultipleMessageDescriptorDeclaration(node: TSESTree.Node) {
   )
 }
 
-function extractMessageDescriptor(
+export function extractMessageDescriptor(
   node?: TSESTree.Expression
 ): MessageDescriptorNodeInfo | undefined {
   if (!node || node.type !== 'ObjectExpression') {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,7 @@ importers:
       karma-sauce-launcher: 4.3.6
       lodash: ^4.17.15
       loud-rejection: ^2.2.0
+      magic-string: ^0.29.0
       make-plural-compiler: 5.1.0
       minimist: ^1.2.5
       picomatch: ^2.3.1
@@ -121,6 +122,8 @@ importers:
       vue-eslint-parser: ^7.3.0
       vue-loader: '17'
       webpack: '5'
+    dependencies:
+      magic-string: 0.29.0
     devDependencies:
       '@babel/core': 7.18.5
       '@babel/helper-plugin-utils': 7.17.12
@@ -328,6 +331,7 @@ importers:
       '@types/picomatch': ^2.3.0
       '@typescript-eslint/typescript-estree': 5.45.0
       emoji-regex: ^10.2.1
+      magic-string: ^0.29.0
       picomatch: ^2.3.1
       tslib: 2.4.0
       typescript: ^4.7
@@ -339,6 +343,7 @@ importers:
       '@types/picomatch': 2.3.0
       '@typescript-eslint/typescript-estree': 5.45.0_typescript@4.9.3
       emoji-regex: 10.2.1
+      magic-string: 0.29.0
       picomatch: 2.3.1
       tslib: 2.4.0
       typescript: 4.9.3
@@ -13161,6 +13166,13 @@ packages:
     dependencies:
       sourcemap-codec: 1.4.8
     dev: true
+
+  /magic-string/0.29.0:
+    resolution: {integrity: sha512-WcfidHrDjMY+eLjlU+8OvwREqHwpgCeKVBUpQ3OhYYuvfaYCUgcbuBzappNzZvg/v8onU3oQj+BYpkOJe9Iw4Q==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.13
+    dev: false
 
   /make-dir/1.3.0:
     resolution: {integrity: sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==}

--- a/website/docs/tooling/linter.md
+++ b/website/docs/tooling/linter.md
@@ -687,3 +687,81 @@ This bans messages that do not require translation.
 #### Why
 
 Messages like `{test}` is not actionable by translators. The code should just directly reference `test`.
+
+### `prefer-formatted-message`
+
+Use `<FormattedMessage>` instead of the imperative `intl.formatMessage(...)` if applicable.
+
+```tsx
+// Bad
+<p>
+  {intl.formatMessage({defaultMessage: 'hello'})}
+</p>
+
+// Good
+<p>
+  <FormattedMessage defaultMessage="hello" />
+</p>
+```
+
+#### Why
+
+Consistent coding style in JSX and less syntax clutter.
+
+### `prefer-pound-in-plural`
+
+Use `#` in the plural argument to reference the count instead of repeating the argument.
+
+```
+// Bad
+I have {count} {
+  count, plural,
+    one {apple}
+    other {apples}
+  }
+}
+// Good
+I have {
+  count, plural,
+    one {# apple}
+    other {# apples}
+  }
+}
+
+// Bad
+I have {
+  count, plural,
+    one {{count} apple}
+    other {{count} apples}
+  }
+}
+// Good
+I have {
+  count, plural,
+    one {# apple}
+    other {# apples}
+  }
+}
+
+// Bad
+I won the {ranking}{
+  count, selectordinal,
+    one {st}
+    two {nd}
+    few {rd}
+    other {th}
+} place.
+// Good
+I won the {ranking}{
+  count, selectordinal,
+    one {#st}
+    two {#nd}
+    few {#rd}
+    other {#th}
+} place.
+```
+
+#### Why
+
+1. More concise message.
+2. Ensures that the count are correctly formatted as numbers.


### PR DESCRIPTION
This PR introduces two new rules:

### `prefer-formatted-message`

Use `<FormattedMessage>` instead of the imperative `intl.formatMessage(...)` if applicable.

```tsx
// Bad
<p>
  {intl.formatMessage({defaultMessage: 'hello'})}
</p>

// Good
<p>
  <FormattedMessage defaultMessage="hello" />
</p>
```

#### Why

Consistent coding style in JSX and less syntax clutter.

### `prefer-pound-in-plural`

Use `#` in the plural argument to reference the count instead of repeating the argument.

```
// Bad
I have {count} {
  count, plural,
    one {apple}
    other {apples}
  }
}
// Good
I have {
  count, plural,
    one {# apple}
    other {# apples}
  }
}

// Bad
I have {
  count, plural,
    one {{count} apple}
    other {{count} apples}
  }
}
// Good
I have {
  count, plural,
    one {# apple}
    other {# apples}
  }
}

// Bad
I won the {ranking}{
  count, selectordinal,
    one {st}
    two {nd}
    few {rd}
    other {th}
} place.
// Good
I won the {ranking}{
  count, selectordinal,
    one {#st}
    two {#nd}
    few {#rd}
    other {#th}
} place.
```

#### Why

1. More concise message.
2. Ensures that the count are correctly formatted as numbers.
