### PR TITLE
docs: add disclaimer about custom rich text formatting

### DIFF
--- a/website/docs/core-concepts/icu-syntax.mdx
+++ b/website/docs/core-concepts/icu-syntax.mdx
@@ -265,6 +265,10 @@ with <link>{pct, number, ::percent} discount</link>`}
   defaultValues='{"price": 2, "pct": 0.2}'
 />
 
+:::info Custom Behavior
+It is expected that the system using embedded rich text formatting will have methods to handle these placeholders external to this library. The tags will be part of the generated output and can either be **post-processed** by your own tooling or use the [defaultRichTextElements](/docs/intl/#defaultRichTextElements) configuration.
+:::
+
 ## Quoting / Escaping
 
 The ASCII apostrophe `'` (U+0027) can be used to escape syntax characters in the text portion of the message, which mimics the [behavior of ICU's quoting/escaping](https://unicode-org.github.io/icu/userguide/format_parse/messages/#quotingescaping).


### PR DESCRIPTION
Prior to this change, it was confusing if formatjs offered styling or if it just supported the ability for users to roll their own.

This change adds an info box explaining that they can post-process tags for their own custom styling needs. This post-process expectation is consistent with how other libraries use formatjs like react-intl.

For projects that use formatjs itself (without a supporting framework) it can be confusing to see <boldThis> and not realize they have to implement that.

For an example of how this could work see this example:
  https://tritarget.org/fiddles/?fiddle=formatjs-custom-rich-text-support.html

The suggestion to post-process is for situations when the canonical defaultRichTextElements is not available either due to requirements or libraries that might disable tags (ignoreTags=true).

In either case it is unclear at this point in the documentation how a user can support rich text.

I was unsure if it was appropriate to also link to examples external to the site so left that out.