### PR TITLE
fix(@formatjs/swc-plugin-experimental): visit JSX nested within the call expression

### DIFF
--- a/packages/babel-plugin-formatjs/tests/__snapshots__/index.test.ts.snap
+++ b/packages/babel-plugin-formatjs/tests/__snapshots__/index.test.ts.snap
@@ -859,6 +859,68 @@ export default class Foo extends Component {
 }
 `;
 
+exports[`jsxNestedInCallExpr 1`] = `
+{
+  "code": "import { useMemo } from 'react';
+import { FormattedMessage, FormattedNumber, useIntl } from 'react-intl';
+export default function IndexPage() {
+  var intl = useIntl();
+  var anotherMessage = useMemo(() => /*#__PURE__*/React.createElement(FormattedMessage, {
+    id: "A+bpLt",
+    defaultMessage: "Hello, World #1!"
+  }), []);
+  return /*#__PURE__*/React.createElement("main", {
+    title: intl.formatMessage({
+      id: "lyiQWH",
+      defaultMessage: "Home"
+    }),
+    description: intl.formatMessage({
+      id: "9CBSZS",
+      defaultMessage: "An example app integrating React Intl with Next.js"
+    })
+  }, /*#__PURE__*/React.createElement("p", null, /*#__PURE__*/React.createElement(FormattedMessage, {
+    id: "wF8i0k",
+    defaultMessage: "Hello, World #2!"
+  })), /*#__PURE__*/React.createElement("p", null, anotherMessage), /*#__PURE__*/React.createElement("div", null, [...Array(10)].map((_, i) => /*#__PURE__*/React.createElement(FormattedMessage, {
+    id: "rpH0bU",
+    defaultMessage: "Hello, World #3!"
+  }))), /*#__PURE__*/React.createElement("p", null, /*#__PURE__*/React.createElement(FormattedNumber, {
+    value: 1000
+  })));
+}",
+  "data": {
+    "messages": [
+      {
+        "defaultMessage": "Hello, World #1!",
+        "description": "Index Page: Content #1",
+        "id": "A+bpLt",
+      },
+      {
+        "defaultMessage": "Home",
+        "description": "Index Page: document title",
+        "id": "lyiQWH",
+      },
+      {
+        "defaultMessage": "An example app integrating React Intl with Next.js",
+        "description": "Index Page: Meta Description",
+        "id": "9CBSZS",
+      },
+      {
+        "defaultMessage": "Hello, World #2!",
+        "description": "Index Page: Content #2",
+        "id": "wF8i0k",
+      },
+      {
+        "defaultMessage": "Hello, World #3!",
+        "description": "Index Page: Content #3",
+        "id": "rpH0bU",
+      },
+    ],
+    "meta": {},
+  },
+}
+`;
+
 exports[`overrideIdFn 1`] = `
 {
   "code": "import React, { Component } from 'react';

--- a/packages/babel-plugin-formatjs/tests/fixtures/jsxNestedInCallExpr.js
+++ b/packages/babel-plugin-formatjs/tests/fixtures/jsxNestedInCallExpr.js
@@ -1,0 +1,48 @@
+import {useMemo} from 'react'
+import {FormattedMessage, FormattedNumber, useIntl} from 'react-intl'
+
+export default function IndexPage() {
+  const intl = useIntl()
+
+  const anotherMessage = useMemo(
+    () => (
+      <FormattedMessage
+        defaultMessage="Hello, World #1!"
+        description="Index Page: Content #1"
+      />
+    ),
+    []
+  )
+
+  return (
+    <main
+      title={intl.formatMessage({
+        defaultMessage: 'Home',
+        description: 'Index Page: document title',
+      })}
+      description={intl.formatMessage({
+        defaultMessage: 'An example app integrating React Intl with Next.js',
+        description: 'Index Page: Meta Description',
+      })}
+    >
+      <p>
+        <FormattedMessage
+          defaultMessage="Hello, World #2!"
+          description="Index Page: Content #2"
+        />
+      </p>
+      <p>{anotherMessage}</p>
+      <div>
+        {[...Array(10)].map((_, i) => (
+          <FormattedMessage
+            defaultMessage="Hello, World #3!"
+            description="Index Page: Content #3"
+          />
+        ))}
+      </div>
+      <p>
+        <FormattedNumber value={1000} />
+      </p>
+    </main>
+  )
+}

--- a/packages/babel-plugin-formatjs/tests/index.test.ts
+++ b/packages/babel-plugin-formatjs/tests/index.test.ts
@@ -183,6 +183,11 @@ test('skipExtractionFormattedMessage', function () {
   transformAndCheck('skipExtractionFormattedMessage')
 })
 
+// See: https://github.com/formatjs/formatjs/issues/3589#issuecomment-1532461569
+test('jsxNestedInCallExpr', () => {
+  transformAndCheck('jsxNestedInCallExpr')
+})
+
 let cacheBust = 1
 
 function transform(

--- a/packages/swc-plugin-experimental/tests/__snapshots__/index.test.ts.snap
+++ b/packages/swc-plugin-experimental/tests/__snapshots__/index.test.ts.snap
@@ -752,6 +752,70 @@ export default class Foo extends Component {
 }
 `;
 
+exports[`explicit pragma jsxNestedInCallExpr 1`] = `
+{
+  "code": "import { useMemo } from 'react';
+import { FormattedMessage, FormattedNumber, useIntl } from 'react-intl';
+export default function IndexPage() {
+    const intl = useIntl();
+    const anotherMessage = useMemo(()=>/*#__PURE__*/ React.createElement(FormattedMessage, {
+            id: "A+bpLt",
+            defaultMessage: "Hello, World #1!"
+        }), []);
+    return /*#__PURE__*/ React.createElement("main", {
+        title: intl.formatMessage({
+            id: "lyiQWH",
+            defaultMessage: "Home"
+        }),
+        description: intl.formatMessage({
+            id: "9CBSZS",
+            defaultMessage: "An example app integrating React Intl with Next.js"
+        })
+    }, /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, {
+        id: "wF8i0k",
+        defaultMessage: "Hello, World #2!"
+    })), /*#__PURE__*/ React.createElement("p", null, anotherMessage), /*#__PURE__*/ React.createElement("div", null, [
+        ...Array(10)
+    ].map((_, i)=>/*#__PURE__*/ React.createElement(FormattedMessage, {
+            id: "rpH0bU",
+            defaultMessage: "Hello, World #3!"
+        }))), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedNumber, {
+        value: 1000
+    })));
+}",
+  "data": {
+    "messages": [
+      {
+        "defaultMessage": "Hello, World #1!",
+        "description": "Index Page: Content #1",
+        "id": "A+bpLt",
+      },
+      {
+        "defaultMessage": "Home",
+        "description": "Index Page: document title",
+        "id": "lyiQWH",
+      },
+      {
+        "defaultMessage": "An example app integrating React Intl with Next.js",
+        "description": "Index Page: Meta Description",
+        "id": "9CBSZS",
+      },
+      {
+        "defaultMessage": "Hello, World #2!",
+        "description": "Index Page: Content #2",
+        "id": "wF8i0k",
+      },
+      {
+        "defaultMessage": "Hello, World #3!",
+        "description": "Index Page: Content #3",
+        "id": "rpH0bU",
+      },
+    ],
+    "meta": {},
+  },
+}
+`;
+
 exports[`explicit pragma preserveWhitespace 1`] = `
 {
   "code": "// @react-intl project:amazing
@@ -1715,6 +1779,70 @@ export default class Foo extends Component {
         "defaultMessage": "Hello World!",
         "description": "The default message",
         "id": "header2",
+      },
+    ],
+    "meta": {},
+  },
+}
+`;
+
+exports[`no pragma jsxNestedInCallExpr 1`] = `
+{
+  "code": "import { useMemo } from 'react';
+import { FormattedMessage, FormattedNumber, useIntl } from 'react-intl';
+export default function IndexPage() {
+    const intl = useIntl();
+    const anotherMessage = useMemo(()=>/*#__PURE__*/ React.createElement(FormattedMessage, {
+            id: "A+bpLt",
+            defaultMessage: "Hello, World #1!"
+        }), []);
+    return /*#__PURE__*/ React.createElement("main", {
+        title: intl.formatMessage({
+            id: "lyiQWH",
+            defaultMessage: "Home"
+        }),
+        description: intl.formatMessage({
+            id: "9CBSZS",
+            defaultMessage: "An example app integrating React Intl with Next.js"
+        })
+    }, /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedMessage, {
+        id: "wF8i0k",
+        defaultMessage: "Hello, World #2!"
+    })), /*#__PURE__*/ React.createElement("p", null, anotherMessage), /*#__PURE__*/ React.createElement("div", null, [
+        ...Array(10)
+    ].map((_, i)=>/*#__PURE__*/ React.createElement(FormattedMessage, {
+            id: "rpH0bU",
+            defaultMessage: "Hello, World #3!"
+        }))), /*#__PURE__*/ React.createElement("p", null, /*#__PURE__*/ React.createElement(FormattedNumber, {
+        value: 1000
+    })));
+}",
+  "data": {
+    "messages": [
+      {
+        "defaultMessage": "Hello, World #1!",
+        "description": "Index Page: Content #1",
+        "id": "A+bpLt",
+      },
+      {
+        "defaultMessage": "Home",
+        "description": "Index Page: document title",
+        "id": "lyiQWH",
+      },
+      {
+        "defaultMessage": "An example app integrating React Intl with Next.js",
+        "description": "Index Page: Meta Description",
+        "id": "9CBSZS",
+      },
+      {
+        "defaultMessage": "Hello, World #2!",
+        "description": "Index Page: Content #2",
+        "id": "wF8i0k",
+      },
+      {
+        "defaultMessage": "Hello, World #3!",
+        "description": "Index Page: Content #3",
+        "id": "rpH0bU",
       },
     ],
     "meta": {},

--- a/packages/swc-plugin-experimental/tests/fixtures/jsxNestedInCallExpr.js
+++ b/packages/swc-plugin-experimental/tests/fixtures/jsxNestedInCallExpr.js
@@ -1,0 +1,48 @@
+import {useMemo} from 'react'
+import {FormattedMessage, FormattedNumber, useIntl} from 'react-intl'
+
+export default function IndexPage() {
+  const intl = useIntl()
+
+  const anotherMessage = useMemo(
+    () => (
+      <FormattedMessage
+        defaultMessage="Hello, World #1!"
+        description="Index Page: Content #1"
+      />
+    ),
+    []
+  )
+
+  return (
+    <main
+      title={intl.formatMessage({
+        defaultMessage: 'Home',
+        description: 'Index Page: document title',
+      })}
+      description={intl.formatMessage({
+        defaultMessage: 'An example app integrating React Intl with Next.js',
+        description: 'Index Page: Meta Description',
+      })}
+    >
+      <p>
+        <FormattedMessage
+          defaultMessage="Hello, World #2!"
+          description="Index Page: Content #2"
+        />
+      </p>
+      <p>{anotherMessage}</p>
+      <div>
+        {[...Array(10)].map((_, i) => (
+          <FormattedMessage
+            defaultMessage="Hello, World #3!"
+            description="Index Page: Content #3"
+          />
+        ))}
+      </div>
+      <p>
+        <FormattedNumber value={1000} />
+      </p>
+    </main>
+  )
+}

--- a/packages/swc-plugin-experimental/tests/index.test.ts
+++ b/packages/swc-plugin-experimental/tests/index.test.ts
@@ -219,4 +219,11 @@ describe.each([
       transformAndCheck('skipExtractionFormattedMessage', pluginOptions)
     ).toMatchSnapshot()
   })
