### PR TITLE
fix(@formatjs/intl-segmenter): fix exports

### DIFF
--- a/packages/intl-segmenter/package.json
+++ b/packages/intl-segmenter/package.json
@@ -7,7 +7,8 @@
   "type": "module",
   "exports": {
     "./polyfill.js": "./polyfill.js",
-    "./polyfill-force.js": "./polyfill-force.js"
+    "./polyfill-force.js": "./polyfill-force.js",
+    "./should-polyfill.js": "./should-polyfill.js"
   },
   "dependencies": {
     "@formatjs/ecma402-abstract": "workspace:*",


### PR DESCRIPTION
### TL;DR

Added `should-polyfill.js` to the exports in the `intl-segmenter` package.

### What changed?

Updated the `package.json` file in the `intl-segmenter` package to expose the `should-polyfill.js` module through the package exports field. This allows consumers to import this module directly from the package.

### How to test?

Verify that the module can be imported using:
```js
import shouldPolyfill from '@formatjs/intl-segmenter/should-polyfill.js';
```

### Why make this change?

This change enables consumers to conditionally load the polyfill only when needed by checking if the current environment supports the Intl.Segmenter API natively. This follows the pattern used in other FormatJS polyfill packages and improves bundle size optimization for applications.