### PR TITLE
Remove suggestion to use a `key` prop on the `IntlProvider`

### DIFF
--- a/website/docs/react-intl/components.md
+++ b/website/docs/react-intl/components.md
@@ -129,18 +129,6 @@ const intl = createIntl({
 <RawIntlProvider value={intl}>{foo}</RawIntlProvider>
 ```
 
-#### Dynamic Language Selection
-
-By default, changes to the `locale` at runtime may not trigger a re-render of child elements. To solve this, and enable dynamic locale modification, add a `key` property to the `<IntlProvider>` and set it to the locale, which persuades React that the component has been modified:
-
-```tsx
-<IntlProvider locale={localeProp} key={localeProp} messages={messagesProp}>
-  <App />
-</IntlProvider>
-```
-
-(See [Issue #243](https://github.com/formatjs/formatjs/issues/243).)
-
 ## FormattedDate
 
 This component uses the [`formatDate`](api.md#formatdate) and [`Intl.DateTimeFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat) APIs and has `props` that correspond to the `DateTimeFormatOptions` specified above.


### PR DESCRIPTION
This suggestion is extremely old, it may have come from the time when the context API was not stable like today. 

In almost all circumstances, adding a `key` prop as a solution to messages not changing is the wrong one. 

It is a misleading statement and potentially dangerous as it mounts a new component tree which, aside from being potentially expensive, [will cause loss of all local state](https://stackblitz.com/edit/react-ts-cg7wtp?file=App.tsx,node_modules%2Freact-intl%2Fsrc%2Futils.d.ts). I've seen this in a PR on my team very recently, and while it is easy to spot in PR review and remove, I don't think it should be an official suggestion in the documentation of `react-intl`

