### PR TITLE
feat(vue-intl)!: convert to ESM

### DIFF
--- a/packages/vue-intl/BUILD.bazel
+++ b/packages/vue-intl/BUILD.bazel
@@ -31,6 +31,7 @@ SRC_DEPS = [
 ts_compile_node(
     name = "dist",
     srcs = [":srcs"],
+    skip_cjs = True,
     deps = SRC_DEPS,
 )
 

--- a/packages/vue-intl/index.ts
+++ b/packages/vue-intl/index.ts
@@ -2,9 +2,9 @@ import {
   IntlFormatters as CoreIntlFormatters,
   MessageDescriptor,
 } from '@formatjs/intl'
-export * from './plugin'
-export * from './provider'
-export {intlKey} from './injection-key'
+export * from './plugin.js'
+export * from './provider.js'
+export {intlKey} from './injection-key.js'
 export {
   IntlShape,
   IntlConfig,

--- a/packages/vue-intl/package.json
+++ b/packages/vue-intl/package.json
@@ -4,6 +4,11 @@
   "version": "6.5.27",
   "license": "ISC",
   "author": "Long Ho <holevietlong@gmail.com>",
+  "type": "module",
+  "types": "index.d.ts",
+  "exports": {
+    ".": "./index.js"
+  },
   "dependencies": {
     "@babel/types": "^7.26.10",
     "@formatjs/icu-messageformat-parser": "workspace:*",
@@ -21,6 +26,5 @@
     "intl",
     "vue"
   ],
-  "main": "index.js",
   "repository": "formatjs/formatjs.git"
 }

--- a/packages/vue-intl/plugin.ts
+++ b/packages/vue-intl/plugin.ts
@@ -5,7 +5,7 @@ import {
   IntlShape,
 } from '@formatjs/intl'
 import type {Plugin} from 'vue'
-import {intlKey} from './injection-key'
+import {intlKey} from './injection-key.js'
 
 declare module 'vue' {
   interface ComponentCustomProperties {

--- a/packages/vue-intl/provider.ts
+++ b/packages/vue-intl/provider.ts
@@ -1,6 +1,6 @@
 import {IntlShape} from '@formatjs/intl'
 import {inject, provide, RendererElement, RendererNode, VNode} from 'vue'
-import {intlKey} from './injection-key'
+import {intlKey} from './injection-key.js'
 
 export function provideIntl(intl: IntlShape<VNode>): void {
   provide(intlKey, intl)

--- a/packages/vue-intl/tests/index.test.ts
+++ b/packages/vue-intl/tests/index.test.ts
@@ -1,5 +1,5 @@
 import {defineComponent, h} from 'vue'
-import {createIntl, intlKey, provideIntl, useIntl} from '../index'
+import {createIntl, intlKey, provideIntl, useIntl} from '../index.js'
 import {mount} from '@vue/test-utils'
 import {createIntl as rawCreateIntl} from '@formatjs/intl'
 import {expect, test} from 'vitest'


### PR DESCRIPTION
### TL;DR

Convert `vue-intl` package to ESM format.

### What changed?

- Added `"type": "module"` to package.json
- Updated exports configuration in package.json to use explicit `.js` extensions
- Modified import statements to include `.js` extensions
- Set `skip_cjs = True` in the Bazel build configuration to prevent CommonJS output
- Removed the `main` field from package.json and added proper `exports` field

### How to test?

1. Build the package with `bazel build //packages/vue-intl:dist`
2. Import the package in an ESM environment
3. Verify that all imports and exports work correctly
4. Run existing tests to ensure functionality is maintained

### Why make this change?

This change modernizes the `vue-intl` package by converting it to use ES Modules format, which is the standard module system for modern JavaScript. This improves compatibility with modern bundlers and build systems, and aligns with the direction of the JavaScript ecosystem.