### PR TITLE
feat(react-intl): move createIntl function to a separate file to support react server components

### DIFF
--- a/packages/react-intl/index.ts
+++ b/packages/react-intl/index.ts
@@ -23,7 +23,8 @@ import injectIntl, {
   WrappedComponentProps,
 } from './src/components/injectIntl'
 import useIntl from './src/components/useIntl'
-import IntlProvider, {createIntl} from './src/components/provider'
+import IntlProvider from './src/components/provider'
+import {createIntl} from './src/components/createIntl'
 import FormattedRelativeTime from './src/components/relative'
 import FormattedPlural from './src/components/plural'
 import FormattedMessage from './src/components/message'

--- a/packages/react-intl/src/components/createIntl.ts
+++ b/packages/react-intl/src/components/createIntl.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2015, Yahoo Inc.
+ * Copyrights licensed under the New BSD License.
+ * See the accompanying LICENSE file for terms.
+ */
+
+import {
+  CreateIntlFn,
+  FormatMessageFn,
+  createIntl as coreCreateIntl,
+  formatMessage as coreFormatMessage,
+} from '@formatjs/intl'
+import * as React from 'react'
+import type {IntlConfig, IntlShape, ResolvedIntlConfig} from '../types'
+import {DEFAULT_INTL_CONFIG, assignUniqueKeysToParts} from '../utils'
+import {
+  FormatXMLElementFn,
+  PrimitiveType,
+  isFormatXMLElementFn,
+} from 'intl-messageformat'
+
+function assignUniqueKeysToFormatXMLElementFnArgument<
+  T extends Record<
+    string,
+    | PrimitiveType
+    | React.ReactNode
+    | FormatXMLElementFn<React.ReactNode, React.ReactNode>
+  > = Record<
+    string,
+    | PrimitiveType
+    | React.ReactNode
+    | FormatXMLElementFn<React.ReactNode, React.ReactNode>
+  >,
+>(values?: T): T | undefined {
+  if (!values) {
+    return values
+  }
+  return Object.keys(values).reduce((acc: T, k) => {
+    const v = values[k]
+    ;(acc as any)[k] = isFormatXMLElementFn<React.ReactNode>(v)
+      ? assignUniqueKeysToParts(v)
+      : v
+    return acc
+  }, {} as T)
+}
+
+const formatMessage: FormatMessageFn<React.ReactNode> = (
+  config,
+  formatters,
+  descriptor,
+  rawValues,
+  ...rest
+) => {
+  const values = assignUniqueKeysToFormatXMLElementFnArgument(rawValues)
+  const chunks = coreFormatMessage(
+    config,
+    formatters,
+    descriptor,
+    values as any,
+    ...rest
+  )
+  if (Array.isArray(chunks)) {
+    return React.Children.toArray(chunks)
+  }
+  return chunks as any
+}
+
+/**
+ * Create intl object
+ * @param config intl config
+ * @param cache cache for formatter instances to prevent memory leak
+ */
+export const createIntl: CreateIntlFn<
+  React.ReactNode,
+  IntlConfig,
+  IntlShape
+> = (
+  {defaultRichTextElements: rawDefaultRichTextElements, ...config},
+  cache
+) => {
+  const defaultRichTextElements = assignUniqueKeysToFormatXMLElementFnArgument(
+    rawDefaultRichTextElements
+  )
+  const coreIntl = coreCreateIntl<React.ReactNode>(
+    {
+      ...DEFAULT_INTL_CONFIG,
+      ...config,
+      defaultRichTextElements,
+    },
+    cache
+  )
+
+  const resolvedConfig: ResolvedIntlConfig = {
+    locale: coreIntl.locale,
+    timeZone: coreIntl.timeZone,
+    fallbackOnEmptyString: coreIntl.fallbackOnEmptyString,
+    formats: coreIntl.formats,
+    defaultLocale: coreIntl.defaultLocale,
+    defaultFormats: coreIntl.defaultFormats,
+    messages: coreIntl.messages,
+    onError: coreIntl.onError,
+    defaultRichTextElements,
+  }
+
+  return {
+    ...coreIntl,
+    formatMessage: formatMessage.bind(
+      null,
+      resolvedConfig,
+      // @ts-expect-error fix this
+      coreIntl.formatters
+    ),
+    // @ts-expect-error fix this
+    $t: formatMessage.bind(null, resolvedConfig, coreIntl.formatters),
+  } as any
+}

