### PR TITLE
fix(@formatjs/intl-durationformat): Fix main file in package.json

### DIFF
--- a/packages/intl-durationformat/package.json
+++ b/packages/intl-durationformat/package.json
@@ -15,7 +15,7 @@
   "author": "Long Ho <holevietlong@gmail.com>",
   "homepage": "https://github.com/formatjs/formatjs#readme",
   "license": "MIT",
-  "main": "index.umd.js",
+  "main": "index.js",
   "types": "index.d.ts",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fix main file from `index.umd.js` to `index.js`

There is no `index.umd.js` file in the package: https://www.npmjs.com/package/@formatjs/intl-durationformat?activeTab=code