### PR TITLE
feat(@formatjs/intl-durationformat)!: convert to esm only

### DIFF
--- a/packages/intl-durationformat/BUILD.bazel
+++ b/packages/intl-durationformat/BUILD.bazel
@@ -34,6 +34,7 @@ SRC_DEPS = [
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
+    skip_cjs = True,
     skip_esm = False,
     deps = SRC_DEPS,
 )

--- a/packages/intl-durationformat/index.ts
+++ b/packages/intl-durationformat/index.ts
@@ -1,1 +1,1 @@
-export * from './src/core'
+export * from './src/core.js'

--- a/packages/intl-durationformat/package.json
+++ b/packages/intl-durationformat/package.json
@@ -4,7 +4,13 @@
   "version": "0.7.6",
   "license": "MIT",
   "author": "Long Ho <holevietlong@gmail.com>",
+  "type": "module",
   "types": "index.d.ts",
+  "exports": {
+    ".": "./index.js",
+    "./polyfill.js": "./polyfill.js",
+    "./polyfill-force.js": "./polyfill-force.js"
+  },
   "dependencies": {
     "@formatjs/ecma402-abstract": "workspace:*",
     "@formatjs/intl-localematcher": "workspace:*",
@@ -22,6 +28,5 @@
     "react-intl",
     "tc39"
   ],
-  "main": "index.js",
   "repository": "formatjs/formatjs.git"
 }

