### PR TITLE
feat(eslint-plugin-formatjs): add `no-literal-string-in-object` rule

### DIFF
--- a/packages/eslint-plugin-formatjs/index.ts
+++ b/packages/eslint-plugin-formatjs/index.ts
@@ -63,6 +63,10 @@ import {
   rule as preferPoundInPlural,
   name as preferPoundInPluralName,
 } from './rules/prefer-pound-in-plural'
+import {
+  rule as noLiteralStringInObject,
+  name as noLiteralStringInObjectName,
+} from './rules/no-literal-string-in-object'
 
 import {name, version} from './package.json'
 
@@ -106,6 +110,8 @@ const rules: ESLint.Plugin['rules'] = {
   [preferPoundInPluralName]: preferPoundInPlural,
   // @ts-expect-error
   [noMissingIcuPluralOnePlaceholdersName]: noMissingIcuPluralOnePlaceholders,
+  // @ts-expect-error
+  [noLiteralStringInObjectName]: noLiteralStringInObject,
 }
 
 // Base plugin

--- a/packages/eslint-plugin-formatjs/rules/no-literal-string-in-object.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-literal-string-in-object.ts
@@ -1,0 +1,116 @@
+import {TSESTree} from '@typescript-eslint/utils'
+import {RuleContext, RuleModule} from '@typescript-eslint/utils/ts-eslint'
+import {getParserServices} from '../context-compat'
+
+type MessageIds = 'untranslatedProperty'
+type PropertyConfig = {
+  include: string[]
+}
+type Options = [PropertyConfig?]
+
+export const name = 'no-literal-string-in-object'
+
+export const rule: RuleModule<MessageIds, Options> = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Enforce translation of specific object properties',
+      url: 'https://formatjs.github.io/docs/tooling/linter#no-literal-string-in-object',
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          include: {
+            type: 'array',
+            items: {type: 'string'},
+            default: ['label'],
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      untranslatedProperty:
+        'Object property: `{{propertyKey}}` might contain an untranslated literal string',
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    const propertyVisitor = (node: TSESTree.Property) => {
+      checkProperty(context, node)
+    }
+
+    const parserServices = getParserServices(context)
+    //@ts-expect-error defineTemplateBodyVisitor exists in Vue parser
+    if (parserServices?.defineTemplateBodyVisitor) {
+      //@ts-expect-error
+      return parserServices.defineTemplateBodyVisitor(
+        {
+          Property: propertyVisitor,
+        },
+        {
+          Property: propertyVisitor,
+        }
+      )
+    }
+    return {
+      Property: propertyVisitor,
+    }
+  },
+}
+
+function checkProperty(
+  context: RuleContext<MessageIds, Options>,
+  node: TSESTree.Property
+) {
+  const config: PropertyConfig = {
+    include: ['label'],
+    ...(context.options[0] || {}),
+  }
+
+  const propertyKey =
+    node.key.type === TSESTree.AST_NODE_TYPES.Identifier
+      ? node.key.name
+      : node.key.type === TSESTree.AST_NODE_TYPES.Literal &&
+          typeof node.key.value === 'string'
+        ? node.key.value
+        : null
+
+  if (!propertyKey || !config.include.includes(propertyKey)) {
+    return
+  }
+
+  checkPropertyValue(context, node.value, propertyKey)
+}
+
+function checkPropertyValue(
+  context: RuleContext<MessageIds, Options>,
+  node: TSESTree.Property['value'] | TSESTree.PrivateIdentifier,
+  propertyKey: string
+) {
+  if (
+    (node.type === 'Literal' &&
+      typeof node.value === 'string' &&
+      node.value.length > 0) ||
+    (node.type === 'TemplateLiteral' &&
+      (node.quasis.length > 1 || node.quasis[0].value.raw.length > 0))
+  ) {
+    context.report({
+      node: node,
+      messageId: 'untranslatedProperty',
+      data: {
+        propertyKey: propertyKey,
+      },
+    })
+  } else if (node.type === 'BinaryExpression' && node.operator === '+') {
+    checkPropertyValue(context, node.left, propertyKey)
+    checkPropertyValue(context, node.right, propertyKey)
+  } else if (node.type === 'ConditionalExpression') {
+    checkPropertyValue(context, node.consequent, propertyKey)
+    checkPropertyValue(context, node.alternate, propertyKey)
+  } else if (node.type === 'LogicalExpression') {
+    checkPropertyValue(context, node.left, propertyKey)
+    checkPropertyValue(context, node.right, propertyKey)
+  }
+}

