### PR TITLE
fix: extend match paramiter types

### DIFF
--- a/packages/intl-localematcher/abstract/CanonicalizeLocaleList.ts
+++ b/packages/intl-localematcher/abstract/CanonicalizeLocaleList.ts
@@ -2,7 +2,9 @@
  * http://ecma-international.org/ecma-402/7.0/index.html#sec-canonicalizelocalelist
  * @param locales
  */
-export function CanonicalizeLocaleList(locales?: string | string[]): string[] {
+export function CanonicalizeLocaleList(
+  locales?: string | readonly string[]
+): string[] {
   // TODO
   return ((Intl as any).getCanonicalLocales as any)(locales)
 }

--- a/packages/intl-localematcher/index.ts
+++ b/packages/intl-localematcher/index.ts
@@ -6,8 +6,8 @@ export interface Opts {
 }
 
 export function match(
-  requestedLocales: string[],
-  availableLocales: string[],
+  requestedLocales: readonly string[],
+  availableLocales: readonly string[],
   defaultLocale: string,
   opts?: Opts
 ): string {


### PR DESCRIPTION
```ts
const availableLocales = ['en-US'] as const;
type AvailableLocale = (typeof availableLocales)[number];
```
In this case I can't pass `availableLocales` to `match` function. Changing the type of `availableLocales` and `requestedLocales` to `readonly string[]` shouldn't have any implications on the existing code. And I think it would make it more clearer that `match` does not mutate its arguments.