### PR TITLE
fix(eslint-plugin-formatjs): loosen check to allow more types of `intl` access

### DIFF
--- a/packages/eslint-plugin-formatjs/tests/no-invalid-icu.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/no-invalid-icu.test.ts
@@ -12,6 +12,10 @@ ruleTester.run(name, rule, {
       defaultMessage: '{count, plural, one {#} other {# more}}',
       description: 'asd'
   }, {count: 1})`,
+    `IntlStore.intl.formatMessage({
+      defaultMessage: '{count, plural, one {#} other {# more}}',
+      description: 'asd'
+  }, {count: 1})`,
     `intl.formatMessage({
     defaultMessage: '{count, plural, one {#} other {# more}}',
     description: 'asd'
@@ -115,6 +119,20 @@ ruleTester.run(name, rule, {
     {
       code: `
         this.intl.formatMessage({
+          defaultMessage: "{aDifferentKey, plur {#} other {# more}}" },
+          { count: 1 }
+        )`,
+      errors: [
+        {
+          messageId: 'icuError',
+          data: {message: 'Error parsing ICU string: INVALID_ARGUMENT_TYPE'},
+        },
+      ],
+    },
+
+    {
+      code: `
+        IntlStore.intl.formatMessage({
           defaultMessage: "{aDifferentKey, plur {#} other {# more}}" },
           { count: 1 }
         )`,

--- a/packages/eslint-plugin-formatjs/util.ts
+++ b/packages/eslint-plugin-formatjs/util.ts
@@ -71,7 +71,6 @@ export function isIntlFormatMessageCall(
     ((node.callee.object.type === 'Identifier' &&
       node.callee.object.name === 'intl') ||
       (node.callee.object.type === 'MemberExpression' &&
-        node.callee.object.object.type === 'ThisExpression' &&
         node.callee.object.property.type === 'Identifier' &&
         node.callee.object.property.name === 'intl')) &&
     node.callee.property.type === 'Identifier' &&


### PR DESCRIPTION
Related to issue https://github.com/formatjs/formatjs/issues/4382

As we've adopted this lint plugin in more packages, we've found other `intl` access patterns that it doesn't support.  In particular, we cache our intl object in a store in some contexts, and access it like `IntlStore.intl.formatMessage(...)`.

The change here is to loosen the checks I added in https://github.com/formatjs/formatjs/pull/4383 to allow for more than just `this.` to the left of `intl`.  Apologies for the churn - I'm still gaining experience writing lint rules and working with the AST.