### PR TITLE
Fix(@formatjs/cli-lib): add newline to compiled file, fix #4539

### DIFF
--- a/packages/cli-lib/src/compile.ts
+++ b/packages/cli-lib/src/compile.ts
@@ -131,11 +131,10 @@ export default async function compileAndWrite(
   compileOpts: CompileCLIOpts = {}
 ) {
   const {outFile, ...opts} = compileOpts
-  const serializedResult = await compile(inputFiles, opts)
+  const serializedResult = (await compile(inputFiles, opts)) + '\n'
   if (outFile) {
     debug('Writing output file:', outFile)
     return outputFile(outFile, serializedResult)
   }
   await writeStdout(serializedResult)
-  await writeStdout('\n')
 }

--- a/packages/eslint-plugin-formatjs/BUILD
+++ b/packages/eslint-plugin-formatjs/BUILD
@@ -23,7 +23,7 @@ npm_package(
 SRCS = glob(["rules/*.ts"]) + [
     "index.ts",
     "util.ts",
-    "context-compat.ts"
+    "context-compat.ts",
 ]
 
 SRC_DEPS = [


### PR DESCRIPTION
Fix #4539

I tested the change manually in my project context, and I didn't go further than what [the similar commit for extract does](https://github.com/formatjs/formatjs/commit/9fbf2af73d1c6a8765f66403758e583365720e2a), please let me know and provide a bit of guidance if you think tests should be changed.

I have 286/286 tests passing locally when I run `pnpm test`, any help with the red CI highly appreciated. I assume it might be simply related to #4541.
