### PR TITLE
docs: remove --output-empty-json from cli docs

### DIFF
--- a/website/docs/tooling/cli.md
+++ b/website/docs/tooling/cli.md
@@ -163,10 +163,6 @@ Additional component names to extract messages from, e.g: `['FormattedFooBarMess
 
 Additional function names to extract messages from, e.g: `['$t']`.
 
-### `--output-empty-json`
-
-Output file with empty [] if src has no messages. For build systems like [bazel](https://bazel.build/) that relies on specific output mapping, not writing out a file can cause issues. (default: `false`)
-
 ### `--ignore [files]`
 
 List of glob paths to **not** extract translations from.


### PR DESCRIPTION
option was removed in https://github.com/formatjs/formatjs/commit/3106618cbcb14eb7b1c63084b47b16a80737092d