### PR TITLE
chore: fix up build pipeline

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -14,8 +14,12 @@ import %workspace%/.aspect/bazelrc/performance.bazelrc
 ### YOUR PROJECT SPECIFIC SETTINGS GO HERE ###
 
 common --enable_bzlmod 
+common --color=yes
 
-build --java_runtime_version=remotejdk_11
+build --java_language_version=17
+build --java_runtime_version=remotejdk_17
+build --tool_java_language_version=17
+build --tool_java_runtime_version=remotejdk_17
 
 build --action_env=PATH=/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin
 
@@ -61,9 +65,9 @@ build --define=NODE_OPTIONS=--max-old-space-size=4096
 
 # BuildBuddy GH Actions Config
 # https://www.buildbuddy.io/docs/rbe-github-actions
-build --bes_results_url=https://app.buildbuddy.io/invocation/
-build --bes_backend=grpcs://remote.buildbuddy.io
-build --remote_cache=grpcs://remote.buildbuddy.io
+build:ci --build_metadata=ROLE=CI
+build:ci --bes_results_url=https://app.buildbuddy.io/invocation/
+build:ci --bes_backend=grpcs://remote.buildbuddy.io
 
 # honor the setting of `skipLibCheck` in the tsconfig.json file
 build --@aspect_rules_ts//ts:skipLibCheck=honor_tsconfig
@@ -74,19 +78,6 @@ query --@aspect_rules_ts//ts:skipLibCheck=honor_tsconfig
 build --@aspect_rules_ts//ts:default_to_tsc_transpiler
 fetch --@aspect_rules_ts//ts:default_to_tsc_transpiler
 query --@aspect_rules_ts//ts:default_to_tsc_transpiler
-
-# BuildBuddy RBE
-build:remote --remote_executor=grpcs://remote.buildbuddy.io
-build:remote --host_platform=@buildbuddy_toolchain//:platform
-build:remote --platforms=@buildbuddy_toolchain//:platform
-build:remote --extra_execution_platforms=@buildbuddy_toolchain//:platform
-build:remote --crosstool_top=@buildbuddy_toolchain//:toolchain
-build:remote --extra_toolchains=@buildbuddy_toolchain//:cc_toolchain
-build:remote --java_language_version=11
-build:remote --tool_java_language_version=11
-build:remote --java_runtime_version=remotejdk_11
-build:remote --tool_java_runtime_version=remotejdk_11
-build:remote --define=EXECUTOR=remote
 
 # Load any settings specific to the current user.
 # .bazelrc.user should appear in .gitignore so that settings are not shared with team members

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,32 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: bazelbuild/setup-bazelisk@v3
+
+      - name: Mount bazel cache
+        uses: actions/cache@v4
+        with:
+          path: '~/.cache/bazel'
+          key: bazel-${{ matrix.os }}
+
+      - name: Run tests
+        run: |
+          bazel test \
+            --config=ci \
+            --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
+            //...

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -497,7 +497,7 @@
         "bzlTransitiveDigest": "5OYPlsMr3+wbJwt66EtdDKuQNIG/wvKMky46IzXJUa4=",
         "usagesDigest": "tsxRjH5DN8xUnGoUELCp/xuIp04EwwlFAtYpnGb6Y+4=",
         "recordedFileInputs": {
-          "@@//package.json": "b0b7ce55ca3a72de9cfcb71ce1f133fa8b14fef35b907819b5374716ccb1fef4"
+          "@@//package.json": "5393670d1d34c20a1452d1b2b1564bc97b3cc2fe01910a7588a6753ed410efb6"
         },
         "recordedDirentsInputs": {},
         "envVariables": {},


### PR DESCRIPTION
### TL;DR

Upgrade Java version from 11 to 17 and set up GitHub Actions CI workflow with BuildBuddy integration.

### What changed?

- Updated Java configuration in `.bazelrc` from Java 11 to Java 17 for both build and tools
- Moved BuildBuddy configuration under a dedicated `ci` config
- Removed unused BuildBuddy RBE configuration
- Added a new GitHub Actions workflow file (`.github/workflows/main.yml`) that:
  - Runs on push to main and pull requests
  - Sets up Bazelisk
  - Configures Bazel cache
  - Runs tests with BuildBuddy integration using a secret API key

### How to test?

1. Create a pull request to verify the GitHub Actions workflow runs correctly
2. Check that the BuildBuddy integration works by examining the test results in the BuildBuddy UI
3. Verify that your Java-based builds work correctly with Java 17

### Why make this change?

Upgrading to Java 17 provides access to newer language features and improved performance. Adding a GitHub Actions workflow with BuildBuddy integration improves CI capabilities, providing better test reporting and build caching. This change streamlines the CI process and ensures consistent testing across all pull requests.