### PR TITLE
feat(swc-plugin-experimental): add support for @swc/core v1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@lerna-lite/version": "2",
         "@napi-rs/cli": "^2.11.0",
         "@swc-node/register": "^1.5.4",
-        "@swc/core": "^1.5.0",
+        "@swc/core": "^1.6.0",
         "@swc/helpers": "^0.5.1",
         "@swc/jest": "^0.2.23",
         "@taplo/cli": "^0.7.0",
@@ -4473,15 +4473,14 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.5.7.tgz",
-      "integrity": "sha512-U4qJRBefIJNJDRCCiVtkfa/hpiZ7w0R6kASea+/KLp+vkus3zcLSB8Ub8SvKgTIxjWpwsKcZlPf5nrv4ls46SQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.6.1.tgz",
+      "integrity": "sha512-Yz5uj5hNZpS5brLtBvKY0L4s2tBAbQ4TjmW8xF1EC3YLFxQRrUjMP49Zm1kp/KYyYvTkSaG48Ffj2YWLu9nChw==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "@swc/counter": "^0.1.2",
-        "@swc/types": "0.1.7"
+        "@swc/counter": "^0.1.3",
+        "@swc/types": "^0.1.8"
       },
       "engines": {
         "node": ">=10"
@@ -4491,19 +4490,19 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.5.7",
-        "@swc/core-darwin-x64": "1.5.7",
-        "@swc/core-linux-arm-gnueabihf": "1.5.7",
-        "@swc/core-linux-arm64-gnu": "1.5.7",
-        "@swc/core-linux-arm64-musl": "1.5.7",
-        "@swc/core-linux-x64-gnu": "1.5.7",
-        "@swc/core-linux-x64-musl": "1.5.7",
-        "@swc/core-win32-arm64-msvc": "1.5.7",
-        "@swc/core-win32-ia32-msvc": "1.5.7",
-        "@swc/core-win32-x64-msvc": "1.5.7"
+        "@swc/core-darwin-arm64": "1.6.1",
+        "@swc/core-darwin-x64": "1.6.1",
+        "@swc/core-linux-arm-gnueabihf": "1.6.1",
+        "@swc/core-linux-arm64-gnu": "1.6.1",
+        "@swc/core-linux-arm64-musl": "1.6.1",
+        "@swc/core-linux-x64-gnu": "1.6.1",
+        "@swc/core-linux-x64-musl": "1.6.1",
+        "@swc/core-win32-arm64-msvc": "1.6.1",
+        "@swc/core-win32-ia32-msvc": "1.6.1",
+        "@swc/core-win32-x64-msvc": "1.6.1"
       },
       "peerDependencies": {
-        "@swc/helpers": "^0.5.0"
+        "@swc/helpers": "*"
       },
       "peerDependenciesMeta": {
         "@swc/helpers": {
@@ -4512,14 +4511,13 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.5.7.tgz",
-      "integrity": "sha512-bZLVHPTpH3h6yhwVl395k0Mtx8v6CGhq5r4KQdAoPbADU974Mauz1b6ViHAJ74O0IVE5vyy7tD3OpkQxL/vMDQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.6.1.tgz",
+      "integrity": "sha512-u6GdwOXsOEdNAdSI6nWq6G2BQw5HiSNIZVcBaH1iSvBnxZvWbnIKyDiZKaYnDwTLHLzig2GuUjjE2NaCJPy4jg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -4529,14 +4527,13 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.5.7.tgz",
-      "integrity": "sha512-RpUyu2GsviwTc2qVajPL0l8nf2vKj5wzO3WkLSHAHEJbiUZk83NJrZd1RVbEknIMO7+Uyjh54hEh8R26jSByaw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.6.1.tgz",
+      "integrity": "sha512-/tXwQibkDNLVbAtr7PUQI0iQjoB708fjhDDDfJ6WILSBVZ3+qs/LHjJ7jHwumEYxVq1XA7Fv2Q7SE/ZSQoWHcQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -4546,14 +4543,13 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.5.7.tgz",
-      "integrity": "sha512-cTZWTnCXLABOuvWiv6nQQM0hP6ZWEkzdgDvztgHI/+u/MvtzJBN5lBQ2lue/9sSFYLMqzqff5EHKlFtrJCA9dQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.6.1.tgz",
+      "integrity": "sha512-aDgipxhJTms8iH78emHVutFR2c16LNhO+NTRCdYi+X4PyIn58/DyYTH6VDZ0AeEcS5f132ZFldU5AEgExwihXA==",
       "cpu": [
         "arm"
       ],
       "dev": true,
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -4563,14 +4559,13 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.5.7.tgz",
-      "integrity": "sha512-hoeTJFBiE/IJP30Be7djWF8Q5KVgkbDtjySmvYLg9P94bHg9TJPSQoC72tXx/oXOgXvElDe/GMybru0UxhKx4g==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.6.1.tgz",
+      "integrity": "sha512-XkJ+eO4zUKG5g458RyhmKPyBGxI0FwfWFgpfIj5eDybxYJ6s4HBT5MoxyBLorB5kMlZ0XoY/usUMobPVY3nL0g==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "linux"
@@ -4580,14 +4575,13 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.5.7.tgz",
-      "integrity": "sha512-+NDhK+IFTiVK1/o7EXdCeF2hEzCiaRSrb9zD7X2Z7inwWlxAntcSuzZW7Y6BRqGQH89KA91qYgwbnjgTQ22PiQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.6.1.tgz",
+      "integrity": "sha512-dr6YbLBg/SsNxs1hDqJhxdcrS8dGMlOXJwXIrUvACiA8jAd6S5BxYCaqsCefLYXtaOmu0bbx1FB/evfodqB70Q==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "linux"
@@ -4597,14 +4591,13 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.5.7.tgz",
-      "integrity": "sha512-25GXpJmeFxKB+7pbY7YQLhWWjkYlR+kHz5I3j9WRl3Lp4v4UD67OGXwPe+DIcHqcouA1fhLhsgHJWtsaNOMBNg==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.6.1.tgz",
+      "integrity": "sha512-A0b/3V+yFy4LXh3O9umIE7LXPC7NBWdjl6AQYqymSMcMu0EOb1/iygA6s6uWhz9y3e172Hpb9b/CGsuD8Px/bg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "linux"
@@ -4614,14 +4607,13 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.5.7.tgz",
-      "integrity": "sha512-0VN9Y5EAPBESmSPPsCJzplZHV26akC0sIgd3Hc/7S/1GkSMoeuVL+V9vt+F/cCuzr4VidzSkqftdP3qEIsXSpg==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.6.1.tgz",
+      "integrity": "sha512-5dJjlzZXhC87nZZZWbpiDP8kBIO0ibis893F/rtPIQBI5poH+iJuA32EU3wN4/WFHeK4et8z6SGSVghPtWyk4g==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "linux"
@@ -4631,14 +4623,13 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.5.7.tgz",
-      "integrity": "sha512-RtoNnstBwy5VloNCvmvYNApkTmuCe4sNcoYWpmY7C1+bPR+6SOo8im1G6/FpNem8AR5fcZCmXHWQ+EUmRWJyuA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.6.1.tgz",
+      "integrity": "sha512-HBi1ZlwvfcUibLtT3g/lP57FaDPC799AD6InolB2KSgkqyBbZJ9wAXM8/CcH67GLIP0tZ7FqblrJTzGXxetTJQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "win32"
@@ -4648,14 +4639,13 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.5.7.tgz",
-      "integrity": "sha512-Xm0TfvcmmspvQg1s4+USL3x8D+YPAfX2JHygvxAnCJ0EHun8cm2zvfNBcsTlnwYb0ybFWXXY129aq1wgFC9TpQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.6.1.tgz",
+      "integrity": "sha512-AKqHohlWERclexar5y6ux4sQ8yaMejEXNxeKXm7xPhXrp13/1p4/I3E5bPVX/jMnvpm4HpcKSP0ee2WsqmhhPw==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
-      "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "win32"
@@ -4665,14 +4655,13 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.5.7.tgz",
-      "integrity": "sha512-tp43WfJLCsKLQKBmjmY/0vv1slVywR5Q4qKjF5OIY8QijaEW7/8VwPyUyVoJZEnDgv9jKtUTG5PzqtIYPZGnyg==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.6.1.tgz",
+      "integrity": "sha512-0dLdTLd+ONve8kgC5T6VQ2Y5G+OZ7y0ujjapnK66wpvCBM6BKYGdT/OKhZKZydrC5gUKaxFN6Y5oOt9JOFUrOQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "win32"
@@ -4717,11 +4706,10 @@
       }
     },
     "node_modules/@swc/types": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.7.tgz",
-      "integrity": "sha512-scHWahbHF0eyj3JsxG9CFJgFdFNaVQCNAimBlT6PzS3n/HptxqREjsm4OH6AN3lYcffZYSPxXW8ua2BEHp0lJQ==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.8.tgz",
+      "integrity": "sha512-RNFA3+7OJFNYY78x0FYwi1Ow+iF1eF5WvmfY1nXPOEH4R2p/D4Cr1vzje7dNAI2aLFqpv8Wyz4oKSWqIZArpQA==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"
       }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@lerna-lite/version": "2",
     "@napi-rs/cli": "^2.11.0",
     "@swc-node/register": "^1.5.4",
-    "@swc/core": "^1.5.0",
+    "@swc/core": "^1.6.0",
     "@swc/helpers": "^0.5.1",
     "@swc/jest": "^0.2.23",
     "@taplo/cli": "^0.7.0",

