### PR TITLE
Run workflows as non-root user

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -8,6 +8,7 @@ actions:
       pull_request:
         branches:
           - '*'
+    user: 'buildbuddy'
     resource_requests:
       memory: 10GB
     bazel_commands:


### PR DESCRIPTION
BuildBuddy will soon be migrating all workflows to run as non-root by default. This PR just ensures that formatjs workflows are compatible with non-root.

This PR does not need to be merged - if tests pass on this PR, and if the repo maintainers are OK with it, I can make this change in our DB, and the PR can be closed. To avoid breaking existing workflow users, we currently have a list of legacy workflows which are still allowed to use the root-by-default behavior, and I can just remove formatjs from the list.