### PR TITLE
chore: add oxlint

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "karma:local": "bazel test :karma",
     "prepare": "husky && syncpack fix-mismatches && syncpack format",
     "prerelease": "HUSKY=0 lerna version --yes --no-private",
-    "test": "syncpack lint && bazel test //..."
+    "test": "syncpack lint && oxlint && bazel test //..."
   },
   "devDependencies": {
     "@babel/core": "^7.26.10",

--- a/packages/ecma402-abstract/262.ts
+++ b/packages/ecma402-abstract/262.ts
@@ -38,7 +38,7 @@ export function ToNumber(arg: any): Decimal {
   if (typeof arg === 'string') {
     try {
       return new Decimal(arg)
-    } catch (e) {
+    } catch {
       return new Decimal(NaN)
     }
   }
@@ -118,7 +118,7 @@ export function SameValue(x: any, y: any): boolean {
  * @param len
  */
 export function ArrayCreate<T = any>(len: number): T[] {
-  return new Array(len)
+  return Array.from({length: len})
 }
 
 /**

--- a/packages/ecma402-abstract/ToIntlMathematicalValue.ts
+++ b/packages/ecma402-abstract/ToIntlMathematicalValue.ts
@@ -21,7 +21,7 @@ export function ToIntlMathematicalValue(input: unknown): Decimal {
   }
   try {
     return new Decimal(primValue)
-  } catch (e) {
+  } catch {
     return new Decimal(NaN)
   }
 }

--- a/packages/ecma402-abstract/scripts/digit-mapping.ts
+++ b/packages/ecma402-abstract/scripts/digit-mapping.ts
@@ -4,7 +4,7 @@ import stringify from 'json-stable-stringify'
 
 // Generate an array of 10 characters with consecutive codepoint, starting from `starCharCode`.
 function generateDigitChars(startCharCode: number): string[] {
-  const arr = new Array<string>(10)
+  const arr = Array.from<string>({length: 10})
   for (let i = 0; i < 10; i++) {
     arr[i] = String.fromCodePoint(startCharCode + i)
   }

--- a/packages/ecma402-abstract/utils.ts
+++ b/packages/ecma402-abstract/utils.ts
@@ -4,7 +4,7 @@ export function repeat(s: string, times: number): string {
   if (typeof s.repeat === 'function') {
     return s.repeat(times)
   }
-  const arr = new Array(times)
+  const arr = Array.from({length: times})
   for (let i = 0; i < arr.length; i++) {
     arr[i] = s
   }

--- a/packages/eslint-plugin-formatjs/rules/no-multiple-whitespaces.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-multiple-whitespaces.ts
@@ -55,7 +55,6 @@ function trimMultiWhitespaces(
           break
         case TYPE.argument:
         case TYPE.date:
-        case TYPE.literal:
         case TYPE.number:
         case TYPE.pound:
         case TYPE.time:

--- a/packages/icu-messageformat-parser/parser.ts
+++ b/packages/icu-messageformat-parser/parser.ts
@@ -110,7 +110,7 @@ try {
    * See https://github.com/formatjs/formatjs/issues/2822
    */
   REGEX_SUPPORTS_U_AND_Y = re.exec('a')?.[0] === 'a'
-} catch (_) {
+} catch {
   REGEX_SUPPORTS_U_AND_Y = false
 }
 
@@ -985,7 +985,7 @@ export class Parser {
     let tokens: NumberSkeletonToken[] = []
     try {
       tokens = parseNumberSkeletonFromString(skeleton)
-    } catch (e) {
+    } catch {
       return this.error(ErrorKind.INVALID_NUMBER_SKELETON, location)
     }
 

--- a/packages/intl-datetimeformat/polyfill.ts
+++ b/packages/intl-datetimeformat/polyfill.ts
@@ -19,7 +19,7 @@ if (shouldPolyfill()) {
     ) {
       try {
         return _toLocaleString(this, locales, options)
-      } catch (error) {
+      } catch {
         return 'Invalid Date'
       }
     },
@@ -33,7 +33,7 @@ if (shouldPolyfill()) {
     ) {
       try {
         return _toLocaleDateString(this, locales, options)
-      } catch (error) {
+      } catch {
         return 'Invalid Date'
       }
     },
@@ -47,7 +47,7 @@ if (shouldPolyfill()) {
     ) {
       try {
         return _toLocaleTimeString(this, locales, options)
-      } catch (error) {
+      } catch {
         return 'Invalid Date'
       }
     },

--- a/packages/intl-datetimeformat/scripts/extract-dates.ts
+++ b/packages/intl-datetimeformat/scripts/extract-dates.ts
@@ -62,7 +62,7 @@ export function getAllLocales(): string[] {
     .filter(l => {
       try {
         return (Intl as any).getCanonicalLocales(l).length
-      } catch (e) {
+      } catch {
         console.warn(`Invalid locale ${l}`)
         return false
       }
@@ -216,7 +216,7 @@ async function loadDatesFields(
           pattern,
           parseDateTimeSkeleton(skeleton, pattern),
         ] as [string, string, Formats]
-      } catch (e) {
+      } catch {
         // ignore
       }
     })

--- a/packages/intl-datetimeformat/should-polyfill.ts
+++ b/packages/intl-datetimeformat/should-polyfill.ts
@@ -8,7 +8,7 @@ function supportsDateStyle() {
         dateStyle: 'short',
       } as any).resolvedOptions() as any
     ).dateStyle
-  } catch (e) {
+  } catch {
     return false
   }
 }