--- a/packages/swc-plugin-experimental/package.json
+++ b/packages/swc-plugin-experimental/package.json
@@ -25,6 +25,6 @@
   },
   "homepage": "https://github.com/formatjs/formatjs#readme",
   "peerDependencies": {
-    "@swc/core": "^1.5.0"
+    "@swc/core": "^1.6.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,7 +62,7 @@ importers:
         version: 0.25.0
       '@commitlint/cli':
         specifier: '17'
-        version: 17.0.3(@swc/core@1.5.7)
+        version: 17.0.3(@swc/core@1.6.1)
       '@commitlint/config-angular':
         specifier: '17'
         version: 17.0.3
@@ -98,16 +98,16 @@ importers:
         version: 2.18.3
       '@swc-node/register':
         specifier: ^1.5.4
-        version: 1.5.4(@swc/core@1.5.7)(typescript@5.2.2)
+        version: 1.5.4(@swc/core@1.6.1)(typescript@5.2.2)
       '@swc/core':
-        specifier: ^1.5.0
-        version: 1.5.7(@swc/helpers@0.5.1)
+        specifier: ^1.6.0
+        version: 1.6.1(@swc/helpers@0.5.1)
       '@swc/helpers':
         specifier: ^0.5.1
         version: 0.5.1
       '@swc/jest':
         specifier: ^0.2.23
-        version: 0.2.23(@swc/core@1.5.7)
+        version: 0.2.23(@swc/core@1.6.1)
       '@taplo/cli':
         specifier: ^0.7.0
         version: 0.7.0
@@ -176,7 +176,7 @@ importers:
         version: 5.0.2
       '@types/webpack':
         specifier: '5'
-        version: 5.28.0(@swc/core@1.5.7)
+        version: 5.28.0(@swc/core@1.6.1)
       '@typescript-eslint/parser':
         specifier: ^6.7.5
         version: 6.7.5(eslint@8.18.0)(typescript@5.2.2)
@@ -386,7 +386,7 @@ importers:
         version: 17.0.0(webpack@5.73.0)
       webpack:
         specifier: '5'
-        version: 5.73.0(@swc/core@1.5.7)
+        version: 5.73.0(@swc/core@1.6.1)
 
   packages/babel-plugin-formatjs:
     dependencies:
@@ -983,8 +983,8 @@ importers:
   packages/swc-plugin-experimental:
     dependencies:
       '@swc/core':
-        specifier: ^1.5.0
-        version: 1.5.7(@swc/helpers@0.5.1)
+        specifier: ^1.6.0
+        version: 1.6.1(@swc/helpers@0.5.1)
 
   packages/ts-transformer:
     dependencies:
@@ -1041,22 +1041,22 @@ importers:
     devDependencies:
       '@docusaurus/core':
         specifier: 3.3.2
-        version: 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+        version: 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/plugin-google-analytics':
         specifier: 3.3.2
-        version: 3.3.2(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+        version: 3.3.2(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/preset-classic':
         specifier: 3.3.2
-        version: 3.3.2(@algolia/client-search@4.23.3)(@swc/core@1.5.7)(@types/react@18.3.2)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(search-insights@2.13.0)(typescript@5.2.2)
+        version: 3.3.2(@algolia/client-search@4.23.3)(@swc/core@1.6.1)(@types/react@18.3.2)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(search-insights@2.13.0)(typescript@5.2.2)
       '@docusaurus/theme-common':
         specifier: 3.3.2
-        version: 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+        version: 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/theme-live-codeblock':
         specifier: 3.3.2
-        version: 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+        version: 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/types':
         specifier: 3.3.2
-        version: 3.3.2(@swc/core@1.5.7)(react-dom@18.3.1)(react@18.3.1)
+        version: 3.3.2(@swc/core@1.6.1)(react-dom@18.3.1)(react@18.3.1)
       '@formatjs/icu-messageformat-parser':
         specifier: workspace:*
         version: link:../packages/icu-messageformat-parser
@@ -3968,14 +3968,14 @@ packages:
     engines: {node: '>=0.1.90'}
     dev: true
 
-  /@commitlint/cli@17.0.3(@swc/core@1.5.7):
+  /@commitlint/cli@17.0.3(@swc/core@1.6.1):
     resolution: {integrity: sha512-oAo2vi5d8QZnAbtU5+0cR2j+A7PO8zuccux65R/EycwvsZrDVyW518FFrnJK2UQxbRtHFFIG+NjQ6vOiJV0Q8A==}
     engines: {node: '>=v14'}
     hasBin: true
     dependencies:
       '@commitlint/format': 17.0.0
       '@commitlint/lint': 17.0.3
-      '@commitlint/load': 17.0.3(@swc/core@1.5.7)
+      '@commitlint/load': 17.0.3(@swc/core@1.6.1)
       '@commitlint/read': 17.0.0
       '@commitlint/types': 17.0.0
       execa: 5.1.1
@@ -4047,7 +4047,7 @@ packages:
       '@commitlint/types': 17.0.0
     dev: true
 
-  /@commitlint/load@17.0.3(@swc/core@1.5.7):
+  /@commitlint/load@17.0.3(@swc/core@1.6.1):
     resolution: {integrity: sha512-3Dhvr7GcKbKa/ey4QJ5MZH3+J7QFlARohUow6hftQyNjzoXXROm+RwpBes4dDFrXG1xDw9QPXA7uzrOShCd4bw==}
     engines: {node: '>=v14'}
     dependencies:
@@ -4058,7 +4058,7 @@ packages:
       '@types/node': 18.19.33
       chalk: 4.1.2
       cosmiconfig: 7.0.1
-      cosmiconfig-typescript-loader: 2.0.2(@swc/core@1.5.7)(@types/node@18.19.33)(cosmiconfig@7.0.1)(typescript@4.9.3)
+      cosmiconfig-typescript-loader: 2.0.2(@swc/core@1.6.1)(@types/node@18.19.33)(cosmiconfig@7.0.1)(typescript@4.9.3)
       lodash: 4.17.21
       resolve-from: 5.0.0
       typescript: 4.9.3
@@ -4179,7 +4179,7 @@ packages:
       - '@algolia/client-search'
     dev: true
 
-  /@docusaurus/core@3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2):
+  /@docusaurus/core@3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2):
     resolution: {integrity: sha512-PzKMydKI3IU1LmeZQDi+ut5RSuilbXnA8QdowGeJEgU8EJjmx3rBHNT1LxQxOVqNEwpWi/csLwd9bn7rUjggPA==}
     engines: {node: '>=18.0'}
     hasBin: true
@@ -4199,10 +4199,10 @@ packages:
       '@babel/traverse': 7.24.5
       '@docusaurus/cssnano-preset': 3.3.2
       '@docusaurus/logger': 3.3.2
-      '@docusaurus/mdx-loader': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(typescript@5.2.2)
+      '@docusaurus/mdx-loader': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(typescript@5.2.2)
       '@docusaurus/utils-common': 3.3.2(@docusaurus/types@3.3.2)
-      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(typescript@5.2.2)
+      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(typescript@5.2.2)
       autoprefixer: 10.4.16(postcss@8.4.38)
       babel-loader: 9.1.3(@babel/core@7.24.4)(webpack@5.89.0)
       babel-plugin-dynamic-import-node: 2.3.3
@@ -4248,11 +4248,11 @@ packages:
       semver: 7.5.4
       serve-handler: 6.1.5
       shelljs: 0.8.5
-      terser-webpack-plugin: 5.3.9(@swc/core@1.5.7)(webpack@5.89.0)
+      terser-webpack-plugin: 5.3.9(@swc/core@1.6.1)(webpack@5.89.0)
       tslib: 2.6.2
       update-notifier: 6.0.2
       url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.89.0)
-      webpack: 5.89.0(@swc/core@1.5.7)
+      webpack: 5.89.0(@swc/core@1.6.1)
       webpack-bundle-analyzer: 4.9.1
       webpack-dev-server: 4.15.1(webpack@5.89.0)
       webpack-merge: 5.10.0
@@ -4294,7 +4294,7 @@ packages:
       tslib: 2.6.2
     dev: true
 
-  /@docusaurus/mdx-loader@3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2):
+  /@docusaurus/mdx-loader@3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2):
     resolution: {integrity: sha512-AFRxj/aOk3/mfYDPxE3wTbrjeayVRvNSZP7mgMuUlrb2UlPRbSVAFX1k2RbgAJrnTSwMgb92m2BhJgYRfptN3g==}
     engines: {node: '>=18.0'}
     peerDependencies:
@@ -4302,8 +4302,8 @@ packages:
       react-dom: ^18.0.0
     dependencies:
       '@docusaurus/logger': 3.3.2
-      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(typescript@5.2.2)
-      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(typescript@5.2.2)
+      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(typescript@5.2.2)
+      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(typescript@5.2.2)
       '@mdx-js/mdx': 3.0.0
       '@slorber/remark-comment': 1.0.0
       escape-html: 1.0.3
@@ -4326,7 +4326,7 @@ packages:
       unist-util-visit: 5.0.0
       url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.89.0)
       vfile: 6.0.1
-      webpack: 5.89.0(@swc/core@1.5.7)
+      webpack: 5.89.0(@swc/core@1.6.1)
     transitivePeerDependencies:
       - '@docusaurus/types'
       - '@swc/core'
@@ -4337,13 +4337,13 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/module-type-aliases@3.3.2(@swc/core@1.5.7)(react-dom@18.3.1)(react@18.3.1):
+  /@docusaurus/module-type-aliases@3.3.2(@swc/core@1.6.1)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-b/XB0TBJah5yKb4LYuJT4buFvL0MGAb0+vJDrJtlYMguRtsEBkf2nWl5xP7h4Dlw6ol0hsHrCYzJ50kNIOEclw==}
     peerDependencies:
       react: '*'
       react-dom: '*'
     dependencies:
-      '@docusaurus/types': 3.3.2(@swc/core@1.5.7)(react-dom@18.3.1)(react@18.3.1)
+      '@docusaurus/types': 3.3.2(@swc/core@1.6.1)(react-dom@18.3.1)(react@18.3.1)
       '@types/history': 4.7.11
       '@types/react': 18.0.25
       '@types/react-router-config': 5.0.9
@@ -4360,20 +4360,20 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/plugin-content-blog@3.3.2(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2):
+  /@docusaurus/plugin-content-blog@3.3.2(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2):
     resolution: {integrity: sha512-fJU+dmqp231LnwDJv+BHVWft8pcUS2xVPZdeYH6/ibH1s2wQ/sLcmUrGWyIv/Gq9Ptj8XWjRPMghlxghuPPoxg==}
     engines: {node: '>=18.0'}
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
     dependencies:
-      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/logger': 3.3.2
-      '@docusaurus/mdx-loader': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/types': 3.3.2(@swc/core@1.5.7)(react-dom@18.3.1)(react@18.3.1)
-      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(typescript@5.2.2)
+      '@docusaurus/mdx-loader': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/types': 3.3.2(@swc/core@1.6.1)(react-dom@18.3.1)(react@18.3.1)
+      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(typescript@5.2.2)
       '@docusaurus/utils-common': 3.3.2(@docusaurus/types@3.3.2)
-      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(typescript@5.2.2)
+      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(typescript@5.2.2)
       cheerio: 1.0.0-rc.12
       feed: 4.2.2
       fs-extra: 11.1.1
@@ -4385,7 +4385,7 @@ packages:
       tslib: 2.6.2
       unist-util-visit: 5.0.0
       utility-types: 3.10.0
-      webpack: 5.89.0(@swc/core@1.5.7)
+      webpack: 5.89.0(@swc/core@1.6.1)
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
@@ -4404,21 +4404,21 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/plugin-content-docs@3.3.2(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2):
+  /@docusaurus/plugin-content-docs@3.3.2(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2):
     resolution: {integrity: sha512-Dm1ri2VlGATTN3VGk1ZRqdRXWa1UlFubjaEL6JaxaK7IIFqN/Esjpl+Xw10R33loHcRww/H76VdEeYayaL76eg==}
     engines: {node: '>=18.0'}
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
     dependencies:
