### PR TITLE
feat(eslint-plugin-formatjs): support tagged template expression like dedent

### DIFF
--- a/packages/eslint-plugin-formatjs/tests/enforce-default-message.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/enforce-default-message.test.ts
@@ -24,8 +24,16 @@ defineMessage({
 \`,
   description: 'asd'
 })`,
+    `intl.formatMessage({
+  defaultMessage: dedent\`a template
+  literal
+\`,
+  description: 'asd'
+})`,
     `import {FormattedMessage} from 'react-intl'
 const a = <FormattedMessage defaultMessage={'asf' + 'bar'}/>`,
+    `import {FormattedMessage} from 'react-intl'
+const a = <FormattedMessage defaultMessage={dedent\`asf\`}/>`,
     dynamicMessage,
     noMatch,
     spreadJsx,

--- a/packages/ts-transformer/src/transform.ts
+++ b/packages/ts-transformer/src/transform.ts
@@ -307,6 +307,25 @@ function extractMessageDescriptor(
             msg.description = initializer.text
             break
         }
+      }
+      // {id: dedent`id`}
+      else if (ts.isTaggedTemplateExpression(initializer)) {
+        const {template} = initializer
+        if (!ts.isNoSubstitutionTemplateLiteral(template)) {
+          throw new Error('Tagged template expression must be no substitution')
+        }
+
+        switch (name.text) {
+          case 'id':
+            msg.id = template.text
+            break
+          case 'defaultMessage':
+            msg.defaultMessage = template.text
+            break
+          case 'description':
+            msg.description = template.text
+            break
+        }
       } else if (ts.isJsxExpression(initializer) && initializer.expression) {
         // <FormattedMessage foo={'barbaz'} />
         if (ts.isStringLiteral(initializer.expression)) {
@@ -344,6 +363,28 @@ function extractMessageDescriptor(
               break
             case 'description':
               msg.description = expression.text
+              break
+          }
+        }
+        // <FormattedMessage foo={dedent`dedent Hello World!`} />
+        else if (ts.isTaggedTemplateExpression(initializer.expression)) {
+          const {
+            expression: {template},
+          } = initializer
+          if (!ts.isNoSubstitutionTemplateLiteral(template)) {
+            throw new Error(
+              'Tagged template expression must be no substitution'
+            )
+          }
+          switch (name.text) {
+            case 'id':
+              msg.id = template.text
+              break
+            case 'defaultMessage':
+              msg.defaultMessage = template.text
+              break
+            case 'description':
+              msg.description = template.text
               break
           }
         }

--- a/packages/ts-transformer/tests/fixtures/templateLiteral.tsx
+++ b/packages/ts-transformer/tests/fixtures/templateLiteral.tsx
@@ -8,14 +8,27 @@ defineMessage({
     extra spaces`,
 })
 
+defineMessage({
+  id: `template dedent`,
+  defaultMessage: dedent`dedent Hello World!`,
+})
+
 export default class Foo extends Component {
   render() {
     return (
-      <FormattedMessage
-        id="foo.bar.baz"
-        defaultMessage={`Hello World!`}
-        description="The default message."
-      />
+      <>
+        <FormattedMessage
+          id="foo.bar.baz"
+          defaultMessage={`Hello World!`}
+          description="The default message."
+        />
+        <FormattedMessage
+          id="dedent foo.bar.baz"
+          defaultMessage={dedent`dedent 
+            Hello World!`}
+          description="The default message."
+        />
+      </>
     )
   }
 }

--- a/packages/ts-transformer/tests/index.test.ts
+++ b/packages/ts-transformer/tests/index.test.ts
@@ -491,9 +491,13 @@ export default class Foo extends Component {
     expect(output.code).toBe(`import React, { Component } from 'react';
 import { FormattedMessage, defineMessage } from 'react-intl';
 defineMessage({ id: "template", defaultMessage: "should remove newline and extra spaces" });
+defineMessage({ id: "template dedent", defaultMessage: "dedent Hello World!" });
 export default class Foo extends Component {
     render() {
-        return (<FormattedMessage id="foo.bar.baz" defaultMessage="Hello World!"/>);
+        return (<>
+        <FormattedMessage id="foo.bar.baz" defaultMessage="Hello World!"/>
+        <FormattedMessage id="dedent foo.bar.baz" defaultMessage="dedent Hello World!"/>
+      </>);
     }
 }
 `)
@@ -504,9 +508,18 @@ export default class Foo extends Component {
         id: 'template',
       },
       {
+        defaultMessage: 'dedent Hello World!',
+        id: 'template dedent',
+      },
+      {
         defaultMessage: 'Hello World!',
         description: 'The default message.',
         id: 'foo.bar.baz',
+      },
+      {
+        defaultMessage: 'dedent Hello World!',
+        description: 'The default message.',
+        id: 'dedent foo.bar.baz',
       },
     ])
   })


### PR DESCRIPTION
# feat(@formatjs/ts-transformer): support tagged template expression like dedent

This PR adds support for tagged template expressions (like `dedent`) in message descriptors for both the ESLint plugin and TS transformer. Now you can use tagged template literals like `dedent` to format your messages while maintaining proper extraction and validation.

The implementation handles tagged templates in:
- JSX expressions
- Object properties
- Template literals

fixes #5015