### PR TITLE
chore: support snapshot for vitest target

### DIFF
--- a/packages/icu-messageformat-parser/tests/__snapshots__/manipulator.test.ts.snap
+++ b/packages/icu-messageformat-parser/tests/__snapshots__/manipulator.test.ts.snap
@@ -1,0 +1,29 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`should hoist plural & select and tag 1`] = `
+"{count,plural,one{{gender,select,male{{count,plural,one{{gender,select,male{I have a male <b>dog</b>
+             and a male <strong>cat</strong>
+                } female{I have a male <b>dog</b>
+             and a female <strong>cat</strong>
+                } other{I have a male <b>dog</b>
+             and a male <strong>cat</strong>
+                }}} other{I have a male <b>dog</b>
+             and many cats}}} female{{count,plural,one{{gender,select,male{I have a female <b>dog</b>
+             and a male <strong>cat</strong>
+                } female{I have a female <b>dog</b>
+             and a female <strong>cat</strong>
+                } other{I have a female <b>dog</b>
+             and a male <strong>cat</strong>
+                }}} other{I have a female <b>dog</b>
+             and many cats}}} other{{count,plural,one{{gender,select,male{I have a male <b>dog</b>
+             and a male <strong>cat</strong>
+                } female{I have a male <b>dog</b>
+             and a female <strong>cat</strong>
+                } other{I have a male <b>dog</b>
+             and a male <strong>cat</strong>
+                }}} other{I have a male <b>dog</b>
+             and many cats}}}}} other{{count,plural,one{{gender,select,male{I have many dogs and a male <strong>cat</strong>
+                } female{I have many dogs and a female <strong>cat</strong>
+                } other{I have many dogs and a male <strong>cat</strong>
+                }}} other{I have many dogs and many cats}}}}"
+`;

--- a/packages/icu-messageformat-parser/tests/manipulator.test.ts
+++ b/packages/icu-messageformat-parser/tests/manipulator.test.ts
@@ -56,32 +56,7 @@ test('should hoist plural & select and tag', function () {
                 other{many cats}}`)
       )
     )
-  )
-    .toBe(`{count,plural,one{{gender,select,male{{count,plural,one{{gender,select,male{I have a male <b>dog</b>
-             and a male <strong>cat</strong>
-                } female{I have a male <b>dog</b>
-             and a female <strong>cat</strong>
-                } other{I have a male <b>dog</b>
-             and a male <strong>cat</strong>
-                }}} other{I have a male <b>dog</b>
-             and many cats}}} female{{count,plural,one{{gender,select,male{I have a female <b>dog</b>
-             and a male <strong>cat</strong>
-                } female{I have a female <b>dog</b>
-             and a female <strong>cat</strong>
-                } other{I have a female <b>dog</b>
-             and a male <strong>cat</strong>
-                }}} other{I have a female <b>dog</b>
-             and many cats}}} other{{count,plural,one{{gender,select,male{I have a male <b>dog</b>
-             and a male <strong>cat</strong>
-                } female{I have a male <b>dog</b>
-             and a female <strong>cat</strong>
-                } other{I have a male <b>dog</b>
-             and a male <strong>cat</strong>
-                }}} other{I have a male <b>dog</b>
-             and many cats}}}}} other{{count,plural,one{{gender,select,male{I have many dogs and a male <strong>cat</strong>
-                } female{I have many dogs and a female <strong>cat</strong>
-                } other{I have many dogs and a male <strong>cat</strong>
-                }}} other{I have many dogs and many cats}}}}`)
+  ).toMatchSnapshot()
 })
 
 test('should hoist 1 plural with number', function () {


### PR DESCRIPTION
### TL;DR

Added snapshot testing support for Vitest tests in the ICU message format parser.

### What changed?

- Added a snapshot test for the "hoist plural & select and tag" test case
- Modified the `vitest.bzl` file to support snapshot testing with Vitest
- Added functionality to generate, update, and manage test snapshots
- Implemented Bazel targets for snapshot management

### How to test?

1. Run the existing tests to verify they pass with the snapshot implementation
2. To update snapshots, use the new `.update` target:
   ```
   bazel run //path/to/package:target.update
   ```
3. Verify that snapshots are correctly generated in the `__snapshots__` directory

### Why make this change?

Snapshot testing provides a more maintainable way to test complex output patterns. Instead of embedding large expected output strings directly in test files, snapshots store these outputs separately, making tests more readable and easier to maintain. This is particularly valuable for the ICU message format parser tests which deal with complex, nested message patterns.