@@ -24,7 +24,7 @@ function hasChromeLt71Bug() {
         hour: 'numeric',
       } as any).formatToParts(0)[2].type !== 'dayPeriod'
     )
-  } catch (e) {
+  } catch {
     return false
   }
 }
@@ -40,7 +40,7 @@ function hasUnthrownDateTimeStyleBug(): boolean {
       dateStyle: 'short',
       hour: 'numeric',
     } as any).format(new Date(0))
-  } catch (e) {
+  } catch {
     return false
   }
 }

--- a/packages/intl-datetimeformat/src/abstract/FormatDateTimeRangeToParts.ts
+++ b/packages/intl-datetimeformat/src/abstract/FormatDateTimeRangeToParts.ts
@@ -11,7 +11,7 @@ export function FormatDateTimeRangeToParts(
   implDetails: FormatDateTimePatternImplDetails & ToLocalTimeImplDetails
 ): IntlDateTimeFormatPart[] {
   const parts = PartitionDateTimeRangePattern(dtf, x, y, implDetails)
-  const result = new Array(0)
+  const result: IntlDateTimeFormatPart[] = []
   for (const part of parts) {
     result.push({
       type: part.type,

--- a/packages/intl-datetimeformat/src/core.ts
+++ b/packages/intl-datetimeformat/src/core.ts
@@ -95,7 +95,7 @@ const formatDescriptor = {
           writable: false,
           value: '',
         })
-      } catch (e) {
+      } catch {
         // In older browser (e.g Chrome 36 like polyfill-fastly.io)
         // TypeError: Cannot redefine property: name
       }
@@ -419,6 +419,6 @@ try {
     enumerable: false,
     configurable: true,
   })
-} catch (e) {
+} catch {
   // Meta fix so we're test262-compliant, not important
 }

--- a/packages/intl-displaynames/index.ts
+++ b/packages/intl-displaynames/index.ts
@@ -288,7 +288,7 @@ try {
     enumerable: false,
     configurable: true,
   })
-} catch (e) {
+} catch {
   // Make test 262 compliant
 }
 

