### PR TITLE
Remove duplicated `no-invalid-icu` rule description

### DIFF
--- a/website/docs/tooling/linter.md
+++ b/website/docs/tooling/linter.md
@@ -767,14 +767,6 @@ export default [
 ]
 ```
 
-### `no-invalid-icu`
-
-This validates the ICU syntax.
-
-#### Why
-
-This will make sure that the ICU message are valid and ready for translation.
-
 ### `no-useless-message`
 
 This bans messages that do not require translation.


### PR DESCRIPTION
I removed the latter that looks less meaningful