### PR TITLE
bazelfix(@formatjs/swc-plugin-experimental): fix crash on next 13.3.2 and swc 1.3.56

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@lerna-lite/list": "^1.10.0",
     "@napi-rs/cli": "^2.11.0",
     "@swc-node/register": "^1.5.1",
-    "@swc/core": "^1.3.20",
+    "@swc/core": "^1.3.56",
     "@swc/jest": "^0.2.23",
     "@taplo/cli": "^0.5.0",
     "@testing-library/jest-dom": "^5.11.5",

--- a/packages/swc-plugin-experimental/BUILD
+++ b/packages/swc-plugin-experimental/BUILD
@@ -5,8 +5,6 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 
 npm_link_all_packages(name = "node_modules")
 
-PACKAGE_NAME = "swc-plugin-experimental"
-
 copy_file(
     name = "wasm",
     src = "//rust/swc-plugin-formatjs:swc_plugin_formatjs.wasm",
@@ -14,24 +12,24 @@ copy_file(
 )
 
 npm_package(
-    name = PACKAGE_NAME,
+    name = "swc-plugin-experimental",
     srcs = [
         "LICENSE.md",
         "README.md",
-        "index.wasm",
         "package.json",
+        ":index.wasm",
     ],
-    package = "@formatjs/%s" % PACKAGE_NAME,
+    package = "@formatjs/swc-plugin-experimental",
     visibility = ["//visibility:public"],
 )
 
 # NOTE: move this into its own Bazel rule and include common dependencies automatically.
 aspect_jest_test(
-    name = "test_plugin",
+    name = "plugin_test",
     config = "//:jest-aspect.config",
     data = [
-        "index.wasm",
         "tests/transform.ts",
+        ":index.wasm",
         "//:node_modules/@jest/transform",
         "//:node_modules/@swc/core",
         "//:node_modules/@swc/jest",

--- a/packages/swc-plugin-experimental/tests/__snapshots__/index.test.ts.snap
+++ b/packages/swc-plugin-experimental/tests/__snapshots__/index.test.ts.snap
@@ -41,7 +41,7 @@ exports[`explicit pragma GH #2663 1`] = `
         Promise.resolve(value).then(_next, _throw);
     }
 }
-function _asyncToGenerator(fn) {
+function _async_to_generator(fn) {
     return function() {
         var self = this, args = arguments;
         return new Promise(function(resolve, reject) {
@@ -56,7 +56,7 @@ function _asyncToGenerator(fn) {
         });
     };
 }
-var __generator = this && this.__generator || function(thisArg, body) {
+function _ts_generator(thisArg, body) {
     var f, y, t, g, _ = {
         label: 0,
         sent: function() {
@@ -150,13 +150,13 @@ var __generator = this && this.__generator || function(thisArg, body) {
             done: true
         };
     }
-};
+}
 function error1() {
     return _error1.apply(this, arguments);
 }
 function _error1() {
-    _error1 = _asyncToGenerator(function() {
-        return __generator(this, function(_state) {
+    _error1 = _async_to_generator(function() {
+        return _ts_generator(this, function(_state) {
             switch(_state.label){
                 case 0:
                     return [
@@ -401,20 +401,6 @@ export default class Foo extends Component {
 exports[`explicit pragma defineMessage 1`] = `
 {
   "code": "// @react-intl project:amazing
-function _extends() {
-    _extends = Object.assign || function(target) {
-        for(var i = 1; i < arguments.length; i++){
-            var source = arguments[i];
-            for(var key in source){
-                if (Object.prototype.hasOwnProperty.call(source, key)) {
-                    target[key] = source[key];
-                }
-            }
-        }
-        return target;
-    };
-    return _extends.apply(this, arguments);
-}
 import React, { Component } from 'react';
 import { defineMessage, FormattedMessage } from 'react-intl';
 const msgs = {
@@ -447,7 +433,7 @@ const msgs = {
 };
 export default class Foo extends Component {
     render() {
-        return /*#__PURE__*/ React.createElement("div", null, /*#__PURE__*/ React.createElement("h1", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.header))), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.content))), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.kittens))));
+        return /*#__PURE__*/ React.createElement("div", null, /*#__PURE__*/ React.createElement("h1", null, /*#__PURE__*/ React.createElement(FormattedMessage, msgs.header)), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, msgs.content)), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, msgs.kittens)));
     }
 }",
   "data": {
@@ -493,20 +479,6 @@ export default class Foo extends Component {
 exports[`explicit pragma defineMessages 1`] = `
 {
   "code": "// @react-intl project:amazing
-function _extends() {
-    _extends = Object.assign || function(target) {
-        for(var i = 1; i < arguments.length; i++){
-            var source = arguments[i];
-            for(var key in source){
-                if (Object.prototype.hasOwnProperty.call(source, key)) {
-                    target[key] = source[key];
-                }
-            }
-        }
-        return target;
-    };
-    return _extends.apply(this, arguments);
-}
 import React, { Component } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 const msgs = defineMessages({
@@ -533,7 +505,7 @@ const msgs = defineMessages({
 });
 export default class Foo extends Component {
     render() {
-        return /*#__PURE__*/ React.createElement("div", null, /*#__PURE__*/ React.createElement("h1", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.header))), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.content))), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.kittens))));
+        return /*#__PURE__*/ React.createElement("div", null, /*#__PURE__*/ React.createElement("h1", null, /*#__PURE__*/ React.createElement(FormattedMessage, msgs.header)), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, msgs.content)), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, msgs.kittens)));
     }
 }",
   "data": {
@@ -807,21 +779,7 @@ export default injectIntl(Foo)",
 
 exports[`explicit pragma idInterpolationPattern default 1`] = `
 {
-  "code": "function _extends() {
-    _extends = Object.assign || function(target) {
-        for(var i = 1; i < arguments.length; i++){
-            var source = arguments[i];
-            for(var key in source){
-                if (Object.prototype.hasOwnProperty.call(source, key)) {
-                    target[key] = source[key];
-                }
-            }
-        }
-        return target;
-    };
-    return _extends.apply(this, arguments);
-}
-import React, { Component } from 'react';
+  "code": "import React, { Component } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 const msgs = defineMessages({
     header: {
@@ -835,7 +793,7 @@ const msgs = defineMessages({
 });
 export default class Foo extends Component {
     render() {
-        return /*#__PURE__*/ React.createElement("div", null, /*#__PURE__*/ React.createElement("h1", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.header))), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.content))), /*#__PURE__*/ React.createElement(FormattedMessage, {
+        return /*#__PURE__*/ React.createElement("div", null, /*#__PURE__*/ React.createElement("h1", null, /*#__PURE__*/ React.createElement(FormattedMessage, msgs.header)), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, msgs.content)), /*#__PURE__*/ React.createElement(FormattedMessage, {
             id: "NqjIBK",
             defaultMessage: "Hello World!"
         }), /*#__PURE__*/ React.createElement(FormattedMessage, {
@@ -919,20 +877,6 @@ export default class Foo extends Component {
 exports[`explicit pragma preserveWhitespace 1`] = `
 {
   "code": "// @react-intl project:amazing
-function _extends() {
-    _extends = Object.assign || function(target) {
-        for(var i = 1; i < arguments.length; i++){
-            var source = arguments[i];
-            for(var key in source){
-                if (Object.prototype.hasOwnProperty.call(source, key)) {
-                    target[key] = source[key];
-                }
-            }
-        }
-        return target;
-    };
-    return _extends.apply(this, arguments);
-}
 import React, { Component } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 const msgs = defineMessages({
@@ -974,9 +918,9 @@ const msgs = defineMessages({
 });
 export default class Foo extends Component {
     render() {
-        return /*#__PURE__*/ React.createElement("div", null, /*#__PURE__*/ React.createElement("h1", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.header))), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.content))), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.kittens))), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, {
+        return /*#__PURE__*/ React.createElement("div", null, /*#__PURE__*/ React.createElement("h1", null, /*#__PURE__*/ React.createElement(FormattedMessage, msgs.header)), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, msgs.content)), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, msgs.kittens)), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, {
             id: "inline.linebreak",
-            defaultMessage: "formatted message with linebreak"
+            defaultMessage: "formatted message       with linebreak"
         })));
     }
 }",
@@ -1197,7 +1141,7 @@ exports[`no pragma GH #2663 1`] = `
         Promise.resolve(value).then(_next, _throw);
     }
 }
-function _asyncToGenerator(fn) {
+function _async_to_generator(fn) {
     return function() {
         var self = this, args = arguments;
         return new Promise(function(resolve, reject) {
@@ -1212,7 +1156,7 @@ function _asyncToGenerator(fn) {
         });
     };
 }
-var __generator = this && this.__generator || function(thisArg, body) {
+function _ts_generator(thisArg, body) {
     var f, y, t, g, _ = {
         label: 0,
         sent: function() {
@@ -1306,13 +1250,13 @@ var __generator = this && this.__generator || function(thisArg, body) {
             done: true
         };
     }
-};
+}
 function error1() {
     return _error1.apply(this, arguments);
 }
 function _error1() {
-    _error1 = _asyncToGenerator(function() {
-        return __generator(this, function(_state) {
+    _error1 = _async_to_generator(function() {
+        return _ts_generator(this, function(_state) {
             switch(_state.label){
                 case 0:
                     return [
@@ -1555,20 +1499,6 @@ export default class Foo extends Component {
 exports[`no pragma defineMessage 1`] = `
 {
   "code": "// @react-intl project:amazing
-function _extends() {
-    _extends = Object.assign || function(target) {
-        for(var i = 1; i < arguments.length; i++){
-            var source = arguments[i];
-            for(var key in source){
-                if (Object.prototype.hasOwnProperty.call(source, key)) {
-                    target[key] = source[key];
-                }
-            }
-        }
-        return target;
-    };
-    return _extends.apply(this, arguments);
-}
 import React, { Component } from 'react';
 import { defineMessage, FormattedMessage } from 'react-intl';
 const msgs = {
@@ -1601,7 +1531,7 @@ const msgs = {
 };
 export default class Foo extends Component {
     render() {
-        return /*#__PURE__*/ React.createElement("div", null, /*#__PURE__*/ React.createElement("h1", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.header))), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.content))), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.kittens))));
+        return /*#__PURE__*/ React.createElement("div", null, /*#__PURE__*/ React.createElement("h1", null, /*#__PURE__*/ React.createElement(FormattedMessage, msgs.header)), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, msgs.content)), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, msgs.kittens)));
     }
 }",
   "data": {
@@ -1645,20 +1575,6 @@ export default class Foo extends Component {
 exports[`no pragma defineMessages 1`] = `
 {
   "code": "// @react-intl project:amazing
-function _extends() {
-    _extends = Object.assign || function(target) {
-        for(var i = 1; i < arguments.length; i++){
-            var source = arguments[i];
-            for(var key in source){
-                if (Object.prototype.hasOwnProperty.call(source, key)) {
-                    target[key] = source[key];
-                }
-            }
-        }
-        return target;
-    };
-    return _extends.apply(this, arguments);
-}
 import React, { Component } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 const msgs = defineMessages({
@@ -1685,7 +1601,7 @@ const msgs = defineMessages({
 });
 export default class Foo extends Component {
     render() {
-        return /*#__PURE__*/ React.createElement("div", null, /*#__PURE__*/ React.createElement("h1", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.header))), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.content))), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.kittens))));
+        return /*#__PURE__*/ React.createElement("div", null, /*#__PURE__*/ React.createElement("h1", null, /*#__PURE__*/ React.createElement(FormattedMessage, msgs.header)), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, msgs.content)), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, msgs.kittens)));
     }
 }",
   "data": {
@@ -1955,21 +1871,7 @@ export default injectIntl(Foo)",
 
 exports[`no pragma idInterpolationPattern default 1`] = `
 {
-  "code": "function _extends() {
-    _extends = Object.assign || function(target) {
-        for(var i = 1; i < arguments.length; i++){
-            var source = arguments[i];
-            for(var key in source){
-                if (Object.prototype.hasOwnProperty.call(source, key)) {
-                    target[key] = source[key];
-                }
-            }
-        }
-        return target;
-    };
-    return _extends.apply(this, arguments);
-}
-import React, { Component } from 'react';
+  "code": "import React, { Component } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 const msgs = defineMessages({
     header: {
@@ -1983,7 +1885,7 @@ const msgs = defineMessages({
 });
 export default class Foo extends Component {
     render() {
-        return /*#__PURE__*/ React.createElement("div", null, /*#__PURE__*/ React.createElement("h1", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.header))), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.content))), /*#__PURE__*/ React.createElement(FormattedMessage, {
+        return /*#__PURE__*/ React.createElement("div", null, /*#__PURE__*/ React.createElement("h1", null, /*#__PURE__*/ React.createElement(FormattedMessage, msgs.header)), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, msgs.content)), /*#__PURE__*/ React.createElement(FormattedMessage, {
             id: "NqjIBK",
             defaultMessage: "Hello World!"
         }), /*#__PURE__*/ React.createElement(FormattedMessage, {
@@ -2067,20 +1969,6 @@ export default class Foo extends Component {
 exports[`no pragma preserveWhitespace 1`] = `
 {
   "code": "// @react-intl project:amazing
-function _extends() {
-    _extends = Object.assign || function(target) {
-        for(var i = 1; i < arguments.length; i++){
-            var source = arguments[i];
-            for(var key in source){
-                if (Object.prototype.hasOwnProperty.call(source, key)) {
-                    target[key] = source[key];
-                }
-            }
-        }
-        return target;
-    };
-    return _extends.apply(this, arguments);
-}
 import React, { Component } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 const msgs = defineMessages({
@@ -2122,9 +2010,9 @@ const msgs = defineMessages({
 });
 export default class Foo extends Component {
     render() {
-        return /*#__PURE__*/ React.createElement("div", null, /*#__PURE__*/ React.createElement("h1", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.header))), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.content))), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, _extends({}, msgs.kittens))), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, {
+        return /*#__PURE__*/ React.createElement("div", null, /*#__PURE__*/ React.createElement("h1", null, /*#__PURE__*/ React.createElement(FormattedMessage, msgs.header)), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, msgs.content)), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, msgs.kittens)), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, {
             id: "inline.linebreak",
-            defaultMessage: "formatted message with linebreak"
+            defaultMessage: "formatted message       with linebreak"
         })));
     }
 }",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
       '@lerna-lite/list': ^1.10.0
       '@napi-rs/cli': ^2.11.0
       '@swc-node/register': ^1.5.1
-      '@swc/core': ^1.3.20
+      '@swc/core': ^1.3.56
       '@swc/jest': ^0.2.23
       '@taplo/cli': ^0.5.0
       '@testing-library/jest-dom': ^5.11.5
@@ -138,16 +138,16 @@ importers:
       '@babel/types': 7.18.4
       '@bazel/bazelisk': 1.12.0
       '@bazel/ibazel': 0.16.2
-      '@commitlint/cli': 17.0.3_@swc+core@1.3.20
+      '@commitlint/cli': 17.0.3_@swc+core@1.3.56
       '@commitlint/config-angular': 17.0.3
       '@jest/transform': 29.5.0
       '@jest/types': 29.5.0
       '@lerna-lite/cli': 1.10.0
       '@lerna-lite/list': 1.10.0
       '@napi-rs/cli': 2.12.0
-      '@swc-node/register': 1.5.4_j23m6epamxsf7ychiu2u22k6gy
-      '@swc/core': 1.3.20
-      '@swc/jest': 0.2.23_@swc+core@1.3.20
+      '@swc-node/register': 1.5.4_cjpfceqy5yezucotz3ojvdgspi
+      '@swc/core': 1.3.56
+      '@swc/jest': 0.2.23_@swc+core@1.3.56
       '@taplo/cli': 0.5.2
       '@testing-library/jest-dom': 5.16.4
       '@testing-library/react': 13.4.0_biqbaboplfbrettd7655fr4n2y
@@ -170,7 +170,7 @@ importers:
       '@types/regenerate': 1.4.1
       '@types/rimraf': 3.0.2
       '@types/serialize-javascript': 5.0.2
-      '@types/webpack': 5.28.0_@swc+core@1.3.20
+      '@types/webpack': 5.28.0_@swc+core@1.3.56
       '@typescript-eslint/parser': 5.29.0_hduvhoecomleogptwyfd7bwak4
       '@typescript-eslint/typescript-estree': 5.29.0_typescript@5.0.4
       '@unicode/unicode-13.0.0': 1.2.2
@@ -225,7 +225,7 @@ importers:
       test262-harness: 10.0.0
       ts-jest: 29.1.0_wqjcsy6lmnxrdakyinpe235mxm
       ts-loader: 9.3.1_4c3ju54lxbuwvvwrcgkb7jwndy
-      ts-node: 10.8.1_uuxzqssszqkjfhuflwhryr2ddq
+      ts-node: 10.8.1_ejfxdjw3bjba5q346ioshphvpa
       tsd: 0.28.1
       tslib: 2.4.0
       typescript: 5.0.4
@@ -235,7 +235,7 @@ importers:
       vue-class-component: 8.0.0-rc.1_vue@3.2.45
       vue-eslint-parser: 7.11.0_eslint@8.18.0
       vue-loader: 17.0.0_webpack@5.73.0
-      webpack: 5.73.0_@swc+core@1.3.20
+      webpack: 5.73.0_@swc+core@1.3.56
 
   packages/babel-plugin-formatjs:
     specifiers:
@@ -3481,14 +3481,14 @@ packages:
     engines: {node: '>=0.1.90'}
     dev: true
 
-  /@commitlint/cli/17.0.3_@swc+core@1.3.20:
+  /@commitlint/cli/17.0.3_@swc+core@1.3.56:
     resolution: {integrity: sha512-oAo2vi5d8QZnAbtU5+0cR2j+A7PO8zuccux65R/EycwvsZrDVyW518FFrnJK2UQxbRtHFFIG+NjQ6vOiJV0Q8A==}
     engines: {node: '>=v14'}
     hasBin: true
     dependencies:
       '@commitlint/format': 17.0.0
       '@commitlint/lint': 17.0.3
-      '@commitlint/load': 17.0.3_@swc+core@1.3.20
+      '@commitlint/load': 17.0.3_@swc+core@1.3.56
       '@commitlint/read': 17.0.0
       '@commitlint/types': 17.0.0
       execa: 5.1.1
@@ -3560,7 +3560,7 @@ packages:
       '@commitlint/types': 17.0.0
     dev: true
 
-  /@commitlint/load/17.0.3_@swc+core@1.3.20:
+  /@commitlint/load/17.0.3_@swc+core@1.3.56:
     resolution: {integrity: sha512-3Dhvr7GcKbKa/ey4QJ5MZH3+J7QFlARohUow6hftQyNjzoXXROm+RwpBes4dDFrXG1xDw9QPXA7uzrOShCd4bw==}
     engines: {node: '>=v14'}
     dependencies:
@@ -3571,7 +3571,7 @@ packages:
       '@types/node': 18.11.9
       chalk: 4.1.2
       cosmiconfig: 7.0.1
-      cosmiconfig-typescript-loader: 2.0.2_ynn263r5r6vh5bdwgm4umyf45m
+      cosmiconfig-typescript-loader: 2.0.2_ldacpcbvssexfik2mistydbqii
       lodash: 4.17.21
       resolve-from: 5.0.0
       typescript: 4.9.3
@@ -5627,24 +5627,24 @@ packages:
       - supports-color
     dev: true
 
-  /@swc-node/core/1.9.1_@swc+core@1.3.20:
+  /@swc-node/core/1.9.1_@swc+core@1.3.56:
     resolution: {integrity: sha512-Mh4T/PmQOpPtqw1BNvU38uWzsXbd5RJji17YBXnj7JDDE5KlTR9sSo2RKxWKDVtHbdcD1S+CtyZXA93aEWlfGQ==}
     engines: {node: '>= 10'}
     peerDependencies:
       '@swc/core': '>= 1.3'
     dependencies:
-      '@swc/core': 1.3.20
+      '@swc/core': 1.3.56
     dev: true
 
-  /@swc-node/register/1.5.4_j23m6epamxsf7ychiu2u22k6gy:
+  /@swc-node/register/1.5.4_cjpfceqy5yezucotz3ojvdgspi:
     resolution: {integrity: sha512-cM5/A63bO6qLUFC4gcBnOlQO5yd8ObSdFUIp7sXf11Oq5mPVAnJy2DqjbWMUsqUaHuNk+lOIt76ie4DEseUIyA==}
     peerDependencies:
       '@swc/core': '>= 1.3'
       typescript: '>= 4.3'
     dependencies:
-      '@swc-node/core': 1.9.1_@swc+core@1.3.20
+      '@swc-node/core': 1.9.1_@swc+core@1.3.56
       '@swc-node/sourcemap-support': 0.2.2
-      '@swc/core': 1.3.20
+      '@swc/core': 1.3.56
       colorette: 2.0.19
       debug: 4.3.4
       pirates: 4.0.5
@@ -5692,8 +5692,8 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core-darwin-arm64/1.3.20:
-    resolution: {integrity: sha512-ZLk5oVP4v/BAdC3FuBuyB0xpnkZStblIajiyo/kpp/7mq3YbABhOxTCUJGDozISbkaZlIZFXjqvHHnIS42tssw==}
+  /@swc/core-darwin-arm64/1.3.56:
+    resolution: {integrity: sha512-DZcu7BzDaLEdWHabz9DRTP0yEBLqkrWmskFcD5BX0lGAvoIvE4duMnAqi5F2B3X7630QioHRCYFoRw2WkeE3Cw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [darwin]
@@ -5709,8 +5709,8 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core-darwin-x64/1.3.20:
-    resolution: {integrity: sha512-yM11/3n8PwougalAi9eWkz1r5QRDAg1qdXMSCn7sWlVGr0RvdPL20viKddm38yn+X3FzZzgdoajh7NGfEeqCIQ==}
+  /@swc/core-darwin-x64/1.3.56:
+    resolution: {integrity: sha512-VH5saqYFasdRXJy6RAT+MXm0+IjkMZvOkohJwUei+oA65cKJofQwrJ1jZro8yOJFYvUSI3jgNRGsdBkmo/4hMw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [darwin]
@@ -5739,8 +5739,8 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core-linux-arm-gnueabihf/1.3.20:
-    resolution: {integrity: sha512-Y8YX7Ma7/xdvCR+hwqhU2lNKF7Qevlx3qZ+eGEpz2fP6k5iu8C5arUBjFWdC2OTY11OuD00TH43TgYfbWpU/Sw==}
+  /@swc/core-linux-arm-gnueabihf/1.3.56:
+    resolution: {integrity: sha512-LWwPo6NnJkH01+ukqvkoNIOpMdw+Zundm4vBeicwyVrkP+mC3kwVfi03TUFpQUz3kRKdw/QEnxGTj+MouCPbtw==}
     engines: {node: '>=10'}
     cpu: [arm]
     os: [linux]
@@ -5756,8 +5756,8 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core-linux-arm64-gnu/1.3.20:
-    resolution: {integrity: sha512-XCjQj4zo2T4QIqxVgzXkKxTLw4adqMgFG2iXBRRu1kOZXJor7Yzc0wH0B4rGtlkcZnh57MBbo+N1TNzH1leSFw==}
+  /@swc/core-linux-arm64-gnu/1.3.56:
+    resolution: {integrity: sha512-GzsUy/4egJ4cMlxbM+Ub7AMi5CKAc+pxBxrh8MUPQbyStW8jGgnQsJouTnGy0LHawtdEnsCOl6PcO6OgvktXuQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
@@ -5773,8 +5773,8 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core-linux-arm64-musl/1.3.20:
-    resolution: {integrity: sha512-f+fIixoNNaDjmHX0kJn8Lm1Z+CJPHqcYocGaPrXETRAv+8F3Q0rUtxO9FhDKtsG4pI6HRLmS5nBQtBBJWOmfvw==}
+  /@swc/core-linux-arm64-musl/1.3.56:
+    resolution: {integrity: sha512-9gxL09BIiAv8zY0DjfnFf19bo8+P4T9tdhzPwcm+1yPJcY5yr1+YFWLNFzz01agtOj6VlZ2/wUJTaOfdjjtc+A==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
@@ -5790,8 +5790,8 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core-linux-x64-gnu/1.3.20:
-    resolution: {integrity: sha512-F5TKwsZh3F7CzfYoTAiNwhZazQ02NCgFZSqSwO4lOYbT7RU+zXI3OfLoi2R8f0dzfqh26QSdeeMFPdMb3LpzXg==}
+  /@swc/core-linux-x64-gnu/1.3.56:
+    resolution: {integrity: sha512-n0ORNknl50vMRkll3BDO1E4WOqY6iISlPV1ZQCRLWQ6YQ2q8/WAryBxc2OAybcGHBUFkxyACpJukeU1QZ/9tNw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
@@ -5807,8 +5807,8 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core-linux-x64-musl/1.3.20:
-    resolution: {integrity: sha512-svbrCeaWU2N9saeg5yKZ2aQh+eYE6vW7y+ptZHgLIriuhnelg38mNqNjKK9emhshUNqOPLFJbW8kA1P+jOyyLw==}
+  /@swc/core-linux-x64-musl/1.3.56:
+    resolution: {integrity: sha512-r+D34WLAOAlJtfw1gaVWpHRwCncU9nzW9i7w9kSw4HpWYnHJOz54jLGSEmNsrhdTCz1VK2ar+V2ktFUsrlGlDA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
@@ -5826,8 +5826,8 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core-win32-arm64-msvc/1.3.20:
-    resolution: {integrity: sha512-rFrC8JtVlnyfj5wTAIMvNWqPv0KXUA8/TmEKUlg7jgF/IweFPOFvF509tiAstz16Ui2JKL9xaA566/I+XLd+og==}
+  /@swc/core-win32-arm64-msvc/1.3.56:
+    resolution: {integrity: sha512-29Yt75Is6X24z3x8h/xZC1HnDPkPpyLH9mDQiM6Cuc0I9mVr1XSriPEUB2N/awf5IE4SA8c+3IVq1DtKWbkJIw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [win32]
@@ -5845,8 +5845,8 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core-win32-ia32-msvc/1.3.20:
-    resolution: {integrity: sha512-xIkBDw0Rd0G0SQ/g9FOUqrcmwcq/Iy7ScBQVV/NzziIGIUlrj9l4nYe3VyoMEH2lwAcyGo9AxwiNB0vq6vDjiQ==}
+  /@swc/core-win32-ia32-msvc/1.3.56:
+    resolution: {integrity: sha512-mplp0zbYDrcHtfvkniXlXdB04e2qIjz2Gq/XHKr4Rnc6xVORJjjXF91IemXKpavx2oZYJws+LNJL7UFQ8jyCdQ==}
     engines: {node: '>=10'}
     cpu: [ia32]
     os: [win32]
@@ -5862,8 +5862,8 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core-win32-x64-msvc/1.3.20:
-    resolution: {integrity: sha512-1/vxiNasPvpCnVdMxGXEXYhRI65l7yNg/AQ9fYLQn3O5ouWJcd60+6ZoeVrnR5i/R87Fyu/A9fMhOJuOKLHXmA==}
+  /@swc/core-win32-x64-msvc/1.3.56:
+    resolution: {integrity: sha512-zp8MBnrw/bjdLenO/ifYzHrImSjKunqL0C2IF4LXYNRfcbYFh2NwobsVQMZ20IT0474lKRdlP8Oxdt+bHuXrzA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [win32]
@@ -5891,31 +5891,35 @@ packages:
       '@swc/core-win32-x64-msvc': 1.2.241
     dev: false
 
-  /@swc/core/1.3.20:
-    resolution: {integrity: sha512-wSuy5mFTbAPYGlo1DGWkTbXwUubpyYxY2Sf10Y861c4EPtwK7D1nbj35Zg0bsIQvcFG5Y2Q4sXNV5QpsnT0+1A==}
+  /@swc/core/1.3.56:
+    resolution: {integrity: sha512-yz/EeXT+PMZucUNrYceRUaTfuNS4IIu5EDZSOlvCEvm4jAmZi7CYH1B/kvzEzoAOzr7zkQiDPNJftcQXLkjbjA==}
     engines: {node: '>=10'}
-    hasBin: true
     requiresBuild: true
+    peerDependencies:
+      '@swc/helpers': ^0.5.0
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
     optionalDependencies:
-      '@swc/core-darwin-arm64': 1.3.20
-      '@swc/core-darwin-x64': 1.3.20
-      '@swc/core-linux-arm-gnueabihf': 1.3.20
-      '@swc/core-linux-arm64-gnu': 1.3.20
-      '@swc/core-linux-arm64-musl': 1.3.20
-      '@swc/core-linux-x64-gnu': 1.3.20
-      '@swc/core-linux-x64-musl': 1.3.20
-      '@swc/core-win32-arm64-msvc': 1.3.20
-      '@swc/core-win32-ia32-msvc': 1.3.20
-      '@swc/core-win32-x64-msvc': 1.3.20
+      '@swc/core-darwin-arm64': 1.3.56
+      '@swc/core-darwin-x64': 1.3.56
+      '@swc/core-linux-arm-gnueabihf': 1.3.56
+      '@swc/core-linux-arm64-gnu': 1.3.56
+      '@swc/core-linux-arm64-musl': 1.3.56
+      '@swc/core-linux-x64-gnu': 1.3.56
+      '@swc/core-linux-x64-musl': 1.3.56
+      '@swc/core-win32-arm64-msvc': 1.3.56
+      '@swc/core-win32-ia32-msvc': 1.3.56
+      '@swc/core-win32-x64-msvc': 1.3.56
 
-  /@swc/jest/0.2.23_@swc+core@1.3.20:
+  /@swc/jest/0.2.23_@swc+core@1.3.56:
     resolution: {integrity: sha512-ZLj17XjHbPtNsgqjm83qizENw05emLkKGu3WuPUttcy9hkngl0/kcc7fDbcSBpADS0GUtsO+iKPjZFWVAtJSlA==}
     engines: {npm: '>= 7.0.0'}
     peerDependencies:
       '@swc/core': '*'
     dependencies:
       '@jest/create-cache-key-function': 27.5.1
-      '@swc/core': 1.3.20
+      '@swc/core': 1.3.56
       jsonc-parser: 3.2.0
     dev: true
 
@@ -6426,12 +6430,12 @@ packages:
     resolution: {integrity: sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==}
     dev: true
 
-  /@types/webpack/5.28.0_@swc+core@1.3.20:
+  /@types/webpack/5.28.0_@swc+core@1.3.56:
     resolution: {integrity: sha512-8cP0CzcxUiFuA9xGJkfeVpqmWTk9nx6CWwamRGCj95ph1SmlRRk9KlCZ6avhCbZd4L68LvYT6l1kpdEnQXrF8w==}
     dependencies:
       '@types/node': 18.11.9
       tapable: 2.2.1
-      webpack: 5.73.0_@swc+core@1.3.20
+      webpack: 5.73.0_@swc+core@1.3.56
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -7358,7 +7362,7 @@ packages:
       loader-utils: 2.0.2
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.73.0_@swc+core@1.3.20
+      webpack: 5.73.0_@swc+core@1.3.56
     dev: true
 
   /babel-plugin-apply-mdx-type-prop/1.6.22_@babel+core@7.12.9:
@@ -8668,7 +8672,7 @@ packages:
     engines: {node: '>= 0.4.0'}
     dev: true
 
-  /cosmiconfig-typescript-loader/2.0.2_ynn263r5r6vh5bdwgm4umyf45m:
+  /cosmiconfig-typescript-loader/2.0.2_ldacpcbvssexfik2mistydbqii:
     resolution: {integrity: sha512-KmE+bMjWMXJbkWCeY4FJX/npHuZPNr9XF9q9CIQ/bpFwi1qHfCmSiKarrCcRa0LO4fWjk93pVoeRtJAkTGcYNw==}
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
@@ -8677,7 +8681,7 @@ packages:
     dependencies:
       '@types/node': 18.11.9
       cosmiconfig: 7.0.1
-      ts-node: 10.8.1_ynn263r5r6vh5bdwgm4umyf45m
+      ts-node: 10.8.1_ldacpcbvssexfik2mistydbqii
       typescript: 4.9.3
     transitivePeerDependencies:
       - '@swc/core'
@@ -11853,7 +11857,7 @@ packages:
       pretty-format: 29.5.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.8.1_uuxzqssszqkjfhuflwhryr2ddq
+      ts-node: 10.8.1_ejfxdjw3bjba5q346ioshphvpa
     transitivePeerDependencies:
       - supports-color
 
@@ -16341,7 +16345,7 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /terser-webpack-plugin/5.3.3_sbxky5tokihco4tfpqg2x3l6hy:
+  /terser-webpack-plugin/5.3.3_vewozu6kjhw3bvdoigycikss7u:
     resolution: {integrity: sha512-Fx60G5HNYknNTNQnzQ1VePRuu89ZVYWfjRAeT5rITuCY/1b08s49e5kSQwHDirKZWuoKOBRFS98EUUoZ9kLEwQ==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -16358,12 +16362,12 @@ packages:
         optional: true
     dependencies:
       '@jridgewell/trace-mapping': 0.3.13
-      '@swc/core': 1.3.20
+      '@swc/core': 1.3.56
       jest-worker: 27.5.1
       schema-utils: 3.1.1
       serialize-javascript: 6.0.0
       terser: 4.8.1
-      webpack: 5.73.0_@swc+core@1.3.20
+      webpack: 5.73.0_@swc+core@1.3.56
     dev: true
 
   /terser-webpack-plugin/5.3.3_webpack@5.73.0:
@@ -16620,10 +16624,10 @@ packages:
       micromatch: 4.0.5
       semver: 7.3.7
       typescript: 5.0.4
-      webpack: 5.73.0_@swc+core@1.3.20
+      webpack: 5.73.0_@swc+core@1.3.56
     dev: true
 
-  /ts-node/10.8.1_uuxzqssszqkjfhuflwhryr2ddq:
+  /ts-node/10.8.1_ejfxdjw3bjba5q346ioshphvpa:
     resolution: {integrity: sha512-Wwsnao4DQoJsN034wePSg5nZiw4YKXf56mPIAeD6wVmiv+RytNSWqc2f3fKvcUoV+Yn2+yocD71VOfQHbmVX4g==}
     hasBin: true
     peerDependencies:
@@ -16638,7 +16642,7 @@ packages:
         optional: true
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
-      '@swc/core': 1.3.20
+      '@swc/core': 1.3.56
       '@tsconfig/node10': 1.0.9
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
@@ -16654,7 +16658,7 @@ packages:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  /ts-node/10.8.1_ynn263r5r6vh5bdwgm4umyf45m:
+  /ts-node/10.8.1_ldacpcbvssexfik2mistydbqii:
     resolution: {integrity: sha512-Wwsnao4DQoJsN034wePSg5nZiw4YKXf56mPIAeD6wVmiv+RytNSWqc2f3fKvcUoV+Yn2+yocD71VOfQHbmVX4g==}
     hasBin: true
     peerDependencies:
@@ -16669,7 +16673,7 @@ packages:
         optional: true
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
-      '@swc/core': 1.3.20
+      '@swc/core': 1.3.56
       '@tsconfig/node10': 1.0.9
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
@@ -17263,7 +17267,7 @@ packages:
       chalk: 4.1.2
       hash-sum: 2.0.0
       loader-utils: 2.0.2
-      webpack: 5.73.0_@swc+core@1.3.20
+      webpack: 5.73.0_@swc+core@1.3.56
     dev: true
 
   /vue/3.2.45:
@@ -17522,7 +17526,7 @@ packages:
       - uglify-js
     dev: true
 
-  /webpack/5.73.0_@swc+core@1.3.20:
+  /webpack/5.73.0_@swc+core@1.3.56:
     resolution: {integrity: sha512-svjudQRPPa0YiOYa2lM/Gacw0r6PvxptHj4FuEKQ2kX05ZLkjbVc5MnPs6its5j7IZljnIqSVo/OsY2X0IpHGA==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -17553,7 +17557,7 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.1.1
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.3_sbxky5tokihco4tfpqg2x3l6hy
+      terser-webpack-plugin: 5.3.3_vewozu6kjhw3bvdoigycikss7u
       watchpack: 2.4.0
       webpack-sources: 3.2.3
     transitivePeerDependencies:

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -40,9 +40,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
 dependencies = [
  "memchr",
 ]
@@ -58,22 +58,35 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.68"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
 name = "ast_node"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf94863c5fdfee166d0907c44e5fee970123b2b7307046d35d1e671aa93afbba"
+checksum = "70151a5226578411132d798aa248df45b30aa34aea2e580628870b4d87be717b"
 dependencies = [
  "darling",
  "pmutil",
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn",
+ "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ast_node"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f7fd7740c5752c16281a1c1f9442b1e69ba41738acde85dc604aaf3ce41890"
+dependencies = [
+ "pmutil",
+ "proc-macro2",
+ "quote",
+ "swc_macros_common",
+ "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -82,7 +95,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi 0.1.19",
+ "hermit-abi 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
  "winapi",
 ]
@@ -116,9 +129,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64ct"
-version = "1.5.3"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "better_scoped_tls"
@@ -136,10 +149,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "block-buffer"
-version = "0.10.3"
+name = "bitflags"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+checksum = "24a6904aef64d73cf10ab17ebace7befb918b82164785cb89907993be7f83813"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
@@ -157,30 +176,31 @@ dependencies = [
 
 [[package]]
 name = "bytecheck"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d11cac2c12b5adc6570dad2ee1b87eff4955dac476fe12d81e5fdd352e52406f"
+checksum = "13fe11640a23eb24562225322cd3e452b93a3d4091d62fab69c70542fcd17d1f"
 dependencies = [
  "bytecheck_derive",
  "ptr_meta",
+ "simdutf8",
 ]
 
 [[package]]
 name = "bytecheck_derive"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e576ebe98e605500b3c8041bb888e966653577172df6dd97398714eb30b9bf"
+checksum = "e31225543cb46f81a7e224762764f4a6a0f097b1db0b175f69e8065efaa42de5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cfg-if"
@@ -190,22 +210,21 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "console"
-version = "0.15.2"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c050367d967ced717c04b65d8c619d863ef9292ce0c5760028655a2fb298718c"
+checksum = "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
 dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
- "terminal_size",
- "winapi",
+ "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
 dependencies = [
  "libc",
 ]
@@ -227,7 +246,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -251,7 +270,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -262,8 +281,14 @@ checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
 
 [[package]]
 name = "debug_unreachable"
@@ -298,9 +323,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "encode_unicode"
@@ -310,41 +335,50 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "enum-iterator"
-version = "1.1.3"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a0ac4aeb3a18f92eaf09c6bb9b3ac30ff61ca95514fc58cbead1c9a6bf5401"
+checksum = "706d9e7cf1c7664859d79cd524e4e53ea2b67ea03c98cc2870c5e539695d597e"
 dependencies = [
  "enum-iterator-derive",
 ]
 
 [[package]]
 name = "enum-iterator-derive"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "828de45d0ca18782232dfb8f3ea9cc428e8ced380eb26a520baaacfc70de39ce"
+checksum = "355f93763ef7b0ae1c43c4d8eccc9d5848d84ad1a1d8ce61c421d1ac85a19d05"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "enum_kind"
-version = "0.2.1"
+name = "errno"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b940da354ae81ef0926c5eaa428207b8f4f091d3956c891dfbd124162bed99"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
- "pmutil",
- "proc-macro2",
- "swc_macros_common",
- "syn",
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.48.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
 name = "fastrand"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
@@ -366,21 +400,21 @@ dependencies = [
 
 [[package]]
 name = "from_variant"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0981e470d2ab9f643df3921d54f1952ea100c39fdb6a3fdc820e20d2291df6c"
+checksum = "1d449976075322384507443937df2f1d5577afbf4282f12a5a66ef29fa3e6307"
 dependencies = [
  "pmutil",
  "proc-macro2",
  "swc_macros_common",
- "syn",
+ "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "generic-array"
-version = "0.14.6"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -388,9 +422,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
  "libc",
@@ -406,20 +440,20 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.27.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec7af912d60cdbd3677c1af9352ebae6fb8394d165568a2234df0fa00f87793"
+checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
 name = "glob"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "hashbrown"
@@ -449,6 +483,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,7 +505,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "similar-asserts",
- "testing 0.30.10",
+ "testing 0.30.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "widestring",
 ]
 
@@ -493,9 +533,9 @@ checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -511,16 +551,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-macro"
-version = "0.2.1"
+name = "io-lifetimes"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c068d4c6b922cd6284c609cfa6dec0e41615c9c5a1a4ba729a970d8daba05fb"
+checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
+dependencies = [
+ "hermit-abi 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
+ "windows-sys 0.48.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "is-macro"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7d079e129b77477a49c5c4f1cfe9ce6c2c909ef52520693e8e811a714c7b20"
 dependencies = [
  "Inflector",
  "pmutil",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -531,9 +582,9 @@ checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
 
 [[package]]
 name = "itoa"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "langtag"
@@ -622,9 +673,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b64f40e5e03e0d54f03845c8197d0291253cdbedfb1cb46b13c2c117554a9f4c"
 
 [[package]]
 name = "lock_api"
@@ -688,7 +745,7 @@ checksum = "6b5bc45b761bcf1b5e6e6c4128cd93b84c218721a8d9b894aa0aff4ed180174c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -753,24 +810,24 @@ version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
 ]
 
 [[package]]
 name = "object"
-version = "0.30.0"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239da7f290cfa979f43f85a8efeee9a8a76d0827c356d37f9d3d7254d6b537fb"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "output_vt100"
@@ -789,9 +846,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owo-colors"
-version = "3.6.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69dc4ec9e7e12502579e09e8a53c6a305b3aceb62ad5c307a62f7c3eada78324"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "parking_lot"
@@ -805,15 +862,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.5"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -854,7 +911,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -880,7 +937,7 @@ checksum = "3894e5d549cccbe44afecf72922f277f603cd4bb0219c8342631ef18fffbe004"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -916,7 +973,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check",
 ]
 
@@ -939,11 +996,20 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -963,14 +1029,14 @@ checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -1011,18 +1077,27 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1031,44 +1106,41 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
- "regex-syntax",
+ "regex-syntax 0.6.29 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.28"
+version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 
 [[package]]
 name = "relative-path"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df32d82cedd1499386877b062ebe8721f806de80b08d183c70184ef17dd1d42"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
+checksum = "4bf2521270932c3c7bed1a59151222bd7643c79310f2916f01925e1e16255698"
 
 [[package]]
 name = "rend"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79af64b4b6362ffba04eef3a4e10829718a4896dac19daa741851c86781edf95"
+checksum = "581008d2099240d37fb08d77ad713bcaec2c4d89d50b5b21a8bb1996bbab68ab"
 dependencies = [
  "bytecheck",
 ]
 
 [[package]]
 name = "rkyv"
-version = "0.7.37"
+version = "0.7.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f08c8062c1fe1253064043b8fc07bfea1b9702b71b4a86c11ea3588183b12e1"
+checksum = "21499ed91807f07ae081880aabb2ccc0235e9d88011867d984525e9a4c3cfa3e"
 dependencies = [
  "bytecheck",
  "hashbrown",
@@ -1080,20 +1152,20 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.7.37"
+version = "0.7.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e289706df51226e84814bf6ba1a9e1013112ae29bc7a9878f73fce360520c403"
+checksum = "ac1c672430eb41556291981f45ca900a0239ad007242d1cb4b4167af842db666"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.21"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc-hash"
@@ -1111,16 +1183,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.11"
+name = "rustix"
+version = "0.37.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
+checksum = "8bbfc1d1c7c40c01715f47d71444744a81669ca84e8b63e25a55e169b1f86433"
+dependencies = [
+ "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.48.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
 
 [[package]]
 name = "ryu"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "scoped-tls"
@@ -1157,29 +1243,29 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.91"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "itoa",
  "ryu",
@@ -1188,13 +1274,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a5ec9fa74a20ebbe5d9ac23dac1fc96ba0ecfe9f50f2843b52e537b10fbcb4e"
+checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1229,6 +1315,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simdutf8"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+
+[[package]]
 name = "similar"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1261,6 +1353,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
+name = "smartstring"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
+dependencies = [
+ "autocfg",
+ "static_assertions",
+ "version_check",
+]
+
+[[package]]
 name = "smawk"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1268,17 +1371,16 @@ checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
 
 [[package]]
 name = "sourcemap"
-version = "6.2.0"
+version = "6.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c46fdc1838ff49cf692226f5c2b0f5b7538f556863d0eca602984714667ac6e7"
+checksum = "eed16231c92d0a6f0388f56e0ab2be24ecff1173f8e22f0ea5e074d0525631cb"
 dependencies = [
- "base64",
+ "data-encoding",
  "if_chain",
- "lazy_static",
- "regex",
  "rustc_version",
  "serde",
  "serde_json",
+ "unicode-id",
  "url",
 ]
 
@@ -1289,6 +1391,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "stacker"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "winapi",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1296,9 +1411,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_cache"
-version = "0.8.4"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213494b7a2b503146286049378ce02b482200519accc31872ee8be91fa820a08"
+checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
 dependencies = [
  "new_debug_unreachable",
  "once_cell",
@@ -1322,15 +1437,15 @@ dependencies = [
 
 [[package]]
 name = "string_enum"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "994453cd270ad0265796eb24abf5540091ed03e681c5f3c12bc33e4db33253e1"
+checksum = "0090512bdfee4b56d82480d66c0fd8a6f53f0fe0f97e075e949b252acdd482e0"
 dependencies = [
  "pmutil",
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn",
+ "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1394,9 +1509,23 @@ dependencies = [
 
 [[package]]
 name = "swc_atoms"
-version = "0.4.32"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ad59af21529fcd3f4f8fa6b1ae399c2b183ec42c68347d76d68d6e5b657956e"
+checksum = "64593af3e0fbacd1b7147a0188f1fd77a2fc8ae3c2425bdb9528de255b9f452b"
+dependencies = [
+ "once_cell",
+ "rustc-hash",
+ "serde",
+ "string_cache",
+ "string_cache_codegen",
+ "triomphe",
+]
+
+[[package]]
+name = "swc_atoms"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "593c2f3e4cea60ddc4179ed731cabebe7eacec209d9e76a3bbcff4b2b020e3f5"
 dependencies = [
  "once_cell",
  "rkyv",
@@ -1414,7 +1543,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3926afd43f50edea791744d97d5fa38bde997978531d36ed507b2b908f920695"
 dependencies = [
  "ahash",
- "ast_node",
+ "ast_node 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty",
  "better_scoped_tls",
  "cfg-if",
@@ -1428,7 +1557,7 @@ dependencies = [
  "serde",
  "siphasher",
  "string_cache",
- "swc_atoms",
+ "swc_atoms 0.4.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "swc_eq_ignore_macros",
  "swc_visit",
  "termcolor",
@@ -1439,13 +1568,13 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.29.25"
+version = "0.31.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "506321cad7393893018aac83a3b3bd25203883e8c47ab0864bb43195d43b22dd"
+checksum = "6f876f826866e402da364d77aa97448fdf67cb4aeb6a5f1c0de39cacf35aa89a"
 dependencies = [
  "ahash",
  "anyhow",
- "ast_node",
+ "ast_node 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty",
  "better_scoped_tls",
  "cfg-if",
@@ -1461,7 +1590,7 @@ dependencies = [
  "siphasher",
  "sourcemap",
  "string_cache",
- "swc_atoms",
+ "swc_atoms 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "swc_eq_ignore_macros",
  "swc_visit",
  "termcolor",
@@ -1472,13 +1601,13 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.51.1"
+version = "0.75.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24c06001762e4a8ace5d30375cb4113fa7430f2b5fb2f506fac44ed9aac08cc5"
+checksum = "4b211443a6a1972009935ad1d5fae68e5c7a3697b4a1121cb4e4aad8ca88ee4a"
 dependencies = [
  "once_cell",
- "swc_atoms",
- "swc_common 0.29.25",
+ "swc_atoms 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "swc_common 0.31.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "swc_ecma_ast",
  "swc_ecma_transforms_base",
  "swc_ecma_transforms_testing",
@@ -1491,27 +1620,27 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.95.9"
+version = "0.103.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cc936f04c4e671ae5918b573a50945c5189d3dcdd57e4faddd47889717e1416"
+checksum = "1087786027e9e938588c0a66d45d1044a5e2285922b0928e023303f03a60900f"
 dependencies = [
- "bitflags",
+ "bitflags 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "is-macro",
  "num-bigint",
  "rkyv",
  "scoped-tls",
  "serde",
  "string_enum",
- "swc_atoms",
- "swc_common 0.29.25",
+ "swc_atoms 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "swc_common 0.31.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-id",
 ]
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.128.15"
+version = "0.138.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "121caf2dde74cbd143035a92cfd249be7744ee31622c4e66ee19a8249e3f6855"
+checksum = "807e07eda1b7f45971ec9a65c9ac032bf53acd0b02dae4456bbcfef3d47da95c"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -1519,8 +1648,8 @@ dependencies = [
  "rustc-hash",
  "serde",
  "sourcemap",
- "swc_atoms",
- "swc_common 0.29.25",
+ "swc_atoms 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "swc_common 0.31.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "swc_ecma_ast",
  "swc_ecma_codegen_macros",
  "tracing",
@@ -1528,31 +1657,32 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen_macros"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0159c99f81f52e48fe692ef7af1b0990b45d3006b14c6629be0b1ffee1b23aea"
+checksum = "bf4ee0caee1018808d94ecd09490cb7affd3d504b19aa11c49238f5fc4b54901"
 dependencies = [
  "pmutil",
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn",
+ "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.123.13"
+version = "0.133.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22225f792dcbcd3d3e77498d6e6fb86161cdd05ba4e24456361768dc41ee2948"
+checksum = "2fa9f6dab04b0e4d148fab7069ecb896ae6e9a3e3ec94a493d52d1d16a780cda"
 dependencies = [
  "either",
- "enum_kind",
  "lexical",
  "num-bigint",
  "serde",
  "smallvec",
- "swc_atoms",
- "swc_common 0.29.25",
+ "smartstring",
+ "stacker",
+ "swc_atoms 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "swc_common 0.31.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "swc_ecma_ast",
  "tracing",
  "typed-arena",
@@ -1572,19 +1702,20 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.112.17"
+version = "0.126.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79dcead560bca9864ea5bae654df4d80dfb30449f357ba0a7ab1cd2930da92ff"
+checksum = "96b6521512d072b082071a569d1aaad638bab56b9a18c9d88edc436055fe13ca"
 dependencies = [
  "better_scoped_tls",
- "bitflags",
+ "bitflags 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap",
  "once_cell",
  "phf",
  "rustc-hash",
  "serde",
  "smallvec",
- "swc_atoms",
- "swc_common 0.29.25",
+ "swc_atoms 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "swc_common 0.31.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "swc_ecma_ast",
  "swc_ecma_parser",
  "swc_ecma_utils",
@@ -1594,9 +1725,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.115.18"
+version = "0.129.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "698d0299427d148e6a966b21bbfa055b744788d135d4fe683596f7c2a9296e51"
+checksum = "e3109919ceca5dc1a89721a2d3ed43917f7fc53eeb87433a020a810286b85ba0"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -1606,7 +1737,7 @@ dependencies = [
  "serde_json",
  "sha-1",
  "sourcemap",
- "swc_common 0.29.25",
+ "swc_common 0.31.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "swc_ecma_ast",
  "swc_ecma_codegen",
  "swc_ecma_parser",
@@ -1615,20 +1746,21 @@ dependencies = [
  "swc_ecma_utils",
  "swc_ecma_visit",
  "tempfile",
- "testing 0.31.27",
+ "testing 0.33.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.106.13"
+version = "0.116.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "199beccb6243107d2906b88a97a5751350cd49491d31cbbf0c0541b46f55d65d"
+checksum = "547cce84256af2ce8b9ee44669872dc514c9e1fe737ab1bd517c4bd21038b7d8"
 dependencies = [
  "indexmap",
  "num_cpus",
  "once_cell",
- "swc_atoms",
- "swc_common 0.29.25",
+ "rustc-hash",
+ "swc_atoms 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "swc_common 0.31.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "swc_ecma_ast",
  "swc_ecma_visit",
  "tracing",
@@ -1637,13 +1769,13 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.81.9"
+version = "0.89.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ebf5de90444c90b1905b7618800a7572fc757faa8c90cc1c6031d1f6ca179df"
+checksum = "4490a5ed042234d72986e1a0c8afb54291fcf82b42af78ea72507b52bcbe13dd"
 dependencies = [
  "num-bigint",
- "swc_atoms",
- "swc_common 0.29.25",
+ "swc_atoms 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "swc_common 0.31.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "swc_ecma_ast",
  "swc_visit",
  "tracing",
@@ -1658,7 +1790,7 @@ dependencies = [
  "pmutil",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1671,32 +1803,32 @@ dependencies = [
  "miette",
  "once_cell",
  "parking_lot",
- "swc_common 0.28.10",
+ "swc_common 0.28.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "swc_error_reporters"
-version = "0.13.26"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fbda0a7583deb49edf379e2c119231312ad2d3a37a219143a3d8678a205a5f"
+checksum = "3afbf2e52ddce38da1ee204252f7b9019a12176ca73aaa0fd0c36ded1ecbec7d"
 dependencies = [
  "anyhow",
  "miette",
  "once_cell",
  "parking_lot",
- "swc_common 0.29.25",
+ "swc_common 0.31.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "swc_macros_common"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4be988307882648d9bc7c71a6a73322b7520ef0211e920489a98f8391d8caa2"
+checksum = "3e582c3e3c2269238524923781df5be49e011dbe29cf7683a2215d600a562ea6"
 dependencies = [
  "pmutil",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1710,24 +1842,24 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_macro"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c00caf955dfbff15974f061f8c2e8a8b9b5ce999cb601f02f3ec66253e81149"
+checksum = "ae095f51123037ae9a8d29ef06b221a273fe11b489a3caa9eeba6a965a8b4cc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "0.23.9"
+version = "0.32.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "654d4b4c16e61289685a75f2dc8b9874faff29754776e514c85a1d34d6349599"
+checksum = "4cd5b2880508aedc964f4f52a4debc07c4b48212b45b44522d651c701b1a4d84"
 dependencies = [
  "better_scoped_tls",
  "rkyv",
- "swc_common 0.29.25",
+ "swc_common 0.31.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "swc_ecma_ast",
  "swc_trace_macro",
  "tracing",
@@ -1741,14 +1873,14 @@ checksum = "a4795c8d23e0de62eef9cac0a20ae52429ee2ffc719768e838490f195b7d7267"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "swc_visit"
-version = "0.5.3"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82f2bcb7223e185c4c7cbf5e0c1207dec6d2bfd5e72e3fb7b3e8d179747e9130"
+checksum = "d1d5999f23421c8e21a0f2bc53a0b9e8244f3b421de89471561af2fbe40b9cca"
 dependencies = [
  "either",
  "swc_visit_macros",
@@ -1756,23 +1888,34 @@ dependencies = [
 
 [[package]]
 name = "swc_visit_macros"
-version = "0.5.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb1f3561674d84947694d41fb6d5737d19539222779baeac1b3a071a2b29428"
+checksum = "ebeed7eb0f545f48ad30f5aab314e5208b735bcea1d1464f26e20f06db904989"
 dependencies = [
  "Inflector",
  "pmutil",
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn",
+ "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1781,23 +1924,22 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.3.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
 dependencies = [
  "cfg-if",
  "fastrand",
- "libc",
- "redox_syscall",
- "remove_dir_all",
- "winapi",
+ "redox_syscall 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustix",
+ "windows-sys 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
 ]
@@ -1824,8 +1966,8 @@ dependencies = [
  "pretty_assertions",
  "regex",
  "serde_json",
- "swc_common 0.28.10",
- "swc_error_reporters 0.12.10",
+ "swc_common 0.28.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "swc_error_reporters 0.12.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "testing_macros",
  "tracing",
  "tracing-subscriber",
@@ -1833,9 +1975,9 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "0.31.27"
+version = "0.33.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488b450d0ccc78a21ab4686c2b1ac7e867a9478bb850af3ee82a841198c6420c"
+checksum = "77e5fcdfc6805d181431333b850f9fde170f654148e29ba97fd8033c7814e665"
 dependencies = [
  "ansi_term",
  "difference",
@@ -1843,8 +1985,8 @@ dependencies = [
  "pretty_assertions",
  "regex",
  "serde_json",
- "swc_common 0.29.25",
- "swc_error_reporters 0.13.26",
+ "swc_common 0.31.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "swc_error_reporters 0.15.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "testing_macros",
  "tracing",
  "tracing-subscriber",
@@ -1852,9 +1994,9 @@ dependencies = [
 
 [[package]]
 name = "testing_macros"
-version = "0.2.7"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e74ff09d2d4d4b7ea140ff67eb7ed8fd35a708e2c327bcde5a25707d66840099"
+checksum = "a5315a85a7262fe1a8898890b616de62c152dd43cb5974752c0927aaabe48891"
 dependencies = [
  "anyhow",
  "glob",
@@ -1864,7 +2006,7 @@ dependencies = [
  "quote",
  "regex",
  "relative-path",
- "syn",
+ "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1880,38 +2022,39 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.4"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
+ "cfg-if",
  "once_cell",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.17"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
+checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
 dependencies = [
  "itoa",
  "serde",
@@ -1927,9 +2070,9 @@ checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "time-macros"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
 dependencies = [
  "time-core",
 ]
@@ -1945,9 +2088,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec_macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tracing"
@@ -1963,13 +2106,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1995,9 +2138,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -2023,9 +2166,9 @@ dependencies = [
 
 [[package]]
 name = "typed-arena"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0685c84d5d54d1c26f7d3eb96cd41550adb97baed141a761cf335d3d33bcd0ae"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typenum"
@@ -2035,9 +2178,9 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.8"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-id"
@@ -2047,9 +2190,9 @@ checksum = "d70b6494226b36008c8366c288d77190b3fad2eb4c10533139c1c1f461127f1a"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "unicode-linebreak"
@@ -2072,9 +2215,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"
@@ -2110,9 +2253,9 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vergen"
-version = "7.4.4"
+version = "7.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efadd36bc6fde40c6048443897d69511a19161c0756cb704ed403f8dfd2b7d1c"
+checksum = "f21b881cd6636ece9735721cf03c1fe1e774fe258683d084bb2812ab67435749"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2184,56 +2327,146 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows_aarch64_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows_i686_gnu 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows_i686_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows_x86_64_gnu 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows_x86_64_gnullvm 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows_x86_64_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows_aarch64_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows_i686_gnu 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows_i686_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows_x86_64_gnu 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows_x86_64_gnullvm 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows_x86_64_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows_aarch64_msvc 0.48.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows_i686_gnu 0.48.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows_i686_msvc 0.48.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows_x86_64_gnu 0.48.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows_x86_64_gnullvm 0.48.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows_x86_64_msvc 0.48.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "yansi"

--- a/rust/cargo-bazel-lock.json
+++ b/rust/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "898de1a584098a034482f1e85478deb5f8177c8822efafdb8c1f597d6842e219",
+  "checksum": "2980508a6cd0631879c402bc164ce07dd3fed9eba5b8340980ce162fa440bf35",
   "crates": {
     "Inflector 0.11.4": {
       "name": "Inflector",
@@ -42,7 +42,7 @@
               "target": "lazy_static"
             },
             {
-              "id": "regex 1.7.0",
+              "id": "regex 1.8.1",
               "target": "regex"
             }
           ],
@@ -84,7 +84,7 @@
         "deps": {
           "common": [
             {
-              "id": "gimli 0.27.0",
+              "id": "gimli 0.27.2",
               "target": "gimli"
             }
           ],
@@ -182,13 +182,13 @@
           "selects": {
             "cfg(any(target_os = \"linux\", target_os = \"android\", target_os = \"windows\", target_os = \"macos\", target_os = \"ios\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"dragonfly\", target_os = \"solaris\", target_os = \"illumos\", target_os = \"fuchsia\", target_os = \"redox\", target_os = \"cloudabi\", target_os = \"haiku\", target_os = \"vxworks\", target_os = \"emscripten\", target_os = \"wasi\"))": [
               {
-                "id": "getrandom 0.2.8",
+                "id": "getrandom 0.2.9",
                 "target": "getrandom"
               }
             ],
             "cfg(not(all(target_arch = \"arm\", target_os = \"none\")))": [
               {
-                "id": "once_cell 1.16.0",
+                "id": "once_cell 1.17.1",
                 "target": "once_cell"
               }
             ]
@@ -213,13 +213,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "aho-corasick 0.7.20": {
+    "aho-corasick 1.0.1": {
       "name": "aho-corasick",
-      "version": "0.7.20",
+      "version": "1.0.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/aho-corasick/0.7.20/download",
-          "sha256": "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+          "url": "https://crates.io/api/v1/crates/aho-corasick/1.0.1/download",
+          "sha256": "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
         }
       },
       "targets": [
@@ -243,6 +243,7 @@
         ],
         "crate_features": [
           "default",
+          "perf-literal",
           "std"
         ],
         "deps": {
@@ -254,8 +255,8 @@
           ],
           "selects": {}
         },
-        "edition": "2018",
-        "version": "0.7.20"
+        "edition": "2021",
+        "version": "1.0.1"
       },
       "license": "Unlicense OR MIT"
     },
@@ -303,13 +304,13 @@
       },
       "license": "MIT"
     },
-    "anyhow 1.0.68": {
+    "anyhow 1.0.71": {
       "name": "anyhow",
-      "version": "1.0.68",
+      "version": "1.0.71",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/anyhow/1.0.68/download",
-          "sha256": "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+          "url": "https://crates.io/api/v1/crates/anyhow/1.0.71/download",
+          "sha256": "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
         }
       },
       "targets": [
@@ -350,14 +351,14 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.68",
+              "id": "anyhow 1.0.71",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.68"
+        "version": "1.0.71"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -366,13 +367,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "ast_node 0.8.6": {
+    "ast_node 0.8.8": {
       "name": "ast_node",
-      "version": "0.8.6",
+      "version": "0.8.8",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/ast_node/0.8.6/download",
-          "sha256": "cf94863c5fdfee166d0907c44e5fee970123b2b7307046d35d1e671aa93afbba"
+          "url": "https://crates.io/api/v1/crates/ast_node/0.8.8/download",
+          "sha256": "70151a5226578411132d798aa248df45b30aa34aea2e580628870b4d87be717b"
         }
       },
       "targets": [
@@ -405,26 +406,84 @@
               "target": "pmutil"
             },
             {
-              "id": "proc-macro2 1.0.49",
+              "id": "proc-macro2 1.0.56",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             },
             {
-              "id": "swc_macros_common 0.3.6",
+              "id": "swc_macros_common 0.3.7",
               "target": "swc_macros_common"
             },
             {
-              "id": "syn 1.0.107",
+              "id": "syn 1.0.109",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.8.6"
+        "version": "0.8.8"
+      },
+      "license": "Apache-2.0"
+    },
+    "ast_node 0.9.3": {
+      "name": "ast_node",
+      "version": "0.9.3",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/ast_node/0.9.3/download",
+          "sha256": "52f7fd7740c5752c16281a1c1f9442b1e69ba41738acde85dc604aaf3ce41890"
+        }
+      },
+      "targets": [
+        {
+          "ProcMacro": {
+            "crate_name": "ast_node",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "ast_node",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "pmutil 0.5.3",
+              "target": "pmutil"
+            },
+            {
+              "id": "proc-macro2 1.0.56",
+              "target": "proc_macro2"
+            },
+            {
+              "id": "quote 1.0.26",
+              "target": "quote"
+            },
+            {
+              "id": "swc_macros_common 0.3.7",
+              "target": "swc_macros_common"
+            },
+            {
+              "id": "syn 1.0.109",
+              "target": "syn"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.9.3"
       },
       "license": "Apache-2.0"
     },
@@ -467,7 +526,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.139",
+                "id": "libc 0.2.142",
                 "target": "libc"
               }
             ],
@@ -576,7 +635,7 @@
               "target": "cfg_if"
             },
             {
-              "id": "libc 0.2.139",
+              "id": "libc 0.2.142",
               "target": "libc"
             },
             {
@@ -584,11 +643,11 @@
               "target": "miniz_oxide"
             },
             {
-              "id": "object 0.30.0",
+              "id": "object 0.30.3",
               "target": "object"
             },
             {
-              "id": "rustc-demangle 0.1.21",
+              "id": "rustc-demangle 0.1.23",
               "target": "rustc_demangle"
             }
           ],
@@ -604,7 +663,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.0.78",
+              "id": "cc 1.0.79",
               "target": "cc"
             }
           ],
@@ -650,13 +709,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "base64ct 1.5.3": {
+    "base64ct 1.6.0": {
       "name": "base64ct",
-      "version": "1.5.3",
+      "version": "1.6.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/base64ct/1.5.3/download",
-          "sha256": "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
+          "url": "https://crates.io/api/v1/crates/base64ct/1.6.0/download",
+          "sha256": "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
         }
       },
       "targets": [
@@ -682,7 +741,7 @@
           "alloc"
         ],
         "edition": "2021",
-        "version": "1.5.3"
+        "version": "1.6.0"
       },
       "license": "Apache-2.0 OR MIT"
     },
@@ -764,13 +823,46 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "block-buffer 0.10.3": {
-      "name": "block-buffer",
-      "version": "0.10.3",
+    "bitflags 2.2.1": {
+      "name": "bitflags",
+      "version": "2.2.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/block-buffer/0.10.3/download",
-          "sha256": "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+          "url": "https://crates.io/api/v1/crates/bitflags/2.2.1/download",
+          "sha256": "24a6904aef64d73cf10ab17ebace7befb918b82164785cb89907993be7f83813"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "bitflags",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "bitflags",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2021",
+        "version": "2.2.1"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "block-buffer 0.10.4": {
+      "name": "block-buffer",
+      "version": "0.10.4",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/block-buffer/0.10.4/download",
+          "sha256": "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
         }
       },
       "targets": [
@@ -795,14 +887,14 @@
         "deps": {
           "common": [
             {
-              "id": "generic-array 0.14.6",
+              "id": "generic-array 0.14.7",
               "target": "generic_array"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.10.3"
+        "version": "0.10.4"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -861,13 +953,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "bytecheck 0.6.9": {
+    "bytecheck 0.6.10": {
       "name": "bytecheck",
-      "version": "0.6.9",
+      "version": "0.6.10",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/bytecheck/0.6.9/download",
-          "sha256": "d11cac2c12b5adc6570dad2ee1b87eff4955dac476fe12d81e5fdd352e52406f"
+          "url": "https://crates.io/api/v1/crates/bytecheck/0.6.10/download",
+          "sha256": "13fe11640a23eb24562225322cd3e452b93a3d4091d62fab69c70542fcd17d1f"
         }
       },
       "targets": [
@@ -902,32 +994,37 @@
           "**"
         ],
         "crate_features": [
+          "simdutf8",
           "std"
         ],
         "deps": {
           "common": [
             {
-              "id": "bytecheck 0.6.9",
+              "id": "bytecheck 0.6.10",
               "target": "build_script_build"
             },
             {
               "id": "ptr_meta 0.1.4",
               "target": "ptr_meta"
+            },
+            {
+              "id": "simdutf8 0.1.4",
+              "target": "simdutf8"
             }
           ],
           "selects": {}
         },
-        "edition": "2018",
+        "edition": "2021",
         "proc_macro_deps": {
           "common": [
             {
-              "id": "bytecheck_derive 0.6.9",
+              "id": "bytecheck_derive 0.6.10",
               "target": "bytecheck_derive"
             }
           ],
           "selects": {}
         },
-        "version": "0.6.9"
+        "version": "0.6.10"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -936,13 +1033,13 @@
       },
       "license": "MIT"
     },
-    "bytecheck_derive 0.6.9": {
+    "bytecheck_derive 0.6.10": {
       "name": "bytecheck_derive",
-      "version": "0.6.9",
+      "version": "0.6.10",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/bytecheck_derive/0.6.9/download",
-          "sha256": "13e576ebe98e605500b3c8041bb888e966653577172df6dd97398714eb30b9bf"
+          "url": "https://crates.io/api/v1/crates/bytecheck_derive/0.6.10/download",
+          "sha256": "e31225543cb46f81a7e224762764f4a6a0f097b1db0b175f69e8065efaa42de5"
         }
       },
       "targets": [
@@ -965,37 +1062,38 @@
           "**"
         ],
         "crate_features": [
+          "default",
           "std"
         ],
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.49",
+              "id": "proc-macro2 1.0.56",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.107",
+              "id": "syn 1.0.109",
               "target": "syn"
             }
           ],
           "selects": {}
         },
-        "edition": "2018",
-        "version": "0.6.9"
+        "edition": "2021",
+        "version": "0.6.10"
       },
       "license": "MIT"
     },
-    "cc 1.0.78": {
+    "cc 1.0.79": {
       "name": "cc",
-      "version": "1.0.78",
+      "version": "1.0.79",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/cc/1.0.78/download",
-          "sha256": "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+          "url": "https://crates.io/api/v1/crates/cc/1.0.79/download",
+          "sha256": "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
         }
       },
       "targets": [
@@ -1030,7 +1128,7 @@
           "**"
         ],
         "edition": "2018",
-        "version": "1.0.78"
+        "version": "1.0.79"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -1067,13 +1165,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "console 0.15.2": {
+    "console 0.15.5": {
       "name": "console",
-      "version": "0.15.2",
+      "version": "0.15.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/console/0.15.2/download",
-          "sha256": "c050367d967ced717c04b65d8c619d863ef9292ce0c5760028655a2fb298718c"
+          "url": "https://crates.io/api/v1/crates/console/0.15.5/download",
+          "sha256": "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
         }
       },
       "targets": [
@@ -1102,12 +1200,8 @@
               "target": "lazy_static"
             },
             {
-              "id": "libc 0.2.139",
+              "id": "libc 0.2.142",
               "target": "libc"
-            },
-            {
-              "id": "terminal_size 0.1.17",
-              "target": "terminal_size"
             }
           ],
           "selects": {
@@ -1117,24 +1211,24 @@
                 "target": "encode_unicode"
               },
               {
-                "id": "winapi 0.3.9",
-                "target": "winapi"
+                "id": "windows-sys 0.42.0",
+                "target": "windows_sys"
               }
             ]
           }
         },
         "edition": "2018",
-        "version": "0.15.2"
+        "version": "0.15.5"
       },
       "license": "MIT"
     },
-    "cpufeatures 0.2.5": {
+    "cpufeatures 0.2.7": {
       "name": "cpufeatures",
-      "version": "0.2.5",
+      "version": "0.2.7",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/cpufeatures/0.2.5/download",
-          "sha256": "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+          "url": "https://crates.io/api/v1/crates/cpufeatures/0.2.7/download",
+          "sha256": "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
         }
       },
       "targets": [
@@ -1159,28 +1253,28 @@
         "deps": {
           "common": [],
           "selects": {
-            "aarch64-apple-darwin": [
-              {
-                "id": "libc 0.2.139",
-                "target": "libc"
-              }
-            ],
             "aarch64-linux-android": [
               {
-                "id": "libc 0.2.139",
+                "id": "libc 0.2.142",
                 "target": "libc"
               }
             ],
             "cfg(all(target_arch = \"aarch64\", target_os = \"linux\"))": [
               {
-                "id": "libc 0.2.139",
+                "id": "libc 0.2.142",
+                "target": "libc"
+              }
+            ],
+            "cfg(all(target_arch = \"aarch64\", target_vendor = \"apple\"))": [
+              {
+                "id": "libc 0.2.142",
                 "target": "libc"
               }
             ]
           }
         },
         "edition": "2018",
-        "version": "0.2.5"
+        "version": "0.2.7"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -1218,7 +1312,7 @@
         "deps": {
           "common": [
             {
-              "id": "generic-array 0.14.6",
+              "id": "generic-array 0.14.7",
               "target": "generic_array"
             },
             {
@@ -1264,11 +1358,11 @@
         "deps": {
           "common": [
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.107",
+              "id": "syn 1.0.109",
               "target": "syn"
             }
           ],
@@ -1377,11 +1471,11 @@
               "target": "ident_case"
             },
             {
-              "id": "proc-macro2 1.0.49",
+              "id": "proc-macro2 1.0.56",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             },
             {
@@ -1389,7 +1483,7 @@
               "target": "strsim"
             },
             {
-              "id": "syn 1.0.107",
+              "id": "syn 1.0.109",
               "target": "syn"
             }
           ],
@@ -1435,11 +1529,11 @@
               "target": "darling_core"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.107",
+              "id": "syn 1.0.109",
               "target": "syn"
             }
           ],
@@ -1447,6 +1541,44 @@
         },
         "edition": "2018",
         "version": "0.13.4"
+      },
+      "license": "MIT"
+    },
+    "data-encoding 2.3.3": {
+      "name": "data-encoding",
+      "version": "2.3.3",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/data-encoding/2.3.3/download",
+          "sha256": "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "data_encoding",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "data_encoding",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "alloc",
+          "default",
+          "std"
+        ],
+        "edition": "2018",
+        "version": "2.3.3"
       },
       "license": "MIT"
     },
@@ -1611,7 +1743,7 @@
         "deps": {
           "common": [
             {
-              "id": "block-buffer 0.10.3",
+              "id": "block-buffer 0.10.4",
               "target": "block_buffer"
             },
             {
@@ -1626,13 +1758,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "either 1.8.0": {
+    "either 1.8.1": {
       "name": "either",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/either/1.8.0/download",
-          "sha256": "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+          "url": "https://crates.io/api/v1/crates/either/1.8.1/download",
+          "sha256": "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
         }
       },
       "targets": [
@@ -1659,9 +1791,9 @@
           "use_std"
         ],
         "edition": "2018",
-        "version": "1.8.0"
+        "version": "1.8.1"
       },
-      "license": "MIT/Apache-2.0"
+      "license": "MIT OR Apache-2.0"
     },
     "encode_unicode 0.3.6": {
       "name": "encode_unicode",
@@ -1700,13 +1832,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "enum-iterator 1.1.3": {
+    "enum-iterator 1.4.0": {
       "name": "enum-iterator",
-      "version": "1.1.3",
+      "version": "1.4.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/enum-iterator/1.1.3/download",
-          "sha256": "45a0ac4aeb3a18f92eaf09c6bb9b3ac30ff61ca95514fc58cbead1c9a6bf5401"
+          "url": "https://crates.io/api/v1/crates/enum-iterator/1.4.0/download",
+          "sha256": "706d9e7cf1c7664859d79cd524e4e53ea2b67ea03c98cc2870c5e539695d597e"
         }
       },
       "targets": [
@@ -1732,23 +1864,23 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "enum-iterator-derive 1.1.0",
+              "id": "enum-iterator-derive 1.2.0",
               "target": "enum_iterator_derive"
             }
           ],
           "selects": {}
         },
-        "version": "1.1.3"
+        "version": "1.4.0"
       },
       "license": "0BSD"
     },
-    "enum-iterator-derive 1.1.0": {
+    "enum-iterator-derive 1.2.0": {
       "name": "enum-iterator-derive",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/enum-iterator-derive/1.1.0/download",
-          "sha256": "828de45d0ca18782232dfb8f3ea9cc428e8ced380eb26a520baaacfc70de39ce"
+          "url": "https://crates.io/api/v1/crates/enum-iterator-derive/1.2.0/download",
+          "sha256": "355f93763ef7b0ae1c43c4d8eccc9d5848d84ad1a1d8ce61c421d1ac85a19d05"
         }
       },
       "targets": [
@@ -1773,38 +1905,38 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.49",
+              "id": "proc-macro2 1.0.56",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.107",
+              "id": "syn 1.0.109",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.1.0"
+        "version": "1.2.0"
       },
       "license": "0BSD"
     },
-    "enum_kind 0.2.1": {
-      "name": "enum_kind",
-      "version": "0.2.1",
+    "errno 0.3.1": {
+      "name": "errno",
+      "version": "0.3.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/enum_kind/0.2.1/download",
-          "sha256": "78b940da354ae81ef0926c5eaa428207b8f4f091d3956c891dfbd124162bed99"
+          "url": "https://crates.io/api/v1/crates/errno/0.3.1/download",
+          "sha256": "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
         }
       },
       "targets": [
         {
-          "ProcMacro": {
-            "crate_name": "enum_kind",
+          "Library": {
+            "crate_name": "errno",
             "crate_root": "src/lib.rs",
             "srcs": {
               "include": [
@@ -1815,7 +1947,87 @@
           }
         }
       ],
-      "library_target_name": "enum_kind",
+      "library_target_name": "errno",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [],
+          "selects": {
+            "cfg(target_os = \"dragonfly\")": [
+              {
+                "id": "errno-dragonfly 0.1.2",
+                "target": "errno_dragonfly"
+              }
+            ],
+            "cfg(target_os = \"hermit\")": [
+              {
+                "id": "libc 0.2.142",
+                "target": "libc"
+              }
+            ],
+            "cfg(target_os = \"wasi\")": [
+              {
+                "id": "libc 0.2.142",
+                "target": "libc"
+              }
+            ],
+            "cfg(unix)": [
+              {
+                "id": "libc 0.2.142",
+                "target": "libc"
+              }
+            ],
+            "cfg(windows)": [
+              {
+                "id": "windows-sys 0.48.0",
+                "target": "windows_sys"
+              }
+            ]
+          }
+        },
+        "edition": "2018",
+        "version": "0.3.1"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "errno-dragonfly 0.1.2": {
+      "name": "errno-dragonfly",
+      "version": "0.1.2",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/errno-dragonfly/0.1.2/download",
+          "sha256": "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "errno_dragonfly",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "errno_dragonfly",
       "common_attrs": {
         "compile_data_glob": [
           "**"
@@ -1823,36 +2035,42 @@
         "deps": {
           "common": [
             {
-              "id": "pmutil 0.5.3",
-              "target": "pmutil"
+              "id": "errno-dragonfly 0.1.2",
+              "target": "build_script_build"
             },
             {
-              "id": "proc-macro2 1.0.49",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "swc_macros_common 0.3.6",
-              "target": "swc_macros_common"
-            },
-            {
-              "id": "syn 1.0.107",
-              "target": "syn"
+              "id": "libc 0.2.142",
+              "target": "libc"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.2.1"
+        "version": "0.1.2"
       },
-      "license": "Apache-2.0/MIT"
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "cc 1.0.79",
+              "target": "cc"
+            }
+          ],
+          "selects": {}
+        }
+      },
+      "license": "MIT"
     },
-    "fastrand 1.8.0": {
+    "fastrand 1.9.0": {
       "name": "fastrand",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/fastrand/1.8.0/download",
-          "sha256": "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+          "url": "https://crates.io/api/v1/crates/fastrand/1.9.0/download",
+          "sha256": "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
         }
       },
       "targets": [
@@ -1877,7 +2095,7 @@
         "deps": {
           "common": [],
           "selects": {
-            "cfg(target_arch = \"wasm32\")": [
+            "cfg(all(target_arch = \"wasm32\", not(target_os = \"wasi\")))": [
               {
                 "id": "instant 0.1.12",
                 "target": "instant"
@@ -1886,7 +2104,7 @@
           }
         },
         "edition": "2018",
-        "version": "1.8.0"
+        "version": "1.9.0"
       },
       "license": "Apache-2.0 OR MIT"
     },
@@ -1969,13 +2187,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "from_variant 0.1.4": {
+    "from_variant 0.1.5": {
       "name": "from_variant",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/from_variant/0.1.4/download",
-          "sha256": "f0981e470d2ab9f643df3921d54f1952ea100c39fdb6a3fdc820e20d2291df6c"
+          "url": "https://crates.io/api/v1/crates/from_variant/0.1.5/download",
+          "sha256": "1d449976075322384507443937df2f1d5577afbf4282f12a5a66ef29fa3e6307"
         }
       },
       "targets": [
@@ -2004,32 +2222,32 @@
               "target": "pmutil"
             },
             {
-              "id": "proc-macro2 1.0.49",
+              "id": "proc-macro2 1.0.56",
               "target": "proc_macro2"
             },
             {
-              "id": "swc_macros_common 0.3.6",
+              "id": "swc_macros_common 0.3.7",
               "target": "swc_macros_common"
             },
             {
-              "id": "syn 1.0.107",
+              "id": "syn 1.0.109",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.1.4"
+        "version": "0.1.5"
       },
       "license": "Apache-2.0"
     },
-    "generic-array 0.14.6": {
+    "generic-array 0.14.7": {
       "name": "generic-array",
-      "version": "0.14.6",
+      "version": "0.14.7",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/generic-array/0.14.6/download",
-          "sha256": "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+          "url": "https://crates.io/api/v1/crates/generic-array/0.14.7/download",
+          "sha256": "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
         }
       },
       "targets": [
@@ -2069,7 +2287,7 @@
         "deps": {
           "common": [
             {
-              "id": "generic-array 0.14.6",
+              "id": "generic-array 0.14.7",
               "target": "build_script_build"
             },
             {
@@ -2080,7 +2298,7 @@
           "selects": {}
         },
         "edition": "2015",
-        "version": "0.14.6"
+        "version": "0.14.7"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -2098,13 +2316,13 @@
       },
       "license": "MIT"
     },
-    "getrandom 0.2.8": {
+    "getrandom 0.2.9": {
       "name": "getrandom",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/getrandom/0.2.8/download",
-          "sha256": "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+          "url": "https://crates.io/api/v1/crates/getrandom/0.2.9/download",
+          "sha256": "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
         }
       },
       "targets": [
@@ -2145,14 +2363,14 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.139",
+                "id": "libc 0.2.142",
                 "target": "libc"
               }
             ]
           }
         },
         "edition": "2018",
-        "version": "0.2.8"
+        "version": "0.2.9"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -2191,15 +2409,15 @@
               "target": "proc_macro_error"
             },
             {
-              "id": "proc-macro2 1.0.49",
+              "id": "proc-macro2 1.0.56",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.107",
+              "id": "syn 1.0.109",
               "target": "syn"
             }
           ],
@@ -2210,13 +2428,13 @@
       },
       "license": "MIT"
     },
-    "gimli 0.27.0": {
+    "gimli 0.27.2": {
       "name": "gimli",
-      "version": "0.27.0",
+      "version": "0.27.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gimli/0.27.0/download",
-          "sha256": "dec7af912d60cdbd3677c1af9352ebae6fb8394d165568a2234df0fa00f87793"
+          "url": "https://crates.io/api/v1/crates/gimli/0.27.2/download",
+          "sha256": "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
         }
       },
       "targets": [
@@ -2243,17 +2461,17 @@
           "read-core"
         ],
         "edition": "2018",
-        "version": "0.27.0"
+        "version": "0.27.2"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "glob 0.3.0": {
+    "glob 0.3.1": {
       "name": "glob",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/glob/0.3.0/download",
-          "sha256": "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+          "url": "https://crates.io/api/v1/crates/glob/0.3.1/download",
+          "sha256": "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
         }
       },
       "targets": [
@@ -2276,9 +2494,9 @@
           "**"
         ],
         "edition": "2015",
-        "version": "0.3.0"
+        "version": "0.3.1"
       },
-      "license": "MIT/Apache-2.0"
+      "license": "MIT OR Apache-2.0"
     },
     "hashbrown 0.12.3": {
       "name": "hashbrown",
@@ -2362,7 +2580,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.139",
+              "id": "libc 0.2.142",
               "target": "libc"
             }
           ],
@@ -2407,7 +2625,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.139",
+              "id": "libc 0.2.142",
               "target": "libc"
             }
           ],
@@ -2417,6 +2635,42 @@
         "version": "0.2.6"
       },
       "license": "MIT/Apache-2.0"
+    },
+    "hermit-abi 0.3.1": {
+      "name": "hermit-abi",
+      "version": "0.3.1",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/hermit-abi/0.3.1/download",
+          "sha256": "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "hermit_abi",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "hermit_abi",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "default"
+        ],
+        "edition": "2021",
+        "version": "0.3.1"
+      },
+      "license": "MIT OR Apache-2.0"
     },
     "hex 0.4.3": {
       "name": "hex",
@@ -2490,15 +2744,15 @@
               "target": "langtag"
             },
             {
-              "id": "once_cell 1.16.0",
+              "id": "once_cell 1.17.1",
               "target": "once_cell"
             },
             {
-              "id": "regex 1.7.0",
+              "id": "regex 1.8.1",
               "target": "regex"
             },
             {
-              "id": "serde 1.0.152",
+              "id": "serde 1.0.160",
               "target": "serde"
             },
             {
@@ -2511,7 +2765,7 @@
         "deps_dev": {
           "common": [
             {
-              "id": "serde_json 1.0.91",
+              "id": "serde_json 1.0.96",
               "target": "serde_json"
             },
             {
@@ -2529,7 +2783,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "serde_repr 0.1.10",
+              "id": "serde_repr 0.1.12",
               "target": "serde_repr"
             }
           ],
@@ -2603,7 +2857,7 @@
         "deps": {
           "common": [
             {
-              "id": "unicode-bidi 0.3.8",
+              "id": "unicode-bidi 0.3.13",
               "target": "unicode_bidi"
             },
             {
@@ -2651,13 +2905,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "indexmap 1.9.2": {
+    "indexmap 1.9.3": {
       "name": "indexmap",
-      "version": "1.9.2",
+      "version": "1.9.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/indexmap/1.9.2/download",
-          "sha256": "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+          "url": "https://crates.io/api/v1/crates/indexmap/1.9.3/download",
+          "sha256": "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
         }
       },
       "targets": [
@@ -2698,14 +2952,14 @@
               "target": "hashbrown"
             },
             {
-              "id": "indexmap 1.9.2",
+              "id": "indexmap 1.9.3",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.9.2"
+        "version": "1.9.3"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -2765,13 +3019,97 @@
       },
       "license": "BSD-3-Clause"
     },
-    "is-macro 0.2.1": {
-      "name": "is-macro",
-      "version": "0.2.1",
+    "io-lifetimes 1.0.10": {
+      "name": "io-lifetimes",
+      "version": "1.0.10",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/is-macro/0.2.1/download",
-          "sha256": "1c068d4c6b922cd6284c609cfa6dec0e41615c9c5a1a4ba729a970d8daba05fb"
+          "url": "https://crates.io/api/v1/crates/io-lifetimes/1.0.10/download",
+          "sha256": "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "io_lifetimes",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "io_lifetimes",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "close",
+          "hermit-abi",
+          "libc",
+          "windows-sys"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "io-lifetimes 1.0.10",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {
+            "cfg(not(windows))": [
+              {
+                "id": "libc 0.2.142",
+                "target": "libc"
+              }
+            ],
+            "cfg(target_os = \"hermit\")": [
+              {
+                "id": "hermit-abi 0.3.1",
+                "target": "hermit_abi"
+              }
+            ],
+            "cfg(windows)": [
+              {
+                "id": "windows-sys 0.48.0",
+                "target": "windows_sys"
+              }
+            ]
+          }
+        },
+        "edition": "2018",
+        "version": "1.0.10"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
+    },
+    "is-macro 0.2.2": {
+      "name": "is-macro",
+      "version": "0.2.2",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/is-macro/0.2.2/download",
+          "sha256": "8a7d079e129b77477a49c5c4f1cfe9ce6c2c909ef52520693e8e811a714c7b20"
         }
       },
       "targets": [
@@ -2804,22 +3142,22 @@
               "target": "pmutil"
             },
             {
-              "id": "proc-macro2 1.0.49",
+              "id": "proc-macro2 1.0.56",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.107",
+              "id": "syn 1.0.109",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.2.1"
+        "version": "0.2.2"
       },
       "license": "MIT"
     },
@@ -2856,13 +3194,13 @@
       },
       "license": "ISC"
     },
-    "itoa 1.0.5": {
+    "itoa 1.0.6": {
       "name": "itoa",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/itoa/1.0.5/download",
-          "sha256": "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+          "url": "https://crates.io/api/v1/crates/itoa/1.0.6/download",
+          "sha256": "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
         }
       },
       "targets": [
@@ -2885,7 +3223,7 @@
           "**"
         ],
         "edition": "2018",
-        "version": "1.0.5"
+        "version": "1.0.6"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -3346,13 +3684,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "libc 0.2.139": {
+    "libc 0.2.142": {
       "name": "libc",
-      "version": "0.2.139",
+      "version": "0.2.142",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/libc/0.2.139/download",
-          "sha256": "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+          "url": "https://crates.io/api/v1/crates/libc/0.2.142/download",
+          "sha256": "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
         }
       },
       "targets": [
@@ -3388,19 +3726,20 @@
         ],
         "crate_features": [
           "default",
+          "extra_traits",
           "std"
         ],
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.139",
+              "id": "libc 0.2.142",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "0.2.139"
+        "version": "0.2.142"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -3408,6 +3747,45 @@
         ]
       },
       "license": "MIT OR Apache-2.0"
+    },
+    "linux-raw-sys 0.3.6": {
+      "name": "linux-raw-sys",
+      "version": "0.3.6",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/linux-raw-sys/0.3.6/download",
+          "sha256": "b64f40e5e03e0d54f03845c8197d0291253cdbedfb1cb46b13c2c117554a9f4c"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "linux_raw_sys",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "linux_raw_sys",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "errno",
+          "general",
+          "ioctl",
+          "no_std"
+        ],
+        "edition": "2018",
+        "version": "0.3.6"
+      },
+      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
     },
     "lock_api 0.4.9": {
       "name": "lock_api",
@@ -3704,11 +4082,11 @@
               "target": "backtrace"
             },
             {
-              "id": "once_cell 1.16.0",
+              "id": "once_cell 1.17.1",
               "target": "once_cell"
             },
             {
-              "id": "owo-colors 3.6.0",
+              "id": "owo-colors 3.5.0",
               "target": "owo_colors"
             },
             {
@@ -3732,7 +4110,7 @@
               "target": "textwrap"
             },
             {
-              "id": "thiserror 1.0.38",
+              "id": "thiserror 1.0.40",
               "target": "thiserror"
             },
             {
@@ -3787,15 +4165,15 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.49",
+              "id": "proc-macro2 1.0.56",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.107",
+              "id": "syn 1.0.109",
               "target": "syn"
             }
           ],
@@ -3990,7 +4368,7 @@
               "target": "num_traits"
             },
             {
-              "id": "serde 1.0.152",
+              "id": "serde 1.0.160",
               "target": "serde"
             }
           ],
@@ -4202,7 +4580,7 @@
             ],
             "cfg(not(windows))": [
               {
-                "id": "libc 0.2.139",
+                "id": "libc 0.2.142",
                 "target": "libc"
               }
             ]
@@ -4213,13 +4591,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "object 0.30.0": {
+    "object 0.30.3": {
       "name": "object",
-      "version": "0.30.0",
+      "version": "0.30.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/object/0.30.0/download",
-          "sha256": "239da7f290cfa979f43f85a8efeee9a8a76d0827c356d37f9d3d7254d6b537fb"
+          "url": "https://crates.io/api/v1/crates/object/0.30.3/download",
+          "sha256": "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
         }
       },
       "targets": [
@@ -4260,17 +4638,17 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.30.0"
+        "version": "0.30.3"
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "once_cell 1.16.0": {
+    "once_cell 1.17.1": {
       "name": "once_cell",
-      "version": "1.16.0",
+      "version": "1.17.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/once_cell/1.16.0/download",
-          "sha256": "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+          "url": "https://crates.io/api/v1/crates/once_cell/1.17.1/download",
+          "sha256": "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
         }
       },
       "targets": [
@@ -4299,7 +4677,7 @@
           "std"
         ],
         "edition": "2021",
-        "version": "1.16.0"
+        "version": "1.17.1"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -4378,13 +4756,13 @@
       },
       "license": "MIT"
     },
-    "owo-colors 3.6.0": {
+    "owo-colors 3.5.0": {
       "name": "owo-colors",
-      "version": "3.6.0",
+      "version": "3.5.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/owo-colors/3.6.0/download",
-          "sha256": "69dc4ec9e7e12502579e09e8a53c6a305b3aceb62ad5c307a62f7c3eada78324"
+          "url": "https://crates.io/api/v1/crates/owo-colors/3.5.0/download",
+          "sha256": "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
         }
       },
       "targets": [
@@ -4407,7 +4785,7 @@
           "**"
         ],
         "edition": "2018",
-        "version": "3.6.0"
+        "version": "3.5.0"
       },
       "license": "MIT"
     },
