### PR TITLE
Add ability to call --skip-errors from the compile-folder command

### DIFF
--- a/packages/cli-lib/src/cli.ts
+++ b/packages/cli-lib/src/cli.ts
@@ -215,6 +215,10 @@ This is especially useful to convert from a TMS-specific format back to react-in
 `
     )
     .option(
+      '--skip-errors',
+      `Whether to continue compiling messages after encountering an error. Any keys with errors will not be included in the output file.`
+    )
+    .option(
       '--ast',
       `Whether to compile to AST. See https://formatjs.io/docs/guides/advanced-usage#pre-parsing-messages
 for more information`


### PR DESCRIPTION
The `--skip-errors` command line option is present in the `compile` command but not in the `compile-folder` command, even though it works when added and is needed for a project I am working on. Adding this in assuming the omission was unintentional.