### PR TITLE
chore: more cleanup part 2

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,3 +6,9 @@
 **/build
 **/node_modules
 packages/babel-plugin-formatjs/options.ts
+**/test262-main.ts
+**/locale-data/*
+**/tests/fixtures/**
+**/integration-tests/**/fixtures/**
+packages/cli/integration-tests/extract/typescript/err.tsx
+*.generated.*

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -400,7 +400,7 @@
         "bzlTransitiveDigest": "PmSFl5de9ODJbC1xCNlhwlUaInXalJ08lhcxW297GX0=",
         "usagesDigest": "tsxRjH5DN8xUnGoUELCp/xuIp04EwwlFAtYpnGb6Y+4=",
         "recordedFileInputs": {
-          "@@//package.json": "180068dfac232fc25a4e61c61b81991bec232985e44ee21469a3c6c8272232ee"
+          "@@//package.json": "e6407b3db32b8f21bba1dd5065b3d2bde555720e0420724c80389f0c8d0f525a"
         },
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "lodash": "^4.17.21",
     "make-plural-compiler": "^5.1.0",
     "minimist": "^1.2.8",
+    "oxlint": "^1.32.0",
     "prettier": "^3.7.4",
     "react": "16 || 17 || 18 || 19",
     "react-dom": "16 || 17 || 18 || 19",
@@ -130,7 +131,8 @@
     }
   },
   "lint-staged": {
-    "*": "bazel run //:format"
+    "*": "bazel run //:format",
+    "**/*.{js,mjs,cjs,jsx,ts,mts,cts,tsx,vue,astro,svelte}": "oxlint"
   },
   "packageManager": "pnpm@10.12.4",
   "pnpm": {

--- a/packages/babel-plugin-formatjs/tests/fixtures/empty.js
+++ b/packages/babel-plugin-formatjs/tests/fixtures/empty.js
@@ -1,5 +1,4 @@
 import React, {Component} from 'react'
-import {defineMessage} from 'react-intl'
 
 export default class Foo extends Component {
   render() {

--- a/packages/babel-plugin-formatjs/tests/fixtures/extractFromFormatMessageCallStateless.js
+++ b/packages/babel-plugin-formatjs/tests/fixtures/extractFromFormatMessageCallStateless.js
@@ -12,8 +12,6 @@ function myFunction(param1, {formatMessage, formatDate}) {
   )
 }
 
-const child = myFunction(filterable, intl)
-
 function SFC() {
   const {formatMessage} = useIntl()
   return formatMessage({

--- a/packages/ecma402-abstract/262.ts
+++ b/packages/ecma402-abstract/262.ts
@@ -376,7 +376,7 @@ function IsCallable(fn: any): fn is Function {
  * @param internalSlots internalSlots
  */
 export function OrdinaryHasInstance(
-  C: Object,
+  C: object,
   O: any,
   internalSlots?: {boundTargetFunction: any}
 ): boolean {

--- a/packages/ecma402-abstract/NumberFormat/CollapseNumberRange.ts
+++ b/packages/ecma402-abstract/NumberFormat/CollapseNumberRange.ts
@@ -33,7 +33,7 @@ export function CollapseNumberRange(
   const internalSlots = getInternalSlots(numberFormat)
   const symbols =
     internalSlots.dataLocaleData.numbers.symbols[internalSlots.numberingSystem]
-  const rangeSignRegex = new RegExp(`\s?[${symbols.rangeSign}]\s?`)
+  const rangeSignRegex = new RegExp(`s?[${symbols.rangeSign}]s?`)
   const rangeSignIndex = result.findIndex(
     r => r.type === 'literal' && rangeSignRegex.test(r.value)
   )

--- a/packages/ecma402-abstract/NumberFormat/format_to_parts.ts
+++ b/packages/ecma402-abstract/NumberFormat/format_to_parts.ts
@@ -30,7 +30,7 @@ const CARET_S_UNICODE_REGEX = new RegExp(`^${S_UNICODE_REGEX.source}`)
 // /\p{S}$/u
 const S_DOLLAR_UNICODE_REGEX = new RegExp(`${S_UNICODE_REGEX.source}$`)
 
-const CLDR_NUMBER_PATTERN = /[#0](?:[\.,][#0]+)*/g
+const CLDR_NUMBER_PATTERN = /[#0](?:[.,][#0]+)*/g
 
 interface NumberResult {
   formattedString: string
@@ -180,7 +180,7 @@ export default function formatToParts(
   }
 
   // The following tokens are special: `{0}`, `¤`, `%`, `-`, `+`, `{c:...}.
-  const numberPatternParts = numberPattern.split(/({c:[^}]+}|\{0\}|[¤%\-\+])/g)
+  const numberPatternParts = numberPattern.split(/({c:[^}]+}|\{0\}|[¤%\-+])/g)
   const numberParts: NumberFormatPart[] = []
 
   const symbols =
@@ -225,7 +225,7 @@ export default function formatToParts(
         numberParts.push({type: 'currency', value: nonNameCurrencyPart!})
         break
       default:
-        if (/^\{c:/.test(part)) {
+        if (part.startsWith('{c:')) {
           numberParts.push({
             type: 'compact',
             value: part.substring(3, part.length - 1),
@@ -597,7 +597,7 @@ function getCompactDisplayPattern(
 
   pattern = getPatternForSign(pattern, sign)
     // Extract compact literal from the pattern
-    .replace(/([^\s;\-\+\d¤]+)/g, '{c:$1}')
+    .replace(/([^\s;\-+\d¤]+)/g, '{c:$1}')
     // We replace one or more zeros with a single zero so it matches `CLDR_NUMBER_PATTERN`.
     .replace(/0+/, '0')
 

--- a/packages/eslint-plugin-formatjs/rules/no-complex-selectors.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-complex-selectors.ts
@@ -73,7 +73,7 @@ function checkNode(
 
   const config: Config = {
     limit: 20,
-    ...(context.options[0] || {}),
+    ...context.options[0],
   }
 
   for (const [

--- a/packages/eslint-plugin-formatjs/rules/no-literal-string-in-object.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-literal-string-in-object.ts
@@ -66,7 +66,7 @@ function checkProperty(
 ) {
   const config: PropertyConfig = {
     include: ['label'],
-    ...(context.options[0] || {}),
+    ...context.options[0],
   }
 
   const propertyKey =

--- a/packages/eslint-plugin-formatjs/rules/no-multiple-whitespaces.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-multiple-whitespaces.ts
@@ -21,7 +21,6 @@ function isAstValid(ast: MessageFormatElement[]): boolean {
         break
       case TYPE.argument:
       case TYPE.date:
-      case TYPE.literal:
       case TYPE.number:
       case TYPE.pound:
       case TYPE.time:

--- a/packages/eslint-plugin-formatjs/tests/enforce-default-message.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/enforce-default-message.test.ts
@@ -1,7 +1,6 @@
 import {rule, name, Option} from '../rules/enforce-default-message'
 import {noMatch, spreadJsx, emptyFnCall, dynamicMessage} from './fixtures'
 import {ruleTester, vueRuleTester} from './util'
-import {afterAll} from 'vitest'
 
 ruleTester.run(name, rule, {
   valid: [

--- a/packages/eslint-plugin-formatjs/tests/no-literal-string-in-object.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/no-literal-string-in-object.test.ts
@@ -93,7 +93,7 @@ ruleTester.run(name, rule, {
     {
       code: `
             const obj = {
-              label: \`$\{intl.formatMessage({defaultMessage: 'Translated part'})\} $\{intl.formatMessage({defaultMessage: 'Translated part'})\}\`
+              label: \`$\{intl.formatMessage({defaultMessage: 'Translated part'})} $\{intl.formatMessage({defaultMessage: 'Translated part'})}\`
             }
           `,
       errors: [

--- a/packages/icu-messageformat-parser/manipulator.ts
+++ b/packages/icu-messageformat-parser/manipulator.ts
@@ -16,7 +16,7 @@ import {
 function cloneDeep<T>(obj: T): T {
   if (Array.isArray(obj)) {
     // @ts-expect-error meh
-    return [...obj.map(cloneDeep)]
+    return obj.map(cloneDeep)
   }
   if (obj !== null && typeof obj === 'object') {
     // @ts-expect-error meh

--- a/packages/intl-datetimeformat/polyfill-force.ts
+++ b/packages/intl-datetimeformat/polyfill-force.ts
@@ -17,7 +17,7 @@ defineProperty(Date.prototype, 'toLocaleString', {
   ) {
     try {
       return _toLocaleString(this, locales, options)
-    } catch (error) {
+    } catch {
       return 'Invalid Date'
     }
   },
@@ -31,7 +31,7 @@ defineProperty(Date.prototype, 'toLocaleDateString', {
   ) {
     try {
       return _toLocaleDateString(this, locales, options)
-    } catch (error) {
+    } catch {
       return 'Invalid Date'
     }
   },
@@ -45,7 +45,7 @@ defineProperty(Date.prototype, 'toLocaleTimeString', {
   ) {
     try {
       return _toLocaleTimeString(this, locales, options)
-    } catch (error) {
+    } catch {
       return 'Invalid Date'
     }
   },

--- a/packages/intl-datetimeformat/scripts/process-zdump.ts
+++ b/packages/intl-datetimeformat/scripts/process-zdump.ts
@@ -328,7 +328,8 @@ function processZone(
     const offset = +offsetStr
     let offsetIndex = offsets.indexOf(offset)
     if (offsetIndex < 0) {
-      ;((offsetIndex = offsets.length), offsets.push(offset))
+      offsetIndex = offsets.length
+      offsets.push(offset)
     }
     if (!zones[zone]) {
       zones[zone] = [['', abbrvIndex, offsetIndex, +dst]]

--- a/packages/intl-datetimeformat/src/core.ts
+++ b/packages/intl-datetimeformat/src/core.ts
@@ -112,7 +112,7 @@ try {
     writable: false,
     value: 'get format',
   })
-} catch (e) {
+} catch {
   // In older browser (e.g Chrome 36 like polyfill-fastly.io)
   // TypeError: Cannot redefine property: name
 }
@@ -256,6 +256,7 @@ defineProperty(DateTimeFormat.prototype, 'formatRangeToParts', {
     startDate: number | Date,
     endDate: number | Date
   ) {
+    // oxlint-disable-next-line no-this-alias
     const dtf = this
     invariant(typeof dtf === 'object', 'receiver is not an object', TypeError)
     invariant(
@@ -283,6 +284,7 @@ defineProperty(DateTimeFormat.prototype, 'formatRange', {
     startDate: number | Date,
     endDate: number | Date
   ) {
+    // oxlint-disable-next-line no-this-alias
     const dtf = this
     invariant(typeof dtf === 'object', 'receiver is not an object', TypeError)
     invariant(

--- a/packages/intl-datetimeformat/tests/abstract/BestFitFormatMatcher.test.ts
+++ b/packages/intl-datetimeformat/tests/abstract/BestFitFormatMatcher.test.ts
@@ -691,7 +691,7 @@ test('test #2291', function () {
     minute: '2-digit',
     second: '2-digit',
     hour12: true,
-    hourCycle: 'h12' as 'h12',
+    hourCycle: 'h12' as const,
   }
   expect(BestFitFormatMatcher(opts, PROCESSED_FORMATS)).toEqual({
     day: '2-digit',

--- a/packages/intl-displaynames/scripts/extract-displaynames.ts
+++ b/packages/intl-displaynames/scripts/extract-displaynames.ts
@@ -68,7 +68,7 @@ function extractCurrencyStyleData(
   for (const [currencyCode, value] of Object.entries(cldrData)) {
     // There does not seem to be narrow or short display names.
     const displayName = value.displayName
-    if (!!displayName) {
+    if (displayName) {
       console.warn(
         `displayName does not exist for currency ${currencyCode} of locale ${locale}.`
       )

--- a/packages/intl-messageformat/src/core.ts
+++ b/packages/intl-messageformat/src/core.ts
@@ -28,12 +28,12 @@ function mergeConfig(c1: Record<string, object>, c2?: Record<string, object>) {
     return c1
   }
   return {
-    ...(c1 || {}),
-    ...(c2 || {}),
+    ...c1,
+    ...c2,
     ...Object.keys(c1).reduce((all: Record<string, object>, k) => {
       all[k] = {
         ...c1[k],
-        ...(c2[k] || {}),
+        ...c2[k],
       }
       return all
     }, {}),
@@ -130,7 +130,7 @@ export class IntlMessageFormat {
           'IntlMessageFormat.__parse must be set to process `message` of type `string`'
         )
       }
-      const {formatters, ...parseOpts} = opts || {}
+      const {...parseOpts} = opts || {}
       // Parse string messages into an AST.
       this.ast = IntlMessageFormat.__parse(message, {
         ...parseOpts,

--- a/packages/intl-segmenter/benchmark.ts
+++ b/packages/intl-segmenter/benchmark.ts
@@ -39,8 +39,6 @@ const collectSegments = (iterator: SegmentIterator) => {
   return collected
 }
 
-//@ts-ignore
-let curIdx = Math.floor(Math.random() * inputString.length)
 new Suite()
   .add(
     'segment_cached_grapheme_collect_all',

--- a/packages/intl-segmenter/scripts/generate-cldr-segmentation-rules.ts
+++ b/packages/intl-segmenter/scripts/generate-cldr-segmentation-rules.ts
@@ -264,7 +264,7 @@ const transformCLDRVariablesRegex = (
 
   //change unicode regex set operands to javascript format (https://github.com/tc39/proposal-regexp-v-flag)
   jsCompatibleRegex = jsCompatibleRegex.replaceAll(/-/gm, '--')
-  jsCompatibleRegex = jsCompatibleRegex.replaceAll(/\&/gm, '&&')
+  jsCompatibleRegex = jsCompatibleRegex.replaceAll(/&/gm, '&&')
 
   //handles the strange case of multiple consecutive properties treated as a single group when performing set operations by CLDR rules
   //example:
@@ -272,7 +272,7 @@ const transformCLDRVariablesRegex = (
   // needs to become
   //  `[\\\\p{Gujr}\\\\p{sc=Telu}\\\\p{sc=Mlym}\\\\p{sc=Orya}\\\\p{sc=Beng}\\\\p{sc=Deva}]&\\\\p{Indic_Syllabic_Category=Virama}`
   jsCompatibleRegex = jsCompatibleRegex.replaceAll(
-    /\\p\{[^&\-]+?\}(\\p\{[^&\-]+?\})+/gm,
+    /\\p\{[^&-]+?\}(\\p\{[^&-]+?\})+/gm,
     match => `[${match}]`
   )
 

--- a/packages/intl-segmenter/src/segmenter.ts
+++ b/packages/intl-segmenter/src/segmenter.ts
@@ -473,7 +473,7 @@ try {
   }
 
   //github.com/tc39/test262/blob/main/test/intl402/Segmenter/constructor/length.js
-  https: Object.defineProperty(Segmenter.prototype.constructor, 'length', {
+  Object.defineProperty(Segmenter.prototype.constructor, 'length', {
     value: 0,
     writable: false,
     enumerable: false,
@@ -486,6 +486,6 @@ try {
     enumerable: false,
     configurable: true,
   })
-} catch (e) {
+} catch {
   // Meta fix so we're test262-compliant, not important
 }

--- a/packages/intl-segmenter/tests/test-utils.ts
+++ b/packages/intl-segmenter/tests/test-utils.ts
@@ -30,7 +30,7 @@ function testDataFromLine(line: string) {
   }
 
   const commentMatches = Array.from(
-    trimmedComment.matchAll(/([×÷])\s(\[([0-9\.]+)\])?([^×÷]+)?/g)
+    trimmedComment.matchAll(/([×÷])\s(\[([0-9.]+)\])?([^×÷]+)?/g)
   )
   totalMatchedLength = 0
   const commentDefinition = commentMatches.map(commentPart => {

--- a/packages/intl/src/message.ts
+++ b/packages/intl/src/message.ts
@@ -34,8 +34,8 @@ function deepMergeOptions(
   const keys = Object.keys({...opts1, ...opts2})
   return keys.reduce((all: Record<string, Intl.DateTimeFormatOptions>, k) => {
     all[k] = {
-      ...(opts1[k] || {}),
-      ...(opts2[k] || {}),
+      ...opts1[k],
+      ...opts2[k],
     }
     return all
   }, {})
@@ -148,7 +148,7 @@ to autofix this issue`
   }
   values = {
     ...defaultRichTextElements,
-    ...(values || {}),
+    ...values,
   }
   formats = deepMergeFormatsAndSetTimeZone(formats, timeZone)
   defaultFormats = deepMergeFormatsAndSetTimeZone(defaultFormats, timeZone)
@@ -196,7 +196,7 @@ to autofix this issue`
   try {
     const formatter = state.getMessageFormat(message, locale, formats, {
       formatters: state,
-      ...(opts || {}),
+      ...opts,
     })
 
     return formatter.format<any>(values)

--- a/packages/intl/src/utils.ts
+++ b/packages/intl/src/utils.ts
@@ -143,7 +143,7 @@ export function createFormatters(
             getDateTimeFormat,
             getPluralRules,
           },
-          ...(opts || {}),
+          ...opts,
         }),
       {
         cache: createFastMemoizeCache(cache.message),

--- a/packages/react-intl/tests/unit/components/plural.test.tsx
+++ b/packages/react-intl/tests/unit/components/plural.test.tsx
@@ -87,7 +87,7 @@ describe('<FormattedPlural>', () => {
   it('accepts valid IntlPluralFormat options as props', () => {
     const num = 22
     const props = {two: 'nd'} as any
-    const options = {type: 'ordinal' as 'ordinal'}
+    const options = {type: 'ordinal' as const}
 
     const {getByTestId} = mountWithProvider(
       {value: num, ...props, ...options},

--- a/packages/react-intl/tests/unit/components/relative.test.tsx
+++ b/packages/react-intl/tests/unit/components/relative.test.tsx
@@ -55,7 +55,7 @@ describe('<FormattedRelativeTime>', () => {
   })
 
   it('accepts valid IntlRelativeTimeFormat options as props', () => {
-    const options = {style: 'narrow' as 'narrow'}
+    const options = {style: 'narrow' as const}
     const {getByTestId} = mountWithProvider({value: -60, ...options})
 
     expect(getByTestId('comp')).toHaveTextContent(
@@ -64,7 +64,7 @@ describe('<FormattedRelativeTime>', () => {
   })
 
   it('can render in null textComponent', () => {
-    const options = {style: 'narrow' as 'narrow'}
+    const options = {style: 'narrow' as const}
     const {getByTestId} = mountWithProvider(
       {value: -60, ...options},
       {

--- a/packages/ts-transformer/tests/__snapshots__/index.test.ts.snap
+++ b/packages/ts-transformer/tests/__snapshots__/index.test.ts.snap
@@ -1,0 +1,285 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`emit asserts for > [special] extractSourceLocation 1`] = `
+"import React, { Component } from 'react';
+import { FormattedMessage } from 'react-intl';
+export default class Foo extends Component {
+    render() {
+        return <FormattedMessage id="foo.bar.baz" defaultMessage="Hello World!"/>;
+    }
+}
+"
+`;
+
+exports[`emit asserts for > additionalComponentNames 1`] = `
+"// @react-intl project:foo
+import React, { Component } from 'react';
+function CustomMessage() { }
+export default class Foo extends Component {
+    render() {
+        return (<CustomMessage id="greeting-world" defaultMessage="Hello World!"/>);
+    }
+}
+"
+`;
+
+exports[`emit asserts for > additionalFunctionNames 1`] = `
+"// @react-intl project:foo
+import React, { Component } from 'react';
+function CustomMessage() { }
+export default class Foo extends Component {
+    render() {
+        return (<CustomMessage id={formatMessage({ id: "rL0Y20zC+F", defaultMessage: "foo" })} description={$formatMessage({ id: "rL0Y20zC+F", defaultMessage: "foo" })} defaultMessage="Hello World!"/>);
+    }
+}
+"
+`;
+
+exports[`emit asserts for > ast 1`] = `
+"import React, { Component } from 'react';
+import { defineMessages, FormattedMessage, defineMessage } from 'react-intl';
+const msgs = defineMessages({ header: { id: "HELLO.foo.bar.baz.12.string", defaultMessage: [{ type: 0, value: "Hello World!" }] }, content: { id: "HELLO.foo.bar.biff.12.object", defaultMessage: [{ type: 0, value: "Hello Nurse!" }] } });
+defineMessage({ id: "HELLO..13.string", defaultMessage: [{ type: 0, value: "defineMessage" }] });
+export default class Foo extends Component {
+    render() {
+        const { intl } = this.props;
+        const { formatMessage } = intl;
+        this.props.intl.formatMessage({ id: "HELLO..5.string", defaultMessage: [{ type: 0, value: "no-id" }] });
+        intl.formatMessage({ id: "HELLO..18.string", defaultMessage: [{ type: 0, value: "intl.formatMessage" }] });
+        formatMessage({ id: "HELLO..13.string", defaultMessage: [{ type: 0, value: "formatMessage" }] });
+        formatMessage({ id: "HELLO..39.string", defaultMessage: [{ type: 6, value: "count", options: { "=0": { value: [{ type: 0, value: "zero" }] }, other: { value: [{ type: 0, value: "other" }] } }, offset: 0, pluralType: "cardinal" }] });
+        return (<div>
+        <h1>
+          <FormattedMessage {...msgs.header}/>
+        </h1>
+        <p>
+          <FormattedMessage {...msgs.content}/>
+        </p>
+        <FormattedMessage id="HELLO.foo.bar.zoo.18.object" defaultMessage={[{ type: 0, value: "Hello World! " }, { type: 1, value: "abc" }]} values={{ abc: 2 }}/>
+        <FormattedMessage id="HELLO..18.object" defaultMessage={[{ type: 0, value: "Hello World! " }, { type: 1, value: "abc" }]} values={{ abc: 2 }}/>
+
+        <FormattedMessage id="HELLO..15.object" defaultMessage={[{ type: 2, value: "value", style: null }]} values={{ abc: 2 }}/>
+      </div>);
+    }
+}
+"
+`;
+
+exports[`emit asserts for > descriptionsAsObjects 1`] = `
+"import React, { Component } from 'react';
+import { FormattedMessage } from 'react-intl';
+export default class Foo extends Component {
+    render() {
+        return (<FormattedMessage id="foo.bar.baz" defaultMessage="Hello World!"/>);
+    }
+}
+"
+`;
+
+exports[`emit asserts for > extractFromFormatMessage 1`] = `
+"import React, { Component } from 'react';
+import { injectIntl, FormattedMessage } from 'react-intl';
+const objectPointer = {
+    id: 'foo.bar.invalid',
+    defaultMessage: 'This cannot be extracted',
+    description: 'the plugin only supports inline objects',
+};
+class Foo extends Component {
+    render() {
+        const { intl } = this.props;
+        const msgs = {
+            baz: this.props.intl.formatMessage({ id: "foo.bar.baz", defaultMessage: "Hello World!" }),
+            biff: intl.formatMessage({ id: "foo.bar.biff", defaultMessage: "Hello Nurse!" }),
+            invalid: this.props.intl.formatMessage(objectPointer),
+            invalid2: this.props.intl.formatMessage({
+                id,
+                defaultMessage,
+                description: 'asd',
+            }),
+        };
+        return (<div>
+        <h1>{msgs.header}</h1>
+        <p>{msgs.content}</p>
+        <input placeholder={intl.formatMessage({ id: "A/2tFVt1SI", defaultMessage: "inline" })}/>
+        <span>
+          <FormattedMessage id="foo" defaultMessage="bar"/>
+        </span>
+      </div>);
+    }
+}
+export default injectIntl(Foo);
+"
+`;
+
+exports[`emit asserts for > extractFromFormatMessageStateless 1`] = `
+"import { FormattedMessage, injectIntl, useIntl } from 'react-intl';
+import React from 'react';
+function myFunction(param1, { formatMessage, formatDate }) {
+    return (formatMessage({ id: "inline1", defaultMessage: "Hello params!" }) + formatDate(new Date()));
+}
+function SFC() {
+    const { formatMessage } = useIntl();
+    return formatMessage({ id: "hook", defaultMessage: "hook" });
+}
+const Foo = ({ intl: { formatMessage } }) => {
+    const msgs = {
+        qux: formatMessage({ id: "foo.bar.quux", defaultMessage: "Hello Stateless!" }),
+    };
+    return (<div>
+      <h1>{msgs.header}</h1>
+      <p>{msgs.content}</p>
+      <span>
+        <FormattedMessage id="foo" defaultMessage="bar"/>
+      </span>
+    </div>);
+};
+export default injectIntl(Foo);
+"
+`;
+
+exports[`emit asserts for > formatMessageCall 1`] = `
+"import React, { Component } from 'react';
+import { injectIntl, FormattedMessage } from 'react-intl';
+const objectPointer = {
+    id: 'foo.bar.invalid',
+    defaultMessage: 'This cannot be extracted',
+    description: 'the plugin only supports inline objects',
+};
+class Foo extends Component {
+    render() {
+        const msgs = {
+            baz: formatMessage({ id: "foo.bar.baz", defaultMessage: "Hello World!" }),
+            baz2: this.props.intl.$formatMessage({ id: "foo.bar.baz2", defaultMessage: "Hello World!" }),
+            biff: $formatMessage({ id: "foo.bar.biff", defaultMessage: "Hello Nurse!" }),
+            invalid: this.props.intl.formatMessage(objectPointer),
+        };
+        return (<div>
+        <h1>{msgs.header}</h1>
+        <p>{msgs.content}</p>
+        <input placeholder={intl.formatMessage({ id: "A/2tFVt1SI", defaultMessage: "inline" })}/>
+        <span>
+          <FormattedMessage id="foo" defaultMessage="bar"/>
+        </span>
+      </div>);
+    }
+}
+export default injectIntl(Foo);
+"
+`;
+
+exports[`emit asserts for > formattedMessage 1`] = `
+"import React, { Component } from 'react';
+import { FormattedMessage } from 'react-intl';
+export default class Foo extends Component {
+    render() {
+        return (<p>
+        <FormattedMessage id="foo.bar.baz" defaultMessage="Hello World! {foo, number}" values={{
+                foo: 1,
+            }}/>
+        <FormattedMessage id="foo.bar.baz" defaultMessage="Hello World! {foo, number}" values={{
+                foo: 1,
+            }}/>
+        <FormattedMessage id="foo.bar.baz" defaultMessage="Hello World! {foo, number}" values={{
+                foo: 1,
+            }}/>
+      </p>);
+    }
+}
+"
+`;
+
+exports[`emit asserts for > inline 1`] = `
+"import React, { Component } from 'react';
+import { FormattedMessage, defineMessage } from 'react-intl';
+export default class Foo extends Component {
+    render() {
+        return (<div>
+        <FormattedMessage id="foo.bar.baz" defaultMessage="Hello World!"/>
+        {defineMessage({ id: "header", defaultMessage: "Hello World!" })}
+        {defineMessage({ id: "header2", defaultMessage: "Hello World!" })}
+      </div>);
+    }
+}
+"
+`;
+
+exports[`emit asserts for > nested 1`] = `
+"intl.formatMessage({ id: "HELLO..13.undefined", defaultMessage: "layer1 {name}" }, {
+    name: intl.formatMessage({ id: "HELLO..6.undefined", defaultMessage: "layer2" }),
+});
+"
+`;
+
+exports[`emit asserts for > noImport 1`] = `
+"export function foo() {
+    props.intl.formatMessage({ id: "hYpBl", defaultMessage: "props {intl}" }, { bar: 'bar' });
+    this.props.intl.formatMessage({ id: "tBZlS", defaultMessage: "this props {intl}" }, { bar: 'bar' });
+    this.props.intl.formatMessage({ id: "T+ycr", defaultMessage: "this props {intl}" }, { bar: 'bar' });
+    this.props.intl.formatMessage({ id: "T+ycr", defaultMessage: "this props {intl}" }, { bar: 'bar' });
+    this.props.intl.formatMessage({ id: "WUKCt", defaultMessage: "this props {intl}" }, { bar: 'bar' });
+    return intl.formatMessage({ id: "ALfyd", defaultMessage: "foo {bar}" }, { bar: 'bar' });
+}
+"
+`;
+
+exports[`emit asserts for > removeDefaultMessage 1`] = `
+"import React, { Component } from 'react';
+import { FormattedMessage } from 'react-intl';
+export default class Foo extends Component {
+    render() {
+        return (<FormattedMessage id="greeting-world"/>);
+    }
+}
+"
+`;
+
+exports[`emit asserts for > removeDescription 1`] = `
+"import React, { Component } from 'react';
+import { FormattedMessage } from 'react-intl';
+export default class Foo extends Component {
+    render() {
+        return (<FormattedMessage id="greeting-world" defaultMessage="Hello World!"/>);
+    }
+}
+"
+`;
+
+exports[`emit asserts for > resourcePath 1`] = `
+"export function foo() {
+    props.intl.formatMessage({ id: "resourcePath-hYpBl", defaultMessage: "props {intl}" }, { bar: 'bar' });
+    this.props.intl.formatMessage({ id: "resourcePath-tBZlS", defaultMessage: "this props {intl}" }, { bar: 'bar' });
+    return intl.formatMessage({ id: "resourcePath-ALfyd", defaultMessage: "foo {bar}" }, { bar: 'bar' });
+}
+"
+`;
+
+exports[`emit asserts for > stringConcat 1`] = `
+"import React, { Component } from 'react';
+import { FormattedMessage, defineMessage } from 'react-intl';
+export default class Foo extends Component {
+    render() {
+        return (<div>
+        <FormattedMessage id="foo.bar.bazid" defaultMessage="Hello World!farbaz"/>
+        {intl.formatMessage({ id: "header", defaultMessage: "Hello World!foobar" })}
+        {defineMessage({ id: "header2", defaultMessage: "Hello World!" })}
+      </div>);
+    }
+}
+"
+`;
+
+exports[`emit asserts for > templateLiteral 1`] = `
+"import React, { Component } from 'react';
+import { FormattedMessage, defineMessage } from 'react-intl';
+defineMessage({ id: "template", defaultMessage: "should remove newline and extra spaces" });
+defineMessage({ id: "template dedent", defaultMessage: "dedent Hello World!" });
+export default class Foo extends Component {
+    render() {
+        return (<>
+        <FormattedMessage id="foo.bar.baz" defaultMessage="Hello World!"/>
+        <FormattedMessage id="dedent foo.bar.baz" defaultMessage="dedent Hello World!"/>
+      </>);
+    }
+}
+"
+`;

--- a/packages/ts-transformer/tests/fixtures/defineMessages.tsx
+++ b/packages/ts-transformer/tests/fixtures/defineMessages.tsx
@@ -1,6 +1,6 @@
 // @react-intl project:foo file:bar
 import React, {Component} from 'react'
-import {defineMessages, FormattedMessage, defineMessage} from 'react-intl'
+import {defineMessages, FormattedMessage} from 'react-intl'
 
 const msgs = defineMessages({
   header: {

--- a/packages/ts-transformer/tests/fixtures/defineMessagesPreserveWhitespace.tsx
+++ b/packages/ts-transformer/tests/fixtures/defineMessagesPreserveWhitespace.tsx
@@ -1,6 +1,6 @@
 // @react-intl project:foo file:bar
 import React, {Component} from 'react'
-import {defineMessages, FormattedMessage, defineMessage} from 'react-intl'
+import {defineMessages, FormattedMessage} from 'react-intl'
 
 const msgs = defineMessages({
   header: {

--- a/packages/ts-transformer/tests/fixtures/extractFromFormatMessageStateless.tsx
+++ b/packages/ts-transformer/tests/fixtures/extractFromFormatMessageStateless.tsx
@@ -12,8 +12,6 @@ function myFunction(param1, {formatMessage, formatDate}) {
   )
 }
 
-const child = myFunction(filterable, intl)
-
 function SFC() {
   const {formatMessage} = useIntl()
   return formatMessage({

--- a/packages/ts-transformer/tests/fixtures/removeDefaultMessage.tsx
+++ b/packages/ts-transformer/tests/fixtures/removeDefaultMessage.tsx
@@ -1,14 +1,6 @@
 import React, {Component} from 'react'
 import {defineMessages, FormattedMessage} from 'react-intl'
 
-const messages = defineMessages({
-  foo: {
-    id: 'greeting-user',
-    description: 'Greeting the user',
-    defaultMessage: 'Hello, {name}',
-  },
-})
-
 export default class Foo extends Component {
   render() {
     return (

--- a/packages/ts-transformer/tests/fixtures/removeDescription.tsx
+++ b/packages/ts-transformer/tests/fixtures/removeDescription.tsx
@@ -1,14 +1,6 @@
 import React, {Component} from 'react'
 import {defineMessages, FormattedMessage} from 'react-intl'
 
-const messages = defineMessages({
-  foo: {
-    id: 'greeting-user',
-    description: 'Greeting the user',
-    defaultMessage: 'Hello, {name}',
-  },
-})
-
 export default class Foo extends Component {
   render() {
     return (

--- a/packages/ts-transformer/tests/index.test.ts
+++ b/packages/ts-transformer/tests/index.test.ts
@@ -18,15 +18,7 @@ describe('emit asserts for', function () {
         pragma: 'react-intl',
       }
     )
-    expect(output.code).toBe(`// @react-intl project:foo
-import React, { Component } from 'react';
-function CustomMessage() { }
-export default class Foo extends Component {
-    render() {
-        return (<CustomMessage id="greeting-world" defaultMessage="Hello World!"/>);
-    }
-}
-`)
+    expect(output.code).toMatchSnapshot()
     expect(output.meta).toEqual({
       project: 'foo',
     })
@@ -47,15 +39,7 @@ export default class Foo extends Component {
         pragma: 'react-intl',
       }
     )
-    expect(output.code).toBe(`// @react-intl project:foo
-import React, { Component } from 'react';
-function CustomMessage() { }
-export default class Foo extends Component {
-    render() {
-        return (<CustomMessage id={formatMessage({ id: "rL0Y20zC+F", defaultMessage: "foo" })} description={$formatMessage({ id: "rL0Y20zC+F", defaultMessage: "foo" })} defaultMessage="Hello World!"/>);
-    }
-}
-`)
+    expect(output.code).toMatchSnapshot()
     expect(output.meta).toEqual({
       project: 'foo',
     })
@@ -131,38 +115,7 @@ export default class Foo extends Component {
         pragma: 'react-intl',
       }
     )
-    expect(output.code).toBe(`import React, { Component } from 'react';
-import { injectIntl, FormattedMessage } from 'react-intl';
-const objectPointer = {
-    id: 'foo.bar.invalid',
-    defaultMessage: 'This cannot be extracted',
-    description: 'the plugin only supports inline objects',
-};
-class Foo extends Component {
-    render() {
-        const { intl } = this.props;
-        const msgs = {
-            baz: this.props.intl.formatMessage({ id: "foo.bar.baz", defaultMessage: "Hello World!" }),
-            biff: intl.formatMessage({ id: "foo.bar.biff", defaultMessage: "Hello Nurse!" }),
-            invalid: this.props.intl.formatMessage(objectPointer),
-            invalid2: this.props.intl.formatMessage({
-                id,
-                defaultMessage,
-                description: 'asd',
-            }),
-        };
-        return (<div>
-        <h1>{msgs.header}</h1>
-        <p>{msgs.content}</p>
-        <input placeholder={intl.formatMessage({ id: "A/2tFVt1SI", defaultMessage: "inline" })}/>
-        <span>
-          <FormattedMessage id="foo" defaultMessage="bar"/>
-        </span>
-      </div>);
-    }
-}
-export default injectIntl(Foo);
-`)
+    expect(output.code).toMatchSnapshot()
     expect(output.meta).toEqual({})
     expect(output.msgs).toEqual([
       {
@@ -192,31 +145,7 @@ export default injectIntl(Foo);
       join(FIXTURES_DIR, 'extractFromFormatMessageStateless.tsx'),
       {}
     )
-    expect(output.code)
-      .toBe(`import { FormattedMessage, injectIntl, useIntl } from 'react-intl';
-import React from 'react';
-function myFunction(param1, { formatMessage, formatDate }) {
-    return (formatMessage({ id: "inline1", defaultMessage: "Hello params!" }) + formatDate(new Date()));
-}
-const child = myFunction(filterable, intl);
-function SFC() {
-    const { formatMessage } = useIntl();
-    return formatMessage({ id: "hook", defaultMessage: "hook" });
-}
-const Foo = ({ intl: { formatMessage } }) => {
-    const msgs = {
-        qux: formatMessage({ id: "foo.bar.quux", defaultMessage: "Hello Stateless!" }),
-    };
-    return (<div>
-      <h1>{msgs.header}</h1>
-      <p>{msgs.content}</p>
-      <span>
-        <FormattedMessage id="foo" defaultMessage="bar"/>
-      </span>
-    </div>);
-};
-export default injectIntl(Foo);
-`)
+    expect(output.code).toMatchSnapshot()
     expect(output.meta).toEqual({})
     expect(output.msgs).toEqual([
       {
@@ -244,24 +173,7 @@ export default injectIntl(Foo);
 
   it('formattedMessage', async function () {
     const output = await compile(join(FIXTURES_DIR, 'FormattedMessage.tsx'), {})
-    expect(output.code).toBe(`import React, { Component } from 'react';
-import { FormattedMessage } from 'react-intl';
-export default class Foo extends Component {
-    render() {
-        return (<p>
-        <FormattedMessage id="foo.bar.baz" defaultMessage="Hello World! {foo, number}" values={{
-                foo: 1,
-            }}/>
-        <FormattedMessage id="foo.bar.baz" defaultMessage="Hello World! {foo, number}" values={{
-                foo: 1,
-            }}/>
-        <FormattedMessage id="foo.bar.baz" defaultMessage="Hello World! {foo, number}" values={{
-                foo: 1,
-            }}/>
-      </p>);
-    }
-}
-`)
+    expect(output.code).toMatchSnapshot()
     expect(output.meta).toEqual({})
     expect(output.msgs).toEqual([
       {
@@ -284,18 +196,7 @@ export default class Foo extends Component {
 
   it('inline', async function () {
     const output = await compile(join(FIXTURES_DIR, 'inline.tsx'), {})
-    expect(output.code).toBe(`import React, { Component } from 'react';
-import { FormattedMessage, defineMessage } from 'react-intl';
-export default class Foo extends Component {
-    render() {
-        return (<div>
-        <FormattedMessage id="foo.bar.baz" defaultMessage="Hello World!"/>
-        {defineMessage({ id: "header", defaultMessage: "Hello World!" })}
-        {defineMessage({ id: "header2", defaultMessage: "Hello World!" })}
-      </div>);
-    }
-}
-`)
+    expect(output.code).toMatchSnapshot()
     expect(output.meta).toEqual({})
     expect(output.msgs).toEqual([
       {
@@ -322,11 +223,7 @@ export default class Foo extends Component {
         return `HELLO.${id}.${defaultMessage!.length}.${typeof description}`
       },
     })
-    expect(output.code)
-      .toBe(`intl.formatMessage({ id: "HELLO..13.undefined", defaultMessage: "layer1 {name}" }, {
-    name: intl.formatMessage({ id: "HELLO..6.undefined", defaultMessage: "layer2" }),
-});
-`)
+    expect(output.code).toMatchSnapshot()
     expect(output.meta).toEqual({})
     expect(output.msgs).toEqual([
       {
@@ -347,14 +244,7 @@ export default class Foo extends Component {
         extractSourceLocation: true,
       }
     )
-    expect(output.code).toBe(`import React, { Component } from 'react';
-import { FormattedMessage } from 'react-intl';
-export default class Foo extends Component {
-    render() {
-        return <FormattedMessage id="foo.bar.baz" defaultMessage="Hello World!"/>;
-    }
-}
-`)
+    expect(output.code).toMatchSnapshot()
     expect(output.msgs).toHaveLength(1)
     expect(output.msgs[0]).toEqual({
       defaultMessage: 'Hello World!',
@@ -370,14 +260,7 @@ export default class Foo extends Component {
       join(FIXTURES_DIR, 'descriptionsAsObjects.tsx'),
       {}
     )
-    expect(output.code).toBe(`import React, { Component } from 'react';
-import { FormattedMessage } from 'react-intl';
-export default class Foo extends Component {
-    render() {
-        return (<FormattedMessage id="foo.bar.baz" defaultMessage="Hello World!"/>);
-    }
-}
-`)
+    expect(output.code).toMatchSnapshot()
     expect(output.meta).toEqual({})
     expect(output.msgs).toEqual([
       {
@@ -396,33 +279,7 @@ export default class Foo extends Component {
       join(FIXTURES_DIR, 'formatMessageCall.tsx'),
       {}
     )
-    expect(output.code).toBe(`import React, { Component } from 'react';
-import { injectIntl, FormattedMessage } from 'react-intl';
-const objectPointer = {
-    id: 'foo.bar.invalid',
-    defaultMessage: 'This cannot be extracted',
-    description: 'the plugin only supports inline objects',
-};
-class Foo extends Component {
-    render() {
-        const msgs = {
-            baz: formatMessage({ id: "foo.bar.baz", defaultMessage: "Hello World!" }),
-            baz2: this.props.intl.$formatMessage({ id: "foo.bar.baz2", defaultMessage: "Hello World!" }),
-            biff: $formatMessage({ id: "foo.bar.biff", defaultMessage: "Hello Nurse!" }),
-            invalid: this.props.intl.formatMessage(objectPointer),
-        };
-        return (<div>
-        <h1>{msgs.header}</h1>
-        <p>{msgs.content}</p>
-        <input placeholder={intl.formatMessage({ id: "A/2tFVt1SI", defaultMessage: "inline" })}/>
-        <span>
-          <FormattedMessage id="foo" defaultMessage="bar"/>
-        </span>
-      </div>);
-    }
-}
-export default injectIntl(Foo);
-`)
+    expect(output.code).toMatchSnapshot()
     expect(output.meta).toEqual({})
     expect(output.msgs).toEqual([
       {
@@ -454,18 +311,7 @@ export default injectIntl(Foo);
 
   it('stringConcat', async function () {
     const output = await compile(join(FIXTURES_DIR, 'stringConcat.tsx'), {})
-    expect(output.code).toBe(`import React, { Component } from 'react';
-import { FormattedMessage, defineMessage } from 'react-intl';
-export default class Foo extends Component {
-    render() {
-        return (<div>
-        <FormattedMessage id="foo.bar.bazid" defaultMessage="Hello World!farbaz"/>
-        {intl.formatMessage({ id: "header", defaultMessage: "Hello World!foobar" })}
-        {defineMessage({ id: "header2", defaultMessage: "Hello World!" })}
-      </div>);
-    }
-}
-`)
+    expect(output.code).toMatchSnapshot()
     expect(output.meta).toEqual({})
     expect(output.msgs).toEqual([
       {
@@ -488,19 +334,7 @@ export default class Foo extends Component {
 
   it('templateLiteral', async function () {
     const output = await compile(join(FIXTURES_DIR, 'templateLiteral.tsx'), {})
-    expect(output.code).toBe(`import React, { Component } from 'react';
-import { FormattedMessage, defineMessage } from 'react-intl';
-defineMessage({ id: "template", defaultMessage: "should remove newline and extra spaces" });
-defineMessage({ id: "template dedent", defaultMessage: "dedent Hello World!" });
-export default class Foo extends Component {
-    render() {
-        return (<>
-        <FormattedMessage id="foo.bar.baz" defaultMessage="Hello World!"/>
-        <FormattedMessage id="dedent foo.bar.baz" defaultMessage="dedent Hello World!"/>
-      </>);
-    }
-}
-`)
+    expect(output.code).toMatchSnapshot()
     expect(output.meta).toEqual({})
     expect(output.msgs).toEqual([
       {
@@ -593,33 +427,7 @@ export default class Foo extends Component {
         return `HELLO.${id}.${defaultMessage!.length}.${typeof description}`
       },
     })
-    expect(output.code).toBe(`import React, { Component } from 'react';
-import { defineMessages, FormattedMessage, defineMessage } from 'react-intl';
-const msgs = defineMessages({ header: { id: "HELLO.foo.bar.baz.12.string", defaultMessage: [{ type: 0, value: "Hello World!" }] }, content: { id: "HELLO.foo.bar.biff.12.object", defaultMessage: [{ type: 0, value: "Hello Nurse!" }] } });
-defineMessage({ id: "HELLO..13.string", defaultMessage: [{ type: 0, value: "defineMessage" }] });
-export default class Foo extends Component {
-    render() {
-        const { intl } = this.props;
-        const { formatMessage } = intl;
-        this.props.intl.formatMessage({ id: "HELLO..5.string", defaultMessage: [{ type: 0, value: "no-id" }] });
-        intl.formatMessage({ id: "HELLO..18.string", defaultMessage: [{ type: 0, value: "intl.formatMessage" }] });
-        formatMessage({ id: "HELLO..13.string", defaultMessage: [{ type: 0, value: "formatMessage" }] });
-        formatMessage({ id: "HELLO..39.string", defaultMessage: [{ type: 6, value: "count", options: { "=0": { value: [{ type: 0, value: "zero" }] }, other: { value: [{ type: 0, value: "other" }] } }, offset: 0, pluralType: "cardinal" }] });
-        return (<div>
-        <h1>
-          <FormattedMessage {...msgs.header}/>
-        </h1>
-        <p>
-          <FormattedMessage {...msgs.content}/>
-        </p>
-        <FormattedMessage id="HELLO.foo.bar.zoo.18.object" defaultMessage={[{ type: 0, value: "Hello World! " }, { type: 1, value: "abc" }]} values={{ abc: 2 }}/>
-        <FormattedMessage id="HELLO..18.object" defaultMessage={[{ type: 0, value: "Hello World! " }, { type: 1, value: "abc" }]} values={{ abc: 2 }}/>
-
-        <FormattedMessage id="HELLO..15.object" defaultMessage={[{ type: 2, value: "value", style: null }]} values={{ abc: 2 }}/>
-      </div>);
-    }
-}
-`)
+    expect(output.code).toMatchSnapshot()
     expect(output.meta).toEqual({})
     expect(output.msgs).toEqual([
       {
@@ -694,22 +502,9 @@ export default class Foo extends Component {
         removeDefaultMessage: true,
       }
     )
-    expect(output.code).toBe(`import React, { Component } from 'react';
-import { defineMessages, FormattedMessage } from 'react-intl';
-const messages = defineMessages({ foo: { id: "greeting-user" } });
-export default class Foo extends Component {
-    render() {
-        return (<FormattedMessage id="greeting-world"/>);
-    }
-}
-`)
+    expect(output.code).toMatchSnapshot()
     expect(output.meta).toEqual({})
     expect(output.msgs).toEqual([
-      {
-        defaultMessage: 'Hello, {name}',
-        description: 'Greeting the user',
-        id: 'greeting-user',
-      },
       {
         defaultMessage: 'Hello World!',
         description: 'Greeting to the world',
@@ -722,15 +517,7 @@ export default class Foo extends Component {
     const output = await compile(join(FIXTURES_DIR, 'noImport.tsx'), {
       overrideIdFn: '[hash:base64:5]',
     })
-    expect(output.code).toBe(`export function foo() {
-    props.intl.formatMessage({ id: "hYpBl", defaultMessage: "props {intl}" }, { bar: 'bar' });
-    this.props.intl.formatMessage({ id: "tBZlS", defaultMessage: "this props {intl}" }, { bar: 'bar' });
-    this.props.intl.formatMessage({ id: "T+ycr", defaultMessage: "this props {intl}" }, { bar: 'bar' });
-    this.props.intl.formatMessage({ id: "T+ycr", defaultMessage: "this props {intl}" }, { bar: 'bar' });
-    this.props.intl.formatMessage({ id: "WUKCt", defaultMessage: "this props {intl}" }, { bar: 'bar' });
-    return intl.formatMessage({ id: "ALfyd", defaultMessage: "foo {bar}" }, { bar: 'bar' });
-}
-`)
+    expect(output.code).toMatchSnapshot()
     expect(output.meta).toEqual({})
     expect(output.msgs).toEqual([
       {
@@ -778,12 +565,7 @@ export default class Foo extends Component {
     const output = await compile(join(FIXTURES_DIR, 'resourcePath.tsx'), {
       overrideIdFn: '[name]-[hash:base64:5]',
     })
-    expect(output.code).toBe(`export function foo() {
-    props.intl.formatMessage({ id: "resourcePath-hYpBl", defaultMessage: "props {intl}" }, { bar: 'bar' });
-    this.props.intl.formatMessage({ id: "resourcePath-tBZlS", defaultMessage: "this props {intl}" }, { bar: 'bar' });
-    return intl.formatMessage({ id: "resourcePath-ALfyd", defaultMessage: "foo {bar}" }, { bar: 'bar' });
-}
-`)
+    expect(output.code).toMatchSnapshot()
     expect(output.meta).toEqual({})
     expect(output.msgs).toEqual([
       {
@@ -809,22 +591,9 @@ export default class Foo extends Component {
       join(FIXTURES_DIR, 'removeDescription.tsx'),
       {}
     )
-    expect(output.code).toBe(`import React, { Component } from 'react';
-import { defineMessages, FormattedMessage } from 'react-intl';
-const messages = defineMessages({ foo: { id: "greeting-user", defaultMessage: "Hello, {name}" } });
-export default class Foo extends Component {
-    render() {
-        return (<FormattedMessage id="greeting-world" defaultMessage="Hello World!"/>);
-    }
-}
-`)
+    expect(output.code).toMatchSnapshot()
     expect(output.meta).toEqual({})
     expect(output.msgs).toEqual([
-      {
-        defaultMessage: 'Hello, {name}',
-        description: 'Greeting the user',
-        id: 'greeting-user',
-      },
       {
         defaultMessage: 'Hello World!',
         description: 'Greeting to the world',
@@ -928,7 +697,7 @@ async function compile(filePath: string, options?: Partial<Opts>) {
           onMetaExtracted: (_, m) => {
             meta = m
           },
-          ...(options || {}),
+          ...options,
         }),
       ],
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -283,6 +283,9 @@ importers:
       minimist:
         specifier: ^1.2.8
         version: 1.2.8
+      oxlint:
+        specifier: ^1.32.0
+        version: 1.32.0
       prettier:
         specifier: ^3.7.4
         version: 3.7.4
@@ -3005,6 +3008,46 @@ packages:
 
   '@oxc-resolver/binding-win32-x64-msvc@5.0.1':
     resolution: {integrity: sha512-ODlCn4Pbd0HEWMixonax1uJtNCG4lEne6Jq98iUsmwSibQYcBzutxPed1qhLKur6KtCsYYa4LtRxys7e/5lZwQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxlint/darwin-arm64@1.32.0':
+    resolution: {integrity: sha512-yrqPmZYu5Qb+49h0P5EXVIq8VxYkDDM6ZQrWzlh16+UGFcD8HOXs4oF3g9RyfaoAbShLCXooSQsM/Ifwx8E/eQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint/darwin-x64@1.32.0':
+    resolution: {integrity: sha512-pQRZrJG/2nAKc3IuocFbaFFbTDlQsjz2WfivRsMn0hw65EEsSuM84WMFMiAfLpTGyTICeUtHZLHlrM5lzVr36A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint/linux-arm64-gnu@1.32.0':
+    resolution: {integrity: sha512-tyomSmU2DzwcTmbaWFmStHgVfRmJDDvqcIvcw4fRB1YlL2Qg/XaM4NJ0m2bdTap38gxD5FSxSgCo0DkQ8GTolg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxlint/linux-arm64-musl@1.32.0':
+    resolution: {integrity: sha512-0W46dRMaf71OGE4+Rd+GHfS1uF/UODl5Mef6871pMhN7opPGfTI2fKJxh9VzRhXeSYXW/Z1EuCq9yCfmIJq+5Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxlint/linux-x64-gnu@1.32.0':
+    resolution: {integrity: sha512-5+6myVCBOMvM62rDB9T3CARXUvIwhGqte6E+HoKRwYaqsxGUZ4bh3pItSgSFwHjLGPrvADS11qJUkk39eQQBzQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxlint/linux-x64-musl@1.32.0':
+    resolution: {integrity: sha512-qwQlwYYgVIC6ScjpUwiKKNyVdUlJckrfwPVpIjC9mvglIQeIjKuuyaDxUZWIOc/rEzeCV/tW6tcbehLkfEzqsw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxlint/win32-arm64@1.32.0':
+    resolution: {integrity: sha512-7qYZF9CiXGtdv8Z/fBkgB5idD2Zokht67I5DKWH0fZS/2R232sDqW2JpWVkXltk0+9yFvmvJ0ouJgQRl9M3S2g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint/win32-x64@1.32.0':
+    resolution: {integrity: sha512-XW1xqCj34MEGJlHteqasTZ/LmBrwYIgluhNW0aP+XWkn90+stKAq3W/40dvJKbMK9F7o09LPCuMVtUW7FIUuiA==}
     cpu: [x64]
     os: [win32]
 
@@ -8191,6 +8234,16 @@ packages:
 
   oxc-resolver@5.0.1:
     resolution: {integrity: sha512-BbclyCSxgnqO5mo05RGcwp8rkVdZL7sf0ugEnFWK67DIBAMq5wR0/GQlQCdPiPkpiv9GESAVX2cbh1DMFux/TQ==}
+
+  oxlint@1.32.0:
+    resolution: {integrity: sha512-HYDQCga7flsdyLMUIxTgSnEx5KBxpP9VINB8NgO+UjV80xBiTQXyVsvjtneMT3ZBLMbL0SlG/Dm03XQAsEshMA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      oxlint-tsgolint: '>=0.8.1'
+    peerDependenciesMeta:
+      oxlint-tsgolint:
+        optional: true
 
   p-cancelable@0.4.1:
     resolution: {integrity: sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==}
@@ -14035,6 +14088,30 @@ snapshots:
   '@oxc-resolver/binding-win32-x64-msvc@5.0.1':
     optional: true
 
+  '@oxlint/darwin-arm64@1.32.0':
+    optional: true
+
+  '@oxlint/darwin-x64@1.32.0':
+    optional: true
+
+  '@oxlint/linux-arm64-gnu@1.32.0':
+    optional: true
+
+  '@oxlint/linux-arm64-musl@1.32.0':
+    optional: true
+
+  '@oxlint/linux-x64-gnu@1.32.0':
+    optional: true
+
+  '@oxlint/linux-x64-musl@1.32.0':
+    optional: true
+
+  '@oxlint/win32-arm64@1.32.0':
+    optional: true
+
+  '@oxlint/win32-x64@1.32.0':
+    optional: true
+
   '@philpl/buble@0.19.7':
     dependencies:
       acorn: 6.4.2
@@ -14696,13 +14773,13 @@ snapshots:
   '@types/react-router-dom@5.3.3':
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 19.1.8
+      '@types/react': 19.2.7
       '@types/react-router': 5.1.20
 
   '@types/react-router@5.1.20':
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 19.1.8
+      '@types/react': 19.2.7
 
   '@types/react@19.0.12':
     dependencies:
@@ -20338,6 +20415,17 @@ snapshots:
       '@oxc-resolver/binding-wasm32-wasi': 5.0.1
       '@oxc-resolver/binding-win32-arm64-msvc': 5.0.1
       '@oxc-resolver/binding-win32-x64-msvc': 5.0.1
+
+  oxlint@1.32.0:
+    optionalDependencies:
+      '@oxlint/darwin-arm64': 1.32.0
+      '@oxlint/darwin-x64': 1.32.0
+      '@oxlint/linux-arm64-gnu': 1.32.0
+      '@oxlint/linux-arm64-musl': 1.32.0
+      '@oxlint/linux-x64-gnu': 1.32.0
+      '@oxlint/linux-x64-musl': 1.32.0
+      '@oxlint/win32-arm64': 1.32.0
+      '@oxlint/win32-x64': 1.32.0
 
   p-cancelable@0.4.1: {}
 

--- a/tools/check-package-json.ts
+++ b/tools/check-package-json.ts
@@ -38,7 +38,7 @@ function main(args: Args) {
   }
   const packageJsonAllDeps = {
     ...packageJsonContent.dependencies,
-    ...(packageJsonContent.peerDependencies || {}),
+    ...packageJsonContent.peerDependencies,
   }
   internalDeps.forEach(pkg => {
     delete packageJsonAllDeps[pkg]

--- a/tools/vitest.bzl
+++ b/tools/vitest.bzl
@@ -93,6 +93,7 @@ def vitest(
         vitest_bin.vitest(
             name = snapshot_target_name,
             srcs = srcs_no_snapshots +
+                   fixtures +
                    deps,
             out_dirs = [snapshot_dir],
             args = [

--- a/website/src/components/IcuEditor.tsx
+++ b/website/src/components/IcuEditor.tsx
@@ -24,14 +24,14 @@ export const IcuEditor = ({defaultMessage, defaultValues}: IcuEditorProps) => {
       let opts = {}
       try {
         opts = JSON.parse(values)
-      } catch (err) {
+      } catch {
         //Ignore invalid JSON error
       }
 
       const msg = new IntlMessageFormat(message).format(opts) as string
       setError(false)
       setResult(msg)
-    } catch (err) {
+    } catch {
       if (err instanceof Error) {
         setResult(err.message)
         setError(true)

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -132,7 +132,6 @@ function IntroSection({className}) {
 }
 
 function EnvSection({className}) {
-  const intl = useIntl()
   return (
     <div className={cx(className, styles.env)}>
       <div className={cx('row', styles.logos)}>


### PR DESCRIPTION
### TL;DR

Added oxlint to the project for improved JavaScript/TypeScript linting and fixed various lint issues across the codebase.

### What changed?

- Added oxlint v1.32.0 to the project dependencies
- Configured oxlint to run as part of the lint-staged process
- Updated .eslintignore to exclude additional files from linting
- Fixed various lint issues across multiple packages:
  - Removed unused imports and variables
  - Fixed regex patterns in several files
  - Improved object spread operations
  - Fixed type assertions
  - Replaced catch blocks with empty handlers where error variables weren't used
  - Fixed various other code quality issues

### How to test?

1. Install dependencies with `pnpm install`
2. Run oxlint on any JavaScript/TypeScript file with `npx oxlint path/to/file.js`
3. Make a change to a JS/TS file and commit it to verify lint-staged runs oxlint

### Why make this change?

Adding oxlint provides additional static analysis to catch potential bugs and improve code quality. Oxlint is a fast JavaScript/TypeScript linter that can identify issues that might be missed by other tools. This change helps maintain code quality and consistency across the codebase while fixing existing issues that were detected by the new linter.