### PR TITLE
fix(intl): explicitly annotate formatters with this: void

### DIFF
--- a/packages/intl/src/create-intl.ts
+++ b/packages/intl/src/create-intl.ts
@@ -96,62 +96,66 @@ export function createIntl<T = string>(
     ...resolvedConfig,
     formatters,
     formatNumber: formatNumber.bind(
-      null,
+      undefined,
       resolvedConfig,
       formatters.getNumberFormat
     ),
     formatNumberToParts: formatNumberToParts.bind(
-      null,
+      undefined,
       resolvedConfig,
       formatters.getNumberFormat
     ),
     formatRelativeTime: formatRelativeTime.bind(
-      null,
+      undefined,
       resolvedConfig,
       formatters.getRelativeTimeFormat
     ),
     formatDate: formatDate.bind(
-      null,
+      undefined,
       resolvedConfig,
       formatters.getDateTimeFormat
     ),
     formatDateToParts: formatDateToParts.bind(
-      null,
+      undefined,
       resolvedConfig,
       formatters.getDateTimeFormat
     ),
     formatTime: formatTime.bind(
-      null,
+      undefined,
       resolvedConfig,
       formatters.getDateTimeFormat
     ),
     formatDateTimeRange: formatDateTimeRange.bind(
-      null,
+      undefined,
       resolvedConfig,
       formatters.getDateTimeFormat
     ),
     formatTimeToParts: formatTimeToParts.bind(
-      null,
+      undefined,
       resolvedConfig,
       formatters.getDateTimeFormat
     ),
     formatPlural: formatPlural.bind(
-      null,
+      undefined,
       resolvedConfig,
       formatters.getPluralRules
     ),
     // @ts-expect-error TODO: will get to this later
-    formatMessage: formatMessage.bind(null, resolvedConfig, formatters),
+    formatMessage: formatMessage.bind(undefined, resolvedConfig, formatters),
     // @ts-expect-error TODO: will get to this later
-    $t: formatMessage.bind(null, resolvedConfig, formatters),
-    formatList: formatList.bind(null, resolvedConfig, formatters.getListFormat),
+    $t: formatMessage.bind(undefined, resolvedConfig, formatters),
+    formatList: formatList.bind(
+      undefined,
+      resolvedConfig,
+      formatters.getListFormat
+    ),
     formatListToParts: formatListToParts.bind(
-      null,
+      undefined,
       resolvedConfig,
       formatters.getListFormat
     ),
     formatDisplayName: formatDisplayName.bind(
-      null,
+      undefined,
       resolvedConfig,
       formatters.getDisplayNames
     ),

--- a/packages/intl/src/dateTime.ts
+++ b/packages/intl/src/dateTime.ts
@@ -72,6 +72,7 @@ export function getFormatter(
 }
 
 export function formatDate(
+  this: void,
   config: {
     locale: string
     timeZone?: string
@@ -94,6 +95,7 @@ export function formatDate(
 }
 
 export function formatTime(
+  this: void,
   config: {
     locale: string
     timeZone?: string
@@ -117,6 +119,7 @@ export function formatTime(
 }
 
 export function formatDateTimeRange(
+  this: void,
   config: {
     locale: string
     timeZone?: string
@@ -145,6 +148,7 @@ export function formatDateTimeRange(
 }
 
 export function formatDateToParts(
+  this: void,
   config: {
     locale: string
     timeZone?: string
@@ -172,6 +176,7 @@ export function formatDateToParts(
 }
 
 export function formatTimeToParts(
+  this: void,
   config: {
     locale: string
     timeZone?: string

--- a/packages/intl/src/displayName.ts
+++ b/packages/intl/src/displayName.ts
@@ -15,6 +15,7 @@ const DISPLAY_NAMES_OPTONS: Array<keyof DisplayNamesOptions> = [
 ]
 
 export function formatDisplayName(
+  this: void,
   {
     locale,
     onError,

--- a/packages/intl/src/list.ts
+++ b/packages/intl/src/list.ts
@@ -18,6 +18,7 @@ function generateToken(i: number): string {
 }
 
 export function formatList(
+  this: void,
   opts: {
     locale: string
     onError: OnErrorFn
@@ -27,6 +28,7 @@ export function formatList(
   options: Parameters<IntlFormatters['formatList']>[1]
 ): string
 export function formatList<T>(
+  this: void,
   opts: {
     locale: string
     onError: OnErrorFn
@@ -55,6 +57,7 @@ export function formatList<T>(
 }
 
 export function formatListToParts<T>(
+  this: void,
   opts: {
     locale: string
     onError: OnErrorFn
@@ -64,6 +67,7 @@ export function formatListToParts<T>(
   options: Parameters<IntlFormatters['formatList']>[1]
 ): Part[]
 export function formatListToParts<T>(
+  this: void,
   {
     locale,
     onError,

--- a/packages/intl/src/message.ts
+++ b/packages/intl/src/message.ts
@@ -65,6 +65,7 @@ function deepMergeFormatsAndSetTimeZone(
 }
 
 export type FormatMessageFn<T> = (
+  this: void,
   {
     locale,
     formats,

--- a/packages/intl/src/number.ts
+++ b/packages/intl/src/number.ts
@@ -61,6 +61,7 @@ export function getFormatter(
 }
 
 export function formatNumber(
+  this: void,
   config: {
     locale: string
 
@@ -83,6 +84,7 @@ export function formatNumber(
 }
 
 export function formatNumberToParts(
+  this: void,
   config: {
     locale: string
     formats: CustomFormats

--- a/packages/intl/src/plural.ts
+++ b/packages/intl/src/plural.ts
@@ -7,6 +7,7 @@ import {LDMLPluralRule} from '@formatjs/ecma402-abstract'
 const PLURAL_FORMAT_OPTIONS: Array<keyof Intl.PluralRulesOptions> = ['type']
 
 export function formatPlural(
+  this: void,
   {
     locale,
     onError,

--- a/packages/intl/src/relativeTime.ts
+++ b/packages/intl/src/relativeTime.ts
@@ -9,6 +9,7 @@ const RELATIVE_TIME_FORMAT_OPTIONS: Array<
 > = ['numeric', 'style']
 
 function getFormatter(
+  this: void,
   {
     locale,
     formats,
@@ -35,6 +36,7 @@ function getFormatter(
 }
 
 export function formatRelativeTime(
+  this: void,
   config: {
     locale: string
     formats: CustomFormats


### PR DESCRIPTION
This MR explicitly annotate formatters functions with `this:void`, as none of them use `this`. 

Without this, destructuring `useIntl` return would generate a lint error for consumers that enabled [this typescript-eslint rule](https://typescript-eslint.io/rules/unbound-method/)

->
before
```
const { formatMessage } = useIntl(); // KO
const intl = useIntl() // OK
```

after
```
const { formatMessage } = useIntl(); // OK
const intl = useIntl() // OK
```

