### PR TITLE
fix(@formatjs/intl-datetimeformat): consistent polyfill with polyfill-force

### DIFF
--- a/packages/intl-datetimeformat/polyfill.ts
+++ b/packages/intl-datetimeformat/polyfill.ts
@@ -12,7 +12,10 @@ if (shouldPolyfill()) {
   defineProperty(Date.prototype, 'toLocaleString', {
     value: function toLocaleString(
       locales?: string | string[],
-      options?: Intl.DateTimeFormatOptions
+      options: Intl.DateTimeFormatOptions = {
+        dateStyle: 'short',
+        timeStyle: 'medium',
+      }
     ) {
       try {
         return _toLocaleString(this, locales, options)
@@ -24,7 +27,9 @@ if (shouldPolyfill()) {
   defineProperty(Date.prototype, 'toLocaleDateString', {
     value: function toLocaleDateString(
       locales?: string | string[],
-      options?: Intl.DateTimeFormatOptions
+      options: Intl.DateTimeFormatOptions = {
+        dateStyle: 'short',
+      }
     ) {
       try {
         return _toLocaleDateString(this, locales, options)
@@ -36,7 +41,9 @@ if (shouldPolyfill()) {
   defineProperty(Date.prototype, 'toLocaleTimeString', {
     value: function toLocaleTimeString(
       locales?: string | string[],
-      options?: Intl.DateTimeFormatOptions
+      options: Intl.DateTimeFormatOptions = {
+        timeStyle: 'medium',
+      }
     ) {
       try {
         return _toLocaleTimeString(this, locales, options)

--- a/packages/intl-datetimeformat/tests/index.test.ts
+++ b/packages/intl-datetimeformat/tests/index.test.ts
@@ -407,7 +407,7 @@ describe('Intl.DateTimeFormat', function () {
     const date1 = new Date('')
     expect(date1.toLocaleString('en-US')).toBe('Invalid Date')
   })
-  it('toLocaleString returns "Invalid Date", GH #3508', function () {
+  it('toLocaleString returns date and time with the default format, GH #3508', function () {
     const date1 = new Date(0)
     expect(date1.toLocaleString('en-US')).toMatch(
       /\d{1,2}\/\d{1,2}\/\d{4}, \d{1,2}:\d{2}:\d{2} [AP]M/


### PR DESCRIPTION
This PR fixes the problem, which is the same as https://github.com/formatjs/formatjs/issues/4589 for `intl-datetimeformat/polyfill`.