### PR TITLE
feat(@formatjs/intl-displaynames)!: convert to ESM

### DIFF
--- a/packages/intl-displaynames/BUILD.bazel
+++ b/packages/intl-displaynames/BUILD.bazel
@@ -58,6 +58,7 @@ TEST_DEPS = SRC_DEPS + [
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
+    skip_cjs = True,
     skip_esm = False,
     deps = SRC_DEPS,
 )

--- a/packages/intl-displaynames/index.ts
+++ b/packages/intl-displaynames/index.ts
@@ -12,8 +12,8 @@ import {
   invariant,
   setInternalSlot,
 } from '@formatjs/ecma402-abstract'
-import {CanonicalCodeForDisplayNames} from './abstract/CanonicalCodeForDisplayNames'
-import {IsValidDateTimeFieldCode} from './abstract/IsValidDateTimeFieldCode'
+import {CanonicalCodeForDisplayNames} from './abstract/CanonicalCodeForDisplayNames.js'
+import {IsValidDateTimeFieldCode} from './abstract/IsValidDateTimeFieldCode.js'
 
 import {ResolveLocale} from '@formatjs/intl-localematcher'
 

--- a/packages/intl-displaynames/package.json
+++ b/packages/intl-displaynames/package.json
@@ -4,7 +4,14 @@
   "version": "6.8.13",
   "license": "MIT",
   "author": "Linjie Ding <pyrocat101@users.noreply.github.com>",
+  "type": "module",
   "types": "index.d.ts",
+  "exports": {
+    ".": "./index.js",
+    "./polyfill.js": "./polyfill.js",
+    "./polyfill-force.js": "./polyfill-force.js",
+    "./should-polyfill.js": "./should-polyfill.js"
+  },
   "dependencies": {
     "@formatjs/ecma402-abstract": "workspace:*",
     "@formatjs/intl-localematcher": "workspace:*",
@@ -25,6 +32,5 @@
     "localization",
     "polyfill"
   ],
-  "main": "index.js",
   "repository": "formatjs/formatjs.git"
 }

