### PR TITLE
Fix date weekday long format

### DIFF
--- a/packages/icu-skeleton-parser/date-time.ts
+++ b/packages/icu-skeleton-parser/date-time.ts
@@ -60,7 +60,7 @@ export function parseDateTimeSkeleton(
         )
       // Weekday
       case 'E':
-        result.weekday = len === 4 ? 'short' : len === 5 ? 'narrow' : 'short'
+        result.weekday = len === 4 ? 'long' : len === 5 ? 'narrow' : 'short'
         break
       case 'e':
         if (len < 4) {

--- a/packages/icu-skeleton-parser/tests/__snapshots__/index.test.ts.snap
+++ b/packages/icu-skeleton-parser/tests/__snapshots__/index.test.ts.snap
@@ -365,6 +365,15 @@ exports[`case: "EEE, MMM d, ''yy" 1`] = `
 }
 `;
 
+exports[`case: "EEEE, d MMMM yyyy" 1`] = `
+{
+  "day": "numeric",
+  "month": "long",
+  "weekday": "long",
+  "year": "numeric",
+}
+`;
+
 exports[`case: "h:mm a" 1`] = `
 {
   "hour": "numeric",

--- a/packages/icu-skeleton-parser/tests/index.test.ts
+++ b/packages/icu-skeleton-parser/tests/index.test.ts
@@ -4,6 +4,7 @@ import {parseNumberSkeletonFromString} from '../number'
 test.each([
   `yyyy.MM.dd G 'at' HH:mm:ss zzzz`,
   `EEE, MMM d, ''yy`,
+  `EEEE, d MMMM yyyy`,
   `h:mm a`,
   ``,
 ])('case: %p', skeleton => {


### PR DESCRIPTION
Date pattern `EEEE` erroneously got detected as `weekday: 'short'`, seemingly a typo.