### PR TITLE
fix(@formatjs/intl): allow string in formatDateTimeRange

### DIFF
--- a/packages/intl/src/dateTime.ts
+++ b/packages/intl/src/dateTime.ts
@@ -125,6 +125,8 @@ export function formatDateTimeRange(
   ...[from, to, options = {}]: Parameters<IntlFormatters['formatDateTimeRange']>
 ): string {
   const {timeZone, locale, onError} = config
+  const fromDate = typeof from === 'string' ? new Date(from || 0) : from
+  const toDate = typeof to === 'string' ? new Date(to || 0) : to
 
   const filteredOptions = filterProps(
     options,
@@ -133,14 +135,17 @@ export function formatDateTimeRange(
   ) as Intl.DateTimeFormatOptions
 
   try {
-    return getDateTimeFormat(locale, filteredOptions).formatRange(from, to)
+    return getDateTimeFormat(locale, filteredOptions).formatRange(
+      fromDate,
+      toDate
+    )
   } catch (e) {
     onError(
       new IntlFormatError('Error formatting date time range.', config.locale, e)
     )
   }
 
-  return String(from)
+  return String(fromDate)
 }
 
 export function formatDateToParts(

--- a/packages/intl/src/types.ts
+++ b/packages/intl/src/types.ts
@@ -120,8 +120,8 @@ export type FormatDisplayNameOptions = Omit<
 export interface IntlFormatters<TBase = unknown> {
   formatDateTimeRange(
     this: void,
-    from: Parameters<Intl.DateTimeFormat['formatRange']>[0],
-    to: Parameters<Intl.DateTimeFormat['formatRange']>[1],
+    from: Parameters<Intl.DateTimeFormat['formatRange']>[0] | string,
+    to: Parameters<Intl.DateTimeFormat['formatRange']>[1] | string,
     opts?: FormatDateOptions
   ): string
   formatDate(


### PR DESCRIPTION
This PR allows strings in `formatDateTimeRange`. The reason for this is consistency.
Back in 2019, we added this to `formatDate` and `formatTime`.

Here are the issue and commits that originated this change:
- Issue: https://github.com/formatjs/formatjs/issues/1396
- Comit: https://github.com/formatjs/formatjs/commit/aed8c6877cff6d32bf1801bb835a0dde81e65ae9#diff-41c7b3ac268a3a1ae5c7be92f1230f600013b7170e44a693570ccbdb183ea36bR95

Also, if you check the documentation on `formatDateTimeRange`, you would be lead to error:
![image](https://github.com/user-attachments/assets/e41e9e37-9910-43ac-90cf-ad6e49aa6ec1)

Even though we see `number | Date | string`, strings don't work.
Right now we get error:
```
Uncaught Error: [@formatjs/intl Error FORMAT_ERROR] Error formatting date time range.
Locale: en-us


Invalid time value
RangeError: Invalid time value
```