### PR TITLE
chore: update dependencies and remove npm package manager requirement

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -16,15 +16,15 @@
     "https://bcr.bazel.build/modules/aspect_bazel_lib/1.38.0/MODULE.bazel": "6307fec451ba9962c1c969eb516ebfe1e46528f7fa92e1c9ac8646bef4cdaa3f",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/1.42.2/MODULE.bazel": "2e0d8ab25c57a14f56ace1c8e881b69050417ff91b2fb7718dc00d201f3c3478",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.14.0/MODULE.bazel": "2b31ffcc9bdc8295b2167e07a757dbbc9ac8906e7028e5170a3708cecaac119f",
-    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.19.4/MODULE.bazel": "d39e4b18e594d81c526d7cfc513e7ecfa8ca9eb5b61488d1d790faa94b34f2d9",
-    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.19.4/source.json": "506fa924e19fd8a33d617e33a17e4fce845f9ff9acb3a2aa7cf7300650698705",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.21.0/MODULE.bazel": "2fbd1f58ccbbe28749a248bdadea068a6db27eda8be45f8d60668f48e4025437",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.21.0/source.json": "9ce346023624f8d3b58d31d3ef1bf773f85495187386f6de63fd8aaef744c63e",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.7.7/MODULE.bazel": "491f8681205e31bb57892d67442ce448cda4f472a8e6b3dc062865e29a64f89c",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.8.1/MODULE.bazel": "812d2dd42f65dca362152101fbec418029cc8fd34cbad1a2fde905383d705838",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.9.3/MODULE.bazel": "66baf724dbae7aff4787bf2245cc188d50cb08e07789769730151c0943587c14",
     "https://bcr.bazel.build/modules/aspect_rules_esbuild/0.22.1/MODULE.bazel": "499ce65b6126f344f9a630040b9db91b36b20c6d1436026120067d922c2d69bd",
     "https://bcr.bazel.build/modules/aspect_rules_esbuild/0.22.1/source.json": "84138a41a9e71655cb97d39fcb80f6e2ba7e754d5601fb14f5a7d14080dff409",
-    "https://bcr.bazel.build/modules/aspect_rules_jest/0.23.2/MODULE.bazel": "3770e4c75a41f119abb23af6971f3c9d81d20fe452f4ead69e91f429743da4f7",
-    "https://bcr.bazel.build/modules/aspect_rules_jest/0.23.2/source.json": "c546cf9420051c141626878ef3932997e5847570399f62802ec7f32d403b58b0",
+    "https://bcr.bazel.build/modules/aspect_rules_jest/0.23.3/MODULE.bazel": "ef00a036052a912c9ef382cbdc2edffd1bbcfaf23959f105fac31af53a14926c",
+    "https://bcr.bazel.build/modules/aspect_rules_jest/0.23.3/source.json": "bda3e74a8be94977a78b74d2342571954908f964e2fc5173a9940605d6c7056d",
     "https://bcr.bazel.build/modules/aspect_rules_js/1.33.1/MODULE.bazel": "db3e7f16e471cf6827059d03af7c21859e7a0d2bc65429a3a11f005d46fc501b",
     "https://bcr.bazel.build/modules/aspect_rules_js/1.40.0/MODULE.bazel": "01a1014e95e6816b68ecee2584ae929c7d6a1b72e4333ab1ff2d2c6c30babdf1",
     "https://bcr.bazel.build/modules/aspect_rules_js/2.0.0/MODULE.bazel": "b45b507574aa60a92796e3e13c195cd5744b3b8aff516a9c0cb5ae6a048161c5",
@@ -33,8 +33,8 @@
     "https://bcr.bazel.build/modules/aspect_rules_lint/0.12.0/MODULE.bazel": "e767c5dbfeb254ec03275a7701b5cfde2c4d2873676804bc7cb27ddff3728fed",
     "https://bcr.bazel.build/modules/aspect_rules_lint/1.4.4/MODULE.bazel": "24459eeeeb084bc3e7628c338e494746718bc17b3a3cbd94415c8df5c7c6dc37",
     "https://bcr.bazel.build/modules/aspect_rules_lint/1.4.4/source.json": "68a98376c993a8113ac3a5e75eaab588bd61f67e5d633dee31770f9a9a6c785b",
-    "https://bcr.bazel.build/modules/aspect_rules_ts/3.6.0/MODULE.bazel": "d0045b5eabb012be550a609589b3e5e47eba682344b19cfd9365d4d896ed07df",
-    "https://bcr.bazel.build/modules/aspect_rules_ts/3.6.0/source.json": "5593e3f1cd0dd5147f7748e163307fd5c2e1077913d6945b58739ad8d770a290",
+    "https://bcr.bazel.build/modules/aspect_rules_ts/3.6.3/MODULE.bazel": "d09db394970f076176ce7bab5b5fa7f0d560fd4f30b8432ea5e2c2570505b130",
+    "https://bcr.bazel.build/modules/aspect_rules_ts/3.6.3/source.json": "641e58c62e5090d52a0d3538451893acdb2d79a36e8b3d1d30a013c580bc2058",
     "https://bcr.bazel.build/modules/bazel_features/0.1.0/MODULE.bazel": "47011d645b0f949f42ee67f2e8775188a9cf4a0a1528aa2fa4952f2fd00906fd",
     "https://bcr.bazel.build/modules/bazel_features/1.0.0/MODULE.bazel": "d7f022dc887efb96e1ee51cec7b2e48d41e36ff59a6e4f216c40e4029e1585bf",
     "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