--- a/packages/intl-displaynames/scripts/extract-displaynames.ts
+++ b/packages/intl-displaynames/scripts/extract-displaynames.ts
@@ -30,7 +30,7 @@ export async function getAllLocales(): Promise<string[]> {
   return fns.map(dirname).filter(l => {
     try {
       return (Intl as any).getCanonicalLocales(l).length
-    } catch (e) {
+    } catch {
       console.warn(`Invalid locale ${l}`)
       return false
     }
@@ -248,7 +248,7 @@ async function loadDisplayNames(
         locale: localePatternData,
       },
     }
-  } catch (e) {
+  } catch {
     console.error(`Failed to load ${locale}`)
   }
 }

--- a/packages/intl-displaynames/should-polyfill.ts
+++ b/packages/intl-displaynames/should-polyfill.ts
@@ -51,7 +51,7 @@ export function shouldPolyfill(locale = 'en'): string | true | undefined {
     if (_shouldPolyfillWithoutLocale() || !supportedLocalesOf(locale)) {
       return match([locale], supportedLocales, 'en')
     }
-  } catch (e) {
+  } catch {
     return true
   }
 }

--- a/packages/intl-durationformat/scripts/utils.ts
+++ b/packages/intl-durationformat/scripts/utils.ts
@@ -12,7 +12,7 @@ export async function getAllLocales(): Promise<string[]> {
   return fns.map(dirname).filter(l => {
     try {
       return (Intl as any).getCanonicalLocales(l).length
-    } catch (e) {
+    } catch {
       console.warn(`Invalid locale ${l}`)
       return false
     }

--- a/packages/intl-durationformat/src/core.ts
+++ b/packages/intl-durationformat/src/core.ts
@@ -248,13 +248,12 @@ export class DurationFormat implements DurationFormatType {
     return ro as any
   }
   formatToParts(duration: DurationInput): DurationFormatPart[] {
-    const df = this
     const locInternalSlots = getInternalSlots(this)
     if (locInternalSlots.initializedDurationFormat === undefined) {
       throw new TypeError('Error uninitialized locale')
     }
     const record = ToDurationRecord(duration)
-    const parts = PartitionDurationFormatPattern(df, record)
+    const parts = PartitionDurationFormatPattern(this, record)
     const result = []
     for (const {type, unit, value} of parts) {
       const obj: DurationFormatPart = {type, value}
@@ -266,13 +265,12 @@ export class DurationFormat implements DurationFormatType {
     return result
   }
   format(duration: DurationInput): string {
-    const df = this
     const locInternalSlots = getInternalSlots(this)
     if (locInternalSlots.initializedDurationFormat === undefined) {
       throw new TypeError('Error uninitialized locale')
     }
     const record = ToDurationRecord(duration)
-    const parts = PartitionDurationFormatPattern(df, record)
+    const parts = PartitionDurationFormatPattern(this, record)
     let result = ''
     for (const {value} of parts) {
       result += value

--- a/packages/intl-enumerator/src/get-supported-calendars.ts
+++ b/packages/intl-enumerator/src/get-supported-calendars.ts
@@ -10,7 +10,7 @@ function isSupportedCalendar(item: Calendar, locale: string = 'en'): boolean {
     const options = dateTimeFormat.resolvedOptions().calendar
 
     if (item !== 'gregory' || options !== 'gregory') return true
-  } catch (_err) {}
+  } catch {}
 
   return false
 }

--- a/packages/intl-enumerator/src/get-supported-collations.ts
+++ b/packages/intl-enumerator/src/get-supported-collations.ts
@@ -7,7 +7,7 @@ function isSupported(collation: Collation, locale: string = 'en'): boolean {
       Intl.Collator(`${locale}-u-co-${collation}`).resolvedOptions()
         .collation === collation
     )
-  } catch (_err) {}
+  } catch {}
 
   return false
 }

--- a/packages/intl-enumerator/src/get-supported-currencies.ts
+++ b/packages/intl-enumerator/src/get-supported-currencies.ts
@@ -21,7 +21,7 @@ function isSupportedCurrency(
     ) {
       return true
     }
-  } catch (_err) {}
+  } catch {}
 
   return false
 }

