### PR TITLE
Documented how to use ember-intl

### DIFF
--- a/website/docs/ember-intl.md
+++ b/website/docs/ember-intl.md
@@ -1,0 +1,129 @@
+---
+id: ember-intl
+title: Overview
+---
+
+`ember-intl` helps you internationalize your Ember projects. It supports TypeScript and [Glint](https://typed-ember.gitbook.io/glint/) (type-check for templates).
+
+## Installation
+
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
+<Tabs
+groupId="installation"
+defaultValue="pnpm"
+values={[
+{label: 'pnpm', value: 'pnpm'},
+{label: 'npm', value: 'npm'},
+{label: 'yarn', value: 'yarn'},
+]}>
+<TabItem value="pnpm">
+
+```sh
+pnpm add ember-intl
+```
+
+</TabItem>
+
+<TabItem value="npm">
+
+```sh
+npm install ember-intl
+```
+
+</TabItem>
+
+<TabItem value="yarn">
+
+```sh
+yarn add ember-intl
+```
+
+</TabItem>
+</Tabs>
+
+For more information, see [Quickstart](https://ember-intl.github.io/ember-intl/docs/quickstart).
+
+## Usage
+
+The complete documentation is available on the [`ember-intl` website](https://ember-intl.github.io/ember-intl/). For brevity, this section covers the most important features.
+
+### Helpers
+
+`ember-intl` provides several locale-aware helpers, so that you can display translations, numbers, dates, etc.
+
+The helper that you will most frequently use is `{{t}}` (the "t helper" or "translation helper"). In a template (an `*.hbs` file), you can render a translation like this:
+
+```hbs
+{{! app/components/hello.hbs }}
+<div data-test-message>
+  {{t 'hello.message' name=@name}}
+</div>
+```
+
+In a `<template>`-tag component (`*.{gjs,gts}`), use the named import to consume the `{{t}}` helper.
+
+```ts
+/* app/components/hello.gts */
+import { t } from 'ember-intl';
+
+<template>
+  <div data-test-message>
+    {{t "hello.message" name=@name}}
+  </div>
+</template>
+```
+
+### Services
+
+`ember-intl` provides 1 locale-aware service: `intl`. This service allows you to use `ember-intl`'s API in _any_ class (components, routes, and even native JS classes).
+
+```ts
+/* app/components/example.ts */
+import {service} from '@ember/service'
+import Component from '@glimmer/component'
+import type {IntlService} from 'ember-intl'
+
+export default class ExampleComponent extends Component {
+  @service declare intl: IntlService
+
+  get options(): string[] {
+    return [
+      this.intl.t('components.example.option-1'),
+      this.intl.t('components.example.option-2'),
+      this.intl.t('components.example.option-3'),
+    ]
+  }
+}
+```
+
+### Test Helpers
+
+`ember-intl` provides a few test helpers, so that you can check locale-dependent code (e.g. component and route templates) under various conditions.
+
+```ts
+/* tests/integration/components/hello.gts */
+import Hello from '#app/components/hello';
+import { render } from '@ember/test-helpers';
+import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Integration | Component | hello', function (hooks) {
+  setupRenderingTest(hooks);
+  setupIntl(hooks, 'de-de');
+
+  test('it renders', async function (assert) {
+    await render(
+      <template>
+        <Hello @name="Zoey" />
+      </template>
+    );
+
+    assert.dom('[data-test-message]').hasText('Hallo, Zoey!');
+  });
+});
+```
+
+Note, the test (this also means you, the developer) sees exactly the text that the user will see.

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -43,6 +43,7 @@ defaultValue="react"
 values={[
 {label: 'Node', value: 'node'},
 {label: 'React', value: 'react'},
+{label: 'Ember', value: 'ember'},
 {label: 'Vue3', value: 'vue'},
 ]}>
 
@@ -87,6 +88,40 @@ console.log(
 
 // 19,00 €
 console.log(intl.formatNumber(19, {style: 'currency', currency: 'EUR'}))
+```
+
+</TabItem>
+
+<TabItem value="ember">
+
+Setup:
+
+```ts
+/* app/routes/application.ts */
+import Route from '@ember/routing/route'
+import {service} from '@ember/service'
+import type {IntlService} from 'ember-intl'
+
+export default class ApplicationRoute extends Route {
+  @service declare intl: IntlService
+
+  beforeModel() {
+    this.intl.setLocale(['de-de', 'en-us'])
+  }
+}
+```
+
+Use:
+
+```ts
+/* app/components/hello.gts */
+import { t } from 'ember-intl';
+
+<template>
+  <div>
+    {{t "hello.message" name=@name}}
+  </div>
+</template>
 ```
 
 </TabItem>

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -33,7 +33,7 @@ export default {
           label: 'API References',
           position: 'left',
           activeBaseRegex:
-            'docs/(vue-intl|intl|react-intl|intl-messageformat|icu-messageformat-parser)',
+            'docs/(vue-intl|intl|ember-intl|react-intl|intl-messageformat|icu-messageformat-parser)',
         },
         {
           to: 'docs/polyfills',

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -31,6 +31,7 @@ module.exports = {
       'react-intl/upgrade-guide-2x',
     ],
     '@formatjs/intl': ['intl'],
+    'ember-intl': ['ember-intl'],
     'vue-intl': ['vue-intl'],
     'intl-messageformat': ['intl-messageformat'],
     'icu-messageformat-parser': ['icu-messageformat-parser'],


### PR DESCRIPTION
Hello, everyone. In https://github.com/ember-intl/ember-intl/issues/1801, @longlho had reached out to see if it might be possible to move the `ember-intl` package to this repo. I had declined the offer and proposed, as an alternative, a larger mention of `ember-intl` in the `formatjs` website, so that people from the wider JS community may learn how to set up and use `ember-intl`.

In case you (and possibly other maintainers) are still open to this idea of updating the `formatjs` documentation, I created this pull request so that we can begin a conversation. Thanks in advance.

Preview:

<img width="900" alt="" src="https://github.com/formatjs/formatjs/assets/16869656/b19a5e34-2f41-4177-87a8-cd0ffd5a4625">


