### PR TITLE
chore(deps): revert typescript peer deps major update

### DIFF
--- a/packages/intl/package.json
+++ b/packages/intl/package.json
@@ -42,7 +42,7 @@
     "@formatjs/intl-numberformat": "workspace:*"
   },
   "peerDependencies": {
-    "typescript": "5"
+    "typescript": "^4.7 || 5"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/packages/react-intl/package.json
+++ b/packages/react-intl/package.json
@@ -145,7 +145,7 @@
   },
   "peerDependencies": {
     "react": "^16.6.0 || 17 || 18",
-    "typescript": "5"
+    "typescript": "^4.7 || 5"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -573,7 +573,7 @@ importers:
         specifier: ^2.4.0
         version: 2.4.0
       typescript:
-        specifier: '5'
+        specifier: ^4.7 || 5
         version: 5.2.2
     devDependencies:
       '@formatjs/intl-datetimeformat':
@@ -815,7 +815,7 @@ importers:
         specifier: ^2.4.0
         version: 2.4.0
       typescript:
-        specifier: '5'
+        specifier: ^4.7 || 5
         version: 5.2.2
     devDependencies:
       '@formatjs/intl-numberformat':


### PR DESCRIPTION
## Description

Restores typescript ^4.7 as a valid peer dep, since removing it acts as a breaking change.

Reverts part of https://github.com/formatjs/formatjs/commit/141dca6dcc7a21ce87010b5f69e5080d74e16b9b.

Closes https://github.com/formatjs/formatjs/issues/4284

### Changes in this Pull Request
- Reverts typescript dependency back to `^4.7 || 5`

