### PR TITLE
chore: tune GHA

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -65,9 +65,12 @@ build --define=NODE_OPTIONS=--max-old-space-size=4096
 
 # BuildBuddy GH Actions Config
 # https://www.buildbuddy.io/docs/rbe-github-actions
+build --remote_cache=grpcs://formatjs.buildbuddy.io
+build --remote_timeout=10m
+build:ci --bes_backend=grpcs://formatjs.buildbuddy.io
+build:ci --bes_results_url=https://formatjs.buildbuddy.io/invocation/
 build:ci --build_metadata=ROLE=CI
-build:ci --bes_results_url=https://app.buildbuddy.io/invocation/
-build:ci --bes_backend=grpcs://remote.buildbuddy.io
+build:ci --build_metadata=VISIBILITY=PUBLIC
 
 # honor the setting of `skipLibCheck` in the tsconfig.json file
 build --@aspect_rules_ts//ts:skipLibCheck=honor_tsconfig


### PR DESCRIPTION
### TL;DR

Updated BuildBuddy configuration to use the formatjs-specific BuildBuddy instance.

### What changed?

- Added remote cache configuration pointing to `formatjs.buildbuddy.io`
- Set remote timeout to 10 minutes
- Updated BES backend URL to use `formatjs.buildbuddy.io` instead of `remote.buildbuddy.io`
- Updated results URL to use `formatjs.buildbuddy.io` instead of `app.buildbuddy.io`
- Added `VISIBILITY=PUBLIC` build metadata

### How to test?

Run a build with the CI configuration to verify it connects to the new BuildBuddy instance:
```
bazel build --config=ci //...
```

### Why make this change?

This change migrates our build system to use a dedicated BuildBuddy instance for the formatjs project, which should provide better performance and reliability for our CI builds. The public visibility setting also makes build results accessible to contributors without requiring authentication.