### PR TITLE
fix(react-intl): add keys on nested rich text elements

### DIFF
--- a/packages/react-intl/src/utils.ts
+++ b/packages/react-intl/src/utils.ts
@@ -73,7 +73,7 @@ export function assignUniqueKeysToParts(
 ): FormatXMLElementFn<React.ReactNode> {
   return function (parts: any) {
     // eslint-disable-next-line prefer-rest-params
-    return formatXMLElementFn(React.Children.toArray(parts)) as any
+    return formatXMLElementFn(toKeyedReactNodeArray(parts)) as any
   }
 }
 


### PR DESCRIPTION
Follow-up of https://github.com/formatjs/formatjs/pull/4895. When XML elements are nested `assignUniqueKeysToParts` uses the old hack `React.Children.toArray` to  generates keys, and React now logs an error message for those: 

```
Each child in a list should have a unique "key" prop.

Check the render method of `FormattedMessage`. See https://react.dev/link/warning-keys for more information.
```

Reproduction: 
https://codesandbox.io/p/sandbox/react-intl-issues-mr6v88


![Capture d’écran 2025-06-23 à 10 30 30](https://github.com/user-attachments/assets/b0eac444-a5d1-4c7d-a139-99dfef9ef3c5)


This fix uses `toKeyedReactNodeArray` to properly silent the error message.

On a side note, the tests are still passing when I ran them against react 19. I guess it's because warning & error messages are permitted in tests. Would something like https://www.npmjs.com/package/jest-fail-on-console useful to be enabled?