--- a/packages/eslint-plugin-formatjs/tests/no-literal-string-in-object.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/no-literal-string-in-object.test.ts
@@ -1,0 +1,324 @@
+import {rule, name} from '../rules/no-literal-string-in-object'
+import {ruleTester, vueRuleTester} from './util'
+import {dynamicMessage, noMatch, spreadJsx, emptyFnCall} from './fixtures'
+
+ruleTester.run(name, rule, {
+  valid: [
+    // Translated property
+    {
+      code: `
+        const obj = {
+          label: intl.formatMessage({defaultMessage: 'Translated label'})
+        }
+      `,
+    },
+    // Custom translation function
+    {
+      code: `
+            const obj = {
+              label: customTranslateFn('Translated label')
+            }
+          `,
+    },
+    // Non-targeted properties
+    {
+      code: `
+        const obj = {
+          tag: 'Untranslated tag',
+        }
+      `,
+    },
+    // Non-targeted properties with custom property list
+    {
+      code: `
+        const obj = {
+          label: 'Untranslated label',
+        }
+      `,
+      options: [
+        {
+          include: ['tag'],
+        },
+      ],
+    },
+    // Properties that aren't strings
+    {
+      code: `
+        const obj = {
+          label: 42,
+          count: 1
+        }
+      `,
+    },
+    // Not an object literal
+    noMatch,
+    dynamicMessage,
+    emptyFnCall,
+    spreadJsx,
+  ],
+  invalid: [
+    // Basic case - string literal
+    {
+      code: `
+        const obj = {
+          label: 'Untranslated label'
+        }
+      `,
+      errors: [
+        {
+          messageId: 'untranslatedProperty',
+          data: {
+            propertyKey: 'label',
+          },
+        },
+      ],
+    },
+    // Template literal
+    {
+      code: `
+        const obj = {
+          label: \`Template literal value\`
+        }
+      `,
+      errors: [
+        {
+          messageId: 'untranslatedProperty',
+          data: {
+            propertyKey: 'label',
+          },
+        },
+      ],
+    },
+    // Multi-part template literal
+    {
+      code: `
+            const obj = {
+              label: \`$\{intl.formatMessage({defaultMessage: 'Translated part'})\} $\{intl.formatMessage({defaultMessage: 'Translated part'})\}\`
+            }
+          `,
+      errors: [
+        {
+          messageId: 'untranslatedProperty',
+          data: {
+            propertyKey: 'label',
+          },
+        },
+      ],
+    },
+    // String concatenation
+    {
+      code: `
+        const obj = {
+          label: 'Untranslated ' + 'concatenated label'
+        }
+      `,
+      errors: [
+        {
+          messageId: 'untranslatedProperty',
+          data: {
+            propertyKey: 'label',
+          },
+        },
+        {
+          messageId: 'untranslatedProperty',
+          data: {
+            propertyKey: 'label',
+          },
+        },
+      ],
+    },
+    // Conditional expression
+    {
+      code: `
+        const obj = {
+          label: isError ? 'Error message' : intl.formatMessage({defaultMessage: 'Success message'})
+        }
+      `,
+      errors: [
+        {
+          messageId: 'untranslatedProperty',
+          data: {
+            propertyKey: 'label',
+          },
+        },
+      ],
+    },
+    // Logical expression
+    {
+      code: `
+        const obj = {
+          label: errorMessage || 'Default error message'
+        }
+      `,
+      errors: [
+        {
+          messageId: 'untranslatedProperty',
+          data: {
+            propertyKey: 'label',
+          },
+        },
+      ],
+    },
+    // Custom property config
+    {
+      code: `
+        const obj = {
+          title: 'Untranslated title',
+          description: 'Some description'
+        }
+      `,
+      options: [
+        {
+          include: ['title', 'description'],
+        },
+      ],
+      errors: [
+        {
+          messageId: 'untranslatedProperty',
+          data: {
+            propertyKey: 'title',
+          },
+        },
+        {
+          messageId: 'untranslatedProperty',
+          data: {
+            propertyKey: 'description',
+          },
+        },
+      ],
+    },
+    // String key
+    {
+      code: `
+        const obj = {
+          'label': 'Untranslated label with string key'
+        }
+      `,
+      errors: [
+        {
+          messageId: 'untranslatedProperty',
+          data: {
+            propertyKey: 'label',
+          },
+        },
+      ],
+    },
+    // Long string (truncated in error message)
+    {
+      code: `
+        const obj = {
+          label: 'This is a very long untranslated label that should be truncated in the error message'
+        }
+      `,
+      errors: [
+        {
+          messageId: 'untranslatedProperty',
+          data: {
+            propertyKey: 'label',
+          },
+        },
+      ],
+    },
+  ],
+})
+
+// Vue tests
+vueRuleTester.run(`vue-${name}`, rule, {
+  valid: [
+    {
+      code: `
+      <template>
+        <div>{{ $formatMessage({ defaultMessage: 'Translated text' }) }}</div>
+      </template>
+      <script>
+      export default {
+        data() {
+          return {
+            item: {
+              label: this.$formatMessage({ defaultMessage: 'Translated label' })
+            }
+          }
+        }
+      }
+      </script>`,
+    },
+    {
+      code: `
+      <template>
+        <div>{{ label }}</div>
+      </template>
+      <script>
+      export default {
+        data() {
+          return {
+            item: {
+              title: 'Untranslated title'
+            }
+          }
+        }
+      }
+      </script>`,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+      <template>
+        <div>{{ label }}</div>
+      </template>
+      <script>
+      export default {
+        data() {
+          return {
+            item: {
+              label: 'Untranslated label'
+            }
+          }
+        }
+      }
+      </script>`,
+      errors: [
+        {
+          messageId: 'untranslatedProperty',
+          data: {
+            propertyKey: 'label',
+          },
+        },
+      ],
+    },
+    {
+      code: `
+      <script>
+      export default {
+        data() {
+          return {
+            config: {
+              title: 'Untranslated title',
+              description: 'Description text'
+            }
+          }
+        }
+      }
+      </script>`,
+      options: [
+        {
+          include: ['title', 'description'],
+        },
+      ],
+      errors: [
+        {
+          messageId: 'untranslatedProperty',
+          data: {
+            propertyKey: 'title',
+          },
+        },
+        {
+          messageId: 'untranslatedProperty',
+          data: {
+            propertyKey: 'description',
+          },
+        },
+      ],
+    },
+  ],
+})

--- a/website/docs/tooling/linter.md
+++ b/website/docs/tooling/linter.md
@@ -572,6 +572,75 @@ The default prop checks are:
 }
 ```
 
+### `no-literal-string-in-object`
+
+This prevents untranslated strings in chosen object properties.
+
+#### Why
+
+- It is easy to forget wrapping literal strings in translation functions, when they are defined in an object field like `{label: "Untranslated label"}`.
+
+```tsx
+const options = () => [
+  // FAILS
+  {value: 'chocolate', label: 'Chocolate'},
+  // WORKS
+  {
+    value: 'strawberry',
+    label: intl.formatMessage({defaultMessage: 'Strawberry'}),
+  },
+  // WORKS, custom translation function
+  {
+    value: 'mint',
+    label: customTranslateFn('Mint'),
+  },
+  // FAILS, string concatenation
+  {
+    value: 'coconut',
+    label: 'Coconut' + intl.formatMessage({defaultMessage: 'Ice Cream'}),
+  },
+  // FAILS, template literal
+  {
+    value: 'mango',
+    label: `Mango ${intl.formatMessage({defaultMessage: 'Ice Cream'})}`,
+  },
+  // FAILS, conditional rendering
+  {
+    value: 'recommended',
+    label: feelLikeSour
+      ? intl.formatMessage({defaultMessage: 'Lime'})
+      : 'Vanilla',
+  },
+]
+
+const MyComponent = () => <Select options={options()} />
+```
+
+This linter reports text literals or string expressions, including string concatenation expressions in the object properties that you can customize.
+
+#### Example
+
+```js
+import formatjs from 'eslint-plugin-formatjs'
+
+export default [
+  {
+    plugins: {
+      formatjs,
+    },
+    rules: {
+      'formatjs/no-literal-string-in-object': [
+        'warn',
+        {
+          // The object properties to check for untranslated literal strings, default: ['label']
+          include: ['label'],
+        },
+      ],
+    },
+  },
+]
+```
+
 ### `no-multiple-whitespaces`
 
 This prevents usage of multiple consecutive whitespaces in message.


### PR DESCRIPTION
Add new ESLint rule that enforces translation of specific object properties like 'label' to prevent untranslated strings in the UI. 

## Why

It is easy to forget wrapping literal string in translation functions, when they are nested in an object.

For example, in React component libraries like

- [@canva/app-ui-kit](https://www.canva.dev/docs/apps/app-ui-kit/storybook/?path=/docs/components-form-select--docs)
- [Ant design](https://ant.design/components/select#usage-upgrade-after-5110)
- [react-select](https://react-select.com/home#getting-started)

An `options` object is used for components like `Select`:

```tsx
const options = [
  { value: 'chocolate', label: 'Chocolate' },
  { value: 'strawberry', label: 'Strawberry' },
  { value: 'vanilla', label: 'Vanilla' }
]

const MyComponent = () => (
  <Select options={options} />
)
```

## What

This linter reports text literals or string expressions, including string concatenation expressions in object properties that can be custom specified (default: `label`). 

