### PR TITLE
docs: rm fastly from intl-segmenter

### DIFF
--- a/website/docs/polyfills/intl-segmenter.md
+++ b/website/docs/polyfills/intl-segmenter.md
@@ -42,16 +42,6 @@ Everything in [intl-segmenter proposal](https://tc39.es/proposal-intl-segmenter)
 
 ## Usage
 
-### Via polyfill-fastly.io
-
-You can use [polyfill-fastly.io URL Builder](https://polyfill-fastly.io/) to create a polyfill script tag for `Intl.Segmenter`.
-For example:
-
-```html
-<!-- Polyfill Intl.Segmenter-->
-<script src="https://polyfill-fastly.io/v3/polyfill.min.js?features=Intl.Segmenter"></script>
-```
-
 ### Simple
 
 ```tsx


### PR DESCRIPTION
### TL;DR

Removed the polyfill-fastly.io section from the Intl.Segmenter documentation.

### What changed?

Removed the "Via polyfill-fastly.io" section from the Intl.Segmenter polyfill documentation, which included instructions and an example HTML script tag for using polyfill-fastly.io to load the Intl.Segmenter polyfill.

### How to test?

1. Navigate to the Intl.Segmenter documentation page
2. Verify that the polyfill-fastly.io section no longer appears
3. Confirm that the "Simple" usage section is still present and appears directly after the "Usage" heading

### Why make this change?

This change likely removes references to polyfill-fastly.io service that may be deprecated, no longer recommended, or to simplify the documentation by focusing on the direct implementation approach. This ensures users follow the current best practices for implementing the Intl.Segmenter polyfill.