### PR TITLE
docs: use clearer naming in icu-syntax select example

### DIFF
--- a/website/docs/core-concepts/icu-syntax.mdx
+++ b/website/docs/core-concepts/icu-syntax.mdx
@@ -171,11 +171,11 @@ The `other` match is special and is used if nothing else matches. (This is simil
 Here's an example of nested arguments.
 
 <IcuEditor
-  defaultMessage={`{0, select,
-    yes {An additional {1, number, percent} tax will be collected.}
+  defaultMessage={`{isTaxed, select,
+    yes {An additional {tax, number, percent} tax will be collected.}
     other {No taxes apply.}
 }`}
-  defaultValues='{"0": "yes", "1": 0.4}'
+  defaultValues='{"isTaxed": "yes", "tax": 0.4}'
 />
 
 ### `{plural}` Format

--- a/website/docs/core-concepts/icu-syntax.mdx
+++ b/website/docs/core-concepts/icu-syntax.mdx
@@ -161,10 +161,10 @@ The `other` match is special and is used if nothing else matches. (This is simil
 
 <IcuEditor
   defaultMessage={`{gender, select,
-    male {He}
-    female {She}
-    other {They}
-} will respond shortly.`}
+    male {He will respond shortly.}
+    female {She will respond shortly.}
+    other {They will respond shortly.}
+}`}
   defaultValues='{"gender": "male"}'
 />
 
@@ -197,30 +197,30 @@ The match is a literal value and is matched to one of these plural categories. N
 :::
 
 <IcuEditor
-  defaultMessage={`Cart: {itemCount} {itemCount, plural,
-    one {item}
-    other {items}
+  defaultMessage={`{itemCount, plural,
+    one {Cart: {itemCount, number} item}
+    other {Cart: {itemCount, number} items}
 }`}
   defaultValues='{"itemCount": 123}'
 />
 
 <IcuEditor
-  defaultMessage={`You have {itemCount, plural,
-    =0 {no items}
-    one {{0} item}
-    other {{0} items}
-}.`}
+  defaultMessage={`{itemCount, plural,
+    =0 {You have no items.}
+    one {You have {itemCount, number} item.}
+    other {You have {itemCount, number} items.}
+}`}
   defaultValues='{"itemCount": 123}'
 />
 
 In the `output` of the match, you can use the `#` special token as a placeholder for the numeric value and it'll be formatted as if it were `{key, number}`. This is the style we prefer to use.
 
 <IcuEditor
-  defaultMessage={`You have {itemCount, plural,
-    =0 {no items}
-    one {# item}
-    other {# items}
-}.`}
+  defaultMessage={`{itemCount, plural,
+    =0 {You have no items.}
+    one {You have # item.}
+    other {You have # items.}
+}`}
   defaultValues='{"itemCount": 123}'
 />
 

--- a/website/docs/intl-messageformat.md
+++ b/website/docs/intl-messageformat.md
@@ -40,10 +40,10 @@ A very common example is formatting messages that have numbers with plural label
 
 ```tsx live
 new IntlMessageFormat(
-  `You have {numPhotos, plural,
-      =0 {no photos.}
-      =1 {one photo.}
-      other {# photos.}
+  `{numPhotos, plural,
+      =0 {You have no photos.}
+      =1 {You have one photo.}
+      other {You have # photos.}
     }`,
   'en-US'
 ).format({numPhotos: 1000})
@@ -51,10 +51,10 @@ new IntlMessageFormat(
 
 ```tsx live
 new IntlMessageFormat(
-  `Usted {numPhotos, plural,
-      =0 {no tiene fotos.}
-      =1 {tiene una foto.}
-      other {tiene # fotos.}
+  `{numPhotos, plural,
+      =0 {Usted no tiene fotos.}
+      =1 {Usted tiene una foto.}
+      other {Usted tiene # fotos.}
     }`,
   'es-ES'
 ).format({numPhotos: 1000})


### PR DESCRIPTION
The examples for the complex placeholders split the prose in an English centric way. This is not advisable instead placing the full prose in each part of the placeholders for maximum context when translating.

> It is tempting to cover only a minimal part of a message string with a complex argument (e.g., plural). However, this is difficult for translators for two reasons: 1. They might have trouble understanding how the sentence fragments in the argument sub-messages interact with the rest of the sentence, and 2. They will not know whether and how they can shrink or grow the extent of the part of the sentence that is inside the argument to make the whole message work for their language.
>
> Recommendation: If possible, use complex arguments as the outermost structure of a message, and write full sentences in their sub-messages. If you have nested select and plural arguments, place the select arguments (with their fixed sets of choices) on the outside and nest the plural arguments (hopefully at most one) inside.
>
> https://unicode-org.github.io/icu/userguide/format_parse/messages/index#messageformat

----

Also, the naming in one of the examples was 0 and 1 which looked odd and like not something we would normally do in production.

This change changes the values to intention revealing names: isTaxed and tax.