@@ -4449,7 +4827,7 @@
               "target": "lock_api"
             },
             {
-              "id": "parking_lot_core 0.9.5",
+              "id": "parking_lot_core 0.9.7",
               "target": "parking_lot_core"
             }
           ],
@@ -4460,13 +4838,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "parking_lot_core 0.9.5": {
+    "parking_lot_core 0.9.7": {
       "name": "parking_lot_core",
-      "version": "0.9.5",
+      "version": "0.9.7",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/parking_lot_core/0.9.5/download",
-          "sha256": "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
+          "url": "https://crates.io/api/v1/crates/parking_lot_core/0.9.7/download",
+          "sha256": "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
         }
       },
       "targets": [
@@ -4507,7 +4885,7 @@
               "target": "cfg_if"
             },
             {
-              "id": "parking_lot_core 0.9.5",
+              "id": "parking_lot_core 0.9.7",
               "target": "build_script_build"
             },
             {
@@ -4524,20 +4902,20 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.139",
+                "id": "libc 0.2.142",
                 "target": "libc"
               }
             ],
             "cfg(windows)": [
               {
-                "id": "windows-sys 0.42.0",
+                "id": "windows-sys 0.45.0",
                 "target": "windows_sys"
               }
             ]
           }
         },
         "edition": "2018",
