### PR TITLE
feat(@formatjs/intl,@formatjs/fast-memoize,@formatjs/icu-messageformat-parser,@formatjs/intl-displaynames,@formatjs/intl-listformat,intl-messageformat,@formatjs/ecma402-abstract,@formatjs/intl-numberformat,@formatjs/icu-skeleton-parser): Revert esm conditional exports

### DIFF
--- a/packages/ecma402-abstract/package.json
+++ b/packages/ecma402-abstract/package.json
@@ -29,14 +29,6 @@
   "main": "index.js",
   "module": "lib/index.js",
   "types": "index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./index.d.ts",
-      "import": "./lib/index.js",
-      "default": "./index.js"
-    },
-    "./package.json": "./package.json"
-  },
   "homepage": "https://github.com/formatjs/formatjs",
   "license": "MIT",
   "gitHead": "a7842673d8ad205171ad7c8cb8bb2f318b427c0c"

--- a/packages/fast-memoize/package.json
+++ b/packages/fast-memoize/package.json
@@ -4,15 +4,6 @@
   "description": "fork of fast-memoize and support esm",
   "main": "index.js",
   "module": "lib/index.js",
-  "types": "index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./index.d.ts",
-      "import": "./lib/index.js",
-      "default": "./index.js"
-    },
-    "./package.json": "./package.json"
-  },
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/formatjs/formatjs.git"

--- a/packages/icu-messageformat-parser/package.json
+++ b/packages/icu-messageformat-parser/package.json
@@ -4,29 +4,6 @@
   "main": "index.js",
   "module": "lib/index.js",
   "types": "index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./index.d.ts",
-      "import": "./lib/index.js",
-      "default": "./index.js"
-    },
-    "./no-parser": {
-      "types": "./no-parser.d.ts",
-      "import": "./lib/no-parser.js",
-      "default": "./no-parser.js"
-    },
-    "./printer": {
-      "types": "./printer.d.ts",
-      "import": "./lib/printer.js",
-      "default": "./printer.js"
-    },
-    "./manipulator": {
-      "types": "./manipulator.d.ts",
-      "import": "./lib/manipulator.js",
-      "default": "./manipulator.js"
-    },
-    "./package.json": "./package.json"
-  },
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/icu-skeleton-parser/package.json
+++ b/packages/icu-skeleton-parser/package.json
@@ -4,14 +4,6 @@
   "main": "index.js",
   "module": "lib/index.js",
   "types": "index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./index.d.ts",
-      "import": "./lib/index.js",
-      "default": "./index.js"
-    },
-    "./package.json": "./package.json"
-  },
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/intl-datetimeformat/package.json
+++ b/packages/intl-datetimeformat/package.json
@@ -4,42 +4,6 @@
   "description": "Intl.DateTimeFormat polyfill",
   "main": "index.js",
   "types": "index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./index.d.ts",
-      "import": "./lib/index.js",
-      "default": "./index.js"
-    },
-    "./polyfill": {
-      "types": "./polyfill.d.ts",
-      "import": "./lib/polyfill.js",
-      "default": "./polyfill.js"
-    },
-    "./polyfill-force": {
-      "types": "./polyfill-force.d.ts",
-      "import": "./lib/polyfill-force.js",
-      "default": "./polyfill-force.js"
-    },
-    "./should-polyfill": {
-      "types": "./should-polyfill.d.ts",
-      "import": "./lib/should-polyfill.js",
-      "default": "./should-polyfill.js"
-    },
-    "./locale-data/*": {
-      "types": "./locale-data/*.d.ts",
-      "default": "./locale-data/*.js"
-    },
-    "./add-all-tz": {
-      "types": "./add-all-tz.d.ts",
-      "default": "./add-all-tz.js"
-    },
-    "./add-golden-tz": {
-      "types": "./add-golden-tz.d.ts",
-      "default": "./add-golden-tz.js"
-    },
-    "./polyfill.iife.js": "./polyfill.iife.js",
-    "./package.json": "./package.json"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/formatjs/formatjs.git"

--- a/packages/intl-displaynames/package.json
+++ b/packages/intl-displaynames/package.json
@@ -16,34 +16,6 @@
   "license": "MIT",
   "main": "index.js",
   "types": "index.d.js",
