### PR TITLE
feat(@formatjs/intl-relativetimeformat)!: convert to ESM

### DIFF
--- a/packages/intl-relativetimeformat/BUILD.bazel
+++ b/packages/intl-relativetimeformat/BUILD.bazel
@@ -56,6 +56,7 @@ SRC_DEPS = [
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
+    skip_cjs = True,
     skip_esm = False,
     deps = SRC_DEPS,
 )

--- a/packages/intl-relativetimeformat/abstract/FormatRelativeTime.ts
+++ b/packages/intl-relativetimeformat/abstract/FormatRelativeTime.ts
@@ -1,5 +1,5 @@
 import {RelativeTimeFormatInternal} from '@formatjs/ecma402-abstract'
-import {PartitionRelativeTimePattern} from './PartitionRelativeTimePattern'
+import {PartitionRelativeTimePattern} from './PartitionRelativeTimePattern.js'
 
 export function FormatRelativeTime(
   rtf: Intl.RelativeTimeFormat,

--- a/packages/intl-relativetimeformat/abstract/FormatRelativeTimeToParts.ts
+++ b/packages/intl-relativetimeformat/abstract/FormatRelativeTimeToParts.ts
@@ -1,5 +1,5 @@
 import {RelativeTimeFormatInternal} from '@formatjs/ecma402-abstract'
-import {PartitionRelativeTimePattern} from './PartitionRelativeTimePattern'
+import {PartitionRelativeTimePattern} from './PartitionRelativeTimePattern.js'
 
 export function FormatRelativeTimeToParts(
   rtf: Intl.RelativeTimeFormat,

--- a/packages/intl-relativetimeformat/abstract/PartitionRelativeTimePattern.ts
+++ b/packages/intl-relativetimeformat/abstract/PartitionRelativeTimePattern.ts
@@ -8,8 +8,8 @@ import {
   ToString,
   Type,
 } from '@formatjs/ecma402-abstract'
-import {SingularRelativeTimeUnit} from './SingularRelativeTimeUnit'
-import {MakePartsList} from './MakePartsList'
+import {SingularRelativeTimeUnit} from './SingularRelativeTimeUnit.js'
+import {MakePartsList} from './MakePartsList.js'
 
 export function PartitionRelativeTimePattern(
   rtf: Intl.RelativeTimeFormat,

--- a/packages/intl-relativetimeformat/index.ts
+++ b/packages/intl-relativetimeformat/index.ts
@@ -5,9 +5,9 @@ import {
   SupportedLocales,
   ToString,
 } from '@formatjs/ecma402-abstract'
-import {InitializeRelativeTimeFormat} from './abstract/InitializeRelativeTimeFormat'
-import {PartitionRelativeTimePattern} from './abstract/PartitionRelativeTimePattern'
-import getInternalSlots from './get_internal_slots'
+import {InitializeRelativeTimeFormat} from './abstract/InitializeRelativeTimeFormat.js'
+import {PartitionRelativeTimePattern} from './abstract/PartitionRelativeTimePattern.js'
+import getInternalSlots from './get_internal_slots.js'
 
 export default class RelativeTimeFormat {
   constructor(

--- a/packages/intl-relativetimeformat/package.json
+++ b/packages/intl-relativetimeformat/package.json
@@ -4,7 +4,13 @@
   "version": "11.4.13",
   "license": "MIT",
   "author": "Long Ho <holevietlong@gmail.com>",
+  "type": "module",
   "types": "index.d.ts",
+  "exports": {
+    ".": "./index.js",
+    "./polyfill.js": "./polyfill.js",
+    "./polyfill-force.js": "./polyfill-force.js"
+  },
   "dependencies": {
     "@formatjs/ecma402-abstract": "workspace:*",
     "@formatjs/intl-localematcher": "workspace:*",
@@ -27,6 +33,5 @@
     "relative",
     "time"
   ],
-  "main": "index.js",
   "repository": "git@github.com:formatjs/formatjs.git"
 }

--- a/packages/intl-relativetimeformat/polyfill-force.ts
+++ b/packages/intl-relativetimeformat/polyfill-force.ts
@@ -1,4 +1,4 @@
-import RelativeTimeFormat from './'
+import RelativeTimeFormat from './index.js'
 Object.defineProperty(Intl, 'RelativeTimeFormat', {
   value: RelativeTimeFormat,
   writable: true,

--- a/packages/intl-relativetimeformat/polyfill.ts
+++ b/packages/intl-relativetimeformat/polyfill.ts
@@ -1,5 +1,5 @@
-import RelativeTimeFormat from './'
-import {shouldPolyfill} from './should-polyfill'
+import RelativeTimeFormat from './index.js'
+import {shouldPolyfill} from './should-polyfill.js'
 if (shouldPolyfill()) {
   Object.defineProperty(Intl, 'RelativeTimeFormat', {
     value: RelativeTimeFormat,

--- a/packages/intl-relativetimeformat/scripts/cldr-raw.ts
+++ b/packages/intl-relativetimeformat/scripts/cldr-raw.ts
@@ -1,4 +1,4 @@
-import {extractRelativeFields, getAllLocales} from './extract-relative'
+import {extractRelativeFields, getAllLocales} from './extract-relative.js'
 import {join} from 'path'
 import {outputFileSync} from 'fs-extra'
 import stringify from 'json-stable-stringify'
@@ -23,6 +23,4 @@ async function main(args: minimist.ParsedArgs) {
   )
 }
 
-if (require.main === module) {
-  ;(async () => main(minimist(process.argv)))()
-}
+;(async () => main(minimist(process.argv)))()

--- a/packages/intl-relativetimeformat/scripts/cldr.ts
+++ b/packages/intl-relativetimeformat/scripts/cldr.ts
@@ -24,6 +24,4 @@ if (Intl.RelativeTimeFormat && typeof Intl.RelativeTimeFormat.__addLocaleData ==
     outputFileSync(join(outDir, locale + '.d.ts'), 'export {}')
   })
 }
-if (require.main === module) {
-  main(minimist<Args>(process.argv))
-}
+main(minimist<Args>(process.argv))

--- a/packages/intl-relativetimeformat/scripts/test262-main-gen.ts
+++ b/packages/intl-relativetimeformat/scripts/test262-main-gen.ts
@@ -16,13 +16,11 @@ function main(args: Args) {
     `/* @generated */
 // prettier-ignore
 // @ts-nocheck
-import './polyfill-force'
+import './polyfill-force.js'
 if (Intl.RelativeTimeFormat && typeof Intl.RelativeTimeFormat.__addLocaleData === 'function') {
   Intl.RelativeTimeFormat.__addLocaleData(${allData.join(',\n')})
 }
 `
   )
 }
-if (require.main === module) {
-  main(minimist<Args>(process.argv))
-}
+main(minimist<Args>(process.argv))

--- a/packages/intl-relativetimeformat/should-polyfill.ts
+++ b/packages/intl-relativetimeformat/should-polyfill.ts
@@ -1,5 +1,5 @@
 import {match} from '@formatjs/intl-localematcher'
-import {supportedLocales} from './supported-locales.generated'
+import {supportedLocales} from './supported-locales.generated.js'
 
 function supportedLocalesOf(locale?: string | string[]) {
   if (!locale) {

--- a/packages/intl-relativetimeformat/test262-main.ts
+++ b/packages/intl-relativetimeformat/test262-main.ts
@@ -1,7 +1,7 @@
 /* @generated */
 // prettier-ignore
 // @ts-nocheck
-import './polyfill-force'
+import './polyfill-force.js'
 if (Intl.RelativeTimeFormat && typeof Intl.RelativeTimeFormat.__addLocaleData === 'function') {
   Intl.RelativeTimeFormat.__addLocaleData({
   "data": {

--- a/packages/intl-relativetimeformat/tests/index.test.ts
+++ b/packages/intl-relativetimeformat/tests/index.test.ts
@@ -8,7 +8,7 @@ import * as zhHant from './locale-data/zh-Hant.json'
 import * as zhHans from './locale-data/zh-Hans.json'
 import * as en from './locale-data/en.json'
 import * as enAI from './locale-data/en-AI.json'
-import RelativeTimeFormat from '..'
+import RelativeTimeFormat from '../index.js'
 import {describe, expect, it} from 'vitest'
 RelativeTimeFormat.__addLocaleData(en, enAI, zh, zhHans, zhHant)
 

--- a/packages/intl-relativetimeformat/tests/supported-locales-of.test.ts
+++ b/packages/intl-relativetimeformat/tests/supported-locales-of.test.ts
@@ -8,7 +8,7 @@ import * as zhHant from './locale-data/zh-Hant.json'
 import * as zhHans from './locale-data/zh-Hans.json'
 import * as en from './locale-data/en.json'
 import * as enAI from './locale-data/en-AI.json'
-import RelativeTimeFormat from '..'
+import RelativeTimeFormat from '../index.js'
 import {describe, expect, it} from 'vitest'
 RelativeTimeFormat.__addLocaleData(en, enAI, zh, zhHans, zhHant)
 


### PR DESCRIPTION
### TL;DR

Convert `intl-relativetimeformat` package to ESM format.

### What changed?

- Added `"type": "module"` to package.json
- Added proper exports configuration in package.json
- Updated all import statements to use `.js` extensions
- Removed CommonJS build by setting `skip_cjs = True` in Bazel config
- Removed Node.js module detection checks in scripts (the `require.main === module` checks)
- Updated import paths throughout the codebase to use explicit `.js` extensions

### How to test?

- Verify the package works correctly when imported as an ES module
- Test the polyfill functionality in both ESM and browser environments
- Ensure all existing tests pass with the new module format

### Why make this change?

This change modernizes the package to use ES modules, which is the standard module format for modern JavaScript. This improves compatibility with newer JavaScript tooling and bundlers while providing a cleaner, more consistent module system. The explicit `.js` extensions in imports are required for proper ESM resolution.