### PR TITLE
fix(react-intl): move types to devDependencies

### DIFF
--- a/packages/react-intl/package.json
+++ b/packages/react-intl/package.json
@@ -133,15 +133,15 @@
     "@formatjs/intl": "workspace:*",
     "@formatjs/intl-displaynames": "workspace:*",
     "@formatjs/intl-listformat": "workspace:*",
-    "@types/hoist-non-react-statics": "^3.3.1",
-    "@types/react": "16 || 17 || 18",
     "hoist-non-react-statics": "^3.3.2",
     "intl-messageformat": "workspace:*",
     "tslib": "^2.4.0"
   },
   "devDependencies": {
     "@formatjs/intl-numberformat": "workspace:*",
-    "@formatjs/intl-relativetimeformat": "workspace:*"
+    "@formatjs/intl-relativetimeformat": "workspace:*",
+    "@types/hoist-non-react-statics": "^3.3.1",
+    "@types/react": "16 || 17 || 18"
   },
   "peerDependencies": {
     "react": "^16.6.0 || 17 || 18",


### PR DESCRIPTION
This fixes conflicting dependencies. https://github.com/formatjs/formatjs/discussions/4002