### PR TITLE
fix(@formatjs/icu-messageformat-parser): remove orphaned type

### DIFF
--- a/packages/icu-messageformat-parser/types.ts
+++ b/packages/icu-messageformat-parser/types.ts
@@ -202,8 +202,3 @@ export function createNumberElement(
     style,
   }
 }
-
-export type IntlLocaleLike = {
-  readonly hourCycle?: Intl.LocaleHourCycleKey
-  readonly hourCycles?: Array<Intl.LocaleHourCycleKey>
-}


### PR DESCRIPTION
Resolves #4413.

There doesn't appear to be any dissent raised to removing this, and it's definitely not used internally, nor would there be any reason to.