### PR TITLE
fix(@formatjs/intl-datetimeformat): methods return "Invalid Date" ins…

### DIFF
--- a/packages/eslint-plugin-formatjs/BUILD
+++ b/packages/eslint-plugin-formatjs/BUILD
@@ -23,7 +23,7 @@ npm_package(
 SRCS = glob(["rules/*.ts"]) + [
     "index.ts",
     "util.ts",
-    "context-compat.ts"
+    "context-compat.ts",
 ]
 
 SRC_DEPS = [

--- a/packages/intl-datetimeformat/polyfill-force.ts
+++ b/packages/intl-datetimeformat/polyfill-force.ts
@@ -12,7 +12,11 @@ defineProperty(Date.prototype, 'toLocaleString', {
     locales?: string | string[],
     options?: Intl.DateTimeFormatOptions
   ) {
-    return _toLocaleString(this, locales, options)
+    try {
+      return _toLocaleString(this, locales, options)
+    } catch (error) {
+      return 'Invalid Date'
+    }
   },
 })
 defineProperty(Date.prototype, 'toLocaleDateString', {
@@ -20,7 +24,11 @@ defineProperty(Date.prototype, 'toLocaleDateString', {
     locales?: string | string[],
     options?: Intl.DateTimeFormatOptions
   ) {
-    return _toLocaleDateString(this, locales, options)
+    try {
+      return _toLocaleDateString(this, locales, options)
+    } catch (error) {
+      return 'Invalid Date'
+    }
   },
 })
 defineProperty(Date.prototype, 'toLocaleTimeString', {
@@ -28,6 +36,10 @@ defineProperty(Date.prototype, 'toLocaleTimeString', {
     locales?: string | string[],
     options?: Intl.DateTimeFormatOptions
   ) {
-    return _toLocaleTimeString(this, locales, options)
+    try {
+      return _toLocaleTimeString(this, locales, options)
+    } catch (error) {
+      return 'Invalid Date'
+    }
   },
 })


### PR DESCRIPTION
…tead of throwing in polyfill-force

When https://github.com/formatjs/formatjs/issues/3508 was fixed in PR https://github.com/formatjs/formatjs/pull/3559, the fix was only applied to `polyfill`, but not to `polyfill-force`. This simply copies the change so that it also applies the fix when using `polyfill-force`.