### PR TITLE
Allow passing resolvedLocale

### DIFF
--- a/packages/intl-messageformat/src/core.ts
+++ b/packages/intl-messageformat/src/core.ts
@@ -59,6 +59,7 @@ function mergeConfigs(
 
 export interface Options extends Omit<ParserOptions, 'locale'> {
   formatters?: Formatters
+  resolvedLocale?: Intl.Locale
 }
 
 function createFastMemoizeCache<V>(
@@ -121,7 +122,8 @@ export class IntlMessageFormat {
   ) {
     // Defined first because it's used to build the format pattern.
     this.locales = locales
-    this.resolvedLocale = IntlMessageFormat.resolveLocale(locales)
+    this.resolvedLocale =
+      opts?.resolvedLocale || IntlMessageFormat.resolveLocale(locales)
 
     if (typeof message === 'string') {
       this.message = message


### PR DESCRIPTION
This update introduces a performance optimization for IntlMessageFormat by enabling the reuse of a resolvedLocale instance across multiple instantiations. Previously, when IntlMessageFormat was instantiated multiple times—such as when formatting a large number of messages for the same locale set—the resolveLocale method could significantly impact performance by being invoked for each instantiation.

To address this, we now allow a resolvedLocale instance to be passed through the options parameter (opts). This means resolveLocale only needs to be called once, prior to any IntlMessageFormat instance creation, thereby reducing overhead and improving execution speed in scenarios involving bulk message formatting.

Sample usage:
```javascript
const messages = [...]; // Array of messages to be formatted
const resolvedLocale = IntlMessageFormat.resolveLocale("en-GB"); // Resolve locale once

messages.forEach(message => {
  const formattedMessage = new IntlMessageFormat(message, "en-GB", undefined, { resolvedLocale }).format();
  // Use the formattedMessage as needed
});
```

By passing the pre-resolved locale object, we eliminate the need for repeated resolveLocale calls.