### PR TITLE
fix(@formatjs/intl-relativetimeformat): fix exports

### DIFF
--- a/packages/intl-relativetimeformat/package.json
+++ b/packages/intl-relativetimeformat/package.json
@@ -9,7 +9,8 @@
   "exports": {
     ".": "./index.js",
     "./polyfill.js": "./polyfill.js",
-    "./polyfill-force.js": "./polyfill-force.js"
+    "./polyfill-force.js": "./polyfill-force.js",
+    "./should-polyfill.js": "./should-polyfill.js"
   },
   "dependencies": {
     "@formatjs/ecma402-abstract": "workspace:*",


### PR DESCRIPTION
### TL;DR

Added `should-polyfill.js` to the exports field in the `intl-relativetimeformat` package.

### What changed?

Added a new export mapping for `./should-polyfill.js` in the package.json exports field of the `intl-relativetimeformat` package. This makes the should-polyfill module accessible to consumers of the package.

### How to test?

1. Import the should-polyfill module in a test file:
   ```js
   import shouldPolyfill from '@formatjs/intl-relativetimeformat/should-polyfill.js';
   ```
2. Verify that the import works without any resolution errors

### Why make this change?

This change exposes the should-polyfill utility which allows consumers to conditionally load the polyfill only when needed. This is useful for optimizing bundle size by only including the polyfill when the browser doesn't natively support RelativeTimeFormat or when the implementation is incomplete.