### PR TITLE
fix(eslint-plugin-formatjs): Continue to next message after idWhitelist match in enforce-id

### DIFF
--- a/packages/eslint-plugin-formatjs/rules/enforce-id.ts
+++ b/packages/eslint-plugin-formatjs/rules/enforce-id.ts
@@ -71,7 +71,7 @@ function checkNode(
           idWhitelistRegexps.some((r: RegExp) => r.test(id))
         ) {
           // messageId is allowlisted so skip interpolation id check
-          return
+          continue
         }
 
         const correctId = interpolateName(

--- a/packages/eslint-plugin-formatjs/tests/enforce-id.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/enforce-id.test.ts
@@ -274,5 +274,25 @@ intl.formatMessage({defaultMessage: "{count, plural, one {#} other {# more}}", d
       output: `
 intl.formatMessage({defaultMessage: "{count, plural, one {#} other {# more}}", id: 'j9qhn+', description: "asd"})`,
     },
+    {
+      code: `
+import { defineMessages } from 'react-intl'
+defineMessages({ example: { defaultMessage: 'example1', id: 'payment_string' }, example2: { defaultMessage: 'example2' }  })`,
+      options: optionsWithWhitelist,
+      errors: [
+        {
+          messageId: 'enforceIdMatchingAllowlisted',
+          data: {
+            idInterpolationPattern: '[sha512:contenthash:base64:6]',
+            expected: 'FnMvk8',
+            actual: 'undefined',
+            idWhitelist: '"/\\./i", "/^payment_.*/i"',
+          },
+        },
+      ],
+      output: `
+import { defineMessages } from 'react-intl'
+defineMessages({ example: { defaultMessage: 'example1', id: 'payment_string' }, example2: { defaultMessage: 'example2', id: 'FnMvk8' }  })`,
+    },
   ],
 })


### PR DESCRIPTION
Fix for https://github.com/formatjs/formatjs/issues/4240