-        "version": "0.9.5"
+        "version": "0.9.7"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -4742,15 +5120,15 @@
               "target": "phf_shared"
             },
             {
-              "id": "proc-macro2 1.0.49",
+              "id": "proc-macro2 1.0.56",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.107",
+              "id": "syn 1.0.109",
               "target": "syn"
             }
           ],
@@ -4880,15 +5258,15 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.49",
+              "id": "proc-macro2 1.0.56",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.107",
+              "id": "syn 1.0.109",
               "target": "syn"
             }
           ],
@@ -5089,15 +5467,15 @@
               "target": "build_script_build"
             },
             {
-              "id": "proc-macro2 1.0.49",
+              "id": "proc-macro2 1.0.56",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.107",
+              "id": "syn 1.0.109",
               "target": "syn"
             }
           ],
@@ -5178,11 +5556,11 @@
               "target": "build_script_build"
             },
             {
-              "id": "proc-macro2 1.0.49",
+              "id": "proc-macro2 1.0.56",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             }
           ],
@@ -5266,13 +5644,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "proc-macro2 1.0.49": {
+    "proc-macro2 1.0.56": {
       "name": "proc-macro2",
-      "version": "1.0.49",
+      "version": "1.0.56",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/proc-macro2/1.0.49/download",
-          "sha256": "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+          "url": "https://crates.io/api/v1/crates/proc-macro2/1.0.56/download",
+          "sha256": "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
         }
       },
       "targets": [
@@ -5313,23 +5691,91 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.49",
+              "id": "proc-macro2 1.0.56",
               "target": "build_script_build"
             },
             {
-              "id": "unicode-ident 1.0.6",
+              "id": "unicode-ident 1.0.8",
               "target": "unicode_ident"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.49"
+        "version": "1.0.56"
       },
       "build_script_attrs": {
         "data_glob": [
           "**"
         ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "psm 0.1.21": {
+      "name": "psm",
+      "version": "0.1.21",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/psm/0.1.21/download",
+          "sha256": "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "psm",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "psm",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "psm 0.1.21",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2015",
+        "version": "0.1.21"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "cc 1.0.79",
+              "target": "cc"
+            }
+          ],
+          "selects": {}
+        }
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -5409,15 +5855,15 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.49",
+              "id": "proc-macro2 1.0.56",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.107",
+              "id": "syn 1.0.109",
               "target": "syn"
             }
           ],
