### PR TITLE
docs: replace ttypescript with ts-patch

### DIFF
--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -177,7 +177,7 @@ Output
 
 ## Adding our babel-plugin/TypeScript Transformer for compilation
 
-Our tooling supports `babel`, `ts-loader`, `ts-jest`, `rollup-plugin-typescript2` & `ttypescript` for message compilation:
+Our tooling supports `babel`, `ts-loader`, `ts-jest`, `rollup-plugin-typescript2` & `ts-patch` for message compilation:
 
 ### Babel
 
@@ -305,7 +305,7 @@ yarn add -D @formatjs/ts-transformer
 
 Take a look at [`ts-jest` guide](https://kulshekhar.github.io/ts-jest/docs/getting-started/options/astTransformers) on how to incorporate custom AST Transformers.
 
-### `ttypescript`
+### `ts-patch`
 
 <Tabs
 groupId="npm"

--- a/website/docs/guides/bundler-plugins.mdx
+++ b/website/docs/guides/bundler-plugins.mdx
@@ -110,7 +110,7 @@ yarn add -D @formatjs/ts-transformer
 </TabItem>
 </Tabs>
 
-If you're using TypeScript, in order to enable custom AST transformer you should consider using [ttypescript](https://github.com/cevek/ttypescript), [ts-loader](https://github.com/TypeStrong/ts-loader) or similar.
+If you're using TypeScript, in order to enable custom AST transformer you should consider using [ts-patch](https://github.com/nonara/ts-patch), [ts-loader](https://github.com/TypeStrong/ts-loader) or similar.
 
 Let's take this simple example:
 

--- a/website/docs/tooling/ts-transformer.md
+++ b/website/docs/tooling/ts-transformer.md
@@ -106,7 +106,7 @@ module.exports = {
 }
 ```
 
-### Via `ttypescript`
+### Via `ts-patch`
 
 ```json
 {


### PR DESCRIPTION
Since [ttypescript](https://github.com/cevek/ttypescript) has been deprecated, [ts-patch](https://github.com/nonara/ts-patch) is recommended and fully compatible with legacy `ttypescript`

Closing #4280 

