### PR TITLE
 Ignore whitepsace only string literals in `formatjs/no-literal-string-in-jsx`

### DIFF
--- a/packages/eslint-plugin-formatjs/rules/no-literal-string-in-jsx.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-literal-string-in-jsx.ts
@@ -147,7 +147,7 @@ export const rule: RuleModule<MessageIds, Options> = {
       if (
         (node.type === 'Literal' &&
           typeof node.value === 'string' &&
-          node.value.length > 0) ||
+          node.value.replace(/\s*/gm, '').length > 0) ||
         (node.type === 'TemplateLiteral' &&
           (node.quasis.length > 1 || node.quasis[0].value.raw.length > 0))
       ) {

--- a/packages/eslint-plugin-formatjs/tests/no-literal-string-in-jsx.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/no-literal-string-in-jsx.test.ts
@@ -117,6 +117,10 @@ ruleTester.run(name, rule, {
       // Ignores empty attributes (as template literal expression in the attribute value).
       code: '<img alt={``} role="presentational" />',
     },
+    {
+      // Ignore spacing string literals
+      code: '<div>{" "}</div>',
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
It looks like the `formatjs/no-literal-string-in-jsx` ignores whitespace only fragments ([here](https://github.com/formatjs/formatjs/blob/b338b972291416c9df2b1de6fc8791bd9b4d9fe6/packages/eslint-plugin-formatjs/rules/no-literal-string-in-jsx.ts#L212-L215)). I'm hoping that we can also ignore whitespace only string literals so that the rule doesn't have to be suppressed for `{" "}` spacers.

Somewhat related: https://github.com/formatjs/formatjs/issues/4180#issuecomment-2297646862 