@@ -5428,13 +5874,13 @@
       },
       "license": "MIT"
     },
-    "quote 1.0.23": {
+    "quote 1.0.26": {
       "name": "quote",
-      "version": "1.0.23",
+      "version": "1.0.26",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/quote/1.0.23/download",
-          "sha256": "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+          "url": "https://crates.io/api/v1/crates/quote/1.0.26/download",
+          "sha256": "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
         }
       },
       "targets": [
@@ -5475,18 +5921,18 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.49",
+              "id": "proc-macro2 1.0.56",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.23"
+        "version": "1.0.26"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -5547,7 +5993,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.139",
+                "id": "libc 0.2.142",
                 "target": "libc"
               }
             ]
@@ -5643,7 +6089,7 @@
         "deps": {
           "common": [
             {
-              "id": "getrandom 0.2.8",
+              "id": "getrandom 0.2.9",
               "target": "getrandom"
             }
           ],
@@ -5696,13 +6142,55 @@
       },
       "license": "MIT"
     },
-    "regex 1.7.0": {
-      "name": "regex",
-      "version": "1.7.0",
+    "redox_syscall 0.3.5": {
+      "name": "redox_syscall",
+      "version": "0.3.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/regex/1.7.0/download",
-          "sha256": "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+          "url": "https://crates.io/api/v1/crates/redox_syscall/0.3.5/download",
+          "sha256": "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "syscall",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "syscall",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "bitflags 1.3.2",
+              "target": "bitflags"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.3.5"
+      },
+      "license": "MIT"
+    },
+    "regex 1.8.1": {
+      "name": "regex",
+      "version": "1.8.1",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/regex/1.8.1/download",
+          "sha256": "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
         }
       },
       "targets": [
@@ -5746,7 +6234,7 @@
         "deps": {
           "common": [
             {
-              "id": "aho-corasick 0.7.20",
+              "id": "aho-corasick 1.0.1",
               "target": "aho_corasick"
             },
             {
@@ -5754,14 +6242,14 @@
               "target": "memchr"
             },
             {
-              "id": "regex-syntax 0.6.28",
+              "id": "regex-syntax 0.7.1",
               "target": "regex_syntax"
             }
           ],
           "selects": {}
         },
-        "edition": "2018",
-        "version": "1.7.0"
+        "edition": "2021",
+        "version": "1.8.1"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -5801,7 +6289,7 @@
         "deps": {
           "common": [
             {
-              "id": "regex-syntax 0.6.28",
+              "id": "regex-syntax 0.6.29",
               "target": "regex_syntax"
             }
           ],
@@ -5812,13 +6300,13 @@
       },
       "license": "Unlicense/MIT"
     },
-    "regex-syntax 0.6.28": {
+    "regex-syntax 0.6.29": {
       "name": "regex-syntax",
-      "version": "0.6.28",
+      "version": "0.6.29",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/regex-syntax/0.6.28/download",
-          "sha256": "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+          "url": "https://crates.io/api/v1/crates/regex-syntax/0.6.29/download",
+          "sha256": "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
         }
       },
       "targets": [
@@ -5852,17 +6340,62 @@
           "unicode-segment"
         ],
         "edition": "2018",
-        "version": "0.6.28"
+        "version": "0.6.29"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "relative-path 1.7.2": {
-      "name": "relative-path",
-      "version": "1.7.2",
+    "regex-syntax 0.7.1": {
+      "name": "regex-syntax",
+      "version": "0.7.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/relative-path/1.7.2/download",
-          "sha256": "0df32d82cedd1499386877b062ebe8721f806de80b08d183c70184ef17dd1d42"
+          "url": "https://crates.io/api/v1/crates/regex-syntax/0.7.1/download",
+          "sha256": "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "regex_syntax",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "regex_syntax",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "default",
+          "std",
+          "unicode",
+          "unicode-age",
+          "unicode-bool",
+          "unicode-case",
+          "unicode-gencat",
+          "unicode-perl",
+          "unicode-script",
+          "unicode-segment"
+        ],
+        "edition": "2021",
+        "version": "0.7.1"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "relative-path 1.8.0": {
+      "name": "relative-path",
+      "version": "1.8.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/relative-path/1.8.0/download",
+          "sha256": "4bf2521270932c3c7bed1a59151222bd7643c79310f2916f01925e1e16255698"
         }
       },
       "targets": [
@@ -5888,61 +6421,17 @@
           "default"
         ],
         "edition": "2018",
-        "version": "1.7.2"
+        "version": "1.8.0"
       },
       "license": "MIT/Apache-2.0"
     },