--- a/packages/intl-enumerator/src/get-supported-numbering-systems.ts
+++ b/packages/intl-enumerator/src/get-supported-numbering-systems.ts
@@ -15,7 +15,7 @@ function isSupportedNumberingSystem(
     ) {
       return true
     }
-  } catch (_err) {}
+  } catch {}
 
   return false
 }

--- a/packages/intl-enumerator/src/get-supported-timezones.ts
+++ b/packages/intl-enumerator/src/get-supported-timezones.ts
@@ -6,7 +6,7 @@ function isSupported(timeZone: Timezone, locale: string = 'en'): boolean {
   try {
     const formatter = createMemoizedDateTimeFormat(locale, {timeZone})
     return formatter.resolvedOptions().timeZone === timeZone
-  } catch (_err) {}
+  } catch {}
 
   return false
 }

--- a/packages/intl-enumerator/src/get-supported-units.ts
+++ b/packages/intl-enumerator/src/get-supported-units.ts
@@ -6,7 +6,7 @@ function isSupported(unit: Unit, locale: string = 'en'): boolean {
   try {
     const formatter = createMemoizedNumberFormat(locale, {style: 'unit', unit})
     return formatter.resolvedOptions().unit === unit
-  } catch (_err) {}
+  } catch {}
 
   return false
 }

--- a/packages/intl-getcanonicallocales/src/parser.ts
+++ b/packages/intl-getcanonicallocales/src/parser.ts
@@ -32,7 +32,7 @@ export function isUnicodeLanguageSubtag(lang: string): boolean {
 export function isStructurallyValidLanguageTag(tag: string): boolean {
   try {
     parseUnicodeLanguageId(tag.split(SEPARATOR))
-  } catch (e) {
+  } catch {
     return false
   }
   return true
@@ -147,7 +147,7 @@ function parseTransformedExtension(chunks: string[]): TransformedExtension {
   let lang: UnicodeLanguageId | undefined
   try {
     lang = parseUnicodeLanguageId(chunks)
-  } catch (e) {
+  } catch {
     // Try just parsing tfield
   }
   const fields: KV[] = []

--- a/packages/intl-listformat/index.ts
+++ b/packages/intl-listformat/index.ts
@@ -373,6 +373,6 @@ try {
     enumerable: false,
     configurable: true,
   })
-} catch (e) {
+} catch {
   // Meta fix so we're test262-compliant, not important
 }

--- a/packages/intl-listformat/scripts/extract-list.ts
+++ b/packages/intl-listformat/scripts/extract-list.ts
@@ -21,7 +21,7 @@ export async function getAllLocales(): Promise<string[]> {
   return fns.map(dirname).filter(l => {
     try {
       return (Intl as any).getCanonicalLocales(l).length
-    } catch (e) {
+    } catch {
       console.warn(`Invalid locale ${l}`)
       return false
     }

--- a/packages/intl-locale/index.ts
+++ b/packages/intl-locale/index.ts
@@ -600,7 +600,7 @@ export class Locale {
     try {
       const maximizedLocale = addLikelySubtags(locale)
       return new Locale(maximizedLocale)
-    } catch (e) {
+    } catch {
       return new Locale(locale)
     }
   }
@@ -613,7 +613,7 @@ export class Locale {
     try {
       const minimizedLocale = removeLikelySubtags(locale)
       return new Locale(minimizedLocale)
-    } catch (e) {
+    } catch {
       return new Locale(locale)
     }
   }
@@ -803,7 +803,7 @@ try {
     enumerable: false,
     configurable: true,
   })
-} catch (e) {
+} catch {
   // Meta fix so we're test262-compliant, not important
 }
 

--- a/packages/intl-locale/scripts/utils.ts
+++ b/packages/intl-locale/scripts/utils.ts
@@ -12,7 +12,7 @@ export async function getAllLocales(): Promise<string[]> {
   return fns.map(dirname).filter(l => {
     try {
       return (Intl as any).getCanonicalLocales(l).length
-    } catch (e) {
+    } catch {
       console.warn(`Invalid locale ${l}`)
       return false
     }

--- a/packages/intl-locale/should-polyfill.ts
+++ b/packages/intl-locale/should-polyfill.ts
@@ -4,7 +4,7 @@
 function hasIntlGetCanonicalLocalesBug(): boolean {
   try {
     return new (Intl as any).Locale('und-x-private').toString() === 'x-private'
-  } catch (e) {
+  } catch {
     return true
   }
 }

--- a/packages/intl-numberformat/scripts/cldr-raw.ts
+++ b/packages/intl-numberformat/scripts/cldr-raw.ts
@@ -13,7 +13,7 @@ async function main(args: minimist.ParsedArgs) {
   const locales = AVAILABLE_LOCALES.availableLocales.full.filter(l => {
     try {
       return (Intl as any).getCanonicalLocales(l).length
-    } catch (e) {
+    } catch {
       console.warn(`Invalid locale ${l}`)
       return false
     }

--- a/packages/intl-numberformat/should-polyfill.ts
+++ b/packages/intl-numberformat/should-polyfill.ts
@@ -32,7 +32,7 @@ function supportsES2020() {
     if (s !== '1E4 bits') {
       return false
     }
-  } catch (e) {
+  } catch {
     return false
   }
   return true
@@ -57,7 +57,7 @@ function supportsES2023() {
       roundingPriority: 'morePrecision',
     }).format(1e8)
     return s === '100.00M'
-  } catch (e) {
+  } catch {
     return false
   }
 }

--- a/packages/intl-numberformat/src/core.ts
+++ b/packages/intl-numberformat/src/core.ts
@@ -131,7 +131,7 @@ try {
     writable: false,
     configurable: true,
   })
-} catch (e) {
+} catch {
   // In older browser (e.g Chrome 36 like polyfill-fastly.io)
   // TypeError: Cannot redefine property: name
 }
@@ -205,7 +205,7 @@ const formatDescriptor = {
           writable: false,
           value: '',
         })
-      } catch (e) {
+      } catch {
         // In older browser (e.g Chrome 36 like polyfill-fastly.io)
         // TypeError: Cannot redefine property: name
       }
@@ -222,7 +222,7 @@ try {
     writable: false,
     value: 'get format',
   })
