### PR TITLE
Mention undocumented `preserveWhitespace` option in plugin docs

### DIFF
--- a/website/docs/tooling/babel-plugin.md
+++ b/website/docs/tooling/babel-plugin.md
@@ -109,3 +109,7 @@ and with option `{pragma: "@intl-meta"}`, we'll parse out `// @intl-meta project
 ### **`ast`**
 
 Pre-parse `defaultMessage` into AST for faster runtime perf. This flag doesn't do anything when `removeDefaultMessage` is `true`.
+
+### **`preserveWhitespace`**
+
+When set to true, message trimming is disabled.


### PR DESCRIPTION
Provide some clarity for this issue: https://github.com/formatjs/formatjs/issues/935