### PR TITLE
fix(babel-plugin-formatjs): small ext miss

### DIFF
--- a/packages/babel-plugin-formatjs/utils.ts
+++ b/packages/babel-plugin-formatjs/utils.ts
@@ -8,7 +8,7 @@ import {
   MessageDescriptor,
   MessageDescriptorPath,
   Options,
-} from './types'
+} from './types.js'
 
 const DESCRIPTOR_PROPS = new Set<keyof MessageDescriptorPath>([
   'id',


### PR DESCRIPTION
### TL;DR

Updated import path to include `.js` extension in babel-plugin-formatjs.

### What changed?

Modified the import statement in `packages/babel-plugin-formatjs/utils.ts` to use the `.js` extension when importing from `./types`. Changed from `from './types'` to `from './types.js'`.

### How to test?

1. Build the babel-plugin-formatjs package
2. Verify that imports resolve correctly
3. Run existing tests to ensure functionality is maintained

### Why make this change?

This change ensures proper module resolution in ESM environments where explicit file extensions are required. Modern JavaScript module systems, especially when using ESM, often require explicit file extensions for local imports.