### PR TITLE
feat(@formatjs/intl-listformat)!: convert to ESM

### DIFF
--- a/packages/intl-listformat/BUILD.bazel
+++ b/packages/intl-listformat/BUILD.bazel
@@ -61,6 +61,7 @@ TEST_DEPS = SRC_DEPS + [
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
+    skip_cjs = True,
     skip_esm = False,
     deps = SRC_DEPS,
 )

--- a/packages/intl-listformat/package.json
+++ b/packages/intl-listformat/package.json
@@ -4,7 +4,14 @@
   "version": "7.7.13",
   "license": "MIT",
   "author": "Long Ho <holevietlong@gmail.com>",
+  "type": "module",
   "types": "index.d.ts",
+  "exports": {
+    ".": "./index.js",
+    "./polyfill.js": "./polyfill.js",
+    "./polyfill-force.js": "./polyfill-force.js",
+    "./should-polyfill.js": "./should-polyfill.js"
+  },
   "dependencies": {
     "@formatjs/ecma402-abstract": "workspace:*",
     "@formatjs/intl-localematcher": "workspace:*",
@@ -25,6 +32,5 @@
     "list",
     "listformat"
   ],
-  "main": "index.js",
   "repository": "git@github.com:formatjs/formatjs.git"
 }

--- a/packages/intl-listformat/polyfill-force.ts
+++ b/packages/intl-listformat/polyfill-force.ts
@@ -1,4 +1,4 @@
-import ListFormat from './'
+import ListFormat from './index.js'
 
 Object.defineProperty(Intl, 'ListFormat', {
   value: ListFormat,

--- a/packages/intl-listformat/polyfill.ts
+++ b/packages/intl-listformat/polyfill.ts
@@ -1,5 +1,5 @@
-import ListFormat from './'
-import {shouldPolyfill} from './should-polyfill'
+import ListFormat from './index.js'
+import {shouldPolyfill} from './should-polyfill.js'
 if (shouldPolyfill()) {
   Object.defineProperty(Intl, 'ListFormat', {
     value: ListFormat,

--- a/packages/intl-listformat/scripts/cldr-raw.ts
+++ b/packages/intl-listformat/scripts/cldr-raw.ts
@@ -1,4 +1,4 @@
-import {extractLists, getAllLocales} from './extract-list'
+import {extractLists, getAllLocales} from './extract-list.js'
 import {join} from 'path'
 import {outputFileSync} from 'fs-extra'
 import stringify from 'json-stable-stringify'

--- a/packages/intl-listformat/scripts/test262-main-gen.ts
+++ b/packages/intl-listformat/scripts/test262-main-gen.ts
@@ -16,7 +16,7 @@ function main(args: Args) {
     out,
     `// @generated
 // @ts-nocheck
-import './polyfill-force';
+import './polyfill-force.js';
 if (Intl.ListFormat && typeof Intl.ListFormat.__addLocaleData === 'function') {
   Intl.ListFormat.__addLocaleData(${allData.join(',\n')})
 }`

--- a/packages/intl-listformat/should-polyfill.ts
+++ b/packages/intl-listformat/should-polyfill.ts
@@ -1,5 +1,5 @@
 import {match} from '@formatjs/intl-localematcher'
-import {supportedLocales} from './supported-locales.generated'
+import {supportedLocales} from './supported-locales.generated.js'
 
 function supportedLocalesOf(locale?: string | string[]) {
   if (!locale) {

--- a/packages/intl-listformat/test262-main.ts
+++ b/packages/intl-listformat/test262-main.ts
@@ -1,6 +1,6 @@
 // @generated
 // @ts-nocheck
-import './polyfill-force';
+import './polyfill-force.js';
 if (Intl.ListFormat && typeof Intl.ListFormat.__addLocaleData === 'function') {
   Intl.ListFormat.__addLocaleData({
   "data": {

--- a/packages/intl-listformat/tests/index.test.ts
+++ b/packages/intl-listformat/tests/index.test.ts
@@ -1,6 +1,6 @@
 import '@formatjs/intl-getcanonicallocales/polyfill'
 import '@formatjs/intl-locale/polyfill'
-import ListFormat from '..'
+import ListFormat from '../index.js'
 import * as en from './locale-data/en.json'
 import * as enAI from './locale-data/en-AI.json'
 import * as zh from './locale-data/zh.json'

--- a/packages/intl-listformat/tests/supported-locales-of.test.ts
+++ b/packages/intl-listformat/tests/supported-locales-of.test.ts
@@ -1,6 +1,6 @@
 import '@formatjs/intl-getcanonicallocales/polyfill'
 import '@formatjs/intl-locale/polyfill'
-import ListFormat from '..'
+import ListFormat from '../index.js'
 import * as en from './locale-data/en.json'
 import * as enAI from './locale-data/en-AI.json'
 import * as zh from './locale-data/zh.json'


### PR DESCRIPTION
### TL;DR

Convert `intl-listformat` package to ESM format.

### What changed?

- Added `"type": "module"` to package.json
- Added proper `exports` field in package.json to define entry points
- Removed `main` field from package.json
- Updated all imports to use `.js` extensions
- Set `skip_cjs = True` in Bazel build configuration
- Updated import paths in tests and polyfill files

### How to test?

1. Build the package with `yarn build`
2. Run tests with `yarn test`
3. Try importing the package in an ESM environment to verify it works correctly
4. Verify that polyfill functionality still works as expected

### Why make this change?

This change modernizes the package to use native ES modules, which provides better compatibility with modern JavaScript tooling and environments. It's part of the ongoing effort to migrate the codebase to ESM format, which offers better tree-shaking, more consistent module resolution, and better alignment with current JavaScript standards.