### PR TITLE
fix(eslint-plugin-formatjs): account for possibly undefined parserServices

### DIFF
--- a/packages/eslint-plugin-formatjs/rules/blocklist-elements.ts
+++ b/packages/eslint-plugin-formatjs/rules/blocklist-elements.ts
@@ -155,8 +155,8 @@ export const rule = createRule({
   create(context) {
     const callExpressionVisitor: ESLintUtils.RuleListener['CallExpression'] =
       node => checkNode(context, node)
-    const parserServices = getParserServices(context)
 
+    const parserServices = getParserServices(context)
     //@ts-expect-error defineTemplateBodyVisitor exists in Vue parser
     if (parserServices?.defineTemplateBodyVisitor) {
       //@ts-expect-error

--- a/packages/eslint-plugin-formatjs/rules/enforce-default-message.ts
+++ b/packages/eslint-plugin-formatjs/rules/enforce-default-message.ts
@@ -70,10 +70,11 @@ export const rule: RuleModule<MessageIds, Options> = {
     const callExpressionVisitor = (node: TSESTree.Node) =>
       checkNode(context, node)
 
+    const parserServices = getParserServices(context)
     //@ts-expect-error defineTemplateBodyVisitor exists in Vue parser
-    if (getParserServices(context).defineTemplateBodyVisitor) {
+    if (parserServices?.defineTemplateBodyVisitor) {
       //@ts-expect-error
-      return getParserServices(context).defineTemplateBodyVisitor(
+      return parserServices.defineTemplateBodyVisitor(
         {
           CallExpression: callExpressionVisitor,
         },

--- a/packages/eslint-plugin-formatjs/rules/enforce-description.ts
+++ b/packages/eslint-plugin-formatjs/rules/enforce-description.ts
@@ -69,10 +69,11 @@ export const rule: RuleModule<MessageIds, Options> = {
     const callExpressionVisitor = (node: TSESTree.Node) =>
       checkNode(context, node)
 
+    const parserServices = getParserServices(context)
     //@ts-expect-error defineTemplateBodyVisitor exists in Vue parser
-    if (getParserServices(context).defineTemplateBodyVisitor) {
+    if (parserServices?.defineTemplateBodyVisitor) {
       //@ts-expect-error
-      return getParserServices(context).defineTemplateBodyVisitor(
+      return parserServices.defineTemplateBodyVisitor(
         {
           CallExpression: callExpressionVisitor,
         },

--- a/packages/eslint-plugin-formatjs/rules/enforce-id.ts
+++ b/packages/eslint-plugin-formatjs/rules/enforce-id.ts
@@ -200,10 +200,11 @@ Actual: {{actual}}`,
     const callExpressionVisitor = (node: TSESTree.Node) =>
       checkNode(context, node, opts)
 
+    const parserServices = getParserServices(context)
     //@ts-expect-error defineTemplateBodyVisitor exists in Vue parser
-    if (getParserServices(context).defineTemplateBodyVisitor) {
+    if (parserServices?.defineTemplateBodyVisitor) {
       //@ts-expect-error
-      return getParserServices(context).defineTemplateBodyVisitor(
+      return parserServices.defineTemplateBodyVisitor(
         {
           CallExpression: callExpressionVisitor,
         },

--- a/packages/eslint-plugin-formatjs/rules/enforce-placeholders.ts
+++ b/packages/eslint-plugin-formatjs/rules/enforce-placeholders.ts
@@ -171,10 +171,11 @@ export const rule: RuleModule<MessageIds, Options> = {
     const callExpressionVisitor = (node: TSESTree.Node) =>
       checkNode(context, node)
 
+    const parserServices = getParserServices(context)
     //@ts-expect-error defineTemplateBodyVisitor exists in Vue parser
-    if (getParserServices(context).defineTemplateBodyVisitor) {
+    if (parserServices?.defineTemplateBodyVisitor) {
       //@ts-expect-error
-      return getParserServices(context).defineTemplateBodyVisitor(
+      return parserServices.defineTemplateBodyVisitor(
         {
           CallExpression: callExpressionVisitor,
         },

--- a/packages/eslint-plugin-formatjs/rules/enforce-plural-rules.ts
+++ b/packages/eslint-plugin-formatjs/rules/enforce-plural-rules.ts
@@ -117,10 +117,12 @@ export const rule: RuleModule<MessageIds, Options> = {
   create(context) {
     const callExpressionVisitor = (node: TSESTree.Node) =>
       checkNode(context, node)
+
+    const parserServices = getParserServices(context)
     //@ts-expect-error defineTemplateBodyVisitor exists in Vue parser
-    if (getParserServices(context).defineTemplateBodyVisitor) {
+    if (parserServices?.defineTemplateBodyVisitor) {
       //@ts-expect-error
-      return getParserServices(context).defineTemplateBodyVisitor(
+      return parserServices.defineTemplateBodyVisitor(
         {
           CallExpression: callExpressionVisitor,
         },

--- a/packages/eslint-plugin-formatjs/rules/no-camel-case.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-camel-case.ts
@@ -86,10 +86,11 @@ export const rule: RuleModule<MessageIds> = {
     const callExpressionVisitor = (node: TSESTree.Node) =>
       checkNode(context, node)
 
+    const parserServices = getParserServices(context)
     //@ts-expect-error defineTemplateBodyVisitor exists in Vue parser
-    if (getParserServices(context).defineTemplateBodyVisitor) {
+    if (parserServices?.defineTemplateBodyVisitor) {
       //@ts-expect-error
-      return getParserServices(context).defineTemplateBodyVisitor(
+      return parserServices.defineTemplateBodyVisitor(
         {
           CallExpression: callExpressionVisitor,
         },

--- a/packages/eslint-plugin-formatjs/rules/no-complex-selectors.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-complex-selectors.ts
@@ -154,10 +154,11 @@ Default complexity limit is 20
     const callExpressionVisitor = (node: TSESTree.Node) =>
       checkNode(context, node)
 
+    const parserServices = getParserServices(context)
     //@ts-expect-error defineTemplateBodyVisitor exists in Vue parser
-    if (getParserServices(context).defineTemplateBodyVisitor) {
+    if (parserServices?.defineTemplateBodyVisitor) {
       //@ts-expect-error
-      return getParserServices(context).defineTemplateBodyVisitor(
+      return parserServices.defineTemplateBodyVisitor(
         {
           CallExpression: callExpressionVisitor,
         },

--- a/packages/eslint-plugin-formatjs/rules/no-emoji.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-emoji.ts
@@ -113,10 +113,11 @@ export const rule: RuleModule<MessageIds, Options> = {
     const callExpressionVisitor = (node: TSESTree.Node) =>
       checkNode(context, node)
 
+    const parserServices = getParserServices(context)
     //@ts-expect-error defineTemplateBodyVisitor exists in Vue parser
-    if (getParserServices(context).defineTemplateBodyVisitor) {
+    if (parserServices?.defineTemplateBodyVisitor) {
       //@ts-expect-error
-      return getParserServices(context).defineTemplateBodyVisitor(
+      return parserServices.defineTemplateBodyVisitor(
         {
           CallExpression: callExpressionVisitor,
         },

--- a/packages/eslint-plugin-formatjs/rules/no-id.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-id.ts
@@ -59,10 +59,11 @@ export const rule: RuleModule<MessageIds> = {
     const callExpressionVisitor = (node: TSESTree.Node) =>
       checkNode(context, node)
 
+    const parserServices = getParserServices(context)
     //@ts-expect-error defineTemplateBodyVisitor exists in Vue parser
-    if (getParserServices(context).defineTemplateBodyVisitor) {
+    if (parserServices?.defineTemplateBodyVisitor) {
       //@ts-expect-error
-      return getParserServices(context).defineTemplateBodyVisitor(
+      return parserServices.defineTemplateBodyVisitor(
         {
           CallExpression: callExpressionVisitor,
         },

--- a/packages/eslint-plugin-formatjs/rules/no-invalid-icu.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-invalid-icu.ts
@@ -61,10 +61,11 @@ export const rule: RuleModule<MessageIds> = {
     const callExpressionVisitor = (node: TSESTree.Node) =>
       checkNode(context, node)
 
+    const parserServices = getParserServices(context)
     //@ts-expect-error defineTemplateBodyVisitor exists in Vue parser
-    if (getParserServices(context).defineTemplateBodyVisitor) {
+    if (parserServices?.defineTemplateBodyVisitor) {
       //@ts-expect-error
-      return getParserServices(context).defineTemplateBodyVisitor(
+      return parserServices.defineTemplateBodyVisitor(
         {
           CallExpression: callExpressionVisitor,
         },

--- a/packages/eslint-plugin-formatjs/rules/no-missing-icu-plural-one-placeholders.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-missing-icu-plural-one-placeholders.ts
@@ -128,10 +128,10 @@ export const rule: RuleModule<MessageIds, Options> = {
   create(context) {
     const callExpressionVisitor = (node: TSESTree.Node) =>
       checkNode(context, node)
-    const parserServices = getParserServices(context)
 
+    const parserServices = getParserServices(context)
     //@ts-expect-error defineTemplateBodyVisitor exists in Vue parser
-    if (parserServices.defineTemplateBodyVisitor) {
+    if (parserServices?.defineTemplateBodyVisitor) {
       //@ts-expect-error
       return parserServices.defineTemplateBodyVisitor(
         {

--- a/packages/eslint-plugin-formatjs/rules/no-multiple-plurals.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-multiple-plurals.ts
@@ -78,10 +78,11 @@ export const rule: RuleModule<MessageIds> = {
     const callExpressionVisitor = (node: TSESTree.Node) =>
       checkNode(context, node)
 
+    const parserServices = getParserServices(context)
     //@ts-expect-error defineTemplateBodyVisitor exists in Vue parser
-    if (getParserServices(context).defineTemplateBodyVisitor) {
+    if (parserServices?.defineTemplateBodyVisitor) {
       //@ts-expect-error
-      return getParserServices(context).defineTemplateBodyVisitor(
+      return parserServices.defineTemplateBodyVisitor(
         {
           CallExpression: callExpressionVisitor,
         },

--- a/packages/eslint-plugin-formatjs/rules/no-multiple-whitespaces.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-multiple-whitespaces.ts
@@ -163,10 +163,11 @@ export const rule: RuleModule<MessageIds> = {
     const callExpressionVisitor = (node: TSESTree.Node) =>
       checkNode(context, node)
 
+    const parserServices = getParserServices(context)
     //@ts-expect-error defineTemplateBodyVisitor exists in Vue parser
-    if (getParserServices(context).defineTemplateBodyVisitor) {
+    if (parserServices?.defineTemplateBodyVisitor) {
       //@ts-expect-error
-      return getParserServices(context).defineTemplateBodyVisitor(
+      return parserServices.defineTemplateBodyVisitor(
         {
           CallExpression: callExpressionVisitor,
         },

--- a/packages/eslint-plugin-formatjs/rules/no-offset.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-offset.ts
@@ -77,10 +77,11 @@ export const rule: RuleModule<MessageIds> = {
     const callExpressionVisitor = (node: TSESTree.Node) =>
       checkNode(context, node)
 
+    const parserServices = getParserServices(context)
     //@ts-expect-error defineTemplateBodyVisitor exists in Vue parser
-    if (getParserServices(context).defineTemplateBodyVisitor) {
+    if (parserServices?.defineTemplateBodyVisitor) {
       //@ts-expect-error
-      return getParserServices(context).defineTemplateBodyVisitor(
+      return parserServices.defineTemplateBodyVisitor(
         {
           CallExpression: callExpressionVisitor,
         },

--- a/packages/eslint-plugin-formatjs/rules/no-useless-message.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-useless-message.ts
@@ -87,10 +87,11 @@ export const rule: RuleModule<MessageIds> = {
     const callExpressionVisitor = (node: TSESTree.Node) =>
       checkNode(context, node)
 
+    const parserServices = getParserServices(context)
     //@ts-expect-error defineTemplateBodyVisitor exists in Vue parser
-    if (getParserServices(context).defineTemplateBodyVisitor) {
+    if (parserServices?.defineTemplateBodyVisitor) {
       //@ts-expect-error
-      return getParserServices(context).defineTemplateBodyVisitor(
+      return parserServices.defineTemplateBodyVisitor(
         {
           CallExpression: callExpressionVisitor,
         },

--- a/packages/eslint-plugin-formatjs/rules/prefer-pound-in-plural.ts
+++ b/packages/eslint-plugin-formatjs/rules/prefer-pound-in-plural.ts
@@ -241,10 +241,11 @@ export const rule: RuleModule<MessageIds> = {
     const callExpressionVisitor = (node: TSESTree.Node) =>
       checkNode(context, node)
 
+    const parserServices = getParserServices(context)
     //@ts-expect-error defineTemplateBodyVisitor exists in Vue parser
-    if (getParserServices(context).defineTemplateBodyVisitor) {
+    if (parserServices?.defineTemplateBodyVisitor) {
       //@ts-expect-error
-      return getParserServices(context).defineTemplateBodyVisitor(
+      return parserServices.defineTemplateBodyVisitor(
         {
           CallExpression: callExpressionVisitor,
         },


### PR DESCRIPTION
This change updates all of the rules to account for cases where the `parserServices` prop isn't on the context.  The type has this prop as possibly undefined, but the code wasn't accounting for that possibility.  It appears that most parsers provide it, so it hasn't been a widespread issue, but for the parsers that aren't providing, this will allow it to not break.  Furthermore, this test is really only needed for the Vue parser compatibility, and in that case, the `parserServices` prop is provided.

Fixes #4524 