### PR TITLE
chore: more cleanup

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -239,6 +239,11 @@ prettier.prettier_binary(
     ],
     # Allow the binary to be run outside bazel
     env = {"BAZEL_BINDIR": "."},
+    fixed_args = [
+        # default log level is "log" which spams on success
+        # https://prettier.io/docs/en/cli.html#--log-level
+        "--log-level=warn",
+    ],
 )
 
 format_multirun(

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "lodash": "^4.17.21",
     "make-plural-compiler": "^5.1.0",
     "minimist": "^1.2.8",
-    "prettier": "^3.3.3",
+    "prettier": "^3.7.4",
     "react": "16 || 17 || 18 || 19",
     "react-dom": "16 || 17 || 18 || 19",
     "regenerate": "^1.4.2",

--- a/packages/ecma376/BUILD.bazel
+++ b/packages/ecma376/BUILD.bazel
@@ -6,7 +6,6 @@ load("//tools:vitest.bzl", "vitest")
 
 exports_files([
     "package.json",
-    "tsconfig.json",
 ])
 
 PACKAGE_NAME = "ecma376"

--- a/packages/ecma402-abstract/types/date-time.ts
+++ b/packages/ecma402-abstract/types/date-time.ts
@@ -161,11 +161,10 @@ export type IntervalFormatsData = {
   intervalFormatFallback: string
 } & Record<string, Record<string, string>>
 
-export interface DateTimeFormat
-  extends Omit<
-    Intl.DateTimeFormat,
-    'resolvedOptions' | 'formatRange' | 'formatRangeToParts' | 'formatToParts'
-  > {
+export interface DateTimeFormat extends Omit<
+  Intl.DateTimeFormat,
+  'resolvedOptions' | 'formatRange' | 'formatRangeToParts' | 'formatToParts'
+> {
   resolvedOptions(): ResolvedDateTimeFormatOptions
   formatToParts(date?: Date | number): IntlDateTimeFormatPart[]
   formatRange(startDate: number | Date, endDate: number | Date): string

--- a/packages/fast-memoize/BUILD.bazel
+++ b/packages/fast-memoize/BUILD.bazel
@@ -8,7 +8,6 @@ npm_link_all_packages()
 
 exports_files([
     "package.json",
-    "tsconfig.json",
 ])
 
 PACKAGE_NAME = "fast-memoize"

--- a/packages/icu-messageformat-parser/types.ts
+++ b/packages/icu-messageformat-parser/types.ts
@@ -72,8 +72,10 @@ export interface TagElement extends BaseElement<TYPE.tag> {
   children: MessageFormatElement[]
 }
 
-export interface SimpleFormatElement<T extends TYPE, S extends Skeleton>
-  extends BaseElement<T> {
+export interface SimpleFormatElement<
+  T extends TYPE,
+  S extends Skeleton,
+> extends BaseElement<T> {
   style?: string | S | null
 }
 

--- a/packages/intl-datetimeformat/src/types.ts
+++ b/packages/intl-datetimeformat/src/types.ts
@@ -20,8 +20,10 @@ export interface UnpackedData {
 }
 
 export type ZoneData = [
-  // Seconds from UTC Time, empty string if NULL
-  number | string,
+  (
+    // Seconds from UTC Time, empty string if NULL
+    number | string
+  ),
   // Index of abbreviation in abbrvs like EST/EDT
   number,
   // Index of offsets in seconds

--- a/packages/intl-getcanonicallocales/BUILD.bazel
+++ b/packages/intl-getcanonicallocales/BUILD.bazel
@@ -10,7 +10,6 @@ npm_link_all_packages()
 
 exports_files([
     "package.json",
-    "tsconfig.json",
 ])
 
 PACKAGE_NAME = "intl-getcanonicallocales"

--- a/packages/intl/src/types.ts
+++ b/packages/intl/src/types.ts
@@ -256,8 +256,7 @@ export interface Formatters {
 }
 
 export interface IntlShape<T = string>
-  extends ResolvedIntlConfig<T>,
-    IntlFormatters<T> {
+  extends ResolvedIntlConfig<T>, IntlFormatters<T> {
   formatters: Formatters
 }
 

--- a/packages/react-intl/examples/BUILD.bazel
+++ b/packages/react-intl/examples/BUILD.bazel
@@ -3,6 +3,7 @@ load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:http-server/package_json.bzl", "bin")
+load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
 
 npm_link_all_packages()
 
@@ -35,7 +36,7 @@ ts_project(
     declaration = True,
     out_dir = "examples-lib",
     resolve_json_module = True,
-    tsconfig = "//:tsconfig",
+    tsconfig = BASE_TSCONFIG,
     deps = EXAMPLES_SRC_DEPS,
 )
 

--- a/packages/react-intl/src/types.ts
+++ b/packages/react-intl/src/types.ts
@@ -22,15 +22,13 @@ export type IntlConfig = Omit<
 > &
   Partial<typeof DEFAULT_INTL_CONFIG>
 
-export interface ResolvedIntlConfig
-  extends CoreResolvedIntlConfig<React.ReactNode> {
+export interface ResolvedIntlConfig extends CoreResolvedIntlConfig<React.ReactNode> {
   textComponent?: React.ComponentType | keyof React.JSX.IntrinsicElements
   wrapRichTextChunksInFragment?: boolean
 }
 
 export interface IntlShape
-  extends ResolvedIntlConfig,
-    IntlFormatters<React.ReactNode> {
+  extends ResolvedIntlConfig, IntlFormatters<React.ReactNode> {
   formatMessage(
     this: void,
     descriptor: MessageDescriptor,

--- a/packages/ts-transformer/integration-tests/integration/jest.config.js
+++ b/packages/ts-transformer/integration-tests/integration/jest.config.js
@@ -6,9 +6,7 @@ module.exports = {
       astTransformers: {
         before: [
           {
-            path: require.resolve(
-              '@formatjs/ts-transformer/ts-jest-integration'
-            ),
+            path: require.resolve('@formatjs/ts-transformer/ts-jest-integration'),
             options: {
               // options
               overrideIdFn: '[sha512:contenthash:base64:6]',

--- a/packages/utils/BUILD.bazel
+++ b/packages/utils/BUILD.bazel
@@ -10,7 +10,6 @@ npm_link_all_packages()
 
 exports_files([
     "package.json",
-    "tsconfig.json",
 ])
 
 PACKAGE_NAME = "utils"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -284,8 +284,8 @@ importers:
         specifier: ^1.2.8
         version: 1.2.8
       prettier:
-        specifier: ^3.3.3
-        version: 3.6.2
+        specifier: ^3.7.4
+        version: 3.7.4
       react:
         specifier: '18'
         version: 18.3.1
@@ -8913,8 +8913,8 @@ packages:
     resolution: {integrity: sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==}
     engines: {node: '>=4'}
 
-  prettier@3.6.2:
-    resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
+  prettier@3.7.4:
+    resolution: {integrity: sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -21067,7 +21067,7 @@ snapshots:
 
   prepend-http@2.0.0: {}
 
-  prettier@3.6.2: {}
+  prettier@3.7.4: {}
 
   pretty-error@4.0.0:
     dependencies:

--- a/tools/index.bzl
+++ b/tools/index.bzl
@@ -64,7 +64,7 @@ def ts_compile(name, srcs, deps = [], skip_cjs = False, skip_esm = True, skip_es
             name = "%s-base" % name,
             srcs = srcs,
             declaration = True,
-            tsconfig = "//:tsconfig",
+            tsconfig = BASE_TSCONFIG,
             resolve_json_module = True,
             deps = deps,
         )

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "NodeNext",
-    "moduleResolution": "NodeNext",
+    "moduleResolution": "bundler",
     "target": "es5",
     "lib": [
       "dom",


### PR DESCRIPTION
### TL;DR

Upgrade Prettier to v3.7.4 and improve TypeScript configuration.

### What changed?

- Upgraded Prettier from v3.3.3 to v3.7.4
- Added `--log-level=warn` to Prettier CLI arguments to reduce success message spam
- Changed TypeScript `moduleResolution` from `NodeNext` to `bundler` in the root tsconfig
- Removed unnecessary `tsconfig.json` exports from several packages
- Fixed multiline interface formatting in various TypeScript files
- Updated BUILD.bazel files to use a consistent TypeScript configuration

### How to test?

1. Run Prettier on the codebase to verify it works with the new version
2. Verify TypeScript compilation works correctly with the updated moduleResolution
3. Build the project to ensure all BUILD.bazel changes are working properly

### Why make this change?

- The Prettier upgrade brings the latest improvements and bug fixes
- Setting log level to warn reduces unnecessary output during successful formatting
- The TypeScript moduleResolution change to "bundler" provides better compatibility with modern module systems
- Removing unnecessary exports and standardizing TypeScript configuration improves build consistency