### PR TITLE
chore: Lerna-Lite --skip-bump-only-releases

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -9,13 +9,14 @@
       "exact": true,
       "ignoreChanges": ["**/tests/**", "**/*.md"],
       "message": "build: publish",
-      "private": false
+      "private": false,
+      "skipBumpOnlyReleases": true
     },
     "run": {
       "stream": true
     },
     "publish": {
-      "removePackageFields": ["devDependencies", "scripts"]
+      "stripPackageKeys": ["devDependencies", "scripts"]
     }
   },
   "packages": ["packages/*"]


### PR DESCRIPTION
- add `--skip-bump-only-releases` option to skip all the "bump only" changelog from the GitHub Release, this reduces the noise by skipping "bump only" from appearing in the GitHub Releases (though they still appear in their respective changelogs)
  - see https://github.com/lerna-lite/lerna-lite/tree/main/packages/version#--skip-bump-only-releases for more info
- also rename previous flag name `--remove-package-fields` to the new flag name `--strip-package-keys` because the old name will be removed in the next major version (it's a simple rename, the functionality is exactly the same as before)

The skip "bump only" releases is to avoid creating empty entries for something like below. You might still want to keep them, it's really up to you, this option is just a visual thing (it's useful if you want to only show the packages that really had changes and skip the "bump only" ones, as below)

<img width="709" height="511" alt="image" src="https://github.com/user-attachments/assets/fbd33265-0f87-4e36-b98f-e28d807caa67" />
