### PR TITLE
fix(react-intl): irrelevant PropTypes import is removed

### DIFF
--- a/website/docs/react-intl/api.md
+++ b/website/docs/react-intl/api.md
@@ -76,7 +76,7 @@ This function is exported by the `react-intl` package and is a High-Order Compon
 By default, the formatting API will be provided to the wrapped component via `props.intl`, but this can be overridden when specifying `options.intlPropName`. The value of the prop will be of type [`IntlShape`](#Intlshape), defined in the next section.
 
 ```tsx
-import React, {PropTypes} from 'react'
+import React from 'react'
 import {injectIntl, FormattedDate} from 'react-intl'
 
 interface Props {


### PR DESCRIPTION
Hi team,

This PR is to quickly fix the documentation that has `PropTypes` as an import in one of the code snippets that not being used anywhere. Noticed it when I was looking for information on how `react-intl` handles `PropTypes`