### PR TITLE
fix(@formatjs/cli-lib): onMsgExtracted / onMetaExtracted not getting called

### DIFF
--- a/packages/cli-lib/src/extract.ts
+++ b/packages/cli-lib/src/extract.ts
@@ -97,13 +97,15 @@ async function processFile(
   let messages: ExtractedMessageDescriptor[] = []
   let meta: Record<string, string> | undefined
 
+  const onMsgExtracted = opts.onMsgExtracted
+
   opts = {
     ...opts,
     additionalComponentNames: [
       '$formatMessage',
       ...(opts.additionalComponentNames || []),
     ],
-    onMsgExtracted(_, msgs) {
+    onMsgExtracted(filePath, msgs) {
       if (opts.extractSourceLocation) {
         msgs = msgs.map(msg => ({
           ...msg,
@@ -111,6 +113,10 @@ async function processFile(
         }))
       }
       messages = messages.concat(msgs)
+
+      if (onMsgExtracted) {
+        onMsgExtracted(filePath, msgs)
+      }
     },
     onMetaExtracted(_, m) {
       meta = m

--- a/packages/cli-lib/src/extract.ts
+++ b/packages/cli-lib/src/extract.ts
@@ -98,6 +98,7 @@ async function processFile(
   let meta: Record<string, string> | undefined
 
   const onMsgExtracted = opts.onMsgExtracted
+  const onMetaExtracted = opts.onMetaExtracted
 
   opts = {
     ...opts,
@@ -118,8 +119,12 @@ async function processFile(
         onMsgExtracted(filePath, msgs)
       }
     },
-    onMetaExtracted(_, m) {
+    onMetaExtracted(filePath, m) {
       meta = m
+
+      if (onMetaExtracted) {
+        onMetaExtracted(filePath, m)
+      }
     },
   }
 


### PR DESCRIPTION
Call `onMsgExtracted` and `onMetaExtracted` options if passed as options to `extract` in cli-lib. Fixes #4343 