### PR TITLE
fix(ecma402): DayFromYear handling for years below 100 AD

### DIFF
--- a/packages/ecma402-abstract/262.ts
+++ b/packages/ecma402-abstract/262.ts
@@ -205,6 +205,13 @@ export function WeekDay(t: number): number {
  * @param y
  */
 export function DayFromYear(y: number): number {
+  if (y < 100) {
+    // Date.UTC parses 0 - 99 as 1900 - 1999
+    const date = new Date(0);
+    date.setUTCFullYear(y, 0, 1);
+    date.setUTCHours(0, 0, 0, 0);
+    return date.getTime() / MS_PER_DAY;
+  }
   return Date.UTC(y, 0) / MS_PER_DAY
 }
 

--- a/packages/ecma402-abstract/262.ts
+++ b/packages/ecma402-abstract/262.ts
@@ -207,10 +207,10 @@ export function WeekDay(t: number): number {
 export function DayFromYear(y: number): number {
   if (y < 100) {
     // Date.UTC parses 0 - 99 as 1900 - 1999
-    const date = new Date(0);
-    date.setUTCFullYear(y, 0, 1);
-    date.setUTCHours(0, 0, 0, 0);
-    return date.getTime() / MS_PER_DAY;
+    const date = new Date(0)
+    date.setUTCFullYear(y, 0, 1)
+    date.setUTCHours(0, 0, 0, 0)
+    return date.getTime() / MS_PER_DAY
   }
   return Date.UTC(y, 0) / MS_PER_DAY
 }

--- a/packages/ecma402-abstract/tests/262.test.ts
+++ b/packages/ecma402-abstract/tests/262.test.ts
@@ -1,0 +1,18 @@
+import {describe, expect, it} from 'vitest'
+import {DayFromYear} from '../262'
+
+describe('262', () => {
+  describe('DayFromYear', () => {
+    it('calculates correct day number for year 1 AD', () => {
+      expect(DayFromYear(1)).toBe(-719162)
+    })
+
+    it('calculates correct day number for year 1970 (Unix epoch)', () => {
+      expect(DayFromYear(1970)).toBe(0)
+    })
+
+    it('calculates correct day number for year 2000', () => {
+      expect(DayFromYear(2000)).toBe(10957)
+    })
+  })
+})


### PR DESCRIPTION
Date.UTC parses dates years 0-99 as 1900-1999 which results in unexpected bugs in functions such as `formatToParts` when given dates below year 100.

Closes #5038