### PR TITLE
fix(github-action): Adjusting Github bot stale period

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/stale@v5
         with:
-          days-before-stale: 15
+          days-before-stale: 30
           exempt-issue-labels: 'pinned,security'
           stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'
           stale-pr-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'


### PR DESCRIPTION
close #4066

Extending to be a month so that the issue's raisers don't have to hassle with the bot