### PR TITLE
Document the workaround for Intl.PluralRules polyfill slowing down the app by seconds

### DIFF
--- a/website/docs/polyfills/intl-pluralrules.md
+++ b/website/docs/polyfills/intl-pluralrules.md
@@ -59,6 +59,16 @@ import '@formatjs/intl-pluralrules/polyfill'
 import '@formatjs/intl-pluralrules/locale-data/en' // locale-data for en
 ```
 
+### React Native
+
+The polyfill conditional detection code runs [very slowly on Android](https://github.com/formatjs/formatjs/issues/4463) and can slow down your app's startup time by seconds. Since React Native uses Hermes which does not support `Intl.PluralRules`, import `/polyfill-force` instead for much better performance:
+
+```tsx
+import '@formatjs/intl-pluralrules/polyfill-force' // instead of /polyfill
+import '@formatjs/intl-pluralrules/locale-data/en'
+```
+
+
 ### Dynamic import + capability detection
 
 ```tsx


### PR DESCRIPTION
Let's at least make this visible.

Relates to:

- https://github.com/bluesky-social/social-app/pull/4554
- https://github.com/formatjs/formatjs/issues/4463#issuecomment-2266095186
- https://github.com/formatjs/formatjs/issues/4369