@@ -60,7 +60,8 @@
     "https://bcr.bazel.build/modules/bazel_skylib/1.6.1/MODULE.bazel": "8fdee2dbaace6c252131c00e1de4b165dc65af02ea278476187765e1a617b917",
     "https://bcr.bazel.build/modules/bazel_skylib/1.7.0/MODULE.bazel": "0db596f4563de7938de764cc8deeabec291f55e8ec15299718b93c4423e9796d",
     "https://bcr.bazel.build/modules/bazel_skylib/1.7.1/MODULE.bazel": "3120d80c5861aa616222ec015332e5f8d3171e062e3e804a2a0253e1be26e59b",
-    "https://bcr.bazel.build/modules/bazel_skylib/1.7.1/source.json": "f121b43eeefc7c29efbd51b83d08631e2347297c95aac9764a701f2a6a2bb953",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.8.1/MODULE.bazel": "88ade7293becda963e0e3ea33e7d54d3425127e0a326e0d17da085a5f1f03ff6",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.8.1/source.json": "7ebaefba0b03efe59cac88ed5bbc67bcf59a3eff33af937345ede2a38b2d368a",
     "https://bcr.bazel.build/modules/buildifier_prebuilt/6.1.2/MODULE.bazel": "2ef4962c8b0b6d8d21928a89190755619254459bc67f870dc0ccb9ba9952d444",
     "https://bcr.bazel.build/modules/buildifier_prebuilt/8.2.0.2/MODULE.bazel": "a9b689711d5b69f9db741649b218c119b9fdf82924ba390415037e09798edd03",
     "https://bcr.bazel.build/modules/buildifier_prebuilt/8.2.0.2/source.json": "51eb0a4b38aaaeab7fa64361576d616c4d8bfd0f17a0a10184aeab7084d79f8e",
@@ -222,7 +223,7 @@
   "moduleExtensions": {
     "@@aspect_rules_esbuild+//esbuild:extensions.bzl%esbuild": {
       "general": {
-        "bzlTransitiveDigest": "nOhoZKf5lUaF4rKmKyl93gD3+fzkD0Pi7buBREUI5Vg=",
+        "bzlTransitiveDigest": "5zeSE77/0Ui2G3Axz5GQx4PXI8BTqbE6hX45hsugYFs=",
         "usagesDigest": "kwkn3FPW+KCy6WWa5RCeba1tFWKuJCFPE5M68azHGzs=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -389,10 +390,10 @@
     },
     "@@aspect_rules_ts+//ts:extensions.bzl%ext": {
       "general": {
-        "bzlTransitiveDigest": "5OYPlsMr3+wbJwt66EtdDKuQNIG/wvKMky46IzXJUa4=",
+        "bzlTransitiveDigest": "PmSFl5de9ODJbC1xCNlhwlUaInXalJ08lhcxW297GX0=",
         "usagesDigest": "tsxRjH5DN8xUnGoUELCp/xuIp04EwwlFAtYpnGb6Y+4=",
         "recordedFileInputs": {
-          "@@//package.json": "1dbf273f27d54e1e61925f93380f2e690ae563dc9ebb92f9716ced86d339c65f"
+          "@@//package.json": "0ba302ae0e53e9fec82b2c72e09a8edb9620469c9225e8810a7b5854d0b2da73"
         },
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/package.json
+++ b/package.json
@@ -125,10 +125,6 @@
     "runtime": {
       "name": "node",
       "version": ">= 18.x"
-    },
-    "packageManager": {
-      "name": "npm",
-      "version": "10.x"
     }
   },
   "lint-staged": {

--- a/packages/cli-lib/package.json
+++ b/packages/cli-lib/package.json
@@ -24,7 +24,7 @@
     "typescript": "^5.6.0"
   },
   "peerDependencies": {
-    "@glimmer/syntax": "^0.94.9 || ^0.95.0",
+    "@glimmer/syntax": "^0.95.0",
     "@vue/compiler-core": "^3.5.12",
     "content-tag": "^3.0.0",
     "ember-template-recast": "^6.1.5",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,7 +11,7 @@
     "@formatjs/cli-lib": "workspace:*"
   },
   "peerDependencies": {
-    "@glimmer/syntax": "^0.94.9 || ^0.95.0",
+    "@glimmer/syntax": "^0.95.0",
     "@vue/compiler-core": "^3.5.12",
     "content-tag": "^3.0.0",
     "ember-template-recast": "^6.1.5",


### PR DESCRIPTION
### TL;DR

Update dependencies and remove unnecessary package manager specification.

### What changed?

- Updated Bazel module dependencies:
  - `aspect_bazel_lib` from 2.19.4 to 2.21.0
  - `aspect_rules_jest` from 0.23.2 to 0.23.3
  - `aspect_rules_ts` from 3.6.0 to 3.6.3
  - `bazel_skylib` from 1.7.1 to 1.8.1
- Removed the `packageManager` specification from the root `package.json`
- Updated `@glimmer/syntax` peer dependency in both `cli-lib` and `cli` packages to require only `^0.95.0` (removing support for `^0.94.9`)

### How to test?

1. Run the build to ensure everything compiles correctly
2. Run tests to verify functionality is maintained
3. Verify that the application works with the updated dependencies

### Why make this change?

This change updates dependencies to their latest versions to benefit from bug fixes and improvements. Removing the package manager specification allows for more flexibility in how the project is managed. The `@glimmer/syntax` peer dependency update ensures compatibility with the latest version while removing support for older versions that may have issues.