### PR TITLE
fix(@formatjs/cli-lib): main is to point to lib_esnext/

### DIFF
--- a/packages/cli-lib/package.json
+++ b/packages/cli-lib/package.json
@@ -53,7 +53,7 @@
     "translate",
     "translation"
   ],
-  "main": "index.js",
+  "main": "lib_esnext/index.js",
   "peerDependenciesMeta": {
     "vue": {
       "optional": true


### PR DESCRIPTION
Attempting to install 7.4.1.

Build results under is `lib_esnext/`, while `main` in package.json points to `.`