--- a/packages/intl-durationformat/polyfill-force.ts
+++ b/packages/intl-durationformat/polyfill-force.ts
@@ -1,4 +1,4 @@
-import {DurationFormat} from './'
+import {DurationFormat} from './index.js'
 if (typeof Intl === 'undefined') {
   if (typeof window !== 'undefined') {
     Object.defineProperty(window, 'Intl', {

--- a/packages/intl-durationformat/polyfill.ts
+++ b/packages/intl-durationformat/polyfill.ts
@@ -1,5 +1,5 @@
-import {DurationFormat} from './'
-import {shouldPolyfill} from './should-polyfill'
+import {DurationFormat} from './index.js'
+import {shouldPolyfill} from './should-polyfill.js'
 if (typeof Intl === 'undefined') {
   if (typeof window !== 'undefined') {
     Object.defineProperty(window, 'Intl', {

--- a/packages/intl-durationformat/scripts/time-separators.ts
+++ b/packages/intl-durationformat/scripts/time-separators.ts
@@ -3,7 +3,7 @@ import stringify from 'json-stable-stringify'
 import minimist from 'minimist'
 
 import arData from 'cldr-numbers-full/main/ar/numbers.json'
-import {getAllLocales} from './utils'
+import {getAllLocales} from './utils.js'
 
 type RawData = typeof arData
 

--- a/packages/intl-durationformat/src/abstract/DurationRecordSign.ts
+++ b/packages/intl-durationformat/src/abstract/DurationRecordSign.ts
@@ -1,5 +1,5 @@
-import {TABLE_1} from '../constants'
-import {DurationRecord} from '../types'
+import {TABLE_1} from '../constants.js'
+import {DurationRecord} from '../types.js'
 
 export function DurationRecordSign(record: DurationRecord): -1 | 0 | 1 {
   for (const key of TABLE_1) {

--- a/packages/intl-durationformat/src/abstract/IsValidDurationRecord.ts
+++ b/packages/intl-durationformat/src/abstract/IsValidDurationRecord.ts
@@ -1,7 +1,7 @@
 import {invariant} from '@formatjs/ecma402-abstract'
-import {TABLE_1} from '../constants'
-import {DurationRecord} from '../types'
-import {DurationRecordSign} from './DurationRecordSign'
+import {TABLE_1} from '../constants.js'
+import {DurationRecord} from '../types.js'
+import {DurationRecordSign} from './DurationRecordSign.js'
 
 export function IsValidDurationRecord(record: DurationRecord): boolean {
   const sign = DurationRecordSign(record)

--- a/packages/intl-durationformat/src/abstract/PartitionDurationFormatPattern.ts
+++ b/packages/intl-durationformat/src/abstract/PartitionDurationFormatPattern.ts
@@ -4,10 +4,10 @@ import {
   createMemoizedNumberFormat,
   invariant,
 } from '@formatjs/ecma402-abstract'
-import {TABLE_2} from '../constants'
-import {DurationFormat} from '../core'
-import {getInternalSlots} from '../get_internal_slots'
-import {DurationFormatPart, DurationRecord} from '../types'
+import {TABLE_2} from '../constants.js'
+import {DurationFormat} from '../core.js'
+import {getInternalSlots} from '../get_internal_slots.js'
+import {DurationFormatPart, DurationRecord} from '../types.js'
 
 export function PartitionDurationFormatPattern(
   df: DurationFormat,

--- a/packages/intl-durationformat/src/abstract/ToDurationRecord.ts
+++ b/packages/intl-durationformat/src/abstract/ToDurationRecord.ts
@@ -1,6 +1,6 @@
-import {DurationInput, DurationRecord} from '../types'
-import {IsValidDurationRecord} from './IsValidDurationRecord'
-import {ToIntegerIfIntegral} from './ToIntegerIfIntegral'
+import {DurationInput, DurationRecord} from '../types.js'
+import {IsValidDurationRecord} from './IsValidDurationRecord.js'
+import {ToIntegerIfIntegral} from './ToIntegerIfIntegral.js'
 
 export function ToDurationRecord(input: DurationInput): DurationRecord {
   if (typeof input !== 'object') {

--- a/packages/intl-durationformat/src/constants.ts
+++ b/packages/intl-durationformat/src/constants.ts
@@ -1,4 +1,4 @@
-import {DurationRecord} from './types'
+import {DurationRecord} from './types.js'
 
 export const TABLE_1: Array<keyof DurationRecord> = [
   'years',

--- a/packages/intl-durationformat/src/core.ts
+++ b/packages/intl-durationformat/src/core.ts
@@ -8,12 +8,12 @@ import {
   invariant,
 } from '@formatjs/ecma402-abstract'
 import {ResolveLocale} from '@formatjs/intl-localematcher'
-import {GetDurationUnitOptions} from './abstract/GetDurationUnitOptions'
-import {PartitionDurationFormatPattern} from './abstract/PartitionDurationFormatPattern'
-import {ToDurationRecord} from './abstract/ToDurationRecord'
-import {getInternalSlots} from './get_internal_slots'
-import {numberingSystemNames} from './numbering-systems.generated'
-import {TIME_SEPARATORS} from './time-separators.generated'
+import {GetDurationUnitOptions} from './abstract/GetDurationUnitOptions.js'
+import {PartitionDurationFormatPattern} from './abstract/PartitionDurationFormatPattern.js'
+import {ToDurationRecord} from './abstract/ToDurationRecord.js'
+import {getInternalSlots} from './get_internal_slots.js'
+import {numberingSystemNames} from './numbering-systems.generated.js'
+import {TIME_SEPARATORS} from './time-separators.generated.js'
 import type {
   DurationFormatLocaleInternalData,
   DurationFormatPart,
@@ -21,8 +21,8 @@ import type {
   DurationInput,
   IntlDurationFormatInternal,
   ResolvedDurationFormatOptions,
-} from './types'
-import {DurationFormatOptions} from './types'
+} from './types.js'
+import {DurationFormatOptions} from './types.js'
 
 const RESOLVED_OPTIONS_KEYS: Array<
   keyof Omit<IntlDurationFormatInternal, 'pattern' | 'boundFormat'>

--- a/packages/intl-durationformat/src/get_internal_slots.ts
+++ b/packages/intl-durationformat/src/get_internal_slots.ts
@@ -1,6 +1,6 @@
 // Type-only circular import
 // eslint-disable-next-line import/no-cycle
-import type {DurationFormat, IntlDurationFormatInternal} from './types'
+import type {DurationFormat, IntlDurationFormatInternal} from './types.js'
 
 const internalSlotMap = new WeakMap<
   DurationFormat,

--- a/packages/intl-durationformat/tests/index.test.ts
+++ b/packages/intl-durationformat/tests/index.test.ts
@@ -1,4 +1,4 @@
-import {DurationFormat} from '../src/core'
+import {DurationFormat} from '../src/core.js'
 import {test, expect} from 'vitest'
 test('Intl.DurationFormat resolvedOptions', function () {
   expect(new DurationFormat('en').resolvedOptions()).toEqual({


### PR DESCRIPTION
### TL;DR

Convert `intl-durationformat` package to ESM format.

### What changed?

- Added `"type": "module"` to package.json
- Updated all import paths to include `.js` extensions
- Configured package exports in package.json
- Removed `main` field from package.json
- Updated Bazel build configuration to skip CommonJS output
- Added proper ESM exports configuration

### How to test?

1. Build the package with `yarn build`
2. Verify that the package works correctly when imported as an ES module
3. Test the polyfill functionality to ensure it still works properly
4. Verify that the package can be imported in both browser and Node.js environments

### Why make this change?

This change modernizes the `intl-durationformat` package by converting it to use ES Modules, which is the standard module format for modern JavaScript. This improves compatibility with newer tooling and bundlers while following JavaScript ecosystem best practices. The change is part of the ongoing effort to update FormatJS packages to use modern module formats.