-  "exports": {
-    ".": {
-      "types": "./index.d.ts",
-      "import": "./lib/index.js",
-      "default": "./index.js"
-    },
-    "./polyfill": {
-      "types": "./polyfill.d.ts",
-      "import": "./lib/polyfill.js",
-      "default": "./polyfill.js"
-    },
-    "./polyfill-force": {
-      "types": "./polyfill-force.d.ts",
-      "import": "./lib/polyfill-force.js",
-      "default": "./polyfill-force.js"
-    },
-    "./should-polyfill": {
-      "types": "./should-polyfill.d.ts",
-      "import": "./lib/should-polyfill.js",
-      "default": "./should-polyfill.js"
-    },
-    "./locale-data/*": {
-      "types": "./locale-data/*.d.ts",
-      "default": "./locale-data/*.js"
-    },
-    "./polyfill.iife.js": "./polyfill.iife.js",
-    "./package.json": "./package.json"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/formatjs/formatjs.git"

--- a/packages/intl-listformat/package.json
+++ b/packages/intl-listformat/package.json
@@ -29,34 +29,6 @@
   },
   "main": "index.js",
   "types": "index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./index.d.ts",
-      "import": "./lib/index.js",
-      "default": "./index.js"
-    },
-    "./polyfill": {
-      "types": "./polyfill.d.ts",
-      "import": "./lib/polyfill.js",
-      "default": "./polyfill.js"
-    },
-    "./polyfill-force": {
-      "types": "./polyfill-force.d.ts",
-      "import": "./lib/polyfill-force.js",
-      "default": "./polyfill-force.js"
-    },
-    "./should-polyfill": {
-      "types": "./should-polyfill.d.ts",
-      "import": "./lib/should-polyfill.js",
-      "default": "./should-polyfill.js"
-    },
-    "./locale-data/*": {
-      "types": "./locale-data/*.d.ts",
-      "default": "./locale-data/*.js"
-    },
-    "./polyfill.iife.js": "./polyfill.iife.js",
-    "./package.json": "./package.json"
-  },
   "homepage": "https://github.com/formatjs/formatjs",
   "license": "MIT",
   "gitHead": "a7842673d8ad205171ad7c8cb8bb2f318b427c0c"

--- a/packages/intl-localematcher/package.json
+++ b/packages/intl-localematcher/package.json
@@ -17,14 +17,6 @@
   "main": "index.js",
   "module": "lib/index.js",
   "types": "index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./index.d.ts",
-      "import": "./lib/index.js",
-      "default": "./index.js"
-    },
-    "./package.json": "./package.json"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/formatjs/formatjs.git"

--- a/packages/intl-messageformat/package.json
+++ b/packages/intl-messageformat/package.json
@@ -30,14 +30,6 @@
   "main": "index.js",
   "module": "lib/index.js",
   "types": "index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./index.d.ts",
-      "import": "./lib/index.js",
-      "default": "./index.js"
-    },
-    "./package.json": "./package.json"
-  },
   "dependencies": {
     "@formatjs/ecma402-abstract": "workspace:*",
     "@formatjs/fast-memoize": "workspace:*",

--- a/packages/intl-numberformat/package.json
+++ b/packages/intl-numberformat/package.json
@@ -17,34 +17,6 @@
   "license": "MIT",
   "main": "index.js",
   "types": "index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./index.d.ts",
-      "import": "./lib/index.js",
-      "default": "./index.js"
-    },
-    "./polyfill": {
-      "types": "./polyfill.d.ts",
-      "import": "./lib/polyfill.js",
-      "default": "./polyfill.js"
-    },
-    "./polyfill-force": {
-      "types": "./polyfill-force.d.ts",
-      "import": "./lib/polyfill-force.js",
-      "default": "./polyfill-force.js"
-    },
-    "./should-polyfill": {
-      "types": "./should-polyfill.d.ts",
-      "import": "./lib/should-polyfill.js",
-      "default": "./should-polyfill.js"
-    },
-    "./locale-data/*": {
-      "types": "./locale-data/*.d.ts",
-      "default": "./locale-data/*.js"
-    },
-    "./polyfill.iife.js": "./polyfill.iife.js",
-    "./package.json": "./package.json"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/formatjs/formatjs.git"

--- a/packages/intl/package.json
+++ b/packages/intl/package.json
@@ -27,15 +27,6 @@
   },
   "main": "index.js",
   "module": "lib/index.js",
-  "types": "index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./index.d.ts",
-      "import": "./lib/index.js",
-      "default": "./index.js"
-    },
-    "./package.json": "./package.json"
-  },
   "sideEffects": false,
   "dependencies": {
     "@formatjs/ecma402-abstract": "workspace:*",


### PR DESCRIPTION
The ESM export chanegs are not properly tested and therefore broke in various scenarios.

Fixes #4128, #4127, #4126

This reverts commit e0d593cc3af3a317a6bd20c441191e5bbb136a93.