### PR TITLE
Update MISSING_TRANSLATION docs

### DIFF
--- a/website/docs/guides/develop.md
+++ b/website/docs/guides/develop.md
@@ -76,7 +76,7 @@ When some native Intl APIs don't support certain locales, or missing `locale-dat
 
 ### `MISSING_TRANSLATION`
 
-This gets triggered whenever we try to look up a translated message in `messages` for a given `id` and it's not there, thus falling back to `defaultMessage`.
+This gets triggered whenever we try to look up a translated message in `messages` for a given `id` and it's not there and there is no fallback `defaultMessage` for the given `id`.
 
 :::caution verbosity
 This error will be triggered very often since it happens for every message that does not have a translation. Therefore if you do log it remotely there should be throttling in place.


### PR DESCRIPTION
This docs change clarifies that the MISSING_TRANSLATION error is only triggered when the translation is missing **and** there is no defaultMessage fallback value.

I was confused by the existing wording:
```
This gets triggered whenever we try to look up a translated message in `messages` for a given `id` and it's not there, thus falling back to `defaultMessage`.
```
and i assumed that MISSING_TRANSLATION would be triggered when the translation was missing.