### PR TITLE
Update type of the <FormattedNumber> `value` prop

### DIFF
--- a/packages/react-intl/index.ts
+++ b/packages/react-intl/index.ts
@@ -27,6 +27,7 @@ import FormattedPlural from './src/components/plural'
 import IntlProvider from './src/components/provider'
 import FormattedRelativeTime from './src/components/relative'
 import useIntl from './src/components/useIntl'
+import {IntlShape} from './src/types'
 export {
   createIntlCache,
   CustomFormatConfig,
@@ -94,7 +95,7 @@ export const FormattedTime: React.FC<
 export const FormattedNumber: React.FC<
   Omit<NumberFormatOptions, 'localeMatcher'> &
     CustomFormatConfig<'number'> & {
-      value: number
+      value: Parameters<IntlShape['formatNumber']>[0]
       children?(formattedNumber: string): React.ReactElement | null
     }
 > = createFormattedComponent('formatNumber')


### PR DESCRIPTION
It was hard-coded as `number`. The `formatNumber()` function has been updated to accept [all values that `Intl.NumberFormat.format()` accepts](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/format#number), so this makes the component match the underlying function.

The component already works correctly if you pass (for example) a numeric string as the `value` prop. This updates the type checking to match the reality of what the component supports.