+
+  // See: https://github.com/formatjs/formatjs/issues/3589#issuecomment-1532461569
+  test('jsxNestedInCallExpr', () => {
+    expect(
+      transformAndCheck('jsxNestedInCallExpr', pluginOptions)
+    ).toMatchSnapshot()
+  })
 })

--- a/rust/swc-formatjs-visitor/src/lib.rs
+++ b/rust/swc-formatjs-visitor/src/lib.rs
@@ -497,11 +497,11 @@ fn interpolate_name(resource_path: &str, name: &str, content: &str) -> Option<St
 
     let content = content;
 
-    let ext = "bin";
-    let basename = "file";
-    let directory = "";
-    let folder = "";
-    let query = "";
+    // let ext = "bin";
+    // let basename = "file";
+    // let directory = "";
+    // let folder = "";
+    // let query = "";
 
     /*
       if (resource_path) {
@@ -541,8 +541,8 @@ fn interpolate_name(resource_path: &str, name: &str, content: &str) -> Option<St
 
     url = r
         .replace(url.as_str(), |cap: &Captures| {
-            let hash_type = cap.get(1);
-            let digest_type = cap.get(2);
+            // let hash_type = cap.get(1);
+            // let digest_type = cap.get(2);
             let max_length = cap.get(3);
 
             // TODO: support hashtype
@@ -905,7 +905,7 @@ impl<C: Clone + Comments, S: SourceMapper> FormatJSVisitor<C, S> {
                     source_location,
                 );
 
-                let first_prop = properties.first().is_some();
+                // let first_prop = properties.first().is_some();
 
                 // Insert ID potentially 1st before removing nodes
                 let id_prop = obj.props.iter().find(|prop| {
@@ -1146,6 +1146,8 @@ impl<C: Clone + Comments, S: SourceMapper> VisitMut for FormatJSVisitor<C, S> {
     }
 
     fn visit_mut_call_expr(&mut self, call_expr: &mut CallExpr) {
+        call_expr.visit_mut_children_with(self);
+
         let callee = &call_expr.callee;
         let args = &mut call_expr.args;
 


### PR DESCRIPTION
The original Rust implementation does not visit the children of the call expression, as was discovered in https://github.com/formatjs/formatjs/issues/3589#issuecomment-1532461569. This PR fixes that.