### PR TITLE
feat(@formatjs/ts-transformer)!: convert to ESM only

### DIFF
--- a/packages/eslint-plugin-formatjs/BUILD.bazel
+++ b/packages/eslint-plugin-formatjs/BUILD.bazel
@@ -45,6 +45,7 @@ SRC_DEPS = [
 ts_compile_node(
     name = "dist",
     srcs = [":srcs"],
+    skip_cjs = True,
     deps = SRC_DEPS,
 )
 

--- a/packages/eslint-plugin-formatjs/index.ts
+++ b/packages/eslint-plugin-formatjs/index.ts
@@ -3,73 +3,76 @@ import {ESLint} from 'eslint'
 import {
   name as blocklistElementRuleName,
   rule as blocklistElements,
-} from './rules/blocklist-elements'
+} from './rules/blocklist-elements.js'
 import {
   rule as enforceDefaultMessage,
   name as enforceDefaultMessageName,
-} from './rules/enforce-default-message'
+} from './rules/enforce-default-message.js'
 import {
   rule as enforceDescription,
   name as enforceDescriptionName,
-} from './rules/enforce-description'
-import {rule as enforceId, name as enforceIdName} from './rules/enforce-id'
+} from './rules/enforce-description.js'
+import {rule as enforceId, name as enforceIdName} from './rules/enforce-id.js'
 import {
   rule as enforcePlaceholders,
   name as enforcePlaceholdersName,
-} from './rules/enforce-placeholders'
+} from './rules/enforce-placeholders.js'
 import {
   rule as enforcePluralRules,
   name as enforcePluralRulesName,
-} from './rules/enforce-plural-rules'
+} from './rules/enforce-plural-rules.js'
 import {
   rule as noCamelCase,
   name as noCamelCaseName,
-} from './rules/no-camel-case'
+} from './rules/no-camel-case.js'
 import {
   rule as noComplexSelectors,
   name as noComplexSelectorsName,
-} from './rules/no-complex-selectors'
-import {rule as noEmoji, name as noEmojiName} from './rules/no-emoji'
-import {rule as noId, name as noIdName} from './rules/no-id'
+} from './rules/no-complex-selectors.js'
+import {rule as noEmoji, name as noEmojiName} from './rules/no-emoji.js'
+import {rule as noId, name as noIdName} from './rules/no-id.js'
 import {
   rule as noInvalidICU,
   name as noInvalidICUName,
-} from './rules/no-invalid-icu'
+} from './rules/no-invalid-icu.js'
 import {
   rule as noLiteralStringInJsx,
   name as noLiteralStringInJsxName,
-} from './rules/no-literal-string-in-jsx'
+} from './rules/no-literal-string-in-jsx.js'
 import {
   rule as noMissingIcuPluralOnePlaceholders,
   name as noMissingIcuPluralOnePlaceholdersName,
-} from './rules/no-missing-icu-plural-one-placeholders'
+} from './rules/no-missing-icu-plural-one-placeholders.js'
 import {
   rule as noMultiplePlurals,
   name as noMultiplePluralsName,
-} from './rules/no-multiple-plurals'
+} from './rules/no-multiple-plurals.js'
 import {
   rule as noMultipleWhitespaces,
   name as noMultipleWhitespacesName,
-} from './rules/no-multiple-whitespaces'
-import {rule as noOffset, name as noOffsetName} from './rules/no-offset'
+} from './rules/no-multiple-whitespaces.js'
+import {rule as noOffset, name as noOffsetName} from './rules/no-offset.js'
 import {
   rule as noUselessMessage,
   name as noUselessMessageName,
-} from './rules/no-useless-message'
+} from './rules/no-useless-message.js'
 import {
   rule as preferFormattedMessage,
   name as preferFormattedMessageName,
-} from './rules/prefer-formatted-message'
+} from './rules/prefer-formatted-message.js'
 import {
   rule as preferPoundInPlural,
   name as preferPoundInPluralName,
-} from './rules/prefer-pound-in-plural'
+} from './rules/prefer-pound-in-plural.js'
 import {
   rule as noLiteralStringInObject,
   name as noLiteralStringInObjectName,
-} from './rules/no-literal-string-in-object'
+} from './rules/no-literal-string-in-object.js'
 
