### PR TITLE
feat(@formatjs/intl-localematcher): fix distance calculation bugs from expanding region variables and comparing script tags

### DIFF
--- a/packages/intl-localematcher/abstract/utils.ts
+++ b/packages/intl-localematcher/abstract/utils.ts
@@ -104,7 +104,7 @@ function isMatched(
       .map(r => regions[r] || [r])
       .reduce((all, list) => [...all, ...list], [])
     matches &&= !(
-      expandedMatchedRegions.indexOf(locale.region || '') > 1 !=
+      expandedMatchedRegions.indexOf(locale.region || '') > -1 !=
       shouldInclude
     )
   } else {
@@ -196,7 +196,7 @@ export function findMatchingDistance(
       },
       {
         language: supportedLocale.language,
-        script: desiredLSR.script,
+        script: supportedLSR.script,
         region: '',
       },
       data

--- a/packages/intl-localematcher/tests/BestFitMatcher.test.ts
+++ b/packages/intl-localematcher/tests/BestFitMatcher.test.ts
@@ -54,3 +54,23 @@ test('GH #4237', function () {
     locale: 'en-US',
   })
 })
+
+test('bestFitMatcher testing $cnsar: zh-HK', function () {
+  expect(BestFitMatcher(['zh-Hant', 'zh-MO'], ['zh-HK'], () => 'en')).toEqual({
+    locale: 'zh-MO',
+  })
+})
+
+test('bestFitMatcher testing $enUS: en-CA', function () {
+  expect(BestFitMatcher(['en-GB', 'en-US'], ['en-CA'], () => 'en-US')).toEqual({
+    locale: 'en-US',
+  })
+})
+
+test('bestFitMatcher testing $americas: es-KY', function () {
+  expect(BestFitMatcher(['es', 'en', 'es-419'], ['es-KY'], () => 'en')).toEqual(
+    {
+      locale: 'es-419',
+    }
+  )
+})

--- a/packages/intl-localematcher/tests/utils.test.ts
+++ b/packages/intl-localematcher/tests/utils.test.ts
@@ -5,7 +5,13 @@ test('findMatchingDistance', () => {
   expect(findMatchingDistance('en-US', 'en-US')).toBe(0)
   expect(findMatchingDistance('zh-TW', 'zh-Hant')).toBe(0)
   expect(findMatchingDistance('zh-HK', 'zh-NO')).toBe(540)
-  expect(findMatchingDistance('zh-HK', 'zh-Hant')).toBe(40)
+  /**
+   * zh-Hant-HK -> zh-Hant-TW, the value of $cnsar is 'HK+MO'
+   * HK belongs to $cnsar, TW doesn't
+   * the distance rule should be zh_Hant_* <-> zh_Hant_* (distance: 5*10)
+   * instead of zh_Hant_$!cnsar <-> zh_Hant_$!cnsar(distance 4*10)
+   */
+  expect(findMatchingDistance('zh-HK', 'zh-Hant')).toBe(50)
   expect(findMatchingDistance('vi', 'fr')).toBe(840)
   expect(findMatchingDistance('es', 'fr')).toBe(838)
   expect(findMatchingDistance('es', 'en')).toBe(840)


### PR DESCRIPTION
see more detail: https://github.com/formatjs/formatjs/issues/4854
feat(@formatjs/intl-localematcher): fix distance calculation bugs from expanding region variables and comparing script tags