--- a/packages/intl-displaynames/polyfill-force.ts
+++ b/packages/intl-displaynames/polyfill-force.ts
@@ -1,4 +1,4 @@
-import {DisplayNames} from './'
+import {DisplayNames} from './index.js'
 
 Object.defineProperty(Intl, 'DisplayNames', {
   value: DisplayNames,

--- a/packages/intl-displaynames/polyfill.ts
+++ b/packages/intl-displaynames/polyfill.ts
@@ -1,5 +1,5 @@
-import {DisplayNames} from './'
-import {shouldPolyfill} from './should-polyfill'
+import {DisplayNames} from './index.js'
+import {shouldPolyfill} from './should-polyfill.js'
 
 if (shouldPolyfill()) {
   Object.defineProperty(Intl, 'DisplayNames', {

--- a/packages/intl-displaynames/scripts/cldr-raw.ts
+++ b/packages/intl-displaynames/scripts/cldr-raw.ts
@@ -1,4 +1,4 @@
-import {extractDisplayNames, getAllLocales} from './extract-displaynames'
+import {extractDisplayNames, getAllLocales} from './extract-displaynames.js'
 import {join} from 'path'
 import {outputFileSync} from 'fs-extra'
 import stringify from 'json-stable-stringify'

--- a/packages/intl-displaynames/scripts/test262-main-gen.ts
+++ b/packages/intl-displaynames/scripts/test262-main-gen.ts
@@ -16,7 +16,7 @@ function main(args: Args) {
     out,
     `// @generated
 // @ts-nocheck
-import './polyfill-force';
+import './polyfill-force.js';
 if (Intl.DisplayNames && typeof Intl.DisplayNames.__addLocaleData === 'function') {
   Intl.DisplayNames.__addLocaleData(${allData.join(',\n')})
 }`

--- a/packages/intl-displaynames/should-polyfill.ts
+++ b/packages/intl-displaynames/should-polyfill.ts
@@ -1,5 +1,5 @@
 import {match} from '@formatjs/intl-localematcher'
-import {supportedLocales} from './supported-locales.generated'
+import {supportedLocales} from './supported-locales.generated.js'
 
 /**
  * https://bugs.chromium.org/p/chromium/issues/detail?id=1097432

--- a/packages/intl-displaynames/test262-main.ts
+++ b/packages/intl-displaynames/test262-main.ts
@@ -1,6 +1,6 @@
 // @generated
 // @ts-nocheck
-import './polyfill-force';
+import './polyfill-force.js';
 if (Intl.DisplayNames && typeof Intl.DisplayNames.__addLocaleData === 'function') {
   Intl.DisplayNames.__addLocaleData({
   "data": {

--- a/packages/intl-displaynames/tests/CanonicalCodeForDisplayNames.test.ts
+++ b/packages/intl-displaynames/tests/CanonicalCodeForDisplayNames.test.ts
@@ -1,4 +1,4 @@
-import {CanonicalCodeForDisplayNames} from '../abstract/CanonicalCodeForDisplayNames'
+import {CanonicalCodeForDisplayNames} from '../abstract/CanonicalCodeForDisplayNames.js'
 import {describe, expect, it} from 'vitest'
 
 describe('CanonicalCodeForDisplayNames', () => {

--- a/packages/intl-displaynames/tests/IsValidDateTimeFieldCode.test.ts
+++ b/packages/intl-displaynames/tests/IsValidDateTimeFieldCode.test.ts
@@ -1,4 +1,4 @@
-import {IsValidDateTimeFieldCode} from '../abstract/IsValidDateTimeFieldCode'
+import {IsValidDateTimeFieldCode} from '../abstract/IsValidDateTimeFieldCode.js'
 import {describe, expect, it} from 'vitest'
 
 describe('IsValidDateTimeFieldCode', () => {

--- a/packages/intl-displaynames/tests/index.test.ts
+++ b/packages/intl-displaynames/tests/index.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import '@formatjs/intl-getcanonicallocales/polyfill'
 import '@formatjs/intl-locale/polyfill'
-import {DisplayNames} from '..'
+import {DisplayNames} from '../index.js'
 import {describe, expect, it} from 'vitest'
 
 import * as en from './locale-data/en.json'

--- a/packages/intl-displaynames/tests/should-polyfill.test.ts
+++ b/packages/intl-displaynames/tests/should-polyfill.test.ts
@@ -1,5 +1,8 @@
-import {DisplayNames} from '..'
-import {_shouldPolyfillWithoutLocale, shouldPolyfill} from '../should-polyfill'
+import {DisplayNames} from '../index.js'
+import {
+  _shouldPolyfillWithoutLocale,
+  shouldPolyfill,
+} from '../should-polyfill.js'
 import {describe, expect, it, test, beforeEach, afterEach} from 'vitest'
 test('should-polyfill should be true', function () {
   // Node 14.9.0/browsers does have this bug


### PR DESCRIPTION
### TL;DR

Convert `intl-displaynames` package to ESM format.

### What changed?

- Added `"type": "module"` to package.json
- Added proper `exports` field in package.json to define entry points
- Updated all import paths to include `.js` extensions
- Removed `main` field from package.json
- Set `skip_cjs = True` in Bazel build configuration
- Updated all internal imports to use explicit `.js` extensions

### How to test?

- Verify the package works correctly when imported as an ES module
- Test that all entry points defined in the exports field are accessible
- Ensure polyfill functionality works as expected
- Run existing tests to confirm no regressions

### Why make this change?

This change modernizes the package to use native ES modules, which provides better compatibility with modern JavaScript tooling and bundlers. Using explicit `.js` extensions and proper exports mapping ensures the package works correctly in both Node.js and browser environments that support ES modules.