### PR TITLE
fix(@formatjs/fast-memoize)!: use named exports

### DIFF
--- a/packages/fast-memoize/index.ts
+++ b/packages/fast-memoize/index.ts
@@ -34,7 +34,7 @@ export interface MemoizeFunc<F extends Func> {
   (fn: F, options?: Options<F>): F
 }
 
-export default function memoize<F extends Func>(fn: F, options?: Options<F>) {
+export function memoize<F extends Func>(fn: F, options?: Options<F>) {
   const cache = options && options.cache ? options.cache : cacheDefault
 
   const serializer =

--- a/packages/fast-memoize/package.json
+++ b/packages/fast-memoize/package.json
@@ -4,8 +4,10 @@
   "description": "fork of fast-memoize and support esm",
   "main": "index.js",
   "module": "lib/index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+  "exports": {
+    "import": "./lib/index.js",
+    "require": "./index.js",
+    "default": "./index.js"
   },
   "repository": {
     "type": "git",

--- a/packages/intl-messageformat/src/core.ts
+++ b/packages/intl-messageformat/src/core.ts
@@ -9,7 +9,7 @@ import {
   MessageFormatElement,
   ParserOptions,
 } from '@formatjs/icu-messageformat-parser'
-import memoize, {Cache, strategies} from '@formatjs/fast-memoize'
+import {memoize, Cache, strategies} from '@formatjs/fast-memoize'
 import {
   FormatterCache,
   Formatters,

--- a/packages/intl-messageformat/tests/benchmark.ts
+++ b/packages/intl-messageformat/tests/benchmark.ts
@@ -2,7 +2,7 @@ import {Suite, Event} from 'benchmark'
 import IntlMessageFormat, {Formatters} from '..'
 import '@formatjs/intl-pluralrules/polyfill'
 import '@formatjs/intl-pluralrules/locale-data/en'
-import memoize from '@formatjs/fast-memoize'
+import {memoize} from '@formatjs/fast-memoize'
 
 const msg =
   '' +

--- a/packages/intl/src/utils.ts
+++ b/packages/intl/src/utils.ts
@@ -7,7 +7,7 @@ import {
   ResolvedIntlConfig,
 } from './types'
 import {IntlMessageFormat} from 'intl-messageformat'
-import memoize, {Cache, strategies} from '@formatjs/fast-memoize'
+import {memoize, Cache, strategies} from '@formatjs/fast-memoize'
 import {UnsupportedFormatterError} from './error'
 import {DateTimeFormat, NumberFormatOptions} from '@formatjs/ecma402-abstract'
 

--- a/website/docs/intl-messageformat.md
+++ b/website/docs/intl-messageformat.md
@@ -277,7 +277,7 @@ For example:
 
 ```ts
 import IntlMessageFormat from 'intl-messageformat'
-import memoize from '@formatjs/fast-memoize'
+import {memoize} from '@formatjs/fast-memoize'
 const formatters = {
   getNumberFormat: memoize(
     (locale, opts) => new Intl.NumberFormat(locale, opts)


### PR DESCRIPTION
Fixes https://github.com/formatjs/formatjs/issues/3999

BREAKING CHANGE: `memoize` is now a named exports rather than a default exporst to workaround shenaginans of bundler compatibility.