-      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/logger': 3.3.2
-      '@docusaurus/mdx-loader': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/module-type-aliases': 3.3.2(@swc/core@1.5.7)(react-dom@18.3.1)(react@18.3.1)
-      '@docusaurus/types': 3.3.2(@swc/core@1.5.7)(react-dom@18.3.1)(react@18.3.1)
-      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(typescript@5.2.2)
+      '@docusaurus/mdx-loader': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/module-type-aliases': 3.3.2(@swc/core@1.6.1)(react-dom@18.3.1)(react@18.3.1)
+      '@docusaurus/types': 3.3.2(@swc/core@1.6.1)(react-dom@18.3.1)(react@18.3.1)
+      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(typescript@5.2.2)
       '@docusaurus/utils-common': 3.3.2(@docusaurus/types@3.3.2)
-      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(typescript@5.2.2)
+      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(typescript@5.2.2)
       '@types/react-router-config': 5.0.9
       combine-promises: 1.1.0
       fs-extra: 11.1.1
@@ -4428,7 +4428,7 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
       tslib: 2.6.2
       utility-types: 3.10.0
-      webpack: 5.89.0(@swc/core@1.5.7)
+      webpack: 5.89.0(@swc/core@1.6.1)
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
@@ -4447,23 +4447,23 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/plugin-content-pages@3.3.2(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2):
+  /@docusaurus/plugin-content-pages@3.3.2(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2):
     resolution: {integrity: sha512-EKc9fQn5H2+OcGER8x1aR+7URtAGWySUgULfqE/M14+rIisdrBstuEZ4lUPDRrSIexOVClML82h2fDS+GSb8Ew==}
     engines: {node: '>=18.0'}
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
     dependencies:
-      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/mdx-loader': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/types': 3.3.2(@swc/core@1.5.7)(react-dom@18.3.1)(react@18.3.1)
-      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(typescript@5.2.2)
-      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(typescript@5.2.2)
+      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/mdx-loader': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/types': 3.3.2(@swc/core@1.6.1)(react-dom@18.3.1)(react@18.3.1)
+      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(typescript@5.2.2)
+      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(typescript@5.2.2)
       fs-extra: 11.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       tslib: 2.6.2
-      webpack: 5.89.0(@swc/core@1.5.7)
+      webpack: 5.89.0(@swc/core@1.6.1)
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
@@ -4482,16 +4482,16 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/plugin-debug@3.3.2(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2):
+  /@docusaurus/plugin-debug@3.3.2(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2):
     resolution: {integrity: sha512-oBIBmwtaB+YS0XlmZ3gCO+cMbsGvIYuAKkAopoCh0arVjtlyPbejzPrHuCoRHB9G7abjNZw7zoONOR8+8LM5+Q==}
     engines: {node: '>=18.0'}
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
     dependencies:
-      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/types': 3.3.2(@swc/core@1.5.7)(react-dom@18.3.1)(react@18.3.1)
-      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(typescript@5.2.2)
+      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/types': 3.3.2(@swc/core@1.6.1)(react-dom@18.3.1)(react@18.3.1)
+      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(typescript@5.2.2)
       fs-extra: 11.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -4515,16 +4515,16 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/plugin-google-analytics@3.3.2(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2):
+  /@docusaurus/plugin-google-analytics@3.3.2(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2):
     resolution: {integrity: sha512-jXhrEIhYPSClMBK6/IA8qf1/FBoxqGXZvg7EuBax9HaK9+kL3L0TJIlatd8jQJOMtds8mKw806TOCc3rtEad1A==}
     engines: {node: '>=18.0'}
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
     dependencies:
-      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/types': 3.3.2(@swc/core@1.5.7)(react-dom@18.3.1)(react@18.3.1)
-      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(typescript@5.2.2)
+      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/types': 3.3.2(@swc/core@1.6.1)(react-dom@18.3.1)(react@18.3.1)
+      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(typescript@5.2.2)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       tslib: 2.6.2
@@ -4546,16 +4546,16 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/plugin-google-gtag@3.3.2(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2):
+  /@docusaurus/plugin-google-gtag@3.3.2(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2):
     resolution: {integrity: sha512-vcrKOHGbIDjVnNMrfbNpRQR1x6Jvcrb48kVzpBAOsKbj9rXZm/idjVAXRaewwobHdOrJkfWS/UJoxzK8wyLRBQ==}
     engines: {node: '>=18.0'}
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
     dependencies:
-      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/types': 3.3.2(@swc/core@1.5.7)(react-dom@18.3.1)(react@18.3.1)
-      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(typescript@5.2.2)
+      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/types': 3.3.2(@swc/core@1.6.1)(react-dom@18.3.1)(react@18.3.1)
+      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(typescript@5.2.2)
       '@types/gtag.js': 0.0.12
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -4578,16 +4578,16 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/plugin-google-tag-manager@3.3.2(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2):
+  /@docusaurus/plugin-google-tag-manager@3.3.2(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2):
     resolution: {integrity: sha512-ldkR58Fdeks0vC+HQ+L+bGFSJsotQsipXD+iKXQFvkOfmPIV6QbHRd7IIcm5b6UtwOiK33PylNS++gjyLUmaGw==}
     engines: {node: '>=18.0'}
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
     dependencies:
-      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/types': 3.3.2(@swc/core@1.5.7)(react-dom@18.3.1)(react@18.3.1)
-      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(typescript@5.2.2)
+      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/types': 3.3.2(@swc/core@1.6.1)(react-dom@18.3.1)(react@18.3.1)
+      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(typescript@5.2.2)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       tslib: 2.6.2
@@ -4609,19 +4609,19 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/plugin-sitemap@3.3.2(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2):
+  /@docusaurus/plugin-sitemap@3.3.2(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2):
     resolution: {integrity: sha512-/ZI1+bwZBhAgC30inBsHe3qY9LOZS+79fRGkNdTcGHRMcdAp6Vw2pCd1gzlxd/xU+HXsNP6cLmTOrggmRp3Ujg==}
     engines: {node: '>=18.0'}
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
     dependencies:
-      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/logger': 3.3.2
-      '@docusaurus/types': 3.3.2(@swc/core@1.5.7)(react-dom@18.3.1)(react@18.3.1)
-      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(typescript@5.2.2)
+      '@docusaurus/types': 3.3.2(@swc/core@1.6.1)(react-dom@18.3.1)(react@18.3.1)
+      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(typescript@5.2.2)
       '@docusaurus/utils-common': 3.3.2(@docusaurus/types@3.3.2)
-      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(typescript@5.2.2)
+      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(typescript@5.2.2)
       fs-extra: 11.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -4645,26 +4645,26 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/preset-classic@3.3.2(@algolia/client-search@4.23.3)(@swc/core@1.5.7)(@types/react@18.3.2)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(search-insights@2.13.0)(typescript@5.2.2):
+  /@docusaurus/preset-classic@3.3.2(@algolia/client-search@4.23.3)(@swc/core@1.6.1)(@types/react@18.3.2)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(search-insights@2.13.0)(typescript@5.2.2):
     resolution: {integrity: sha512-1SDS7YIUN1Pg3BmD6TOTjhB7RSBHJRpgIRKx9TpxqyDrJ92sqtZhomDc6UYoMMLQNF2wHFZZVGFjxJhw2VpL+Q==}
     engines: {node: '>=18.0'}
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
     dependencies:
