### PR TITLE
fix(@formatjs/fast-memoize): fix type

### DIFF
--- a/packages/fast-memoize/index.ts
+++ b/packages/fast-memoize/index.ts
@@ -34,10 +34,7 @@ export interface MemoizeFunc<F extends Func> {
   (fn: F, options?: Options<F>): F
 }
 
-export function memoize<F extends Func>(
-  fn: F,
-  options?: Options<F>
-): F | ((arg: any) => any) {
+export function memoize<F extends Func>(fn: F, options?: Options<F>): F {
   const cache = options && options.cache ? options.cache : cacheDefault
 
   const serializer =
@@ -112,8 +109,8 @@ function assemble<F extends Func>(
   strategy: StrategyFn,
   cache: DefaultCache<string, ReturnType<F>>,
   serialize: Serializer
-) {
-  return strategy.bind(context, fn, cache, serialize)
+): F {
+  return strategy.bind(context, fn, cache, serialize) as F
 }
 
 function strategyDefault<F extends Func>(


### PR DESCRIPTION
### TL;DR

Fixed TypeScript return type for the `memoize` function to properly return the original function type.

Fix #5048

### What changed?

- Updated the return type of `memoize<F extends Func>` from `F | ((arg: any) => any)` to just `F`
- Added a return type annotation to the `assemble` function to explicitly return type `F`
- Added a type assertion to the `strategy.bind()` call to ensure it returns the correct function type

### How to test?

- Verify that TypeScript code using the `memoize` function compiles without type errors
- Ensure that memoized functions maintain their original type signatures
- Check that existing code using this function continues to work as expected

### Why make this change?

The previous implementation had an incorrect return type that could cause TypeScript type checking issues. The function was returning a union type `F | ((arg: any) => any)` which could lead to type errors when using the memoized function. This change ensures that the memoized function maintains the exact same type signature as the original function, providing better type safety and developer experience.