-} catch (e) {
+} catch {
   // In older browser (e.g Chrome 36 like polyfill-fastly.io)
   // TypeError: Cannot redefine property: name
 }
@@ -318,6 +318,6 @@ try {
     writable: false,
     value: NumberFormat.prototype,
   })
-} catch (e) {
+} catch {
   // Meta fix so we're test262-compliant, not important
 }

--- a/packages/intl-pluralrules/index.ts
+++ b/packages/intl-pluralrules/index.ts
@@ -96,10 +96,9 @@ export class PluralRules implements Intl.PluralRules {
     return opts
   }
   public select(val: number): LDMLPluralRule {
-    const pr = this
-    validateInstance(pr, 'select')
+    validateInstance(this, 'select')
     const n = ToNumber(val)
-    return ResolvePlural(pr, n, {getInternalSlots, PluralRuleSelect})
+    return ResolvePlural(this, n, {getInternalSlots, PluralRuleSelect})
   }
   toString() {
     return '[object Intl.PluralRules]'
@@ -152,7 +151,7 @@ try {
       enumerable: false,
       configurable: true,
     })
-  } catch (error) {
+  } catch {
     // IE 11 sets Function.prototype.length to be non-configurable which will cause the
     // above Object.defineProperty to throw an error.
   }
@@ -176,6 +175,6 @@ try {
     enumerable: false,
     configurable: true,
   })
-} catch (ex) {
+} catch {
   // Meta fixes for test262
 }