--- a/packages/react-intl/tests/unit/components/date.tsx
+++ b/packages/react-intl/tests/unit/components/date.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import {FormattedDate, FormattedDateParts} from '../../../'
 import {mountFormattedComponentWithProvider} from '../testUtils'
-import {createIntl} from '../../../src/components/provider'
+import {createIntl} from '../../../src/components/createIntl'
 import {IntlShape} from '../../../'
 import {render} from '@testing-library/react'
 

--- a/packages/react-intl/tests/unit/components/dateTimeRange.tsx
+++ b/packages/react-intl/tests/unit/components/dateTimeRange.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import {FormattedDateTimeRange} from '../../../'
 import {mountFormattedComponentWithProvider} from '../testUtils'
-import {createIntl} from '../../../src/components/provider'
+import {createIntl} from '../../../src/components/createIntl'
 import {IntlShape} from '../../../'
 import {render} from '@testing-library/react'
 const mountWithProvider = mountFormattedComponentWithProvider(

--- a/packages/react-intl/tests/unit/components/message.tsx
+++ b/packages/react-intl/tests/unit/components/message.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import FormattedMessage from '../../../src/components/message'
-import IntlProvider, {createIntl} from '../../../src/components/provider'
+import IntlProvider from '../../../src/components/provider'
+import {createIntl} from '../../../src/components/createIntl'
 import {mountFormattedComponentWithProvider} from '../testUtils'
 import {IntlShape} from '../../../'
 import {render} from '@testing-library/react'

--- a/packages/react-intl/tests/unit/components/number.tsx
+++ b/packages/react-intl/tests/unit/components/number.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import {FormattedNumber, FormattedNumberParts} from '../../../'
-import {createIntl} from '../../../src/components/provider'
+import {createIntl} from '../../../src/components/createIntl'
 import {mountFormattedComponentWithProvider} from '../testUtils'
 import {NumberFormatOptions} from '@formatjs/ecma402-abstract'
 import {render} from '@testing-library/react'

--- a/packages/react-intl/tests/unit/components/plural.tsx
+++ b/packages/react-intl/tests/unit/components/plural.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import FormattedPlural from '../../../src/components/plural'
 import {mountFormattedComponentWithProvider} from '../testUtils'
-import {createIntl} from '../../../src/components/provider'
+import {createIntl} from '../../../src/components/createIntl'
 import {IntlShape} from '@formatjs/intl'
 import {render} from '@testing-library/react'
 import {LDMLPluralRule} from '@formatjs/ecma402-abstract'

--- a/packages/react-intl/tests/unit/components/relative.tsx
+++ b/packages/react-intl/tests/unit/components/relative.tsx
@@ -1,7 +1,7 @@
 import '@formatjs/intl-relativetimeformat/polyfill'
 import * as React from 'react'
 import FormattedRelativeTime from '../../../src/components/relative'
-import {createIntl} from '../../../src/components/provider'
+import {createIntl} from '../../../src/components/createIntl'
 import {IntlShape} from '../../../src/types'
 import {mountFormattedComponentWithProvider} from '../testUtils'
 import type {IntlConfig} from '../../../src/types'

--- a/packages/react-intl/tests/unit/components/time.tsx
+++ b/packages/react-intl/tests/unit/components/time.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import {FormattedTime, FormattedTimeParts} from '../../../'
 import {mountFormattedComponentWithProvider} from '../testUtils'
-import {createIntl} from '../../../src/components/provider'
+import {createIntl} from '../../../src/components/createIntl'
 import {IntlShape} from '@formatjs/intl'
 import {render} from '@testing-library/react'
 


### PR DESCRIPTION
fix #4192 