### PR TITLE
feat(@formatjs/cli-lib): add `ignoreTag` parser option to the compile command

### DIFF
--- a/packages/cli-lib/src/cli.ts
+++ b/packages/cli-lib/src/cli.ts
@@ -184,6 +184,11 @@ for more information`
       `Whether to generate pseudo-locale files. See https://formatjs.io/docs/tooling/cli#--pseudo-locale-pseudolocale for possible values. 
 "--ast" is required for this to work.`
     )
+    .option(
+      '--ignore-tag',
+      `Whether the parser to treat HTML/XML tags as string literal instead of parsing them as tag token. When this is false we only allow 
+simple tags without any attributes.`
+    )
     .action(async (filePatterns: string[], opts: CompileCLIOpts) => {
       debug('File pattern:', filePatterns)
       debug('Options:', opts)

--- a/packages/cli-lib/src/compile.ts
+++ b/packages/cli-lib/src/compile.ts
@@ -40,6 +40,13 @@ export interface Opts {
    * Whether to compile to pseudo locale
    */
   pseudoLocale?: PseudoLocale
+  /**
+   * Whether the parser to treat HTML/XML tags as string literal
+   * instead of parsing them as tag token.
+   * When this is false we only allow simple tags without
+   * any attributes
+   */
+  ignoreTag?: boolean
 }
 
 /**
@@ -53,7 +60,7 @@ export interface Opts {
  */
 export async function compile(inputFiles: string[], opts: Opts = {}) {
   debug('Compiling files:', inputFiles)
-  const {ast, format, pseudoLocale, skipErrors} = opts
+  const {ast, format, pseudoLocale, skipErrors, ignoreTag} = opts
   const formatter = await resolveBuiltinFormatter(format)
 
   const messages: Record<string, string> = {}
@@ -76,7 +83,7 @@ Message from ${inputFile}: ${compiled[id]}
 `)
       }
       try {
-        const msgAst = parse(compiled[id])
+        const msgAst = parse(compiled[id], {ignoreTag})
         messages[id] = compiled[id]
         switch (pseudoLocale) {
           case 'xx-LS':

--- a/packages/cli/integration-tests/compile/__snapshots__/integration.test.ts.snap
+++ b/packages/cli/integration-tests/compile/__snapshots__/integration.test.ts.snap
@@ -178,6 +178,10 @@ Options:
                                   https://formatjs.io/docs/tooling/cli#--pseudo-locale-pseudolocale
                                   for possible values.
                                   "--ast" is required for this to work.
+  --ignore-tag                    Whether the parser to treat HTML/XML tags as
+                                  string literal instead of parsing them as tag
+                                  token. When this is false we only allow
+                                  simple tags without any attributes.
   -h, --help                      display help for command
 ",
 }
@@ -775,6 +779,20 @@ exports[`out-file --ast 2`] = `
       "value": "a message",
     },
   ],
+}
+`;
+
+exports[`out-file --ignore-tag 1`] = `
+{
+  "stderr": "",
+  "stdout": "",
+}
+`;
+
+exports[`out-file --ignore-tag 2`] = `
+{
+  "brmsg": "a message with a non-explicit <br> self-closing tag",
+  "linkmsg": "a message containing <a href=\"https://formatjs.io/\">a link</a>",
 }
 `;
 

--- a/packages/cli/integration-tests/compile/integration.test.ts
+++ b/packages/cli/integration-tests/compile/integration.test.ts
@@ -197,6 +197,19 @@ test('out-file --ast', async () => {
   expect(require(outFilePath)).toMatchSnapshot()
 }, 20000)
 
+test('out-file --ignore-tag', async () => {
+  const outFilePath = join(ARTIFACT_PATH, 'ignore-tag.json')
+  await expect(
+    exec(
+      `${BIN_PATH} compile --ignore-tag ${join(
+        __dirname,
+        'lang/html-messages.json'
+      )} --out-file ${outFilePath}`
+    )
+  ).resolves.toMatchSnapshot()
+  expect(require(outFilePath)).toMatchSnapshot()
+}, 20000)
+
 test('compile glob', async () => {
   await expect(
     exec(`${BIN_PATH} compile "${join(__dirname, 'glob/*.json')}"`)

--- a/packages/cli/integration-tests/compile/lang/html-messages.json
+++ b/packages/cli/integration-tests/compile/lang/html-messages.json
@@ -1,0 +1,8 @@
+{
+  "brmsg": {
+    "defaultMessage": "a message with a non-explicit <br> self-closing tag"
+  },
+  "linkmsg": {
+    "defaultMessage": "a message containing <a href=\"https://formatjs.io/\">a link</a>"
+  }
+}


### PR DESCRIPTION
This PR is a proposal related to discussion #4576. The discussion didn't have any answer at the moment but I think the change is straightforward enough to have the PR ready.

---

This PR adds the option `--ignore-tag` to the compile command, so this option can be passed to the parser. For instance:
```
"msgId": {
  "defaultMessage": "This message contains <a href="https://formatjs.io/">a link</a>."
}
```
Is compiled without error when running:
```
formatjs compile lang/en-us.json --out-file compiled/en-us.json --ignore-tag
```