### PR TITLE
chore: bump up test size for intl-numberformat

### DIFF
--- a/packages/intl-numberformat/BUILD.bazel
+++ b/packages/intl-numberformat/BUILD.bazel
@@ -172,6 +172,7 @@ LOCALE_TEST_TYPES = [
 
 vitest(
     name = "all_tests",
+    size = "large",
     srcs = [":srcs"] +
            ["tests/%sTest.ts" % type for type in LOCALE_TEST_TYPES] +
            [":%s_%s_test_gen" % (type, locale) for type in LOCALE_TEST_TYPES for locale in UNIT_TEST_LOCALES] +


### PR DESCRIPTION
### TL;DR

Added `size = "large"` to the vitest test target in the intl-numberformat package.

### What changed?

Updated the `vitest` rule in `packages/intl-numberformat/BUILD.bazel` to specify `size = "large"` for the `all_tests` target. This helps Bazel properly allocate resources for this test suite.

### How to test?

Run the tests for the intl-numberformat package using Bazel:
```
bazel test //packages/intl-numberformat:all_tests
```
Verify that the tests execute successfully with the new size configuration.

### Why make this change?

The intl-numberformat test suite is resource-intensive and may time out under default size constraints. Setting the size to "large" gives the tests more time and resources to complete, preventing potential timeouts in CI environments and ensuring more reliable test execution.