### PR TITLE
feat(eslint-plugin-formatjs): improve codebase with better types

### DIFF
--- a/packages/eslint-plugin-formatjs/BUILD
+++ b/packages/eslint-plugin-formatjs/BUILD
@@ -27,7 +27,6 @@ SRCS = glob(["rules/*.ts"]) + [
 
 SRC_DEPS = [
     "//:node_modules/@types/eslint",
-    "//:node_modules/@types/estree",
     "//:node_modules/@types/node",
     "//:node_modules/@types/picomatch",
     "//:node_modules/@typescript-eslint/utils",

--- a/packages/eslint-plugin-formatjs/index.ts
+++ b/packages/eslint-plugin-formatjs/index.ts
@@ -29,7 +29,7 @@ import {
   name as noComplexSelectorsName,
 } from './rules/no-complex-selectors'
 import {rule as noEmoji, name as noEmojiName} from './rules/no-emoji'
-import noId from './rules/no-id'
+import {rule as noId, name as noIdName} from './rules/no-id'
 import noMultiplePlurals from './rules/no-multiple-plurals'
 import noMultipleWhitespaces from './rules/no-multiple-whitespaces'
 import noOffset from './rules/no-offset'
@@ -50,7 +50,7 @@ const plugin: Plugin = {
     [noCamelCaseName]: noCamelCase,
     [noComplexSelectorsName]: noComplexSelectors,
     [noEmojiName]: noEmoji,
-    'no-id': noId,
+    [noIdName]: noId,
     'no-invalid-icu': noInvalidICU,
     'no-literal-string-in-jsx': noLiteralStringInJsx,
     'no-multiple-plurals': noMultiplePlurals,

--- a/packages/eslint-plugin-formatjs/index.ts
+++ b/packages/eslint-plugin-formatjs/index.ts
@@ -15,7 +15,10 @@ import {
   rule as enforcePlaceholders,
   name as enforcePlaceholdersName,
 } from './rules/enforce-placeholders'
-import noInvalidICU from './rules/no-invalid-icu'
+import {
+  rule as noInvalidICU,
+  name as noInvalidICUName,
+} from './rules/no-invalid-icu'
 import {
   rule as enforcePluralRules,
   name as enforcePluralRulesName,
@@ -51,7 +54,7 @@ const plugin: Plugin = {
     [noComplexSelectorsName]: noComplexSelectors,
     [noEmojiName]: noEmoji,
     [noIdName]: noId,
-    'no-invalid-icu': noInvalidICU,
+    [noInvalidICUName]: noInvalidICU,
     'no-literal-string-in-jsx': noLiteralStringInJsx,
     'no-multiple-plurals': noMultiplePlurals,
     'no-multiple-whitespaces': noMultipleWhitespaces,

--- a/packages/eslint-plugin-formatjs/index.ts
+++ b/packages/eslint-plugin-formatjs/index.ts
@@ -1,5 +1,11 @@
-import blocklistElements from './rules/blocklist-elements'
-import enforceDefaultMessage from './rules/enforce-default-message'
+import {
+  rule as blocklistElements,
+  name as blocklistElementRuleName,
+} from './rules/blocklist-elements'
+import {
+  rule as enforceDefaultMessage,
+  name as enforceDefaultMessageName,
+} from './rules/enforce-default-message'
 import enforceDescription from './rules/enforce-description'
 import enforceId from './rules/enforce-id'
 import enforcePlaceholders from './rules/enforce-placeholders'
@@ -16,11 +22,12 @@ import noLiteralStringInJsx from './rules/no-literal-string-in-jsx'
 import noUselessMessage from './rules/no-useless-message'
 import preferFormattedMessage from './rules/prefer-formatted-message'
 import preferPoundInPlural from './rules/prefer-pound-in-plural'
+import {RuleModule} from '@typescript-eslint/utils/ts-eslint'
 
-const plugin = {
+const plugin: Plugin = {
   rules: {
-    'blocklist-elements': blocklistElements,
-    'enforce-default-message': enforceDefaultMessage,
+    [blocklistElementRuleName]: blocklistElements,
+    [enforceDefaultMessageName]: enforceDefaultMessage,
     'enforce-description': enforceDescription,
     'enforce-id': enforceId,
     'enforce-placeholders': enforcePlaceholders,
@@ -40,6 +47,8 @@ const plugin = {
   },
 }
 
-export type Plugin = typeof plugin
+export type Plugin = {
+  rules: Record<string, RuleModule<string, readonly unknown[]>>
+}
 
 module.exports = plugin

--- a/packages/eslint-plugin-formatjs/index.ts
+++ b/packages/eslint-plugin-formatjs/index.ts
@@ -36,7 +36,10 @@ import {rule as noId, name as noIdName} from './rules/no-id'
 import noMultiplePlurals from './rules/no-multiple-plurals'
 import noMultipleWhitespaces from './rules/no-multiple-whitespaces'
 import noOffset from './rules/no-offset'
-import noLiteralStringInJsx from './rules/no-literal-string-in-jsx'
+import {
+  rule as noLiteralStringInJsx,
+  name as noLiteralStringInJsxName,
+} from './rules/no-literal-string-in-jsx'
 import noUselessMessage from './rules/no-useless-message'
 import preferFormattedMessage from './rules/prefer-formatted-message'
 import preferPoundInPlural from './rules/prefer-pound-in-plural'
@@ -55,7 +58,7 @@ const plugin: Plugin = {
     [noEmojiName]: noEmoji,
     [noIdName]: noId,
     [noInvalidICUName]: noInvalidICU,
-    'no-literal-string-in-jsx': noLiteralStringInJsx,
+    [noLiteralStringInJsxName]: noLiteralStringInJsx,
     'no-multiple-plurals': noMultiplePlurals,
     'no-multiple-whitespaces': noMultipleWhitespaces,
     'no-offset': noOffset,

--- a/packages/eslint-plugin-formatjs/index.ts
+++ b/packages/eslint-plugin-formatjs/index.ts
@@ -16,7 +16,10 @@ import {
   name as enforcePlaceholdersName,
 } from './rules/enforce-placeholders'
 import noInvalidICU from './rules/no-invalid-icu'
-import enforcePluralRules from './rules/enforce-plural-rules'
+import {
+  rule as enforcePluralRules,
+  name as enforcePluralRulesName,
+} from './rules/enforce-plural-rules'
 import noCamelCase from './rules/no-camel-case'
 import noComplexSelectors from './rules/no-complex-selectors'
 import noEmoji from './rules/no-emoji'
@@ -37,7 +40,7 @@ const plugin: Plugin = {
     [enforceDescriptionName]: enforceDescription,
     [enforceIdName]: enforceId,
     [enforcePlaceholdersName]: enforcePlaceholders,
-    'enforce-plural-rules': enforcePluralRules,
+    [enforcePluralRulesName]: enforcePluralRules,
     'no-camel-case': noCamelCase,
     'no-complex-selectors': noComplexSelectors,
     'no-emoji': noEmoji,

--- a/packages/eslint-plugin-formatjs/index.ts
+++ b/packages/eslint-plugin-formatjs/index.ts
@@ -24,7 +24,10 @@ import {
   rule as noCamelCase,
   name as noCamelCaseName,
 } from './rules/no-camel-case'
-import noComplexSelectors from './rules/no-complex-selectors'
+import {
+  rule as noComplexSelectors,
+  name as noComplexSelectorsName,
+} from './rules/no-complex-selectors'
 import noEmoji from './rules/no-emoji'
 import noId from './rules/no-id'
 import noMultiplePlurals from './rules/no-multiple-plurals'
@@ -45,7 +48,7 @@ const plugin: Plugin = {
     [enforcePlaceholdersName]: enforcePlaceholders,
     [enforcePluralRulesName]: enforcePluralRules,
     [noCamelCaseName]: noCamelCase,
-    'no-complex-selectors': noComplexSelectors,
+    [noComplexSelectorsName]: noComplexSelectors,
     'no-emoji': noEmoji,
     'no-id': noId,
     'no-invalid-icu': noInvalidICU,

--- a/packages/eslint-plugin-formatjs/index.ts
+++ b/packages/eslint-plugin-formatjs/index.ts
@@ -33,7 +33,10 @@ import {
 } from './rules/no-complex-selectors'
 import {rule as noEmoji, name as noEmojiName} from './rules/no-emoji'
 import {rule as noId, name as noIdName} from './rules/no-id'
-import noMultiplePlurals from './rules/no-multiple-plurals'
+import {
+  rule as noMultiplePlurals,
+  name as noMultiplePluralsName,
+} from './rules/no-multiple-plurals'
 import noMultipleWhitespaces from './rules/no-multiple-whitespaces'
 import noOffset from './rules/no-offset'
 import {
@@ -59,7 +62,7 @@ const plugin: Plugin = {
     [noIdName]: noId,
     [noInvalidICUName]: noInvalidICU,
     [noLiteralStringInJsxName]: noLiteralStringInJsx,
-    'no-multiple-plurals': noMultiplePlurals,
+    [noMultiplePluralsName]: noMultiplePlurals,
     'no-multiple-whitespaces': noMultipleWhitespaces,
     'no-offset': noOffset,
     'no-useless-message': noUselessMessage,

--- a/packages/eslint-plugin-formatjs/index.ts
+++ b/packages/eslint-plugin-formatjs/index.ts
@@ -11,7 +11,10 @@ import {
   name as enforceDescriptionName,
 } from './rules/enforce-description'
 import {rule as enforceId, name as enforceIdName} from './rules/enforce-id'
-import enforcePlaceholders from './rules/enforce-placeholders'
+import {
+  rule as enforcePlaceholders,
+  name as enforcePlaceholdersName,
+} from './rules/enforce-placeholders'
 import noInvalidICU from './rules/no-invalid-icu'
 import enforcePluralRules from './rules/enforce-plural-rules'
 import noCamelCase from './rules/no-camel-case'
@@ -33,7 +36,7 @@ const plugin: Plugin = {
     [enforceDefaultMessageName]: enforceDefaultMessage,
     [enforceDescriptionName]: enforceDescription,
     [enforceIdName]: enforceId,
-    'enforce-placeholders': enforcePlaceholders,
+    [enforcePlaceholdersName]: enforcePlaceholders,
     'enforce-plural-rules': enforcePluralRules,
     'no-camel-case': noCamelCase,
     'no-complex-selectors': noComplexSelectors,

--- a/packages/eslint-plugin-formatjs/index.ts
+++ b/packages/eslint-plugin-formatjs/index.ts
@@ -20,7 +20,10 @@ import {
   rule as enforcePluralRules,
   name as enforcePluralRulesName,
 } from './rules/enforce-plural-rules'
-import noCamelCase from './rules/no-camel-case'
+import {
+  rule as noCamelCase,
+  name as noCamelCaseName,
+} from './rules/no-camel-case'
 import noComplexSelectors from './rules/no-complex-selectors'
 import noEmoji from './rules/no-emoji'
 import noId from './rules/no-id'
@@ -41,7 +44,7 @@ const plugin: Plugin = {
     [enforceIdName]: enforceId,
     [enforcePlaceholdersName]: enforcePlaceholders,
     [enforcePluralRulesName]: enforcePluralRules,
-    'no-camel-case': noCamelCase,
+    [noCamelCaseName]: noCamelCase,
     'no-complex-selectors': noComplexSelectors,
     'no-emoji': noEmoji,
     'no-id': noId,

--- a/packages/eslint-plugin-formatjs/index.ts
+++ b/packages/eslint-plugin-formatjs/index.ts
@@ -28,7 +28,7 @@ import {
   rule as noComplexSelectors,
   name as noComplexSelectorsName,
 } from './rules/no-complex-selectors'
-import noEmoji from './rules/no-emoji'
+import {rule as noEmoji, name as noEmojiName} from './rules/no-emoji'
 import noId from './rules/no-id'
 import noMultiplePlurals from './rules/no-multiple-plurals'
 import noMultipleWhitespaces from './rules/no-multiple-whitespaces'
@@ -49,7 +49,7 @@ const plugin: Plugin = {
     [enforcePluralRulesName]: enforcePluralRules,
     [noCamelCaseName]: noCamelCase,
     [noComplexSelectorsName]: noComplexSelectors,
-    'no-emoji': noEmoji,
+    [noEmojiName]: noEmoji,
     'no-id': noId,
     'no-invalid-icu': noInvalidICU,
     'no-literal-string-in-jsx': noLiteralStringInJsx,

--- a/packages/eslint-plugin-formatjs/index.ts
+++ b/packages/eslint-plugin-formatjs/index.ts
@@ -10,7 +10,7 @@ import {
   rule as enforceDescription,
   name as enforceDescriptionName,
 } from './rules/enforce-description'
-import enforceId from './rules/enforce-id'
+import {rule as enforceId, name as enforceIdName} from './rules/enforce-id'
 import enforcePlaceholders from './rules/enforce-placeholders'
 import noInvalidICU from './rules/no-invalid-icu'
 import enforcePluralRules from './rules/enforce-plural-rules'
@@ -32,7 +32,7 @@ const plugin: Plugin = {
     [blocklistElementRuleName]: blocklistElements,
     [enforceDefaultMessageName]: enforceDefaultMessage,
     [enforceDescriptionName]: enforceDescription,
-    'enforce-id': enforceId,
+    [enforceIdName]: enforceId,
     'enforce-placeholders': enforcePlaceholders,
     'enforce-plural-rules': enforcePluralRules,
     'no-camel-case': noCamelCase,

--- a/packages/eslint-plugin-formatjs/index.ts
+++ b/packages/eslint-plugin-formatjs/index.ts
@@ -6,7 +6,10 @@ import {
   rule as enforceDefaultMessage,
   name as enforceDefaultMessageName,
 } from './rules/enforce-default-message'
-import enforceDescription from './rules/enforce-description'
+import {
+  rule as enforceDescription,
+  name as enforceDescriptionName,
+} from './rules/enforce-description'
 import enforceId from './rules/enforce-id'
 import enforcePlaceholders from './rules/enforce-placeholders'
 import noInvalidICU from './rules/no-invalid-icu'
@@ -28,7 +31,7 @@ const plugin: Plugin = {
   rules: {
     [blocklistElementRuleName]: blocklistElements,
     [enforceDefaultMessageName]: enforceDefaultMessage,
-    'enforce-description': enforceDescription,
+    [enforceDescriptionName]: enforceDescription,
     'enforce-id': enforceId,
     'enforce-placeholders': enforcePlaceholders,
     'enforce-plural-rules': enforcePluralRules,

--- a/packages/eslint-plugin-formatjs/index.ts
+++ b/packages/eslint-plugin-formatjs/index.ts
@@ -54,7 +54,10 @@ import {
   rule as preferFormattedMessage,
   name as preferFormattedMessageName,
 } from './rules/prefer-formatted-message'
-import preferPoundInPlural from './rules/prefer-pound-in-plural'
+import {
+  rule as preferPoundInPlural,
+  name as preferPoundInPluralName,
+} from './rules/prefer-pound-in-plural'
 import {RuleModule} from '@typescript-eslint/utils/ts-eslint'
 
 const plugin: Plugin = {
@@ -76,7 +79,7 @@ const plugin: Plugin = {
     [noOffsetName]: noOffset,
     [noUselessMessageName]: noUselessMessage,
     [preferFormattedMessageName]: preferFormattedMessage,
-    'prefer-pound-in-plural': preferPoundInPlural,
+    [preferPoundInPluralName]: preferPoundInPlural,
   },
 }
 

--- a/packages/eslint-plugin-formatjs/index.ts
+++ b/packages/eslint-plugin-formatjs/index.ts
@@ -41,7 +41,7 @@ import {
   rule as noMultipleWhitespaces,
   name as noMultipleWhitespacesName,
 } from './rules/no-multiple-whitespaces'
-import noOffset from './rules/no-offset'
+import {rule as noOffset, name as noOffsetName} from './rules/no-offset'
 import {
   rule as noLiteralStringInJsx,
   name as noLiteralStringInJsxName,
@@ -67,7 +67,7 @@ const plugin: Plugin = {
     [noLiteralStringInJsxName]: noLiteralStringInJsx,
     [noMultiplePluralsName]: noMultiplePlurals,
     [noMultipleWhitespacesName]: noMultipleWhitespaces,
-    'no-offset': noOffset,
+    [noOffsetName]: noOffset,
     'no-useless-message': noUselessMessage,
     'prefer-formatted-message': preferFormattedMessage,
     'prefer-pound-in-plural': preferPoundInPlural,

--- a/packages/eslint-plugin-formatjs/index.ts
+++ b/packages/eslint-plugin-formatjs/index.ts
@@ -37,7 +37,10 @@ import {
   rule as noMultiplePlurals,
   name as noMultiplePluralsName,
 } from './rules/no-multiple-plurals'
-import noMultipleWhitespaces from './rules/no-multiple-whitespaces'
+import {
+  rule as noMultipleWhitespaces,
+  name as noMultipleWhitespacesName,
+} from './rules/no-multiple-whitespaces'
 import noOffset from './rules/no-offset'
 import {
   rule as noLiteralStringInJsx,
@@ -63,7 +66,7 @@ const plugin: Plugin = {
     [noInvalidICUName]: noInvalidICU,
     [noLiteralStringInJsxName]: noLiteralStringInJsx,
     [noMultiplePluralsName]: noMultiplePlurals,
-    'no-multiple-whitespaces': noMultipleWhitespaces,
+    [noMultipleWhitespacesName]: noMultipleWhitespaces,
     'no-offset': noOffset,
     'no-useless-message': noUselessMessage,
     'prefer-formatted-message': preferFormattedMessage,

--- a/packages/eslint-plugin-formatjs/index.ts
+++ b/packages/eslint-plugin-formatjs/index.ts
@@ -50,7 +50,10 @@ import {
   rule as noUselessMessage,
   name as noUselessMessageName,
 } from './rules/no-useless-message'
-import preferFormattedMessage from './rules/prefer-formatted-message'
+import {
+  rule as preferFormattedMessage,
+  name as preferFormattedMessageName,
+} from './rules/prefer-formatted-message'
 import preferPoundInPlural from './rules/prefer-pound-in-plural'
 import {RuleModule} from '@typescript-eslint/utils/ts-eslint'
 
@@ -72,7 +75,7 @@ const plugin: Plugin = {
     [noMultipleWhitespacesName]: noMultipleWhitespaces,
     [noOffsetName]: noOffset,
     [noUselessMessageName]: noUselessMessage,
-    'prefer-formatted-message': preferFormattedMessage,
+    [preferFormattedMessageName]: preferFormattedMessage,
     'prefer-pound-in-plural': preferPoundInPlural,
   },
 }

--- a/packages/eslint-plugin-formatjs/index.ts
+++ b/packages/eslint-plugin-formatjs/index.ts
@@ -46,7 +46,10 @@ import {
   rule as noLiteralStringInJsx,
   name as noLiteralStringInJsxName,
 } from './rules/no-literal-string-in-jsx'
-import noUselessMessage from './rules/no-useless-message'
+import {
+  rule as noUselessMessage,
+  name as noUselessMessageName,
+} from './rules/no-useless-message'
 import preferFormattedMessage from './rules/prefer-formatted-message'
 import preferPoundInPlural from './rules/prefer-pound-in-plural'
 import {RuleModule} from '@typescript-eslint/utils/ts-eslint'
@@ -68,7 +71,7 @@ const plugin: Plugin = {
     [noMultiplePluralsName]: noMultiplePlurals,
     [noMultipleWhitespacesName]: noMultipleWhitespaces,
     [noOffsetName]: noOffset,
-    'no-useless-message': noUselessMessage,
+    [noUselessMessageName]: noUselessMessage,
     'prefer-formatted-message': preferFormattedMessage,
     'prefer-pound-in-plural': preferPoundInPlural,
   },

--- a/packages/eslint-plugin-formatjs/package.json
+++ b/packages/eslint-plugin-formatjs/package.json
@@ -24,13 +24,13 @@
     "@formatjs/ts-transformer": "workspace:*",
     "@types/eslint": "7 || 8",
     "@types/picomatch": "^2.3.0",
-    "@typescript-eslint/utils": "^6.5.0",
+    "@typescript-eslint/utils": "^6.18.1",
     "emoji-regex": "^10.2.1",
     "magic-string": "^0.30.0",
     "picomatch": "^2.3.1",
     "tslib": "2.6.2",
     "typescript": "5",
-    "unicode-emoji-utils": "^1.1.1"
+    "unicode-emoji-utils": "^1.2.0"
   },
   "peerDependencies": {
     "eslint": "7 || 8"

--- a/packages/eslint-plugin-formatjs/rules/enforce-description.ts
+++ b/packages/eslint-plugin-formatjs/rules/enforce-description.ts
@@ -1,8 +1,23 @@
 import {TSESTree} from '@typescript-eslint/utils'
-import {Rule} from 'eslint'
+import {
+  RuleContext,
+  RuleModule,
+  RuleListener,
+} from '@typescript-eslint/utils/ts-eslint'
 import {extractMessages, getSettings} from '../util'
 
-function checkNode(context: Rule.RuleContext, node: TSESTree.Node) {
+export enum Option {
+  literal = 'literal',
+  anything = 'anything',
+}
+
+type MessageIds = 'enforceDescription' | 'enforceDescriptionLiteral'
+type Options = [`${Option}`?]
+
+function checkNode(
+  context: RuleContext<MessageIds, Options>,
+  node: TSESTree.Node
+) {
   const msgs = extractMessages(node, getSettings(context))
   const {
     options: [type],
@@ -17,40 +32,49 @@ function checkNode(context: Rule.RuleContext, node: TSESTree.Node) {
       if (type === 'literal' && descriptionNode) {
         context.report({
           node: descriptionNode as any,
-          message:
-            '`description` has to be a string literal (not function call or variable)',
+          messageId: 'enforceDescriptionLiteral',
         })
       } else if (!descriptionNode) {
         context.report({
           node: node as any,
-          message: '`description` has to be specified in message descriptor',
+          messageId: 'enforceDescription',
         })
       }
     }
   }
 }
 
-export default {
+export const name = 'enforce-description'
+
+export const rule: RuleModule<MessageIds, Options, RuleListener> = {
   meta: {
     type: 'problem',
     docs: {
       description: 'Enforce description in message descriptor',
-      category: 'Errors',
-      recommended: false,
       url: 'https://formatjs.io/docs/tooling/linter#enforce-description',
     },
     fixable: 'code',
     schema: [
       {
-        enum: ['literal', 'anything'],
+        type: 'string',
+        enum: Object.keys(Option),
       },
     ],
+    messages: {
+      enforceDescription:
+        '`description` has to be specified in message descriptor',
+      enforceDescriptionLiteral:
+        '`description` has to be a string literal (not function call or variable)',
+    },
   },
+  defaultOptions: [],
   create(context) {
     const callExpressionVisitor = (node: TSESTree.Node) =>
       checkNode(context, node)
 
+    //@ts-expect-error defineTemplateBodyVisitor exists in Vue parser
     if (context.parserServices.defineTemplateBodyVisitor) {
+      //@ts-expect-error
       return context.parserServices.defineTemplateBodyVisitor(
         {
           CallExpression: callExpressionVisitor,
@@ -65,4 +89,4 @@ export default {
       CallExpression: callExpressionVisitor,
     }
   },
-} as Rule.RuleModule
+}

--- a/packages/eslint-plugin-formatjs/rules/enforce-description.ts
+++ b/packages/eslint-plugin-formatjs/rules/enforce-description.ts
@@ -31,12 +31,12 @@ function checkNode(
     if (!description) {
       if (type === 'literal' && descriptionNode) {
         context.report({
-          node: descriptionNode as any,
+          node: descriptionNode,
           messageId: 'enforceDescriptionLiteral',
         })
       } else if (!descriptionNode) {
         context.report({
-          node: node as any,
+          node: node,
           messageId: 'enforceDescription',
         })
       }

--- a/packages/eslint-plugin-formatjs/rules/enforce-id.ts
+++ b/packages/eslint-plugin-formatjs/rules/enforce-id.ts
@@ -109,27 +109,25 @@ function checkNode(
             fix(fixer) {
               if (idPropNode) {
                 if (idPropNode.type === 'JSXAttribute') {
-                  return fixer.replaceText(
-                    idPropNode as any,
-                    `id="${correctId}"`
+                  return fixer.replaceText(idPropNode, `id="${correctId}"`)
+                }
+                return fixer.replaceText(idPropNode, `id: '${correctId}'`)
+              }
+
+              if (messagePropNode) {
+                // Insert after default message node
+                if (messagePropNode.type === 'JSXAttribute') {
+                  return fixer.insertTextAfter(
+                    messagePropNode,
+                    ` id="${correctId}"`
                   )
                 }
-                return fixer.replaceText(
-                  idPropNode as any,
-                  `id: '${correctId}'`
-                )
-              }
-              // Insert after default message node
-              if (messagePropNode!.type === 'JSXAttribute') {
                 return fixer.insertTextAfter(
-                  messagePropNode as any,
-                  ` id="${correctId}"`
+                  messagePropNode,
+                  `, id: '${correctId}'`
                 )
               }
-              return fixer.insertTextAfter(
-                messagePropNode as any,
-                `, id: '${correctId}'`
-              )
+              return null
             },
           })
         }

--- a/packages/eslint-plugin-formatjs/rules/enforce-plural-rules.ts
+++ b/packages/eslint-plugin-formatjs/rules/enforce-plural-rules.ts
@@ -4,16 +4,12 @@ import {
   parse,
 } from '@formatjs/icu-messageformat-parser'
 import {TSESTree} from '@typescript-eslint/utils'
-import {Rule} from 'eslint'
+import {
+  RuleContext,
+  RuleModule,
+  RuleListener,
+} from '@typescript-eslint/utils/ts-eslint'
 import {extractMessages, getSettings} from '../util'
-
-class PluralRulesEnforcement extends Error {
-  public message: string
-  constructor(message: string) {
-    super()
-    this.message = message
-  }
-}
 
 enum LDML {
   zero = 'zero',
@@ -24,37 +20,44 @@ enum LDML {
   other = 'other',
 }
 
-function verifyAst(
-  plConfig: Record<LDML, boolean>,
-  ast: MessageFormatElement[]
-) {
+type PluralConfig = {[key in LDML]?: boolean}
+export type Options = [PluralConfig?]
+type MessageIds = 'missingPlural' | 'forbidden'
+
+function verifyAst(plConfig: PluralConfig, ast: MessageFormatElement[]) {
+  const errors: {messageId: MessageIds; data: Record<string, unknown>}[] = []
   for (const el of ast) {
     if (isPluralElement(el)) {
       const rules = Object.keys(plConfig) as Array<LDML>
       for (const rule of rules) {
         if (plConfig[rule] && !el.options[rule]) {
-          throw new PluralRulesEnforcement(`Missing plural rule "${rule}"`)
+          errors.push({messageId: 'missingPlural', data: {rule}})
         }
         if (!plConfig[rule] && el.options[rule]) {
-          throw new PluralRulesEnforcement(`Plural rule "${rule}" is forbidden`)
+          errors.push({messageId: 'forbidden', data: {rule}})
         }
       }
       const {options} = el
       for (const selector of Object.keys(options)) {
-        verifyAst(plConfig, options[selector].value)
+        errors.push(...verifyAst(plConfig, options[selector].value))
       }
     }
   }
+
+  return errors
 }
 
-function checkNode(context: Rule.RuleContext, node: TSESTree.Node) {
+function checkNode(
+  context: RuleContext<MessageIds, Options>,
+  node: TSESTree.Node
+) {
   const settings = getSettings(context)
   const msgs = extractMessages(node, settings)
   if (!msgs.length) {
     return
   }
 
-  const plConfig: Record<keyof LDML, boolean> = context.options[0]
+  const plConfig = context.options[0]
   if (!plConfig) {
     return
   }
@@ -67,30 +70,29 @@ function checkNode(context: Rule.RuleContext, node: TSESTree.Node) {
     if (!defaultMessage || !messageNode) {
       continue
     }
-    try {
-      verifyAst(
-        context.options[0],
-        parse(defaultMessage, {
-          ignoreTag: settings.ignoreTag,
-        })
-      )
-    } catch (e) {
+    const errors = verifyAst(
+      plConfig,
+      parse(defaultMessage, {
+        ignoreTag: settings.ignoreTag,
+      })
+    )
+    for (const error of errors) {
       context.report({
-        node: messageNode as any,
-        message: e instanceof Error ? e.message : String(e),
+        node: messageNode,
+        ...error,
       })
     }
   }
 }
 
-const rule: Rule.RuleModule = {
+export const name = 'enforce-plural-rules'
+
+export const rule: RuleModule<MessageIds, Options, RuleListener> = {
   meta: {
     type: 'problem',
     docs: {
       description:
         'Enforce plural rules to always specify certain categories like `one`/`other`',
-      category: 'Errors',
-      recommended: false,
       url: 'https://formatjs.io/docs/tooling/linter#enforce-plural-rules',
     },
     fixable: 'code',
@@ -109,12 +111,18 @@ const rule: Rule.RuleModule = {
         additionalProperties: false,
       },
     ],
+    messages: {
+      missingPlural: `Missing plural rule "{{rule}}"`,
+      forbidden: `Plural rule "{{rule}}" is forbidden`,
+    },
   },
+  defaultOptions: [],
   create(context) {
     const callExpressionVisitor = (node: TSESTree.Node) =>
       checkNode(context, node)
-
+    //@ts-expect-error defineTemplateBodyVisitor exists in Vue parser
     if (context.parserServices.defineTemplateBodyVisitor) {
+      //@ts-expect-error
       return context.parserServices.defineTemplateBodyVisitor(
         {
           CallExpression: callExpressionVisitor,
@@ -130,5 +138,3 @@ const rule: Rule.RuleModule = {
     }
   },
 }
-
-export default rule

--- a/packages/eslint-plugin-formatjs/rules/no-emoji.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-emoji.ts
@@ -54,7 +54,7 @@ function checkNode(
         for (const emoji of extractEmojis(defaultMessage)) {
           if (!allowedEmojis.includes(emoji)) {
             context.report({
-              node: messageNode as any,
+              node: messageNode,
               messageId: 'notAllowedAboveVersion',
               data: {
                 versionAbove,
@@ -65,7 +65,7 @@ function checkNode(
         }
       } else {
         context.report({
-          node: messageNode as any,
+          node: messageNode,
           messageId: 'notAllowed',
         })
       }

--- a/packages/eslint-plugin-formatjs/rules/no-emoji.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-emoji.ts
@@ -88,7 +88,6 @@ const versionAboveEnums: EmojiVersion[] = [
   '13.1',
   '14.0',
   '15.0',
-  '15.1',
 ]
 
 export const rule: RuleModule<MessageIds, Options, RuleListener> = {

--- a/packages/eslint-plugin-formatjs/rules/no-id.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-id.ts
@@ -30,8 +30,8 @@ function checkNode(
         messageId: 'noId',
         fix(fixer) {
           const src = context.getSourceCode()
-          const token = src.getTokenAfter(idPropNode as any)
-          const fixes = [fixer.remove(idPropNode as any)]
+          const token = src.getTokenAfter(idPropNode)
+          const fixes = [fixer.remove(idPropNode)]
           if (token && !isComment(token) && token?.value === ',') {
             fixes.push(fixer.remove(token))
           }

--- a/packages/eslint-plugin-formatjs/rules/no-invalid-icu.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-invalid-icu.ts
@@ -1,9 +1,21 @@
 import {parse} from '@formatjs/icu-messageformat-parser'
 import {TSESTree} from '@typescript-eslint/utils'
-import {Rule} from 'eslint'
+import {
+  RuleContext,
+  RuleModule,
+  RuleListener,
+} from '@typescript-eslint/utils/ts-eslint'
 import {extractMessages, getSettings} from '../util'
 
-function checkNode(context: Rule.RuleContext, node: TSESTree.Node) {
+type MessageIds = 'icuError'
+type Options = []
+
+export const name = 'no-invalid-icu'
+
+function checkNode(
+  context: RuleContext<MessageIds, Options>,
+  node: TSESTree.Node
+) {
   const settings = getSettings(context)
   const msgs = extractMessages(node, settings)
 
@@ -28,28 +40,34 @@ function checkNode(context: Rule.RuleContext, node: TSESTree.Node) {
     } catch (e) {
       const msg = e instanceof Error ? e.message : e
       context.report({
-        node: messageNode as any,
-        message: `Error parsing ICU string: ${msg}`,
+        node: messageNode,
+        messageId: 'icuError',
+        data: {message: `Error parsing ICU string: ${msg}`},
       })
     }
   }
 }
 
-const rule: Rule.RuleModule = {
+export const rule: RuleModule<MessageIds, Options, RuleListener> = {
   meta: {
     type: 'problem',
     docs: {
       description: `Make sure ICU messages are formatted correctly with no bad select statements, plurals, etc.`,
-      category: 'Errors',
-      recommended: true,
     },
     fixable: 'code',
+    schema: [],
+    messages: {
+      icuError: 'Invalid ICU Message format: {{message}}',
+    },
   },
+  defaultOptions: [],
   create(context) {
     const callExpressionVisitor = (node: TSESTree.Node) =>
       checkNode(context, node)
 
+    //@ts-expect-error defineTemplateBodyVisitor exists in Vue parser
     if (context.parserServices.defineTemplateBodyVisitor) {
+      //@ts-expect-error
       return context.parserServices.defineTemplateBodyVisitor(
         {
           CallExpression: callExpressionVisitor,
@@ -65,5 +83,3 @@ const rule: Rule.RuleModule = {
     }
   },
 }
-
-export default rule

--- a/packages/eslint-plugin-formatjs/rules/no-literal-string-in-jsx.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-literal-string-in-jsx.ts
@@ -1,5 +1,6 @@
 import {TSESTree} from '@typescript-eslint/utils'
-import type {Rule} from 'eslint'
+import {JSONSchema4ArraySchema} from '@typescript-eslint/utils/json-schema'
+import {RuleModule, RuleListener} from '@typescript-eslint/utils/ts-eslint'
 import picomatch from 'picomatch'
 
 type PropMatcher = readonly [TagNamePattern: string, PropNamePattern: string][]
@@ -16,13 +17,16 @@ type Config = {
   }
 }
 
-const propMatcherSchema = {
+type MessageIds = 'noLiteralStringInJsx'
+type Options = [Config?]
+
+const propMatcherSchema: JSONSchema4ArraySchema = {
   type: 'array',
   items: {
     type: 'array',
     items: [{type: 'string'}, {type: 'string'}],
   },
-} as const
+}
 
 const defaultPropIncludePattern: PropMatcher = [
   ['*', 'aria-{label,description,details,errormessage}'],
@@ -52,13 +56,13 @@ function compilePropMatcher(propMatcher: PropMatcher): CompiledPropMatcher {
   })
 }
 
-const rule: Rule.RuleModule = {
+export const name = 'no-literal-string-in-jsx'
+
+export const rule: RuleModule<MessageIds, Options, RuleListener> = {
   meta: {
     type: 'problem',
     docs: {
       description: 'Disallow untranslated literal strings without translation.',
-      category: 'Errors',
-      recommended: false,
       url: 'https://formatjs.io/docs/tooling/linter#no-literal-string-in-jsx',
     },
     schema: [
@@ -79,7 +83,11 @@ const rule: Rule.RuleModule = {
         },
       },
     ],
+    messages: {
+      noLiteralStringInJsx: 'Cannot have untranslated text in JSX',
+    },
   },
+  defaultOptions: [],
   // TODO: Vue support
   create(context) {
     const userConfig: Config = context.options[0] || {}
@@ -144,8 +152,8 @@ const rule: Rule.RuleModule = {
           (node.quasis.length > 1 || node.quasis[0].value.raw.length > 0))
       ) {
         context.report({
-          node: node as any,
-          message: 'Cannot have untranslated text in JSX',
+          node: node,
+          messageId: 'noLiteralStringInJsx',
         })
       } else if (node.type === 'BinaryExpression' && node.operator === '+') {
         checkJSXExpression(node.left)
@@ -189,8 +197,8 @@ const rule: Rule.RuleModule = {
           node.value.value.length > 0
         ) {
           context.report({
-            node: node as any,
-            message: 'Cannot have untranslated text in JSX',
+            node: node,
+            messageId: 'noLiteralStringInJsx',
           })
         } else if (
           node.value.type === 'JSXExpressionContainer' &&
@@ -207,8 +215,8 @@ const rule: Rule.RuleModule = {
         }
 
         context.report({
-          node: node as any,
-          message: 'Cannot have untranslated text in JSX',
+          node: node,
+          messageId: 'noLiteralStringInJsx',
         })
       },
 
@@ -220,8 +228,6 @@ const rule: Rule.RuleModule = {
           checkJSXExpression(node.expression)
         }
       },
-    } as any
+    }
   },
 }
-
-export default rule

--- a/packages/eslint-plugin-formatjs/rules/prefer-formatted-message.ts
+++ b/packages/eslint-plugin-formatjs/rules/prefer-formatted-message.ts
@@ -34,7 +34,7 @@ export const rule: RuleModule<MessageIds, Options, RuleListener> = {
             return
           }
           context.report({
-            node: child as any,
+            node: child,
             messageId: 'jsxChildren',
           })
         })

--- a/packages/eslint-plugin-formatjs/rules/prefer-formatted-message.ts
+++ b/packages/eslint-plugin-formatjs/rules/prefer-formatted-message.ts
@@ -1,21 +1,27 @@
 import {TSESTree} from '@typescript-eslint/utils'
-import type {Rule} from 'eslint'
+import {RuleModule, RuleListener} from '@typescript-eslint/utils/ts-eslint'
 import {isIntlFormatMessageCall} from '../util'
 
-const rule: Rule.RuleModule = {
+type MessageIds = 'jsxChildren'
+type Options = []
+
+export const name = 'prefer-formatted-message'
+
+export const rule: RuleModule<MessageIds, Options, RuleListener> = {
   meta: {
     type: 'suggestion',
     docs: {
       description:
         'Prefer `FormattedMessage` component over `intl.formatMessage` if applicable.',
-      recommended: false,
       url: 'https://formatjs.io/docs/tooling/linter#prefer-formatted-message',
     },
     messages: {
       jsxChildren:
         'Prefer `FormattedMessage` over `intl.formatMessage` in the JSX children expression.',
     },
+    schema: [],
   },
+  defaultOptions: [],
   // TODO: Vue support
   create(context) {
     return {
@@ -33,8 +39,6 @@ const rule: Rule.RuleModule = {
           })
         })
       },
-    } as any
+    }
   },
 }
-
-export default rule

--- a/packages/eslint-plugin-formatjs/tests/blocklist-elements.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/blocklist-elements.test.ts
@@ -1,22 +1,22 @@
-import blocklistElements from '../rules/blocklist-elements'
+import {rule, Element, name} from '../rules/blocklist-elements'
 import {dynamicMessage, emptyFnCall, noMatch, spreadJsx} from './fixtures'
 import {ruleTester, vueRuleTester} from './util'
 
-ruleTester.run('blocklist-elements', blocklistElements, {
+ruleTester.run(name, rule, {
   valid: [
     {
       code: `import {defineMessage} from 'react-intl'
   defineMessage({
       defaultMessage: '{count, plural, one {#} other {# more}}'
   })`,
-      options: [['selectordinal']],
+      options: [[Element.selectordinal]],
     },
     {
       code: `import {defineMessage} from 'react-intl'
   defineMessage({
       defaultMessage: '{count, plural, one {#} other {# more}} <a href="asd"></a>'
   })`,
-      options: [['selectordinal']],
+      options: [[Element.selectordinal]],
       settings: {
         formatjs: {
           ignoreTag: true,
@@ -28,7 +28,7 @@ ruleTester.run('blocklist-elements', blocklistElements, {
   $t({
       defaultMessage: '{count, plural, one {#} other {# more}}'
   })`,
-      options: [['selectordinal']],
+      options: [[Element.selectordinal]],
       settings: {
         formatjs: {
           additionalFunctionNames: ['$t'],
@@ -47,10 +47,11 @@ ruleTester.run('blocklist-elements', blocklistElements, {
               defineMessage({
                   defaultMessage: '{count, selectordinal, offset:1 one {#} other {# more}}'
               })`,
-      options: [['selectordinal']],
+      options: [[Element.selectordinal]],
       errors: [
         {
-          message: 'selectordinal element is blocklisted',
+          messageId: 'blocklist',
+          data: {type: 'selectordinal'},
         },
       ],
     },
@@ -59,7 +60,7 @@ ruleTester.run('blocklist-elements', blocklistElements, {
               $t({
                   defaultMessage: '{count, selectordinal, offset:1 one {#} other {# more}}'
               })`,
-      options: [['selectordinal']],
+      options: [[Element.selectordinal]],
       settings: {
         formatjs: {
           additionalFunctionNames: ['$t'],
@@ -67,14 +68,15 @@ ruleTester.run('blocklist-elements', blocklistElements, {
       },
       errors: [
         {
-          message: 'selectordinal element is blocklisted',
+          messageId: 'blocklist',
+          data: {type: 'selectordinal'},
         },
       ],
     },
   ],
 })
 
-vueRuleTester.run('vue/blocklist-elements', blocklistElements, {
+vueRuleTester.run('vue/blocklist-elements', rule, {
   valid: [
     {
       code: `<template>
@@ -82,7 +84,7 @@ vueRuleTester.run('vue/blocklist-elements', blocklistElements, {
         defaultMessage: '{count, plural, offset:1 one {#} other {# more} }'
       }) }} World!</p>
     </template>`,
-      options: [['selectordinal']],
+      options: [[Element.selectordinal]],
     },
     `<script>${dynamicMessage}</script>`,
     `<script>${noMatch}</script>`,
@@ -95,10 +97,11 @@ vueRuleTester.run('vue/blocklist-elements', blocklistElements, {
               intl.formatMessage({
                   defaultMessage: '{count, selectordinal, offset:1 one {#} other {# more}}'
               })</script>`,
-      options: [['selectordinal']],
+      options: [[Element.selectordinal]],
       errors: [
         {
-          message: 'selectordinal element is blocklisted',
+          messageId: 'blocklist',
+          data: {type: 'selectordinal'},
         },
       ],
     },
@@ -109,10 +112,11 @@ vueRuleTester.run('vue/blocklist-elements', blocklistElements, {
     defaultMessage: '{count, selectordinal, offset:1 one {#} other {# more} }'
   }) }} World!</p>
 </template>`,
-      options: [['selectordinal']],
+      options: [[Element.selectordinal]],
       errors: [
         {
-          message: 'selectordinal element is blocklisted',
+          messageId: 'blocklist',
+          data: {type: 'selectordinal'},
         },
       ],
     },

--- a/packages/eslint-plugin-formatjs/tests/enforce-default-message.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/enforce-default-message.test.ts
@@ -1,4 +1,4 @@
-import {rule, name} from '../rules/enforce-default-message'
+import {rule, name, Option} from '../rules/enforce-default-message'
 import {noMatch, spreadJsx, emptyFnCall, dynamicMessage} from './fixtures'
 import {ruleTester, vueRuleTester} from './util'
 
@@ -67,7 +67,7 @@ const a = <FormattedMessage defaultMessage={'asf' + 'bar'}/>`,
           messageId: 'defaultMessageLiteral',
         },
       ],
-      options: ['literal'],
+      options: [Option.literal],
     },
     {
       code: `
@@ -80,7 +80,7 @@ const a = <FormattedMessage defaultMessage={'asf' + 'bar'}/>`,
           messageId: 'defaultMessageLiteral',
         },
       ],
-      options: ['literal'],
+      options: [Option.literal],
     },
     {
       code: `
@@ -93,7 +93,7 @@ const a = <FormattedMessage defaultMessage={'asf' + 'bar'}/>`,
           messageId: 'defaultMessageLiteral',
         },
       ],
-      options: ['literal'],
+      options: [Option.literal],
     },
     {
       code: `
@@ -159,7 +159,7 @@ const a = <FormattedMessage defaultMessage={'asf' + 'bar'}/>`,
           messageId: 'defaultMessageLiteral',
         },
       ],
-      options: ['literal'],
+      options: [Option.literal],
     },
     {
       code: `
@@ -170,7 +170,7 @@ const a = <FormattedMessage defaultMessage={'asf' + 'bar'}/>`,
           messageId: 'defaultMessageLiteral',
         },
       ],
-      options: ['literal'],
+      options: [Option.literal],
     },
     {
       code: `
@@ -181,7 +181,7 @@ const a = <FormattedMessage defaultMessage={'asf' + 'bar'}/>`,
           messageId: 'defaultMessageLiteral',
         },
       ],
-      options: ['literal'],
+      options: [Option.literal],
     },
     {
       code: `
@@ -192,7 +192,7 @@ const a = <FormattedMessage defaultMessage={'asf' + 'bar'}/>`,
           messageId: 'defaultMessageLiteral',
         },
       ],
-      options: ['literal'],
+      options: [Option.literal],
     },
   ],
 })
@@ -238,7 +238,7 @@ vueRuleTester.run(`vue/${name}`, rule, {
           messageId: 'defaultMessageLiteral',
         },
       ],
-      options: ['literal'],
+      options: [Option.literal],
     },
   ],
 })

--- a/packages/eslint-plugin-formatjs/tests/enforce-default-message.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/enforce-default-message.test.ts
@@ -1,8 +1,8 @@
-import enforceDefaultMessage from '../rules/enforce-default-message'
+import {rule, name} from '../rules/enforce-default-message'
 import {noMatch, spreadJsx, emptyFnCall, dynamicMessage} from './fixtures'
 import {ruleTester, vueRuleTester} from './util'
 
-ruleTester.run('enforce-default-message', enforceDefaultMessage, {
+ruleTester.run(name, rule, {
   valid: [
     `import {defineMessage} from 'react-intl'
 defineMessage({
@@ -39,7 +39,7 @@ const a = <FormattedMessage defaultMessage={'asf' + 'bar'}/>`,
             })`,
       errors: [
         {
-          message: '`defaultMessage` has to be specified in message descriptor',
+          messageId: 'defaultMessage',
         },
       ],
     },
@@ -51,7 +51,7 @@ const a = <FormattedMessage defaultMessage={'asf' + 'bar'}/>`,
             })`,
       errors: [
         {
-          message: '`defaultMessage` has to be specified in message descriptor',
+          messageId: 'defaultMessage',
         },
       ],
     },
@@ -64,9 +64,7 @@ const a = <FormattedMessage defaultMessage={'asf' + 'bar'}/>`,
             })`,
       errors: [
         {
-          message: `"defaultMessage" must be:
-- a string literal or
-- template literal without variable`,
+          messageId: 'defaultMessageLiteral',
         },
       ],
       options: ['literal'],
@@ -79,9 +77,7 @@ const a = <FormattedMessage defaultMessage={'asf' + 'bar'}/>`,
             })`,
       errors: [
         {
-          message: `"defaultMessage" must be:
-- a string literal or
-- template literal without variable`,
+          messageId: 'defaultMessageLiteral',
         },
       ],
       options: ['literal'],
@@ -94,9 +90,7 @@ const a = <FormattedMessage defaultMessage={'asf' + 'bar'}/>`,
             })`,
       errors: [
         {
-          message: `"defaultMessage" must be:
-- a string literal or
-- template literal without variable`,
+          messageId: 'defaultMessageLiteral',
         },
       ],
       options: ['literal'],
@@ -108,7 +102,7 @@ const a = <FormattedMessage defaultMessage={'asf' + 'bar'}/>`,
             })`,
       errors: [
         {
-          message: '`defaultMessage` has to be specified in message descriptor',
+          messageId: 'defaultMessage',
         },
       ],
     },
@@ -122,7 +116,7 @@ const a = <FormattedMessage defaultMessage={'asf' + 'bar'}/>`,
             })`,
       errors: [
         {
-          message: '`defaultMessage` has to be specified in message descriptor',
+          messageId: 'defaultMessage',
         },
       ],
     },
@@ -132,7 +126,7 @@ const a = <FormattedMessage defaultMessage={'asf' + 'bar'}/>`,
             const a = <FormattedMessage description="this is description"/>`,
       errors: [
         {
-          message: '`defaultMessage` has to be specified in message descriptor',
+          messageId: 'defaultMessage',
         },
       ],
     },
@@ -142,7 +136,7 @@ const a = <FormattedMessage defaultMessage={'asf' + 'bar'}/>`,
             const a = <FormattedMessage />`,
       errors: [
         {
-          message: '`defaultMessage` has to be specified in message descriptor',
+          messageId: 'defaultMessage',
         },
       ],
     },
@@ -152,7 +146,7 @@ const a = <FormattedMessage defaultMessage={'asf' + 'bar'}/>`,
             const a = <FormattedMessage description="this is description"></FormattedMessage>`,
       errors: [
         {
-          message: '`defaultMessage` has to be specified in message descriptor',
+          messageId: 'defaultMessage',
         },
       ],
     },
@@ -162,9 +156,7 @@ const a = <FormattedMessage defaultMessage={'asf' + 'bar'}/>`,
             const a = <FormattedMessage defaultMessage={defaultMessage} description="this is description"/>`,
       errors: [
         {
-          message: `"defaultMessage" must be:
-- a string literal or
-- template literal without variable`,
+          messageId: 'defaultMessageLiteral',
         },
       ],
       options: ['literal'],
@@ -175,9 +167,7 @@ const a = <FormattedMessage defaultMessage={'asf' + 'bar'}/>`,
             const a = <FormattedMessage defaultMessage={defaultMessage}/>`,
       errors: [
         {
-          message: `"defaultMessage" must be:
-- a string literal or
-- template literal without variable`,
+          messageId: 'defaultMessageLiteral',
         },
       ],
       options: ['literal'],
@@ -188,9 +178,7 @@ const a = <FormattedMessage defaultMessage={'asf' + 'bar'}/>`,
             const a = <FormattedMessage defaultMessage={\`asf \${foo}\`} description="this is description"></FormattedMessage>`,
       errors: [
         {
-          message: `"defaultMessage" must be:
-- a string literal or
-- template literal without variable`,
+          messageId: 'defaultMessageLiteral',
         },
       ],
       options: ['literal'],
@@ -201,9 +189,7 @@ const a = <FormattedMessage defaultMessage={'asf' + 'bar'}/>`,
             const a = <FormattedMessage defaultMessage={\`asf \${aas}\`}/>`,
       errors: [
         {
-          message: `"defaultMessage" must be:
-- a string literal or
-- template literal without variable`,
+          messageId: 'defaultMessageLiteral',
         },
       ],
       options: ['literal'],
@@ -211,7 +197,7 @@ const a = <FormattedMessage defaultMessage={'asf' + 'bar'}/>`,
   ],
 })
 
-vueRuleTester.run('vue/enforce-default-message', enforceDefaultMessage, {
+vueRuleTester.run(`vue/${name}`, rule, {
   valid: [
     `<template>
 <p>{{$formatMessage({
@@ -236,7 +222,7 @@ vueRuleTester.run('vue/enforce-default-message', enforceDefaultMessage, {
             })}}</p></template>`,
       errors: [
         {
-          message: '`defaultMessage` has to be specified in message descriptor',
+          messageId: 'defaultMessage',
         },
       ],
     },
@@ -249,9 +235,7 @@ vueRuleTester.run('vue/enforce-default-message', enforceDefaultMessage, {
             })}}</p></template>`,
       errors: [
         {
-          message: `"defaultMessage" must be:
-- a string literal or
-- template literal without variable`,
+          messageId: 'defaultMessageLiteral',
         },
       ],
       options: ['literal'],

--- a/packages/eslint-plugin-formatjs/tests/enforce-description.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/enforce-description.test.ts
@@ -1,8 +1,8 @@
-import enforceDescription from '../rules/enforce-description'
+import {Option, name, rule} from '../rules/enforce-description'
 import {noMatch, spreadJsx, emptyFnCall, dynamicMessage} from './fixtures'
 import {ruleTester} from './util'
 
-ruleTester.run('enforce-description', enforceDescription, {
+ruleTester.run(name, rule, {
   valid: [
     `import {defineMessage} from 'react-intl'
 defineMessage({
@@ -39,7 +39,7 @@ description={'asd' + 'azz'}
             })`,
       errors: [
         {
-          message: '`description` has to be specified in message descriptor',
+          messageId: 'enforceDescription',
         },
       ],
     },
@@ -52,11 +52,10 @@ description={'asd' + 'azz'}
             })`,
       errors: [
         {
-          message:
-            '`description` has to be a string literal (not function call or variable)',
+          messageId: 'enforceDescriptionLiteral',
         },
       ],
-      options: ['literal'],
+      options: [Option.literal],
     },
     {
       code: `
@@ -65,7 +64,7 @@ description={'asd' + 'azz'}
             })`,
       errors: [
         {
-          message: '`description` has to be specified in message descriptor',
+          messageId: 'enforceDescription',
         },
       ],
     },
@@ -76,7 +75,7 @@ description={'asd' + 'azz'}
             })`,
       errors: [
         {
-          message: '`description` has to be specified in message descriptor',
+          messageId: 'enforceDescription',
         },
       ],
     },
@@ -90,7 +89,7 @@ description={'asd' + 'azz'}
             })`,
       errors: [
         {
-          message: '`description` has to be specified in message descriptor',
+          messageId: 'enforceDescription',
         },
       ],
     },
@@ -104,7 +103,7 @@ description={'asd' + 'azz'}
               })`,
       errors: [
         {
-          message: '`description` has to be specified in message descriptor',
+          messageId: 'enforceDescription',
         },
       ],
     },
@@ -114,7 +113,7 @@ description={'asd' + 'azz'}
             const a = <FormattedMessage defaultMessage="{count2, plural, one {#} other {# more}}"/>`,
       errors: [
         {
-          message: '`description` has to be specified in message descriptor',
+          messageId: 'enforceDescription',
         },
       ],
     },
@@ -124,7 +123,7 @@ description={'asd' + 'azz'}
             const a = <FormattedMessage defaultMessage="{count2, plural, one {#} other {# more}}"></FormattedMessage>`,
       errors: [
         {
-          message: '`description` has to be specified in message descriptor',
+          messageId: 'enforceDescription',
         },
       ],
     },

--- a/packages/eslint-plugin-formatjs/tests/enforce-id.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/enforce-id.test.ts
@@ -1,8 +1,10 @@
-import enforceId from '../rules/enforce-id'
+import {name, rule, Option} from '../rules/enforce-id'
 import {ruleTester} from './util'
 import {noMatch, spreadJsx, emptyFnCall} from './fixtures'
-const options = [{idInterpolationPattern: '[sha512:contenthash:base64:6]'}]
-ruleTester.run('enforce-id', enforceId, {
+const options: [Option] = [
+  {idInterpolationPattern: '[sha512:contenthash:base64:6]'},
+]
+ruleTester.run(name, rule, {
   valid: [
     {
       code: `intl.formatMessage({ id: 'j9qhn+', defaultMessage: '{count, plural, one {#} other {# more}}', description: 'asd'})`,
@@ -27,9 +29,12 @@ ruleTester.run('enforce-id', enforceId, {
 intl.formatMessage({ id: 'foo', defaultMessage: '{count, plural, one {#} other {# more}}', description: 'asd'})`,
       errors: [
         {
-          message: `"id" does not match with hash pattern [sha512:contenthash:base64:6].
-Expected: j9qhn+
-Actual: foo`,
+          messageId: 'enforceIdMatching',
+          data: {
+            idInterpolationPattern: '[sha512:contenthash:base64:6]',
+            expected: 'j9qhn+',
+            actual: 'foo',
+          },
         },
       ],
       options,
@@ -41,9 +46,12 @@ intl.formatMessage({ id: 'j9qhn+', defaultMessage: '{count, plural, one {#} othe
 intl.$t({ id: 'foo', defaultMessage: '{count, plural, one {#} other {# more}}', description: 'asd'})`,
       errors: [
         {
-          message: `"id" does not match with hash pattern [sha512:contenthash:base64:6].
-Expected: j9qhn+
-Actual: foo`,
+          messageId: 'enforceIdMatching',
+          data: {
+            idInterpolationPattern: '[sha512:contenthash:base64:6]',
+            expected: 'j9qhn+',
+            actual: 'foo',
+          },
         },
       ],
       options,
@@ -55,7 +63,7 @@ intl.$t({ id: 'j9qhn+', defaultMessage: '{count, plural, one {#} other {# more}}
 intl.formatMessage({defaultMessage: '{count, plural, one {#} other {# more}}', description: 'asd'})`,
       errors: [
         {
-          message: `id must be specified`,
+          messageId: 'enforceId',
         },
       ],
     },
@@ -64,9 +72,12 @@ intl.formatMessage({defaultMessage: '{count, plural, one {#} other {# more}}', d
 intl.formatMessage({defaultMessage: '{count, plural, one {#} other {# more}}', description: 'asd'})`,
       errors: [
         {
-          message: `"id" does not match with hash pattern [sha512:contenthash:base64:6].
-Expected: j9qhn+
-Actual: undefined`,
+          messageId: 'enforceIdMatching',
+          data: {
+            idInterpolationPattern: '[sha512:contenthash:base64:6]',
+            expected: 'j9qhn+',
+            actual: 'undefined',
+          },
         },
       ],
       options,
@@ -79,9 +90,12 @@ intl.formatMessage({ id: 'bar', defaultMessage: '{aDifferentKey, plural, one {#}
 }, {foo: 1})`,
       errors: [
         {
-          message: `"id" does not match with hash pattern [sha512:contenthash:base64:6].
-Expected: 73owpx
-Actual: bar`,
+          messageId: 'enforceIdMatching',
+          data: {
+            idInterpolationPattern: '[sha512:contenthash:base64:6]',
+            expected: '73owpx',
+            actual: 'bar',
+          },
         },
       ],
       options,
@@ -98,9 +112,12 @@ defaultMessage="{count, plural, one {#} other {# more}}"
 />`,
       errors: [
         {
-          message: `"id" does not match with hash pattern [sha512:contenthash:base64:6].
-Expected: /e77jM
-Actual: undefined`,
+          messageId: 'enforceIdMatching',
+          data: {
+            idInterpolationPattern: '[sha512:contenthash:base64:6]',
+            expected: '/e77jM',
+            actual: 'undefined',
+          },
         },
       ],
       options,
@@ -119,9 +136,12 @@ const a = (
 )`,
       errors: [
         {
-          message: `"id" does not match with hash pattern [sha512:contenthash:base64:6].
-Expected: /e77jM
-Actual: bas`,
+          messageId: 'enforceIdMatching',
+          data: {
+            idInterpolationPattern: '[sha512:contenthash:base64:6]',
+            expected: '/e77jM',
+            actual: 'bas',
+          },
         },
       ],
       options,
@@ -139,9 +159,12 @@ const a = (
 )`,
       errors: [
         {
-          message: `"id" does not match with hash pattern [sha512:contenthash:base64:6].
-Expected: /e77jM
-Actual: undefined`,
+          messageId: 'enforceIdMatching',
+          data: {
+            idInterpolationPattern: '[sha512:contenthash:base64:6]',
+            expected: '/e77jM',
+            actual: 'undefined',
+          },
         },
       ],
       options,
@@ -159,9 +182,12 @@ intl.formatMessage({ id, defaultMessage: '{count, plural, one {<a>#</a>} other {
 })`,
       errors: [
         {
-          message: `"id" does not match with hash pattern [sha512:contenthash:base64:6].
-Expected: UoHSIG
-Actual: undefined`,
+          messageId: 'enforceIdMatching',
+          data: {
+            idInterpolationPattern: '[sha512:contenthash:base64:6]',
+            expected: 'UoHSIG',
+            actual: 'undefined',
+          },
         },
       ],
       options,
@@ -178,9 +204,12 @@ import { defineMessages } from 'react-intl'
 defineMessages({ example: { defaultMessage: 'example' } })`,
       errors: [
         {
-          message: `"id" does not match with hash pattern [sha512:contenthash:base64:6].
-Expected: O7Eu2j
-Actual: undefined`,
+          messageId: 'enforceIdMatching',
+          data: {
+            idInterpolationPattern: '[sha512:contenthash:base64:6]',
+            expected: 'O7Eu2j',
+            actual: 'undefined',
+          },
         },
       ],
       options,
@@ -192,13 +221,13 @@ defineMessages({ example: { defaultMessage: 'example', id: 'O7Eu2j' } })`,
   ],
 })
 
-const optionsWithWhitelist = [
+const optionsWithWhitelist: [Option] = [
   {
     idInterpolationPattern: '[sha512:contenthash:base64:6]',
     idWhitelist: ['\\.', '^payment_.*'],
   },
 ]
-ruleTester.run('enforce-id', enforceId, {
+ruleTester.run(name, rule, {
   valid: [
     {
       options: optionsWithWhitelist,
@@ -214,9 +243,13 @@ defineMessages({ example: { defaultMessage: 'example2', id: 'payment_string' } }
 intl.formatMessage({defaultMessage: '{count, plural, one {#} other {# more}}', description: 'asd'})`,
       errors: [
         {
-          message: `"id" does not match with hash pattern [sha512:contenthash:base64:6] or allowlisted patterns ["/\\./i", "/^payment_.*/i"].
-Expected: j9qhn+
-Actual: undefined`,
+          messageId: 'enforceIdMatchingAllowlisted',
+          data: {
+            idInterpolationPattern: '[sha512:contenthash:base64:6]',
+            expected: 'j9qhn+',
+            actual: 'undefined',
+            idWhitelist: '"/\\./i", "/^payment_.*/i"',
+          },
         },
       ],
       options: optionsWithWhitelist,
@@ -228,9 +261,13 @@ intl.formatMessage({defaultMessage: '{count, plural, one {#} other {# more}}', i
 intl.formatMessage({defaultMessage: "{count, plural, one {#} other {# more}}", description: "asd"})`,
       errors: [
         {
-          message: `"id" does not match with hash pattern [sha512:contenthash:base64:6] or allowlisted patterns ["/\\./i", "/^payment_.*/i"].
-Expected: j9qhn+
-Actual: undefined`,
+          messageId: 'enforceIdMatchingAllowlisted',
+          data: {
+            idInterpolationPattern: '[sha512:contenthash:base64:6]',
+            expected: 'j9qhn+',
+            actual: 'undefined',
+            idWhitelist: '"/\\./i", "/^payment_.*/i"',
+          },
         },
       ],
       options: optionsWithWhitelist,

--- a/packages/eslint-plugin-formatjs/tests/enforce-placeholders.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/enforce-placeholders.test.ts
@@ -1,7 +1,7 @@
-import enforcePlaceholders from '../rules/enforce-placeholders'
+import {rule, name} from '../rules/enforce-placeholders'
 import {ruleTester} from './util'
 import {dynamicMessage, noMatch, spreadJsx, emptyFnCall} from './fixtures'
-ruleTester.run('enforce-placeholders', enforcePlaceholders, {
+ruleTester.run(name, rule, {
   valid: [
     `intl.formatMessage({
       defaultMessage: '{count, plural, one {#} other {# more}}',
@@ -80,9 +80,7 @@ ruleTester.run('enforce-placeholders', enforcePlaceholders, {
           defaultMessage: '{count, plural, one {#} other {# more}}',
           description: 'asd'
       })`,
-      errors: [
-        {message: 'Missing value(s) for the following placeholder(s): count.'},
-      ],
+      errors: [{messageId: 'missingValue', data: {list: 'count'}}],
     },
     {
       code: `
@@ -90,9 +88,7 @@ ruleTester.run('enforce-placeholders', enforcePlaceholders, {
           defaultMessage: '<b>foo</b>',
           description: 'asd'
       })`,
-      errors: [
-        {message: 'Missing value(s) for the following placeholder(s): b.'},
-      ],
+      errors: [{messageId: 'missingValue', data: {list: 'b'}}],
     },
     {
       code: `
@@ -101,11 +97,8 @@ ruleTester.run('enforce-placeholders', enforcePlaceholders, {
           description: 'asd'
       }, {foo: 1})`,
       errors: [
-        {
-          message:
-            'Missing value(s) for the following placeholder(s): aDifferentKey.',
-        },
-        {message: 'Value not used by the message.'},
+        {messageId: 'missingValue', data: {list: 'aDifferentKey'}},
+        {messageId: 'unusedValue'},
       ],
     },
     {
@@ -114,9 +107,7 @@ ruleTester.run('enforce-placeholders', enforcePlaceholders, {
         const a = <FormattedMessage
         defaultMessage="{count, plural, one {#} other {# more}}"
         />`,
-      errors: [
-        {message: 'Missing value(s) for the following placeholder(s): count.'},
-      ],
+      errors: [{messageId: 'missingValue', data: {list: 'count'}}],
     },
     {
       code: `
@@ -126,8 +117,8 @@ ruleTester.run('enforce-placeholders', enforcePlaceholders, {
         values={{foo: 1}}
         />`,
       errors: [
-        {message: 'Missing value(s) for the following placeholder(s): count.'},
-        {message: 'Value not used by the message.'},
+        {messageId: 'missingValue', data: {list: 'count'}},
+        {messageId: 'unusedValue'},
       ],
     },
     {
@@ -135,8 +126,8 @@ ruleTester.run('enforce-placeholders', enforcePlaceholders, {
         import {FormattedMessage} from 'react-intl'
         const a = <FormattedMessage id="myMessage" defaultMessage="Hello {name}" values={{ notName: "Denis" }} />`,
       errors: [
-        {message: 'Missing value(s) for the following placeholder(s): name.'},
-        {message: 'Value not used by the message.'},
+        {messageId: 'missingValue', data: {list: 'name'}},
+        {messageId: 'unusedValue'},
       ],
     },
     {
@@ -145,7 +136,8 @@ ruleTester.run('enforce-placeholders', enforcePlaceholders, {
         const a = <FormattedMessage defaultMessage="Hello <bold>{name}</bold>" values={{ bold: (msg) => <strong>{msg}</strong> }} />`,
       errors: [
         {
-          message: 'Missing value(s) for the following placeholder(s): name.',
+          messageId: 'missingValue',
+          data: {list: 'name'},
         },
       ],
     },
@@ -160,7 +152,8 @@ ruleTester.run('enforce-placeholders', enforcePlaceholders, {
         `,
       errors: [
         {
-          message: 'Missing value(s) for the following placeholder(s): a.',
+          messageId: 'missingValue',
+          data: {list: 'a'},
         },
       ],
     },
@@ -172,7 +165,8 @@ ruleTester.run('enforce-placeholders', enforcePlaceholders, {
       `,
       errors: [
         {
-          message: 'Missing value(s) for the following placeholder(s): name.',
+          messageId: 'missingValue',
+          data: {list: 'name'},
         },
       ],
     },
@@ -183,10 +177,7 @@ ruleTester.run('enforce-placeholders', enforcePlaceholders, {
         defaultMessage="{count, plural, one {#} other {# more}}"
         values={{foo: 0, count: 1, bar: 2}}
         />`,
-      errors: [
-        {message: 'Value not used by the message.'},
-        {message: 'Value not used by the message.'},
-      ],
+      errors: [{messageId: 'unusedValue'}, {messageId: 'unusedValue'}],
     },
     {
       code: `
@@ -194,12 +185,7 @@ ruleTester.run('enforce-placeholders', enforcePlaceholders, {
         const a = <FormattedMessage
         defaultMessage="{foo} {bar}"
         />`,
-      errors: [
-        {
-          message:
-            'Missing value(s) for the following placeholder(s): foo, bar.',
-        },
-      ],
+      errors: [{messageId: 'missingValue', data: {list: 'foo, bar'}}],
     },
     // Does not crash when there are parser errors
     {
@@ -210,7 +196,10 @@ ruleTester.run('enforce-placeholders', enforcePlaceholders, {
       `,
       errors: [
         {
-          message: 'EXPECT_ARGUMENT_CLOSING_BRACE',
+          messageId: 'parserError',
+          data: {
+            message: 'EXPECT_ARGUMENT_CLOSING_BRACE',
+          },
         },
       ],
     },

--- a/packages/eslint-plugin-formatjs/tests/enforce-plural-rules.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/enforce-plural-rules.test.ts
@@ -1,7 +1,7 @@
-import enforcePluralRules from '../rules/enforce-plural-rules'
+import {name, rule} from '../rules/enforce-plural-rules'
 import {ruleTester} from './util'
 import {dynamicMessage, noMatch, spreadJsx, emptyFnCall} from './fixtures'
-ruleTester.run('enforce-plural-rules', enforcePluralRules, {
+ruleTester.run(name, rule, {
   valid: [
     {
       code: `import {defineMessage} from 'react-intl'
@@ -60,7 +60,8 @@ ruleTester.run('enforce-plural-rules', enforcePluralRules, {
       ],
       errors: [
         {
-          message: 'Plural rule "one" is forbidden',
+          messageId: 'forbidden',
+          data: {rule: 'one'},
         },
       ],
     },
@@ -78,7 +79,8 @@ ruleTester.run('enforce-plural-rules', enforcePluralRules, {
       ],
       errors: [
         {
-          message: 'Missing plural rule "two"',
+          messageId: 'missingPlural',
+          data: {rule: 'two'},
         },
       ],
     },

--- a/packages/eslint-plugin-formatjs/tests/no-camel-case.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/no-camel-case.test.ts
@@ -1,5 +1,5 @@
 import {ruleTester} from './util'
-import noCamelCase from '../rules/no-camel-case'
+import {rule, name} from '../rules/no-camel-case'
 import {
   dynamicMessage,
   noMatch,
@@ -8,7 +8,7 @@ import {
   defineMessage,
 } from './fixtures'
 
-ruleTester.run('no-camel-case', noCamelCase, {
+ruleTester.run(name, rule, {
   valid: [defineMessage, dynamicMessage, noMatch, spreadJsx, emptyFnCall],
   invalid: [
     {
@@ -17,11 +17,7 @@ ruleTester.run('no-camel-case', noCamelCase, {
               defineMessage({
                   defaultMessage: 'a {placeHolder}'
               })`,
-      errors: [
-        {
-          message: 'Camel case arguments are not allowed',
-        },
-      ],
+      errors: [{messageId: 'camelcase'}],
     },
   ],
 })

--- a/packages/eslint-plugin-formatjs/tests/no-complex-selectors.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/no-complex-selectors.test.ts
@@ -1,4 +1,4 @@
-import noComplexSelectors from '../rules/no-complex-selectors'
+import {rule, name} from '../rules/no-complex-selectors'
 import {ruleTester} from './util'
 import {
   dynamicMessage,
@@ -7,7 +7,7 @@ import {
   emptyFnCall,
   defineMessage,
 } from './fixtures'
-ruleTester.run('no-complex-selectors', noComplexSelectors, {
+ruleTester.run(name, rule, {
   valid: [
     defineMessage,
     dynamicMessage,
@@ -37,7 +37,12 @@ ruleTester.run('no-complex-selectors', noComplexSelectors, {
         })
       `,
       options: [{limit: 1}],
-      errors: [{message: 'EXPECT_ARGUMENT_CLOSING_BRACE'}],
+      errors: [
+        {
+          messageId: 'parserError',
+          data: {message: 'EXPECT_ARGUMENT_CLOSING_BRACE'},
+        },
+      ],
     },
     {
       code: `
@@ -50,11 +55,7 @@ ruleTester.run('no-complex-selectors', noComplexSelectors, {
           limit: 1,
         },
       ],
-      errors: [
-        {
-          message: 'Message complexity is too high (4 vs limit at 1)',
-        },
-      ],
+      errors: [{messageId: 'tooComplex', data: {complexity: 4, limit: 1}}],
     },
     {
       code: `
@@ -83,11 +84,7 @@ ruleTester.run('no-complex-selectors', noComplexSelectors, {
           limit: 3,
         },
       ],
-      errors: [
-        {
-          message: 'Message complexity is too high (16 vs limit at 3)',
-        },
-      ],
+      errors: [{messageId: 'tooComplex', data: {complexity: 16, limit: 3}}],
     },
     {
       code: `
@@ -102,7 +99,11 @@ ruleTester.run('no-complex-selectors', noComplexSelectors, {
       ],
       errors: [
         {
-          message: 'Message complexity is too high (3 vs limit at 1)',
+          messageId: 'tooComplex',
+          data: {
+            complexity: 3,
+            limit: 1,
+          },
         },
       ],
     },
@@ -119,7 +120,11 @@ ruleTester.run('no-complex-selectors', noComplexSelectors, {
       ],
       errors: [
         {
-          message: 'Message complexity is too high (4 vs limit at 1)',
+          messageId: 'tooComplex',
+          data: {
+            complexity: 4,
+            limit: 1,
+          },
         },
       ],
     },
@@ -134,7 +139,15 @@ ruleTester.run('no-complex-selectors', noComplexSelectors, {
           limit: 1,
         },
       ],
-      errors: [{message: 'Message complexity is too high (2 vs limit at 1)'}],
+      errors: [
+        {
+          messageId: 'tooComplex',
+          data: {
+            complexity: 2,
+            limit: 1,
+          },
+        },
+      ],
     },
   ],
 })

--- a/packages/eslint-plugin-formatjs/tests/no-emoji.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/no-emoji.test.ts
@@ -1,7 +1,7 @@
 import {ruleTester} from './util'
-import noEmoji from '../rules/no-emoji'
+import {rule, name} from '../rules/no-emoji'
 
-ruleTester.run('no-emoji', noEmoji, {
+ruleTester.run(name, rule, {
   valid: [
     {
       code: `import {defineMessage} from 'react-intl'

--- a/packages/eslint-plugin-formatjs/tests/no-id.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/no-id.test.ts
@@ -1,7 +1,7 @@
-import noId from '../rules/no-id'
+import {rule, name} from '../rules/no-id'
 import {ruleTester} from './util'
 import {dynamicMessage, noMatch, spreadJsx, emptyFnCall} from './fixtures'
-ruleTester.run('no-id', noId, {
+ruleTester.run(name, rule, {
   valid: [
     `intl.formatMessage({
       defaultMessage: '{count, plural, one {#} other {# more}}',
@@ -59,11 +59,7 @@ ruleTester.run('no-id', noId, {
   invalid: [
     {
       code: dynamicMessage,
-      errors: [
-        {
-          message: 'Manual `id` are not allowed in message descriptor',
-        },
-      ],
+      errors: [{messageId: 'noId'}],
       output: `
 import {defineMessage} from 'react-intl'
 defineMessage({ defaultMessage, description})`,
@@ -72,11 +68,7 @@ defineMessage({ defaultMessage, description})`,
       code: `
 intl.formatMessage({ id: 'foo', defaultMessage: '{count, plural, one {#} other {# more}}', description: 'asd'
 })`,
-      errors: [
-        {
-          message: 'Manual `id` are not allowed in message descriptor',
-        },
-      ],
+      errors: [{messageId: 'noId'}],
       output: `
 intl.formatMessage({  defaultMessage: '{count, plural, one {#} other {# more}}', description: 'asd'
 })`,
@@ -85,11 +77,7 @@ intl.formatMessage({  defaultMessage: '{count, plural, one {#} other {# more}}',
       code: `
 intl.formatMessage({ id: 'bar', defaultMessage: '{aDifferentKey, plural, one {#} other {# more}}', description: 'asd'
 }, {foo: 1})`,
-      errors: [
-        {
-          message: 'Manual `id` are not allowed in message descriptor',
-        },
-      ],
+      errors: [{messageId: 'noId'}],
       output: `
 intl.formatMessage({  defaultMessage: '{aDifferentKey, plural, one {#} other {# more}}', description: 'asd'
 }, {foo: 1})`,
@@ -101,11 +89,7 @@ const a = <FormattedMessage
 id={id}
 defaultMessage="{count, plural, one {#} other {# more}}"
 />`,
-      errors: [
-        {
-          message: 'Manual `id` are not allowed in message descriptor',
-        },
-      ],
+      errors: [{messageId: 'noId'}],
       output: `
 import {FormattedMessage} from 'react-intl'
 const a = <FormattedMessage
@@ -119,11 +103,7 @@ import {FormattedMessage} from 'react-intl'
 const a = (
   <FormattedMessage id="bas" defaultMessage="{count, plural, one {#} other {# more}}" values={{foo: 1}} />
 )`,
-      errors: [
-        {
-          message: 'Manual `id` are not allowed in message descriptor',
-        },
-      ],
+      errors: [{messageId: 'noId'}],
       output: `
 import {FormattedMessage} from 'react-intl'
 const a = (
@@ -136,11 +116,7 @@ intl.formatMessage({ id, defaultMessage: '{count, plural, one {<a>#</a>} other {
 }, {
   count: 1,
 })`,
-      errors: [
-        {
-          message: 'Manual `id` are not allowed in message descriptor',
-        },
-      ],
+      errors: [{messageId: 'noId'}],
       output: `
 intl.formatMessage({  defaultMessage: '{count, plural, one {<a>#</a>} other {# more}}', description: 'asd'
 }, {

--- a/packages/eslint-plugin-formatjs/tests/no-invalid-icu.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/no-invalid-icu.test.ts
@@ -1,8 +1,8 @@
-import noMalformedICU from '../rules/no-invalid-icu'
+import {name, rule} from '../rules/no-invalid-icu'
 import {ruleTester} from './util'
 import {dynamicMessage, noMatch, spreadJsx, emptyFnCall} from './fixtures'
 
-ruleTester.run('no-invalid-icu', noMalformedICU, {
+ruleTester.run(name, rule, {
   valid: [
     `intl.formatMessage({
       defaultMessage: '{count, plural, one {#} other {# more}}',
@@ -63,7 +63,7 @@ ruleTester.run('no-invalid-icu', noMalformedICU, {
           defaultMessage: '{count, plural, one {#} other {# more}}',
           description: 'asd'
       })`,
-      options: [{ignoreList: ['count']}],
+      options: [],
     },
     {
       code: `
@@ -71,7 +71,7 @@ ruleTester.run('no-invalid-icu', noMalformedICU, {
           defaultMessage: '<b>foo</b>',
           description: 'asd'
       })`,
-      options: [{ignoreList: ['b']}],
+      options: [],
     },
   ],
   invalid: [
@@ -85,7 +85,11 @@ ruleTester.run('no-invalid-icu', noMalformedICU, {
         })`,
       errors: [
         {
-          message: 'Error parsing ICU string: EXPECT_PLURAL_ARGUMENT_SELECTOR',
+          messageId: 'icuError',
+          data: {
+            message:
+              'Error parsing ICU string: EXPECT_PLURAL_ARGUMENT_SELECTOR',
+          },
         },
       ],
     },
@@ -98,7 +102,8 @@ ruleTester.run('no-invalid-icu', noMalformedICU, {
         )`,
       errors: [
         {
-          message: 'Error parsing ICU string: INVALID_ARGUMENT_TYPE',
+          messageId: 'icuError',
+          data: {message: 'Error parsing ICU string: INVALID_ARGUMENT_TYPE'},
         },
       ],
     },

--- a/packages/eslint-plugin-formatjs/tests/no-literal-string-in-jsx.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/no-literal-string-in-jsx.test.ts
@@ -1,7 +1,7 @@
-import noLiteralStringInJsx from '../rules/no-literal-string-in-jsx'
+import {rule, name} from '../rules/no-literal-string-in-jsx'
 import {ruleTester} from './util'
 
-ruleTester.run('no-literal-string-in-jsx', noLiteralStringInJsx, {
+ruleTester.run(name, rule, {
   valid: [
     {
       code: '<FormattedMessage defaultMessage="Test" />',
@@ -121,55 +121,55 @@ ruleTester.run('no-literal-string-in-jsx', noLiteralStringInJsx, {
   invalid: [
     {
       code: '<h1>Test</h1>',
-      errors: [{message: 'Cannot have untranslated text in JSX'}],
+      errors: [{messageId: 'noLiteralStringInJsx'}],
     },
     {
       code: '<img src="/example.png" alt="Example" />',
-      errors: [{message: 'Cannot have untranslated text in JSX'}],
+      errors: [{messageId: 'noLiteralStringInJsx'}],
     },
     {
       code: '<img src="/example.png" alt={"Example"} />',
-      errors: [{message: 'Cannot have untranslated text in JSX'}],
+      errors: [{messageId: 'noLiteralStringInJsx'}],
     },
     {
       code: '<img src="/example.png" alt={"Exa" + `mple`} />',
       errors: [
-        {message: 'Cannot have untranslated text in JSX'},
-        {message: 'Cannot have untranslated text in JSX'},
+        {messageId: 'noLiteralStringInJsx'},
+        {messageId: 'noLiteralStringInJsx'},
       ],
     },
     {
       code: '<img src="/example.png" alt={`Example`} />',
-      errors: [{message: 'Cannot have untranslated text in JSX'}],
+      errors: [{messageId: 'noLiteralStringInJsx'}],
     },
     {
       code: '<div title="title" />',
-      errors: [{message: 'Cannot have untranslated text in JSX'}],
+      errors: [{messageId: 'noLiteralStringInJsx'}],
     },
     {
       code: '<div title="title">text</div>',
       errors: [
-        {message: 'Cannot have untranslated text in JSX'},
-        {message: 'Cannot have untranslated text in JSX'},
+        {messageId: 'noLiteralStringInJsx'},
+        {messageId: 'noLiteralStringInJsx'},
       ],
     },
     {
       code: '<div aria-label="test">test</div>',
       errors: [
-        {message: 'Cannot have untranslated text in JSX'},
-        {message: 'Cannot have untranslated text in JSX'},
+        {messageId: 'noLiteralStringInJsx'},
+        {messageId: 'noLiteralStringInJsx'},
       ],
     },
     {
       code: '<div aria-description="test">test</div>',
       errors: [
-        {message: 'Cannot have untranslated text in JSX'},
-        {message: 'Cannot have untranslated text in JSX'},
+        {messageId: 'noLiteralStringInJsx'},
+        {messageId: 'noLiteralStringInJsx'},
       ],
     },
     {
       code: '<div>{"foo"}</div>',
-      errors: [{message: 'Cannot have untranslated text in JSX'}],
+      errors: [{messageId: 'noLiteralStringInJsx'}],
     },
     {
       code: `
@@ -180,10 +180,10 @@ ruleTester.run('no-literal-string-in-jsx', noLiteralStringInJsx, {
         </div>
       `,
       errors: [
-        {message: 'Cannot have untranslated text in JSX'},
-        {message: 'Cannot have untranslated text in JSX'},
-        {message: 'Cannot have untranslated text in JSX'},
-        {message: 'Cannot have untranslated text in JSX'},
+        {messageId: 'noLiteralStringInJsx'},
+        {messageId: 'noLiteralStringInJsx'},
+        {messageId: 'noLiteralStringInJsx'},
+        {messageId: 'noLiteralStringInJsx'},
       ],
     },
     {
@@ -196,8 +196,8 @@ ruleTester.run('no-literal-string-in-jsx', noLiteralStringInJsx, {
         </div>
       `,
       errors: [
-        {message: 'Cannot have untranslated text in JSX'},
-        {message: 'Cannot have untranslated text in JSX'},
+        {messageId: 'noLiteralStringInJsx'},
+        {messageId: 'noLiteralStringInJsx'},
       ],
     },
     // Inclusion works
@@ -210,7 +210,7 @@ ruleTester.run('no-literal-string-in-jsx', noLiteralStringInJsx, {
           },
         },
       ],
-      errors: [{message: 'Cannot have untranslated text in JSX'}],
+      errors: [{messageId: 'noLiteralStringInJsx'}],
     },
     {
       code: '<UI.Button<T> name="test" />',
@@ -223,65 +223,65 @@ ruleTester.run('no-literal-string-in-jsx', noLiteralStringInJsx, {
           },
         },
       ],
-      errors: [{message: 'Cannot have untranslated text in JSX'}],
+      errors: [{messageId: 'noLiteralStringInJsx'}],
     },
     // Multiple
     {
       code: '<UI.Button<T> aria-label={`label`} aria-description="description">Child</UI.Button>',
       errors: [
-        {message: 'Cannot have untranslated text in JSX'},
-        {message: 'Cannot have untranslated text in JSX'},
-        {message: 'Cannot have untranslated text in JSX'},
+        {messageId: 'noLiteralStringInJsx'},
+        {messageId: 'noLiteralStringInJsx'},
+        {messageId: 'noLiteralStringInJsx'},
       ],
     },
     {
       code: '<input type="text" placeholder="foo" aria-label="bar" />',
       errors: [
-        {message: 'Cannot have untranslated text in JSX'},
-        {message: 'Cannot have untranslated text in JSX'},
+        {messageId: 'noLiteralStringInJsx'},
+        {messageId: 'noLiteralStringInJsx'},
       ],
     },
     // Conditional expression
     {
       code: '<div>{a ? "b" : "c"}</div>',
       errors: [
-        {message: 'Cannot have untranslated text in JSX'},
-        {message: 'Cannot have untranslated text in JSX'},
+        {messageId: 'noLiteralStringInJsx'},
+        {messageId: 'noLiteralStringInJsx'},
       ],
     },
     {
       code: '<div aria-label={a ? "b" : "c"} />',
       errors: [
-        {message: 'Cannot have untranslated text in JSX'},
-        {message: 'Cannot have untranslated text in JSX'},
+        {messageId: 'noLiteralStringInJsx'},
+        {messageId: 'noLiteralStringInJsx'},
       ],
     },
     {
       code: '<div aria-label={a ? b ? "c" : d : e} />',
-      errors: [{message: 'Cannot have untranslated text in JSX'}],
+      errors: [{messageId: 'noLiteralStringInJsx'}],
     },
     // Logical expression
     {
       code: '<div>{a && "a"}</div>',
-      errors: [{message: 'Cannot have untranslated text in JSX'}],
+      errors: [{messageId: 'noLiteralStringInJsx'}],
     },
     {
       code: '<div>{"a" && a}</div>',
-      errors: [{message: 'Cannot have untranslated text in JSX'}],
+      errors: [{messageId: 'noLiteralStringInJsx'}],
     },
     {
       code: '<div>{a || "a"}</div>',
-      errors: [{message: 'Cannot have untranslated text in JSX'}],
+      errors: [{messageId: 'noLiteralStringInJsx'}],
     },
     {
       code: '<div>{a ?? "a"}</div>',
-      errors: [{message: 'Cannot have untranslated text in JSX'}],
+      errors: [{messageId: 'noLiteralStringInJsx'}],
     },
     {
       code: '<div>{a && "b" ?? "c"}</div>',
       errors: [
-        {message: 'Cannot have untranslated text in JSX'},
-        {message: 'Cannot have untranslated text in JSX'},
+        {messageId: 'noLiteralStringInJsx'},
+        {messageId: 'noLiteralStringInJsx'},
       ],
     },
   ],

--- a/packages/eslint-plugin-formatjs/tests/no-multiple-plurals.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/no-multiple-plurals.test.ts
@@ -1,4 +1,4 @@
-import noMultiplePlurals from '../rules/no-multiple-plurals'
+import {name, rule} from '../rules/no-multiple-plurals'
 import {ruleTester} from './util'
 import {
   dynamicMessage,
@@ -7,7 +7,7 @@ import {
   emptyFnCall,
   defineMessage,
 } from './fixtures'
-ruleTester.run('no-multiple-plurals', noMultiplePlurals, {
+ruleTester.run(name, rule, {
   valid: [defineMessage, dynamicMessage, noMatch, spreadJsx, emptyFnCall],
   invalid: [
     {
@@ -18,7 +18,7 @@ ruleTester.run('no-multiple-plurals', noMultiplePlurals, {
               })`,
       errors: [
         {
-          message: 'Cannot specify more than 1 plural rules',
+          messageId: 'noMultiplePlurals',
         },
       ],
     },
@@ -30,7 +30,7 @@ ruleTester.run('no-multiple-plurals', noMultiplePlurals, {
               })`,
       errors: [
         {
-          message: 'Cannot specify more than 1 plural rules',
+          messageId: 'noMultiplePlurals',
         },
       ],
     },

--- a/packages/eslint-plugin-formatjs/tests/no-multiple-whitespaces.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/no-multiple-whitespaces.test.ts
@@ -1,4 +1,4 @@
-import noMultipleWhitespaces from '../rules/no-multiple-whitespaces'
+import {name, rule} from '../rules/no-multiple-whitespaces'
 import {ruleTester} from './util'
 import {
   dynamicMessage,
@@ -8,7 +8,7 @@ import {
   defineMessage,
 } from './fixtures'
 
-ruleTester.run('no-multiple-whitespaces', noMultipleWhitespaces, {
+ruleTester.run(name, rule, {
   valid: [
     defineMessage,
     dynamicMessage,
@@ -32,7 +32,7 @@ ruleTester.run('no-multiple-whitespaces', noMultipleWhitespaces, {
                   {placeHolder}'})",
       errors: [
         {
-          message: 'Multiple consecutive whitespaces are not allowed',
+          messageId: 'noMultipleWhitespaces',
         },
       ],
       output: `import {defineMessage} from 'react-intl';defineMessage({defaultMessage: "a {placeHolder}"})`,
@@ -41,7 +41,7 @@ ruleTester.run('no-multiple-whitespaces', noMultipleWhitespaces, {
       code: "<FormattedMessage defaultMessage='a   thing'/>",
       errors: [
         {
-          message: 'Multiple consecutive whitespaces are not allowed',
+          messageId: 'noMultipleWhitespaces',
         },
       ],
       output: `<FormattedMessage defaultMessage="a thing"/>`,
@@ -54,7 +54,7 @@ ruleTester.run('no-multiple-whitespaces', noMultipleWhitespaces, {
               })`,
       errors: [
         {
-          message: 'Multiple consecutive whitespaces are not allowed',
+          messageId: 'noMultipleWhitespaces',
         },
       ],
       output: `
@@ -75,7 +75,7 @@ ruleTester.run('no-multiple-whitespaces', noMultipleWhitespaces, {
       `,
       errors: [
         {
-          message: 'Multiple consecutive whitespaces are not allowed',
+          messageId: 'noMultipleWhitespaces',
         },
       ],
       output: `
@@ -93,7 +93,7 @@ ruleTester.run('no-multiple-whitespaces', noMultipleWhitespaces, {
       code: "import {defineMessage} from 'react-intl';defineMessage({defaultMessage: `a\\\\  \\`  {placeHolder}`})",
       errors: [
         {
-          message: 'Multiple consecutive whitespaces are not allowed',
+          messageId: 'noMultipleWhitespaces',
         },
       ],
       output:
@@ -101,14 +101,14 @@ ruleTester.run('no-multiple-whitespaces', noMultipleWhitespaces, {
     },
     {
       code: "import {defineMessage} from 'react-intl';defineMessage({defaultMessage: `<em>a  b</em>`})",
-      errors: [{message: 'Multiple consecutive whitespaces are not allowed'}],
+      errors: [{messageId: 'noMultipleWhitespaces'}],
       output:
         "import {defineMessage} from 'react-intl';defineMessage({defaultMessage: `<em>a b</em>`})",
     },
     // Multi-line JSX attribute
     {
       code: `<FormattedMessage defaultMessage="a\n  b" />`,
-      errors: [{message: 'Multiple consecutive whitespaces are not allowed'}],
+      errors: [{messageId: 'noMultipleWhitespaces'}],
       output: `<FormattedMessage defaultMessage="a b" />`,
     },
   ],

--- a/packages/eslint-plugin-formatjs/tests/no-offset.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/no-offset.test.ts
@@ -1,7 +1,7 @@
-import noOffset from '../rules/no-offset'
+import {rule, name} from '../rules/no-offset'
 import {ruleTester} from './util'
 import {dynamicMessage, noMatch, spreadJsx, emptyFnCall} from './fixtures'
-ruleTester.run('no-offset', noOffset, {
+ruleTester.run(name, rule, {
   valid: [
     `import {defineMessage} from 'react-intl'
   defineMessage({
@@ -21,19 +21,7 @@ ruleTester.run('no-offset', noOffset, {
               })`,
       errors: [
         {
-          message: 'offset are not allowed in plural rules',
-        },
-      ],
-    },
-    {
-      code: `
-              import {defineMessage} from 'react-intl'
-              defineMessage({
-                  defaultMessage: '{count, plural, offset:1 one {#} other {# more}'
-              })`,
-      errors: [
-        {
-          message: 'EXPECT_ARGUMENT_CLOSING_BRACE',
+          messageId: 'noOffset',
         },
       ],
     },

--- a/packages/eslint-plugin-formatjs/tests/no-useless-message.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/no-useless-message.test.ts
@@ -1,4 +1,4 @@
-import noUselessMessage from '../rules/no-useless-message'
+import {name, rule} from '../rules/no-useless-message'
 import {ruleTester} from './util'
 import {
   dynamicMessage,
@@ -8,7 +8,7 @@ import {
   defineMessage,
 } from './fixtures'
 
-ruleTester.run('no-useless-message', noUselessMessage, {
+ruleTester.run(name, rule, {
   valid: [defineMessage, dynamicMessage, noMatch, spreadJsx, emptyFnCall],
   invalid: [
     {
@@ -16,7 +16,7 @@ ruleTester.run('no-useless-message', noUselessMessage, {
       import {FormattedMessage} from 'react-intl';
       <FormattedMessage defaultMessage="{test}" />
       `,
-      errors: [{message: 'Unnecessary formatted message.'}],
+      errors: [{messageId: 'unnecessaryFormat'}],
     },
     {
       code: `
@@ -25,8 +25,7 @@ ruleTester.run('no-useless-message', noUselessMessage, {
       `,
       errors: [
         {
-          message:
-            'Unnecessary formatted message: just use FormattedNumber or intl.formatNumber.',
+          messageId: 'unnecessaryFormatNumber',
         },
       ],
     },
@@ -35,24 +34,14 @@ ruleTester.run('no-useless-message', noUselessMessage, {
       import {FormattedMessage} from 'react-intl';
       <FormattedMessage defaultMessage="{test, date}" />
       `,
-      errors: [
-        {
-          message:
-            'Unnecessary formatted message: just use FormattedDate or intl.formatDate.',
-        },
-      ],
+      errors: [{messageId: 'unnecessaryFormatDate'}],
     },
     {
       code: `
       import {FormattedMessage} from 'react-intl';
       <FormattedMessage defaultMessage="{test, time}" />
       `,
-      errors: [
-        {
-          message:
-            'Unnecessary formatted message: just use FormattedTime or intl.formatTime.',
-        },
-      ],
+      errors: [{messageId: 'unnecessaryFormatTime'}],
     },
   ],
 })

--- a/packages/eslint-plugin-formatjs/tests/prefer-formatted-message.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/prefer-formatted-message.test.ts
@@ -1,4 +1,4 @@
-import preferFormattedMessage from '../rules/prefer-formatted-message'
+import {rule, name} from '../rules/prefer-formatted-message'
 import {ruleTester} from './util'
 import {
   dynamicMessage,
@@ -8,7 +8,7 @@ import {
   defineMessage,
 } from './fixtures'
 
-ruleTester.run('prefer-formatted-message', preferFormattedMessage, {
+ruleTester.run(name, rule, {
   valid: [
     defineMessage,
     dynamicMessage,
@@ -37,8 +37,7 @@ ruleTester.run('prefer-formatted-message', preferFormattedMessage, {
       `,
       errors: [
         {
-          message:
-            'Prefer `FormattedMessage` over `intl.formatMessage` in the JSX children expression.',
+          messageId: 'jsxChildren',
         },
       ],
     },
@@ -56,12 +55,10 @@ ruleTester.run('prefer-formatted-message', preferFormattedMessage, {
       `,
       errors: [
         {
-          message:
-            'Prefer `FormattedMessage` over `intl.formatMessage` in the JSX children expression.',
+          messageId: 'jsxChildren',
         },
         {
-          message:
-            'Prefer `FormattedMessage` over `intl.formatMessage` in the JSX children expression.',
+          messageId: 'jsxChildren',
         },
       ],
     },

--- a/packages/eslint-plugin-formatjs/tests/prefer-pound-in-plural.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/prefer-pound-in-plural.test.ts
@@ -1,4 +1,4 @@
-import preferPoundInPlural from '../rules/prefer-pound-in-plural'
+import {rule, name} from '../rules/prefer-pound-in-plural'
 import {ruleTester} from './util'
 import {
   dynamicMessage,
@@ -8,7 +8,7 @@ import {
   defineMessage,
 } from './fixtures'
 
-ruleTester.run('no-multiple-whitespaces', preferPoundInPlural, {
+ruleTester.run(name, rule, {
   valid: [
     defineMessage,
     dynamicMessage,

--- a/packages/eslint-plugin-formatjs/tests/util.ts
+++ b/packages/eslint-plugin-formatjs/tests/util.ts
@@ -1,25 +1,23 @@
-import {RuleTester} from 'eslint'
+import {TSESLint} from '@typescript-eslint/utils'
 
-export const ruleTester = new RuleTester({
+export const ruleTester = new TSESLint.RuleTester({
   parser: require.resolve('@typescript-eslint/parser'),
   parserOptions: {
     ecmaVersion: 6,
     sourceType: 'module',
     ecmaFeatures: {
-      modules: true,
       jsx: true,
     },
   },
 })
 
-export const vueRuleTester = new RuleTester({
+export const vueRuleTester = new TSESLint.RuleTester({
   parser: require.resolve('vue-eslint-parser'),
   parserOptions: {
     ecmaVersion: 6,
     sourceType: 'module',
     ecmaFeatures: {
       globalReturn: false,
-      impliedStrict: false,
       jsx: false,
     },
   },

--- a/packages/eslint-plugin-formatjs/util.ts
+++ b/packages/eslint-plugin-formatjs/util.ts
@@ -1,6 +1,6 @@
 import {MessageFormatElement} from '@formatjs/icu-messageformat-parser'
 import {TSESTree} from '@typescript-eslint/utils'
-import {Rule} from 'eslint'
+import {RuleContext} from '@typescript-eslint/utils/ts-eslint'
 
 export interface MessageDescriptor {
   id?: string
@@ -27,7 +27,10 @@ export interface MessageDescriptorNodeInfo {
   idPropNode?: TSESTree.Property | TSESTree.JSXAttribute
 }
 
-export function getSettings({settings}: Rule.RuleContext): Settings {
+export function getSettings<
+  TMessageIds extends string,
+  TOptions extends readonly unknown[],
+>({settings}: RuleContext<TMessageIds, TOptions>): Settings {
   return settings.formatjs ?? settings
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -492,8 +492,8 @@ importers:
         specifier: ^2.3.0
         version: 2.3.0
       '@typescript-eslint/utils':
-        specifier: ^6.5.0
-        version: 6.7.5(eslint@8.18.0)(typescript@5.2.2)
+        specifier: ^6.18.1
+        version: 6.18.1(eslint@8.18.0)(typescript@5.2.2)
       emoji-regex:
         specifier: ^10.2.1
         version: 10.2.1
@@ -513,8 +513,8 @@ importers:
         specifier: '5'
         version: 5.2.2
       unicode-emoji-utils:
-        specifier: ^1.1.1
-        version: 1.1.1
+        specifier: ^1.2.0
+        version: 1.2.0
 
   packages/fast-memoize:
     dependencies:
@@ -6963,16 +6963,53 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/scope-manager@6.18.1:
+    resolution: {integrity: sha512-BgdBwXPFmZzaZUuw6wKiHKIovms97a7eTImjkXCZE04TGHysG+0hDQPmygyvgtkoB/aOQwSM/nWv3LzrOIQOBw==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    dependencies:
+      '@typescript-eslint/types': 6.18.1
+      '@typescript-eslint/visitor-keys': 6.18.1
+    dev: false
+
   /@typescript-eslint/scope-manager@6.7.5:
     resolution: {integrity: sha512-GAlk3eQIwWOJeb9F7MKQ6Jbah/vx1zETSDw8likab/eFcqkjSD7BI75SDAeC5N2L0MmConMoPvTsmkrg71+B1A==}
     engines: {node: ^16.0.0 || >=18.0.0}
     dependencies:
       '@typescript-eslint/types': 6.7.5
       '@typescript-eslint/visitor-keys': 6.7.5
+    dev: true
+
+  /@typescript-eslint/types@6.18.1:
+    resolution: {integrity: sha512-4TuMAe+tc5oA7wwfqMtB0Y5OrREPF1GeJBAjqwgZh1lEMH5PJQgWgHGfYufVB51LtjD+peZylmeyxUXPfENLCw==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    dev: false
 
   /@typescript-eslint/types@6.7.5:
     resolution: {integrity: sha512-WboQBlOXtdj1tDFPyIthpKrUb+kZf2VroLZhxKa/VlwLlLyqv/PwUNgL30BlTVZV1Wu4Asu2mMYPqarSO4L5ZQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
+    dev: true
+
+  /@typescript-eslint/typescript-estree@6.18.1(typescript@5.2.2):
+    resolution: {integrity: sha512-fv9B94UAhywPRhUeeV/v+3SBDvcPiLxRZJw/xZeeGgRLQZ6rLMG+8krrJUyIf6s1ecWTzlsbp0rlw7n9sjufHA==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 6.18.1
+      '@typescript-eslint/visitor-keys': 6.18.1
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      minimatch: 9.0.3
+      semver: 7.5.4
+      ts-api-utils: 1.0.3(typescript@5.2.2)
+      typescript: 5.2.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /@typescript-eslint/typescript-estree@6.7.5(typescript@5.2.2):
     resolution: {integrity: sha512-NhJiJ4KdtwBIxrKl0BqG1Ur+uw7FiOnOThcYx9DpOGJ/Abc9z2xNzLeirCG02Ig3vkvrc2qFLmYSSsaITbKjlg==}
@@ -6993,6 +7030,26 @@ packages:
       typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@typescript-eslint/utils@6.18.1(eslint@8.18.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-zZmTuVZvD1wpoceHvoQpOiewmWu3uP9FuTWo8vqpy2ffsmfCE8mklRPi+vmnIYAIk9t/4kOThri2QCDgor+OpQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.18.0)
+      '@types/json-schema': 7.0.13
+      '@types/semver': 7.5.3
+      '@typescript-eslint/scope-manager': 6.18.1
+      '@typescript-eslint/types': 6.18.1
+      '@typescript-eslint/typescript-estree': 6.18.1(typescript@5.2.2)
+      eslint: 8.18.0
+      semver: 7.5.4
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: false
 
   /@typescript-eslint/utils@6.7.5(eslint@8.18.0)(typescript@5.2.2):
     resolution: {integrity: sha512-pfRRrH20thJbzPPlPc4j0UNGvH1PjPlhlCMq4Yx7EGjV7lvEeGX0U6MJYe8+SyFutWgSHsdbJ3BXzZccYggezA==}
@@ -7011,6 +7068,15 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
+    dev: true
+
+  /@typescript-eslint/visitor-keys@6.18.1:
+    resolution: {integrity: sha512-/kvt0C5lRqGoCfsbmm7/CwMqoSkY3zzHLIjdhHZQW3VFrnz7ATecOHR7nb7V+xn4286MBxfnQfQhAmCI0u+bJA==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    dependencies:
+      '@typescript-eslint/types': 6.18.1
+      eslint-visitor-keys: 3.4.3
+    dev: false
 
   /@typescript-eslint/visitor-keys@6.7.5:
     resolution: {integrity: sha512-3MaWdDZtLlsexZzDSdQWsFQ9l9nL8B80Z4fImSpyllFC/KLqWQRdEcB+gGGO+N3Q2uL40EsG66wZLsohPxNXvg==}
@@ -7018,6 +7084,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 6.7.5
       eslint-visitor-keys: 3.4.3
+    dev: true
 
   /@ungap/structured-clone@1.2.0:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
@@ -8344,7 +8411,6 @@ packages:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
     dependencies:
       balanced-match: 1.0.2
-    dev: true
 
   /braces@3.0.2:
     resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
@@ -10195,6 +10261,10 @@ packages:
 
   /emoji-regex@10.2.1:
     resolution: {integrity: sha512-97g6QgOk8zlDRdgq1WxwgTMgEWGVAQvB5Fdpgc1MkNy56la5SKP9GsMXKDOdqwn90/41a8yPwIGk1Y6WVbeMQA==}
+
+  /emoji-regex@10.3.0:
+    resolution: {integrity: sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==}
+    dev: false
 
   /emoji-regex@7.0.3:
     resolution: {integrity: sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==}
@@ -14630,7 +14700,6 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
       brace-expansion: 2.0.1
-    dev: true
 
   /minimist-options@4.1.0:
     resolution: {integrity: sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==}
@@ -18573,6 +18642,13 @@ packages:
     resolution: {integrity: sha512-QEg0BNool1kItuftJp79SbWYzgW8Rnf8I+Q5NIDSkUw8y+KS+mLBoOaxSO+nFFUyIHGEt24I2Fn1iJ74LpiDcA==}
     dependencies:
       emoji-regex: 10.2.1
+    dev: true
+
+  /unicode-emoji-utils@1.2.0:
+    resolution: {integrity: sha512-djUB91p/6oYpgps4W5K/MAvM+UspoAANHSUW495BrxeLRoned3iNPEDQgrKx9LbLq93VhNz0NWvI61vcfrwYoA==}
+    dependencies:
+      emoji-regex: 10.3.0
+    dev: false
 
   /unicode-match-property-ecmascript@2.0.0:
     resolution: {integrity: sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==}


### PR DESCRIPTION
This PR improve the eslint-plugin-formatjs codebase with stricter typescript integrations:
- Updated ts-eslint dependencies
- Updated rules to use `@typescript-eslint/utils` tooling to get all the Typescript benefits
- Added `MessageIds` and `Options` types to each plugins
- Updated tests to check against `messageId` instead of copy-paste error message
- Removed `node as any` and others type casting

Note: Some extensions of `vue-eslint-parser` (such as `defineTemplateBodyVisitor`) are non-standard, and `@typescript-eslint/utils` won't support it as [it doesn't follow the core eslint](https://github.com/typescript-eslint/typescript-eslint/issues/767). Therefore, there are `ts-expect-error` when referencing them

# How to test

`bazel test //packages/eslint-plugin-formatjs:unit_test`

