### PR TITLE
feat(eslint-plugin-formatjs): more performant and versatile no-complex-selectors

### DIFF
--- a/packages/eslint-plugin-formatjs/rules/no-complex-selectors.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-complex-selectors.ts
@@ -3,26 +3,58 @@ import {TSESTree} from '@typescript-eslint/typescript-estree'
 import {extractMessages, getSettings} from '../util'
 import {
   parse,
-  isPluralElement,
   MessageFormatElement,
-  isSelectElement,
+  TYPE,
 } from '@formatjs/icu-messageformat-parser'
-import {hoistSelectors} from '@formatjs/icu-messageformat-parser/manipulator'
 
 interface Config {
   limit: number
 }
 
 function calculateComplexity(ast: MessageFormatElement[]): number {
-  if (ast.length === 1) {
-    const el = ast[0]
-    if (isPluralElement(el) || isSelectElement(el)) {
-      return Object.keys(el.options).reduce((complexity, k) => {
-        return complexity + calculateComplexity(el.options[k].value)
-      }, 0)
+  // Dynamic programming: define a complexity function f, where:
+  //   f(plural | select) = sum(f(option) for each option) * f(next element),
+  //   f(tag) = f(first element of children) * f(next element),
+  //   f(other) = f(next element),
+  //   f(out of bound) = 1.
+  const complexityByNode = new Map<MessageFormatElement, number>()
+  return _calculate(ast, 0)
+
+  function _calculate(ast: MessageFormatElement[], index: number): number {
+    const element: MessageFormatElement | undefined = ast[index]
+    if (!element) {
+      return 1
     }
+
+    const cachedComplexity = complexityByNode.get(element)
+    if (cachedComplexity !== undefined) {
+      return cachedComplexity
+    }
+
+    let complexity: number
+
+    switch (element.type) {
+      case TYPE.plural:
+      case TYPE.select: {
+        let sumOfOptions = 0
+        for (const {value} of Object.values(element.options)) {
+          sumOfOptions += _calculate(value, 0)
+        }
+        complexity = sumOfOptions * _calculate(ast, index + 1)
+        break
+      }
+      case TYPE.tag:
+        complexity =
+          _calculate(element.children, 0) * _calculate(ast, index + 1)
+        break
+      default:
+        complexity = _calculate(ast, index + 1)
+        break
+    }
+
+    complexityByNode.set(element, complexity)
+    return complexity
   }
-  return 1
 }
 
 function checkNode(context: Rule.RuleContext, node: TSESTree.Node) {
@@ -62,8 +94,7 @@ function checkNode(context: Rule.RuleContext, node: TSESTree.Node) {
 
     let complexity = 0
     try {
-      const hoistedAst = hoistSelectors(ast)
-      complexity = calculateComplexity(hoistedAst)
+      complexity = calculateComplexity(ast)
     } catch (e) {
       context.report({
         node: messageNode as any,

--- a/packages/eslint-plugin-formatjs/tests/no-complex-selectors.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/no-complex-selectors.test.ts
@@ -134,12 +134,7 @@ ruleTester.run('no-complex-selectors', noComplexSelectors, {
           limit: 1,
         },
       ],
-      errors: [
-        {
-          message:
-            'Cannot hoist plural/select within a tag element. Please put the tag element inside each plural/select option',
-        },
-      ],
+      errors: [{message: 'Message complexity is too high (2 vs limit at 1)'}],
     },
   ],
 })


### PR DESCRIPTION
Rewrite the complexity computation to not depend on `hoistSelectors`, but via a simple dynamic programming based approach. This brings:

1. O(n) asymptotic time complexity where n is the number of elements in the AST, as well as O(n) space complexity of memoize the intermediate result.
2. More capable linter rule that can handle plural arguments within the tags.