### PR TITLE
fix(react-intl): add keys to rich text components

### DIFF
--- a/packages/react-intl/package.json
+++ b/packages/react-intl/package.json
@@ -56,6 +56,7 @@
     "Jiayi Hu <steph.jiayi@gmail.com>",
     "Jimmy Jia <tesrin@gmail.com>",
     "Joe Lencioni <joe.lencioni@gmail.com>",
+    "Johannes Wüller <johanneswueller@gmail.com>",
     "Jonas Antonelli <jonas.antonelli@gmail.com>",
     "Jose G <josegranafdez@gmail.com>",
     "Juan Ignacio Dopazo <juan@dopazo.me>",

--- a/packages/react-intl/src/components/createIntl.ts
+++ b/packages/react-intl/src/components/createIntl.ts
@@ -17,7 +17,11 @@ import {
 } from 'intl-messageformat'
 import * as React from 'react'
 import type {IntlConfig, IntlShape, ResolvedIntlConfig} from '../types'
-import {DEFAULT_INTL_CONFIG, assignUniqueKeysToParts} from '../utils'
+import {
+  DEFAULT_INTL_CONFIG,
+  assignUniqueKeysToParts,
+  toKeyedReactNodeArray,
+} from '../utils'
 
 function assignUniqueKeysToFormatXMLElementFnArgument<
   T extends Record<
@@ -59,10 +63,7 @@ const formatMessage: FormatMessageFn<React.ReactNode> = (
     values as any,
     ...rest
   )
-  if (Array.isArray(chunks)) {
-    return React.Children.toArray(chunks)
-  }
-  return chunks as any
+  return toKeyedReactNodeArray(chunks)
 }
 
 /**

--- a/packages/react-intl/src/components/message.tsx
+++ b/packages/react-intl/src/components/message.tsx
@@ -50,16 +50,16 @@ function FormattedMessage(props: Props) {
   } = props
 
   const descriptor = {id, description, defaultMessage}
-  let nodes: React.ReactNode = formatMessage(descriptor, values, {
+  const nodes = formatMessage(descriptor, values, {
     ignoreTag,
   })
 
   if (typeof children === 'function') {
-    return children(Array.isArray(nodes) ? nodes : [nodes])
+    return children(nodes)
   }
 
   if (Component) {
-    return <Component>{React.Children.toArray(nodes)}</Component>
+    return <Component>{nodes}</Component>
   }
   return <>{nodes}</>
 }

--- a/packages/react-intl/src/utils.ts
+++ b/packages/react-intl/src/utils.ts
@@ -39,6 +39,29 @@ export const DEFAULT_INTL_CONFIG: DefaultIntlConfig = {
   textComponent: React.Fragment,
 }
 
+const arbitraryKeyProps = {key: 42}
+const toArbitrarilyKeyedReactNode = (reactNode: React.ReactNode) =>
+  React.isValidElement(reactNode)
+    ? React.createElement(React.Fragment, arbitraryKeyProps, reactNode)
+    : reactNode
+
+/**
+ * Builds an array of {@link React.ReactNode}s with index-based keys, similar to
+ * {@link React.Children.toArray}. However, this function tells React that it
+ * was intentional, so they won't produce a bunch of warnings about it.
+ *
+ * React doesn't recommend doing this because it makes reordering inefficient,
+ * but we mostly need this for message chunks, which don't tend to reorder to
+ * begin with.
+ */
+export const toKeyedReactNodeArray: typeof React.Children.toArray = children =>
+  /**
+   * Note: {@link React.Children.map} will add its own index-based prefix to
+   * every key anyway, so the auto-injected one doesn't even have to be unique.
+   * This basically just tells React that it's explicit/intentional.
+   */
+  React.Children.map(children, toArbitrarilyKeyedReactNode) ?? []
+
 /**
  * Takes a `formatXMLElementFn`, and composes it in function, which passes
  * argument `parts` through, assigning unique key to each part, to prevent


### PR DESCRIPTION
User-supplied chunk renderers are not true React components due to their incompatible signature, so they are unable to inherit keys from the parent context.

In addition, user chunk renderers might be invoked multiple times per message, so they can't use static keys either. They also don't receive sufficient information to compute unique and deterministic per-call keys.

We therefore must supply unique keys, preferably in a way that doesn't adversely affect user-supplied render functions.

This implementation individually wraps user-rendered chunks in an appropriately-keyed fragment, so the original element remains unchanged. This sidesteps various problems, like having to deal with element cloning and merging refs.

Previous implementations partially relied on implicitly generated keys from `React.Children.toArray` to do produce similar results, but React generates warnings for those. This implementation makes keys explicit instead.

Fixes #4782 