### PR TITLE
fix(babel-plugin-formatjs): 1.Filter non-static-ids

### DIFF
--- a/packages/babel-plugin-formatjs/tests/__snapshots__/index.test.ts.snap
+++ b/packages/babel-plugin-formatjs/tests/__snapshots__/index.test.ts.snap
@@ -1225,6 +1225,72 @@ export default class Foo extends Component {
 }
 `;
 
+exports[`skipExtractionCallFormattedMessage 1`] = `
+{
+  "code": "import React from 'react';
+import { FormattedMessage, useIntl } from 'react-intl';
+
+function nonStaticId() {
+  return 'baz';
+}
+
+export default function IndexPage() {
+  var intl = useIntl();
+  return /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement("h1", null, intl.formatMessage({
+    id: "test"
+  })), /*#__PURE__*/React.createElement("h1", null, intl.formatMessage({
+    id: 'test.' + nonStaticId()
+  })), /*#__PURE__*/React.createElement("h1", null, intl.formatMessage({
+    id: "test.".concat(nonStaticId),
+    defaultMessage: 'testMassage'
+  })));
+}",
+  "data": {
+    "messages": [
+      {
+        "defaultMessage": undefined,
+        "description": undefined,
+        "id": "test",
+      },
+    ],
+    "meta": {},
+  },
+}
+`;
+
+exports[`skipExtractionExpressionFormattedMessage 1`] = `
+{
+  "code": "import React from 'react';
+import { FormattedMessage, useIntl } from 'react-intl';
+
+function nonStaticId() {
+  return 'baz';
+}
+
+export default function IndexPage() {
+  var intl = useIntl();
+  return /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement("h1", null, intl.formatMessage({
+    id: "test"
+  })), /*#__PURE__*/React.createElement("h1", null, intl.formatMessage({
+    id: 'test.' + nonStaticId()
+  })), /*#__PURE__*/React.createElement("h1", null, intl.formatMessage({
+    id: "test.".concat(nonStaticId),
+    defaultMessage: 'testMassage'
+  })));
+}",
+  "data": {
+    "messages": [
+      {
+        "defaultMessage": undefined,
+        "description": undefined,
+        "id": "test",
+      },
+    ],
+    "meta": {},
+  },
+}
+`;
+
 exports[`skipExtractionFormattedMessage 1`] = `
 {
   "code": "import React, { Component } from 'react';

--- a/packages/babel-plugin-formatjs/tests/__snapshots__/index.test.ts.snap
+++ b/packages/babel-plugin-formatjs/tests/__snapshots__/index.test.ts.snap
@@ -1225,39 +1225,6 @@ export default class Foo extends Component {
 }
 `;
 
-exports[`skipExtractionCallFormattedMessage 1`] = `
-{
-  "code": "import React from 'react';
-import { FormattedMessage, useIntl } from 'react-intl';
-
-function nonStaticId() {
-  return 'baz';
-}
-
-export default function IndexPage() {
-  var intl = useIntl();
-  return /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement("h1", null, intl.formatMessage({
-    id: "test"
-  })), /*#__PURE__*/React.createElement("h1", null, intl.formatMessage({
-    id: 'test.' + nonStaticId()
-  })), /*#__PURE__*/React.createElement("h1", null, intl.formatMessage({
-    id: "test.".concat(nonStaticId),
-    defaultMessage: 'testMassage'
-  })));
-}",
-  "data": {
-    "messages": [
-      {
-        "defaultMessage": undefined,
-        "description": undefined,
-        "id": "test",
-      },
-    ],
-    "meta": {},
-  },
-}
-`;
-
 exports[`skipExtractionExpressionFormattedMessage 1`] = `
 {
   "code": "import React from 'react';

--- a/packages/babel-plugin-formatjs/tests/fixtures/skipExtractionExpressionFormattedMessage.js
+++ b/packages/babel-plugin-formatjs/tests/fixtures/skipExtractionExpressionFormattedMessage.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import {FormattedMessage, useIntl} from 'react-intl'
+function nonStaticId() {
+  return 'baz'
+}
+
+export default function IndexPage() {
+  const intl = useIntl()
+  return (
+    <>
+      <h1>{intl.formatMessage({id: `test`})}</h1>
+
+      <h1>{intl.formatMessage({id: 'test.' + nonStaticId()})}</h1>
+      <h1>
+        {intl.formatMessage({
+          id: `test.${nonStaticId}`,
+          defaultMessage: 'testMassage',
+        })}
+      </h1>
+    </>
+  )
+}

--- a/packages/babel-plugin-formatjs/tests/index.test.ts
+++ b/packages/babel-plugin-formatjs/tests/index.test.ts
@@ -182,7 +182,9 @@ test('Properly throws parse errors', () => {
 test('skipExtractionFormattedMessage', function () {
   transformAndCheck('skipExtractionFormattedMessage')
 })
-
+test('skipExtractionExpressionFormattedMessage', function () {
+  transformAndCheck('skipExtractionExpressionFormattedMessage')
+})
 // See: https://github.com/formatjs/formatjs/issues/3589#issuecomment-1532461569
 test('jsxNestedInCallExpr', () => {
   transformAndCheck('jsxNestedInCallExpr')

--- a/packages/babel-plugin-formatjs/visitors/call-expression.ts
+++ b/packages/babel-plugin-formatjs/visitors/call-expression.ts
@@ -100,6 +100,11 @@ export const visitor: VisitNodeFunction<PluginPass & State, t.CallExpression> =
         )
       )
 
+      // Filter non-static ids
+      if (descriptorPath.id && !descriptorPath.id?.evaluate()?.confident) {
+        return
+      }
+
       // If the message is already compiled, don't re-compile it
       if (descriptorPath.defaultMessage?.isArrayExpression()) {
         return

--- a/packages/babel-plugin-formatjs/visitors/jsx-opening-element.ts
+++ b/packages/babel-plugin-formatjs/visitors/jsx-opening-element.ts
@@ -57,6 +57,11 @@ export const visitor: VisitNodeFunction<
     ])
   )
 
+  // Filter non-static ids
+  if (descriptorPath.id && !descriptorPath.id?.evaluate()?.confident) {
+    return
+  }
+
   // In order for a default message to be extracted when
   // declaring a JSX element, it must be done with standard
   // `key=value` attributes. But it's completely valid to


### PR DESCRIPTION
Enhanced filtering of non-static ids.  fix: #2910