### PR TITLE
Fix react-intl typescript error with `formatMessage` type inference

### DIFF
--- a/packages/intl/src/types.ts
+++ b/packages/intl/src/types.ts
@@ -161,11 +161,11 @@ export interface IntlFormatters<TBase = unknown> {
     values?: Record<string, PrimitiveType | FormatXMLElementFn<string, string>>,
     opts?: IntlMessageFormatOptions
   ): string
-  formatMessage<T extends TBase>(
+  formatMessage<T extends TBase, TValue extends T | FormatXMLElementFn<T>>(
     descriptor: MessageDescriptor,
-    values?: Record<string, PrimitiveType | T | FormatXMLElementFn<T>>,
+    values?: Record<string, PrimitiveType | TValue>,
     opts?: IntlMessageFormatOptions
-  ): string | T | (T | string)[]
+  ): string | T | Array<string | T>
   $t(
     descriptor: MessageDescriptor,
     values?: Record<string, PrimitiveType | FormatXMLElementFn<string, string>>,


### PR DESCRIPTION
Example code:

```tsx
intl.formatMessage(
  {
    id: "test",
    defaultMessage: "Hello <link>world</link>",
  },
  {
    link: (children) => <a href="/test">{children}</a>,
  },
)
```

With the example code above and typescript's strict mode turned on, `formatMessage` with rich text formatting yields the following typescript error:

```ts
No overload matches this call.
  Overload 1 of 2, '(descriptor: MessageDescriptor, values?: Record<string, PrimitiveType | FormatXMLElementFn<string, string>> | undefined, opts?: Options | undefined): string', gave the following error.
    Type '(children: string[]) => Element' is not assignable to type 'PrimitiveType | FormatXMLElementFn<string, string>'.
      Type '(children: string[]) => Element' is not assignable to type 'FormatXMLElementFn<string, string>'.
        Type 'Element' is not assignable to type 'string'.
  Overload 2 of 2, '(descriptor: MessageDescriptor, values?: Record<string, Element | PrimitiveType | FormatXMLElementFn<Element>> | undefined, opts?: Options | undefined): string | ... 1 more ... | (string | Element)[]', gave the following error.
    Type '(children: string[]) => Element' is not assignable to type 'Element | PrimitiveType | FormatXMLElementFn<Element>'.
      Type '(children: string[]) => Element' is not assignable to type 'FormatXMLElementFn<Element>'.
        Types of parameters 'children' and 'parts' are incompatible.
          Type '(string | Element)[]' is not assignable to type 'string[]'.
            Type 'string | Element' is not assignable to type 'string'.
              Type 'Element' is not assignable to type 'string'.typescript(2769)
index.tsx(19, 21): Did you mean to call this expression?
```

When strict mode is turned off this code doesn't yield an error.

It appears typescript is hitting the non-generic type definition for `formatMessage` instead of the generic one. Switching the order of the overloaded definition for `formatMessage` seems to resolve the issue but I'm not sure if this really solving the issue. I'm hoping a maintainer can weigh in here.

Related PR:
 - https://github.com/formatjs/formatjs/pull/3858

Related issues:
 - https://github.com/formatjs/formatjs/issues/3856
 - https://github.com/formatjs/formatjs/issues/3707

[Reproduction codesandbox](https://codesandbox.io/p/devbox/typescript-react-intl-formatmessage-error-reproduction-forked-3qr5zm?file=%2Fsrc%2Findex.tsx%3A13%2C23)