### PR TITLE
perf(@formatjs/intl-datetimeformat): cache number format instances in `formatDateParts`

### DIFF
--- a/packages/ecma402-abstract/types/date-time.ts
+++ b/packages/ecma402-abstract/types/date-time.ts
@@ -51,6 +51,9 @@ export interface IntlDateTimeFormatInternal {
   format: Formats
   rangePatterns: Record<TABLE_2 | 'default', RangePatterns>
   boundFormat?: Intl.DateTimeFormat['format']
+  numberFormat?: Intl.NumberFormat
+  numberFormatTwoIntegerDigits?: Intl.NumberFormat
+  numberFormatFractionalSecondDigits?: Intl.NumberFormat
 }
 
 export interface RangePatternPart<

--- a/packages/intl-datetimeformat/src/abstract/FormatDateTimePattern.ts
+++ b/packages/intl-datetimeformat/src/abstract/FormatDateTimePattern.ts
@@ -77,21 +77,38 @@ export function FormatDateTimePattern(
   /** IMPL END */
 
   const locale = internalSlots.locale
-  const nfOptions = Object.create(null)
-  nfOptions.useGrouping = false
 
-  const nf = new Intl.NumberFormat(locale, nfOptions)
-  const nf2Options = Object.create(null)
-  nf2Options.minimumIntegerDigits = 2
-  nf2Options.useGrouping = false
-  const nf2 = new Intl.NumberFormat(locale, nf2Options)
+  if (internalSlots.numberFormat === undefined) {
+    const nfOptions = Object.create(null)
+    nfOptions.useGrouping = false
+    internalSlots.numberFormat = new Intl.NumberFormat(locale, nfOptions)
+  }
+  const nf = internalSlots.numberFormat
+
+  if (internalSlots.numberFormatTwoIntegerDigits === undefined) {
+    const nf2Options = Object.create(null)
+    nf2Options.minimumIntegerDigits = 2
+    nf2Options.useGrouping = false
+    internalSlots.numberFormatTwoIntegerDigits = new Intl.NumberFormat(
+      locale,
+      nf2Options
+    )
+  }
+  const nf2 = internalSlots.numberFormatTwoIntegerDigits
+
   const fractionalSecondDigits = internalSlots.fractionalSecondDigits
   let nf3: Intl.NumberFormat
   if (fractionalSecondDigits !== undefined) {
-    const nf3Options = Object.create(null)
-    nf3Options.minimumIntegerDigits = fractionalSecondDigits
-    nf3Options.useGrouping = false
-    nf3 = new Intl.NumberFormat(locale, nf3Options)
+    if (internalSlots.numberFormatFractionalSecondDigits === undefined) {
+      const nf3Options = Object.create(null)
+      nf3Options.minimumIntegerDigits = fractionalSecondDigits
+      nf3Options.useGrouping = false
+      internalSlots.numberFormatFractionalSecondDigits = new Intl.NumberFormat(
+        locale,
+        nf3Options
+      )
+    }
+    nf3 = internalSlots.numberFormatFractionalSecondDigits
   }
   const tm = ToLocalTime(
     x,


### PR DESCRIPTION
Closes #4510

Hey! As discussed in #4510, I noticed that calling `DateTimeFormat.formatDateParts()` creates new instances of `NumberFormat` on every call. As creating `NumberFormat` can be quite heavy due to the `bestfit` mode of `LocaleMatcher` (see #4276 for more details), it's best to cache `NumberFormat` instances.

To keep performance of the `DateTimeFormat` constructor as-is, I lazily initialize the three (sometimes just two) `NumberFormat` instances during the first call to `formatDateParts` and store them in the `internalSlots` of the `DateTimeFormat`.

I'm not 100% sure if `internalSlots` is the right place to store these internal instances, if not, let me know where I could store them instead.

Thanks!
