### PR TITLE
fix(@formatjs/intl-durationformat): fix exports

### DIFF
--- a/packages/intl-durationformat/package.json
+++ b/packages/intl-durationformat/package.json
@@ -9,7 +9,8 @@
   "exports": {
     ".": "./index.js",
     "./polyfill.js": "./polyfill.js",
-    "./polyfill-force.js": "./polyfill-force.js"
+    "./polyfill-force.js": "./polyfill-force.js",
+    "./should-polyfill.js": "./should-polyfill.js"
   },
   "dependencies": {
     "@formatjs/ecma402-abstract": "workspace:*",


### PR DESCRIPTION
### TL;DR

Added `should-polyfill.js` to the exports in the `intl-durationformat` package.

### What changed?

Added a new export path for `./should-polyfill.js` in the `package.json` exports field of the `intl-durationformat` package. This allows consumers to import the should-polyfill utility directly.

### How to test?

Verify that the following import works in a project using this package:
```js
import shouldPolyfill from '@formatjs/intl-durationformat/should-polyfill.js';
```

### Why make this change?

This change exposes the `should-polyfill.js` module to consumers, allowing them to conditionally load the polyfill only when needed. This follows the pattern used in other Intl polyfill packages and provides a more efficient way for applications to determine if the polyfill is required in the current environment.