-      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-content-blog': 3.3.2(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-content-docs': 3.3.2(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-content-pages': 3.3.2(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-debug': 3.3.2(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-google-analytics': 3.3.2(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-google-gtag': 3.3.2(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-google-tag-manager': 3.3.2(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-sitemap': 3.3.2(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/theme-classic': 3.3.2(@swc/core@1.5.7)(@types/react@18.3.2)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/theme-common': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/theme-search-algolia': 3.3.2(@algolia/client-search@4.23.3)(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(@types/react@18.3.2)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(search-insights@2.13.0)(typescript@5.2.2)
-      '@docusaurus/types': 3.3.2(@swc/core@1.5.7)(react-dom@18.3.1)(react@18.3.1)
+      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-content-blog': 3.3.2(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-content-docs': 3.3.2(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-content-pages': 3.3.2(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-debug': 3.3.2(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-google-analytics': 3.3.2(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-google-gtag': 3.3.2(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-google-tag-manager': 3.3.2(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-sitemap': 3.3.2(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/theme-classic': 3.3.2(@swc/core@1.6.1)(@types/react@18.3.2)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/theme-common': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/theme-search-algolia': 3.3.2(@algolia/client-search@4.23.3)(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(@types/react@18.3.2)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(search-insights@2.13.0)(typescript@5.2.2)
+      '@docusaurus/types': 3.3.2(@swc/core@1.6.1)(react-dom@18.3.1)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
@@ -4697,25 +4697,25 @@ packages:
       react: 18.3.1
     dev: true
 
-  /@docusaurus/theme-classic@3.3.2(@swc/core@1.5.7)(@types/react@18.3.2)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2):
+  /@docusaurus/theme-classic@3.3.2(@swc/core@1.6.1)(@types/react@18.3.2)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2):
     resolution: {integrity: sha512-gepHFcsluIkPb4Im9ukkiO4lXrai671wzS3cKQkY9BXQgdVwsdPf/KS0Vs4Xlb0F10fTz+T3gNjkxNEgSN9M0A==}
     engines: {node: '>=18.0'}
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
     dependencies:
-      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/mdx-loader': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/module-type-aliases': 3.3.2(@swc/core@1.5.7)(react-dom@18.3.1)(react@18.3.1)
-      '@docusaurus/plugin-content-blog': 3.3.2(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-content-docs': 3.3.2(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-content-pages': 3.3.2(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/theme-common': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/mdx-loader': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/module-type-aliases': 3.3.2(@swc/core@1.6.1)(react-dom@18.3.1)(react@18.3.1)
+      '@docusaurus/plugin-content-blog': 3.3.2(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-content-docs': 3.3.2(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-content-pages': 3.3.2(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/theme-common': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/theme-translations': 3.3.2
-      '@docusaurus/types': 3.3.2(@swc/core@1.5.7)(react-dom@18.3.1)(react@18.3.1)
-      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(typescript@5.2.2)
+      '@docusaurus/types': 3.3.2(@swc/core@1.6.1)(react-dom@18.3.1)(react@18.3.1)
+      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(typescript@5.2.2)
       '@docusaurus/utils-common': 3.3.2(@docusaurus/types@3.3.2)
-      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(typescript@5.2.2)
+      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(typescript@5.2.2)
       '@mdx-js/react': 3.0.1(@types/react@18.3.2)(react@18.3.1)
       clsx: 2.1.1
       copy-text-to-clipboard: 3.2.0
@@ -4750,19 +4750,19 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/theme-common@3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2):
+  /@docusaurus/theme-common@3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2):
     resolution: {integrity: sha512-kXqSaL/sQqo4uAMQ4fHnvRZrH45Xz2OdJ3ABXDS7YVGPSDTBC8cLebFrRR4YF9EowUHto1UC/EIklJZQMG/usA==}
     engines: {node: '>=18.0'}
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
     dependencies:
-      '@docusaurus/mdx-loader': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/module-type-aliases': 3.3.2(@swc/core@1.5.7)(react-dom@18.3.1)(react@18.3.1)
-      '@docusaurus/plugin-content-blog': 3.3.2(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-content-docs': 3.3.2(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-content-pages': 3.3.2(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(typescript@5.2.2)
+      '@docusaurus/mdx-loader': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/module-type-aliases': 3.3.2(@swc/core@1.6.1)(react-dom@18.3.1)(react@18.3.1)
+      '@docusaurus/plugin-content-blog': 3.3.2(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-content-docs': 3.3.2(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-content-pages': 3.3.2(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(typescript@5.2.2)
       '@docusaurus/utils-common': 3.3.2(@docusaurus/types@3.3.2)
       '@types/history': 4.7.11
       '@types/react': 18.0.25
@@ -4793,17 +4793,17 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/theme-live-codeblock@3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2):
+  /@docusaurus/theme-live-codeblock@3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2):
     resolution: {integrity: sha512-04ZyMVKOuWFwvmkx+pR4vq9IiaKf753pfxFWLp5FCGuPS9YWzkxg8ZifhobftAY+3uey6BcwfS84ewNvbOwoQA==}
     engines: {node: '>=18.0'}
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
     dependencies:
-      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/theme-common': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/theme-common': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/theme-translations': 3.3.2
-      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(typescript@5.2.2)
+      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(typescript@5.2.2)
       '@philpl/buble': 0.19.7
       clsx: 2.0.0
       fs-extra: 11.1.1
@@ -4830,7 +4830,7 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/theme-search-algolia@3.3.2(@algolia/client-search@4.23.3)(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(@types/react@18.3.2)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(search-insights@2.13.0)(typescript@5.2.2):
+  /@docusaurus/theme-search-algolia@3.3.2(@algolia/client-search@4.23.3)(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(@types/react@18.3.2)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(search-insights@2.13.0)(typescript@5.2.2):
     resolution: {integrity: sha512-qLkfCl29VNBnF1MWiL9IyOQaHxUvicZp69hISyq/xMsNvFKHFOaOfk9xezYod2Q9xx3xxUh9t/QPigIei2tX4w==}
     engines: {node: '>=18.0'}
     peerDependencies:
@@ -4838,13 +4838,13 @@ packages:
       react-dom: ^18.0.0
     dependencies:
       '@docsearch/react': 3.5.2(@algolia/client-search@4.23.3)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1)(search-insights@2.13.0)
-      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/logger': 3.3.2
-      '@docusaurus/plugin-content-docs': 3.3.2(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/theme-common': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-content-docs': 3.3.2(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/theme-common': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/theme-translations': 3.3.2
-      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(typescript@5.2.2)
-      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(typescript@5.2.2)
+      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(typescript@5.2.2)
+      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(typescript@5.2.2)
       algoliasearch: 4.20.0
       algoliasearch-helper: 3.15.0(algoliasearch@4.20.0)
       clsx: 2.1.1
@@ -4885,7 +4885,7 @@ packages:
       tslib: 2.6.2
     dev: true
 
-  /@docusaurus/types@3.3.2(@swc/core@1.5.7)(react-dom@18.3.1)(react@18.3.1):
+  /@docusaurus/types@3.3.2(@swc/core@1.6.1)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-5p201S7AZhliRxTU7uMKtSsoC8mgPA9bs9b5NQg1IRdRxJfflursXNVsgc3PcMqiUTul/v1s3k3rXXFlRE890w==}
     peerDependencies:
       react: ^18.0.0
@@ -4900,7 +4900,7 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
       react-helmet-async: 1.3.0(react-dom@18.3.1)(react@18.3.1)
       utility-types: 3.10.0
-      webpack: 5.89.0(@swc/core@1.5.7)
+      webpack: 5.89.0(@swc/core@1.6.1)
       webpack-merge: 5.10.0
     transitivePeerDependencies:
       - '@swc/core'
@@ -4919,16 +4919,16 @@ packages:
       '@docusaurus/types':
         optional: true
     dependencies:
-      '@docusaurus/types': 3.3.2(@swc/core@1.5.7)(react-dom@18.3.1)(react@18.3.1)
+      '@docusaurus/types': 3.3.2(@swc/core@1.6.1)(react-dom@18.3.1)(react@18.3.1)
       tslib: 2.6.2
     dev: true
 
-  /@docusaurus/utils-validation@3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(typescript@5.2.2):
+  /@docusaurus/utils-validation@3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(typescript@5.2.2):
     resolution: {integrity: sha512-itDgFs5+cbW9REuC7NdXals4V6++KifgVMzoGOOOSIifBQw+8ULhy86u5e1lnptVL0sv8oAjq2alO7I40GR7pA==}
     engines: {node: '>=18.0'}
     dependencies:
       '@docusaurus/logger': 3.3.2
-      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(typescript@5.2.2)
+      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(typescript@5.2.2)
       '@docusaurus/utils-common': 3.3.2(@docusaurus/types@3.3.2)
       joi: 17.11.0
       js-yaml: 4.1.0
@@ -4943,7 +4943,7 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/utils@3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(typescript@5.2.2):
+  /@docusaurus/utils@3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(typescript@5.2.2):
     resolution: {integrity: sha512-f4YMnBVymtkSxONv4Y8js3Gez9IgHX+Lcg6YRMOjVbq8sgCcdYK1lf6SObAuz5qB/mxiSK7tW0M9aaiIaUSUJg==}
     engines: {node: '>=18.0'}
     peerDependencies:
@@ -4953,7 +4953,7 @@ packages:
         optional: true
     dependencies:
       '@docusaurus/logger': 3.3.2
-      '@docusaurus/types': 3.3.2(@swc/core@1.5.7)(react-dom@18.3.1)(react@18.3.1)
+      '@docusaurus/types': 3.3.2(@swc/core@1.6.1)(react-dom@18.3.1)(react@18.3.1)
       '@docusaurus/utils-common': 3.3.2(@docusaurus/types@3.3.2)
       '@svgr/webpack': 8.1.0(typescript@5.2.2)
       escape-string-regexp: 4.0.0
@@ -4971,7 +4971,7 @@ packages:
       shelljs: 0.8.5
       tslib: 2.6.2
       url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.89.0)
-      webpack: 5.89.0(@swc/core@1.5.7)
+      webpack: 5.89.0(@swc/core@1.6.1)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -5869,9 +5869,9 @@ packages:
       react: '>= 18.0.0'
       react-dom: '>= 18.0.0'
     dependencies:
-      '@docusaurus/plugin-content-docs': 3.3.2(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/theme-common': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.5.7)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/types': 3.3.2(@swc/core@1.5.7)(react-dom@18.3.1)(react@18.3.1)
+      '@docusaurus/plugin-content-docs': 3.3.2(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/theme-common': 3.3.2(@docusaurus/types@3.3.2)(@swc/core@1.6.1)(eslint@8.18.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/types': 3.3.2(@swc/core@1.6.1)(react-dom@18.3.1)(react@18.3.1)
       '@orama/highlight': 0.1.6
       '@orama/orama': 2.0.18
       '@orama/plugin-analytics': 2.0.18
@@ -6304,24 +6304,24 @@ packages:
       - typescript
     dev: true
 
-  /@swc-node/core@1.9.1(@swc/core@1.5.7):
+  /@swc-node/core@1.9.1(@swc/core@1.6.1):
     resolution: {integrity: sha512-Mh4T/PmQOpPtqw1BNvU38uWzsXbd5RJji17YBXnj7JDDE5KlTR9sSo2RKxWKDVtHbdcD1S+CtyZXA93aEWlfGQ==}
     engines: {node: '>= 10'}
     peerDependencies:
       '@swc/core': '>= 1.3'
     dependencies:
-      '@swc/core': 1.5.7(@swc/helpers@0.5.1)
+      '@swc/core': 1.6.1(@swc/helpers@0.5.1)
     dev: true
 
-  /@swc-node/register@1.5.4(@swc/core@1.5.7)(typescript@5.2.2):
+  /@swc-node/register@1.5.4(@swc/core@1.6.1)(typescript@5.2.2):
     resolution: {integrity: sha512-cM5/A63bO6qLUFC4gcBnOlQO5yd8ObSdFUIp7sXf11Oq5mPVAnJy2DqjbWMUsqUaHuNk+lOIt76ie4DEseUIyA==}
     peerDependencies:
       '@swc/core': '>= 1.3'
       typescript: '>= 4.3'
     dependencies:
-      '@swc-node/core': 1.9.1(@swc/core@1.5.7)
+      '@swc-node/core': 1.9.1(@swc/core@1.6.1)
       '@swc-node/sourcemap-support': 0.2.2
-      '@swc/core': 1.5.7(@swc/helpers@0.5.1)
+      '@swc/core': 1.6.1(@swc/helpers@0.5.1)
       colorette: 2.0.19
       debug: 4.3.4
       pirates: 4.0.5
@@ -6344,10 +6344,28 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@swc/core-darwin-arm64@1.6.1:
+    resolution: {integrity: sha512-u6GdwOXsOEdNAdSI6nWq6G2BQw5HiSNIZVcBaH1iSvBnxZvWbnIKyDiZKaYnDwTLHLzig2GuUjjE2NaCJPy4jg==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
     optional: true
 
   /@swc/core-darwin-x64@1.5.7:
     resolution: {integrity: sha512-RpUyu2GsviwTc2qVajPL0l8nf2vKj5wzO3WkLSHAHEJbiUZk83NJrZd1RVbEknIMO7+Uyjh54hEh8R26jSByaw==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@swc/core-darwin-x64@1.6.1:
+    resolution: {integrity: sha512-/tXwQibkDNLVbAtr7PUQI0iQjoB708fjhDDDfJ6WILSBVZ3+qs/LHjJ7jHwumEYxVq1XA7Fv2Q7SE/ZSQoWHcQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [darwin]
@@ -6360,10 +6378,28 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@swc/core-linux-arm-gnueabihf@1.6.1:
+    resolution: {integrity: sha512-aDgipxhJTms8iH78emHVutFR2c16LNhO+NTRCdYi+X4PyIn58/DyYTH6VDZ0AeEcS5f132ZFldU5AEgExwihXA==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
     optional: true
 
   /@swc/core-linux-arm64-gnu@1.5.7:
     resolution: {integrity: sha512-hoeTJFBiE/IJP30Be7djWF8Q5KVgkbDtjySmvYLg9P94bHg9TJPSQoC72tXx/oXOgXvElDe/GMybru0UxhKx4g==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@swc/core-linux-arm64-gnu@1.6.1:
+    resolution: {integrity: sha512-XkJ+eO4zUKG5g458RyhmKPyBGxI0FwfWFgpfIj5eDybxYJ6s4HBT5MoxyBLorB5kMlZ0XoY/usUMobPVY3nL0g==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
@@ -6376,10 +6412,28 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@swc/core-linux-arm64-musl@1.6.1:
+    resolution: {integrity: sha512-dr6YbLBg/SsNxs1hDqJhxdcrS8dGMlOXJwXIrUvACiA8jAd6S5BxYCaqsCefLYXtaOmu0bbx1FB/evfodqB70Q==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
     optional: true
 
   /@swc/core-linux-x64-gnu@1.5.7:
     resolution: {integrity: sha512-25GXpJmeFxKB+7pbY7YQLhWWjkYlR+kHz5I3j9WRl3Lp4v4UD67OGXwPe+DIcHqcouA1fhLhsgHJWtsaNOMBNg==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@swc/core-linux-x64-gnu@1.6.1:
+    resolution: {integrity: sha512-A0b/3V+yFy4LXh3O9umIE7LXPC7NBWdjl6AQYqymSMcMu0EOb1/iygA6s6uWhz9y3e172Hpb9b/CGsuD8Px/bg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
@@ -6392,10 +6446,28 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@swc/core-linux-x64-musl@1.6.1:
+    resolution: {integrity: sha512-5dJjlzZXhC87nZZZWbpiDP8kBIO0ibis893F/rtPIQBI5poH+iJuA32EU3wN4/WFHeK4et8z6SGSVghPtWyk4g==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
     optional: true
 
   /@swc/core-win32-arm64-msvc@1.5.7:
     resolution: {integrity: sha512-RtoNnstBwy5VloNCvmvYNApkTmuCe4sNcoYWpmY7C1+bPR+6SOo8im1G6/FpNem8AR5fcZCmXHWQ+EUmRWJyuA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@swc/core-win32-arm64-msvc@1.6.1:
+    resolution: {integrity: sha512-HBi1ZlwvfcUibLtT3g/lP57FaDPC799AD6InolB2KSgkqyBbZJ9wAXM8/CcH67GLIP0tZ7FqblrJTzGXxetTJQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [win32]
@@ -6408,10 +6480,28 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@swc/core-win32-ia32-msvc@1.6.1:
+    resolution: {integrity: sha512-AKqHohlWERclexar5y6ux4sQ8yaMejEXNxeKXm7xPhXrp13/1p4/I3E5bPVX/jMnvpm4HpcKSP0ee2WsqmhhPw==}
+    engines: {node: '>=10'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
     optional: true
 
   /@swc/core-win32-x64-msvc@1.5.7:
     resolution: {integrity: sha512-tp43WfJLCsKLQKBmjmY/0vv1slVywR5Q4qKjF5OIY8QijaEW7/8VwPyUyVoJZEnDgv9jKtUTG5PzqtIYPZGnyg==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@swc/core-win32-x64-msvc@1.6.1:
+    resolution: {integrity: sha512-0dLdTLd+ONve8kgC5T6VQ2Y5G+OZ7y0ujjapnK66wpvCBM6BKYGdT/OKhZKZydrC5gUKaxFN6Y5oOt9JOFUrOQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [win32]
@@ -6442,6 +6532,32 @@ packages:
       '@swc/core-win32-arm64-msvc': 1.5.7
       '@swc/core-win32-ia32-msvc': 1.5.7
       '@swc/core-win32-x64-msvc': 1.5.7
+    dev: false
+
+  /@swc/core@1.6.1(@swc/helpers@0.5.1):
+    resolution: {integrity: sha512-Yz5uj5hNZpS5brLtBvKY0L4s2tBAbQ4TjmW8xF1EC3YLFxQRrUjMP49Zm1kp/KYyYvTkSaG48Ffj2YWLu9nChw==}
+    engines: {node: '>=10'}
+    requiresBuild: true
+    peerDependencies:
+      '@swc/helpers': '*'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+    dependencies:
+      '@swc/counter': 0.1.3
+      '@swc/helpers': 0.5.1
+      '@swc/types': 0.1.8
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.6.1
+      '@swc/core-darwin-x64': 1.6.1
+      '@swc/core-linux-arm-gnueabihf': 1.6.1
+      '@swc/core-linux-arm64-gnu': 1.6.1
+      '@swc/core-linux-arm64-musl': 1.6.1
+      '@swc/core-linux-x64-gnu': 1.6.1
+      '@swc/core-linux-x64-musl': 1.6.1
+      '@swc/core-win32-arm64-msvc': 1.6.1
+      '@swc/core-win32-ia32-msvc': 1.6.1
+      '@swc/core-win32-x64-msvc': 1.6.1
 
   /@swc/counter@0.1.3:
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
@@ -6451,19 +6567,25 @@ packages:
     dependencies:
       tslib: 2.6.2
 
-  /@swc/jest@0.2.23(@swc/core@1.5.7):
+  /@swc/jest@0.2.23(@swc/core@1.6.1):
     resolution: {integrity: sha512-ZLj17XjHbPtNsgqjm83qizENw05emLkKGu3WuPUttcy9hkngl0/kcc7fDbcSBpADS0GUtsO+iKPjZFWVAtJSlA==}
     engines: {npm: '>= 7.0.0'}
     peerDependencies:
       '@swc/core': '*'
     dependencies:
       '@jest/create-cache-key-function': 27.5.1
-      '@swc/core': 1.5.7(@swc/helpers@0.5.1)
+      '@swc/core': 1.6.1(@swc/helpers@0.5.1)
       jsonc-parser: 3.2.0
     dev: true
 
   /@swc/types@0.1.7:
     resolution: {integrity: sha512-scHWahbHF0eyj3JsxG9CFJgFdFNaVQCNAimBlT6PzS3n/HptxqREjsm4OH6AN3lYcffZYSPxXW8ua2BEHp0lJQ==}
+    dependencies:
+      '@swc/counter': 0.1.3
+    dev: false
+
+  /@swc/types@0.1.8:
+    resolution: {integrity: sha512-RNFA3+7OJFNYY78x0FYwi1Ow+iF1eF5WvmfY1nXPOEH4R2p/D4Cr1vzje7dNAI2aLFqpv8Wyz4oKSWqIZArpQA==}
     dependencies:
       '@swc/counter': 0.1.3
 
@@ -7089,12 +7211,12 @@ packages:
     resolution: {integrity: sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ==}
     dev: true
 
-  /@types/webpack@5.28.0(@swc/core@1.5.7):
+  /@types/webpack@5.28.0(@swc/core@1.6.1):
     resolution: {integrity: sha512-8cP0CzcxUiFuA9xGJkfeVpqmWTk9nx6CWwamRGCj95ph1SmlRRk9KlCZ6avhCbZd4L68LvYT6l1kpdEnQXrF8w==}
     dependencies:
       '@types/node': 18.19.33
       tapable: 2.2.1
-      webpack: 5.73.0(@swc/core@1.5.7)
+      webpack: 5.73.0(@swc/core@1.6.1)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -8191,7 +8313,7 @@ packages:
       '@babel/core': 7.18.5
       find-cache-dir: 3.3.2
       schema-utils: 4.0.0
-      webpack: 5.73.0(@swc/core@1.5.7)
+      webpack: 5.73.0(@swc/core@1.6.1)
     dev: true
 
   /babel-loader@9.1.3(@babel/core@7.24.4)(webpack@5.89.0):
@@ -8204,7 +8326,7 @@ packages:
       '@babel/core': 7.24.4
       find-cache-dir: 4.0.0
       schema-utils: 4.0.0
-      webpack: 5.89.0(@swc/core@1.5.7)
+      webpack: 5.89.0(@swc/core@1.6.1)
     dev: true
 
   /babel-plugin-dynamic-import-node@2.3.3:
@@ -9536,7 +9658,7 @@ packages:
       normalize-path: 3.0.0
       schema-utils: 4.0.0
       serialize-javascript: 6.0.1
-      webpack: 5.89.0(@swc/core@1.5.7)
+      webpack: 5.89.0(@swc/core@1.6.1)
     dev: true
 
   /core-js-compat@3.23.2:
@@ -9584,7 +9706,7 @@ packages:
     engines: {node: '>= 0.4.0'}
     dev: true
 
-  /cosmiconfig-typescript-loader@2.0.2(@swc/core@1.5.7)(@types/node@18.19.33)(cosmiconfig@7.0.1)(typescript@4.9.3):
+  /cosmiconfig-typescript-loader@2.0.2(@swc/core@1.6.1)(@types/node@18.19.33)(cosmiconfig@7.0.1)(typescript@4.9.3):
     resolution: {integrity: sha512-KmE+bMjWMXJbkWCeY4FJX/npHuZPNr9XF9q9CIQ/bpFwi1qHfCmSiKarrCcRa0LO4fWjk93pVoeRtJAkTGcYNw==}
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
@@ -9594,7 +9716,7 @@ packages:
     dependencies:
       '@types/node': 18.19.33
       cosmiconfig: 7.0.1
-      ts-node: 10.8.1(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@4.9.3)
+      ts-node: 10.8.1(@swc/core@1.6.1)(@types/node@18.19.33)(typescript@4.9.3)
       typescript: 4.9.3
     transitivePeerDependencies:
       - '@swc/core'
@@ -9714,7 +9836,7 @@ packages:
       postcss-modules-values: 4.0.0(postcss@8.4.38)
       postcss-value-parser: 4.2.0
       semver: 7.5.4
-      webpack: 5.89.0(@swc/core@1.5.7)
+      webpack: 5.89.0(@swc/core@1.6.1)
     dev: true
 
   /css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.2)(webpack@5.89.0):
@@ -9749,7 +9871,7 @@ packages:
       postcss: 8.4.38
       schema-utils: 4.2.0
       serialize-javascript: 6.0.1
-      webpack: 5.89.0(@swc/core@1.5.7)
+      webpack: 5.89.0(@swc/core@1.6.1)
     dev: true
 
   /css-select@4.3.0:
@@ -11297,7 +11419,7 @@ packages:
     dependencies:
       loader-utils: 2.0.2
       schema-utils: 3.3.0
-      webpack: 5.89.0(@swc/core@1.5.7)
+      webpack: 5.89.0(@swc/core@1.6.1)
     dev: true
 
   /file-type@3.9.0:
@@ -11503,7 +11625,7 @@ packages:
       semver: 7.6.2
       tapable: 1.1.3
       typescript: 5.2.2
-      webpack: 5.89.0(@swc/core@1.5.7)
+      webpack: 5.89.0(@swc/core@1.6.1)
     dev: true
 
   /form-data-encoder@2.1.4:
@@ -12573,7 +12695,7 @@ packages:
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.89.0(@swc/core@1.5.7)
+      webpack: 5.89.0(@swc/core@1.6.1)
     dev: true
 
   /htmlparser2@6.1.0:
@@ -13432,7 +13554,7 @@ packages:
       ci-info: 3.3.2
       deepmerge: 4.2.2
       glob: 7.2.3
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       jest-circus: 29.5.0
       jest-environment-node: 29.5.0
       jest-get-type: 29.4.3
@@ -15586,7 +15708,7 @@ packages:
       webpack: ^5.0.0
     dependencies:
       schema-utils: 4.2.0
-      webpack: 5.89.0(@swc/core@1.5.7)
+      webpack: 5.89.0(@swc/core@1.6.1)
     dev: true
 
   /minimalistic-assert@1.0.1:
@@ -16727,7 +16849,7 @@ packages:
       jiti: 1.21.0
       postcss: 8.4.38
       semver: 7.5.4
-      webpack: 5.89.0(@swc/core@1.5.7)
+      webpack: 5.89.0(@swc/core@1.6.1)
     transitivePeerDependencies:
       - typescript
     dev: true
@@ -17417,7 +17539,7 @@ packages:
       strip-ansi: 6.0.1
       text-table: 0.2.0
       typescript: 5.2.2
-      webpack: 5.89.0(@swc/core@1.5.7)
+      webpack: 5.89.0(@swc/core@1.6.1)
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -17509,7 +17631,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.23.2
       react-loadable: /@docusaurus/react-loadable@6.0.0(react@18.3.1)
-      webpack: 5.89.0(@swc/core@1.5.7)
+      webpack: 5.89.0(@swc/core@1.6.1)
     dev: true
 
   /react-markdown@9.0.1(@types/react@18.3.2)(react@18.3.1):
@@ -19539,7 +19661,7 @@ packages:
     engines: {node: '>=14.16'}
     dev: true
 
-  /terser-webpack-plugin@5.3.3(@swc/core@1.5.7)(webpack@5.73.0):
+  /terser-webpack-plugin@5.3.3(@swc/core@1.6.1)(webpack@5.73.0):
     resolution: {integrity: sha512-Fx60G5HNYknNTNQnzQ1VePRuu89ZVYWfjRAeT5rITuCY/1b08s49e5kSQwHDirKZWuoKOBRFS98EUUoZ9kLEwQ==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -19556,15 +19678,15 @@ packages:
         optional: true
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
-      '@swc/core': 1.5.7(@swc/helpers@0.5.1)
+      '@swc/core': 1.6.1(@swc/helpers@0.5.1)
       jest-worker: 27.5.1
       schema-utils: 3.1.1
       serialize-javascript: 6.0.0
       terser: 5.27.0
-      webpack: 5.73.0(@swc/core@1.5.7)
+      webpack: 5.73.0(@swc/core@1.6.1)
     dev: true
 
-  /terser-webpack-plugin@5.3.9(@swc/core@1.5.7)(webpack@5.89.0):
+  /terser-webpack-plugin@5.3.9(@swc/core@1.6.1)(webpack@5.89.0):
     resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -19581,12 +19703,12 @@ packages:
         optional: true
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
-      '@swc/core': 1.5.7(@swc/helpers@0.5.1)
+      '@swc/core': 1.6.1(@swc/helpers@0.5.1)
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       terser: 5.27.0
-      webpack: 5.89.0(@swc/core@1.5.7)
+      webpack: 5.89.0(@swc/core@1.6.1)
     dev: true
 
   /terser@5.27.0:
@@ -19894,10 +20016,10 @@ packages:
       micromatch: 4.0.5
       semver: 7.3.7
       typescript: 5.2.2
-      webpack: 5.73.0(@swc/core@1.5.7)
+      webpack: 5.73.0(@swc/core@1.6.1)
     dev: true
 
-  /ts-node@10.8.1(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@4.9.3):
+  /ts-node@10.8.1(@swc/core@1.6.1)(@types/node@18.19.33)(typescript@4.9.3):
     resolution: {integrity: sha512-Wwsnao4DQoJsN034wePSg5nZiw4YKXf56mPIAeD6wVmiv+RytNSWqc2f3fKvcUoV+Yn2+yocD71VOfQHbmVX4g==}
     hasBin: true
     peerDependencies:
@@ -19912,7 +20034,7 @@ packages:
         optional: true
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
-      '@swc/core': 1.5.7(@swc/helpers@0.5.1)
+      '@swc/core': 1.6.1(@swc/helpers@0.5.1)
       '@tsconfig/node10': 1.0.9
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
@@ -20377,7 +20499,7 @@ packages:
       loader-utils: 2.0.2
       mime-types: 2.1.35
       schema-utils: 3.3.0
-      webpack: 5.89.0(@swc/core@1.5.7)
+      webpack: 5.89.0(@swc/core@1.6.1)
     dev: true
 
   /url-parse-lax@3.0.0:
@@ -20579,7 +20701,7 @@ packages:
       chalk: 4.1.2
       hash-sum: 2.0.0
       loader-utils: 2.0.2
-      webpack: 5.73.0(@swc/core@1.5.7)
+      webpack: 5.73.0(@swc/core@1.6.1)
     dev: true
 
   /vue@3.4.0(typescript@5.2.2):
@@ -20744,7 +20866,7 @@ packages:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.2.0
-      webpack: 5.89.0(@swc/core@1.5.7)
+      webpack: 5.89.0(@swc/core@1.6.1)
     dev: true
 
   /webpack-dev-server@4.15.1(webpack@5.89.0):
@@ -20788,7 +20910,7 @@ packages:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack: 5.89.0(@swc/core@1.5.7)
+      webpack: 5.89.0(@swc/core@1.6.1)
       webpack-dev-middleware: 5.3.3(webpack@5.89.0)
       ws: 8.16.0
     transitivePeerDependencies:
@@ -20812,7 +20934,7 @@ packages:
     engines: {node: '>=10.13.0'}
     dev: true
 
-  /webpack@5.73.0(@swc/core@1.5.7):
+  /webpack@5.73.0(@swc/core@1.6.1):
     resolution: {integrity: sha512-svjudQRPPa0YiOYa2lM/Gacw0r6PvxptHj4FuEKQ2kX05ZLkjbVc5MnPs6its5j7IZljnIqSVo/OsY2X0IpHGA==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -20843,7 +20965,7 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.1.1
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.3(@swc/core@1.5.7)(webpack@5.73.0)
+      terser-webpack-plugin: 5.3.3(@swc/core@1.6.1)(webpack@5.73.0)
       watchpack: 2.4.0
       webpack-sources: 3.2.3
     transitivePeerDependencies:
@@ -20852,7 +20974,7 @@ packages:
       - uglify-js
     dev: true
 
-  /webpack@5.89.0(@swc/core@1.5.7):
+  /webpack@5.89.0(@swc/core@1.6.1):
     resolution: {integrity: sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -20883,7 +21005,7 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(@swc/core@1.5.7)(webpack@5.89.0)
+      terser-webpack-plugin: 5.3.9(@swc/core@1.6.1)(webpack@5.89.0)
       watchpack: 2.4.0
       webpack-sources: 3.2.3
     transitivePeerDependencies:
@@ -20902,7 +21024,7 @@ packages:
       consola: 2.15.3
       pretty-time: 1.1.0
       std-env: 3.1.1
-      webpack: 5.89.0(@swc/core@1.5.7)
+      webpack: 5.89.0(@swc/core@1.6.1)
     dev: true
 
   /websocket-driver@0.7.4:

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1054,6 +1054,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
+name = "ryu-js"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad97d4ce1560a5e27cec89519dc8300d1aa6035b099821261c651486a19e44d5"
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1346,9 +1352,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.33.26"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2f9706038906e66f3919028f9f7a37f3ed552f1b85578e93f4468742e2da438"
+checksum = "5d0a5e455ba23fcd687b05ee944ea2c4b026f7de6bb648be3061a434509963e2"
 dependencies = [
  "anyhow",
  "ast_node",
@@ -1378,9 +1384,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.92.7"
+version = "0.95.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd5db8f3366e64dfa51569bde51a90abf7bd1bf9b291135baa87c0364208524"
+checksum = "2d98a9010ece859955625a9c1a54ac60986063d755acd8e1fd3a6d7a7e96bce1"
 dependencies = [
  "once_cell",
  "swc_atoms",
@@ -1397,9 +1403,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.113.5"
+version = "0.115.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa77fca9412729a3fe634e55c354f6c70c7983f127411ce8684e4c7edf32ed3"
+checksum = "065b55c4d3bf7994a47abd420b9d69c69dd48e602030cbc85557077d5705fb63"
 dependencies = [
  "bitflags 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytecheck",
@@ -1417,9 +1423,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.149.2"
+version = "0.151.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ab6d5e7bbd9208f980b5dad2a4a6ae798c97569f809a48c3f92e6ae7e183c6c"
+checksum = "cc6602bcf4fd78b2ef0c7b2abcdbd3e35dfa564a6bcfb0f256e86b41ff3299d7"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -1448,9 +1454,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.144.1"
+version = "0.146.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0499e69683ae5d67a20ff0279b94bc90f29df7922a46331b54d5dd367bf89570"
+checksum = "f884c766155c58b98503961612d1caced9d50267fcbf7914d9407d6fc5447efe"
 dependencies = [
  "either",
  "new_debug_unreachable",
@@ -1470,9 +1476,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_testing"
-version = "0.22.23"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbe778ce5eae6a7e620e1f6b5326e78f00203c4548e0c659fd22da8be0538fd1"
+checksum = "7f495dae76f1ef3f5be46993b050c3c7f9bf534bcdacf1e40789d32255040776"
 dependencies = [
  "anyhow",
  "hex",
@@ -1483,9 +1489,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.138.2"
+version = "0.140.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddb95c2bdad1c9c29edf35712e1e0f9b9ddc1cdb5ba2d582fd93468cb075a03"
+checksum = "daee7af0abfccc9855656fc36ac472e1e6a61398a3a1a1b3bf05ef7a7e7af6b0"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1506,9 +1512,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.141.1"
+version = "0.143.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686445efd086ca6dd52874b4d1935663914e2fb76514c0ad7b0105cec7859451"
+checksum = "2622a94000bb4e04548afe0540150f616c58296d5485c0653d1fae69c23efd98"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -1532,14 +1538,15 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.128.2"
+version = "0.130.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f978f911664091d2d161ed7fedfb2128f6a8af77765a264b470195d6e20b768"
+checksum = "831490c6d4a52f06932fa2c3d87fc0d0aa43211a5df6b5e05a1ec2c57a2f2519"
 dependencies = [
  "indexmap",
  "num_cpus",
  "once_cell",
  "rustc-hash",
+ "ryu-js",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
@@ -1550,9 +1557,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.99.1"
+version = "0.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6ce28ad8e591f8d627f1f9cb26b25e5d83052a9bc1b674d95fc28040cfa98"
+checksum = "ce0d997f0c9b4e181225f603d161f6757c2a97022258170982cfe005ec69ec92"
 dependencies = [
  "num-bigint",
  "serde",
@@ -1576,9 +1583,9 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "0.17.20"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72100a5f7b0c178adf7bcc5e7c8ad9d4180f499a5f5bae9faf3f417c7cbc4915"
+checksum = "9bd8f9a90efb59dc5d918b4470e5d152f34cac2f8733bfba141a96440cab3eff"
 dependencies = [
  "anyhow",
  "miette",
@@ -1620,9 +1627,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "0.42.1"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98974702046356b67da841a8de561480fd75f963f5d406eee40d690e014e4b55"
+checksum = "98740e5a1ac82ad0de823bcf4aea97a76dce77c1ccff167d148e8a114b2932c0"
 dependencies = [
  "better_scoped_tls",
  "rkyv",
@@ -1727,9 +1734,9 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "0.35.25"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15028f8ec7f95006f4e00e6c5ab6620f322bc6dc208a6cba09afa36375981cec"
+checksum = "27d395aa823f3ad1ad845ed74b96188f493b469794cfbe9ef82f03196064086f"
 dependencies = [
  "ansi_term",
  "cargo_metadata 0.15.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/rust/cargo-bazel-lock.json
+++ b/rust/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "ba43d2e4dd9d65940cdc1943b343a1e7e0d371b8f5323428e46dd3c6caa61970",
+  "checksum": "dacea3d65a5e1cba44f6bc2c8432f136ce455a97a41e7758db253600ed370e78",
   "crates": {
     "Inflector 0.11.4": {
       "name": "Inflector",
@@ -2787,7 +2787,7 @@
               "target": "similar_asserts"
             },
             {
-              "id": "testing 0.35.25",
+              "id": "testing 0.36.0",
               "target": "testing"
             }
           ],
@@ -6064,6 +6064,39 @@
       },
       "license": "Apache-2.0 OR BSL-1.0"
     },
+    "ryu-js 1.0.1": {
+      "name": "ryu-js",
+      "version": "1.0.1",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/ryu-js/1.0.1/download",
+          "sha256": "ad97d4ce1560a5e27cec89519dc8300d1aa6035b099821261c651486a19e44d5"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "ryu_js",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "ryu_js",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2018",
+        "version": "1.0.1"
+      },
+      "license": "Apache-2.0 OR BSL-1.0"
+    },
     "scoped-tls 1.0.1": {
       "name": "scoped-tls",
       "version": "1.0.1",
@@ -7509,7 +7542,7 @@
               "target": "sha2"
             },
             {
-              "id": "swc_core 0.92.7",
+              "id": "swc_core 0.95.2",
               "target": "swc_core"
             }
           ],
@@ -7550,7 +7583,7 @@
               "target": "serde_json"
             },
             {
-              "id": "swc_core 0.92.7",
+              "id": "swc_core 0.95.2",
               "target": "swc_core"
             }
           ],
@@ -7629,13 +7662,13 @@
       },
       "license": "Apache-2.0"
     },
-    "swc_common 0.33.26": {
+    "swc_common 0.34.1": {
       "name": "swc_common",
-      "version": "0.33.26",
+      "version": "0.34.1",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/swc_common/0.33.26/download",
-          "sha256": "a2f9706038906e66f3919028f9f7a37f3ed552f1b85578e93f4468742e2da438"
+          "url": "https://static.crates.io/crates/swc_common/0.34.1/download",
+          "sha256": "5d0a5e455ba23fcd687b05ee944ea2c4b026f7de6bb648be3061a434509963e2"
         }
       },
       "targets": [
@@ -7784,17 +7817,17 @@
           ],
           "selects": {}
         },
-        "version": "0.33.26"
+        "version": "0.34.1"
       },
       "license": "Apache-2.0"
     },
-    "swc_core 0.92.7": {
+    "swc_core 0.95.2": {
       "name": "swc_core",
-      "version": "0.92.7",
+      "version": "0.95.2",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/swc_core/0.92.7/download",
-          "sha256": "3fd5db8f3366e64dfa51569bde51a90abf7bd1bf9b291135baa87c0364208524"
+          "url": "https://static.crates.io/crates/swc_core/0.95.2/download",
+          "sha256": "2d98a9010ece859955625a9c1a54ac60986063d755acd8e1fd3a6d7a7e96bce1"
         }
       },
       "targets": [
@@ -7864,27 +7897,27 @@
               "target": "swc_atoms"
             },
             {
-              "id": "swc_common 0.33.26",
+              "id": "swc_common 0.34.1",
               "target": "swc_common"
             },
             {
-              "id": "swc_core 0.92.7",
+              "id": "swc_core 0.95.2",
               "target": "build_script_build"
             },
             {
-              "id": "swc_ecma_ast 0.113.5",
+              "id": "swc_ecma_ast 0.115.0",
               "target": "swc_ecma_ast"
             },
             {
-              "id": "swc_ecma_transforms_base 0.138.2",
+              "id": "swc_ecma_transforms_base 0.140.0",
               "target": "swc_ecma_transforms_base"
             },
             {
-              "id": "swc_ecma_transforms_testing 0.141.1",
+              "id": "swc_ecma_transforms_testing 0.143.0",
               "target": "swc_ecma_transforms_testing"
             },
             {
-              "id": "swc_ecma_visit 0.99.1",
+              "id": "swc_ecma_visit 0.101.0",
               "target": "swc_ecma_visit"
             },
             {
@@ -7892,7 +7925,7 @@
               "target": "swc_plugin"
             },
             {
-              "id": "swc_plugin_proxy 0.42.1",
+              "id": "swc_plugin_proxy 0.44.0",
               "target": "swc_plugin_proxy"
             }
           ],
@@ -7908,7 +7941,7 @@
           ],
           "selects": {}
         },
-        "version": "0.92.7"
+        "version": "0.95.2"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -7926,13 +7959,13 @@
       },
       "license": "Apache-2.0"
     },
-    "swc_ecma_ast 0.113.5": {
+    "swc_ecma_ast 0.115.0": {
       "name": "swc_ecma_ast",
-      "version": "0.113.5",
+      "version": "0.115.0",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/swc_ecma_ast/0.113.5/download",
-          "sha256": "0fa77fca9412729a3fe634e55c354f6c70c7983f127411ce8684e4c7edf32ed3"
+          "url": "https://static.crates.io/crates/swc_ecma_ast/0.115.0/download",
+          "sha256": "065b55c4d3bf7994a47abd420b9d69c69dd48e602030cbc85557077d5705fb63"
         }
       },
       "targets": [
@@ -7998,7 +8031,7 @@
               "target": "swc_atoms"
             },
             {
-              "id": "swc_common 0.33.26",
+              "id": "swc_common 0.34.1",
               "target": "swc_common"
             },
             {
@@ -8022,17 +8055,17 @@
           ],
           "selects": {}
         },
-        "version": "0.113.5"
+        "version": "0.115.0"
       },
       "license": "Apache-2.0"
     },
-    "swc_ecma_codegen 0.149.2": {
+    "swc_ecma_codegen 0.151.0": {
       "name": "swc_ecma_codegen",
-      "version": "0.149.2",
+      "version": "0.151.0",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/swc_ecma_codegen/0.149.2/download",
-          "sha256": "6ab6d5e7bbd9208f980b5dad2a4a6ae798c97569f809a48c3f92e6ae7e183c6c"
+          "url": "https://static.crates.io/crates/swc_ecma_codegen/0.151.0/download",
+          "sha256": "cc6602bcf4fd78b2ef0c7b2abcdbd3e35dfa564a6bcfb0f256e86b41ff3299d7"
         }
       },
       "targets": [
@@ -8085,11 +8118,11 @@
               "target": "swc_atoms"
             },
             {
-              "id": "swc_common 0.33.26",
+              "id": "swc_common 0.34.1",
               "target": "swc_common"
             },
             {
-              "id": "swc_ecma_ast 0.113.5",
+              "id": "swc_ecma_ast 0.115.0",
               "target": "swc_ecma_ast"
             },
             {
@@ -8109,7 +8142,7 @@
           ],
           "selects": {}
         },
-        "version": "0.149.2"
+        "version": "0.151.0"
       },
       "license": "Apache-2.0"
     },
@@ -8167,13 +8200,13 @@
       },
       "license": "Apache-2.0"
     },
-    "swc_ecma_parser 0.144.1": {
+    "swc_ecma_parser 0.146.1": {
       "name": "swc_ecma_parser",
-      "version": "0.144.1",
+      "version": "0.146.1",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/swc_ecma_parser/0.144.1/download",
-          "sha256": "0499e69683ae5d67a20ff0279b94bc90f29df7922a46331b54d5dd367bf89570"
+          "url": "https://static.crates.io/crates/swc_ecma_parser/0.146.1/download",
+          "sha256": "f884c766155c58b98503961612d1caced9d50267fcbf7914d9407d6fc5447efe"
         }
       },
       "targets": [
@@ -8239,11 +8272,11 @@
               "target": "swc_atoms"
             },
             {
-              "id": "swc_common 0.33.26",
+              "id": "swc_common 0.34.1",
               "target": "swc_common"
             },
             {
-              "id": "swc_ecma_ast 0.113.5",
+              "id": "swc_ecma_ast 0.115.0",
               "target": "swc_ecma_ast"
             },
             {
@@ -8265,17 +8298,17 @@
           }
         },
         "edition": "2021",
-        "version": "0.144.1"
+        "version": "0.146.1"
       },
       "license": "Apache-2.0"
     },
-    "swc_ecma_testing 0.22.23": {
+    "swc_ecma_testing 0.23.0": {
       "name": "swc_ecma_testing",
-      "version": "0.22.23",
+      "version": "0.23.0",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/swc_ecma_testing/0.22.23/download",
-          "sha256": "dbe778ce5eae6a7e620e1f6b5326e78f00203c4548e0c659fd22da8be0538fd1"
+          "url": "https://static.crates.io/crates/swc_ecma_testing/0.23.0/download",
+          "sha256": "7f495dae76f1ef3f5be46993b050c3c7f9bf534bcdacf1e40789d32255040776"
         }
       },
       "targets": [
@@ -8312,7 +8345,7 @@
               "target": "sha2"
             },
             {
-              "id": "testing 0.35.25",
+              "id": "testing 0.36.0",
               "target": "testing"
             },
             {
@@ -8323,17 +8356,17 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.22.23"
+        "version": "0.23.0"
       },
       "license": "Apache-2.0"
     },
-    "swc_ecma_transforms_base 0.138.2": {
+    "swc_ecma_transforms_base 0.140.0": {
       "name": "swc_ecma_transforms_base",
-      "version": "0.138.2",
+      "version": "0.140.0",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/swc_ecma_transforms_base/0.138.2/download",
-          "sha256": "eddb95c2bdad1c9c29edf35712e1e0f9b9ddc1cdb5ba2d582fd93468cb075a03"
+          "url": "https://static.crates.io/crates/swc_ecma_transforms_base/0.140.0/download",
+          "sha256": "daee7af0abfccc9855656fc36ac472e1e6a61398a3a1a1b3bf05ef7a7e7af6b0"
         }
       },
       "targets": [
@@ -8394,23 +8427,23 @@
               "target": "swc_atoms"
             },
             {
-              "id": "swc_common 0.33.26",
+              "id": "swc_common 0.34.1",
               "target": "swc_common"
             },
             {
-              "id": "swc_ecma_ast 0.113.5",
+              "id": "swc_ecma_ast 0.115.0",
               "target": "swc_ecma_ast"
             },
             {
-              "id": "swc_ecma_parser 0.144.1",
+              "id": "swc_ecma_parser 0.146.1",
               "target": "swc_ecma_parser"
             },
             {
-              "id": "swc_ecma_utils 0.128.2",
+              "id": "swc_ecma_utils 0.130.0",
               "target": "swc_ecma_utils"
             },
             {
-              "id": "swc_ecma_visit 0.99.1",
+              "id": "swc_ecma_visit 0.101.0",
               "target": "swc_ecma_visit"
             },
             {
@@ -8421,17 +8454,17 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.138.2"
+        "version": "0.140.0"
       },
       "license": "Apache-2.0"
     },
-    "swc_ecma_transforms_testing 0.141.1": {
+    "swc_ecma_transforms_testing 0.143.0": {
       "name": "swc_ecma_transforms_testing",
-      "version": "0.141.1",
+      "version": "0.143.0",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/swc_ecma_transforms_testing/0.141.1/download",
-          "sha256": "686445efd086ca6dd52874b4d1935663914e2fb76514c0ad7b0105cec7859451"
+          "url": "https://static.crates.io/crates/swc_ecma_transforms_testing/0.143.0/download",
+          "sha256": "2622a94000bb4e04548afe0540150f616c58296d5485c0653d1fae69c23efd98"
         }
       },
       "targets": [
@@ -8488,35 +8521,35 @@
               "target": "sourcemap"
             },
             {
-              "id": "swc_common 0.33.26",
+              "id": "swc_common 0.34.1",
               "target": "swc_common"
             },
             {
-              "id": "swc_ecma_ast 0.113.5",
+              "id": "swc_ecma_ast 0.115.0",
               "target": "swc_ecma_ast"
             },
             {
-              "id": "swc_ecma_codegen 0.149.2",
+              "id": "swc_ecma_codegen 0.151.0",
               "target": "swc_ecma_codegen"
             },
             {
-              "id": "swc_ecma_parser 0.144.1",
+              "id": "swc_ecma_parser 0.146.1",
               "target": "swc_ecma_parser"
             },
             {
-              "id": "swc_ecma_testing 0.22.23",
+              "id": "swc_ecma_testing 0.23.0",
               "target": "swc_ecma_testing"
             },
             {
-              "id": "swc_ecma_transforms_base 0.138.2",
+              "id": "swc_ecma_transforms_base 0.140.0",
               "target": "swc_ecma_transforms_base"
             },
             {
-              "id": "swc_ecma_utils 0.128.2",
+              "id": "swc_ecma_utils 0.130.0",
               "target": "swc_ecma_utils"
             },
             {
-              "id": "swc_ecma_visit 0.99.1",
+              "id": "swc_ecma_visit 0.101.0",
               "target": "swc_ecma_visit"
             },
             {
@@ -8524,24 +8557,24 @@
               "target": "tempfile"
             },
             {
-              "id": "testing 0.35.25",
+              "id": "testing 0.36.0",
               "target": "testing"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.141.1"
+        "version": "0.143.0"
       },
       "license": "Apache-2.0"
     },
-    "swc_ecma_utils 0.128.2": {
+    "swc_ecma_utils 0.130.0": {
       "name": "swc_ecma_utils",
-      "version": "0.128.2",
+      "version": "0.130.0",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/swc_ecma_utils/0.128.2/download",
-          "sha256": "2f978f911664091d2d161ed7fedfb2128f6a8af77765a264b470195d6e20b768"
+          "url": "https://static.crates.io/crates/swc_ecma_utils/0.130.0/download",
+          "sha256": "831490c6d4a52f06932fa2c3d87fc0d0aa43211a5df6b5e05a1ec2c57a2f2519"
         }
       },
       "targets": [
@@ -8582,19 +8615,23 @@
               "target": "rustc_hash"
             },
             {
+              "id": "ryu-js 1.0.1",
+              "target": "ryu_js"
+            },
+            {
               "id": "swc_atoms 0.6.7",
               "target": "swc_atoms"
             },
             {
-              "id": "swc_common 0.33.26",
+              "id": "swc_common 0.34.1",
               "target": "swc_common"
             },
             {
-              "id": "swc_ecma_ast 0.113.5",
+              "id": "swc_ecma_ast 0.115.0",
               "target": "swc_ecma_ast"
             },
             {
-              "id": "swc_ecma_visit 0.99.1",
+              "id": "swc_ecma_visit 0.101.0",
               "target": "swc_ecma_visit"
             },
             {
@@ -8609,17 +8646,17 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.128.2"
+        "version": "0.130.0"
       },
       "license": "Apache-2.0"
     },
-    "swc_ecma_visit 0.99.1": {
+    "swc_ecma_visit 0.101.0": {
       "name": "swc_ecma_visit",
-      "version": "0.99.1",
+      "version": "0.101.0",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/swc_ecma_visit/0.99.1/download",
-          "sha256": "28a6ce28ad8e591f8d627f1f9cb26b25e5d83052a9bc1b674d95fc28040cfa98"
+          "url": "https://static.crates.io/crates/swc_ecma_visit/0.101.0/download",
+          "sha256": "ce0d997f0c9b4e181225f603d161f6757c2a97022258170982cfe005ec69ec92"
         }
       },
       "targets": [
@@ -8660,11 +8697,11 @@
               "target": "swc_atoms"
             },
             {
-              "id": "swc_common 0.33.26",
+              "id": "swc_common 0.34.1",
               "target": "swc_common"
             },
             {
-              "id": "swc_ecma_ast 0.113.5",
+              "id": "swc_ecma_ast 0.115.0",
               "target": "swc_ecma_ast"
             },
             {
@@ -8679,7 +8716,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.99.1"
+        "version": "0.101.0"
       },
       "license": "Apache-2.0"
     },
@@ -8733,13 +8770,13 @@
       },
       "license": "Apache-2.0"
     },
-    "swc_error_reporters 0.17.20": {
+    "swc_error_reporters 0.18.0": {
       "name": "swc_error_reporters",
-      "version": "0.17.20",
+      "version": "0.18.0",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/swc_error_reporters/0.17.20/download",
-          "sha256": "72100a5f7b0c178adf7bcc5e7c8ad9d4180f499a5f5bae9faf3f417c7cbc4915"
+          "url": "https://static.crates.io/crates/swc_error_reporters/0.18.0/download",
+          "sha256": "9bd8f9a90efb59dc5d918b4470e5d152f34cac2f8733bfba141a96440cab3eff"
         }
       },
       "targets": [
@@ -8780,14 +8817,14 @@
               "target": "parking_lot"
             },
             {
-              "id": "swc_common 0.33.26",
+              "id": "swc_common 0.34.1",
               "target": "swc_common"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.17.20"
+        "version": "0.18.0"
       },
       "license": "Apache-2.0"
     },
@@ -8933,13 +8970,13 @@
       },
       "license": "Apache-2.0"
     },
-    "swc_plugin_proxy 0.42.1": {
+    "swc_plugin_proxy 0.44.0": {
       "name": "swc_plugin_proxy",
-      "version": "0.42.1",
+      "version": "0.44.0",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/swc_plugin_proxy/0.42.1/download",
-          "sha256": "98974702046356b67da841a8de561480fd75f963f5d406eee40d690e014e4b55"
+          "url": "https://static.crates.io/crates/swc_plugin_proxy/0.44.0/download",
+          "sha256": "98740e5a1ac82ad0de823bcf4aea97a76dce77c1ccff167d148e8a114b2932c0"
         }
       },
       "targets": [
@@ -8979,11 +9016,11 @@
               "target": "rkyv"
             },
             {
-              "id": "swc_common 0.33.26",
+              "id": "swc_common 0.34.1",
               "target": "swc_common"
             },
             {
-              "id": "swc_ecma_ast 0.113.5",
+              "id": "swc_ecma_ast 0.115.0",
               "target": "swc_ecma_ast"
             },
             {
@@ -9003,7 +9040,7 @@
           ],
           "selects": {}
         },
-        "version": "0.42.1"
+        "version": "0.44.0"
       },
       "license": "Apache-2.0"
     },