--- a/packages/intl-pluralrules/scripts/cldr-raw.ts
+++ b/packages/intl-pluralrules/scripts/cldr-raw.ts
@@ -39,7 +39,7 @@ function main(args: Args) {
     .filter(locale => {
       try {
         ;(Intl as any).getCanonicalLocales(locale)
-      } catch (e) {
+      } catch {
         console.warn(`Invalid locale ${locale}`)
         return false
       }

--- a/packages/intl-relativetimeformat/index.ts
+++ b/packages/intl-relativetimeformat/index.ts
@@ -146,6 +146,6 @@ try {
     enumerable: false,
     configurable: true,
   })
-} catch (e) {
+} catch {
   // Meta fix so we're test262-compliant, not important
 }

--- a/packages/intl-relativetimeformat/scripts/extract-relative.ts
+++ b/packages/intl-relativetimeformat/scripts/extract-relative.ts
@@ -52,7 +52,7 @@ export async function getAllLocales(): Promise<string[]> {
   return fns.map(dirname).filter(l => {
     try {
       return (Intl as any).getCanonicalLocales(l).length
-    } catch (e) {
+    } catch {
       console.warn(`Invalid locale ${l}`)
       return false
     }

--- a/packages/intl-relativetimeformat/should-polyfill.ts
+++ b/packages/intl-relativetimeformat/should-polyfill.ts
@@ -20,7 +20,7 @@ function hasResolvedOptionsNumberingSystem(locale?: string | string[]) {
         numeric: 'auto',
       }).resolvedOptions()
     )
-  } catch (_) {
+  } catch {
     return false
   }
 }

--- a/packages/ts-transformer/src/interpolate-name.ts
+++ b/packages/ts-transformer/src/interpolate-name.ts
@@ -125,10 +125,11 @@ export function interpolateName(
   if (regExp && loaderContext.resourcePath) {
     const match = loaderContext.resourcePath.match(new RegExp(regExp))
 
-    match &&
+    if (match) {
       match.forEach((matched, i) => {
         url = url.replace(new RegExp('\\[' + i + '\\]', 'ig'), matched)
       })
+    }
   }
 
   if (

--- a/packages/ts-transformer/src/transform.ts
+++ b/packages/ts-transformer/src/transform.ts
@@ -44,7 +44,7 @@ function isValidIdentifier(k: string): boolean {
   try {
     new Function(`return {${k}:1}`)
     return true
-  } catch (e) {
+  } catch {
     return false
   }
 }

--- a/packages/utils/src/defaultTimezone.ts
+++ b/packages/utils/src/defaultTimezone.ts
@@ -52,7 +52,7 @@ export function defaultTimezone(
       dtf.formatToParts(now).find(p => p.type === 'timeZoneName')?.value ||
       'UTC'
     )
-  } catch (e) {
+  } catch {
     return 'UTC'
   }
 }


### PR DESCRIPTION
### TL;DR

Replace unused catch variables with empty catch blocks and improve array initialization patterns.

### What changed?

- Updated array initialization to use `Array.from({length: n})` instead of `new Array(n)` for better initialization semantics
- Replaced catch blocks with unused error variables (like `catch (e)` or `catch (_)`) with empty catch blocks (`catch {}`)
- Fixed a bug in the `no-multiple-whitespaces` ESLint rule by removing the `literal` case
- Added `oxlint` to the test script in package.json

### How to test?

1. Run the test suite with `npm test` to verify all tests pass
2. Verify that the linting works correctly with the new oxlint integration
3. Check that array initialization behaves correctly in edge cases

### Why make this change?

- Empty catch blocks are more concise and avoid declaring unused variables
- Using `Array.from({length: n})` creates arrays with actual undefined elements rather than empty slots, which prevents subtle bugs when iterating
- Adding oxlint improves code quality by catching additional issues
- These changes follow modern JavaScript best practices and improve code maintainability