### PR TITLE
docs: Use `locale` in import path for "Dynamic Import" example code

### DIFF
--- a/website/docs/polyfills/intl-datetimeformat.md
+++ b/website/docs/polyfills/intl-datetimeformat.md
@@ -92,7 +92,7 @@ async function polyfill(locale: string) {
   // Parallelize CLDR data loading
   const dataPolyfills = [
     import('@formatjs/intl-datetimeformat/add-all-tz'),
-    import(`@formatjs/intl-datetimeformat/locale-data/${unsupportedLocale}`),
+    import(`@formatjs/intl-datetimeformat/locale-data/${locale}`),
   ]
   await Promise.all(dataPolyfills)
 }

--- a/website/docs/polyfills/intl-listformat.md
+++ b/website/docs/polyfills/intl-listformat.md
@@ -71,7 +71,7 @@ async function polyfill(locale: string) {
   }
   // Load the polyfill 1st BEFORE loading data
   await import('@formatjs/intl-listformat/polyfill-force')
-  await import(`@formatjs/intl-listformat/locale-data/${unsupportedLocale}`)
+  await import(`@formatjs/intl-listformat/locale-data/${locale}`)
 }
 ```
 

--- a/website/docs/polyfills/intl-numberformat.md
+++ b/website/docs/polyfills/intl-numberformat.md
@@ -88,7 +88,7 @@ async function polyfill(locale: string) {
   }
   // Load the polyfill 1st BEFORE loading data
   await import('@formatjs/intl-numberformat/polyfill-force')
-  await import(`@formatjs/intl-numberformat/locale-data/${unsupportedLocale}`)
+  await import(`@formatjs/intl-numberformat/locale-data/${locale}`)
 }
 ```
 

--- a/website/docs/polyfills/intl-pluralrules.md
+++ b/website/docs/polyfills/intl-pluralrules.md
@@ -71,6 +71,6 @@ async function polyfill(locale: string) {
   }
   // Load the polyfill 1st BEFORE loading data
   await import('@formatjs/intl-pluralrules/polyfill-force')
-  await import(`@formatjs/intl-pluralrules/locale-data/${unsupportedLocale}`)
+  await import(`@formatjs/intl-pluralrules/locale-data/${locale}`)
 }
 ```

--- a/website/docs/polyfills/intl-relativetimeformat.md
+++ b/website/docs/polyfills/intl-relativetimeformat.md
@@ -76,7 +76,7 @@ async function polyfill(locale: string) {
   // Load the polyfill 1st BEFORE loading data
   await import('@formatjs/intl-relativetimeformat/polyfill-force')
   await import(
-    `@formatjs/intl-relativetimeformat/locale-data/${unsupportedLocale}`
+    `@formatjs/intl-relativetimeformat/locale-data/${locale}`
   )
 }
 ```


### PR DESCRIPTION
I think this is just a typo.

The `unsupportedLocale` var is used above, but it is a boolean, not the `locale` string that is passed in these examples.

For example, `intl-displaynames.md` has the correct example code:

https://github.com/formatjs/formatjs/blob/f71ce48aaf8ada6a77d393d3f2293fc14f2c38c2/website/docs/polyfills/intl-displaynames.md#L78