@@ -9496,13 +9533,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "testing 0.35.25": {
+    "testing 0.36.0": {
       "name": "testing",
-      "version": "0.35.25",
+      "version": "0.36.0",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/testing/0.35.25/download",
-          "sha256": "15028f8ec7f95006f4e00e6c5ab6620f322bc6dc208a6cba09afa36375981cec"
+          "url": "https://static.crates.io/crates/testing/0.36.0/download",
+          "sha256": "27d395aa823f3ad1ad845ed74b96188f493b469794cfbe9ef82f03196064086f"
         }
       },
       "targets": [
@@ -9559,11 +9596,11 @@
               "target": "serde_json"
             },
             {
-              "id": "swc_common 0.33.26",
+              "id": "swc_common 0.34.1",
               "target": "swc_common"
             },
             {
-              "id": "swc_error_reporters 0.17.20",
+              "id": "swc_error_reporters 0.18.0",
               "target": "swc_error_reporters"
             },
             {
@@ -9587,7 +9624,7 @@
           ],
           "selects": {}
         },
-        "version": "0.35.25"
+        "version": "0.36.0"
       },
       "license": "Apache-2.0"
     },

--- a/rust/icu-messageformat-parser/Cargo.toml
+++ b/rust/icu-messageformat-parser/Cargo.toml
@@ -20,4 +20,4 @@ widestring = { version = "1.0.2", optional = true }
 [dev-dependencies]
 serde_json      = "1.0.83"
 similar-asserts = "1.4.2"
