### PR TITLE
chore(ci): use ubuntu@20 to run buildbuddy actions

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -1,5 +1,6 @@
 actions:
   - name: 'Test all targets'
+    container_image: 'ubuntu-20.04'
     triggers:
       push:
         branches:


### PR DESCRIPTION
I noticed the pipeline is constantly failing because of `GLIBC_2.28 not found`. Bumping ubuntu to 20 should fix the issue here