### PR TITLE
Improved hasNativeStartsWith check

### DIFF
--- a/packages/icu-messageformat-parser/parser.ts
+++ b/packages/icu-messageformat-parser/parser.ts
@@ -79,7 +79,8 @@ function createLocation(start: Position, end: Position): Location {
 
 // #region Ponyfills
 // Consolidate these variables up top for easier toggling during debugging
-const hasNativeStartsWith = !!String.prototype.startsWith
+const hasNativeStartsWith =
+  !!String.prototype.startsWith && '_a'.startsWith('a', 1)
 const hasNativeFromCodePoint = !!String.fromCodePoint
 const hasNativeFromEntries = !!(Object as any).fromEntries
 const hasNativeCodePointAt = !!String.prototype.codePointAt


### PR DESCRIPTION
There are JS environments where `String.startsWith` exists but doesn't support the `position` parameter (e.g. in the taskpane of Outlook web add-ins). This commit adds a test for proper handling of `position` to the polyfill check.

Note: Turns out this broken polyfill comes with Microsoft's Office JS API in [https://ajax.aspnetcdn.com/ajax/3.5/MicrosoftAjax.js](https://ajax.aspnetcdn.com/ajax/3.5/MicrosoftAjax.js) 😱

Here's a regular Chrome dev console:

![image](https://github.com/formatjs/formatjs/assets/494674/c7ebfab6-bc4e-44d6-aa73-d72b082fcc90)
![image](https://github.com/formatjs/formatjs/assets/494674/7f313d00-7a69-41d4-a769-66558bf39871)

Here's the behavior in the dev console of an Outlook add-in:

![image](https://github.com/formatjs/formatjs/assets/494674/eb222bbf-06a5-407f-ba56-1ee6428ee702)
![image](https://github.com/formatjs/formatjs/assets/494674/1893aa07-def4-4fd5-8089-ea0caf15a027)

This is how it breaks `formatjs` in an Outlook add-in taskpane:

A simple message with tags:
```tsx
<FormattedMessage id="test" defaultMessage="<b>test</b>" />
```

The broken `startsWith` implementation breaks the parser. `parseTag()` throws INVALID_TAG because `startsWith` used in `bumpIf()` requires a proper handling of the position parameter (`this.offset()` in this case).

```
utils.js:20  Error: [@formatjs/intl Error FORMAT_ERROR] Error formatting default message for: "test", rendering default message verbatim
MessageID: test
Default Message: <b>test</b>
Description: undefined

Locale: en


INVALID_TAG
SyntaxError: INVALID_TAG (at error.js:58:1)
    at Function.parse [as __parse] (index.js:33:1)
    at new IntlMessageFormat (core.js:137:1)
    at utils.js:110:1
    at variadic (index.js:33:1)
    at formatMessage (message.js:69:1)
    at formatMessage (provider.js:46:18)
    at FormattedMessage (message.js:21:1)
    at renderWithHooks (react-dom.development.js:16305:1)
    at mountIndeterminateComponent (react-dom.development.js:20074:1)
    at beginWork (react-dom.development.js:21587:1)
    at MessageFormatError.IntlFormatError [as constructor] (error.js:58:1)
    at new MessageFormatError (error.js:68:1)
    at formatMessage (message.js:73:1)
    at formatMessage (provider.js:46:18)
    at FormattedMessage (message.js:21:1)
    at renderWithHooks (react-dom.development.js:16305:1)
    at mountIndeterminateComponent (react-dom.development.js:20074:1)
    at beginWork (react-dom.development.js:21587:1)
    at beginWork$1 (react-dom.development.js:27426:1)
    at performUnitOfWork (react-dom.development.js:26560:1)
```