-testing         = "0.35.25"
+testing         = "0.36.0"

--- a/rust/swc-formatjs-custom-transform/Cargo.toml
+++ b/rust/swc-formatjs-custom-transform/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = { version = "1.0.85", features = ["unbounded_depth"] }
 swc-formatjs-visitor = { path = "../swc-formatjs-visitor", features = [
   "custom_transform",
 ] }
-swc_core = { version = "0.92.7", features = [
+swc_core = { version = "0.95.2", features = [
   "common_concurrent",
   "ecma_transforms",
   "ecma_ast",

--- a/rust/swc-formatjs-visitor/Cargo.toml
+++ b/rust/swc-formatjs-visitor/Cargo.toml
@@ -21,7 +21,7 @@ regex = "1.6.0"
 serde = { version = "1.0.143", features = ["derive"] }
 serde_json = "1.0.83"
 sha2 = "0.10"
-swc_core = { version = "0.92.7", features = ["common", "ecma_visit", "ecma_ast"] }
+swc_core = { version = "0.95.2", features = ["common", "ecma_visit", "ecma_ast"] }
 
 [dev-dependencies]
 pretty_assertions = "1.3.0"

--- a/rust/swc-plugin-formatjs/Cargo.toml
+++ b/rust/swc-plugin-formatjs/Cargo.toml
@@ -16,4 +16,4 @@ serde_json = "1"
 swc-formatjs-visitor = { path = "../swc-formatjs-visitor", version = "0.0.2", features = [
   "plugin",
 ] }
-swc_core = { version = "0.92.7", features = ["ecma_plugin_transform", "ecma_ast_serde"] }
+swc_core = { version = "0.95.2", features = ["ecma_plugin_transform", "ecma_ast_serde"] }


### PR DESCRIPTION
Bump `swc_core` dependencies to support latest @swc/core version.