### PR TITLE
fix(eslint): emit plugin types correctly

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -393,7 +393,7 @@
         "bzlTransitiveDigest": "PmSFl5de9ODJbC1xCNlhwlUaInXalJ08lhcxW297GX0=",
         "usagesDigest": "tsxRjH5DN8xUnGoUELCp/xuIp04EwwlFAtYpnGb6Y+4=",
         "recordedFileInputs": {
-          "@@//package.json": "4d68e39b46b376f4f541b856b9faf1ddec6b9edb3ff12b94703990d33fff7f0e"
+          "@@//package.json": "e4edab02776e50b1112aedc7b8197371bc02b32125026c5568bb4f0411905298"
         },
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/packages/eslint-plugin-formatjs/index.ts
+++ b/packages/eslint-plugin-formatjs/index.ts
@@ -197,4 +197,4 @@ const configs: ESLint.Plugin['configs'] = {
 }
 plugin.configs = configs
 
-module.exports = plugin
+export default plugin

--- a/packages/eslint-plugin-formatjs/index.ts
+++ b/packages/eslint-plugin-formatjs/index.ts
@@ -1,3 +1,4 @@
+import type {Linter} from 'eslint'
 import {ESLint} from 'eslint'
 import {
   name as blocklistElementRuleName,
@@ -114,14 +115,27 @@ const rules: ESLint.Plugin['rules'] = {
   [noLiteralStringInObjectName]: noLiteralStringInObject,
 }
 
+type Plugin = {
+  meta: {
+    name: string
+    version: string
+  }
+  rules: ESLint.Plugin['rules']
+  configs: {
+    strict: Linter.Config
+    recommended: Linter.Config
+  }
+}
+
 // Base plugin
-const plugin: ESLint.Plugin = {
+const plugin: Plugin = {
   meta: {name, version},
   rules,
+  configs: {} as Plugin['configs'], // will be populated later
 }
 
 // Configs
-const configs: ESLint.Plugin['configs'] = {
+const configs: Plugin['configs'] = {
   strict: {
     name: 'formatjs/strict',
     plugins: {formatjs: plugin},

--- a/packages/eslint-plugin-formatjs/package.json
+++ b/packages/eslint-plugin-formatjs/package.json
@@ -27,5 +27,6 @@
     "i18n"
   ],
   "main": "index.js",
+  "types": "index.d.ts",
   "repository": "formatjs/formatjs.git"
 }

--- a/packages/eslint-plugin-formatjs/package.json
+++ b/packages/eslint-plugin-formatjs/package.json
@@ -4,6 +4,7 @@
   "version": "5.4.2",
   "license": "MIT",
   "author": "Long Ho <holevietlong@gmail.com>",
+  "types": "index.d.ts",
   "dependencies": {
     "@formatjs/icu-messageformat-parser": "workspace:*",
     "@formatjs/ts-transformer": "workspace:*",
@@ -27,6 +28,5 @@
     "i18n"
   ],
   "main": "index.js",
-  "types": "index.d.ts",
   "repository": "formatjs/formatjs.git"
 }


### PR DESCRIPTION
fixes #5133 

Since `index.ts` was using `module.exports`, the generated type definition file did not contain the correct contents.

This PR fixes the issue so that the type definition file is generated correctly and explicitly adds the `types` field to the package.json.