### PR TITLE
fix(locale): migrate locale info getters to get methods

### DIFF
--- a/packages/intl-locale/index.ts
+++ b/packages/intl-locale/index.ts
@@ -696,9 +696,9 @@ export class Locale {
   }
 
   /**
-   * https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.weekInfo
+   * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getWeekInfo
    */
-  public get weekInfo() {
+  public getWeekInfo() {
     try {
       const info = Object.create(Object.prototype)
       const wi = weekInfoOfLocale(this)
@@ -729,6 +729,14 @@ export class Locale {
     } catch (e) {
       throw new TypeError('Error retrieving weekInfo')
     }
+  }
+
+  /**
+   * @deprecated – use local.getWeekInfo() instead
+   * https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.weekInfo
+   */
+  public get weekInfo() {
+    return this.getWeekInfo()
   }
 
   static relevantExtensionKeys = RELEVANT_EXTENSION_KEYS

--- a/packages/intl-locale/index.ts
+++ b/packages/intl-locale/index.ts
@@ -640,44 +640,90 @@ export class Locale {
   }
 
   /**
-   * https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.calendars
+   * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getCalendars
+   * https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.getCalendars
    */
-  public get calendars() {
+  public getCalendars() {
     return calendarsOfLocale(this)
   }
 
   /**
-   * https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.collations
+   * @deprecated – use local.getCalendars() instead
+   * https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.calendars
    */
-  public get collations() {
+  public get calendars() {
+    return this.getCalendars()
+  }
+
+  /**
+   * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getCollations
+   * https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.getCollations
+   */
+  public getCollations() {
     return collationsOfLocale(this)
   }
 
   /**
-   * https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.hourCycles
+   * @deprecated – use local.getCollations() instead
+   * https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.collations
    */
-  public get hourCycles() {
+  public get collations() {
+    return this.getCollations()
+  }
+
+  /**
+   * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getHourCycles
+   * https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.getHourCycles
+   */
+  public getHourCycles() {
     return hourCyclesOfLocale(this)
   }
 
   /**
-   * https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.numberingSystems
+   * @deprecated – use local.getHourCycles() instead
+   * https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.hourCycles
    */
-  public get numberingSystems() {
+  public get hourCycles() {
+    return this.getHourCycles()
+  }
+
+  /**
+   * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getNumberingSystems
+   * https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.getNumberingSystems
+   */
+  public getNumberingSystems() {
     return numberingSystemsOfLocale(this)
   }
 
   /**
-   * https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.timeZones
+   * @deprecated – use local.getNumberingSystems() instead
+   * https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.numberingSystems
    */
-  public get timeZones() {
+  public get numberingSystems() {
+    return this.getNumberingSystems()
+  }
+
+  /**
+   * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getTimeZones
+   * https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.getTimeZones
+   */
+  public getTimeZones() {
     return timeZonesOfLocale(this)
   }
 
   /**
-   * https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.textInfo
+   * @deprecated – use local.getTimeZones() instead
+   * https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.timeZones
    */
-  public get textInfo() {
+  public get timeZones() {
+    return this.getTimeZones()
+  }
+
+  /**
+   * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getTextInfo
+   * https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.getTextInfo
+   */
+  public getTextInfo() {
     try {
       const info = Object.create(Object.prototype)
       const dir = characterDirectionOfLocale(this)
@@ -695,8 +741,17 @@ export class Locale {
     }
   }
 
+   /**
+    * @deprecated – use local.getTextInfo() instead
+    * https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.textInfo
+    */
+   public get textInfo() {
+    return this.getTextInfo()
+   }
+
   /**
    * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getWeekInfo
+   * https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.getWeekInfo
    */
   public getWeekInfo() {
     try {
@@ -732,7 +787,7 @@ export class Locale {
   }
 
   /**
-   * @deprecated – use local.getWeekInfo() instead
+   * @deprecated – use local.getWeekInfo() instead
    * https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.weekInfo
    */
   public get weekInfo() {

--- a/packages/intl-locale/index.ts
+++ b/packages/intl-locale/index.ts
@@ -1,5 +1,6 @@
 import {supportedValuesOf} from '@formatjs/intl-enumerator'
 import {
+  defineProperty,
   GetOption,
   invariant,
   SameValue,
@@ -723,7 +724,7 @@ export class Locale {
       const info = Object.create(Object.prototype)
       const dir = characterDirectionOfLocale(this)
 
-      Object.defineProperty(info, 'direction', {
+      defineProperty(info, 'direction', {
         value: dir,
         writable: true,
         enumerable: true,
@@ -767,21 +768,21 @@ export class Locale {
       const wi = weekInfoOfLocale(this)
       const we = wi.weekend
 
-      Object.defineProperty(info, 'firstDay', {
+      defineProperty(info, 'firstDay', {
         value: wi.firstDay,
         writable: true,
         enumerable: true,
         configurable: true,
       })
 
-      Object.defineProperty(info, 'weekend', {
+      defineProperty(info, 'weekend', {
         value: we,
         writable: true,
         enumerable: true,
         configurable: true,
       })
 
-      Object.defineProperty(info, 'minimalDays', {
+      defineProperty(info, 'minimalDays', {
         value: wi.minimalDays,
         writable: true,
         enumerable: true,

--- a/packages/intl-locale/index.ts
+++ b/packages/intl-locale/index.ts
@@ -730,9 +730,6 @@ export class Locale {
 
     defineProperty(info, 'direction', {
       value: dir,
-      writable: true,
-      enumerable: true,
-      configurable: true,
     })
 
     return info
@@ -775,23 +772,14 @@ export class Locale {
 
     defineProperty(info, 'firstDay', {
       value: wi.firstDay,
-      writable: true,
-      enumerable: true,
-      configurable: true,
     })
 
     defineProperty(info, 'weekend', {
       value: we,
-      writable: true,
-      enumerable: true,
-      configurable: true,
     })
 
     defineProperty(info, 'minimalDays', {
       value: wi.minimalDays,
-      writable: true,
-      enumerable: true,
-      configurable: true,
     })
 
     return info

--- a/packages/intl-locale/index.ts
+++ b/packages/intl-locale/index.ts
@@ -648,11 +648,10 @@ export class Locale {
   }
 
   /**
-   * @deprecated – use local.getCalendars() instead
    * https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.calendars
    */
   public get calendars() {
-    return this.getCalendars()
+    return calendarsOfLocale(this)
   }
 
   /**
@@ -664,11 +663,10 @@ export class Locale {
   }
 
   /**
-   * @deprecated – use local.getCollations() instead
    * https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.collations
    */
   public get collations() {
-    return this.getCollations()
+    return collationsOfLocale(this)
   }
 
   /**
@@ -680,11 +678,10 @@ export class Locale {
   }
 
   /**
-   * @deprecated – use local.getHourCycles() instead
    * https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.hourCycles
    */
   public get hourCycles() {
-    return this.getHourCycles()
+    return hourCyclesOfLocale(this)
   }
 
   /**
@@ -696,11 +693,10 @@ export class Locale {
   }
 
   /**
-   * @deprecated – use local.getNumberingSystems() instead
    * https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.numberingSystems
    */
   public get numberingSystems() {
-    return this.getNumberingSystems()
+    return numberingSystemsOfLocale(this)
   }
 
   /**
@@ -712,11 +708,10 @@ export class Locale {
   }
 
   /**
-   * @deprecated – use local.getTimeZones() instead
    * https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.timeZones
    */
   public get timeZones() {
-    return this.getTimeZones()
+    return timeZonesOfLocale(this)
   }
 
   /**
@@ -742,11 +737,24 @@ export class Locale {
   }
 
   /**
-   * @deprecated – use local.getTextInfo() instead
    * https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.textInfo
    */
   public get textInfo() {
-    return this.getTextInfo()
+    try {
+      const info = Object.create(Object.prototype)
+      const dir = characterDirectionOfLocale(this)
+
+      Object.defineProperty(info, 'direction', {
+        value: dir,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      })
+
+      return info
+    } catch (e) {
+      throw new TypeError('Error retrieving textInfo')
+    }
   }
 
   /**
@@ -787,11 +795,39 @@ export class Locale {
   }
 
   /**
-   * @deprecated – use local.getWeekInfo() instead
    * https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.weekInfo
    */
   public get weekInfo() {
-    return this.getWeekInfo()
+    try {
+      const info = Object.create(Object.prototype)
+      const wi = weekInfoOfLocale(this)
+      const we = wi.weekend
+
+      Object.defineProperty(info, 'firstDay', {
+        value: wi.firstDay,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      })
+
+      Object.defineProperty(info, 'weekend', {
+        value: we,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      })
+
+      Object.defineProperty(info, 'minimalDays', {
+        value: wi.minimalDays,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      })
+
+      return info
+    } catch (e) {
+      throw new TypeError('Error retrieving weekInfo')
+    }
   }
 
   static relevantExtensionKeys = RELEVANT_EXTENSION_KEYS

--- a/packages/intl-locale/index.ts
+++ b/packages/intl-locale/index.ts
@@ -741,13 +741,13 @@ export class Locale {
     }
   }
 
-   /**
-    * @deprecated – use local.getTextInfo() instead
-    * https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.textInfo
-    */
-   public get textInfo() {
+  /**
+   * @deprecated – use local.getTextInfo() instead
+   * https://tc39.es/proposal-intl-locale/#sec-Intl.Locale.prototype.textInfo
+   */
+  public get textInfo() {
     return this.getTextInfo()
-   }
+  }
 
   /**
    * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getWeekInfo

--- a/packages/intl-locale/index.ts
+++ b/packages/intl-locale/index.ts
@@ -720,21 +720,17 @@ export class Locale {
    * https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.getTextInfo
    */
   public getTextInfo() {
-    try {
-      const info = Object.create(Object.prototype)
-      const dir = characterDirectionOfLocale(this)
+    const info = Object.create(Object.prototype)
+    const dir = characterDirectionOfLocale(this)
 
-      defineProperty(info, 'direction', {
-        value: dir,
-        writable: true,
-        enumerable: true,
-        configurable: true,
-      })
+    defineProperty(info, 'direction', {
+      value: dir,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    })
 
-      return info
-    } catch (e) {
-      throw new TypeError('Error retrieving textInfo')
-    }
+    return info
   }
 
   /**
@@ -763,36 +759,32 @@ export class Locale {
    * https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.getWeekInfo
    */
   public getWeekInfo() {
-    try {
-      const info = Object.create(Object.prototype)
-      const wi = weekInfoOfLocale(this)
-      const we = wi.weekend
+    const info = Object.create(Object.prototype)
+    const wi = weekInfoOfLocale(this)
+    const we = wi.weekend
 
-      defineProperty(info, 'firstDay', {
-        value: wi.firstDay,
-        writable: true,
-        enumerable: true,
-        configurable: true,
-      })
+    defineProperty(info, 'firstDay', {
+      value: wi.firstDay,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    })
 
-      defineProperty(info, 'weekend', {
-        value: we,
-        writable: true,
-        enumerable: true,
-        configurable: true,
-      })
+    defineProperty(info, 'weekend', {
+      value: we,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    })
 
-      defineProperty(info, 'minimalDays', {
-        value: wi.minimalDays,
-        writable: true,
-        enumerable: true,
-        configurable: true,
-      })
+    defineProperty(info, 'minimalDays', {
+      value: wi.minimalDays,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    })
 
-      return info
-    } catch (e) {
-      throw new TypeError('Error retrieving weekInfo')
-    }
+    return info
   }
 
   /**

--- a/packages/intl-locale/index.ts
+++ b/packages/intl-locale/index.ts
@@ -675,6 +675,11 @@ export class Locale {
    * https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.getHourCycles
    */
   public getHourCycles() {
+    const locInternalSlots = getInternalSlots(this)
+    if (locInternalSlots.initializedLocale === undefined) {
+      throw new TypeError('Error uninitialized locale')
+    }
+
     return hourCyclesOfLocale(this)
   }
 
@@ -760,6 +765,11 @@ export class Locale {
    */
   public getWeekInfo() {
     const info = Object.create(Object.prototype)
+    const locInternalSlots = getInternalSlots(this)
+    if (locInternalSlots.initializedLocale === undefined) {
+      throw new TypeError('Error uninitialized locale')
+    }
+
     const wi = weekInfoOfLocale(this)
     const we = wi.weekend
 


### PR DESCRIPTION
## Why?

Fixes https://github.com/formatjs/formatjs/issues/4134

## What does this PR do?

- Add, in addition to the getter `locale.weekInfo`, a new method `locale.getWeekInfo()` to be spec compliant , and keep `locale.weekInfo` in the polyfill
- Apply the same logic to:
  - `calendars` -> `getCalendars()`
  - `collations` -> `getCollations()`
  - `hourCycles` -> `getHourCycles()`
  - `numberingSystems` -> `getNumberingSystems()`
  - `textInfo` -> `getTextInfo()`
  - `timeZones` -> `getTimeZones()`
