### PR TITLE
feat(eslint-plugin-formatjs): support `children` for `exclude` in no-literal-string-in-jsx

### DIFF
--- a/packages/eslint-plugin-formatjs/tests/no-literal-string-in-jsx.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/no-literal-string-in-jsx.test.ts
@@ -88,6 +88,59 @@ ruleTester.run(name, rule, {
     {
       code: '<input type="text" placeholder={f("foo")} aria-label={f("bar")} />',
     },
+    // Exclude children of specific elements
+    {
+      code: '<MenubarShortcut>Ctrl+C</MenubarShortcut>',
+      options: [
+        {
+          props: {
+            exclude: [['MenubarShortcut', 'children']],
+          },
+        },
+      ],
+    },
+    {
+      code: '<MenubarShortcut>{"Ctrl+C"}</MenubarShortcut>',
+      options: [
+        {
+          props: {
+            exclude: [['MenubarShortcut', 'children']],
+          },
+        },
+      ],
+    },
+    {
+      code: '<MenubarShortcut>{`Ctrl+C`}</MenubarShortcut>',
+      options: [
+        {
+          props: {
+            exclude: [['MenubarShortcut', 'children']],
+          },
+        },
+      ],
+    },
+    // Exclude children with wildcard pattern
+    {
+      code: '<Kbd>Ctrl+C</Kbd>',
+      options: [
+        {
+          props: {
+            exclude: [['*', 'children']],
+          },
+        },
+      ],
+    },
+    // Exclude children of specific pattern
+    {
+      code: '<UI.Shortcut>Ctrl+C</UI.Shortcut>',
+      options: [
+        {
+          props: {
+            exclude: [['UI.*', 'children']],
+          },
+        },
+      ],
+    },
     {
       code: `
         <Component
@@ -283,6 +336,39 @@ ruleTester.run(name, rule, {
         {messageId: 'noLiteralStringInJsx'},
         {messageId: 'noLiteralStringInJsx'},
       ],
+    },
+    // Children are not excluded when not specified
+    {
+      code: '<MenubarShortcut>Ctrl+C</MenubarShortcut>',
+      errors: [{messageId: 'noLiteralStringInJsx'}],
+    },
+    {
+      code: '<MenubarShortcut>{"Ctrl+C"}</MenubarShortcut>',
+      errors: [{messageId: 'noLiteralStringInJsx'}],
+    },
+    // Children exclusion is specific to the element
+    {
+      code: '<OtherComponent>text</OtherComponent>',
+      options: [
+        {
+          props: {
+            exclude: [['MenubarShortcut', 'children']],
+          },
+        },
+      ],
+      errors: [{messageId: 'noLiteralStringInJsx'}],
+    },
+    // Attributes are still checked even when children are excluded
+    {
+      code: '<MenubarShortcut aria-label="label">Ctrl+C</MenubarShortcut>',
+      options: [
+        {
+          props: {
+            exclude: [['MenubarShortcut', 'children']],
+          },
+        },
+      ],
+      errors: [{messageId: 'noLiteralStringInJsx'}],
     },
   ],
 })


### PR DESCRIPTION
### TL;DR

Added support for excluding children of specific JSX elements in the `no-literal-string-in-jsx` rule.

Fix #5132

### What changed?

- Implemented a new `shouldSkipCurrentJsxElement()` function to check if children of the current JSX element should be excluded based on tag name patterns
- Applied this check in the JSX text and expression container handlers
- Added comprehensive test cases for the new functionality, including:
  - Excluding children of specific elements
  - Using wildcard patterns for element names
  - Handling namespaced components
  - Verifying that attributes are still checked even when children are excluded

### How to test?

Test with configurations like:

```js
{
  props: {
    exclude: [
      ['MenubarShortcut', 'children'],
      ['UI.*', 'children'],
      ['*', 'children'] // Wildcard to exclude all children
    ]
  }
}
```

Verify that literal strings in children of excluded elements don't trigger linting errors, while attributes on those same elements are still properly checked.

### Why make this change?

This enhancement provides more flexibility for the `no-literal-string-in-jsx` rule by allowing developers to exclude children of specific components from internationalization requirements. This is particularly useful for components that should intentionally display literal strings, such as keyboard shortcuts, code snippets, or technical identifiers that shouldn't be translated.