### PR TITLE
fix(@formatjs/cli-lib): instantiate FormatFn with unknown in Formatter definition

### DIFF
--- a/packages/cli-lib/src/compile.ts
+++ b/packages/cli-lib/src/compile.ts
@@ -35,7 +35,7 @@ export interface Opts {
    * Path to a formatter file that converts <translation_files> to
    * `Record<string, string>` so we can compile.
    */
-  format?: string | Formatter
+  format?: string | Formatter<unknown>
   /**
    * Whether to compile to pseudo locale
    */

--- a/packages/cli-lib/src/extract.ts
+++ b/packages/cli-lib/src/extract.ts
@@ -69,7 +69,7 @@ export type ExtractOpts = Opts & {
   /**
    * Path to a formatter file that controls the shape of JSON file from `outFile`.
    */
-  format?: string | Formatter
+  format?: string | Formatter<unknown>
   /**
    * Whether to hoist selectors & flatten sentences
    */
@@ -217,7 +217,9 @@ export async function extract(
     }
   }
 
-  const formatter: Formatter = await resolveBuiltinFormatter(opts.format)
+  const formatter: Formatter<unknown> = await resolveBuiltinFormatter(
+    opts.format
+  )
   const extractionResults = rawResults.filter((r): r is ExtractionResult => !!r)
 
   const extractedMessages = new Map<string, MessageDescriptor>()

--- a/packages/cli-lib/src/formatters/index.ts
+++ b/packages/cli-lib/src/formatters/index.ts
@@ -9,15 +9,15 @@ import * as simple from './simple'
 import * as smartling from './smartling'
 import * as transifex from './transifex'
 
-export interface Formatter {
-  serialize?: SerializeFn
-  format: FormatFn
-  compile: CompileFn
+export interface Formatter<T> {
+  serialize?: SerializeFn<T>
+  format: FormatFn<T>
+  compile: CompileFn<T>
   compareMessages?: Comparator
 }
 
 export async function resolveBuiltinFormatter(
-  format?: string | Formatter
+  format?: string | Formatter<unknown>
 ): Promise<any> {
   if (!format) {
     return defaultFormatter


### PR DESCRIPTION
Whenever we use `FormatFn` without explicit type argument, it's being instantiated with default type argument as follows
```
(msgs: Record<string, MessageDescriptor>) => Record<string, MessageDescriptor>
``` 
which is not correct in many places and lead to pretty much any custom formatter being non-assignable to `Formatter` interface:

<img width="630" alt="image" src="https://github.com/user-attachments/assets/23db6338-8560-453f-9bec-ff073fc683d6">

We probably should instantiate it with `any` or `unknown` because we actually do not care about the return type and leave it up to a user.