### PR TITLE
fix(@formatjs/swc-plugin-experimental): fix crash when there is no pragma

### DIFF
--- a/packages/swc-plugin-experimental/BUILD
+++ b/packages/swc-plugin-experimental/BUILD
@@ -1,7 +1,7 @@
 load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@aspect_rules_js//npm/private:npm_package.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:jest.bzl", "jest_test")
+load("@aspect_rules_jest//jest:defs.bzl", aspect_jest_test = "jest_test")
 
 npm_link_all_packages(name = "node_modules")
 
@@ -25,21 +25,25 @@ npm_package(
     visibility = ["//visibility:public"],
 )
 
-jest_test(
+# NOTE: move this into its own Bazel rule and include common dependencies automatically.
+aspect_jest_test(
     name = "test_plugin",
-    srcs = glob(
-        ["tests/**/*.test.ts"],
-    ),
-    snapshots = glob([
-        "tests/**/*.snap",
-    ]),
-    deps = [
+    config = "//:jest-aspect.config",
+    data = [
         "index.wasm",
         "tests/transform.ts",
+        "//:node_modules/@jest/transform",
         "//:node_modules/@swc/core",
         "//:node_modules/@swc/jest",
+        "//:node_modules/@types/jest",
         "//:node_modules/@types/node",
-    ] + glob([
-        "tests/fixtures/**/*",
-    ]),
+        "//:node_modules/ts-jest",
+        "//:node_modules/tslib",
+        "//:tsconfig",
+    ] + glob(
+        ["tests/**/*.test.ts"],
+    ) + glob(
+        ["tests/fixtures/**/*"],
+    ),
+    snapshots = glob(["tests/__snapshots__/*.snap"])
 )

--- a/packages/swc-plugin-experimental/tests/__snapshots__/index.test.ts.snap
+++ b/packages/swc-plugin-experimental/tests/__snapshots__/index.test.ts.snap
@@ -1,32 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`FormattedMessage 1`] = `
-Object {
+exports[`explicit pragma FormattedMessage 1`] = `
+{
   "code": "import React, { Component } from 'react';
 import { FormattedMessage } from 'react-intl';
 export default class Foo extends Component {
     render() {
         return /*#__PURE__*/ React.createElement(FormattedMessage, {
-            id: \\"foo.bar.baz\\",
-            defaultMessage: \\"Hello World!\\"
+            id: "foo.bar.baz",
+            defaultMessage: "Hello World!"
         });
     }
 }",
-  "data": Object {
-    "messages": Array [
-      Object {
+  "data": {
+    "messages": [
+      {
         "defaultMessage": "Hello World!",
         "description": "The default message.",
         "id": "foo.bar.baz",
       },
     ],
-    "meta": Object {},
+    "meta": {},
   },
 }
 `;
 
-exports[`GH #2663 1`] = `
-Object {
+exports[`explicit pragma GH #2663 1`] = `
+{
   "code": "function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) {
     try {
         var info = gen[key](arg);
@@ -47,10 +47,10 @@ function _asyncToGenerator(fn) {
         return new Promise(function(resolve, reject) {
             var gen = fn.apply(self, args);
             function _next(value) {
-                asyncGeneratorStep(gen, resolve, reject, _next, _throw, \\"next\\", value);
+                asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value);
             }
             function _throw(err) {
-                asyncGeneratorStep(gen, resolve, reject, _next, _throw, \\"throw\\", err);
+                asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err);
             }
             _next(undefined);
         });
@@ -68,9 +68,9 @@ var __generator = this && this.__generator || function(thisArg, body) {
     };
     return g = {
         next: verb(0),
-        \\"throw\\": verb(1),
-        \\"return\\": verb(2)
-    }, typeof Symbol === \\"function\\" && (g[Symbol.iterator] = function() {
+        "throw": verb(1),
+        "return": verb(2)
+    }, typeof Symbol === "function" && (g[Symbol.iterator] = function() {
         return this;
     }), g;
     function verb(n) {
@@ -82,9 +82,9 @@ var __generator = this && this.__generator || function(thisArg, body) {
         };
     }
     function step(op) {
-        if (f) throw new TypeError(\\"Generator is already executing.\\");
+        if (f) throw new TypeError("Generator is already executing.");
         while(_)try {
-            if (f = 1, y && (t = op[0] & 2 ? y[\\"return\\"] : op[0] ? y[\\"throw\\"] || ((t = y[\\"return\\"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
             if (y = 0, t) op = [
                 op[0] & 2,
                 t.value
@@ -162,8 +162,8 @@ function _error1() {
                     return [
                         4,
                         intl.formatMessage({
-                            id: \\"dI+HS6\\",
-                            defaultMessage: \\"foo\\"
+                            id: "dI+HS6",
+                            defaultMessage: "foo"
                         })
                     ];
                 case 1:
@@ -174,106 +174,136 @@ function _error1() {
             }
         });
     }",
-  "data": Object {
-    "messages": Array [
-      Object {
+  "data": {
+    "messages": [
+      {
         "defaultMessage": "foo",
         "description": "foo",
         "id": "dI+HS6",
       },
     ],
-    "meta": Object {},
+    "meta": {},
   },
 }
 `;
 
-exports[`additionalComponentNames 1`] = `
-Object {
+exports[`explicit pragma additionalComponentNames 1`] = `
+{
   "code": "import React, { Component } from 'react';
 function CustomMessage() {}
 export default class Foo extends Component {
     render() {
         return /*#__PURE__*/ React.createElement(CustomMessage, {
-            id: \\"greeting-world\\",
-            defaultMessage: \\"Hello World!\\"
+            id: "greeting-world",
+            defaultMessage: "Hello World!"
         });
     }
 }",
-  "data": Object {
-    "messages": Array [
-      Object {
+  "data": {
+    "messages": [
+      {
         "defaultMessage": "Hello World!",
         "description": "Greeting to the world",
         "id": "greeting-world",
       },
     ],
-    "meta": Object {},
+    "meta": {},
   },
 }
 `;
 
-exports[`additionalFunctionNames 1`] = `
-Object {
+exports[`explicit pragma additionalFunctionNames 1`] = `
+{
   "code": "// @react-intl project:foo
 import React, { Component } from 'react';
 function CustomMessage() {}
 export default class Foo extends Component {
     render() {
         t({
-            id: \\"mfl9RV\\",
-            defaultMessage: \\"t\\"
+            id: "mfl9RV",
+            defaultMessage: "t"
         });
         return /*#__PURE__*/ React.createElement(CustomMessage, {
             id: formatMessage({
-                id: \\"9/u6bg\\",
-                defaultMessage: \\"foo\\"
+                id: "9/u6bg",
+                defaultMessage: "foo"
             }),
             description: $formatMessage({
-                id: \\"3jMyCE\\",
-                defaultMessage: \\"foo2\\"
+                id: "3jMyCE",
+                defaultMessage: "foo2"
             }),
-            defaultMessage: \\"Hello World!\\"
+            defaultMessage: "Hello World!"
         });
     }
 }",
-  "data": Object {
-    "messages": Array [
-      Object {
+  "data": {
+    "messages": [
+      {
         "defaultMessage": "t",
         "id": "mfl9RV",
       },
-      Object {
+      {
         "defaultMessage": "foo",
         "id": "9/u6bg",
       },
-      Object {
+      {
         "defaultMessage": "foo2",
         "id": "3jMyCE",
       },
     ],
-    "meta": Object {
+    "meta": {
       "project": "foo",
     },
   },
 }
 `;
 
-exports[`ast 1`] = `
-Object {
+exports[`explicit pragma ast 1`] = `
+{
   "code": "import React, { Component } from 'react';
 import { FormattedMessage, defineMessage, defineMessages } from 'react-intl';
 defineMessage({
     id: 'defineMessage',
-    defaultMessage: '[{\\"type\\":0,\\"value\\":\\"this is a \\"},{\\"type\\":3,\\"value\\":\\"dt\\",\\"style\\":\\"full\\"}]'
+    defaultMessage: [
+        {
+            type: 0,
+            value: "this is a "
+        },
+        {
+            style: "full",
+            type: 3,
+            value: "dt"
+        }
+    ]
 });
 defineMessages({
     foo: {
         id: 'defineMessages1',
-        defaultMessage: '[{\\"type\\":0,\\"value\\":\\"this is a \\"},{\\"type\\":4,\\"value\\":\\"dt\\",\\"style\\":\\"full\\"}]'
+        defaultMessage: [
+            {
+                type: 0,
+                value: "this is a "
+            },
+            {
+                style: "full",
+                type: 4,
+                value: "dt"
+            }
+        ]
     },
     bar: {
         id: 'defineMessages2',
-        defaultMessage: '[{\\"type\\":0,\\"value\\":\\"this is a \\"},{\\"type\\":2,\\"value\\":\\"dt\\",\\"style\\":null}]'
+        defaultMessage: [
+            {
+                type: 0,
+                value: "this is a "
+            },
+            {
+                style: null,
+                type: 2,
+                value: "dt"
+            }
+        ]
     },
     baz: {
         id: 'compiled',
@@ -289,13 +319,42 @@ export default class Foo extends Component {
     render() {
         Intl.formatMessage({
             id: 'intl.formatMessage',
-            defaultMessage: '[{\\"type\\":0,\\"value\\":\\"foo \\"},{\\"type\\":6,\\"value\\":\\"s\\",\\"options\\":{\\"one\\":{\\"value\\":[{\\"type\\":0,\\"value\\":\\"1\\"}]},\\"other\\":{\\"value\\":[{\\"type\\":0,\\"value\\":\\"2\\"}]}},\\"offset\\":0,\\"pluralType\\":\\"cardinal\\"}]'
+            defaultMessage: [
+                {
+                    type: 0,
+                    value: "foo "
+                },
+                {
+                    offset: 0,
+                    options: {
+                        one: {
+                            value: [
+                                {
+                                    type: 0,
+                                    value: "1"
+                                }
+                            ]
+                        },
+                        other: {
+                            value: [
+                                {
+                                    type: 0,
+                                    value: "2"
+                                }
+                            ]
+                        }
+                    },
+                    pluralType: "cardinal",
+                    type: 6,
+                    value: "s"
+                }
+            ]
         });
         return /*#__PURE__*/ React.createElement(React.Fragment, null, /*#__PURE__*/ React.createElement(FormattedMessage, {
-            id: \\"foo.bar.baz\\",
-            defaultMessage: \\"Hello World!\\"
+            id: "foo.bar.baz",
+            defaultMessage: "Hello World!"
         }), /*#__PURE__*/ React.createElement(FormattedMessage, {
-            id: \\"compiled2\\",
+            id: "compiled2",
             defaultMessage: [
                 {
                     type: 0,
@@ -305,42 +364,42 @@ export default class Foo extends Component {
         }));
     }
 }",
-  "data": Object {
-    "messages": Array [
-      Object {
+  "data": {
+    "messages": [
+      {
         "defaultMessage": "this is a {dt, date, full}",
         "id": "defineMessage",
       },
-      Object {
+      {
         "defaultMessage": "this is a {dt, time, full}",
         "id": "defineMessages1",
       },
-      Object {
+      {
         "defaultMessage": "this is a {dt, number}",
         "id": "defineMessages2",
       },
-      Object {
+      {
         "defaultMessage": "foo {s, plural, one{1} other{2}}",
         "id": "intl.formatMessage",
       },
-      Object {
+      {
         "defaultMessage": "Hello World!",
         "description": "The default message.",
         "id": "foo.bar.baz",
       },
-      Object {
+      {
         "defaultMessage": "",
         "description": "The default message.",
         "id": "compiled2",
       },
     ],
-    "meta": Object {},
+    "meta": {},
   },
 }
 `;
 
-exports[`defineMessage 1`] = `
-Object {
+exports[`explicit pragma defineMessage 1`] = `
+{
   "code": "// @react-intl project:amazing
 function _extends() {
     _extends = Object.assign || function(target) {
@@ -361,78 +420,78 @@ import { defineMessage, FormattedMessage } from 'react-intl';
 const msgs = {
     header: defineMessage({
         id: 'foo.bar.baz',
-        defaultMessage: \\"Hello World!\\"
+        defaultMessage: "Hello World!"
     }),
     content: defineMessage({
         id: 'foo.bar.biff',
-        defaultMessage: \\"Hello Nurse!\\"
+        defaultMessage: "Hello Nurse!"
     }),
     kittens: defineMessage({
         id: 'app.home.kittens',
-        defaultMessage: \\"{count, plural, =0 {😭} one {# kitten} other {# kittens}}\\"
+        defaultMessage: "{count, plural, =0 {😭} one {# kitten} other {# kittens}}"
     }),
     trailingWhitespace: defineMessage({
         id: 'trailing.ws',
-        defaultMessage: \\"Some whitespace\\"
+        defaultMessage: "Some whitespace"
     }),
     escaped: defineMessage({
         id: 'escaped.apostrophe',
-        defaultMessage: \\"A quoted value ''{value}'\\"
+        defaultMessage: "A quoted value ''{value}'"
     }),
     stringKeys: defineMessage({
         // prettier-ignore
         'id': 'string.key.id',
         // prettier-ignore
-        'defaultMessage': \\"This is message\\"
+        'defaultMessage': "This is message"
     })
 };
 export default class Foo extends Component {
     render() {
-        return /*#__PURE__*/ React.createElement(\\"div\\", null, /*#__PURE__*/ React.createElement(\\"h1\\", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.header))), /*#__PURE__*/ React.createElement(\\"p\\", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.content))), /*#__PURE__*/ React.createElement(\\"p\\", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.kittens))));
+        return /*#__PURE__*/ React.createElement("div", null, /*#__PURE__*/ React.createElement("h1", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.header))), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.content))), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.kittens))));
     }
 }",
-  "data": Object {
-    "messages": Array [
-      Object {
+  "data": {
+    "messages": [
+      {
         "defaultMessage": "Hello World!",
         "description": "The default message",
         "id": "foo.bar.baz",
       },
-      Object {
+      {
         "defaultMessage": "Hello Nurse!",
         "description": "Another message",
         "id": "foo.bar.biff",
       },
-      Object {
+      {
         "defaultMessage": "{count, plural, =0 {😭} one {# kitten} other {# kittens}}",
         "description": "Counts kittens",
         "id": "app.home.kittens",
       },
-      Object {
+      {
         "defaultMessage": "Some whitespace",
         "description": "Whitespace",
         "id": "trailing.ws",
       },
-      Object {
+      {
         "defaultMessage": "A quoted value ''{value}'",
         "description": "Escaped apostrophe",
         "id": "escaped.apostrophe",
       },
-      Object {
+      {
         "defaultMessage": "This is message",
         "description": "Keys as a string literal",
         "id": "string.key.id",
       },
     ],
-    "meta": Object {
+    "meta": {
       "project": "amazing",
     },
   },
 }
 `;
 
-exports[`defineMessages 1`] = `
-Object {
+exports[`explicit pragma defineMessages 1`] = `
+{
   "code": "// @react-intl project:amazing
 function _extends() {
     _extends = Object.assign || function(target) {
@@ -453,114 +512,114 @@ import { defineMessages, FormattedMessage } from 'react-intl';
 const msgs = defineMessages({
     header: {
         id: 'foo.bar.baz',
-        defaultMessage: \\"Hello World!\\"
+        defaultMessage: "Hello World!"
     },
     content: {
         id: 'foo.bar.biff',
-        defaultMessage: \\"Hello Nurse!\\"
+        defaultMessage: "Hello Nurse!"
     },
     kittens: {
         id: 'app.home.kittens',
-        defaultMessage: \\"{count, plural, =0 {😭} one {# kitten} other {# kittens}}\\"
+        defaultMessage: "{count, plural, =0 {😭} one {# kitten} other {# kittens}}"
     },
     trailingWhitespace: {
         id: 'trailing.ws',
-        defaultMessage: \\"Some whitespace\\"
+        defaultMessage: "Some whitespace"
     },
     escaped: {
         id: 'escaped.apostrophe',
-        defaultMessage: \\"A quoted value ''{value}'\\"
+        defaultMessage: "A quoted value ''{value}'"
     }
 });
 export default class Foo extends Component {
     render() {
-        return /*#__PURE__*/ React.createElement(\\"div\\", null, /*#__PURE__*/ React.createElement(\\"h1\\", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.header))), /*#__PURE__*/ React.createElement(\\"p\\", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.content))), /*#__PURE__*/ React.createElement(\\"p\\", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.kittens))));
+        return /*#__PURE__*/ React.createElement("div", null, /*#__PURE__*/ React.createElement("h1", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.header))), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.content))), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.kittens))));
     }
 }",
-  "data": Object {
-    "messages": Array [
-      Object {
+  "data": {
+    "messages": [
+      {
         "defaultMessage": "Hello World!",
         "description": "The default message",
         "id": "foo.bar.baz",
       },
-      Object {
+      {
         "defaultMessage": "Hello Nurse!",
         "description": "Another message",
         "id": "foo.bar.biff",
       },
-      Object {
+      {
         "defaultMessage": "{count, plural, =0 {😭} one {# kitten} other {# kittens}}",
         "description": "Counts kittens",
         "id": "app.home.kittens",
       },
-      Object {
+      {
         "defaultMessage": "Some whitespace",
         "description": "Whitespace",
         "id": "trailing.ws",
       },
-      Object {
+      {
         "defaultMessage": "A quoted value ''{value}'",
         "description": "Escaped apostrophe",
         "id": "escaped.apostrophe",
       },
     ],
-    "meta": Object {
+    "meta": {
       "project": "amazing",
     },
   },
 }
 `;
 
-exports[`descriptionsAsObjects 1`] = `
-Object {
+exports[`explicit pragma descriptionsAsObjects 1`] = `
+{
   "code": "import React, { Component } from 'react';
 import { FormattedMessage } from 'react-intl';
 // @react-intl project:amazing2
 export default class Foo extends Component {
     render() {
         return /*#__PURE__*/ React.createElement(FormattedMessage, {
-            id: \\"foo.bar.baz\\",
-            defaultMessage: \\"Hello World!\\"
+            id: "foo.bar.baz",
+            defaultMessage: "Hello World!"
         });
     }
 }",
-  "data": Object {
-    "messages": Array [
-      Object {
+  "data": {
+    "messages": [
+      {
         "defaultMessage": "Hello World!",
-        "description": Object {
+        "description": {
           "metadata": "Additional metadata content.",
           "text": "Something for the translator.",
         },
         "id": "foo.bar.baz",
       },
     ],
-    "meta": Object {
+    "meta": {
       "project": "amazing2",
     },
   },
 }
 `;
 
-exports[`empty 1`] = `
-Object {
+exports[`explicit pragma empty 1`] = `
+{
   "code": "import React, { Component } from 'react';
 import { defineMessage } from 'react-intl';
 export default class Foo extends Component {
     render() {
-        return /*#__PURE__*/ React.createElement(\\"div\\", null);
+        return /*#__PURE__*/ React.createElement("div", null);
     }
 }",
-  "data": Object {
-    "messages": Array [],
-    "meta": Object {},
+  "data": {
+    "messages": [],
+    "meta": {},
   },
 }
 `;
 
-exports[`extractFromFormatMessageCall 1`] = `
-Object {
+exports[`explicit pragma extractFromFormatMessageCall 1`] = `
+{
   "code": "import { FormattedMessage, injectIntl } from 'react-intl';
 import React, { Component } from 'react';
 const objectPointer = {
@@ -575,61 +634,61 @@ class Foo extends Component {
         const msgs = {
             baz: this.props.intl.formatMessage({
                 id: 'foo.bar.baz',
-                defaultMessage: \\"Hello World!\\"
+                defaultMessage: "Hello World!"
             }),
             biff: intl.formatMessage({
                 id: 'foo.bar.biff',
-                defaultMessage: \\"Hello Nurse!\\"
+                defaultMessage: "Hello Nurse!"
             }),
             qux: formatMessage({
                 id: 'foo.bar.qux',
-                defaultMessage: \\"Hello Stranger!\\"
+                defaultMessage: "Hello Stranger!"
             }),
             invalid: this.props.intl.formatMessage(objectPointer)
         };
-        return /*#__PURE__*/ React.createElement(\\"div\\", null, /*#__PURE__*/ React.createElement(\\"h1\\", null, msgs.header), /*#__PURE__*/ React.createElement(\\"p\\", null, msgs.content), /*#__PURE__*/ React.createElement(\\"span\\", null, /*#__PURE__*/ React.createElement(FormattedMessage, {
-            id: \\"foo\\",
-            defaultMessage: \\"bar\\"
+        return /*#__PURE__*/ React.createElement("div", null, /*#__PURE__*/ React.createElement("h1", null, msgs.header), /*#__PURE__*/ React.createElement("p", null, msgs.content), /*#__PURE__*/ React.createElement("span", null, /*#__PURE__*/ React.createElement(FormattedMessage, {
+            id: "foo",
+            defaultMessage: "bar"
         })));
     }
 }
 export default injectIntl(Foo)",
-  "data": Object {
-    "messages": Array [
-      Object {
+  "data": {
+    "messages": [
+      {
         "defaultMessage": "Hello World!",
         "description": "The default message",
         "id": "foo.bar.baz",
       },
-      Object {
+      {
         "defaultMessage": "Hello Nurse!",
         "description": "Another message",
         "id": "foo.bar.biff",
       },
-      Object {
+      {
         "defaultMessage": "Hello Stranger!",
         "description": "A different message",
         "id": "foo.bar.qux",
       },
-      Object {
+      {
         "defaultMessage": "bar",
         "description": "baz",
         "id": "foo",
       },
     ],
-    "meta": Object {},
+    "meta": {},
   },
 }
 `;
 
-exports[`extractFromFormatMessageCallStateless 1`] = `
-Object {
+exports[`explicit pragma extractFromFormatMessageCallStateless 1`] = `
+{
   "code": "import { FormattedMessage, injectIntl, useIntl } from 'react-intl';
 import React from 'react';
 function myFunction(param1, { formatMessage , formatDate  }) {
     return formatMessage({
         id: 'inline1',
-        defaultMessage: \\"Hello params!\\"
+        defaultMessage: "Hello params!"
     }) + formatDate(new Date());
 }
 const child = myFunction(filterable, intl);
@@ -637,65 +696,65 @@ function SFC() {
     const { formatMessage  } = useIntl();
     return formatMessage({
         id: 'hook',
-        defaultMessage: \\"hook <b>foo</b>\\"
+        defaultMessage: "hook <b>foo</b>"
     });
 }
 const Foo = ({ intl: { formatMessage  }  })=>{
     const msgs = {
         qux: formatMessage({
             id: 'foo.bar.quux',
-            defaultMessage: \\"Hello <b>Stateless!</b>\\"
+            defaultMessage: "Hello <b>Stateless!</b>"
         })
     };
-    return /*#__PURE__*/ React.createElement(\\"div\\", null, /*#__PURE__*/ React.createElement(\\"h1\\", null, msgs.header), /*#__PURE__*/ React.createElement(\\"p\\", null, msgs.content), /*#__PURE__*/ React.createElement(\\"span\\", null, /*#__PURE__*/ React.createElement(FormattedMessage, {
-        id: \\"foo\\",
-        defaultMessage: \\"bar\\"
+    return /*#__PURE__*/ React.createElement("div", null, /*#__PURE__*/ React.createElement("h1", null, msgs.header), /*#__PURE__*/ React.createElement("p", null, msgs.content), /*#__PURE__*/ React.createElement("span", null, /*#__PURE__*/ React.createElement(FormattedMessage, {
+        id: "foo",
+        defaultMessage: "bar"
     })));
 };
 export default injectIntl(Foo)",
-  "data": Object {
-    "messages": Array [
-      Object {
+  "data": {
+    "messages": [
+      {
         "defaultMessage": "Hello params!",
         "description": "A stateless message",
         "id": "inline1",
       },
-      Object {
+      {
         "defaultMessage": "hook <b>foo</b>",
         "description": "hook",
         "id": "hook",
       },
-      Object {
+      {
         "defaultMessage": "Hello <b>Stateless!</b>",
         "description": "A stateless message",
         "id": "foo.bar.quux",
       },
-      Object {
+      {
         "defaultMessage": "bar",
         "description": "baz",
         "id": "foo",
       },
     ],
-    "meta": Object {},
+    "meta": {},
   },
 }
 `;
 
-exports[`extractSourceLocation 1`] = `
+exports[`explicit pragma extractSourceLocation 1`] = `
 "import React, { Component } from 'react';
 import { FormattedMessage } from 'react-intl';
 export default class Foo extends Component {
     render() {
         return /*#__PURE__*/ React.createElement(FormattedMessage, {
-            id: \\"foo.bar.baz\\",
-            defaultMessage: \\"Hello World!\\"
+            id: "foo.bar.baz",
+            defaultMessage: "Hello World!"
         });
     }
 }"
 `;
 
-exports[`formatMessageCall 1`] = `
-Object {
+exports[`explicit pragma formatMessageCall 1`] = `
+{
   "code": "import React, { Component } from 'react';
 import { injectIntl, FormattedMessage } from 'react-intl';
 const objectPointer = {
@@ -708,103 +767,46 @@ class Foo extends Component {
         const msgs = {
             baz: this.props.intl.formatMessage({
                 id: 'foo.bar.baz',
-                defaultMessage: \\"Hello World!\\"
+                defaultMessage: "Hello World!"
             }),
             biff: this.props.intl.formatMessage({
                 id: 'foo.bar.biff',
-                defaultMessage: \\"Hello Nurse!\\"
+                defaultMessage: "Hello Nurse!"
             }),
             invalid: this.props.intl.formatMessage(objectPointer)
         };
-        return /*#__PURE__*/ React.createElement(\\"div\\", null, /*#__PURE__*/ React.createElement(\\"h1\\", null, msgs.header), /*#__PURE__*/ React.createElement(\\"p\\", null, msgs.content), /*#__PURE__*/ React.createElement(\\"span\\", null, /*#__PURE__*/ React.createElement(FormattedMessage, {
-            id: \\"foo\\",
-            defaultMessage: \\"bar\\"
+        return /*#__PURE__*/ React.createElement("div", null, /*#__PURE__*/ React.createElement("h1", null, msgs.header), /*#__PURE__*/ React.createElement("p", null, msgs.content), /*#__PURE__*/ React.createElement("span", null, /*#__PURE__*/ React.createElement(FormattedMessage, {
+            id: "foo",
+            defaultMessage: "bar"
         })));
     }
 }
 export default injectIntl(Foo)",
-  "data": Object {
-    "messages": Array [
-      Object {
+  "data": {
+    "messages": [
+      {
         "defaultMessage": "Hello World!",
         "description": "The default message",
         "id": "foo.bar.baz",
       },
-      Object {
+      {
         "defaultMessage": "Hello Nurse!",
         "description": "Another message",
         "id": "foo.bar.biff",
       },
-      Object {
+      {
         "defaultMessage": "bar",
         "description": "baz",
         "id": "foo",
       },
     ],
-    "meta": Object {},
+    "meta": {},
   },
 }
 `;
 
-exports[`idInterpolationPattern 1`] = `
-Object {
-  "code": "import React, { Component } from 'react';
-import { defineMessages, FormattedMessage } from 'react-intl';
-var msgs = defineMessages({
-  header: {
-    id: \\"fixtures.idInterpolationPattern.4d1460\\",
-    defaultMessage: \\"Hello World!\\"
-  },
-  content: {
-    id: \\"foo.bar.biff\\",
-    defaultMessage: \\"Hello Nurse!\\"
-  }
-});
-export default class Foo extends Component {
-  render() {
-    return /*#__PURE__*/React.createElement(\\"div\\", null, /*#__PURE__*/React.createElement(\\"h1\\", null, /*#__PURE__*/React.createElement(FormattedMessage, msgs.header)), /*#__PURE__*/React.createElement(\\"p\\", null, /*#__PURE__*/React.createElement(FormattedMessage, msgs.content)), /*#__PURE__*/React.createElement(FormattedMessage, {
-      id: \\"fixtures.idInterpolationPattern.36a8c8\\",
-      defaultMessage: \\"Hello World!\\"
-    }), /*#__PURE__*/React.createElement(FormattedMessage, {
-      id: \\"fixtures.idInterpolationPattern.5ce864\\",
-      defaultMessage: \\"NO ID\\"
-    }));
-  }
-
-}",
-  "data": Object {
-    "messages": Array [
-      Object {
-        "defaultMessage": "Hello World!",
-        "description": "The default message",
-        "id": "fixtures.idInterpolationPattern.4d1460",
-      },
-      Object {
-        "defaultMessage": "Hello Nurse!",
-        "description": Object {
-          "metadata": "Additional metadata content.",
-          "text": "Something for the translator.",
-        },
-        "id": "foo.bar.biff",
-      },
-      Object {
-        "defaultMessage": "Hello World!",
-        "description": "Something for the translator. Another description",
-        "id": "fixtures.idInterpolationPattern.36a8c8",
-      },
-      Object {
-        "defaultMessage": "NO ID",
-        "description": "Something for the translator. Another description",
-        "id": "fixtures.idInterpolationPattern.5ce864",
-      },
-    ],
-    "meta": Object {},
-  },
-}
-`;
-
-exports[`idInterpolationPattern default 1`] = `
-Object {
+exports[`explicit pragma idInterpolationPattern default 1`] = `
+{
   "code": "function _extends() {
     _extends = Object.assign || function(target) {
         for(var i = 1; i < arguments.length; i++){
@@ -823,162 +825,99 @@ import React, { Component } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 const msgs = defineMessages({
     header: {
-        id: \\"TRRgnX\\",
-        defaultMessage: \\"Hello World!\\"
+        id: "TRRgnX",
+        defaultMessage: "Hello World!"
     },
     content: {
         id: 'foo.bar.biff',
-        defaultMessage: \\"Hello Nurse!\\"
+        defaultMessage: "Hello Nurse!"
     }
 });
 export default class Foo extends Component {
     render() {
-        return /*#__PURE__*/ React.createElement(\\"div\\", null, /*#__PURE__*/ React.createElement(\\"h1\\", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.header))), /*#__PURE__*/ React.createElement(\\"p\\", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.content))), /*#__PURE__*/ React.createElement(FormattedMessage, {
-            id: \\"NqjIBK\\",
-            defaultMessage: \\"Hello World!\\"
+        return /*#__PURE__*/ React.createElement("div", null, /*#__PURE__*/ React.createElement("h1", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.header))), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.content))), /*#__PURE__*/ React.createElement(FormattedMessage, {
+            id: "NqjIBK",
+            defaultMessage: "Hello World!"
         }), /*#__PURE__*/ React.createElement(FormattedMessage, {
-            id: \\"XOhkQy\\",
-            defaultMessage: \\"NO ID\\"
+            id: "XOhkQy",
+            defaultMessage: "NO ID"
         }));
     }
 }",
-  "data": Object {
-    "messages": Array [
-      Object {
+  "data": {
+    "messages": [
+      {
         "defaultMessage": "Hello World!",
         "description": "The default message",
         "id": "TRRgnX",
       },
-      Object {
+      {
         "defaultMessage": "Hello Nurse!",
-        "description": Object {
+        "description": {
           "metadata": "Additional metadata content.",
           "text": "Something for the translator.",
         },
         "id": "foo.bar.biff",
       },
-      Object {
+      {
         "defaultMessage": "Hello World!",
         "description": "Something for the translator. Another description",
         "id": "NqjIBK",
       },
-      Object {
+      {
         "defaultMessage": "NO ID",
         "description": "Something for the translator. Another description",
         "id": "XOhkQy",
       },
     ],
-    "meta": Object {},
+    "meta": {},
   },
 }
 `;
 
-exports[`inline 1`] = `
-Object {
+exports[`explicit pragma inline 1`] = `
+{
   "code": "import React, { Component } from 'react';
 import { FormattedMessage, defineMessage } from 'react-intl';
 export default class Foo extends Component {
     render() {
-        return /*#__PURE__*/ React.createElement(\\"div\\", null, /*#__PURE__*/ React.createElement(FormattedMessage, {
-            id: \\"foo.bar.baz\\",
-            defaultMessage: \\"Hello World!\\"
+        return /*#__PURE__*/ React.createElement("div", null, /*#__PURE__*/ React.createElement(FormattedMessage, {
+            id: "foo.bar.baz",
+            defaultMessage: "Hello World!"
         }), defineMessage({
             id: 'header',
-            defaultMessage: \\"Hello World!\\"
+            defaultMessage: "Hello World!"
         }), defineMessage({
             id: 'header2',
-            defaultMessage: \\"Hello World!\\"
+            defaultMessage: "Hello World!"
         }));
     }
 }",
-  "data": Object {
-    "messages": Array [
-      Object {
+  "data": {
+    "messages": [
+      {
         "defaultMessage": "Hello World!",
         "description": "The default message.",
         "id": "foo.bar.baz",
       },
-      Object {
+      {
         "defaultMessage": "Hello World!",
         "description": "The default message",
         "id": "header",
       },
-      Object {
+      {
         "defaultMessage": "Hello World!",
         "description": "The default message",
         "id": "header2",
       },
     ],
-    "meta": Object {},
+    "meta": {},
   },
 }
 `;
 
-exports[`overrideIdFn 1`] = `
-Object {
-  "code": "import React, { Component } from 'react';
-import { defineMessages, FormattedMessage } from 'react-intl';
-var msgs = defineMessages({
-  header: {
-    id: \\"overrideIdFn.js.foo.bar.baz.12.string\\",
-    defaultMessage: \\"Hello World!\\"
-  },
-  content: {
-    id: \\"overrideIdFn.js.foo.bar.biff.12.object\\",
-    defaultMessage: \\"Hello Nurse!\\"
-  }
-});
-export default class Foo extends Component {
-  render() {
-    return /*#__PURE__*/React.createElement(\\"div\\", null, /*#__PURE__*/React.createElement(\\"h1\\", null, /*#__PURE__*/React.createElement(FormattedMessage, msgs.header)), /*#__PURE__*/React.createElement(\\"p\\", null, /*#__PURE__*/React.createElement(FormattedMessage, msgs.content)), /*#__PURE__*/React.createElement(FormattedMessage, {
-      id: \\"overrideIdFn.js.foo.bar.zoo.12.object\\",
-      defaultMessage: \\"Hello World!\\"
-    }), /*#__PURE__*/React.createElement(FormattedMessage, {
-      id: \\"overrideIdFn.js..5.object\\",
-      defaultMessage: \\"NO ID\\"
-    }));
-  }
-
-}",
-  "data": Object {
-    "messages": Array [
-      Object {
-        "defaultMessage": "Hello World!",
-        "description": "The default message",
-        "id": "overrideIdFn.js.foo.bar.baz.12.string",
-      },
-      Object {
-        "defaultMessage": "Hello Nurse!",
-        "description": Object {
-          "metadata": "Additional metadata content.",
-          "text": "Something for the translator.",
-        },
-        "id": "overrideIdFn.js.foo.bar.biff.12.object",
-      },
-      Object {
-        "defaultMessage": "Hello World!",
-        "description": Object {
-          "metadata": "Additional metadata content.",
-          "text": "Something for the translator. Another description",
-        },
-        "id": "overrideIdFn.js.foo.bar.zoo.12.object",
-      },
-      Object {
-        "defaultMessage": "NO ID",
-        "description": Object {
-          "metadata": "Additional metadata content.",
-          "text": "Something for the translator. Another description",
-        },
-        "id": "overrideIdFn.js..5.object",
-      },
-    ],
-    "meta": Object {},
-  },
-}
-`;
-
-exports[`preserveWhitespace 1`] = `
-Object {
+exports[`explicit pragma preserveWhitespace 1`] = `
+{
   "code": "// @react-intl project:amazing
 function _extends() {
     _extends = Object.assign || function(target) {
@@ -999,81 +938,81 @@ import { defineMessages, FormattedMessage } from 'react-intl';
 const msgs = defineMessages({
     header: {
         id: 'foo.bar.baz',
-        defaultMessage: \\"Hello World!\\"
+        defaultMessage: "Hello World!"
     },
     content: {
         id: 'foo.bar.biff',
-        defaultMessage: \\"Hello Nurse!\\"
+        defaultMessage: "Hello Nurse!"
     },
     kittens: {
         id: 'app.home.kittens',
-        defaultMessage: \\"{count, plural, =0 {😭} one {# kitten} other {# kittens}}\\"
+        defaultMessage: "{count, plural, =0 {😭} one {# kitten} other {# kittens}}"
     },
     trailingWhitespace: {
         id: 'trailing.ws',
-        defaultMessage: \\"   Some whitespace   \\"
+        defaultMessage: "   Some whitespace   "
     },
     escaped: {
         id: 'escaped.apostrophe',
-        defaultMessage: \\"A quoted value ''{value}'\\"
+        defaultMessage: "A quoted value ''{value}'"
     },
     newline: {
         id: 'newline',
-        defaultMessage: \\"this is     a message\\"
+        defaultMessage: "this is     a message"
     },
     linebreak: {
         id: 'linebreak',
-        defaultMessage: \\"this is\\\\na message\\"
+        defaultMessage: "this is\\na message"
     },
     templateLinebreak: {
         id: 'templateLinebreak',
         description: \`this is
     a
     description\`,
-        defaultMessage: \\"this is\\\\n    a message\\"
+        defaultMessage: "this is\\n    a message"
     }
 });
 export default class Foo extends Component {
     render() {
-        return /*#__PURE__*/ React.createElement(\\"div\\", null, /*#__PURE__*/ React.createElement(\\"h1\\", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.header))), /*#__PURE__*/ React.createElement(\\"p\\", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.content))), /*#__PURE__*/ React.createElement(\\"p\\", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.kittens))), /*#__PURE__*/ React.createElement(\\"p\\", null, /*#__PURE__*/ React.createElement(FormattedMessage, {
-            id: \\"inline.linebreak\\",
-            defaultMessage: \\"formatted message with linebreak\\"
+        return /*#__PURE__*/ React.createElement("div", null, /*#__PURE__*/ React.createElement("h1", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.header))), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.content))), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.kittens))), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, {
+            id: "inline.linebreak",
+            defaultMessage: "formatted message with linebreak"
         })));
     }
 }",
-  "data": Object {
-    "messages": Array [
-      Object {
+  "data": {
+    "messages": [
+      {
         "defaultMessage": "Hello World!",
         "description": "The default message",
         "id": "foo.bar.baz",
       },
-      Object {
+      {
         "defaultMessage": "Hello Nurse!",
         "description": "Another message",
         "id": "foo.bar.biff",
       },
-      Object {
+      {
         "defaultMessage": "{count, plural, =0 {😭} one {# kitten} other {# kittens}}",
         "description": "Counts kittens",
         "id": "app.home.kittens",
       },
-      Object {
+      {
         "defaultMessage": "   Some whitespace   ",
         "description": "Whitespace",
         "id": "trailing.ws",
       },
-      Object {
+      {
         "defaultMessage": "A quoted value ''{value}'",
         "description": "Escaped apostrophe",
         "id": "escaped.apostrophe",
       },
-      Object {
+      {
         "defaultMessage": "this is     a message",
         "description": "this is     a     description",
         "id": "newline",
       },
-      Object {
+      {
         "defaultMessage": "this is
 a message",
         "description": "this is
@@ -1081,12 +1020,12 @@ a
 description",
         "id": "linebreak",
       },
-      Object {
+      {
         "defaultMessage": "this is
     a message",
         "id": "templateLinebreak",
       },
-      Object {
+      {
         "defaultMessage": "formatted message
 						with linebreak",
         "description": "foo
@@ -1094,80 +1033,15 @@ description",
         "id": "inline.linebreak",
       },
     ],
-    "meta": Object {
+    "meta": {
       "project": "amazing",
     },
   },
 }
 `;
 
-exports[`removeDefaultMessage + overrideIdFn 1`] = `
-Object {
-  "code": "import React, { Component } from 'react';
-import { defineMessages, FormattedMessage } from 'react-intl';
-defineMessages({
-  foo: {
-    id: \\"removeDefaultMessage.js.greeting-user.13.string\\"
-  },
-  foo2: {
-    id: \\"removeDefaultMessage.js..8.string\\"
-  },
-  foo3: {
-    id: \\"removeDefaultMessage.js..8.string\\"
-  }
-});
-export default class Foo extends Component {
-  render() {
-    return /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement(FormattedMessage, {
-      id: \\"removeDefaultMessage.js.greeting-world.12.string\\"
-    }), /*#__PURE__*/React.createElement(FormattedMessage, {
-      id: \\"removeDefaultMessage.js..17.string\\"
-    }), /*#__PURE__*/React.createElement(FormattedMessage, {
-      id: \\"removeDefaultMessage.js..12.string\\"
-    }));
-  }
-
-}",
-  "data": Object {
-    "messages": Array [
-      Object {
-        "defaultMessage": "Hello, {name}",
-        "description": "Greeting the user",
-        "id": "removeDefaultMessage.js.greeting-user.13.string",
-      },
-      Object {
-        "defaultMessage": "foo2-msg",
-        "description": "foo2",
-        "id": "removeDefaultMessage.js..8.string",
-      },
-      Object {
-        "defaultMessage": "foo3-msg",
-        "description": undefined,
-        "id": "removeDefaultMessage.js..8.string",
-      },
-      Object {
-        "defaultMessage": "Hello World!",
-        "description": "Greeting to the world",
-        "id": "removeDefaultMessage.js.greeting-world.12.string",
-      },
-      Object {
-        "defaultMessage": "message with desc",
-        "description": "desc with desc",
-        "id": "removeDefaultMessage.js..17.string",
-      },
-      Object {
-        "defaultMessage": "message only",
-        "description": undefined,
-        "id": "removeDefaultMessage.js..12.string",
-      },
-    ],
-    "meta": Object {},
-  },
-}
-`;
-
-exports[`removeDefaultMessage 1`] = `
-Object {
+exports[`explicit pragma removeDefaultMessage 1`] = `
+{
   "code": "import React, { Component } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 defineMessages({
@@ -1175,61 +1049,61 @@ defineMessages({
         id: 'greeting-user'
     },
     foo2: {
-        id: \\"xoMBqZ\\"
+        id: "xoMBqZ"
     },
     foo3: {
-        id: \\"s0FUZ6\\"
+        id: "s0FUZ6"
     }
 });
 export default class Foo extends Component {
     render() {
         return /*#__PURE__*/ React.createElement(React.Fragment, null, /*#__PURE__*/ React.createElement(FormattedMessage, {
-            id: \\"greeting-world\\"
+            id: "greeting-world"
         }), /*#__PURE__*/ React.createElement(FormattedMessage, {
-            id: \\"mdcDCs\\"
+            id: "mdcDCs"
         }), /*#__PURE__*/ React.createElement(FormattedMessage, {
-            id: \\"xjsqOM\\"
+            id: "xjsqOM"
         }));
     }
 }",
-  "data": Object {
-    "messages": Array [
-      Object {
+  "data": {
+    "messages": [
+      {
         "defaultMessage": "Hello, {name}",
         "description": "Greeting the user",
         "id": "greeting-user",
       },
-      Object {
+      {
         "defaultMessage": "foo2-msg",
         "description": "foo2",
         "id": "xoMBqZ",
       },
-      Object {
+      {
         "defaultMessage": "foo3-msg",
         "id": "s0FUZ6",
       },
-      Object {
+      {
         "defaultMessage": "Hello World!",
         "description": "Greeting to the world",
         "id": "greeting-world",
       },
-      Object {
+      {
         "defaultMessage": "message with desc",
         "description": "desc with desc",
         "id": "mdcDCs",
       },
-      Object {
+      {
         "defaultMessage": "message only",
         "id": "xjsqOM",
       },
     ],
-    "meta": Object {},
+    "meta": {},
   },
 }
 `;
 
-exports[`skipExtractionFormattedMessage 1`] = `
-Object {
+exports[`explicit pragma skipExtractionFormattedMessage 1`] = `
+{
   "code": "import React, { Component } from 'react';
 import { FormattedMessage } from 'react-intl';
 function nonStaticId() {
@@ -1242,42 +1116,1188 @@ export default class Foo extends Component {
         });
     }
 }",
-  "data": Object {
-    "messages": Array [],
-    "meta": Object {},
+  "data": {
+    "messages": [],
+    "meta": {},
   },
 }
 `;
 
-exports[`templateLiteral 1`] = `
-Object {
+exports[`explicit pragma templateLiteral 1`] = `
+{
   "code": "import React, { Component } from 'react';
 import { FormattedMessage, defineMessage } from 'react-intl';
 defineMessage({
     id: \`template\`,
-    defaultMessage: \\"should remove newline and extra spaces\\"
+    defaultMessage: "should remove newline and extra spaces"
 });
 export default class Foo extends Component {
     render() {
         return /*#__PURE__*/ React.createElement(FormattedMessage, {
-            id: \\"foo.bar.baz\\",
+            id: "foo.bar.baz",
             defaultMessage: \`Hello World!\`
         });
     }
 }",
-  "data": Object {
-    "messages": Array [
-      Object {
+  "data": {
+    "messages": [
+      {
         "defaultMessage": "should remove newline and extra spaces",
         "id": "template",
       },
-      Object {
+      {
         "defaultMessage": "Hello World!",
         "description": "The default message.",
         "id": "foo.bar.baz",
       },
     ],
-    "meta": Object {},
+    "meta": {},
+  },
+}
+`;
+
+exports[`no pragma FormattedMessage 1`] = `
+{
+  "code": "import React, { Component } from 'react';
+import { FormattedMessage } from 'react-intl';
+export default class Foo extends Component {
+    render() {
+        return /*#__PURE__*/ React.createElement(FormattedMessage, {
+            id: "foo.bar.baz",
+            defaultMessage: "Hello World!"
+        });
+    }
+}",
+  "data": {
+    "messages": [
+      {
+        "defaultMessage": "Hello World!",
+        "description": "The default message.",
+        "id": "foo.bar.baz",
+      },
+    ],
+    "meta": {},
+  },
+}
+`;
+
+exports[`no pragma GH #2663 1`] = `
+{
+  "code": "function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) {
+    try {
+        var info = gen[key](arg);
+        var value = info.value;
+    } catch (error) {
+        reject(error);
+        return;
+    }
+    if (info.done) {
+        resolve(value);
+    } else {
+        Promise.resolve(value).then(_next, _throw);
+    }
+}
+function _asyncToGenerator(fn) {
+    return function() {
+        var self = this, args = arguments;
+        return new Promise(function(resolve, reject) {
+            var gen = fn.apply(self, args);
+            function _next(value) {
+                asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value);
+            }
+            function _throw(err) {
+                asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err);
+            }
+            _next(undefined);
+        });
+    };
+}
+var __generator = this && this.__generator || function(thisArg, body) {
+    var f, y, t, g, _ = {
+        label: 0,
+        sent: function() {
+            if (t[0] & 1) throw t[1];
+            return t[1];
+        },
+        trys: [],
+        ops: []
+    };
+    return g = {
+        next: verb(0),
+        "throw": verb(1),
+        "return": verb(2)
+    }, typeof Symbol === "function" && (g[Symbol.iterator] = function() {
+        return this;
+    }), g;
+    function verb(n) {
+        return function(v) {
+            return step([
+                n,
+                v
+            ]);
+        };
+    }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while(_)try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [
+                op[0] & 2,
+                t.value
+            ];
+            switch(op[0]){
+                case 0:
+                case 1:
+                    t = op;
+                    break;
+                case 4:
+                    _.label++;
+                    return {
+                        value: op[1],
+                        done: false
+                    };
+                case 5:
+                    _.label++;
+                    y = op[1];
+                    op = [
+                        0
+                    ];
+                    continue;
+                case 7:
+                    op = _.ops.pop();
+                    _.trys.pop();
+                    continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) {
+                        _ = 0;
+                        continue;
+                    }
+                    if (op[0] === 3 && (!t || op[1] > t[0] && op[1] < t[3])) {
+                        _.label = op[1];
+                        break;
+                    }
+                    if (op[0] === 6 && _.label < t[1]) {
+                        _.label = t[1];
+                        t = op;
+                        break;
+                    }
+                    if (t && _.label < t[2]) {
+                        _.label = t[2];
+                        _.ops.push(op);
+                        break;
+                    }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop();
+                    continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) {
+            op = [
+                6,
+                e
+            ];
+            y = 0;
+        } finally{
+            f = t = 0;
+        }
+        if (op[0] & 5) throw op[1];
+        return {
+            value: op[0] ? op[1] : void 0,
+            done: true
+        };
+    }
+};
+function error1() {
+    return _error1.apply(this, arguments);
+}
+function _error1() {
+    _error1 = _asyncToGenerator(function() {
+        return __generator(this, function(_state) {
+            switch(_state.label){
+                case 0:
+                    return [
+                        4,
+                        intl.formatMessage({
+                            id: "dI+HS6",
+                            defaultMessage: "foo"
+                        })
+                    ];
+                case 1:
+                    _state.sent();
+                    return [
+                        2
+                    ];
+            }
+        });
+    }",
+  "data": {
+    "messages": [
+      {
+        "defaultMessage": "foo",
+        "description": "foo",
+        "id": "dI+HS6",
+      },
+    ],
+    "meta": {},
+  },
+}
+`;
+
+exports[`no pragma additionalComponentNames 1`] = `
+{
+  "code": "import React, { Component } from 'react';
+function CustomMessage() {}
+export default class Foo extends Component {
+    render() {
+        return /*#__PURE__*/ React.createElement(CustomMessage, {
+            id: "greeting-world",
+            defaultMessage: "Hello World!"
+        });
+    }
+}",
+  "data": {
+    "messages": [
+      {
+        "defaultMessage": "Hello World!",
+        "description": "Greeting to the world",
+        "id": "greeting-world",
+      },
+    ],
+    "meta": {},
+  },
+}
+`;
+
+exports[`no pragma additionalFunctionNames 1`] = `
+{
+  "code": "// @react-intl project:foo
+import React, { Component } from 'react';
+function CustomMessage() {}
+export default class Foo extends Component {
+    render() {
+        t({
+            id: "mfl9RV",
+            defaultMessage: "t"
+        });
+        return /*#__PURE__*/ React.createElement(CustomMessage, {
+            id: formatMessage({
+                id: "9/u6bg",
+                defaultMessage: "foo"
+            }),
+            description: $formatMessage({
+                id: "3jMyCE",
+                defaultMessage: "foo2"
+            }),
+            defaultMessage: "Hello World!"
+        });
+    }
+}",
+  "data": {
+    "messages": [
+      {
+        "defaultMessage": "t",
+        "id": "mfl9RV",
+      },
+      {
+        "defaultMessage": "foo",
+        "id": "9/u6bg",
+      },
+      {
+        "defaultMessage": "foo2",
+        "id": "3jMyCE",
+      },
+    ],
+    "meta": {},
+  },
+}
+`;
+
+exports[`no pragma ast 1`] = `
+{
+  "code": "import React, { Component } from 'react';
+import { FormattedMessage, defineMessage, defineMessages } from 'react-intl';
+defineMessage({
+    id: 'defineMessage',
+    defaultMessage: [
+        {
+            type: 0,
+            value: "this is a "
+        },
+        {
+            style: "full",
+            type: 3,
+            value: "dt"
+        }
+    ]
+});
+defineMessages({
+    foo: {
+        id: 'defineMessages1',
+        defaultMessage: [
+            {
+                type: 0,
+                value: "this is a "
+            },
+            {
+                style: "full",
+                type: 4,
+                value: "dt"
+            }
+        ]
+    },
+    bar: {
+        id: 'defineMessages2',
+        defaultMessage: [
+            {
+                type: 0,
+                value: "this is a "
+            },
+            {
+                style: null,
+                type: 2,
+                value: "dt"
+            }
+        ]
+    },
+    baz: {
+        id: 'compiled',
+        defaultMessage: [
+            {
+                type: 0,
+                value: 'asd'
+            }
+        ]
+    }
+});
+export default class Foo extends Component {
+    render() {
+        Intl.formatMessage({
+            id: 'intl.formatMessage',
+            defaultMessage: [
+                {
+                    type: 0,
+                    value: "foo "
+                },
+                {
+                    offset: 0,
+                    options: {
+                        one: {
+                            value: [
+                                {
+                                    type: 0,
+                                    value: "1"
+                                }
+                            ]
+                        },
+                        other: {
+                            value: [
+                                {
+                                    type: 0,
+                                    value: "2"
+                                }
+                            ]
+                        }
+                    },
+                    pluralType: "cardinal",
+                    type: 6,
+                    value: "s"
+                }
+            ]
+        });
+        return /*#__PURE__*/ React.createElement(React.Fragment, null, /*#__PURE__*/ React.createElement(FormattedMessage, {
+            id: "foo.bar.baz",
+            defaultMessage: "Hello World!"
+        }), /*#__PURE__*/ React.createElement(FormattedMessage, {
+            id: "compiled2",
+            defaultMessage: [
+                {
+                    type: 0,
+                    value: 'compiled comp'
+                }
+            ]
+        }));
+    }
+}",
+  "data": {
+    "messages": [
+      {
+        "defaultMessage": "this is a {dt, date, full}",
+        "id": "defineMessage",
+      },
+      {
+        "defaultMessage": "this is a {dt, time, full}",
+        "id": "defineMessages1",
+      },
+      {
+        "defaultMessage": "this is a {dt, number}",
+        "id": "defineMessages2",
+      },
+      {
+        "defaultMessage": "foo {s, plural, one{1} other{2}}",
+        "id": "intl.formatMessage",
+      },
+      {
+        "defaultMessage": "Hello World!",
+        "description": "The default message.",
+        "id": "foo.bar.baz",
+      },
+      {
+        "defaultMessage": "",
+        "description": "The default message.",
+        "id": "compiled2",
+      },
+    ],
+    "meta": {},
+  },
+}
+`;
+
+exports[`no pragma defineMessage 1`] = `
+{
+  "code": "// @react-intl project:amazing
+function _extends() {
+    _extends = Object.assign || function(target) {
+        for(var i = 1; i < arguments.length; i++){
+            var source = arguments[i];
+            for(var key in source){
+                if (Object.prototype.hasOwnProperty.call(source, key)) {
+                    target[key] = source[key];
+                }
+            }
+        }
+        return target;
+    };
+    return _extends.apply(this, arguments);
+}
+import React, { Component } from 'react';
+import { defineMessage, FormattedMessage } from 'react-intl';
+const msgs = {
+    header: defineMessage({
+        id: 'foo.bar.baz',
+        defaultMessage: "Hello World!"
+    }),
+    content: defineMessage({
+        id: 'foo.bar.biff',
+        defaultMessage: "Hello Nurse!"
+    }),
+    kittens: defineMessage({
+        id: 'app.home.kittens',
+        defaultMessage: "{count, plural, =0 {😭} one {# kitten} other {# kittens}}"
+    }),
+    trailingWhitespace: defineMessage({
+        id: 'trailing.ws',
+        defaultMessage: "Some whitespace"
+    }),
+    escaped: defineMessage({
+        id: 'escaped.apostrophe',
+        defaultMessage: "A quoted value ''{value}'"
+    }),
+    stringKeys: defineMessage({
+        // prettier-ignore
+        'id': 'string.key.id',
+        // prettier-ignore
+        'defaultMessage': "This is message"
+    })
+};
+export default class Foo extends Component {
+    render() {
+        return /*#__PURE__*/ React.createElement("div", null, /*#__PURE__*/ React.createElement("h1", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.header))), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.content))), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.kittens))));
+    }
+}",
+  "data": {
+    "messages": [
+      {
+        "defaultMessage": "Hello World!",
+        "description": "The default message",
+        "id": "foo.bar.baz",
+      },
+      {
+        "defaultMessage": "Hello Nurse!",
+        "description": "Another message",
+        "id": "foo.bar.biff",
+      },
+      {
+        "defaultMessage": "{count, plural, =0 {😭} one {# kitten} other {# kittens}}",
+        "description": "Counts kittens",
+        "id": "app.home.kittens",
+      },
+      {
+        "defaultMessage": "Some whitespace",
+        "description": "Whitespace",
+        "id": "trailing.ws",
+      },
+      {
+        "defaultMessage": "A quoted value ''{value}'",
+        "description": "Escaped apostrophe",
+        "id": "escaped.apostrophe",
+      },
+      {
+        "defaultMessage": "This is message",
+        "description": "Keys as a string literal",
+        "id": "string.key.id",
+      },
+    ],
+    "meta": {},
+  },
+}
+`;
+
+exports[`no pragma defineMessages 1`] = `
+{
+  "code": "// @react-intl project:amazing
+function _extends() {
+    _extends = Object.assign || function(target) {
+        for(var i = 1; i < arguments.length; i++){
+            var source = arguments[i];
+            for(var key in source){
+                if (Object.prototype.hasOwnProperty.call(source, key)) {
+                    target[key] = source[key];
+                }
+            }
+        }
+        return target;
+    };
+    return _extends.apply(this, arguments);
+}
+import React, { Component } from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+const msgs = defineMessages({
+    header: {
+        id: 'foo.bar.baz',
+        defaultMessage: "Hello World!"
+    },
+    content: {
+        id: 'foo.bar.biff',
+        defaultMessage: "Hello Nurse!"
+    },
+    kittens: {
+        id: 'app.home.kittens',
+        defaultMessage: "{count, plural, =0 {😭} one {# kitten} other {# kittens}}"
+    },
+    trailingWhitespace: {
+        id: 'trailing.ws',
+        defaultMessage: "Some whitespace"
+    },
+    escaped: {
+        id: 'escaped.apostrophe',
+        defaultMessage: "A quoted value ''{value}'"
+    }
+});
+export default class Foo extends Component {
+    render() {
+        return /*#__PURE__*/ React.createElement("div", null, /*#__PURE__*/ React.createElement("h1", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.header))), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.content))), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.kittens))));
+    }
+}",
+  "data": {
+    "messages": [
+      {
+        "defaultMessage": "Hello World!",
+        "description": "The default message",
+        "id": "foo.bar.baz",
+      },
+      {
+        "defaultMessage": "Hello Nurse!",
+        "description": "Another message",
+        "id": "foo.bar.biff",
+      },
+      {
+        "defaultMessage": "{count, plural, =0 {😭} one {# kitten} other {# kittens}}",
+        "description": "Counts kittens",
+        "id": "app.home.kittens",
+      },
+      {
+        "defaultMessage": "Some whitespace",
+        "description": "Whitespace",
+        "id": "trailing.ws",
+      },
+      {
+        "defaultMessage": "A quoted value ''{value}'",
+        "description": "Escaped apostrophe",
+        "id": "escaped.apostrophe",
+      },
+    ],
+    "meta": {},
+  },
+}
+`;
+
+exports[`no pragma descriptionsAsObjects 1`] = `
+{
+  "code": "import React, { Component } from 'react';
+import { FormattedMessage } from 'react-intl';
+// @react-intl project:amazing2
+export default class Foo extends Component {
+    render() {
+        return /*#__PURE__*/ React.createElement(FormattedMessage, {
+            id: "foo.bar.baz",
+            defaultMessage: "Hello World!"
+        });
+    }
+}",
+  "data": {
+    "messages": [
+      {
+        "defaultMessage": "Hello World!",
+        "description": {
+          "metadata": "Additional metadata content.",
+          "text": "Something for the translator.",
+        },
+        "id": "foo.bar.baz",
+      },
+    ],
+    "meta": {},
+  },
+}
+`;
+
+exports[`no pragma empty 1`] = `
+{
+  "code": "import React, { Component } from 'react';
+import { defineMessage } from 'react-intl';
+export default class Foo extends Component {
+    render() {
+        return /*#__PURE__*/ React.createElement("div", null);
+    }
+}",
+  "data": {
+    "messages": [],
+    "meta": {},
+  },
+}
+`;
+
+exports[`no pragma extractFromFormatMessageCall 1`] = `
+{
+  "code": "import { FormattedMessage, injectIntl } from 'react-intl';
+import React, { Component } from 'react';
+const objectPointer = {
+    id: 'foo.bar.invalid',
+    defaultMessage: 'This cannot be extracted',
+    description: 'the plugin only supports inline objects'
+};
+class Foo extends Component {
+    render() {
+        const { intl  } = this.props;
+        const { intl: { formatMessage  }  } = this.props;
+        const msgs = {
+            baz: this.props.intl.formatMessage({
+                id: 'foo.bar.baz',
+                defaultMessage: "Hello World!"
+            }),
+            biff: intl.formatMessage({
+                id: 'foo.bar.biff',
+                defaultMessage: "Hello Nurse!"
+            }),
+            qux: formatMessage({
+                id: 'foo.bar.qux',
+                defaultMessage: "Hello Stranger!"
+            }),
+            invalid: this.props.intl.formatMessage(objectPointer)
+        };
+        return /*#__PURE__*/ React.createElement("div", null, /*#__PURE__*/ React.createElement("h1", null, msgs.header), /*#__PURE__*/ React.createElement("p", null, msgs.content), /*#__PURE__*/ React.createElement("span", null, /*#__PURE__*/ React.createElement(FormattedMessage, {
+            id: "foo",
+            defaultMessage: "bar"
+        })));
+    }
+}
+export default injectIntl(Foo)",
+  "data": {
+    "messages": [
+      {
+        "defaultMessage": "Hello World!",
+        "description": "The default message",
+        "id": "foo.bar.baz",
+      },
+      {
+        "defaultMessage": "Hello Nurse!",
+        "description": "Another message",
+        "id": "foo.bar.biff",
+      },
+      {
+        "defaultMessage": "Hello Stranger!",
+        "description": "A different message",
+        "id": "foo.bar.qux",
+      },
+      {
+        "defaultMessage": "bar",
+        "description": "baz",
+        "id": "foo",
+      },
+    ],
+    "meta": {},
+  },
+}
+`;
+
+exports[`no pragma extractFromFormatMessageCallStateless 1`] = `
+{
+  "code": "import { FormattedMessage, injectIntl, useIntl } from 'react-intl';
+import React from 'react';
+function myFunction(param1, { formatMessage , formatDate  }) {
+    return formatMessage({
+        id: 'inline1',
+        defaultMessage: "Hello params!"
+    }) + formatDate(new Date());
+}
+const child = myFunction(filterable, intl);
+function SFC() {
+    const { formatMessage  } = useIntl();
+    return formatMessage({
+        id: 'hook',
+        defaultMessage: "hook <b>foo</b>"
+    });
+}
+const Foo = ({ intl: { formatMessage  }  })=>{
+    const msgs = {
+        qux: formatMessage({
+            id: 'foo.bar.quux',
+            defaultMessage: "Hello <b>Stateless!</b>"
+        })
+    };
+    return /*#__PURE__*/ React.createElement("div", null, /*#__PURE__*/ React.createElement("h1", null, msgs.header), /*#__PURE__*/ React.createElement("p", null, msgs.content), /*#__PURE__*/ React.createElement("span", null, /*#__PURE__*/ React.createElement(FormattedMessage, {
+        id: "foo",
+        defaultMessage: "bar"
+    })));
+};
+export default injectIntl(Foo)",
+  "data": {
+    "messages": [
+      {
+        "defaultMessage": "Hello params!",
+        "description": "A stateless message",
+        "id": "inline1",
+      },
+      {
+        "defaultMessage": "hook <b>foo</b>",
+        "description": "hook",
+        "id": "hook",
+      },
+      {
+        "defaultMessage": "Hello <b>Stateless!</b>",
+        "description": "A stateless message",
+        "id": "foo.bar.quux",
+      },
+      {
+        "defaultMessage": "bar",
+        "description": "baz",
+        "id": "foo",
+      },
+    ],
+    "meta": {},
+  },
+}
+`;
+
+exports[`no pragma extractSourceLocation 1`] = `
+"import React, { Component } from 'react';
+import { FormattedMessage } from 'react-intl';
+export default class Foo extends Component {
+    render() {
+        return /*#__PURE__*/ React.createElement(FormattedMessage, {
+            id: "foo.bar.baz",
+            defaultMessage: "Hello World!"
+        });
+    }
+}"
+`;
+
+exports[`no pragma formatMessageCall 1`] = `
+{
+  "code": "import React, { Component } from 'react';
+import { injectIntl, FormattedMessage } from 'react-intl';
+const objectPointer = {
+    id: 'foo.bar.invalid',
+    defaultMessage: 'This cannot be extracted',
+    description: 'the plugin only supports inline objects'
+};
+class Foo extends Component {
+    render() {
+        const msgs = {
+            baz: this.props.intl.formatMessage({
+                id: 'foo.bar.baz',
+                defaultMessage: "Hello World!"
+            }),
+            biff: this.props.intl.formatMessage({
+                id: 'foo.bar.biff',
+                defaultMessage: "Hello Nurse!"
+            }),
+            invalid: this.props.intl.formatMessage(objectPointer)
+        };
+        return /*#__PURE__*/ React.createElement("div", null, /*#__PURE__*/ React.createElement("h1", null, msgs.header), /*#__PURE__*/ React.createElement("p", null, msgs.content), /*#__PURE__*/ React.createElement("span", null, /*#__PURE__*/ React.createElement(FormattedMessage, {
+            id: "foo",
+            defaultMessage: "bar"
+        })));
+    }
+}
+export default injectIntl(Foo)",
+  "data": {
+    "messages": [
+      {
+        "defaultMessage": "Hello World!",
+        "description": "The default message",
+        "id": "foo.bar.baz",
+      },
+      {
+        "defaultMessage": "Hello Nurse!",
+        "description": "Another message",
+        "id": "foo.bar.biff",
+      },
+      {
+        "defaultMessage": "bar",
+        "description": "baz",
+        "id": "foo",
+      },
+    ],
+    "meta": {},
+  },
+}
+`;
+
+exports[`no pragma idInterpolationPattern default 1`] = `
+{
+  "code": "function _extends() {
+    _extends = Object.assign || function(target) {
+        for(var i = 1; i < arguments.length; i++){
+            var source = arguments[i];
+            for(var key in source){
+                if (Object.prototype.hasOwnProperty.call(source, key)) {
+                    target[key] = source[key];
+                }
+            }
+        }
+        return target;
+    };
+    return _extends.apply(this, arguments);
+}
+import React, { Component } from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+const msgs = defineMessages({
+    header: {
+        id: "TRRgnX",
+        defaultMessage: "Hello World!"
+    },
+    content: {
+        id: 'foo.bar.biff',
+        defaultMessage: "Hello Nurse!"
+    }
+});
+export default class Foo extends Component {
+    render() {
+        return /*#__PURE__*/ React.createElement("div", null, /*#__PURE__*/ React.createElement("h1", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.header))), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.content))), /*#__PURE__*/ React.createElement(FormattedMessage, {
+            id: "NqjIBK",
+            defaultMessage: "Hello World!"
+        }), /*#__PURE__*/ React.createElement(FormattedMessage, {
+            id: "XOhkQy",
+            defaultMessage: "NO ID"
+        }));
+    }
+}",
+  "data": {
+    "messages": [
+      {
+        "defaultMessage": "Hello World!",
+        "description": "The default message",
+        "id": "TRRgnX",
+      },
+      {
+        "defaultMessage": "Hello Nurse!",
+        "description": {
+          "metadata": "Additional metadata content.",
+          "text": "Something for the translator.",
+        },
+        "id": "foo.bar.biff",
+      },
+      {
+        "defaultMessage": "Hello World!",
+        "description": "Something for the translator. Another description",
+        "id": "NqjIBK",
+      },
+      {
+        "defaultMessage": "NO ID",
+        "description": "Something for the translator. Another description",
+        "id": "XOhkQy",
+      },
+    ],
+    "meta": {},
+  },
+}
+`;
+
+exports[`no pragma inline 1`] = `
+{
+  "code": "import React, { Component } from 'react';
+import { FormattedMessage, defineMessage } from 'react-intl';
+export default class Foo extends Component {
+    render() {
+        return /*#__PURE__*/ React.createElement("div", null, /*#__PURE__*/ React.createElement(FormattedMessage, {
+            id: "foo.bar.baz",
+            defaultMessage: "Hello World!"
+        }), defineMessage({
+            id: 'header',
+            defaultMessage: "Hello World!"
+        }), defineMessage({
+            id: 'header2',
+            defaultMessage: "Hello World!"
+        }));
+    }
+}",
+  "data": {
+    "messages": [
+      {
+        "defaultMessage": "Hello World!",
+        "description": "The default message.",
+        "id": "foo.bar.baz",
+      },
+      {
+        "defaultMessage": "Hello World!",
+        "description": "The default message",
+        "id": "header",
+      },
+      {
+        "defaultMessage": "Hello World!",
+        "description": "The default message",
+        "id": "header2",
+      },
+    ],
+    "meta": {},
+  },
+}
+`;
+
+exports[`no pragma preserveWhitespace 1`] = `
+{
+  "code": "// @react-intl project:amazing
+function _extends() {
+    _extends = Object.assign || function(target) {
+        for(var i = 1; i < arguments.length; i++){
+            var source = arguments[i];
+            for(var key in source){
+                if (Object.prototype.hasOwnProperty.call(source, key)) {
+                    target[key] = source[key];
+                }
+            }
+        }
+        return target;
+    };
+    return _extends.apply(this, arguments);
+}
+import React, { Component } from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+const msgs = defineMessages({
+    header: {
+        id: 'foo.bar.baz',
+        defaultMessage: "Hello World!"
+    },
+    content: {
+        id: 'foo.bar.biff',
+        defaultMessage: "Hello Nurse!"
+    },
+    kittens: {
+        id: 'app.home.kittens',
+        defaultMessage: "{count, plural, =0 {😭} one {# kitten} other {# kittens}}"
+    },
+    trailingWhitespace: {
+        id: 'trailing.ws',
+        defaultMessage: "   Some whitespace   "
+    },
+    escaped: {
+        id: 'escaped.apostrophe',
+        defaultMessage: "A quoted value ''{value}'"
+    },
+    newline: {
+        id: 'newline',
+        defaultMessage: "this is     a message"
+    },
+    linebreak: {
+        id: 'linebreak',
+        defaultMessage: "this is\\na message"
+    },
+    templateLinebreak: {
+        id: 'templateLinebreak',
+        description: \`this is
+    a
+    description\`,
+        defaultMessage: "this is\\n    a message"
+    }
+});
+export default class Foo extends Component {
+    render() {
+        return /*#__PURE__*/ React.createElement("div", null, /*#__PURE__*/ React.createElement("h1", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.header))), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.content))), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.kittens))), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, {
+            id: "inline.linebreak",
+            defaultMessage: "formatted message with linebreak"
+        })));
+    }
+}",
+  "data": {
+    "messages": [
+      {
+        "defaultMessage": "Hello World!",
+        "description": "The default message",
+        "id": "foo.bar.baz",
+      },
+      {
+        "defaultMessage": "Hello Nurse!",
+        "description": "Another message",
+        "id": "foo.bar.biff",
+      },
+      {
+        "defaultMessage": "{count, plural, =0 {😭} one {# kitten} other {# kittens}}",
+        "description": "Counts kittens",
+        "id": "app.home.kittens",
+      },
+      {
+        "defaultMessage": "   Some whitespace   ",
+        "description": "Whitespace",
+        "id": "trailing.ws",
+      },
+      {
+        "defaultMessage": "A quoted value ''{value}'",
+        "description": "Escaped apostrophe",
+        "id": "escaped.apostrophe",
+      },
+      {
+        "defaultMessage": "this is     a message",
+        "description": "this is     a     description",
+        "id": "newline",
+      },
+      {
+        "defaultMessage": "this is
+a message",
+        "description": "this is
+a
+description",
+        "id": "linebreak",
+      },
+      {
+        "defaultMessage": "this is
+    a message",
+        "id": "templateLinebreak",
+      },
+      {
+        "defaultMessage": "formatted message
+						with linebreak",
+        "description": "foo
+						bar",
+        "id": "inline.linebreak",
+      },
+    ],
+    "meta": {},
+  },
+}
+`;
+
+exports[`no pragma removeDefaultMessage 1`] = `
+{
+  "code": "import React, { Component } from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+defineMessages({
+    foo: {
+        id: 'greeting-user'
+    },
+    foo2: {
+        id: "xoMBqZ"
+    },
+    foo3: {
+        id: "s0FUZ6"
+    }
+});
+export default class Foo extends Component {
+    render() {
+        return /*#__PURE__*/ React.createElement(React.Fragment, null, /*#__PURE__*/ React.createElement(FormattedMessage, {
+            id: "greeting-world"
+        }), /*#__PURE__*/ React.createElement(FormattedMessage, {
+            id: "mdcDCs"
+        }), /*#__PURE__*/ React.createElement(FormattedMessage, {
+            id: "xjsqOM"
+        }));
+    }
+}",
+  "data": {
+    "messages": [
+      {
+        "defaultMessage": "Hello, {name}",
+        "description": "Greeting the user",
+        "id": "greeting-user",
+      },
+      {
+        "defaultMessage": "foo2-msg",
+        "description": "foo2",
+        "id": "xoMBqZ",
+      },
+      {
+        "defaultMessage": "foo3-msg",
+        "id": "s0FUZ6",
+      },
+      {
+        "defaultMessage": "Hello World!",
+        "description": "Greeting to the world",
+        "id": "greeting-world",
+      },
+      {
+        "defaultMessage": "message with desc",
+        "description": "desc with desc",
+        "id": "mdcDCs",
+      },
+      {
+        "defaultMessage": "message only",
+        "id": "xjsqOM",
+      },
+    ],
+    "meta": {},
+  },
+}
+`;
+
+exports[`no pragma skipExtractionFormattedMessage 1`] = `
+{
+  "code": "import React, { Component } from 'react';
+import { FormattedMessage } from 'react-intl';
+function nonStaticId() {
+    return 'baz';
+}
+export default class Foo extends Component {
+    render() {
+        return /*#__PURE__*/ React.createElement(FormattedMessage, {
+            id: \`foo.bar.\${nonStaticId()}\`
+        });
+    }
+}",
+  "data": {
+    "messages": [],
+    "meta": {},
+  },
+}
+`;
+
+exports[`no pragma templateLiteral 1`] = `
+{
+  "code": "import React, { Component } from 'react';
+import { FormattedMessage, defineMessage } from 'react-intl';
+defineMessage({
+    id: \`template\`,
+    defaultMessage: "should remove newline and extra spaces"
+});
+export default class Foo extends Component {
+    render() {
+        return /*#__PURE__*/ React.createElement(FormattedMessage, {
+            id: "foo.bar.baz",
+            defaultMessage: \`Hello World!\`
+        });
+    }
+}",
+  "data": {
+    "messages": [
+      {
+        "defaultMessage": "should remove newline and extra spaces",
+        "id": "template",
+      },
+      {
+        "defaultMessage": "Hello World!",
+        "description": "The default message.",
+        "id": "foo.bar.baz",
+      },
+    ],
+    "meta": {},
   },
 }
 `;

--- a/packages/swc-plugin-experimental/tests/index.test.ts
+++ b/packages/swc-plugin-experimental/tests/index.test.ts
@@ -7,10 +7,7 @@ export function transformAndCheck(
   transformOptions?: any
 ) {
   const filePath = path.join(__dirname, 'fixtures', `${fn}.js`)
-  const {code} = transform(filePath, transformOptions, {
-    pragma: '@react-intl',
-    ...opts,
-  })
+  const {code} = transform(filePath, transformOptions, opts)
 
   const [ret, comments] = code.split('/*__formatjs__messages_extracted__::')
   const data = JSON.parse(comments.substring(0, comments.indexOf('*/')))
@@ -21,177 +18,205 @@ export function transformAndCheck(
   }
 }
 
-test('additionalComponentNames', function () {
-  expect(
-    transformAndCheck('additionalComponentNames', {
-      additionalComponentNames: ['CustomMessage'],
-    })
-  ).toMatchSnapshot()
-})
-
-test('additionalFunctionNames', function () {
-  expect(
-    transformAndCheck('additionalFunctionNames', {
-      additionalFunctionNames: ['t'],
-    })
-  ).toMatchSnapshot()
-})
-
-test('ast', function () {
-  expect(
-    transformAndCheck('ast', {
-      ast: true,
-    })
-  ).toMatchSnapshot()
-})
-
-test('defineMessage', function () {
-  expect(transformAndCheck('defineMessage')).toMatchSnapshot()
-})
-
-test('descriptionsAsObjects', function () {
-  expect(transformAndCheck('descriptionsAsObjects')).toMatchSnapshot()
-})
-
-test('defineMessages', function () {
-  expect(transformAndCheck('defineMessages')).toMatchSnapshot()
-})
-test('empty', function () {
-  expect(transformAndCheck('empty')).toMatchSnapshot()
-})
-test('extractFromFormatMessageCall', function () {
-  expect(transformAndCheck('extractFromFormatMessageCall')).toMatchSnapshot()
-})
-test('extractFromFormatMessageCallStateless', function () {
-  expect(
-    transformAndCheck('extractFromFormatMessageCallStateless')
-  ).toMatchSnapshot()
-})
-test('formatMessageCall', function () {
-  expect(transformAndCheck('formatMessageCall')).toMatchSnapshot()
-})
-test('FormattedMessage', function () {
-  expect(transformAndCheck('FormattedMessage')).toMatchSnapshot()
-})
-test('inline', function () {
-  expect(transformAndCheck('inline')).toMatchSnapshot()
-})
-test('templateLiteral', function () {
-  expect(transformAndCheck('templateLiteral')).toMatchSnapshot()
-})
-
-// NOT FULLY IMPLEMENTED
-test.skip('idInterpolationPattern', function () {
-  expect(
-    transformAndCheck('idInterpolationPattern', {
-      idInterpolationPattern: '[folder].[name].[sha512:contenthash:hex:6]',
-    })
-  ).toMatchSnapshot()
-})
-
-test('idInterpolationPattern default', function () {
-  expect(transformAndCheck('idInterpolationPattern')).toMatchSnapshot()
-})
-
-test('GH #2663', function () {
-  expect(
-    transformAndCheck('2663', undefined, {
-      jsc: {
-        target: 'es5',
-      },
-    })
-  ).toMatchSnapshot()
-})
-
-// UNSUPPORTED
-test.skip('overrideIdFn', function () {
-  expect(
-    transformAndCheck('overrideIdFn', {
-      overrideIdFn: (
-        id?: string,
-        defaultMessage?: string,
-        description?: string,
-        filePath?: string
-      ) => {
-        const filename = path.basename(filePath!)
-        return `${filename}.${id}.${
-          defaultMessage!.length
-        }.${typeof description}`
-      },
-    })
-  ).toMatchSnapshot()
-})
-
-test('removeDefaultMessage', function () {
-  expect(
-    transformAndCheck('removeDefaultMessage', {
-      removeDefaultMessage: true,
-    })
-  ).toMatchSnapshot()
-})
-
-// UNSUPPORTED
-test.skip('removeDefaultMessage + overrideIdFn', function () {
-  expect(
-    transformAndCheck('removeDefaultMessage', {
-      removeDefaultMessage: true,
-      overrideIdFn: (
-        id?: string,
-        defaultMessage?: string,
-        description?: string,
-        filePath?: string
-      ) => {
-        const filename = path.basename(filePath!)
-        return `${filename}.${id}.${
-          defaultMessage!.length
-        }.${typeof description}`
-      },
-    })
-  ).toMatchSnapshot()
-})
-test('preserveWhitespace', function () {
-  expect(
-    transformAndCheck('preserveWhitespace', {
-      preserveWhitespace: true,
-    })
-  ).toMatchSnapshot()
-})
-
-test('extractSourceLocation', function () {
-  const {data, code} = transformAndCheck('extractSourceLocation', {
-    extractSourceLocation: true,
+describe.each([
+  ['explicit pragma', {pragma: '@react-intl'}],
+  ['no pragma', {}],
+])('%s', (_, pluginOptions) => {
+  test('additionalComponentNames', function () {
+    expect(
+      transformAndCheck('additionalComponentNames', {
+        ...pluginOptions,
+        additionalComponentNames: ['CustomMessage'],
+      })
+    ).toMatchSnapshot()
   })
 
-  expect(code).toMatchSnapshot()
+  test('additionalFunctionNames', function () {
+    expect(
+      transformAndCheck('additionalFunctionNames', {
+        ...pluginOptions,
+        additionalFunctionNames: ['t'],
+      })
+    ).toMatchSnapshot()
+  })
 
-  expect(data).toEqual({
-    messages: [
-      {
-        defaultMessage: 'Hello World!',
-        id: 'foo.bar.baz',
-        loc: {
-          end: {
-            col: 78,
-            line: 6,
-          },
-          file: path.join(__dirname, 'fixtures/extractSourceLocation.js'),
-          start: {
-            col: 11,
-            line: 6,
+  test('ast', function () {
+    expect(
+      transformAndCheck('ast', {
+        ...pluginOptions,
+        ast: true,
+      })
+    ).toMatchSnapshot()
+  })
+
+  test('defineMessage', function () {
+    expect(transformAndCheck('defineMessage', pluginOptions)).toMatchSnapshot()
+  })
+
+  test('descriptionsAsObjects', function () {
+    expect(
+      transformAndCheck('descriptionsAsObjects', pluginOptions)
+    ).toMatchSnapshot()
+  })
+
+  test('defineMessages', function () {
+    expect(transformAndCheck('defineMessages', pluginOptions)).toMatchSnapshot()
+  })
+  test('empty', function () {
+    expect(transformAndCheck('empty', pluginOptions)).toMatchSnapshot()
+  })
+  test('extractFromFormatMessageCall', function () {
+    expect(
+      transformAndCheck('extractFromFormatMessageCall', pluginOptions)
+    ).toMatchSnapshot()
+  })
+  test('extractFromFormatMessageCallStateless', function () {
+    expect(
+      transformAndCheck('extractFromFormatMessageCallStateless', pluginOptions)
+    ).toMatchSnapshot()
+  })
+  test('formatMessageCall', function () {
+    expect(
+      transformAndCheck('formatMessageCall', pluginOptions)
+    ).toMatchSnapshot()
+  })
+  test('FormattedMessage', function () {
+    expect(
+      transformAndCheck('FormattedMessage', pluginOptions)
+    ).toMatchSnapshot()
+  })
+  test('inline', function () {
+    expect(transformAndCheck('inline', pluginOptions)).toMatchSnapshot()
+  })
+  test('templateLiteral', function () {
+    expect(
+      transformAndCheck('templateLiteral', pluginOptions)
+    ).toMatchSnapshot()
+  })
+
+  // NOT FULLY IMPLEMENTED
+  test.skip('idInterpolationPattern', function () {
+    expect(
+      transformAndCheck('idInterpolationPattern', {
+        ...pluginOptions,
+        idInterpolationPattern: '[folder].[name].[sha512:contenthash:hex:6]',
+      })
+    ).toMatchSnapshot()
+  })
+
+  test('idInterpolationPattern default', function () {
+    expect(
+      transformAndCheck('idInterpolationPattern', pluginOptions)
+    ).toMatchSnapshot()
+  })
+
+  test('GH #2663', function () {
+    expect(
+      transformAndCheck('2663', pluginOptions, {
+        jsc: {
+          target: 'es5',
+        },
+      })
+    ).toMatchSnapshot()
+  })
+
+  // UNSUPPORTED
+  test.skip('overrideIdFn', function () {
+    expect(
+      transformAndCheck('overrideIdFn', {
+        ...pluginOptions,
+        overrideIdFn: (
+          id?: string,
+          defaultMessage?: string,
+          description?: string,
+          filePath?: string
+        ) => {
+          const filename = path.basename(filePath!)
+          return `${filename}.${id}.${
+            defaultMessage!.length
+          }.${typeof description}`
+        },
+      })
+    ).toMatchSnapshot()
+  })
+
+  test('removeDefaultMessage', function () {
+    expect(
+      transformAndCheck('removeDefaultMessage', {
+        ...pluginOptions,
+        removeDefaultMessage: true,
+      })
+    ).toMatchSnapshot()
+  })
+
+  // UNSUPPORTED
+  test.skip('removeDefaultMessage + overrideIdFn', function () {
+    expect(
+      transformAndCheck('removeDefaultMessage', {
+        ...pluginOptions,
+        removeDefaultMessage: true,
+        overrideIdFn: (
+          id?: string,
+          defaultMessage?: string,
+          description?: string,
+          filePath?: string
+        ) => {
+          const filename = path.basename(filePath!)
+          return `${filename}.${id}.${
+            defaultMessage!.length
+          }.${typeof description}`
+        },
+      })
+    ).toMatchSnapshot()
+  })
+  test('preserveWhitespace', function () {
+    expect(
+      transformAndCheck('preserveWhitespace', {
+        ...pluginOptions,
+        preserveWhitespace: true,
+      })
+    ).toMatchSnapshot()
+  })
+
+  test('extractSourceLocation', function () {
+    const {data, code} = transformAndCheck('extractSourceLocation', {
+      ...pluginOptions,
+      extractSourceLocation: true,
+    })
+
+    expect(code).toMatchSnapshot()
+
+    expect(data).toEqual({
+      messages: [
+        {
+          defaultMessage: 'Hello World!',
+          id: 'foo.bar.baz',
+          loc: {
+            end: {
+              col: 78,
+              line: 6,
+            },
+            file: path.join(__dirname, 'fixtures/extractSourceLocation.js'),
+            start: {
+              col: 11,
+              line: 6,
+            },
           },
         },
-      },
-    ],
-    meta: {},
+      ],
+      meta: {},
+    })
   })
-})
 
-test('Properly throws parse errors', () => {
-  expect(() => transformAndCheck('icuSyntax')).toThrow(
-    'SyntaxError: MALFORMED_ARGUMENT'
-  )
-})
+  test('Properly throws parse errors', () => {
+    expect(() => transformAndCheck('icuSyntax', pluginOptions)).toThrow(
+      'SyntaxError: MALFORMED_ARGUMENT'
+    )
+  })
 
-test('skipExtractionFormattedMessage', function () {
-  expect(transformAndCheck('skipExtractionFormattedMessage')).toMatchSnapshot()
+  test('skipExtractionFormattedMessage', function () {
+    expect(
+      transformAndCheck('skipExtractionFormattedMessage', pluginOptions)
+    ).toMatchSnapshot()
+  })
 })

--- a/packages/swc-plugin-experimental/tests/transform.ts
+++ b/packages/swc-plugin-experimental/tests/transform.ts
@@ -62,7 +62,6 @@ export const transform = (
 
   const testPluginOptions = {
     ...pluginOptions,
-    pragma: '@react-intl',
     debugExtractedMessagesComment: true,
   }
 


### PR DESCRIPTION
1. Fixes the plugin crash when there is no pragma specified in the file to be processed.
2. Fixes AST generation code that should generate an expression instead of a JSON string.