### PR TITLE
fix(react-intl): move @types/react to peerDep

### DIFF
--- a/packages/react-intl/package.json
+++ b/packages/react-intl/package.json
@@ -11,12 +11,12 @@
     "@formatjs/icu-messageformat-parser": "workspace:*",
     "@formatjs/intl": "workspace:*",
     "@types/hoist-non-react-statics": "^3.3.1",
-    "@types/react": "16 || 17 || 18 || 19",
     "hoist-non-react-statics": "^3.3.2",
     "intl-messageformat": "workspace:*",
     "tslib": "^2.8.0"
   },
   "peerDependencies": {
+    "@types/react": "16 || 17 || 18 || 19",
     "react": "16 || 17 || 18 || 19",
     "typescript": "^5.6.0"
   },


### PR DESCRIPTION
### TL;DR

Move `@types/react` from dependencies to peerDependencies in react-intl package.


Fix #5141

### What changed?

Moved the `@types/react` package from the `dependencies` section to the `peerDependencies` section in the `package.json` file of the react-intl package. The version specification `"16 || 17 || 18 || 19"` remains unchanged.

### How to test?

1. Install the package in a project that uses React
2. Verify that TypeScript types work correctly with different React versions
3. Ensure no type errors occur when using react-intl components

### Why make this change?

This change aligns `@types/react` with the React peer dependency, which is the correct pattern for TypeScript type definitions. Having `@types/react` as a direct dependency can cause duplicate type definitions and potential conflicts when projects use different React versions. Moving it to peerDependencies ensures that the project's React version and its corresponding type definitions are used consistently.