### PR TITLE
fix: use global 'time' Formats override with formatTime/FormattedTimeParts 'format' config instead of 'date' Formats, add strict 'format' overrides typing to FormattedDate and FormattedTime

### DIFF
--- a/packages/intl/src/types.ts
+++ b/packages/intl/src/types.ts
@@ -100,6 +100,11 @@ export type FormatDateOptions = Omit<
   'localeMatcher'
 > &
   CustomFormatConfig<'date'>
+export type FormatTimeOptions = Omit<
+  Intl.DateTimeFormatOptions,
+  'localeMatcher'
+> &
+  CustomFormatConfig<'time'>
 export type FormatNumberOptions = Omit<NumberFormatOptions, 'localeMatcher'> &
   CustomFormatConfig<'number'>
 export type FormatRelativeTimeOptions = Omit<
@@ -139,7 +144,7 @@ export interface IntlFormatters<TBase = unknown> {
   formatTime(
     this: void,
     value: Parameters<Intl.DateTimeFormat['format']>[0] | string,
-    opts?: FormatDateOptions
+    opts?: FormatTimeOptions
   ): string
   formatDateToParts(
     this: void,

--- a/packages/intl/tests/global_type_overrides.test-d.ts
+++ b/packages/intl/tests/global_type_overrides.test-d.ts
@@ -1,5 +1,9 @@
 import {expectType} from 'tsd'
-import {MessageDescriptor, ResolvedIntlConfig} from '../src/types'
+import {
+  IntlFormatters,
+  MessageDescriptor,
+  ResolvedIntlConfig,
+} from '../src/types'
 
 // Example type overrides
 declare global {
@@ -10,9 +14,25 @@ declare global {
     interface IntlConfig {
       locale: 'en-US' | 'zh-CN'
     }
+    interface Formats {
+      date: 'short' | 'long'
+      time: 'medium' | 'full'
+    }
   }
 }
 
 // Check that the type overrides actually work.
 expectType<'a' | 'b'>(null as any as NonNullable<MessageDescriptor['id']>)
 expectType<'en-US' | 'zh-CN'>(null as any as ResolvedIntlConfig['locale'])
+
+expectType<'short' | 'long'>(
+  null as any as NonNullable<
+    NonNullable<Parameters<IntlFormatters['formatDate']>[1]>['format']
+  >
+)
+
+expectType<'medium' | 'full'>(
+  null as any as NonNullable<
+    NonNullable<Parameters<IntlFormatters['formatTime']>[1]>['format']
+  >
+)

--- a/packages/react-intl/BUILD
+++ b/packages/react-intl/BUILD
@@ -1,8 +1,10 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
+load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
+load("@npm//:tsd/package_json.bzl", tsd_bin = "bin")
 load("//tools:index.bzl", "package_json_test", "ts_compile")
 load("//tools:vitest.bzl", "vitest")
 
@@ -97,6 +99,39 @@ write_source_files(
 package_json_test(
     name = "package_json_test",
     deps = SRC_DEPS,
+)
+
+# TODO: make this a macro that paramtrizes on `.test-d.ts` files.
+copy_to_directory(
+    name = "global_type_overrides_test_files",
+    srcs = [
+        "tests/global_type_overrides.test-d.ts",
+        "tsconfig.json",
+        ":pkg",
+    ],
+    out = "global_type_overrides_test_files",
+    # Remove the prefix so the package directory merges with the test file directory.
+    replace_prefixes = dict([
+        (
+            "pkg",
+            "",
+        ),
+    ]),
+)
+
+tsd_bin.tsd_test(
+    name = "global_type_overrides_test",
+    size = "small",
+    args = [
+        "--files",
+        "tests/global_type_overrides.test-d.ts",
+    ],
+    chdir = "packages/%s/global_type_overrides_test_files" % PACKAGE_NAME,
+    data = [
+        "tsconfig.json",
+        ":global_type_overrides_test_files",
+        "//:node_modules/tsd",
+    ] + SRC_DEPS,
 )
 
 copy_to_bin(

--- a/packages/react-intl/index.ts
+++ b/packages/react-intl/index.ts
@@ -7,6 +7,7 @@ import {NumberFormatOptions} from '@formatjs/ecma402-abstract'
 import {
   CustomFormatConfig,
   FormatDateOptions,
+  FormatTimeOptions,
   MessageDescriptor,
 } from '@formatjs/intl'
 import * as React from 'react'
@@ -116,7 +117,7 @@ export const FormattedDateParts: React.FC<
   }
 > = createFormattedDateTimePartsComponent('formatDate')
 export const FormattedTimeParts: React.FC<
-  FormatDateOptions & {
+  FormatTimeOptions & {
     value: Parameters<Intl.DateTimeFormat['format']>[0] | string
     children(val: Intl.DateTimeFormatPart[]): React.ReactElement | null
   }

--- a/packages/react-intl/index.ts
+++ b/packages/react-intl/index.ts
@@ -80,14 +80,14 @@ export function defineMessage<T extends MessageDescriptor>(msg: T): T {
 // IMPORTANT: Explicit here to prevent api-extractor from outputing `import('./src/types').CustomFormatConfig`
 export const FormattedDate: React.FC<
   Intl.DateTimeFormatOptions &
-    CustomFormatConfig & {
+    CustomFormatConfig<'date'> & {
       value: string | number | Date | undefined
       children?(formattedDate: string): React.ReactElement | null
     }
 > = createFormattedComponent('formatDate')
 export const FormattedTime: React.FC<
   Intl.DateTimeFormatOptions &
-    CustomFormatConfig & {
+    CustomFormatConfig<'time'> & {
       value: string | number | Date | undefined
       children?(formattedTime: string): React.ReactElement | null
     }

--- a/packages/react-intl/tests/global_type_overrides.test-d.ts
+++ b/packages/react-intl/tests/global_type_overrides.test-d.ts
@@ -1,5 +1,10 @@
 import {expectType} from 'tsd'
-import {FormattedDate, FormattedTime} from '../'
+import {
+  FormattedDate,
+  FormattedDateParts,
+  FormattedTime,
+  FormattedTimeParts,
+} from '../'
 import {ComponentProps} from 'react'
 
 declare global {
@@ -14,6 +19,16 @@ declare global {
 expectType<'short' | 'long'>(
   null as any as NonNullable<ComponentProps<typeof FormattedDate>['format']>
 )
+expectType<'short' | 'long'>(
+  null as any as NonNullable<
+    ComponentProps<typeof FormattedDateParts>['format']
+  >
+)
 expectType<'medium' | 'full'>(
   null as any as NonNullable<ComponentProps<typeof FormattedTime>['format']>
+)
+expectType<'medium' | 'full'>(
+  null as any as NonNullable<
+    ComponentProps<typeof FormattedTimeParts>['format']
+  >
 )

--- a/packages/react-intl/tests/global_type_overrides.test-d.ts
+++ b/packages/react-intl/tests/global_type_overrides.test-d.ts
@@ -1,0 +1,19 @@
+import {expectType} from 'tsd'
+import {FormattedDate, FormattedTime} from '../'
+import {ComponentProps} from 'react'
+
+declare global {
+  namespace FormatjsIntl {
+    interface Formats {
+      date: 'short' | 'long'
+      time: 'medium' | 'full'
+    }
+  }
+}
+
+expectType<'short' | 'long'>(
+  null as any as NonNullable<ComponentProps<typeof FormattedDate>['format']>
+)
+expectType<'medium' | 'full'>(
+  null as any as NonNullable<ComponentProps<typeof FormattedTime>['format']>
+)

--- a/website/docs/react-intl.md
+++ b/website/docs/react-intl.md
@@ -308,6 +308,41 @@ declare global {
 }
 ```
 
+## Typing custom formats
+
+By default, the type for the `format` prop of `<FormattedDate>`, `<FormattedDateParts>`, `<FormattedTime>` and `<FormattedTimeParts>` is `string`. The same applies to the `format` configuration of `formatDate`, `formatDateParts`, `formatTime`, and `formatTimeParts`. However, you can set a more restrictive type to get autocomplete and error checking. In order to do this, override the following global namespace with the union type of all of your custom format names. You can do this by including the following somewhere in your code:
+
+```ts
+declare global {
+  namespace FormatjsIntl {
+    interface Formats {
+      date: keyof (typeof customFormats)['date']
+      time: keyof (typeof customFormats)['time']
+    }
+  }
+}
+```
+
+Where `customFormats` is the object you would normally pass to `<IntlProvider>`, and would look something like:
+
+```ts
+const customFormats = {
+  date: {
+    short: {
+      month: 'numeric',
+      day: 'numeric',
+      year: '2-digit',
+    },
+  },
+  time: {
+    short: {
+      hour: 'numeric',
+      minute: 'numeric',
+    },
+  },
+}
+```
+
 # Advanced Usage
 
 Our [Advanced Usage](guides/advanced-usage.md) has further guides for production setup in environments where performance is important.


### PR DESCRIPTION
Currently, `formatTime` uses `CustomFormatConfig<'date'>` for it's type. When you override `FormatjsIntl.Formats` ([as described here, but for `Formats` instead of `Message`](https://formatjs.github.io/docs/react-intl/#typing-message-ids-and-locale)), this results in the `format` property of the config being strictly typed to the `date` format keys. Instead, this should use `CustomFormatConfig<'time'>` to properly use the `time` format keys. The `FormattedTimeParts` component is also incorrectly using `CustomFormatConfig<'date'>` vs `CustomFormatConfig<'time'>`.

Additionally, the `FormattedDate` and `FormattedTime` components do not use the strict typing from `FormatjsIntl.Formats` at all, and instead accept any string when `FormatjsIntl.Formats` is set.

This PR fixes both issue, as well as updates the documentation for overriding `FormatjsIntl.Formats`, as it currently only documents `FormatjsIntl.Message` and `FormatjsIntl.IntlConfig`.

I tried to make a reproduction in CodeSandbox, but it seems to currently be having issues with Typescript, where it always gave me a Typescript server error. Not sure if this is a me thing, or an everyone thing.

I did add tsd tests though. So you can run the tests and without my changes in order to see the failures. I tried to utilize the "example-sandboxes" instead at first, but they seem to be very out of date and I could not get them to run. The tsd tests ended up being a more proper solution anyway once I realized that was an option.