### PR TITLE
feat(@formatjs/intl-segmenter)!: convert to ESM only

### DIFF
--- a/packages/intl-segmenter/BUILD.bazel
+++ b/packages/intl-segmenter/BUILD.bazel
@@ -63,6 +63,7 @@ TESTS = glob([
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
+    skip_cjs = True,
     skip_esm = False,
     deps = SRC_DEPS,
 )

--- a/packages/intl-segmenter/benchmark.ts
+++ b/packages/intl-segmenter/benchmark.ts
@@ -2,9 +2,9 @@ import {Suite, Event} from 'benchmark'
 
 //@ts-ignore
 // const Segmenter = Intl.Segmenter
-import {Segmenter} from './src/segmenter'
+import {Segmenter} from './src/segmenter.js'
 
-import {SegmentIterator} from './src/segmenter'
+import {SegmentIterator} from './src/segmenter.js'
 const locale = 'en'
 let inputString = `
 

--- a/packages/intl-segmenter/debug.ts
+++ b/packages/intl-segmenter/debug.ts
@@ -5,8 +5,8 @@
  * example: `npx ts-node debug word 1700-1701`
  */
 
-import {Segmenter} from './src/segmenter'
-import {segmentationTests} from './tests/test-utils'
+import {Segmenter} from './src/segmenter.js'
+import {segmentationTests} from './tests/test-utils.js'
 
 //parse argvs
 const lastArg = process.argv[process.argv.length - 1]

--- a/packages/intl-segmenter/package.json
+++ b/packages/intl-segmenter/package.json
@@ -4,7 +4,11 @@
   "version": "11.7.12",
   "license": "MIT",
   "author": "Matija Gaspar <matijagaspar@gmail.com>",
-  "types": "index.d.ts",
+  "type": "module",
+  "exports": {
+    "./polyfill.js": "./polyfill.js",
+    "./polyfill-force.js": "./polyfill-force.js"
+  },
   "dependencies": {
     "@formatjs/ecma402-abstract": "workspace:*",
     "@formatjs/intl-localematcher": "workspace:*",
@@ -20,6 +24,5 @@
     "tc39",
     "unicode"
   ],
-  "main": "index.js",
   "repository": "git@github.com:formatjs/formatjs.git"
 }

--- a/packages/intl-segmenter/polyfill-force.ts
+++ b/packages/intl-segmenter/polyfill-force.ts
@@ -1,4 +1,4 @@
-import {Segmenter} from './src/segmenter'
+import {Segmenter} from './src/segmenter.js'
 
 Object.defineProperty(Intl, 'Segmenter', {
   value: Segmenter,

--- a/packages/intl-segmenter/polyfill.ts
+++ b/packages/intl-segmenter/polyfill.ts
@@ -1,5 +1,5 @@
-import {Segmenter} from './src/segmenter'
-import {shouldPolyfill} from './should-polyfill'
+import {Segmenter} from './src/segmenter.js'
+import {shouldPolyfill} from './should-polyfill.js'
 
 if (shouldPolyfill()) {
   Object.defineProperty(Intl, 'Segmenter', {

--- a/packages/intl-segmenter/scripts/generate-cldr-segmentation-rules.ts
+++ b/packages/intl-segmenter/scripts/generate-cldr-segmentation-rules.ts
@@ -539,6 +539,4 @@ async function main({out, unicodeFiles}: Args) {
   )
 }
 
-if (require.main === module) {
-  main(minimist<Args>(process.argv))
-}
+main(minimist<Args>(process.argv))

--- a/packages/intl-segmenter/scripts/test262-main-gen.ts
+++ b/packages/intl-segmenter/scripts/test262-main-gen.ts
@@ -14,11 +14,9 @@ function main(args: Args) {
     out,
     `// @generated
 // @ts-nocheck
-import './polyfill-force';
+import './polyfill-force.js';
 `
   )
 }
 
-if (require.main === module) {
-  main(minimist<Args>(process.argv))
-}
+main(minimist<Args>(process.argv))

--- a/packages/intl-segmenter/src/segmenter.ts
+++ b/packages/intl-segmenter/src/segmenter.ts
@@ -8,8 +8,8 @@ import {
   setInternalSlot,
 } from '@formatjs/ecma402-abstract'
 import {ResolveLocale} from '@formatjs/intl-localematcher'
-import {SegmentationRules} from './cldr-segmentation-rules.generated'
-import {isSurrogate, replaceVariables} from './segmentation-utils'
+import {SegmentationRules} from './cldr-segmentation-rules.generated.js'
+import {isSurrogate, replaceVariables} from './segmentation-utils.js'
 
 type SegmentationRule = {
   breaks: boolean

--- a/packages/intl-segmenter/test262-main.ts
+++ b/packages/intl-segmenter/test262-main.ts
@@ -1,3 +1,3 @@
 // @generated
 // @ts-nocheck
-import './polyfill-force';
+import './polyfill-force.js';

--- a/packages/intl-segmenter/tests/grapheme.test.ts
+++ b/packages/intl-segmenter/tests/grapheme.test.ts
@@ -1,5 +1,5 @@
-import {Segmenter} from '../src/segmenter'
-import {segmentationTests} from './test-utils'
+import {Segmenter} from '../src/segmenter.js'
+import {segmentationTests} from './test-utils.js'
 import {describe, expect, it} from 'vitest'
 const ucdTests = segmentationTests.grapheme
 describe('Granularity grapheme', () => {

--- a/packages/intl-segmenter/tests/sentence.test.ts
+++ b/packages/intl-segmenter/tests/sentence.test.ts
@@ -1,5 +1,5 @@
-import {Segmenter} from '../src/segmenter'
-import {segmentationTests} from './test-utils'
+import {Segmenter} from '../src/segmenter.js'
+import {segmentationTests} from './test-utils.js'
 import {describe, expect, it} from 'vitest'
 // TODO: Fix this
 const excluded = [

--- a/packages/intl-segmenter/tests/word.test.ts
+++ b/packages/intl-segmenter/tests/word.test.ts
@@ -1,5 +1,5 @@
-import {Segmenter} from '../src/segmenter'
-import {segmentationTests} from './test-utils'
+import {Segmenter} from '../src/segmenter.js'
+import {segmentationTests} from './test-utils.js'
 import {describe, expect, it} from 'vitest'
 // TODO: This seems broken in CLDRv43
 const EXCLUDED_CASES_INPUTS = new Set([

--- a/tools/index.bzl
+++ b/tools/index.bzl
@@ -65,6 +65,7 @@ def ts_compile(name, srcs, deps = [], skip_cjs = False, skip_esm = True, skip_es
         visibility: visibility
     """
     deps = deps + ["//:node_modules/tslib"]
+    esm_out_dir = "lib" if not skip_cjs else None
     if not skip_cjs:
         ts_project(
             name = "%s-base" % name,
@@ -79,7 +80,7 @@ def ts_compile(name, srcs, deps = [], skip_cjs = False, skip_esm = True, skip_es
             name = "%s-esm" % name,
             srcs = srcs,
             declaration = True,
-            out_dir = "lib",
+            out_dir = esm_out_dir,
             tsconfig = ESM_TSCONFIG,
             resolve_json_module = True,
             deps = deps,


### PR DESCRIPTION
### TL;DR

Convert `intl-segmenter` package to ESM-only format.

### What changed?

- Updated `package.json` to specify `"type": "module"` and defined proper exports
- Added `.js` extensions to all import statements
- Removed CommonJS build by setting `skip_cjs = True` in Bazel config
- Updated the Bazel build configuration to properly handle ESM output
- Modified script execution logic to work with ESM
- Removed conditional `require.main === module` checks that are not needed in ESM

### How to test?

1. Build the package with `yarn build`
2. Run tests with `yarn test`
3. Verify the package can be imported in an ESM environment
4. Ensure the polyfill works correctly when imported via `import '@formatjs/intl-segmenter/polyfill.js'`

### Why make this change?

This change is part of the ongoing effort to modernize the FormatJS packages by moving to ESM-only format. ESM is the standard module system for JavaScript and provides better tree-shaking, static analysis, and compatibility with modern tooling.