### PR TITLE
feat: add `quoteStyle` option to eslint `enforce-id` rule

### DIFF
--- a/packages/eslint-plugin-formatjs/rules/enforce-id.ts
+++ b/packages/eslint-plugin-formatjs/rules/enforce-id.ts
@@ -7,6 +7,7 @@ import {extractMessages, getSettings} from '../util'
 export type Option = {
   idInterpolationPattern: string
   idWhitelist?: string[]
+  quoteStyle?: 'single' | 'double'
 }
 
 type MessageIds =
@@ -31,9 +32,11 @@ function checkNode(
   {
     idInterpolationPattern,
     idWhitelistRegexps,
+    quoteStyle,
   }: {
     idInterpolationPattern: string
     idWhitelistRegexps?: RegExp[]
+    quoteStyle: 'single' | 'double'
   }
 ) {
   const msgs = extractMessages(node, getSettings(context))
@@ -99,6 +102,7 @@ function checkNode(
             }
           }
 
+          const quote = quoteStyle === 'double' ? '"' : "'"
           context.report({
             node,
             messageId,
@@ -106,9 +110,15 @@ function checkNode(
             fix(fixer) {
               if (idPropNode) {
                 if (idPropNode.type === 'JSXAttribute') {
-                  return fixer.replaceText(idPropNode, `id="${correctId}"`)
+                  return fixer.replaceText(
+                    idPropNode,
+                    `id=${quote}${correctId}${quote}`
+                  )
                 }
-                return fixer.replaceText(idPropNode, `id: '${correctId}'`)
+                return fixer.replaceText(
+                  idPropNode,
+                  `id: ${quote}${correctId}${quote}`
+                )
               }
 
               if (messagePropNode) {
@@ -116,12 +126,12 @@ function checkNode(
                 if (messagePropNode.type === 'JSXAttribute') {
                   return fixer.insertTextAfter(
                     messagePropNode,
-                    ` id="${correctId}"`
+                    ` id=${quote}${correctId}${quote}`
                   )
                 }
                 return fixer.insertTextAfter(
                   messagePropNode,
-                  `, id: '${correctId}'`
+                  `, id: ${quote}${correctId}${quote}`
                 )
               }
               return null
@@ -160,6 +170,12 @@ export const rule: RuleModule<MessageIds, Options> = {
               type: 'string',
             },
           },
+          quoteStyle: {
+            type: 'string',
+            enum: ['single', 'double'],
+            description:
+              'Quote style for generated IDs. Defaults to single quotes.',
+          },
         },
         required: ['idInterpolationPattern'],
         additionalProperties: false,
@@ -180,6 +196,7 @@ Actual: {{actual}}`,
   defaultOptions: [
     {
       idInterpolationPattern: '[sha512:contenthash:base64:6]',
+      quoteStyle: 'single',
     },
   ],
   create(context) {
@@ -187,8 +204,10 @@ Actual: {{actual}}`,
     let opts: {
       idInterpolationPattern: string
       idWhitelistRegexps?: RegExp[]
+      quoteStyle: 'single' | 'double'
     } = {
       idInterpolationPattern: tmp?.idInterpolationPattern,
+      quoteStyle: tmp?.quoteStyle || 'single',
     }
     if (Array.isArray(tmp?.idWhitelist)) {
       const {idWhitelist} = tmp

--- a/packages/eslint-plugin-formatjs/rules/enforce-id.ts
+++ b/packages/eslint-plugin-formatjs/rules/enforce-id.ts
@@ -110,10 +110,8 @@ function checkNode(
             fix(fixer) {
               if (idPropNode) {
                 if (idPropNode.type === 'JSXAttribute') {
-                  return fixer.replaceText(
-                    idPropNode,
-                    `id=${quote}${correctId}${quote}`
-                  )
+                  // Always use double quotes for JSX attributes
+                  return fixer.replaceText(idPropNode, `id="${correctId}"`)
                 }
                 return fixer.replaceText(
                   idPropNode,
@@ -124,9 +122,10 @@ function checkNode(
               if (messagePropNode) {
                 // Insert after default message node
                 if (messagePropNode.type === 'JSXAttribute') {
+                  // Always use double quotes for JSX attributes
                   return fixer.insertTextAfter(
                     messagePropNode,
-                    ` id=${quote}${correctId}${quote}`
+                    ` id="${correctId}"`
                   )
                 }
                 return fixer.insertTextAfter(

--- a/packages/eslint-plugin-formatjs/tests/enforce-id.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/enforce-id.test.ts
@@ -297,6 +297,97 @@ defineMessages({ example: { defaultMessage: 'example1', id: 'payment_string' }, 
   ],
 })
 
+const optionsWithDoubleQuote: [Option] = [
+  {
+    idInterpolationPattern: '[sha512:contenthash:base64:6]',
+    quoteStyle: 'double',
+  },
+]
+
+ruleTester.run(`${name} with quoteStyle: 'double'`, rule, {
+  valid: [],
+  invalid: [
+    {
+      code: `
+intl.formatMessage({ id: 'foo', defaultMessage: '{count, plural, one {#} other {# more}}', description: 'asd'})`,
+      errors: [
+        {
+          messageId: 'enforceIdMatching',
+          data: {
+            idInterpolationPattern: '[sha512:contenthash:base64:6]',
+            expected: 'j9qhn+',
+            actual: 'foo',
+          },
+        },
+      ],
+      options: optionsWithDoubleQuote,
+      output: `
+intl.formatMessage({ id: "j9qhn+", defaultMessage: '{count, plural, one {#} other {# more}}', description: 'asd'})`,
+    },
+    {
+      code: `
+intl.formatMessage({defaultMessage: '{count, plural, one {#} other {# more}}', description: 'asd'})`,
+      errors: [
+        {
+          messageId: 'enforceIdMatching',
+          data: {
+            idInterpolationPattern: '[sha512:contenthash:base64:6]',
+            expected: 'j9qhn+',
+            actual: 'undefined',
+          },
+        },
+      ],
+      options: optionsWithDoubleQuote,
+      output: `
+intl.formatMessage({defaultMessage: '{count, plural, one {#} other {# more}}', id: "j9qhn+", description: 'asd'})`,
+    },
+    {
+      code: `
+import {FormattedMessage} from 'react-intl'
+const a = (
+  <FormattedMessage defaultMessage="{count, plural, one {#} other {# more}}" values={{foo: 1}} />
+)`,
+      errors: [
+        {
+          messageId: 'enforceIdMatching',
+          data: {
+            idInterpolationPattern: '[sha512:contenthash:base64:6]',
+            expected: '/e77jM',
+            actual: 'undefined',
+          },
+        },
+      ],
+      options: optionsWithDoubleQuote,
+      output: `
+import {FormattedMessage} from 'react-intl'
+const a = (
+  <FormattedMessage defaultMessage="{count, plural, one {#} other {# more}}" id="/e77jM" values={{foo: 1}} />
+)`,
+    },
+    {
+      code: `
+import { defineMessages } from 'react-intl'
+
+defineMessages({ example: { defaultMessage: 'example' } })`,
+      errors: [
+        {
+          messageId: 'enforceIdMatching',
+          data: {
+            idInterpolationPattern: '[sha512:contenthash:base64:6]',
+            expected: 'O7Eu2j',
+            actual: 'undefined',
+          },
+        },
+      ],
+      options: optionsWithDoubleQuote,
+      output: `
+import { defineMessages } from 'react-intl'
+
+defineMessages({ example: { defaultMessage: 'example', id: "O7Eu2j" } })`,
+    },
+  ],
+})
+
 vueRuleTester.run(`vue-${name}`, rule, {
   valid: [
     {


### PR DESCRIPTION
Adds a new `quoteStyle` option to the `enforce-id` rule that allows configuring whether to use single or double quotes when auto-fixing ID attributes. Defaults to single quotes to maintain backward compatibility.

We use double quotes in our repo so I always have to run prettier after running this eslint rule which is a bit annoying. 

Disclaimer - I used Claude Code to help me with this. But I understand the changes.