### PR TITLE
fix(@formatjs/intl-localematcher): return unicode locale extension field in BestFitMatcher

### DIFF
--- a/packages/intl-localematcher/abstract/BestFitMatcher.ts
+++ b/packages/intl-localematcher/abstract/BestFitMatcher.ts
@@ -34,11 +34,16 @@ export function BestFitMatcher(
   })
 
   let foundLocale: string | undefined
+  let extension: string | undefined
   for (const l of requestedLocales) {
     if (foundLocale) {
       break
     }
     const noExtensionLocale = l.replace(UNICODE_EXTENSION_SEQUENCE_REGEX, '')
+
+    if (l !== noExtensionLocale) {
+      extension = l.slice(noExtensionLocale.length, l.length)
+    }
 
     if (availableLocales.has(noExtensionLocale)) {
       foundLocale = noExtensionLocale
@@ -76,5 +81,6 @@ export function BestFitMatcher(
       canonicalizedLocaleMap[foundLocale] ||
       minimizedAvailableLocaleMap[foundLocale] ||
       foundLocale,
+    extension,
   }
 }

--- a/packages/intl-localematcher/abstract/LookupMatcher.ts
+++ b/packages/intl-localematcher/abstract/LookupMatcher.ts
@@ -26,10 +26,7 @@ export function LookupMatcher(
     if (availableLocale) {
       result.locale = availableLocale
       if (locale !== noExtensionLocale) {
-        result.extension = locale.slice(
-          noExtensionLocale.length + 1,
-          locale.length
-        )
+        result.extension = locale.slice(noExtensionLocale.length, locale.length)
       }
       return result
     }

--- a/packages/intl-localematcher/tests/BestFitMatcher.test.ts
+++ b/packages/intl-localematcher/tests/BestFitMatcher.test.ts
@@ -21,3 +21,12 @@ test('BestFitMatcher en', function () {
     locale: 'en',
   })
 })
+
+test('BestFitMatcher extension', function () {
+  expect(
+    BestFitMatcher(new Set(['th']), ['th-u-ca-gregory'], () => 'en')
+  ).toEqual({
+    locale: 'th',
+    extension: '-u-ca-gregory',
+  })
+})

--- a/packages/intl-localematcher/tests/LookupMatcher.test.ts
+++ b/packages/intl-localematcher/tests/LookupMatcher.test.ts
@@ -15,3 +15,12 @@ test('LookupMatcher', function () {
     locale: 'zh',
   })
 })
+
+test('LookupMatcher', function () {
+  expect(
+    LookupMatcher(new Set(['th']), ['th-u-ca-gregory'], () => 'en')
+  ).toEqual({
+    locale: 'th',
+    extension: '-u-ca-gregory',
+  })
+})

--- a/packages/intl-localematcher/tests/ResolveLocale.test.ts
+++ b/packages/intl-localematcher/tests/ResolveLocale.test.ts
@@ -28,6 +28,29 @@ test('ResolveLocale', function () {
     dataLocale: 'zh-Hant-TW',
     locale: 'zh-Hant-TW',
   })
+
+  expect(
+    ResolveLocale(
+      new Set(['th', 'en']),
+      ['th-u-ca-gregory'],
+      {localeMatcher: 'best fit'},
+      ['ca', 'nu', 'hc'],
+      {
+        th: {
+          nu: ['latn'],
+          ca: ['buddhist', 'gregory'],
+          hc: ['h23', 'h12'],
+        },
+      },
+      () => 'en'
+    )
+  ).toEqual({
+    dataLocale: 'th',
+    locale: 'th-u-ca-gregory',
+    nu: 'latn',
+    ca: 'gregory',
+    hc: 'h23',
+  })
 })
 
 test('empty requested', function () {


### PR DESCRIPTION
Fixes #4186 