-    "remove_dir_all 0.5.3": {
-      "name": "remove_dir_all",
-      "version": "0.5.3",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/remove_dir_all/0.5.3/download",
-          "sha256": "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "remove_dir_all",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        }
-      ],
-      "library_target_name": "remove_dir_all",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [],
-          "selects": {
-            "cfg(windows)": [
-              {
-                "id": "winapi 0.3.9",
-                "target": "winapi"
-              }
-            ]
-          }
-        },
-        "edition": "2015",
-        "version": "0.5.3"
-      },
-      "license": "MIT/Apache-2.0"
-    },
-    "rend 0.3.6": {
+    "rend 0.4.0": {
       "name": "rend",
-      "version": "0.3.6",
+      "version": "0.4.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/rend/0.3.6/download",
-          "sha256": "79af64b4b6362ffba04eef3a4e10829718a4896dac19daa741851c86781edf95"
+          "url": "https://crates.io/api/v1/crates/rend/0.4.0/download",
+          "sha256": "581008d2099240d37fb08d77ad713bcaec2c4d89d50b5b21a8bb1996bbab68ab"
         }
       },
       "targets": [
@@ -5978,23 +6467,24 @@
         ],
         "crate_features": [
           "bytecheck",
-          "std"
+          "std",
+          "validation"
         ],
         "deps": {
           "common": [
             {
-              "id": "bytecheck 0.6.9",
+              "id": "bytecheck 0.6.10",
               "target": "bytecheck"
             },
             {
-              "id": "rend 0.3.6",
+              "id": "rend 0.4.0",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.6"
+        "version": "0.4.0"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -6003,13 +6493,13 @@
       },
       "license": "MIT"
     },
-    "rkyv 0.7.37": {
+    "rkyv 0.7.41": {
       "name": "rkyv",
-      "version": "0.7.37",
+      "version": "0.7.41",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/rkyv/0.7.37/download",
-          "sha256": "1f08c8062c1fe1253064043b8fc07bfea1b9702b71b4a86c11ea3588183b12e1"
+          "url": "https://crates.io/api/v1/crates/rkyv/0.7.41/download",
+          "sha256": "21499ed91807f07ae081880aabb2ccc0235e9d88011867d984525e9a4c3cfa3e"
         }
       },
       "targets": [
@@ -6050,12 +6540,14 @@
           "hashbrown",
           "rend",
           "size_32",
-          "std"
+          "std",
+          "strict",
+          "validation"
         ],
         "deps": {
           "common": [
             {
-              "id": "bytecheck 0.6.9",
+              "id": "bytecheck 0.6.10",
               "target": "bytecheck"
             },
             {
@@ -6067,11 +6559,11 @@
               "target": "ptr_meta"
             },
             {
-              "id": "rend 0.3.6",
+              "id": "rend 0.4.0",
               "target": "rend"
             },
             {
-              "id": "rkyv 0.7.37",
+              "id": "rkyv 0.7.41",
               "target": "build_script_build"
             },
             {
@@ -6081,17 +6573,17 @@
           ],
           "selects": {}
         },
-        "edition": "2018",
+        "edition": "2021",
         "proc_macro_deps": {
           "common": [
             {
-              "id": "rkyv_derive 0.7.37",
+              "id": "rkyv_derive 0.7.41",
               "target": "rkyv_derive"
             }
           ],
           "selects": {}
         },
-        "version": "0.7.37"
+        "version": "0.7.41"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -6100,13 +6592,13 @@
       },
       "license": "MIT"
     },
-    "rkyv_derive 0.7.37": {
+    "rkyv_derive 0.7.41": {
       "name": "rkyv_derive",
-      "version": "0.7.37",
+      "version": "0.7.41",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/rkyv_derive/0.7.37/download",
-          "sha256": "e289706df51226e84814bf6ba1a9e1013112ae29bc7a9878f73fce360520c403"
+          "url": "https://crates.io/api/v1/crates/rkyv_derive/0.7.41/download",
+          "sha256": "ac1c672430eb41556291981f45ca900a0239ad007242d1cb4b4167af842db666"
         }
       },
       "targets": [
@@ -6129,37 +6621,38 @@
           "**"
         ],
         "crate_features": [
-          "default"
+          "default",
+          "strict"
         ],
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.49",
+              "id": "proc-macro2 1.0.56",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.107",
+              "id": "syn 1.0.109",
               "target": "syn"
             }
           ],
           "selects": {}
         },
-        "edition": "2018",
-        "version": "0.7.37"
+        "edition": "2021",
+        "version": "0.7.41"
       },
       "license": "MIT"
     },
-    "rustc-demangle 0.1.21": {
+    "rustc-demangle 0.1.23": {
       "name": "rustc-demangle",
-      "version": "0.1.21",
+      "version": "0.1.23",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/rustc-demangle/0.1.21/download",
-          "sha256": "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+          "url": "https://crates.io/api/v1/crates/rustc-demangle/0.1.23/download",
+          "sha256": "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
         }
       },
       "targets": [
@@ -6182,7 +6675,7 @@
           "**"
         ],
         "edition": "2015",
-        "version": "0.1.21"
+        "version": "0.1.23"
       },
       "license": "MIT/Apache-2.0"
     },
@@ -6265,13 +6758,127 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "rustversion 1.0.11": {
-      "name": "rustversion",
-      "version": "1.0.11",
+    "rustix 0.37.18": {
+      "name": "rustix",
+      "version": "0.37.18",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/rustversion/1.0.11/download",
-          "sha256": "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
+          "url": "https://crates.io/api/v1/crates/rustix/0.37.18/download",
+          "sha256": "8bbfc1d1c7c40c01715f47d71444744a81669ca84e8b63e25a55e169b1f86433"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "rustix",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "rustix",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "default",
+          "fs",
+          "io-lifetimes",
+          "libc",
+          "std",
+          "use-libc-auxv"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "bitflags 1.3.2",
+              "target": "bitflags"
+            },
+            {
+              "id": "io-lifetimes 1.0.10",
+              "target": "io_lifetimes"
+            },
+            {
+              "id": "rustix 0.37.18",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {
+            "cfg(all(any(target_os = \"android\", target_os = \"linux\"), any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"), all(target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"powerpc64\", target_arch = \"riscv64\", target_arch = \"mips\", target_arch = \"mips64\"))))))))": [
+              {
+                "id": "linux-raw-sys 0.3.6",
+                "target": "linux_raw_sys"
+              }
+            ],
+            "cfg(all(not(rustix_use_libc), not(miri), target_os = \"linux\", any(target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"), all(target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"powerpc64\", target_arch = \"riscv64\", target_arch = \"mips\", target_arch = \"mips64\")))))": [
+              {
+                "id": "libc 0.2.142",
+                "target": "libc"
+              },
+              {
+                "id": "linux-raw-sys 0.3.6",
+                "target": "linux_raw_sys"
+              }
+            ],
+            "cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"), all(target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"powerpc64\", target_arch = \"riscv64\", target_arch = \"mips\", target_arch = \"mips64\"))))))))": [
+              {
+                "id": "errno 0.3.1",
+                "target": "errno",
+                "alias": "libc_errno"
+              },
+              {
+                "id": "libc 0.2.142",
+                "target": "libc"
+              }
+            ],
+            "cfg(windows)": [
+              {
+                "id": "errno 0.3.1",
+                "target": "errno",
+                "alias": "libc_errno"
+              },
+              {
+                "id": "windows-sys 0.48.0",
+                "target": "windows_sys"
+              }
+            ]
+          }
+        },
+        "edition": "2018",
+        "version": "0.37.18"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
+    },
+    "rustversion 1.0.12": {
+      "name": "rustversion",
+      "version": "1.0.12",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/rustversion/1.0.12/download",
+          "sha256": "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
         }
       },
       "targets": [
@@ -6308,14 +6915,14 @@
         "deps": {
           "common": [
             {
-              "id": "rustversion 1.0.11",
+              "id": "rustversion 1.0.12",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.11"
+        "version": "1.0.12"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -6324,13 +6931,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "ryu 1.0.12": {
+    "ryu 1.0.13": {
       "name": "ryu",
-      "version": "1.0.12",
+      "version": "1.0.13",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/ryu/1.0.12/download",
-          "sha256": "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+          "url": "https://crates.io/api/v1/crates/ryu/1.0.13/download",
+          "sha256": "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
         }
       },
       "targets": [
@@ -6353,7 +6960,7 @@
           "**"
         ],
         "edition": "2018",
-        "version": "1.0.12"
+        "version": "1.0.13"
       },
       "license": "Apache-2.0 OR BSL-1.0"
     },
@@ -6537,13 +7144,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "serde 1.0.152": {
+    "serde 1.0.160": {
       "name": "serde",
-      "version": "1.0.152",
+      "version": "1.0.160",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde/1.0.152/download",
-          "sha256": "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+          "url": "https://crates.io/api/v1/crates/serde/1.0.160/download",
+          "sha256": "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
         }
       },
       "targets": [
@@ -6587,7 +7194,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.152",
+              "id": "serde 1.0.160",
               "target": "build_script_build"
             }
           ],
@@ -6597,13 +7204,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "serde_derive 1.0.152",
+              "id": "serde_derive 1.0.160",
               "target": "serde_derive"
             }
           ],
           "selects": {}
         },
-        "version": "1.0.152"
+        "version": "1.0.160"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -6612,13 +7219,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "serde_derive 1.0.152": {
+    "serde_derive 1.0.160": {
       "name": "serde_derive",
-      "version": "1.0.152",
+      "version": "1.0.160",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde_derive/1.0.152/download",
-          "sha256": "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+          "url": "https://crates.io/api/v1/crates/serde_derive/1.0.160/download",
+          "sha256": "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
         }
       },
       "targets": [
@@ -6658,26 +7265,26 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.49",
+              "id": "proc-macro2 1.0.56",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             },
             {
-              "id": "serde_derive 1.0.152",
+              "id": "serde_derive 1.0.160",
               "target": "build_script_build"
             },
             {
-              "id": "syn 1.0.107",
+              "id": "syn 2.0.15",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "1.0.152"
+        "version": "1.0.160"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -6686,13 +7293,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "serde_json 1.0.91": {
+    "serde_json 1.0.96": {
       "name": "serde_json",
-      "version": "1.0.91",
+      "version": "1.0.96",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde_json/1.0.91/download",
-          "sha256": "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+          "url": "https://crates.io/api/v1/crates/serde_json/1.0.96/download",
+          "sha256": "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
         }
       },
       "targets": [
@@ -6733,26 +7340,26 @@
         "deps": {
           "common": [
             {
-              "id": "itoa 1.0.5",
+              "id": "itoa 1.0.6",
               "target": "itoa"
             },
             {
-              "id": "ryu 1.0.12",
+              "id": "ryu 1.0.13",
               "target": "ryu"
             },
             {
-              "id": "serde 1.0.152",
+              "id": "serde 1.0.160",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.91",
+              "id": "serde_json 1.0.96",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.91"
+        "version": "1.0.96"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -6761,13 +7368,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "serde_repr 0.1.10": {
+    "serde_repr 0.1.12": {
       "name": "serde_repr",
-      "version": "0.1.10",
+      "version": "0.1.12",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde_repr/0.1.10/download",
-          "sha256": "9a5ec9fa74a20ebbe5d9ac23dac1fc96ba0ecfe9f50f2843b52e537b10fbcb4e"
+          "url": "https://crates.io/api/v1/crates/serde_repr/0.1.12/download",
+          "sha256": "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
         }
       },
       "targets": [
@@ -6792,22 +7399,22 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.49",
+              "id": "proc-macro2 1.0.56",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.107",
+              "id": "syn 2.0.15",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.1.10"
+        "version": "0.1.12"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -6857,7 +7464,7 @@
           "selects": {
             "cfg(any(target_arch = \"aarch64\", target_arch = \"x86\", target_arch = \"x86_64\"))": [
               {
-                "id": "cpufeatures 0.2.5",
+                "id": "cpufeatures 0.2.7",
                 "target": "cpufeatures"
               }
             ]
@@ -6914,7 +7521,7 @@
           "selects": {
             "cfg(any(target_arch = \"aarch64\", target_arch = \"x86_64\", target_arch = \"x86\"))": [
               {
-                "id": "cpufeatures 0.2.5",
+                "id": "cpufeatures 0.2.7",
                 "target": "cpufeatures"
               }
             ]
@@ -6967,6 +7574,42 @@
       },
       "license": "MIT"
     },
+    "simdutf8 0.1.4": {
+      "name": "simdutf8",
+      "version": "0.1.4",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/simdutf8/0.1.4/download",
+          "sha256": "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "simdutf8",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "simdutf8",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "std"
+        ],
+        "edition": "2018",
+        "version": "0.1.4"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
     "similar 2.2.1": {
       "name": "similar",
       "version": "2.2.1",
@@ -7010,7 +7653,7 @@
               "target": "bstr"
             },
             {
-              "id": "unicode-segmentation 1.10.0",
+              "id": "unicode-segmentation 1.10.1",
               "target": "unicode_segmentation"
             }
           ],
@@ -7056,7 +7699,7 @@
         "deps": {
           "common": [
             {
-              "id": "console 0.15.2",
+              "id": "console 0.15.5",
               "target": "console"
             },
             {
@@ -7141,6 +7784,86 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "smartstring 1.0.1": {
+      "name": "smartstring",
+      "version": "1.0.1",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/smartstring/1.0.1/download",
+          "sha256": "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "smartstring",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "smartstring",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "default",
+          "std"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "smartstring 1.0.1",
+              "target": "build_script_build"
+            },
+            {
+              "id": "static_assertions 1.1.0",
+              "target": "static_assertions"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "1.0.1"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "autocfg 1.1.0",
+              "target": "autocfg"
+            },
+            {
+              "id": "version_check 0.9.4",
+              "target": "version_check"
+            }
+          ],
+          "selects": {}
+        }
+      },
+      "license": "MPL-2.0+"
+    },
     "smawk 0.3.1": {
       "name": "smawk",
       "version": "0.3.1",
@@ -7174,13 +7897,13 @@
       },
       "license": "MIT"
     },
-    "sourcemap 6.2.0": {
+    "sourcemap 6.2.3": {
       "name": "sourcemap",
-      "version": "6.2.0",
+      "version": "6.2.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/sourcemap/6.2.0/download",
-          "sha256": "c46fdc1838ff49cf692226f5c2b0f5b7538f556863d0eca602984714667ac6e7"
+          "url": "https://crates.io/api/v1/crates/sourcemap/6.2.3/download",
+          "sha256": "eed16231c92d0a6f0388f56e0ab2be24ecff1173f8e22f0ea5e074d0525631cb"
         }
       },
       "targets": [
@@ -7205,28 +7928,24 @@
         "deps": {
           "common": [
             {
-              "id": "base64 0.13.1",
-              "target": "base64"
+              "id": "data-encoding 2.3.3",
+              "target": "data_encoding"
             },
             {
               "id": "if_chain 1.0.2",
               "target": "if_chain"
             },
             {
-              "id": "lazy_static 1.4.0",
-              "target": "lazy_static"
-            },
-            {
-              "id": "regex 1.7.0",
-              "target": "regex"
-            },
-            {
-              "id": "serde 1.0.152",
+              "id": "serde 1.0.160",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.91",
+              "id": "serde_json 1.0.96",
               "target": "serde_json"
+            },
+            {
+              "id": "unicode-id 0.3.3",
+              "target": "unicode_id"
             },
             {
               "id": "url 2.3.1",
@@ -7236,7 +7955,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "6.2.0"
+        "version": "6.2.3"
       },
       "license": "BSD-3-Clause"
     },
@@ -7273,6 +7992,93 @@
       },
       "license": "MIT/Apache-2.0"
     },
+    "stacker 0.1.15": {
+      "name": "stacker",
+      "version": "0.1.15",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/stacker/0.1.15/download",
+          "sha256": "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "stacker",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "stacker",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "cfg-if 1.0.0",
+              "target": "cfg_if"
+            },
+            {
+              "id": "libc 0.2.142",
+              "target": "libc"
+            },
+            {
+              "id": "psm 0.1.21",
+              "target": "psm"
+            },
+            {
+              "id": "stacker 0.1.15",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {
+            "cfg(windows)": [
+              {
+                "id": "winapi 0.3.9",
+                "target": "winapi"
+              }
+            ]
+          }
+        },
+        "edition": "2015",
+        "version": "0.1.15"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "cc 1.0.79",
+              "target": "cc"
+            }
+          ],
+          "selects": {}
+        }
+      },
+      "license": "MIT OR Apache-2.0"
+    },
     "static_assertions 1.1.0": {
       "name": "static_assertions",
       "version": "1.1.0",
@@ -7306,13 +8112,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "string_cache 0.8.4": {
+    "string_cache 0.8.7": {
       "name": "string_cache",
-      "version": "0.8.4",
+      "version": "0.8.7",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/string_cache/0.8.4/download",
-          "sha256": "213494b7a2b503146286049378ce02b482200519accc31872ee8be91fa820a08"
+          "url": "https://crates.io/api/v1/crates/string_cache/0.8.7/download",
+          "sha256": "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
         }
       },
       "targets": [
@@ -7346,7 +8152,7 @@
               "target": "debug_unreachable"
             },
             {
-              "id": "once_cell 1.16.0",
+              "id": "once_cell 1.17.1",
               "target": "once_cell"
             },
             {
@@ -7362,16 +8168,16 @@
               "target": "precomputed_hash"
             },
             {
-              "id": "serde 1.0.152",
+              "id": "serde 1.0.160",
               "target": "serde"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.8.4"
+        "version": "0.8.7"
       },
-      "license": "MIT / Apache-2.0"
+      "license": "MIT OR Apache-2.0"
     },
     "string_cache_codegen 0.5.2": {
       "name": "string_cache_codegen",
@@ -7412,11 +8218,11 @@
               "target": "phf_shared"
             },
             {
-              "id": "proc-macro2 1.0.49",
+              "id": "proc-macro2 1.0.56",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             }
           ],
@@ -7427,13 +8233,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "string_enum 0.3.2": {
+    "string_enum 0.4.0": {
       "name": "string_enum",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/string_enum/0.3.2/download",
-          "sha256": "994453cd270ad0265796eb24abf5540091ed03e681c5f3c12bc33e4db33253e1"
+          "url": "https://crates.io/api/v1/crates/string_enum/0.4.0/download",
+          "sha256": "0090512bdfee4b56d82480d66c0fd8a6f53f0fe0f97e075e949b252acdd482e0"
         }
       },
       "targets": [
@@ -7462,26 +8268,26 @@
               "target": "pmutil"
             },
             {
-              "id": "proc-macro2 1.0.49",
+              "id": "proc-macro2 1.0.56",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             },
             {
-              "id": "swc_macros_common 0.3.6",
+              "id": "swc_macros_common 0.3.7",
               "target": "swc_macros_common"
             },
             {
-              "id": "syn 1.0.107",
+              "id": "syn 1.0.109",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.3.2"
+        "version": "0.4.0"
       },
       "license": "Apache-2.0"
     },
@@ -7677,23 +8483,23 @@
         "deps": {
           "common": [
             {
-              "id": "base64ct 1.5.3",
+              "id": "base64ct 1.6.0",
               "target": "base64ct"
             },
             {
-              "id": "once_cell 1.16.0",
+              "id": "once_cell 1.17.1",
               "target": "once_cell"
             },
             {
-              "id": "regex 1.7.0",
+              "id": "regex 1.8.1",
               "target": "regex"
             },
             {
-              "id": "serde 1.0.152",
+              "id": "serde 1.0.160",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.91",
+              "id": "serde_json 1.0.96",
               "target": "serde_json"
             },
             {
@@ -7701,7 +8507,7 @@
               "target": "sha2"
             },
             {
-              "id": "swc_core 0.51.1",
+              "id": "swc_core 0.75.42",
               "target": "swc_core"
             }
           ],
@@ -7734,15 +8540,15 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.152",
+              "id": "serde 1.0.160",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.91",
+              "id": "serde_json 1.0.96",
               "target": "serde_json"
             },
             {
-              "id": "swc_core 0.51.1",
+              "id": "swc_core 0.75.42",
               "target": "swc_core"
             }
           ],
@@ -7753,13 +8559,101 @@
       },
       "license": "MIT"
     },
-    "swc_atoms 0.4.32": {
+    "swc_atoms 0.4.43": {
       "name": "swc_atoms",
-      "version": "0.4.32",
+      "version": "0.4.43",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/swc_atoms/0.4.32/download",
-          "sha256": "9ad59af21529fcd3f4f8fa6b1ae399c2b183ec42c68347d76d68d6e5b657956e"
+          "url": "https://crates.io/api/v1/crates/swc_atoms/0.4.43/download",
+          "sha256": "64593af3e0fbacd1b7147a0188f1fd77a2fc8ae3c2425bdb9528de255b9f452b"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "swc_atoms",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "swc_atoms",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "once_cell 1.17.1",
+              "target": "once_cell"
+            },
+            {
+              "id": "rustc-hash 1.1.0",
+              "target": "rustc_hash"
+            },
+            {
+              "id": "serde 1.0.160",
+              "target": "serde"
+            },
+            {
+              "id": "string_cache 0.8.7",
+              "target": "string_cache"
+            },
+            {
+              "id": "swc_atoms 0.4.43",
+              "target": "build_script_build"
+            },
+            {
+              "id": "triomphe 0.1.8",
+              "target": "triomphe"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.4.43"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "string_cache_codegen 0.5.2",
+              "target": "string_cache_codegen"
+            }
+          ],
+          "selects": {}
+        }
+      },
+      "license": "Apache-2.0"
+    },
+    "swc_atoms 0.5.3": {
+      "name": "swc_atoms",
+      "version": "0.5.3",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/swc_atoms/0.5.3/download",
+          "sha256": "593c2f3e4cea60ddc4179ed731cabebe7eacec209d9e76a3bbcff4b2b020e3f5"
         }
       },
       "targets": [
@@ -7801,11 +8695,11 @@
         "deps": {
           "common": [
             {
-              "id": "once_cell 1.16.0",
+              "id": "once_cell 1.17.1",
               "target": "once_cell"
             },
             {
-              "id": "rkyv 0.7.37",
+              "id": "rkyv 0.7.41",
               "target": "rkyv"
             },
             {
@@ -7813,15 +8707,15 @@
               "target": "rustc_hash"
             },
             {
-              "id": "serde 1.0.152",
+              "id": "serde 1.0.160",
               "target": "serde"
             },
             {
-              "id": "string_cache 0.8.4",
+              "id": "string_cache 0.8.7",
               "target": "string_cache"
             },
             {
-              "id": "swc_atoms 0.4.32",
+              "id": "swc_atoms 0.5.3",
               "target": "build_script_build"
             },
             {
@@ -7832,7 +8726,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.4.32"
+        "version": "0.5.3"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -7909,7 +8803,7 @@
               "target": "debug_unreachable"
             },
             {
-              "id": "either 1.8.0",
+              "id": "either 1.8.1",
               "target": "either"
             },
             {
@@ -7917,7 +8811,7 @@
               "target": "num_bigint"
             },
             {
-              "id": "once_cell 1.16.0",
+              "id": "once_cell 1.17.1",
               "target": "once_cell"
             },
             {
@@ -7929,7 +8823,7 @@
               "target": "rustc_hash"
             },
             {
-              "id": "serde 1.0.152",
+              "id": "serde 1.0.160",
               "target": "serde"
             },
             {
@@ -7937,19 +8831,19 @@
               "target": "siphasher"
             },
             {
-              "id": "string_cache 0.8.4",
+              "id": "string_cache 0.8.7",
               "target": "string_cache"
             },
             {
-              "id": "swc_atoms 0.4.32",
+              "id": "swc_atoms 0.4.43",
               "target": "swc_atoms"
             },
             {
-              "id": "swc_visit 0.5.3",
+              "id": "swc_visit 0.5.5",
               "target": "swc_visit"
             },
             {
-              "id": "termcolor 1.1.3",
+              "id": "termcolor 1.2.0",
               "target": "termcolor"
             },
             {
@@ -7971,11 +8865,11 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "ast_node 0.8.6",
+              "id": "ast_node 0.8.8",
               "target": "ast_node"
             },
             {
-              "id": "from_variant 0.1.4",
+              "id": "from_variant 0.1.5",
               "target": "from_variant"
             },
             {
@@ -7989,13 +8883,13 @@
       },
       "license": "Apache-2.0"
     },
-    "swc_common 0.29.25": {
+    "swc_common 0.31.5": {
       "name": "swc_common",
-      "version": "0.29.25",
+      "version": "0.31.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/swc_common/0.29.25/download",
-          "sha256": "506321cad7393893018aac83a3b3bd25203883e8c47ab0864bb43195d43b22dd"
+          "url": "https://crates.io/api/v1/crates/swc_common/0.31.5/download",
+          "sha256": "6f876f826866e402da364d77aa97448fdf67cb4aeb6a5f1c0de39cacf35aa89a"
         }
       },
       "targets": [
@@ -8043,7 +8937,7 @@
               "target": "ahash"
             },
             {
-              "id": "anyhow 1.0.68",
+              "id": "anyhow 1.0.71",
               "target": "anyhow"
             },
             {
@@ -8059,7 +8953,7 @@
               "target": "cfg_if"
             },
             {
-              "id": "either 1.8.0",
+              "id": "either 1.8.1",
               "target": "either"
             },
             {
@@ -8071,7 +8965,7 @@
               "target": "num_bigint"
             },
             {
-              "id": "once_cell 1.16.0",
+              "id": "once_cell 1.17.1",
               "target": "once_cell"
             },
             {
@@ -8079,7 +8973,7 @@
               "target": "parking_lot"
             },
             {
-              "id": "rkyv 0.7.37",
+              "id": "rkyv 0.7.41",
               "target": "rkyv"
             },
             {
@@ -8087,7 +8981,7 @@
               "target": "rustc_hash"
             },
             {
-              "id": "serde 1.0.152",
+              "id": "serde 1.0.160",
               "target": "serde"
             },
             {
@@ -8095,23 +8989,23 @@
               "target": "siphasher"
             },
             {
-              "id": "sourcemap 6.2.0",
+              "id": "sourcemap 6.2.3",
               "target": "sourcemap"
             },
             {
-              "id": "string_cache 0.8.4",
+              "id": "string_cache 0.8.7",
               "target": "string_cache"
             },
             {
-              "id": "swc_atoms 0.4.32",
+              "id": "swc_atoms 0.5.3",
               "target": "swc_atoms"
             },
             {
-              "id": "swc_visit 0.5.3",
+              "id": "swc_visit 0.5.5",
               "target": "swc_visit"
             },
             {
-              "id": "termcolor 1.1.3",
+              "id": "termcolor 1.2.0",
               "target": "termcolor"
             },
             {
@@ -8133,11 +9027,11 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "ast_node 0.8.6",
+              "id": "ast_node 0.9.3",
               "target": "ast_node"
             },
             {
-              "id": "from_variant 0.1.4",
+              "id": "from_variant 0.1.5",
               "target": "from_variant"
             },
             {
@@ -8147,17 +9041,17 @@
           ],
           "selects": {}
         },
-        "version": "0.29.25"
+        "version": "0.31.5"
       },
       "license": "Apache-2.0"
     },
