### PR TITLE
docs: update intl-displaynames.md

### DIFF
--- a/website/docs/polyfills/intl-displaynames.md
+++ b/website/docs/polyfills/intl-displaynames.md
@@ -75,6 +75,6 @@ async function polyfill(locale: string) {
   }
   // Load the polyfill 1st BEFORE loading data
   await import('@formatjs/intl-displaynames/polyfill-force')
-  await import(`@formatjs/intl-displaynames/locale-data/${unsupportedLocale}`)
+  await import(`@formatjs/intl-displaynames/locale-data/${locale}`)
 }
 ```


### PR DESCRIPTION
`unsupportedLocale` returns a boolean - wouldn't we need the `locale` to import the appropriate file?