### PR TITLE
fix(eslint-plugin-formatjs): disallow extra properties in rule options

### DIFF
--- a/packages/eslint-plugin-formatjs/rules/no-literal-string-in-jsx.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-literal-string-in-jsx.ts
@@ -68,9 +68,11 @@ export const rule: RuleModule<MessageIds, Options> = {
     schema: [
       {
         type: 'object',
+        additionalProperties: false,
         properties: {
           props: {
             type: 'object',
+            additionalProperties: false,
             properties: {
               include: {
                 ...propMatcherSchema,


### PR DESCRIPTION
[no-literal-string-in-jsx](https://github.com/formatjs/formatjs/blob/3fe4b50d4b14e04717072217adf8514c580b55b7/packages/eslint-plugin-formatjs/rules/no-literal-string-in-jsx.ts#L70) rule currently allows extra properties to be passed in options object, which should not be allowed. This makes it easier for typos in rule options to go unnoticed.

This PR simply disallows extra properties in this rule's schema.