-    "swc_core 0.51.1": {
+    "swc_core 0.75.42": {
       "name": "swc_core",
-      "version": "0.51.1",
+      "version": "0.75.42",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/swc_core/0.51.1/download",
-          "sha256": "24c06001762e4a8ace5d30375cb4113fa7430f2b5fb2f506fac44ed9aac08cc5"
+          "url": "https://crates.io/api/v1/crates/swc_core/0.75.42/download",
+          "sha256": "4b211443a6a1972009935ad1d5fae68e5c7a3697b4a1121cb4e4aad8ca88ee4a"
         }
       },
       "targets": [
@@ -8202,6 +9096,7 @@
           "common",
           "common_plugin_transform",
           "ecma_ast",
+          "ecma_ast_serde",
           "ecma_plugin_transform",
           "ecma_visit",
           "once_cell",
@@ -8218,35 +9113,35 @@
         "deps": {
           "common": [
             {
-              "id": "once_cell 1.16.0",
+              "id": "once_cell 1.17.1",
               "target": "once_cell"
             },
             {
-              "id": "swc_atoms 0.4.32",
+              "id": "swc_atoms 0.5.3",
               "target": "swc_atoms"
             },
             {
-              "id": "swc_common 0.29.25",
+              "id": "swc_common 0.31.5",
               "target": "swc_common"
             },
             {
-              "id": "swc_core 0.51.1",
+              "id": "swc_core 0.75.42",
               "target": "build_script_build"
             },
             {
-              "id": "swc_ecma_ast 0.95.9",
+              "id": "swc_ecma_ast 0.103.5",
               "target": "swc_ecma_ast"
             },
             {
-              "id": "swc_ecma_transforms_base 0.112.17",
+              "id": "swc_ecma_transforms_base 0.126.18",
               "target": "swc_ecma_transforms_base"
             },
             {
-              "id": "swc_ecma_transforms_testing 0.115.18",
+              "id": "swc_ecma_transforms_testing 0.129.18",
               "target": "swc_ecma_transforms_testing"
             },
             {
-              "id": "swc_ecma_visit 0.81.9",
+              "id": "swc_ecma_visit 0.89.5",
               "target": "swc_ecma_visit"
             },
             {
@@ -8254,7 +9149,7 @@
               "target": "swc_plugin"
             },
             {
-              "id": "swc_plugin_proxy 0.23.9",
+              "id": "swc_plugin_proxy 0.32.5",
               "target": "swc_plugin_proxy"
             }
           ],
@@ -8264,13 +9159,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "swc_plugin_macro 0.9.10",
+              "id": "swc_plugin_macro 0.9.11",
               "target": "swc_plugin_macro"
             }
           ],
           "selects": {}
         },
-        "version": "0.51.1"
+        "version": "0.75.42"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -8279,7 +9174,7 @@
         "deps": {
           "common": [
             {
-              "id": "vergen 7.4.4",
+              "id": "vergen 7.5.1",
               "target": "vergen"
             }
           ],
@@ -8288,13 +9183,13 @@
       },
       "license": "Apache-2.0"
     },
-    "swc_ecma_ast 0.95.9": {
+    "swc_ecma_ast 0.103.5": {
       "name": "swc_ecma_ast",
-      "version": "0.95.9",
+      "version": "0.103.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/swc_ecma_ast/0.95.9/download",
-          "sha256": "3cc936f04c4e671ae5918b573a50945c5189d3dcdd57e4faddd47889717e1416"
+          "url": "https://crates.io/api/v1/crates/swc_ecma_ast/0.103.5/download",
+          "sha256": "1087786027e9e938588c0a66d45d1044a5e2285922b0928e023303f03a60900f"
         }
       },
       "targets": [
@@ -8302,18 +9197,6 @@
           "Library": {
             "crate_name": "swc_ecma_ast",
             "crate_root": "src/lib.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
             "srcs": {
               "include": [
                 "**/*.rs"
@@ -8332,12 +9215,14 @@
           "__rkyv",
           "default",
           "rkyv",
-          "rkyv-impl"
+          "rkyv-impl",
+          "serde",
+          "serde-impl"
         ],
         "deps": {
           "common": [
             {
-              "id": "bitflags 1.3.2",
+              "id": "bitflags 2.2.1",
               "target": "bitflags"
             },
             {
@@ -8345,7 +9230,7 @@
               "target": "num_bigint"
             },
             {
-              "id": "rkyv 0.7.37",
+              "id": "rkyv 0.7.41",
               "target": "rkyv"
             },
             {
@@ -8353,20 +9238,16 @@
               "target": "scoped_tls"
             },
             {
-              "id": "serde 1.0.152",
+              "id": "serde 1.0.160",
               "target": "serde"
             },
             {
-              "id": "swc_atoms 0.4.32",
+              "id": "swc_atoms 0.5.3",
               "target": "swc_atoms"
             },
             {
-              "id": "swc_common 0.29.25",
+              "id": "swc_common 0.31.5",
               "target": "swc_common"
-            },
-            {
-              "id": "swc_ecma_ast 0.95.9",
-              "target": "build_script_build"
             },
             {
               "id": "unicode-id 0.3.3",
@@ -8379,32 +9260,27 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "is-macro 0.2.1",
+              "id": "is-macro 0.2.2",
               "target": "is_macro"
             },
             {
-              "id": "string_enum 0.3.2",
+              "id": "string_enum 0.4.0",
               "target": "string_enum"
             }
           ],
           "selects": {}
         },
-        "version": "0.95.9"
-      },
-      "build_script_attrs": {
-        "data_glob": [
-          "**"
-        ]
+        "version": "0.103.5"
       },
       "license": "Apache-2.0"
     },
-    "swc_ecma_codegen 0.128.15": {
+    "swc_ecma_codegen 0.138.15": {
       "name": "swc_ecma_codegen",
-      "version": "0.128.15",
+      "version": "0.138.15",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/swc_ecma_codegen/0.128.15/download",
-          "sha256": "121caf2dde74cbd143035a92cfd249be7744ee31622c4e66ee19a8249e3f6855"
+          "url": "https://crates.io/api/v1/crates/swc_ecma_codegen/0.138.15/download",
+          "sha256": "807e07eda1b7f45971ec9a65c9ac032bf53acd0b02dae4456bbcfef3d47da95c"
         }
       },
       "targets": [
@@ -8437,7 +9313,7 @@
               "target": "num_bigint"
             },
             {
-              "id": "once_cell 1.16.0",
+              "id": "once_cell 1.17.1",
               "target": "once_cell"
             },
             {
@@ -8445,23 +9321,23 @@
               "target": "rustc_hash"
             },
             {
-              "id": "serde 1.0.152",
+              "id": "serde 1.0.160",
               "target": "serde"
             },
             {
-              "id": "sourcemap 6.2.0",
+              "id": "sourcemap 6.2.3",
               "target": "sourcemap"
             },
             {
-              "id": "swc_atoms 0.4.32",
+              "id": "swc_atoms 0.5.3",
               "target": "swc_atoms"
             },
             {
-              "id": "swc_common 0.29.25",
+              "id": "swc_common 0.31.5",
               "target": "swc_common"
             },
             {
-              "id": "swc_ecma_ast 0.95.9",
+              "id": "swc_ecma_ast 0.103.5",
               "target": "swc_ecma_ast"
             },
             {
@@ -8475,23 +9351,23 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "swc_ecma_codegen_macros 0.7.1",
+              "id": "swc_ecma_codegen_macros 0.7.2",
               "target": "swc_ecma_codegen_macros"
             }
           ],
           "selects": {}
         },
-        "version": "0.128.15"
+        "version": "0.138.15"
       },
       "license": "Apache-2.0"
     },
-    "swc_ecma_codegen_macros 0.7.1": {
+    "swc_ecma_codegen_macros 0.7.2": {
       "name": "swc_ecma_codegen_macros",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/swc_ecma_codegen_macros/0.7.1/download",
-          "sha256": "0159c99f81f52e48fe692ef7af1b0990b45d3006b14c6629be0b1ffee1b23aea"
+          "url": "https://crates.io/api/v1/crates/swc_ecma_codegen_macros/0.7.2/download",
+          "sha256": "bf4ee0caee1018808d94ecd09490cb7affd3d504b19aa11c49238f5fc4b54901"
         }
       },
       "targets": [
@@ -8520,36 +9396,36 @@
               "target": "pmutil"
             },
             {
-              "id": "proc-macro2 1.0.49",
+              "id": "proc-macro2 1.0.56",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             },
             {
-              "id": "swc_macros_common 0.3.6",
+              "id": "swc_macros_common 0.3.7",
               "target": "swc_macros_common"
             },
             {
-              "id": "syn 1.0.107",
+              "id": "syn 1.0.109",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.7.1"
+        "version": "0.7.2"
       },
       "license": "Apache-2.0"
     },
-    "swc_ecma_parser 0.123.13": {
+    "swc_ecma_parser 0.133.12": {
       "name": "swc_ecma_parser",
-      "version": "0.123.13",
+      "version": "0.133.12",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/swc_ecma_parser/0.123.13/download",
-          "sha256": "22225f792dcbcd3d3e77498d6e6fb86161cdd05ba4e24456361768dc41ee2948"
+          "url": "https://crates.io/api/v1/crates/swc_ecma_parser/0.133.12/download",
+          "sha256": "2fa9f6dab04b0e4d148fab7069ecb896ae6e9a3e3ec94a493d52d1d16a780cda"
         }
       },
       "targets": [
@@ -8578,7 +9454,7 @@
         "deps": {
           "common": [
             {
-              "id": "either 1.8.0",
+              "id": "either 1.8.1",
               "target": "either"
             },
             {
@@ -8590,7 +9466,7 @@
               "target": "num_bigint"
             },
             {
-              "id": "serde 1.0.152",
+              "id": "serde 1.0.160",
               "target": "serde"
             },
             {
@@ -8598,15 +9474,19 @@
               "target": "smallvec"
             },
             {
-              "id": "swc_atoms 0.4.32",
+              "id": "smartstring 1.0.1",
+              "target": "smartstring"
+            },
+            {
+              "id": "swc_atoms 0.5.3",
               "target": "swc_atoms"
             },
             {
-              "id": "swc_common 0.29.25",
+              "id": "swc_common 0.31.5",
               "target": "swc_common"
             },
             {
-              "id": "swc_ecma_ast 0.95.9",
+              "id": "swc_ecma_ast 0.103.5",
               "target": "swc_ecma_ast"
             },
             {
@@ -8614,23 +9494,21 @@
               "target": "tracing"
             },
             {
-              "id": "typed-arena 2.0.1",
+              "id": "typed-arena 2.0.2",
               "target": "typed_arena"
             }
           ],
-          "selects": {}
+          "selects": {
+            "cfg(not(any(target_arch = \"wasm32\", target_arch = \"arm\")))": [
+              {
+                "id": "stacker 0.1.15",
+                "target": "stacker"
+              }
+            ]
+          }
         },
         "edition": "2021",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "enum_kind 0.2.1",
-              "target": "enum_kind"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "0.123.13"
+        "version": "0.133.12"
       },
       "license": "Apache-2.0"
     },
@@ -8665,7 +9543,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.68",
+              "id": "anyhow 1.0.71",
               "target": "anyhow"
             },
             {
@@ -8688,13 +9566,13 @@
       },
       "license": "Apache-2.0"
     },
-    "swc_ecma_transforms_base 0.112.17": {
+    "swc_ecma_transforms_base 0.126.18": {
       "name": "swc_ecma_transforms_base",
-      "version": "0.112.17",
+      "version": "0.126.18",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/swc_ecma_transforms_base/0.112.17/download",
-          "sha256": "79dcead560bca9864ea5bae654df4d80dfb30449f357ba0a7ab1cd2930da92ff"
+          "url": "https://crates.io/api/v1/crates/swc_ecma_transforms_base/0.126.18/download",
+          "sha256": "96b6521512d072b082071a569d1aaad638bab56b9a18c9d88edc436055fe13ca"
         }
       },
       "targets": [
@@ -8723,11 +9601,15 @@
               "target": "better_scoped_tls"
             },
             {
-              "id": "bitflags 1.3.2",
+              "id": "bitflags 2.2.1",
               "target": "bitflags"
             },
             {
-              "id": "once_cell 1.16.0",
+              "id": "indexmap 1.9.3",
+              "target": "indexmap"
+            },
+            {
+              "id": "once_cell 1.17.1",
               "target": "once_cell"
             },
             {
@@ -8739,7 +9621,7 @@
               "target": "rustc_hash"
             },
             {
-              "id": "serde 1.0.152",
+              "id": "serde 1.0.160",
               "target": "serde"
             },
             {
@@ -8747,27 +9629,27 @@
               "target": "smallvec"
             },
             {
-              "id": "swc_atoms 0.4.32",
+              "id": "swc_atoms 0.5.3",
               "target": "swc_atoms"
             },
             {
-              "id": "swc_common 0.29.25",
+              "id": "swc_common 0.31.5",
               "target": "swc_common"
             },
             {
-              "id": "swc_ecma_ast 0.95.9",
+              "id": "swc_ecma_ast 0.103.5",
               "target": "swc_ecma_ast"
             },
             {
-              "id": "swc_ecma_parser 0.123.13",
+              "id": "swc_ecma_parser 0.133.12",
               "target": "swc_ecma_parser"
             },
             {
-              "id": "swc_ecma_utils 0.106.13",
+              "id": "swc_ecma_utils 0.116.12",
               "target": "swc_ecma_utils"
             },
             {
-              "id": "swc_ecma_visit 0.81.9",
+              "id": "swc_ecma_visit 0.89.5",
               "target": "swc_ecma_visit"
             },
             {
@@ -8778,17 +9660,17 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.112.17"
+        "version": "0.126.18"
       },
       "license": "Apache-2.0"
     },
-    "swc_ecma_transforms_testing 0.115.18": {
+    "swc_ecma_transforms_testing 0.129.18": {
       "name": "swc_ecma_transforms_testing",
-      "version": "0.115.18",
+      "version": "0.129.18",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/swc_ecma_transforms_testing/0.115.18/download",
-          "sha256": "698d0299427d148e6a966b21bbfa055b744788d135d4fe683596f7c2a9296e51"
+          "url": "https://crates.io/api/v1/crates/swc_ecma_transforms_testing/0.129.18/download",
+          "sha256": "e3109919ceca5dc1a89721a2d3ed43917f7fc53eeb87433a020a810286b85ba0"
         }
       },
       "targets": [
@@ -8817,7 +9699,7 @@
               "target": "ansi_term"
             },
             {
-              "id": "anyhow 1.0.68",
+              "id": "anyhow 1.0.71",
               "target": "anyhow"
             },
             {
@@ -8829,11 +9711,11 @@
               "target": "hex"
             },
             {
-              "id": "serde 1.0.152",
+              "id": "serde 1.0.160",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.91",
+              "id": "serde_json 1.0.96",
               "target": "serde_json"
             },
             {
@@ -8841,23 +9723,23 @@
               "target": "sha1"
             },
             {
-              "id": "sourcemap 6.2.0",
+              "id": "sourcemap 6.2.3",
               "target": "sourcemap"
             },
             {
-              "id": "swc_common 0.29.25",
+              "id": "swc_common 0.31.5",
               "target": "swc_common"
             },
             {
-              "id": "swc_ecma_ast 0.95.9",
+              "id": "swc_ecma_ast 0.103.5",
               "target": "swc_ecma_ast"
             },
             {
-              "id": "swc_ecma_codegen 0.128.15",
+              "id": "swc_ecma_codegen 0.138.15",
               "target": "swc_ecma_codegen"
             },
             {
-              "id": "swc_ecma_parser 0.123.13",
+              "id": "swc_ecma_parser 0.133.12",
               "target": "swc_ecma_parser"
             },
             {
@@ -8865,40 +9747,40 @@
               "target": "swc_ecma_testing"
             },
             {
-              "id": "swc_ecma_transforms_base 0.112.17",
+              "id": "swc_ecma_transforms_base 0.126.18",
               "target": "swc_ecma_transforms_base"
             },
             {
-              "id": "swc_ecma_utils 0.106.13",
+              "id": "swc_ecma_utils 0.116.12",
               "target": "swc_ecma_utils"
             },
             {
-              "id": "swc_ecma_visit 0.81.9",
+              "id": "swc_ecma_visit 0.89.5",
               "target": "swc_ecma_visit"
             },
             {
-              "id": "tempfile 3.3.0",
+              "id": "tempfile 3.5.0",
               "target": "tempfile"
             },
             {
-              "id": "testing 0.31.27",
+              "id": "testing 0.33.6",
               "target": "testing"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.115.18"
+        "version": "0.129.18"
       },
       "license": "Apache-2.0"
     },
-    "swc_ecma_utils 0.106.13": {
+    "swc_ecma_utils 0.116.12": {
       "name": "swc_ecma_utils",
-      "version": "0.106.13",
+      "version": "0.116.12",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/swc_ecma_utils/0.106.13/download",
-          "sha256": "199beccb6243107d2906b88a97a5751350cd49491d31cbbf0c0541b46f55d65d"
+          "url": "https://crates.io/api/v1/crates/swc_ecma_utils/0.116.12/download",
+          "sha256": "547cce84256af2ce8b9ee44669872dc514c9e1fe737ab1bd517c4bd21038b7d8"
         }
       },
       "targets": [
@@ -8923,7 +9805,7 @@
         "deps": {
           "common": [
             {
-              "id": "indexmap 1.9.2",
+              "id": "indexmap 1.9.3",
               "target": "indexmap"
             },
             {
@@ -8931,23 +9813,27 @@
               "target": "num_cpus"
             },
             {
-              "id": "once_cell 1.16.0",
+              "id": "once_cell 1.17.1",
               "target": "once_cell"
             },
             {
-              "id": "swc_atoms 0.4.32",
+              "id": "rustc-hash 1.1.0",
+              "target": "rustc_hash"
+            },
+            {
+              "id": "swc_atoms 0.5.3",
               "target": "swc_atoms"
             },
             {
-              "id": "swc_common 0.29.25",
+              "id": "swc_common 0.31.5",
               "target": "swc_common"
             },
             {
-              "id": "swc_ecma_ast 0.95.9",
+              "id": "swc_ecma_ast 0.103.5",
               "target": "swc_ecma_ast"
             },
             {
-              "id": "swc_ecma_visit 0.81.9",
+              "id": "swc_ecma_visit 0.89.5",
               "target": "swc_ecma_visit"
             },
             {
@@ -8962,17 +9848,17 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.106.13"
+        "version": "0.116.12"
       },
       "license": "Apache-2.0"
     },
-    "swc_ecma_visit 0.81.9": {
+    "swc_ecma_visit 0.89.5": {
       "name": "swc_ecma_visit",
-      "version": "0.81.9",
+      "version": "0.89.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/swc_ecma_visit/0.81.9/download",
-          "sha256": "0ebf5de90444c90b1905b7618800a7572fc757faa8c90cc1c6031d1f6ca179df"
+          "url": "https://crates.io/api/v1/crates/swc_ecma_visit/0.89.5/download",
+          "sha256": "4490a5ed042234d72986e1a0c8afb54291fcf82b42af78ea72507b52bcbe13dd"
         }
       },
       "targets": [
@@ -9004,19 +9890,19 @@
               "target": "num_bigint"
             },
             {
-              "id": "swc_atoms 0.4.32",
+              "id": "swc_atoms 0.5.3",
               "target": "swc_atoms"
             },
             {
-              "id": "swc_common 0.29.25",
+              "id": "swc_common 0.31.5",
               "target": "swc_common"
             },
             {
-              "id": "swc_ecma_ast 0.95.9",
+              "id": "swc_ecma_ast 0.103.5",
               "target": "swc_ecma_ast"
             },
             {
-              "id": "swc_visit 0.5.3",
+              "id": "swc_visit 0.5.5",
               "target": "swc_visit"
             },
             {
@@ -9027,7 +9913,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.81.9"
+        "version": "0.89.5"
       },
       "license": "Apache-2.0"
     },
@@ -9066,15 +9952,15 @@
               "target": "pmutil"
             },
             {
-              "id": "proc-macro2 1.0.49",
+              "id": "proc-macro2 1.0.56",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.107",
+              "id": "syn 1.0.109",
               "target": "syn"
             }
           ],
@@ -9116,7 +10002,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.68",
+              "id": "anyhow 1.0.71",
               "target": "anyhow"
             },
             {
@@ -9124,7 +10010,7 @@
               "target": "miette"
             },
             {
-              "id": "once_cell 1.16.0",
+              "id": "once_cell 1.17.1",
               "target": "once_cell"
             },
             {
@@ -9143,13 +10029,13 @@
       },
       "license": "Apache-2.0"
     },
-    "swc_error_reporters 0.13.26": {
+    "swc_error_reporters 0.15.5": {
       "name": "swc_error_reporters",
-      "version": "0.13.26",
+      "version": "0.15.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/swc_error_reporters/0.13.26/download",
-          "sha256": "81fbda0a7583deb49edf379e2c119231312ad2d3a37a219143a3d8678a205a5f"
+          "url": "https://crates.io/api/v1/crates/swc_error_reporters/0.15.5/download",
+          "sha256": "3afbf2e52ddce38da1ee204252f7b9019a12176ca73aaa0fd0c36ded1ecbec7d"
         }
       },
       "targets": [
@@ -9174,7 +10060,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.68",
+              "id": "anyhow 1.0.71",
               "target": "anyhow"
             },
             {
@@ -9182,7 +10068,7 @@
               "target": "miette"
             },
             {
-              "id": "once_cell 1.16.0",
+              "id": "once_cell 1.17.1",
               "target": "once_cell"
             },
             {
@@ -9190,24 +10076,24 @@
               "target": "parking_lot"
             },
             {
-              "id": "swc_common 0.29.25",
+              "id": "swc_common 0.31.5",
               "target": "swc_common"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.13.26"
+        "version": "0.15.5"
       },
       "license": "Apache-2.0"
     },
-    "swc_macros_common 0.3.6": {
+    "swc_macros_common 0.3.7": {
       "name": "swc_macros_common",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/swc_macros_common/0.3.6/download",
-          "sha256": "a4be988307882648d9bc7c71a6a73322b7520ef0211e920489a98f8391d8caa2"
+          "url": "https://crates.io/api/v1/crates/swc_macros_common/0.3.7/download",
+          "sha256": "3e582c3e3c2269238524923781df5be49e011dbe29cf7683a2215d600a562ea6"
         }
       },
       "targets": [
@@ -9236,22 +10122,22 @@
               "target": "pmutil"
             },
             {
-              "id": "proc-macro2 1.0.49",
+              "id": "proc-macro2 1.0.56",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.107",
+              "id": "syn 1.0.109",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.3.6"
+        "version": "0.3.7"
       },
       "license": "Apache-2.0"
     },
@@ -9286,7 +10172,7 @@
         "deps": {
           "common": [
             {
-              "id": "once_cell 1.16.0",
+              "id": "once_cell 1.17.1",
               "target": "once_cell"
             }
           ],
@@ -9297,13 +10183,13 @@
       },
       "license": "Apache-2.0"
     },
-    "swc_plugin_macro 0.9.10": {
+    "swc_plugin_macro 0.9.11": {
       "name": "swc_plugin_macro",
-      "version": "0.9.10",
+      "version": "0.9.11",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/swc_plugin_macro/0.9.10/download",
-          "sha256": "8c00caf955dfbff15974f061f8c2e8a8b9b5ce999cb601f02f3ec66253e81149"
+          "url": "https://crates.io/api/v1/crates/swc_plugin_macro/0.9.11/download",
+          "sha256": "ae095f51123037ae9a8d29ef06b221a273fe11b489a3caa9eeba6a965a8b4cc1"
         }
       },
       "targets": [
@@ -9328,32 +10214,32 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.49",
+              "id": "proc-macro2 1.0.56",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.107",
+              "id": "syn 1.0.109",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.9.10"
+        "version": "0.9.11"
       },
       "license": "Apache-2.0"
     },
