### PR TITLE
fix(eslint-plugin-formatjs): check intl.$t function calls

### DIFF
--- a/packages/eslint-plugin-formatjs/tests/enforce-description.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/enforce-description.test.ts
@@ -13,6 +13,10 @@ defineMessage({
     defaultMessage: '{count, plural, one {#} other {# more}}',
     description: 'asd'
 })`,
+    `intl.$t({
+    defaultMessage: '{count, plural, one {#} other {# more}}',
+    description: 'asd'
+})`,
     `intl.formatMessage({
   defaultMessage: '{count, plural, one {#} other {# more}}',
   description: 'asd' + 'aaz'
@@ -57,6 +61,17 @@ description={'asd' + 'azz'}
     {
       code: `
             intl.formatMessage({
+                defaultMessage: '{count, plural, one {#} other {# more}}'
+            })`,
+      errors: [
+        {
+          message: '`description` has to be specified in message descriptor',
+        },
+      ],
+    },
+    {
+      code: `
+            intl.$t({
                 defaultMessage: '{count, plural, one {#} other {# more}}'
             })`,
       errors: [

--- a/packages/eslint-plugin-formatjs/tests/enforce-id.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/enforce-id.test.ts
@@ -9,6 +9,10 @@ ruleTester.run('enforce-id', enforceId, {
       options,
     },
     {
+      code: `intl.$t({ id: 'j9qhn+', defaultMessage: '{count, plural, one {#} other {# more}}', description: 'asd'})`,
+      options,
+    },
+    {
       code: `<FormattedMessage id="/e77jM" defaultMessage="{count, plural, one {#} other {# more}}" values={{foo: 1}} />`,
       options,
     },
@@ -31,6 +35,20 @@ Actual: foo`,
       options,
       output: `
 intl.formatMessage({ id: 'j9qhn+', defaultMessage: '{count, plural, one {#} other {# more}}', description: 'asd'})`,
+    },
+    {
+      code: `
+intl.$t({ id: 'foo', defaultMessage: '{count, plural, one {#} other {# more}}', description: 'asd'})`,
+      errors: [
+        {
+          message: `"id" does not match with hash pattern [sha512:contenthash:base64:6].
+Expected: j9qhn+
+Actual: foo`,
+        },
+      ],
+      options,
+      output: `
+intl.$t({ id: 'j9qhn+', defaultMessage: '{count, plural, one {#} other {# more}}', description: 'asd'})`,
     },
     {
       code: `

--- a/packages/eslint-plugin-formatjs/util.ts
+++ b/packages/eslint-plugin-formatjs/util.ts
@@ -68,7 +68,8 @@ export function isIntlFormatMessageCall(
     node.callee.object.type === 'Identifier' &&
     node.callee.object.name === 'intl' &&
     node.callee.property.type === 'Identifier' &&
-    node.callee.property.name === 'formatMessage' &&
+    (node.callee.property.name === 'formatMessage' ||
+      node.callee.property.name === '$t') &&
     node.arguments.length >= 1 &&
     node.arguments[0].type === 'ObjectExpression'
   )


### PR DESCRIPTION
Fixes #4182 

We currently check `intl.formatMessage` function calls, so we should also check its shorthand counterpart.

Added this check and a couple of test cases.