-import {name, version} from './package.json'
+import * as packageJsonNs from './package.json' with {type: 'json'}
+
+const packageJson = (packageJsonNs as any).default ?? packageJsonNs
+const {name, version} = packageJson
 
 // All rules
 const rules: ESLint.Plugin['rules'] = {
@@ -211,4 +214,4 @@ const configs: Plugin['configs'] = {
 }
 plugin.configs = configs
 
-module.exports = plugin
+export default plugin

--- a/packages/eslint-plugin-formatjs/package.json
+++ b/packages/eslint-plugin-formatjs/package.json
@@ -4,6 +4,7 @@
   "version": "5.4.2",
   "license": "MIT",
   "author": "Long Ho <holevietlong@gmail.com>",
+  "type": "module",
   "types": "index.d.ts",
   "dependencies": {
     "@formatjs/icu-messageformat-parser": "workspace:*",

--- a/packages/eslint-plugin-formatjs/rules/blocklist-elements.ts
+++ b/packages/eslint-plugin-formatjs/rules/blocklist-elements.ts
@@ -12,8 +12,8 @@ import {
 } from '@formatjs/icu-messageformat-parser'
 import {ESLintUtils, TSESTree} from '@typescript-eslint/utils'
 import {RuleContext} from '@typescript-eslint/utils/ts-eslint'
-import {getParserServices} from '../context-compat'
-import {extractMessages, getSettings} from '../util'
+import {getParserServices} from '../context-compat.js'
+import {extractMessages, getSettings} from '../util.js'
 
 type MessageIds = 'blocklist'
 

--- a/packages/eslint-plugin-formatjs/rules/enforce-default-message.ts
+++ b/packages/eslint-plugin-formatjs/rules/enforce-default-message.ts
@@ -1,7 +1,7 @@
 import {TSESTree} from '@typescript-eslint/utils'
 import {RuleContext, RuleModule} from '@typescript-eslint/utils/ts-eslint'
-import {getParserServices} from '../context-compat'
-import {extractMessages, getSettings} from '../util'
+import {getParserServices} from '../context-compat.js'
+import {extractMessages, getSettings} from '../util.js'
 
 export enum Option {
   literal = 'literal',

--- a/packages/eslint-plugin-formatjs/rules/enforce-description.ts
+++ b/packages/eslint-plugin-formatjs/rules/enforce-description.ts
@@ -1,7 +1,7 @@
 import {TSESTree} from '@typescript-eslint/utils'
 import {RuleContext, RuleModule} from '@typescript-eslint/utils/ts-eslint'
-import {getParserServices} from '../context-compat'
-import {extractMessages, getSettings} from '../util'
+import {getParserServices} from '../context-compat.js'
+import {extractMessages, getSettings} from '../util.js'
 
 export enum Option {
   literal = 'literal',

--- a/packages/eslint-plugin-formatjs/rules/enforce-id.ts
+++ b/packages/eslint-plugin-formatjs/rules/enforce-id.ts
@@ -1,8 +1,8 @@
 import {interpolateName} from '@formatjs/ts-transformer'
 import {TSESTree} from '@typescript-eslint/utils'
 import {RuleContext, RuleModule} from '@typescript-eslint/utils/ts-eslint'
-import {getParserServices} from '../context-compat'
-import {extractMessages, getSettings} from '../util'
+import {getParserServices} from '../context-compat.js'
+import {extractMessages, getSettings} from '../util.js'
 
 export type Option = {
   idInterpolationPattern: string

--- a/packages/eslint-plugin-formatjs/rules/enforce-placeholders.ts
+++ b/packages/eslint-plugin-formatjs/rules/enforce-placeholders.ts
@@ -5,8 +5,8 @@ import {
 } from '@formatjs/icu-messageformat-parser'
 import {TSESTree} from '@typescript-eslint/utils'
 import {RuleContext, RuleModule} from '@typescript-eslint/utils/ts-eslint'
-import {getParserServices} from '../context-compat'
-import {extractMessages, getSettings} from '../util'
+import {getParserServices} from '../context-compat.js'
+import {extractMessages, getSettings} from '../util.js'
 
 type MessageIds = 'parserError' | 'missingValue' | 'unusedValue'
 type Options = [{ignoreList: string[]}?]

--- a/packages/eslint-plugin-formatjs/rules/enforce-plural-rules.ts
+++ b/packages/eslint-plugin-formatjs/rules/enforce-plural-rules.ts
@@ -5,8 +5,8 @@ import {
 } from '@formatjs/icu-messageformat-parser'
 import {TSESTree} from '@typescript-eslint/utils'
 import {RuleContext, RuleModule} from '@typescript-eslint/utils/ts-eslint'
-import {getParserServices} from '../context-compat'
-import {extractMessages, getSettings} from '../util'
+import {getParserServices} from '../context-compat.js'
+import {extractMessages, getSettings} from '../util.js'
 
 enum LDML {
   zero = 'zero',

--- a/packages/eslint-plugin-formatjs/rules/no-camel-case.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-camel-case.ts
@@ -6,8 +6,8 @@ import {
 } from '@formatjs/icu-messageformat-parser'
 import {TSESTree} from '@typescript-eslint/utils'
 import {RuleContext, RuleModule} from '@typescript-eslint/utils/ts-eslint'
-import {getParserServices} from '../context-compat'
-import {extractMessages, getSettings} from '../util'
+import {getParserServices} from '../context-compat.js'
+import {extractMessages, getSettings} from '../util.js'
 
 type MessageIds = 'camelcase'
 

--- a/packages/eslint-plugin-formatjs/rules/no-complex-selectors.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-complex-selectors.ts
@@ -5,8 +5,8 @@ import {
 } from '@formatjs/icu-messageformat-parser'
 import {TSESTree} from '@typescript-eslint/utils'
 import {RuleContext, RuleModule} from '@typescript-eslint/utils/ts-eslint'
-import {getParserServices} from '../context-compat'
-import {extractMessages, getSettings} from '../util'
+import {getParserServices} from '../context-compat.js'
+import {extractMessages, getSettings} from '../util.js'
 
 interface Config {
   limit: number

--- a/packages/eslint-plugin-formatjs/rules/no-emoji.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-emoji.ts
@@ -8,8 +8,8 @@ import {
   isValidEmojiVersion,
   type EmojiVersion,
 } from 'unicode-emoji-utils'
-import {getParserServices} from '../context-compat'
-import {extractMessages, getSettings} from '../util'
+import {getParserServices} from '../context-compat.js'
+import {extractMessages, getSettings} from '../util.js'
 
 export const name = 'no-emoji'
 type MessageIds = 'notAllowed' | 'notAllowedAboveVersion'

--- a/packages/eslint-plugin-formatjs/rules/no-id.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-id.ts
@@ -4,8 +4,8 @@ import {
   RuleModule,
   SourceCode,
 } from '@typescript-eslint/utils/ts-eslint'
-import {getParserServices} from '../context-compat'
-import {extractMessages, getSettings} from '../util'
+import {getParserServices} from '../context-compat.js'
+import {extractMessages, getSettings} from '../util.js'
 
 function isComment(
   token: ReturnType<SourceCode['getTokenAfter']>

--- a/packages/eslint-plugin-formatjs/rules/no-invalid-icu.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-invalid-icu.ts
@@ -1,8 +1,8 @@
 import {parse} from '@formatjs/icu-messageformat-parser'
 import {TSESTree} from '@typescript-eslint/utils'
 import {RuleContext, RuleModule} from '@typescript-eslint/utils/ts-eslint'
-import {getParserServices} from '../context-compat'
-import {extractMessages, getSettings} from '../util'
+import {getParserServices} from '../context-compat.js'
+import {extractMessages, getSettings} from '../util.js'
 
 type MessageIds = 'icuError'
 

--- a/packages/eslint-plugin-formatjs/rules/no-literal-string-in-jsx.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-literal-string-in-jsx.ts
@@ -1,7 +1,9 @@
 import {TSESTree} from '@typescript-eslint/utils'
 import {JSONSchema4ArraySchema} from '@typescript-eslint/utils/json-schema'
 import {RuleModule} from '@typescript-eslint/utils/ts-eslint'
-import picomatch from 'picomatch'
+import * as picomatchNs from 'picomatch'
+
+const picomatch = (picomatchNs as any).default ?? picomatchNs
 
 type PropMatcher = readonly [TagNamePattern: string, PropNamePattern: string][]
 

--- a/packages/eslint-plugin-formatjs/rules/no-literal-string-in-object.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-literal-string-in-object.ts
@@ -1,6 +1,6 @@
 import {TSESTree} from '@typescript-eslint/utils'
 import {RuleContext, RuleModule} from '@typescript-eslint/utils/ts-eslint'
-import {getParserServices} from '../context-compat'
+import {getParserServices} from '../context-compat.js'
 
 type MessageIds = 'untranslatedProperty'
 type PropertyConfig = {

--- a/packages/eslint-plugin-formatjs/rules/no-missing-icu-plural-one-placeholders.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-missing-icu-plural-one-placeholders.ts
@@ -9,8 +9,8 @@ import {
 import {TSESTree} from '@typescript-eslint/utils'
 import {RuleContext, RuleModule} from '@typescript-eslint/utils/ts-eslint'
 import MagicString from 'magic-string'
-import {getParserServices} from '../context-compat'
-import {extractMessages, patchMessage} from '../util'
+import {getParserServices} from '../context-compat.js'
+import {extractMessages, patchMessage} from '../util.js'
 
 export const name = 'no-missing-icu-plural-one-placeholders'
 

--- a/packages/eslint-plugin-formatjs/rules/no-multiple-plurals.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-multiple-plurals.ts
@@ -5,8 +5,8 @@ import {
 } from '@formatjs/icu-messageformat-parser'
 import {TSESTree} from '@typescript-eslint/utils'
 import {RuleContext, RuleModule} from '@typescript-eslint/utils/ts-eslint'
-import {getParserServices} from '../context-compat'
-import {extractMessages, getSettings} from '../util'
+import {getParserServices} from '../context-compat.js'
+import {extractMessages, getSettings} from '../util.js'
 
 type MessageIds = 'noMultiplePlurals'
 

--- a/packages/eslint-plugin-formatjs/rules/no-multiple-whitespaces.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-multiple-whitespaces.ts
@@ -6,8 +6,8 @@ import {
 } from '@formatjs/icu-messageformat-parser'
 import {TSESTree} from '@typescript-eslint/utils'
 import {RuleContext, RuleModule} from '@typescript-eslint/utils/ts-eslint'
-import {getParserServices} from '../context-compat'
-import {extractMessages, getSettings, patchMessage} from '../util'
+import {getParserServices} from '../context-compat.js'
+import {extractMessages, getSettings, patchMessage} from '../util.js'
 
 type MessageIds = 'noMultipleWhitespaces' | 'parserError'
 

--- a/packages/eslint-plugin-formatjs/rules/no-offset.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-offset.ts
@@ -5,8 +5,8 @@ import {
 } from '@formatjs/icu-messageformat-parser'
 import {TSESTree} from '@typescript-eslint/utils'
 import {RuleContext, RuleModule} from '@typescript-eslint/utils/ts-eslint'
-import {getParserServices} from '../context-compat'
-import {extractMessages, getSettings} from '../util'
+import {getParserServices} from '../context-compat.js'
+import {extractMessages, getSettings} from '../util.js'
 
 type MessageIds = 'noOffset'
 

--- a/packages/eslint-plugin-formatjs/rules/no-useless-message.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-useless-message.ts
@@ -5,8 +5,8 @@ import {
 } from '@formatjs/icu-messageformat-parser'
 import {TSESTree} from '@typescript-eslint/utils'
 import {RuleContext, RuleModule} from '@typescript-eslint/utils/ts-eslint'
-import {getParserServices} from '../context-compat'
-import {extractMessages, getSettings} from '../util'
+import {getParserServices} from '../context-compat.js'
+import {extractMessages, getSettings} from '../util.js'
 
 type MessageIds =
   | 'unnecessaryFormat'

--- a/packages/eslint-plugin-formatjs/rules/prefer-formatted-message.ts
+++ b/packages/eslint-plugin-formatjs/rules/prefer-formatted-message.ts
@@ -1,6 +1,6 @@
 import {TSESTree} from '@typescript-eslint/utils'
 import {RuleModule} from '@typescript-eslint/utils/ts-eslint'
-import {isIntlFormatMessageCall} from '../util'
+import {isIntlFormatMessageCall} from '../util.js'
 
 type MessageIds = 'jsxChildren'
 

--- a/packages/eslint-plugin-formatjs/rules/prefer-pound-in-plural.ts
+++ b/packages/eslint-plugin-formatjs/rules/prefer-pound-in-plural.ts
@@ -7,8 +7,8 @@ import {
 import {TSESTree} from '@typescript-eslint/utils'
 import {RuleContext, RuleModule} from '@typescript-eslint/utils/ts-eslint'
 import MagicString from 'magic-string'
-import {getParserServices} from '../context-compat'
-import {extractMessages, getSettings, patchMessage} from '../util'
+import {getParserServices} from '../context-compat.js'
+import {extractMessages, getSettings, patchMessage} from '../util.js'
 
 type MessageIds = 'preferPoundInPlurals' | 'parseError'
 

--- a/packages/eslint-plugin-formatjs/tests/blocklist-elements.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/blocklist-elements.test.ts
@@ -1,4 +1,4 @@
-import {Element, name, rule} from '../rules/blocklist-elements'
+import {Element, name, rule} from '../rules/blocklist-elements.js'
 import {dynamicMessage, emptyFnCall, noMatch, spreadJsx} from './fixtures'
 import {ruleTester, vueRuleTester} from './util'
 

--- a/packages/eslint-plugin-formatjs/tests/enforce-default-message.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/enforce-default-message.test.ts
@@ -1,4 +1,4 @@
-import {rule, name, Option} from '../rules/enforce-default-message'
+import {rule, name, Option} from '../rules/enforce-default-message.js'
 import {noMatch, spreadJsx, emptyFnCall, dynamicMessage} from './fixtures'
 import {ruleTester, vueRuleTester} from './util'
 

--- a/packages/eslint-plugin-formatjs/tests/enforce-description.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/enforce-description.test.ts
@@ -1,4 +1,4 @@
-import {Option, name, rule} from '../rules/enforce-description'
+import {Option, name, rule} from '../rules/enforce-description.js'
 import {noMatch, spreadJsx, emptyFnCall, dynamicMessage} from './fixtures'
 import {ruleTester} from './util'
 

--- a/packages/eslint-plugin-formatjs/tests/enforce-id.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/enforce-id.test.ts
@@ -1,4 +1,4 @@
-import {name, Option, rule} from '../rules/enforce-id'
+import {name, Option, rule} from '../rules/enforce-id.js'
 import {emptyFnCall, noMatch, spreadJsx} from './fixtures'
 import {ruleTester, vueRuleTester} from './util'
 const options: [Option] = [

--- a/packages/eslint-plugin-formatjs/tests/enforce-placeholders.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/enforce-placeholders.test.ts
@@ -1,4 +1,4 @@
-import {name, rule} from '../rules/enforce-placeholders'
+import {name, rule} from '../rules/enforce-placeholders.js'
 import {dynamicMessage, emptyFnCall, noMatch, spreadJsx} from './fixtures'
 import {ruleTester} from './util'
 ruleTester.run(name, rule, {

--- a/packages/eslint-plugin-formatjs/tests/enforce-plural-rules.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/enforce-plural-rules.test.ts
@@ -1,4 +1,4 @@
-import {name, rule} from '../rules/enforce-plural-rules'
+import {name, rule} from '../rules/enforce-plural-rules.js'
 import {ruleTester} from './util'
 import {dynamicMessage, noMatch, spreadJsx, emptyFnCall} from './fixtures'
 ruleTester.run(name, rule, {

--- a/packages/eslint-plugin-formatjs/tests/no-camel-case.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/no-camel-case.test.ts
@@ -1,5 +1,5 @@
 import {ruleTester} from './util'
-import {rule, name} from '../rules/no-camel-case'
+import {rule, name} from '../rules/no-camel-case.js'
 import {
   dynamicMessage,
   noMatch,

--- a/packages/eslint-plugin-formatjs/tests/no-complex-selectors.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/no-complex-selectors.test.ts
@@ -1,4 +1,4 @@
-import {rule, name} from '../rules/no-complex-selectors'
+import {rule, name} from '../rules/no-complex-selectors.js'
 import {ruleTester} from './util'
 import {
   dynamicMessage,

--- a/packages/eslint-plugin-formatjs/tests/no-emoji.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/no-emoji.test.ts
@@ -1,5 +1,5 @@
 import {ruleTester} from './util'
-import {rule, name} from '../rules/no-emoji'
+import {rule, name} from '../rules/no-emoji.js'
 
 ruleTester.run(name, rule, {
   valid: [

--- a/packages/eslint-plugin-formatjs/tests/no-id.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/no-id.test.ts
@@ -1,4 +1,4 @@
-import {name, rule} from '../rules/no-id'
+import {name, rule} from '../rules/no-id.js'
 import {dynamicMessage, emptyFnCall, noMatch, spreadJsx} from './fixtures'
 import {ruleTester} from './util'
 ruleTester.run(name, rule, {

--- a/packages/eslint-plugin-formatjs/tests/no-invalid-icu.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/no-invalid-icu.test.ts
@@ -1,4 +1,4 @@
-import {name, rule} from '../rules/no-invalid-icu'
+import {name, rule} from '../rules/no-invalid-icu.js'
 import {dynamicMessage, emptyFnCall, noMatch, spreadJsx} from './fixtures'
 import {ruleTester} from './util'
 

--- a/packages/eslint-plugin-formatjs/tests/no-literal-string-in-jsx.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/no-literal-string-in-jsx.test.ts
@@ -1,4 +1,4 @@
-import {rule, name} from '../rules/no-literal-string-in-jsx'
+import {rule, name} from '../rules/no-literal-string-in-jsx.js'
 import {ruleTester} from './util'
 
 ruleTester.run(name, rule, {

--- a/packages/eslint-plugin-formatjs/tests/no-literal-string-in-object.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/no-literal-string-in-object.test.ts
@@ -1,4 +1,4 @@
-import {rule, name} from '../rules/no-literal-string-in-object'
+import {rule, name} from '../rules/no-literal-string-in-object.js'
 import {ruleTester, vueRuleTester} from './util'
 import {dynamicMessage, noMatch, spreadJsx, emptyFnCall} from './fixtures'
 

--- a/packages/eslint-plugin-formatjs/tests/no-missing-icu-plural-one-placeholders.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/no-missing-icu-plural-one-placeholders.test.ts
@@ -1,4 +1,4 @@
-import {name, rule} from '../rules/no-missing-icu-plural-one-placeholders'
+import {name, rule} from '../rules/no-missing-icu-plural-one-placeholders.js'
 import {ruleTester} from './util'
 
 ruleTester.run(name, rule, {

--- a/packages/eslint-plugin-formatjs/tests/no-multiple-plurals.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/no-multiple-plurals.test.ts
@@ -1,4 +1,4 @@
-import {name, rule} from '../rules/no-multiple-plurals'
+import {name, rule} from '../rules/no-multiple-plurals.js'
 import {ruleTester} from './util'
 import {
   dynamicMessage,

--- a/packages/eslint-plugin-formatjs/tests/no-multiple-whitespaces.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/no-multiple-whitespaces.test.ts
@@ -1,4 +1,4 @@
-import {name, rule} from '../rules/no-multiple-whitespaces'
+import {name, rule} from '../rules/no-multiple-whitespaces.js'
 import {
   defineMessage,
   dynamicMessage,

--- a/packages/eslint-plugin-formatjs/tests/no-offset.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/no-offset.test.ts
@@ -1,4 +1,4 @@
-import {name, rule} from '../rules/no-offset'
+import {name, rule} from '../rules/no-offset.js'
 import {dynamicMessage, emptyFnCall, noMatch, spreadJsx} from './fixtures'
 import {ruleTester} from './util'
 ruleTester.run(name, rule, {

--- a/packages/eslint-plugin-formatjs/tests/no-useless-message.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/no-useless-message.test.ts
@@ -1,4 +1,4 @@
-import {name, rule} from '../rules/no-useless-message'
+import {name, rule} from '../rules/no-useless-message.js'
 import {ruleTester} from './util'
 import {
   dynamicMessage,

--- a/packages/eslint-plugin-formatjs/tests/prefer-formatted-message.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/prefer-formatted-message.test.ts
@@ -1,4 +1,4 @@
-import {rule, name} from '../rules/prefer-formatted-message'
+import {rule, name} from '../rules/prefer-formatted-message.js'
 import {ruleTester} from './util'
 import {
   dynamicMessage,

--- a/packages/eslint-plugin-formatjs/tests/prefer-pound-in-plural.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/prefer-pound-in-plural.test.ts
@@ -1,4 +1,4 @@
-import {name, rule} from '../rules/prefer-pound-in-plural'
+import {name, rule} from '../rules/prefer-pound-in-plural.js'
 import {
   defineMessage,
   dynamicMessage,

--- a/packages/ts-transformer/BUILD.bazel
+++ b/packages/ts-transformer/BUILD.bazel
@@ -44,6 +44,7 @@ SRC_DEPS = [
 ts_compile_node(
     name = "dist",
     srcs = [":srcs"],
+    skip_cjs = True,
     deps = SRC_DEPS + [
         "//:node_modules/@jest/types",
         "//:node_modules/@types/jest",

--- a/packages/ts-transformer/index.ts
+++ b/packages/ts-transformer/index.ts
@@ -1,3 +1,3 @@
-export * from './src/transform'
-export * from './src/types'
-export * from './src/interpolate-name'
+export * from './src/transform.js'
+export * from './src/types.js'
+export * from './src/interpolate-name.js'

--- a/packages/ts-transformer/package.json
+++ b/packages/ts-transformer/package.json
@@ -4,6 +4,7 @@
   "version": "3.14.2",
   "license": "MIT",
   "author": "Long Ho <holevietlong@gmail.com>",
+  "type": "module",
   "types": "index.d.ts",
   "dependencies": {
     "@formatjs/icu-messageformat-parser": "workspace:*",

--- a/packages/ts-transformer/src/console_utils.ts
+++ b/packages/ts-transformer/src/console_utils.ts
@@ -1,10 +1,12 @@
-import {green, red, yellow} from 'chalk'
+import * as chalkNs from 'chalk'
 import {format} from 'util'
 
+const chalk = (chalkNs as any).default ?? chalkNs
+
 const LEVEL_COLORS = {
-  debug: green,
-  warn: yellow,
-  error: red,
+  debug: chalk.green,
+  warn: chalk.yellow,
+  error: chalk.red,
 }
 
 function label(level: keyof typeof LEVEL_COLORS, message: string) {

--- a/packages/ts-transformer/src/transform.ts
+++ b/packages/ts-transformer/src/transform.ts
@@ -1,9 +1,11 @@
 import {MessageFormatElement, parse} from '@formatjs/icu-messageformat-parser'
-import stringify from 'json-stable-stringify'
+import * as stringifyNs from 'json-stable-stringify'
 import * as typescript from 'typescript'
-import {debug} from './console_utils'
-import {interpolateName} from './interpolate-name'
-import {MessageDescriptor} from './types'
+import {debug} from './console_utils.js'
+import {interpolateName} from './interpolate-name.js'
+import {MessageDescriptor} from './types.js'
+
+const stringify = (stringifyNs as any).default || stringifyNs
 export type Extractor = (filePath: string, msgs: MessageDescriptor[]) => void
 export type MetaExtractor = (
   filePath: string,


### PR DESCRIPTION
### TL;DR

Convert ts-transformer package to ESM format.

### What changed?

- Added `"type": "module"` to package.json
- Updated import paths to include `.js` extensions
- Set `skip_cjs = True` in the Bazel build configuration
- Fixed imports for chalk and json-stable-stringify to work in ESM context

### How to test?

1. Build the ts-transformer package
2. Verify that imports from this package work correctly in ESM projects
3. Ensure existing functionality continues to work as expected

### Why make this change?

This change is part of the ongoing effort to modernize the codebase by migrating to ESM format. Using native ES modules improves compatibility with modern JavaScript tooling and aligns with current best practices for package development.