-    "swc_plugin_proxy 0.23.9": {
+    "swc_plugin_proxy 0.32.5": {
       "name": "swc_plugin_proxy",
-      "version": "0.23.9",
+      "version": "0.32.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/swc_plugin_proxy/0.23.9/download",
-          "sha256": "654d4b4c16e61289685a75f2dc8b9874faff29754776e514c85a1d34d6349599"
+          "url": "https://crates.io/api/v1/crates/swc_plugin_proxy/0.32.5/download",
+          "sha256": "4cd5b2880508aedc964f4f52a4debc07c4b48212b45b44522d651c701b1a4d84"
         }
       },
       "targets": [
@@ -9361,18 +10247,6 @@
           "Library": {
             "crate_name": "swc_plugin_proxy",
             "crate_root": "src/lib.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
             "srcs": {
               "include": [
                 "**/*.rs"
@@ -9401,20 +10275,16 @@
               "target": "better_scoped_tls"
             },
             {
-              "id": "rkyv 0.7.37",
+              "id": "rkyv 0.7.41",
               "target": "rkyv"
             },
             {
-              "id": "swc_common 0.29.25",
+              "id": "swc_common 0.31.5",
               "target": "swc_common"
             },
             {
-              "id": "swc_ecma_ast 0.95.9",
+              "id": "swc_ecma_ast 0.103.5",
               "target": "swc_ecma_ast"
-            },
-            {
-              "id": "swc_plugin_proxy 0.23.9",
-              "target": "build_script_build"
             },
             {
               "id": "tracing 0.1.37",
@@ -9433,12 +10303,7 @@
           ],
           "selects": {}
         },
-        "version": "0.23.9"
-      },
-      "build_script_attrs": {
-        "data_glob": [
-          "**"
-        ]
+        "version": "0.32.5"
       },
       "license": "Apache-2.0"
     },
@@ -9473,15 +10338,15 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.49",
+              "id": "proc-macro2 1.0.56",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.107",
+              "id": "syn 1.0.109",
               "target": "syn"
             }
           ],
@@ -9492,13 +10357,13 @@
       },
       "license": "Apache-2.0"
     },
-    "swc_visit 0.5.3": {
+    "swc_visit 0.5.5": {
       "name": "swc_visit",
-      "version": "0.5.3",
+      "version": "0.5.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/swc_visit/0.5.3/download",
-          "sha256": "82f2bcb7223e185c4c7cbf5e0c1207dec6d2bfd5e72e3fb7b3e8d179747e9130"
+          "url": "https://crates.io/api/v1/crates/swc_visit/0.5.5/download",
+          "sha256": "d1d5999f23421c8e21a0f2bc53a0b9e8244f3b421de89471561af2fbe40b9cca"
         }
       },
       "targets": [
@@ -9523,7 +10388,7 @@
         "deps": {
           "common": [
             {
-              "id": "either 1.8.0",
+              "id": "either 1.8.1",
               "target": "either"
             }
           ],
@@ -9533,23 +10398,23 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "swc_visit_macros 0.5.4",
+              "id": "swc_visit_macros 0.5.6",
               "target": "swc_visit_macros"
             }
           ],
           "selects": {}
         },
-        "version": "0.5.3"
+        "version": "0.5.5"
       },
       "license": "Apache-2.0"
     },
-    "swc_visit_macros 0.5.4": {
+    "swc_visit_macros 0.5.6": {
       "name": "swc_visit_macros",
-      "version": "0.5.4",
+      "version": "0.5.6",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/swc_visit_macros/0.5.4/download",
-          "sha256": "8fb1f3561674d84947694d41fb6d5737d19539222779baeac1b3a071a2b29428"
+          "url": "https://crates.io/api/v1/crates/swc_visit_macros/0.5.6/download",
+          "sha256": "ebeed7eb0f545f48ad30f5aab314e5208b735bcea1d1464f26e20f06db904989"
         }
       },
       "targets": [
@@ -9582,36 +10447,36 @@
               "target": "pmutil"
             },
             {
-              "id": "proc-macro2 1.0.49",
+              "id": "proc-macro2 1.0.56",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             },
             {
-              "id": "swc_macros_common 0.3.6",
+              "id": "swc_macros_common 0.3.7",
               "target": "swc_macros_common"
             },
             {
-              "id": "syn 1.0.107",
+              "id": "syn 1.0.109",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.5.4"
+        "version": "0.5.6"
       },
       "license": "Apache-2.0"
     },
-    "syn 1.0.107": {
+    "syn 1.0.109": {
       "name": "syn",
-      "version": "1.0.107",
+      "version": "1.0.109",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/syn/1.0.107/download",
-          "sha256": "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+          "url": "https://crates.io/api/v1/crates/syn/1.0.109/download",
+          "sha256": "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
         }
       },
       "targets": [
@@ -9662,26 +10527,26 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.49",
+              "id": "proc-macro2 1.0.56",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.107",
+              "id": "syn 1.0.109",
               "target": "build_script_build"
             },
             {
-              "id": "unicode-ident 1.0.6",
+              "id": "unicode-ident 1.0.8",
               "target": "unicode_ident"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.107"
+        "version": "1.0.109"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -9690,13 +10555,75 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "tempfile 3.3.0": {
-      "name": "tempfile",
-      "version": "3.3.0",
+    "syn 2.0.15": {
+      "name": "syn",
+      "version": "2.0.15",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tempfile/3.3.0/download",
-          "sha256": "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+          "url": "https://crates.io/api/v1/crates/syn/2.0.15/download",
+          "sha256": "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "syn",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "syn",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "clone-impls",
+          "default",
+          "derive",
+          "extra-traits",
+          "full",
+          "parsing",
+          "printing",
+          "proc-macro",
+          "quote",
+          "visit-mut"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "proc-macro2 1.0.56",
+              "target": "proc_macro2"
+            },
+            {
+              "id": "quote 1.0.26",
+              "target": "quote"
+            },
+            {
+              "id": "unicode-ident 1.0.8",
+              "target": "unicode_ident"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "2.0.15"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "tempfile 3.5.0": {
+      "name": "tempfile",
+      "version": "3.5.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/tempfile/3.5.0/download",
+          "sha256": "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
         }
       },
       "targets": [
@@ -9725,47 +10652,43 @@
               "target": "cfg_if"
             },
             {
-              "id": "fastrand 1.8.0",
+              "id": "fastrand 1.9.0",
               "target": "fastrand"
-            },
-            {
-              "id": "remove_dir_all 0.5.3",
-              "target": "remove_dir_all"
             }
           ],
           "selects": {
             "cfg(any(unix, target_os = \"wasi\"))": [
               {
-                "id": "libc 0.2.139",
-                "target": "libc"
+                "id": "rustix 0.37.18",
+                "target": "rustix"
               }
             ],
             "cfg(target_os = \"redox\")": [
               {
-                "id": "redox_syscall 0.2.16",
+                "id": "redox_syscall 0.3.5",
                 "target": "syscall"
               }
             ],
             "cfg(windows)": [
               {
-                "id": "winapi 0.3.9",
-                "target": "winapi"
+                "id": "windows-sys 0.45.0",
+                "target": "windows_sys"
               }
             ]
           }
         },
         "edition": "2018",
-        "version": "3.3.0"
+        "version": "3.5.0"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "termcolor 1.1.3": {
+    "termcolor 1.2.0": {
       "name": "termcolor",
-      "version": "1.1.3",
+      "version": "1.2.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/termcolor/1.1.3/download",
-          "sha256": "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+          "url": "https://crates.io/api/v1/crates/termcolor/1.2.0/download",
+          "sha256": "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
         }
       },
       "targets": [
@@ -9799,7 +10722,7 @@
           }
         },
         "edition": "2018",
-        "version": "1.1.3"
+        "version": "1.2.0"
       },
       "license": "Unlicense OR MIT"
     },
@@ -9836,7 +10759,7 @@
           "selects": {
             "cfg(not(windows))": [
               {
-                "id": "libc 0.2.139",
+                "id": "libc 0.2.142",
                 "target": "libc"
               }
             ],
@@ -9892,7 +10815,7 @@
               "target": "difference"
             },
             {
-              "id": "once_cell 1.16.0",
+              "id": "once_cell 1.17.1",
               "target": "once_cell"
             },
             {
@@ -9900,11 +10823,11 @@
               "target": "pretty_assertions"
             },
             {
-              "id": "regex 1.7.0",
+              "id": "regex 1.8.1",
               "target": "regex"
             },
             {
-              "id": "serde_json 1.0.91",
+              "id": "serde_json 1.0.96",
               "target": "serde_json"
             },
             {
@@ -9920,7 +10843,7 @@
               "target": "tracing"
             },
             {
-              "id": "tracing-subscriber 0.3.16",
+              "id": "tracing-subscriber 0.3.17",
               "target": "tracing_subscriber"
             }
           ],
@@ -9930,7 +10853,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "testing_macros 0.2.7",
+              "id": "testing_macros 0.2.9",
               "target": "testing_macros"
             }
           ],
@@ -9940,13 +10863,13 @@
       },
       "license": "Apache-2.0"
     },
-    "testing 0.31.27": {
+    "testing 0.33.6": {
       "name": "testing",
-      "version": "0.31.27",
+      "version": "0.33.6",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/testing/0.31.27/download",
-          "sha256": "488b450d0ccc78a21ab4686c2b1ac7e867a9478bb850af3ee82a841198c6420c"
+          "url": "https://crates.io/api/v1/crates/testing/0.33.6/download",
+          "sha256": "77e5fcdfc6805d181431333b850f9fde170f654148e29ba97fd8033c7814e665"
         }
       },
       "targets": [
@@ -9979,7 +10902,7 @@
               "target": "difference"
             },
             {
-              "id": "once_cell 1.16.0",
+              "id": "once_cell 1.17.1",
               "target": "once_cell"
             },
             {
@@ -9987,19 +10910,19 @@
               "target": "pretty_assertions"
             },
             {
-              "id": "regex 1.7.0",
+              "id": "regex 1.8.1",
               "target": "regex"
             },
             {
-              "id": "serde_json 1.0.91",
+              "id": "serde_json 1.0.96",
               "target": "serde_json"
             },
             {
-              "id": "swc_common 0.29.25",
+              "id": "swc_common 0.31.5",
               "target": "swc_common"
             },
             {
-              "id": "swc_error_reporters 0.13.26",
+              "id": "swc_error_reporters 0.15.5",
               "target": "swc_error_reporters"
             },
             {
@@ -10007,7 +10930,7 @@
               "target": "tracing"
             },
             {
-              "id": "tracing-subscriber 0.3.16",
+              "id": "tracing-subscriber 0.3.17",
               "target": "tracing_subscriber"
             }
           ],
@@ -10017,23 +10940,23 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "testing_macros 0.2.7",
+              "id": "testing_macros 0.2.9",
               "target": "testing_macros"
             }
           ],
           "selects": {}
         },
-        "version": "0.31.27"
+        "version": "0.33.6"
       },
       "license": "Apache-2.0"
     },
-    "testing_macros 0.2.7": {
+    "testing_macros 0.2.9": {
       "name": "testing_macros",
-      "version": "0.2.7",
+      "version": "0.2.9",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/testing_macros/0.2.7/download",
-          "sha256": "e74ff09d2d4d4b7ea140ff67eb7ed8fd35a708e2c327bcde5a25707d66840099"
+          "url": "https://crates.io/api/v1/crates/testing_macros/0.2.9/download",
+          "sha256": "a5315a85a7262fe1a8898890b616de62c152dd43cb5974752c0927aaabe48891"
         }
       },
       "targets": [
@@ -10058,15 +10981,15 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.68",
+              "id": "anyhow 1.0.71",
               "target": "anyhow"
             },
             {
-              "id": "glob 0.3.0",
+              "id": "glob 0.3.1",
               "target": "glob"
             },
             {
-              "id": "once_cell 1.16.0",
+              "id": "once_cell 1.17.1",
               "target": "once_cell"
             },
             {
@@ -10074,30 +10997,30 @@
               "target": "pmutil"
             },
             {
-              "id": "proc-macro2 1.0.49",
+              "id": "proc-macro2 1.0.56",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             },
             {
-              "id": "regex 1.7.0",
+              "id": "regex 1.8.1",
               "target": "regex"
             },
             {
-              "id": "relative-path 1.7.2",
+              "id": "relative-path 1.8.0",
               "target": "relative_path"
             },
             {
-              "id": "syn 1.0.107",
+              "id": "syn 1.0.109",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.2.7"
+        "version": "0.2.9"
       },
       "license": "Apache-2.0"
     },
@@ -10157,13 +11080,13 @@
       },
       "license": "MIT"
     },
-    "thiserror 1.0.38": {
+    "thiserror 1.0.40": {
       "name": "thiserror",
-      "version": "1.0.38",
+      "version": "1.0.40",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/thiserror/1.0.38/download",
-          "sha256": "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+          "url": "https://crates.io/api/v1/crates/thiserror/1.0.40/download",
+          "sha256": "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
         }
       },
       "targets": [
@@ -10200,7 +11123,7 @@
         "deps": {
           "common": [
             {
-              "id": "thiserror 1.0.38",
+              "id": "thiserror 1.0.40",
               "target": "build_script_build"
             }
           ],
@@ -10210,13 +11133,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "thiserror-impl 1.0.38",
+              "id": "thiserror-impl 1.0.40",
               "target": "thiserror_impl"
             }
           ],
           "selects": {}
         },
-        "version": "1.0.38"
+        "version": "1.0.40"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -10225,13 +11148,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "thiserror-impl 1.0.38": {
+    "thiserror-impl 1.0.40": {
       "name": "thiserror-impl",
-      "version": "1.0.38",
+      "version": "1.0.40",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/thiserror-impl/1.0.38/download",
-          "sha256": "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+          "url": "https://crates.io/api/v1/crates/thiserror-impl/1.0.40/download",
+          "sha256": "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
         }
       },
       "targets": [
@@ -10256,32 +11179,32 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.49",
+              "id": "proc-macro2 1.0.56",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.107",
+              "id": "syn 2.0.15",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.38"
+        "version": "1.0.40"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "thread_local 1.1.4": {
+    "thread_local 1.1.7": {
       "name": "thread_local",
-      "version": "1.1.4",
+      "version": "1.1.7",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/thread_local/1.1.4/download",
-          "sha256": "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+          "url": "https://crates.io/api/v1/crates/thread_local/1.1.7/download",
+          "sha256": "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
         }
       },
       "targets": [
@@ -10306,24 +11229,28 @@
         "deps": {
           "common": [
             {
-              "id": "once_cell 1.16.0",
+              "id": "cfg-if 1.0.0",
+              "target": "cfg_if"
+            },
+            {
+              "id": "once_cell 1.17.1",
               "target": "once_cell"
             }
           ],
           "selects": {}
         },
-        "edition": "2018",
-        "version": "1.1.4"
+        "edition": "2021",
+        "version": "1.1.7"
       },
-      "license": "Apache-2.0/MIT"
+      "license": "MIT OR Apache-2.0"
     },
-    "time 0.3.17": {
+    "time 0.3.20": {
       "name": "time",
-      "version": "0.3.17",
+      "version": "0.3.20",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/time/0.3.17/download",
-          "sha256": "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
+          "url": "https://crates.io/api/v1/crates/time/0.3.20/download",
+          "sha256": "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
         }
       },
       "targets": [
@@ -10354,11 +11281,11 @@
         "deps": {
           "common": [
             {
-              "id": "itoa 1.0.5",
+              "id": "itoa 1.0.6",
               "target": "itoa"
             },
             {
-              "id": "serde 1.0.152",
+              "id": "serde 1.0.160",
               "target": "serde"
             },
             {
@@ -10372,13 +11299,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "time-macros 0.2.6",
+              "id": "time-macros 0.2.8",
               "target": "time_macros"
             }
           ],
           "selects": {}
         },
-        "version": "0.3.17"
+        "version": "0.3.20"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -10415,13 +11342,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "time-macros 0.2.6": {
+    "time-macros 0.2.8": {
       "name": "time-macros",
-      "version": "0.2.6",
+      "version": "0.2.8",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/time-macros/0.2.6/download",
-          "sha256": "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+          "url": "https://crates.io/api/v1/crates/time-macros/0.2.8/download",
+          "sha256": "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
         }
       },
       "targets": [
@@ -10456,7 +11383,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.2.6"
+        "version": "0.2.8"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -10496,7 +11423,7 @@
         "deps": {
           "common": [
             {
-              "id": "tinyvec_macros 0.1.0",
+              "id": "tinyvec_macros 0.1.1",
               "target": "tinyvec_macros"
             }
           ],
@@ -10507,13 +11434,13 @@
       },
       "license": "Zlib OR Apache-2.0 OR MIT"
     },
-    "tinyvec_macros 0.1.0": {
+    "tinyvec_macros 0.1.1": {
       "name": "tinyvec_macros",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tinyvec_macros/0.1.0/download",
-          "sha256": "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+          "url": "https://crates.io/api/v1/crates/tinyvec_macros/0.1.1/download",
+          "sha256": "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
         }
       },
       "targets": [
@@ -10536,7 +11463,7 @@
           "**"
         ],
         "edition": "2018",
-        "version": "0.1.0"
+        "version": "0.1.1"
       },
       "license": "MIT OR Apache-2.0 OR Zlib"
     },
@@ -10595,7 +11522,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "tracing-attributes 0.1.23",
+              "id": "tracing-attributes 0.1.24",
               "target": "tracing_attributes"
             }
           ],
@@ -10605,13 +11532,13 @@
       },
       "license": "MIT"
     },
-    "tracing-attributes 0.1.23": {
+    "tracing-attributes 0.1.24": {
       "name": "tracing-attributes",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tracing-attributes/0.1.23/download",
-          "sha256": "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+          "url": "https://crates.io/api/v1/crates/tracing-attributes/0.1.24/download",
+          "sha256": "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
         }
       },
       "targets": [
@@ -10636,22 +11563,22 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.49",
+              "id": "proc-macro2 1.0.56",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.23",
+              "id": "quote 1.0.26",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.107",
+              "id": "syn 2.0.15",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.1.23"
+        "version": "0.1.24"
       },
       "license": "MIT"
     },
@@ -10692,7 +11619,7 @@
         "deps": {
           "common": [
             {
-              "id": "once_cell 1.16.0",
+              "id": "once_cell 1.17.1",
               "target": "once_cell"
             }
           ],
@@ -10764,13 +11691,13 @@
       },
       "license": "MIT"
     },
-    "tracing-subscriber 0.3.16": {
+    "tracing-subscriber 0.3.17": {
       "name": "tracing-subscriber",
-      "version": "0.3.16",
+      "version": "0.3.17",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tracing-subscriber/0.3.16/download",
-          "sha256": "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+          "url": "https://crates.io/api/v1/crates/tracing-subscriber/0.3.17/download",
+          "sha256": "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
         }
       },
       "targets": [
@@ -10821,11 +11748,11 @@
               "target": "nu_ansi_term"
             },
             {
-              "id": "once_cell 1.16.0",
+              "id": "once_cell 1.17.1",
               "target": "once_cell"
             },
             {
-              "id": "regex 1.7.0",
+              "id": "regex 1.8.1",
               "target": "regex"
             },
             {
@@ -10837,7 +11764,7 @@
               "target": "smallvec"
             },
             {
-              "id": "thread_local 1.1.4",
+              "id": "thread_local 1.1.7",
               "target": "thread_local"
             },
             {
@@ -10856,7 +11783,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.16"
+        "version": "0.3.17"
       },
       "license": "MIT"
     },
@@ -10897,7 +11824,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.152",
+              "id": "serde 1.0.160",
               "target": "serde"
             },
             {
@@ -10912,13 +11839,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "typed-arena 2.0.1": {
+    "typed-arena 2.0.2": {
       "name": "typed-arena",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/typed-arena/2.0.1/download",
-          "sha256": "0685c84d5d54d1c26f7d3eb96cd41550adb97baed141a761cf335d3d33bcd0ae"
+          "url": "https://crates.io/api/v1/crates/typed-arena/2.0.2/download",
+          "sha256": "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
         }
       },
       "targets": [
@@ -10945,7 +11872,7 @@
           "std"
         ],
         "edition": "2015",
-        "version": "2.0.1"
+        "version": "2.0.2"
       },
       "license": "MIT"
     },
@@ -11008,13 +11935,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "unicode-bidi 0.3.8": {
+    "unicode-bidi 0.3.13": {
       "name": "unicode-bidi",
-      "version": "0.3.8",
+      "version": "0.3.13",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/unicode-bidi/0.3.8/download",
-          "sha256": "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+          "url": "https://crates.io/api/v1/crates/unicode-bidi/0.3.13/download",
+          "sha256": "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
         }
       },
       "targets": [
@@ -11042,7 +11969,7 @@
           "std"
         ],
         "edition": "2018",
-        "version": "0.3.8"
+        "version": "0.3.13"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -11082,13 +12009,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "unicode-ident 1.0.6": {
+    "unicode-ident 1.0.8": {
       "name": "unicode-ident",
-      "version": "1.0.6",
+      "version": "1.0.8",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/unicode-ident/1.0.6/download",
-          "sha256": "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+          "url": "https://crates.io/api/v1/crates/unicode-ident/1.0.8/download",
+          "sha256": "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
         }
       },
       "targets": [
@@ -11111,7 +12038,7 @@
           "**"
         ],
         "edition": "2018",
-        "version": "1.0.6"
+        "version": "1.0.8"
       },
       "license": "(MIT OR Apache-2.0) AND Unicode-DFS-2016"
     },
@@ -11178,7 +12105,7 @@
               "target": "hashbrown"
             },
             {
-              "id": "regex 1.7.0",
+              "id": "regex 1.8.1",
               "target": "regex"
             }
           ],
@@ -11233,13 +12160,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "unicode-segmentation 1.10.0": {
+    "unicode-segmentation 1.10.1": {
       "name": "unicode-segmentation",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/unicode-segmentation/1.10.0/download",
-          "sha256": "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
+          "url": "https://crates.io/api/v1/crates/unicode-segmentation/1.10.1/download",
+          "sha256": "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
         }
       },
       "targets": [
@@ -11262,7 +12189,7 @@
           "**"
         ],
         "edition": "2018",
-        "version": "1.10.0"
+        "version": "1.10.1"
       },
       "license": "MIT/Apache-2.0"
     },
@@ -11460,13 +12387,13 @@
       },
       "license": "MIT"
     },
-    "vergen 7.4.4": {
+    "vergen 7.5.1": {
       "name": "vergen",
-      "version": "7.4.4",
+      "version": "7.5.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/vergen/7.4.4/download",
-          "sha256": "efadd36bc6fde40c6048443897d69511a19161c0756cb704ed403f8dfd2b7d1c"
+          "url": "https://crates.io/api/v1/crates/vergen/7.5.1/download",
+          "sha256": "f21b881cd6636ece9735721cf03c1fe1e774fe258683d084bb2812ab67435749"
         }
       },
       "targets": [
@@ -11506,7 +12433,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.68",
+              "id": "anyhow 1.0.71",
               "target": "anyhow"
             },
             {
@@ -11514,15 +12441,15 @@
               "target": "cfg_if"
             },
             {
-              "id": "enum-iterator 1.1.3",
+              "id": "enum-iterator 1.4.0",
               "target": "enum_iterator"
             },
             {
-              "id": "thiserror 1.0.38",
+              "id": "thiserror 1.0.40",
               "target": "thiserror"
             },
             {
-              "id": "vergen 7.4.4",
+              "id": "vergen 7.5.1",
               "target": "build_script_build"
             }
           ],
@@ -11538,7 +12465,7 @@
           ],
           "selects": {}
         },
-        "version": "7.4.4"
+        "version": "7.5.1"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -11547,11 +12474,11 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.68",
+              "id": "anyhow 1.0.71",
               "target": "anyhow"
             },
             {
-              "id": "time 0.3.17",
+              "id": "time 0.3.20",
               "target": "time"
             }
           ],
@@ -11560,7 +12487,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "rustversion 1.0.11",
+              "id": "rustversion 1.0.12",
               "target": "rustversion"
             }
           ],
@@ -11663,10 +12590,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": [
-          "default",
-          "std"
-        ],
         "edition": "2018",
         "version": "0.11.0+wasi-snapshot-preview1"
       },
@@ -11753,11 +12676,14 @@
         "crate_features": [
           "consoleapi",
           "errhandlingapi",
+          "fibersapi",
           "fileapi",
           "handleapi",
+          "memoryapi",
           "minwinbase",
           "minwindef",
           "processenv",
+          "processthreadsapi",
           "std",
           "winbase",
           "wincon",
@@ -11990,10 +12916,13 @@
         "crate_features": [
           "Win32",
           "Win32_Foundation",
+          "Win32_Storage",
+          "Win32_Storage_FileSystem",
           "Win32_System",
-          "Win32_System_LibraryLoader",
-          "Win32_System_SystemServices",
-          "Win32_System_WindowsProgramming",
+          "Win32_System_Console",
+          "Win32_UI",
+          "Win32_UI_Input",
+          "Win32_UI_Input_KeyboardAndMouse",
           "default"
         ],
         "deps": {
@@ -12001,73 +12930,73 @@
           "selects": {
             "aarch64-pc-windows-gnullvm": [
               {
-                "id": "windows_aarch64_gnullvm 0.42.0",
+                "id": "windows_aarch64_gnullvm 0.42.2",
                 "target": "windows_aarch64_gnullvm"
               }
             ],
             "aarch64-pc-windows-msvc": [
               {
-                "id": "windows_aarch64_msvc 0.42.0",
+                "id": "windows_aarch64_msvc 0.42.2",
                 "target": "windows_aarch64_msvc"
               }
             ],
             "aarch64-uwp-windows-msvc": [
               {
-                "id": "windows_aarch64_msvc 0.42.0",
+                "id": "windows_aarch64_msvc 0.42.2",
                 "target": "windows_aarch64_msvc"
               }
             ],
             "i686-pc-windows-gnu": [
               {
-                "id": "windows_i686_gnu 0.42.0",
+                "id": "windows_i686_gnu 0.42.2",
                 "target": "windows_i686_gnu"
               }
             ],
             "i686-pc-windows-msvc": [
               {
-                "id": "windows_i686_msvc 0.42.0",
+                "id": "windows_i686_msvc 0.42.2",
                 "target": "windows_i686_msvc"
               }
             ],
             "i686-uwp-windows-gnu": [
               {
-                "id": "windows_i686_gnu 0.42.0",
+                "id": "windows_i686_gnu 0.42.2",
                 "target": "windows_i686_gnu"
               }
             ],
             "i686-uwp-windows-msvc": [
               {
-                "id": "windows_i686_msvc 0.42.0",
+                "id": "windows_i686_msvc 0.42.2",
                 "target": "windows_i686_msvc"
               }
             ],
             "x86_64-pc-windows-gnu": [
               {
-                "id": "windows_x86_64_gnu 0.42.0",
+                "id": "windows_x86_64_gnu 0.42.2",
                 "target": "windows_x86_64_gnu"
               }
             ],
             "x86_64-pc-windows-gnullvm": [
               {
-                "id": "windows_x86_64_gnullvm 0.42.0",
+                "id": "windows_x86_64_gnullvm 0.42.2",
                 "target": "windows_x86_64_gnullvm"
               }
             ],
             "x86_64-pc-windows-msvc": [
               {
-                "id": "windows_x86_64_msvc 0.42.0",
+                "id": "windows_x86_64_msvc 0.42.2",
                 "target": "windows_x86_64_msvc"
               }
             ],
             "x86_64-uwp-windows-gnu": [
               {
-                "id": "windows_x86_64_gnu 0.42.0",
+                "id": "windows_x86_64_gnu 0.42.2",
                 "target": "windows_x86_64_gnu"
               }
             ],
             "x86_64-uwp-windows-msvc": [
               {
-                "id": "windows_x86_64_msvc 0.42.0",
+                "id": "windows_x86_64_msvc 0.42.2",
                 "target": "windows_x86_64_msvc"
               }
             ]
@@ -12078,13 +13007,317 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "windows_aarch64_gnullvm 0.42.0": {
-      "name": "windows_aarch64_gnullvm",
-      "version": "0.42.0",
+    "windows-sys 0.45.0": {
+      "name": "windows-sys",
+      "version": "0.45.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/windows_aarch64_gnullvm/0.42.0/download",
-          "sha256": "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+          "url": "https://crates.io/api/v1/crates/windows-sys/0.45.0/download",
+          "sha256": "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_sys",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "windows_sys",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "Win32",
+          "Win32_Foundation",
+          "Win32_Storage",
+          "Win32_Storage_FileSystem",
+          "Win32_System",
+          "Win32_System_LibraryLoader",
+          "Win32_System_SystemServices",
+          "Win32_System_WindowsProgramming",
+          "default"
+        ],
+        "deps": {
+          "common": [],
+          "selects": {
+            "cfg(not(windows_raw_dylib))": [
+              {
+                "id": "windows-targets 0.42.2",
+                "target": "windows_targets"
+              }
+            ]
+          }
+        },
+        "edition": "2018",
+        "version": "0.45.0"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "windows-sys 0.48.0": {
+      "name": "windows-sys",
+      "version": "0.48.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/windows-sys/0.48.0/download",
+          "sha256": "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_sys",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "windows_sys",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "Win32",
+          "Win32_Foundation",
+          "Win32_NetworkManagement",
+          "Win32_NetworkManagement_IpHelper",
+          "Win32_Networking",
+          "Win32_Networking_WinSock",
+          "Win32_Security",
+          "Win32_Storage",
+          "Win32_Storage_FileSystem",
+          "Win32_System",
+          "Win32_System_Diagnostics",
+          "Win32_System_Diagnostics_Debug",
+          "Win32_System_IO",
+          "Win32_System_Threading",
+          "default"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "windows-targets 0.48.0",
+              "target": "windows_targets"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.48.0"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "windows-targets 0.42.2": {
+      "name": "windows-targets",
+      "version": "0.42.2",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/windows-targets/0.42.2/download",
+          "sha256": "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_targets",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "windows_targets",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [],
+          "selects": {
+            "aarch64-pc-windows-gnullvm": [
+              {
+                "id": "windows_aarch64_gnullvm 0.42.2",
+                "target": "windows_aarch64_gnullvm"
+              }
+            ],
+            "aarch64-pc-windows-msvc": [
+              {
+                "id": "windows_aarch64_msvc 0.42.2",
+                "target": "windows_aarch64_msvc"
+              }
+            ],
+            "aarch64-uwp-windows-msvc": [
+              {
+                "id": "windows_aarch64_msvc 0.42.2",
+                "target": "windows_aarch64_msvc"
+              }
+            ],
+            "i686-pc-windows-gnu": [
+              {
+                "id": "windows_i686_gnu 0.42.2",
+                "target": "windows_i686_gnu"
+              }
+            ],
+            "i686-pc-windows-msvc": [
+              {
+                "id": "windows_i686_msvc 0.42.2",
+                "target": "windows_i686_msvc"
+              }
+            ],
+            "i686-uwp-windows-gnu": [
+              {
+                "id": "windows_i686_gnu 0.42.2",
+                "target": "windows_i686_gnu"
+              }
+            ],
+            "i686-uwp-windows-msvc": [
+              {
+                "id": "windows_i686_msvc 0.42.2",
+                "target": "windows_i686_msvc"
+              }
+            ],
+            "x86_64-pc-windows-gnu": [
+              {
+                "id": "windows_x86_64_gnu 0.42.2",
+                "target": "windows_x86_64_gnu"
+              }
+            ],
+            "x86_64-pc-windows-gnullvm": [
+              {
+                "id": "windows_x86_64_gnullvm 0.42.2",
+                "target": "windows_x86_64_gnullvm"
+              }
+            ],
+            "x86_64-pc-windows-msvc": [
+              {
+                "id": "windows_x86_64_msvc 0.42.2",
+                "target": "windows_x86_64_msvc"
+              }
+            ],
+            "x86_64-uwp-windows-gnu": [
+              {
+                "id": "windows_x86_64_gnu 0.42.2",
+                "target": "windows_x86_64_gnu"
+              }
+            ],
+            "x86_64-uwp-windows-msvc": [
+              {
+                "id": "windows_x86_64_msvc 0.42.2",
+                "target": "windows_x86_64_msvc"
+              }
+            ]
+          }
+        },
+        "edition": "2018",
+        "version": "0.42.2"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "windows-targets 0.48.0": {
+      "name": "windows-targets",
+      "version": "0.48.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/windows-targets/0.48.0/download",
+          "sha256": "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_targets",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "windows_targets",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [],
+          "selects": {
+            "cfg(all(target_arch = \"aarch64\", target_env = \"gnu\", target_abi = \"llvm\", not(windows_raw_dylib)))": [
+              {
+                "id": "windows_aarch64_gnullvm 0.48.0",
+                "target": "windows_aarch64_gnullvm"
+              }
+            ],
+            "cfg(all(target_arch = \"aarch64\", target_env = \"msvc\", not(windows_raw_dylib)))": [
+              {
+                "id": "windows_aarch64_msvc 0.48.0",
+                "target": "windows_aarch64_msvc"
+              }
+            ],
+            "cfg(all(target_arch = \"x86\", target_env = \"gnu\", not(windows_raw_dylib)))": [
+              {
+                "id": "windows_i686_gnu 0.48.0",
+                "target": "windows_i686_gnu"
+              }
+            ],
+            "cfg(all(target_arch = \"x86\", target_env = \"msvc\", not(windows_raw_dylib)))": [
+              {
+                "id": "windows_i686_msvc 0.48.0",
+                "target": "windows_i686_msvc"
+              }
+            ],
+            "cfg(all(target_arch = \"x86_64\", target_env = \"gnu\", not(target_abi = \"llvm\"), not(windows_raw_dylib)))": [
+              {
+                "id": "windows_x86_64_gnu 0.48.0",
+                "target": "windows_x86_64_gnu"
+              }
+            ],
+            "cfg(all(target_arch = \"x86_64\", target_env = \"gnu\", target_abi = \"llvm\", not(windows_raw_dylib)))": [
+              {
+                "id": "windows_x86_64_gnullvm 0.48.0",
+                "target": "windows_x86_64_gnullvm"
+              }
+            ],
+            "cfg(all(target_arch = \"x86_64\", target_env = \"msvc\", not(windows_raw_dylib)))": [
+              {
+                "id": "windows_x86_64_msvc 0.48.0",
+                "target": "windows_x86_64_msvc"
+              }
+            ]
+          }
+        },
+        "edition": "2018",
+        "version": "0.48.0"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "windows_aarch64_gnullvm 0.42.2": {
+      "name": "windows_aarch64_gnullvm",
+      "version": "0.42.2",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/windows_aarch64_gnullvm/0.42.2/download",
+          "sha256": "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
         }
       },
       "targets": [
@@ -12121,14 +13354,14 @@
         "deps": {
           "common": [
             {
-              "id": "windows_aarch64_gnullvm 0.42.0",
+              "id": "windows_aarch64_gnullvm 0.42.2",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.42.0"
+        "version": "0.42.2"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -12137,13 +13370,72 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "windows_aarch64_msvc 0.42.0": {
-      "name": "windows_aarch64_msvc",
-      "version": "0.42.0",
+    "windows_aarch64_gnullvm 0.48.0": {
+      "name": "windows_aarch64_gnullvm",
+      "version": "0.48.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/windows_aarch64_msvc/0.42.0/download",
-          "sha256": "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+          "url": "https://crates.io/api/v1/crates/windows_aarch64_gnullvm/0.48.0/download",
+          "sha256": "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_aarch64_gnullvm",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "windows_aarch64_gnullvm",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "windows_aarch64_gnullvm 0.48.0",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.48.0"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "windows_aarch64_msvc 0.42.2": {
+      "name": "windows_aarch64_msvc",
+      "version": "0.42.2",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/windows_aarch64_msvc/0.42.2/download",
+          "sha256": "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
         }
       },
       "targets": [
@@ -12180,14 +13472,14 @@
         "deps": {
           "common": [
             {
-              "id": "windows_aarch64_msvc 0.42.0",
+              "id": "windows_aarch64_msvc 0.42.2",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.42.0"
+        "version": "0.42.2"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -12196,13 +13488,72 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "windows_i686_gnu 0.42.0": {
-      "name": "windows_i686_gnu",
-      "version": "0.42.0",
+    "windows_aarch64_msvc 0.48.0": {
+      "name": "windows_aarch64_msvc",
+      "version": "0.48.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/windows_i686_gnu/0.42.0/download",
-          "sha256": "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+          "url": "https://crates.io/api/v1/crates/windows_aarch64_msvc/0.48.0/download",
+          "sha256": "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_aarch64_msvc",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "windows_aarch64_msvc",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "windows_aarch64_msvc 0.48.0",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.48.0"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "windows_i686_gnu 0.42.2": {
+      "name": "windows_i686_gnu",
+      "version": "0.42.2",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/windows_i686_gnu/0.42.2/download",
+          "sha256": "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
         }
       },
       "targets": [
@@ -12239,14 +13590,14 @@
         "deps": {
           "common": [
             {
-              "id": "windows_i686_gnu 0.42.0",
+              "id": "windows_i686_gnu 0.42.2",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.42.0"
+        "version": "0.42.2"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -12255,13 +13606,72 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "windows_i686_msvc 0.42.0": {
-      "name": "windows_i686_msvc",
-      "version": "0.42.0",
+    "windows_i686_gnu 0.48.0": {
+      "name": "windows_i686_gnu",
+      "version": "0.48.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/windows_i686_msvc/0.42.0/download",
-          "sha256": "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+          "url": "https://crates.io/api/v1/crates/windows_i686_gnu/0.48.0/download",
+          "sha256": "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_i686_gnu",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "windows_i686_gnu",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "windows_i686_gnu 0.48.0",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.48.0"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "windows_i686_msvc 0.42.2": {
+      "name": "windows_i686_msvc",
+      "version": "0.42.2",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/windows_i686_msvc/0.42.2/download",
+          "sha256": "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
         }
       },
       "targets": [
@@ -12298,14 +13708,14 @@
         "deps": {
           "common": [
             {
-              "id": "windows_i686_msvc 0.42.0",
+              "id": "windows_i686_msvc 0.42.2",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.42.0"
+        "version": "0.42.2"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -12314,13 +13724,72 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "windows_x86_64_gnu 0.42.0": {
-      "name": "windows_x86_64_gnu",
-      "version": "0.42.0",
+    "windows_i686_msvc 0.48.0": {
+      "name": "windows_i686_msvc",
+      "version": "0.48.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/windows_x86_64_gnu/0.42.0/download",
-          "sha256": "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+          "url": "https://crates.io/api/v1/crates/windows_i686_msvc/0.48.0/download",
+          "sha256": "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_i686_msvc",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "windows_i686_msvc",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "windows_i686_msvc 0.48.0",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.48.0"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "windows_x86_64_gnu 0.42.2": {
+      "name": "windows_x86_64_gnu",
+      "version": "0.42.2",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/windows_x86_64_gnu/0.42.2/download",
+          "sha256": "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
         }
       },
       "targets": [
@@ -12357,14 +13826,14 @@
         "deps": {
           "common": [
             {
-              "id": "windows_x86_64_gnu 0.42.0",
+              "id": "windows_x86_64_gnu 0.42.2",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.42.0"
+        "version": "0.42.2"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -12373,13 +13842,72 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "windows_x86_64_gnullvm 0.42.0": {
-      "name": "windows_x86_64_gnullvm",
-      "version": "0.42.0",
+    "windows_x86_64_gnu 0.48.0": {
+      "name": "windows_x86_64_gnu",
+      "version": "0.48.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/windows_x86_64_gnullvm/0.42.0/download",
-          "sha256": "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+          "url": "https://crates.io/api/v1/crates/windows_x86_64_gnu/0.48.0/download",
+          "sha256": "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_x86_64_gnu",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "windows_x86_64_gnu",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "windows_x86_64_gnu 0.48.0",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.48.0"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "windows_x86_64_gnullvm 0.42.2": {
+      "name": "windows_x86_64_gnullvm",
+      "version": "0.42.2",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/windows_x86_64_gnullvm/0.42.2/download",
+          "sha256": "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
         }
       },
       "targets": [
@@ -12416,14 +13944,14 @@
         "deps": {
           "common": [
             {
-              "id": "windows_x86_64_gnullvm 0.42.0",
+              "id": "windows_x86_64_gnullvm 0.42.2",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.42.0"
+        "version": "0.42.2"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -12432,13 +13960,72 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "windows_x86_64_msvc 0.42.0": {
-      "name": "windows_x86_64_msvc",
-      "version": "0.42.0",
+    "windows_x86_64_gnullvm 0.48.0": {
+      "name": "windows_x86_64_gnullvm",
+      "version": "0.48.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/windows_x86_64_msvc/0.42.0/download",
-          "sha256": "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+          "url": "https://crates.io/api/v1/crates/windows_x86_64_gnullvm/0.48.0/download",
+          "sha256": "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_x86_64_gnullvm",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "windows_x86_64_gnullvm",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "windows_x86_64_gnullvm 0.48.0",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.48.0"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "windows_x86_64_msvc 0.42.2": {
+      "name": "windows_x86_64_msvc",
+      "version": "0.42.2",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/windows_x86_64_msvc/0.42.2/download",
+          "sha256": "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
         }
       },
       "targets": [
@@ -12475,14 +14062,73 @@
         "deps": {
           "common": [
             {
-              "id": "windows_x86_64_msvc 0.42.0",
+              "id": "windows_x86_64_msvc 0.42.2",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.42.0"
+        "version": "0.42.2"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "windows_x86_64_msvc 0.48.0": {
+      "name": "windows_x86_64_msvc",
+      "version": "0.48.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/windows_x86_64_msvc/0.48.0/download",
+          "sha256": "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_x86_64_msvc",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "windows_x86_64_msvc",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "windows_x86_64_msvc 0.48.0",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.48.0"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -12526,7 +14172,7 @@
     }
   },
   "binary_crates": [
-    "cc 1.0.78",
+    "cc 1.0.79",
     "difference 2.0.0",
     "phf_generator 0.10.0"
   ],
@@ -12536,9 +14182,6 @@
     "swc-plugin-formatjs 0.0.2": "rust/swc-plugin-formatjs"
   },
   "conditions": {
-    "aarch64-apple-darwin": [
-      "aarch64-apple-darwin"
-    ],
     "aarch64-linux-android": [
       "aarch64-linux-android"
     ],
@@ -12546,8 +14189,65 @@
     "aarch64-pc-windows-msvc": [],
     "aarch64-uwp-windows-msvc": [],
     "cfg(all(any(target_arch = \"x86_64\", target_arch = \"aarch64\"), target_os = \"hermit\"))": [],
+    "cfg(all(any(target_os = \"android\", target_os = \"linux\"), any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"), all(target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"powerpc64\", target_arch = \"riscv64\", target_arch = \"mips\", target_arch = \"mips64\"))))))))": [
+      "aarch64-linux-android",
+      "armv7-linux-androideabi",
+      "i686-linux-android",
+      "powerpc-unknown-linux-gnu",
+      "s390x-unknown-linux-gnu",
+      "x86_64-linux-android"
+    ],
+    "cfg(all(not(rustix_use_libc), not(miri), target_os = \"linux\", any(target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"), all(target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"powerpc64\", target_arch = \"riscv64\", target_arch = \"mips\", target_arch = \"mips64\")))))": [
+      "aarch64-unknown-linux-gnu",
+      "arm-unknown-linux-gnueabi",
+      "armv7-unknown-linux-gnueabi",
+      "i686-unknown-linux-gnu",
+      "x86_64-unknown-linux-gnu"
+    ],
+    "cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"), all(target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"powerpc64\", target_arch = \"riscv64\", target_arch = \"mips\", target_arch = \"mips64\"))))))))": [
+      "aarch64-apple-darwin",
+      "aarch64-apple-ios",
+      "aarch64-apple-ios-sim",
+      "aarch64-linux-android",
+      "armv7-linux-androideabi",
+      "i686-apple-darwin",
+      "i686-linux-android",
+      "i686-unknown-freebsd",
+      "powerpc-unknown-linux-gnu",
+      "riscv32imc-unknown-none-elf",
+      "s390x-unknown-linux-gnu",
+      "wasm32-unknown-unknown",
+      "wasm32-wasi",
+      "x86_64-apple-darwin",
+      "x86_64-apple-ios",
+      "x86_64-linux-android",
+      "x86_64-unknown-freebsd"
+    ],
+    "cfg(all(target_arch = \"aarch64\", target_env = \"gnu\", target_abi = \"llvm\", not(windows_raw_dylib)))": [],
+    "cfg(all(target_arch = \"aarch64\", target_env = \"msvc\", not(windows_raw_dylib)))": [],
     "cfg(all(target_arch = \"aarch64\", target_os = \"linux\"))": [
       "aarch64-unknown-linux-gnu"
+    ],
+    "cfg(all(target_arch = \"aarch64\", target_vendor = \"apple\"))": [
+      "aarch64-apple-darwin",
+      "aarch64-apple-ios",
+      "aarch64-apple-ios-sim"
+    ],
+    "cfg(all(target_arch = \"wasm32\", not(target_os = \"wasi\")))": [
+      "wasm32-unknown-unknown"
+    ],
+    "cfg(all(target_arch = \"x86\", target_env = \"gnu\", not(windows_raw_dylib)))": [
+      "i686-unknown-linux-gnu"
+    ],
+    "cfg(all(target_arch = \"x86\", target_env = \"msvc\", not(windows_raw_dylib)))": [
+      "i686-pc-windows-msvc"
+    ],
+    "cfg(all(target_arch = \"x86_64\", target_env = \"gnu\", not(target_abi = \"llvm\"), not(windows_raw_dylib)))": [
+      "x86_64-unknown-linux-gnu"
+    ],
+    "cfg(all(target_arch = \"x86_64\", target_env = \"gnu\", target_abi = \"llvm\", not(windows_raw_dylib)))": [],
+    "cfg(all(target_arch = \"x86_64\", target_env = \"msvc\", not(windows_raw_dylib)))": [
+      "x86_64-pc-windows-msvc"
     ],
     "cfg(any(target_arch = \"aarch64\", target_arch = \"x86\", target_arch = \"x86_64\"))": [
       "aarch64-apple-darwin",
@@ -12657,6 +14357,27 @@
       "x86_64-unknown-freebsd",
       "x86_64-unknown-linux-gnu"
     ],
+    "cfg(not(any(target_arch = \"wasm32\", target_arch = \"arm\")))": [
+      "aarch64-apple-darwin",
+      "aarch64-apple-ios",
+      "aarch64-apple-ios-sim",
+      "aarch64-linux-android",
+      "aarch64-unknown-linux-gnu",
+      "i686-apple-darwin",
+      "i686-linux-android",
+      "i686-pc-windows-msvc",
+      "i686-unknown-freebsd",
+      "i686-unknown-linux-gnu",
+      "powerpc-unknown-linux-gnu",
+      "riscv32imc-unknown-none-elf",
+      "s390x-unknown-linux-gnu",
+      "x86_64-apple-darwin",
+      "x86_64-apple-ios",
+      "x86_64-linux-android",
+      "x86_64-pc-windows-msvc",
+      "x86_64-unknown-freebsd",
+      "x86_64-unknown-linux-gnu"
+    ],
     "cfg(not(windows))": [
       "aarch64-apple-darwin",
       "aarch64-apple-ios",
@@ -12681,10 +14402,33 @@
       "x86_64-unknown-freebsd",
       "x86_64-unknown-linux-gnu"
     ],
-    "cfg(target_arch = \"wasm32\")": [
+    "cfg(not(windows_raw_dylib))": [
+      "aarch64-apple-darwin",
+      "aarch64-apple-ios",
+      "aarch64-apple-ios-sim",
+      "aarch64-linux-android",
+      "aarch64-unknown-linux-gnu",
+      "arm-unknown-linux-gnueabi",
+      "armv7-linux-androideabi",
+      "armv7-unknown-linux-gnueabi",
+      "i686-apple-darwin",
+      "i686-linux-android",
+      "i686-pc-windows-msvc",
+      "i686-unknown-freebsd",
+      "i686-unknown-linux-gnu",
+      "powerpc-unknown-linux-gnu",
+      "riscv32imc-unknown-none-elf",
+      "s390x-unknown-linux-gnu",
       "wasm32-unknown-unknown",
-      "wasm32-wasi"
+      "wasm32-wasi",
+      "x86_64-apple-darwin",
+      "x86_64-apple-ios",
+      "x86_64-linux-android",
+      "x86_64-pc-windows-msvc",
+      "x86_64-unknown-freebsd",
+      "x86_64-unknown-linux-gnu"
     ],
+    "cfg(target_os = \"dragonfly\")": [],
     "cfg(target_os = \"hermit\")": [],
     "cfg(target_os = \"redox\")": [],
     "cfg(target_os = \"wasi\")": [

--- a/rust/swc-formatjs-custom-transform/Cargo.toml
+++ b/rust/swc-formatjs-custom-transform/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = { version = "1.0.85", features = ["unbounded_depth"] }
 swc-formatjs-visitor = { path = "../swc-formatjs-visitor", features = [
   "custom_transform",
 ] }
-swc_core = { version = "0.43", features = [
+swc_core = { version = "0.75.42", features = [
   "common_concurrent",
   "ecma_transforms",
   "ecma_ast",

--- a/rust/swc-formatjs-visitor/Cargo.toml
+++ b/rust/swc-formatjs-visitor/Cargo.toml
@@ -21,7 +21,7 @@ regex = "1.6.0"
 serde = { version = "1.0.143", features = ["derive"] }
 serde_json = "1.0.83"
 sha2 = "0.10"
-swc_core = { version = "0.51", features = ["common", "ecma_visit", "ecma_ast"] }
+swc_core = { version = "0.75.42", features = ["common", "ecma_visit", "ecma_ast"] }
 
 [dev-dependencies]
 pretty_assertions = "1.3.0"

--- a/rust/swc-plugin-formatjs/BUILD
+++ b/rust/swc-plugin-formatjs/BUILD
@@ -36,7 +36,6 @@ rust_wasm_library(
     proc_macro_deps = all_crate_deps(
         proc_macro = True,
     ),
-    tags = ["manual"],
     visibility = ["@//packages/swc-plugin-experimental:__pkg__"],
     wasi = True,
     deps = ["//rust/swc-formatjs-visitor"] + all_crate_deps(

--- a/rust/swc-plugin-formatjs/Cargo.toml
+++ b/rust/swc-plugin-formatjs/Cargo.toml
@@ -16,4 +16,4 @@ serde_json = "1"
 swc-formatjs-visitor = { path = "../swc-formatjs-visitor", version = "0.0.2", features = [
   "plugin",
 ] }
-swc_core = { version = "0.51", features = ["ecma_plugin_transform"] }
+swc_core = { version = "0.75.42", features = ["ecma_plugin_transform", "ecma_ast_serde"] }


### PR DESCRIPTION
For https://github.com/formatjs/formatjs/issues/3589

Update `swc_core` Rust crate and the `swc` NPM package used in the Node.js test. This PR should fix the crash that are reported on the latest version of next.js.

I have tested the following combination:
- plugin built from this PR
- next 13.3.2
- swc 1.3.56
