### PR TITLE
feat(@formatjs/intl-datetimeformat)!: convert to ESM

### DIFF
--- a/packages/intl-datetimeformat/BUILD.bazel
+++ b/packages/intl-datetimeformat/BUILD.bazel
@@ -74,6 +74,7 @@ TEST_DEPS = SRC_DEPS + [
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
+    skip_cjs = True,
     skip_esm = False,
     deps = SRC_DEPS,
 )

--- a/packages/intl-datetimeformat/index.ts
+++ b/packages/intl-datetimeformat/index.ts
@@ -1,1 +1,1 @@
-export * from './src/core'
+export * from './src/core.js'

--- a/packages/intl-datetimeformat/package.json
+++ b/packages/intl-datetimeformat/package.json
@@ -4,7 +4,16 @@
   "version": "6.18.2",
   "license": "MIT",
   "author": "Long Ho <holevietlong@gmail.com>",
+  "type": "module",
   "types": "index.d.ts",
+  "exports": {
+    ".": "./index.js",
+    "./polyfill.js": "./polyfill.js",
+    "./polyfill-force.js": "./polyfill-force.js",
+    "./should-polyfill.js": "./should-polyfill.js",
+    "./add-all-tz.js": "./add-all-tz.js",
+    "./locale-data/*": "./locale-data/*"
+  },
   "dependencies": {
     "@formatjs/ecma402-abstract": "workspace:*",
     "@formatjs/intl-localematcher": "workspace:*",
@@ -24,6 +33,5 @@
     "intl",
     "polyfill"
   ],
-  "main": "index.js",
   "repository": "formatjs/formatjs.git"
 }

--- a/packages/intl-datetimeformat/polyfill-force.ts
+++ b/packages/intl-datetimeformat/polyfill-force.ts
@@ -1,10 +1,10 @@
 import {defineProperty} from '@formatjs/ecma402-abstract'
-import {DateTimeFormat} from './'
+import {DateTimeFormat} from './index.js'
 import {
   toLocaleDateString as _toLocaleDateString,
   toLocaleString as _toLocaleString,
   toLocaleTimeString as _toLocaleTimeString,
-} from './src/to_locale_string'
+} from './src/to_locale_string.js'
 
 defineProperty(Intl, 'DateTimeFormat', {value: DateTimeFormat})
 defineProperty(Date.prototype, 'toLocaleString', {

--- a/packages/intl-datetimeformat/polyfill.ts
+++ b/packages/intl-datetimeformat/polyfill.ts
@@ -1,11 +1,11 @@
-import {DateTimeFormat} from './'
+import {DateTimeFormat} from './index.js'
 import {defineProperty} from '@formatjs/ecma402-abstract'
-import {shouldPolyfill} from './should-polyfill'
+import {shouldPolyfill} from './should-polyfill.js'
 import {
   toLocaleString as _toLocaleString,
   toLocaleDateString as _toLocaleDateString,
   toLocaleTimeString as _toLocaleTimeString,
-} from './src/to_locale_string'
+} from './src/to_locale_string.js'
 
 if (shouldPolyfill()) {
   defineProperty(Intl, 'DateTimeFormat', {value: DateTimeFormat})

--- a/packages/intl-datetimeformat/scripts/cldr-raw.ts
+++ b/packages/intl-datetimeformat/scripts/cldr-raw.ts
@@ -1,4 +1,4 @@
-import {extractDatesFields, getAllLocales} from './extract-dates'
+import {extractDatesFields, getAllLocales} from './extract-dates.js'
 import {join} from 'path'
 import {outputJSONSync} from 'fs-extra'
 

--- a/packages/intl-datetimeformat/scripts/test262-main-gen.ts
+++ b/packages/intl-datetimeformat/scripts/test262-main-gen.ts
@@ -17,8 +17,8 @@ function main(args: Args) {
     out,
     `/* @generated */
 // @ts-nocheck
-import './polyfill-force'
-import allData from './src/data/all-tz'
+import './polyfill-force.js'
+import allData from './src/data/all-tz.js'
 defineProperty(Intl, 'DateTimeFormat', {value: DateTimeFormat})
 Intl.DateTimeFormat.__addLocaleData(${allData.join(',\n')})
 Intl.DateTimeFormat.__addTZData(allData)`

--- a/packages/intl-datetimeformat/should-polyfill.ts
+++ b/packages/intl-datetimeformat/should-polyfill.ts
@@ -1,5 +1,5 @@
 import {match} from '@formatjs/intl-localematcher'
-import {supportedLocales} from './supported-locales.generated'
+import {supportedLocales} from './supported-locales.generated.js'
 
 function supportsDateStyle() {
   try {

--- a/packages/intl-datetimeformat/src/abstract/BasicFormatMatcher.ts
+++ b/packages/intl-datetimeformat/src/abstract/BasicFormatMatcher.ts
@@ -8,7 +8,7 @@ import {
   shortLessPenalty,
   longLessPenalty,
   offsetPenalty,
-} from './utils'
+} from './utils.js'
 
 /**
  * https://tc39.es/ecma402/#sec-basicformatmatcher

--- a/packages/intl-datetimeformat/src/abstract/BestFitFormatMatcher.ts
+++ b/packages/intl-datetimeformat/src/abstract/BestFitFormatMatcher.ts
@@ -1,5 +1,5 @@
 import {Formats, TABLE_6, invariant} from '@formatjs/ecma402-abstract'
-import {processDateTimePattern} from './skeleton'
+import {processDateTimePattern} from './skeleton.js'
 import {
   DATE_TIME_PROPS,
   additionPenalty,
@@ -9,7 +9,7 @@ import {
   removalPenalty,
   shortLessPenalty,
   shortMorePenalty,
-} from './utils'
+} from './utils.js'
 
 function isNumericType(
   t: 'numeric' | '2-digit' | 'narrow' | 'short' | 'long'

--- a/packages/intl-datetimeformat/src/abstract/FormatDateTime.ts
+++ b/packages/intl-datetimeformat/src/abstract/FormatDateTime.ts
@@ -1,6 +1,6 @@
 import {DateTimeFormat} from '@formatjs/ecma402-abstract'
 import Decimal from 'decimal.js'
-import {PartitionDateTimePattern} from './PartitionDateTimePattern'
+import {PartitionDateTimePattern} from './PartitionDateTimePattern.js'
 
 /**
  * https://tc39.es/ecma402/#sec-formatdatetime

--- a/packages/intl-datetimeformat/src/abstract/FormatDateTimePattern.ts
+++ b/packages/intl-datetimeformat/src/abstract/FormatDateTimePattern.ts
@@ -8,8 +8,8 @@ import {
 } from '@formatjs/ecma402-abstract'
 
 import Decimal from 'decimal.js'
-import {ToLocalTime, ToLocalTimeImplDetails} from './ToLocalTime'
-import {DATE_TIME_PROPS} from './utils'
+import {ToLocalTime, ToLocalTimeImplDetails} from './ToLocalTime.js'
+import {DATE_TIME_PROPS} from './utils.js'
 
 function pad(n: number): string {
   if (n < 10) {

--- a/packages/intl-datetimeformat/src/abstract/FormatDateTimeRange.ts
+++ b/packages/intl-datetimeformat/src/abstract/FormatDateTimeRange.ts
@@ -1,7 +1,7 @@
 import Decimal from 'decimal.js'
-import {FormatDateTimePatternImplDetails} from './FormatDateTimePattern'
-import {PartitionDateTimeRangePattern} from './PartitionDateTimeRangePattern'
-import {ToLocalTimeImplDetails} from './ToLocalTime'
+import {FormatDateTimePatternImplDetails} from './FormatDateTimePattern.js'
+import {PartitionDateTimeRangePattern} from './PartitionDateTimeRangePattern.js'
+import {ToLocalTimeImplDetails} from './ToLocalTime.js'
 
 export function FormatDateTimeRange(
   dtf: Intl.DateTimeFormat,

--- a/packages/intl-datetimeformat/src/abstract/FormatDateTimeRangeToParts.ts
+++ b/packages/intl-datetimeformat/src/abstract/FormatDateTimeRangeToParts.ts
@@ -1,8 +1,8 @@
 import {IntlDateTimeFormatPart} from '@formatjs/ecma402-abstract'
 import {Decimal} from 'decimal.js'
-import {FormatDateTimePatternImplDetails} from './FormatDateTimePattern'
-import {PartitionDateTimeRangePattern} from './PartitionDateTimeRangePattern'
-import {ToLocalTimeImplDetails} from './ToLocalTime'
+import {FormatDateTimePatternImplDetails} from './FormatDateTimePattern.js'
+import {PartitionDateTimeRangePattern} from './PartitionDateTimeRangePattern.js'
+import {ToLocalTimeImplDetails} from './ToLocalTime.js'
 
 export function FormatDateTimeRangeToParts(
   dtf: Intl.DateTimeFormat,

--- a/packages/intl-datetimeformat/src/abstract/FormatDateTimeToParts.ts
+++ b/packages/intl-datetimeformat/src/abstract/FormatDateTimeToParts.ts
@@ -1,6 +1,6 @@
 import {ArrayCreate, IntlDateTimeFormatPart} from '@formatjs/ecma402-abstract'
 import Decimal from 'decimal.js'
-import {PartitionDateTimePattern} from './PartitionDateTimePattern'
+import {PartitionDateTimePattern} from './PartitionDateTimePattern.js'
 
 /**
  * https://tc39.es/ecma402/#sec-formatdatetimetoparts

--- a/packages/intl-datetimeformat/src/abstract/InitializeDateTimeFormat.ts
+++ b/packages/intl-datetimeformat/src/abstract/InitializeDateTimeFormat.ts
@@ -11,11 +11,11 @@ import {
   invariant,
 } from '@formatjs/ecma402-abstract'
 import {ResolveLocale} from '@formatjs/intl-localematcher'
-import {BasicFormatMatcher} from './BasicFormatMatcher'
-import {BestFitFormatMatcher} from './BestFitFormatMatcher'
-import {DateTimeStyleFormat} from './DateTimeStyleFormat'
-import {ToDateTimeOptions} from './ToDateTimeOptions'
-import {DATE_TIME_PROPS} from './utils'
+import {BasicFormatMatcher} from './BasicFormatMatcher.js'
+import {BestFitFormatMatcher} from './BestFitFormatMatcher.js'
+import {DateTimeStyleFormat} from './DateTimeStyleFormat.js'
+import {ToDateTimeOptions} from './ToDateTimeOptions.js'
+import {DATE_TIME_PROPS} from './utils.js'
 
 function isTimeRelated(opt: Opt) {
   for (const prop of ['hour', 'minute', 'second'] as Array<

--- a/packages/intl-datetimeformat/src/abstract/PartitionDateTimePattern.ts
+++ b/packages/intl-datetimeformat/src/abstract/PartitionDateTimePattern.ts
@@ -10,8 +10,8 @@ import Decimal from 'decimal.js'
 import {
   FormatDateTimePattern,
   FormatDateTimePatternImplDetails,
-} from './FormatDateTimePattern'
-import {ToLocalTimeImplDetails} from './ToLocalTime'
+} from './FormatDateTimePattern.js'
+import {ToLocalTimeImplDetails} from './ToLocalTime.js'
 
 /**
  * https://tc39.es/ecma402/#sec-partitiondatetimepattern

--- a/packages/intl-datetimeformat/src/abstract/PartitionDateTimeRangePattern.ts
+++ b/packages/intl-datetimeformat/src/abstract/PartitionDateTimeRangePattern.ts
@@ -11,8 +11,8 @@ import Decimal from 'decimal.js'
 import {
   FormatDateTimePattern,
   FormatDateTimePatternImplDetails,
-} from './FormatDateTimePattern'
-import {ToLocalTime, ToLocalTimeImplDetails} from './ToLocalTime'
+} from './FormatDateTimePattern.js'
+import {ToLocalTime, ToLocalTimeImplDetails} from './ToLocalTime.js'
 
 const TABLE_2_FIELDS: Array<TABLE_2> = [
   'era',

--- a/packages/intl-datetimeformat/src/core.ts
+++ b/packages/intl-datetimeformat/src/core.ts
@@ -14,17 +14,17 @@ import {
   invariant,
 } from '@formatjs/ecma402-abstract'
 import Decimal from 'decimal.js'
-import {FormatDateTime} from './abstract/FormatDateTime'
-import {FormatDateTimeRange} from './abstract/FormatDateTimeRange'
-import {FormatDateTimeRangeToParts} from './abstract/FormatDateTimeRangeToParts'
-import {FormatDateTimeToParts} from './abstract/FormatDateTimeToParts'
-import {InitializeDateTimeFormat} from './abstract/InitializeDateTimeFormat'
-import {parseDateTimeSkeleton} from './abstract/skeleton'
-import {DATE_TIME_PROPS} from './abstract/utils'
-import links from './data/links'
-import getInternalSlots from './get_internal_slots'
-import {unpack} from './packer'
-import {PackedData, RawDateTimeLocaleData} from './types'
+import {FormatDateTime} from './abstract/FormatDateTime.js'
+import {FormatDateTimeRange} from './abstract/FormatDateTimeRange.js'
+import {FormatDateTimeRangeToParts} from './abstract/FormatDateTimeRangeToParts.js'
+import {FormatDateTimeToParts} from './abstract/FormatDateTimeToParts.js'
+import {InitializeDateTimeFormat} from './abstract/InitializeDateTimeFormat.js'
+import {parseDateTimeSkeleton} from './abstract/skeleton.js'
+import {DATE_TIME_PROPS} from './abstract/utils.js'
+import links from './data/links.js'
+import getInternalSlots from './get_internal_slots.js'
+import {unpack} from './packer.js'
+import {PackedData, RawDateTimeLocaleData} from './types.js'
 
 const UPPERCASED_LINKS = Object.keys(links).reduce(
   (all: Record<string, string>, l) => {

--- a/packages/intl-datetimeformat/src/packer.ts
+++ b/packages/intl-datetimeformat/src/packer.ts
@@ -1,4 +1,4 @@
-import {UnpackedData, PackedData} from './types'
+import {UnpackedData, PackedData} from './types.js'
 import {UnpackedZoneData} from '@formatjs/ecma402-abstract'
 
 export function pack(data: UnpackedData): PackedData {

--- a/packages/intl-datetimeformat/src/to_locale_string.ts
+++ b/packages/intl-datetimeformat/src/to_locale_string.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line import/no-cycle
-import {DateTimeFormat} from './core'
-import {ToDateTimeOptions} from './abstract/ToDateTimeOptions'
+import {DateTimeFormat} from './core.js'
+import {ToDateTimeOptions} from './abstract/ToDateTimeOptions.js'
 
 /**
  * Number.prototype.toLocaleString ponyfill

--- a/packages/intl-datetimeformat/test262-main.ts
+++ b/packages/intl-datetimeformat/test262-main.ts
@@ -1,7 +1,7 @@
 /* @generated */
 // @ts-nocheck
-import './polyfill-force'
-import allData from './src/data/all-tz'
+import './polyfill-force.js'
+import allData from './src/data/all-tz.js'
 defineProperty(Intl, 'DateTimeFormat', {value: DateTimeFormat})
 Intl.DateTimeFormat.__addLocaleData({
   "data": {

--- a/packages/react-intl/examples/index.tsx
+++ b/packages/react-intl/examples/index.tsx
@@ -19,9 +19,9 @@ import '@formatjs/intl-pluralrules/polyfill'
 import '@formatjs/intl-numberformat/locale-data/en' // locale-data for en
 import '@formatjs/intl-numberformat/polyfill'
 
-import '@formatjs/intl-datetimeformat/add-all-tz' // Add ALL tz data
-import '@formatjs/intl-datetimeformat/locale-data/en' // locale-data for en
-import '@formatjs/intl-datetimeformat/polyfill'
+import '@formatjs/intl-datetimeformat/add-all-tz.js' // Add ALL tz data
+import '@formatjs/intl-datetimeformat/locale-data/en.js' // locale-data for en
+import '@formatjs/intl-datetimeformat/polyfill.js'
 
 ReactDOM.render(<Timezone />, document.getElementById('timezone'))
 


### PR DESCRIPTION
### TL;DR

Convert `intl-datetimeformat` package to ESM format.

### What changed?

- Added `"type": "module"` to package.json
- Added proper exports configuration in package.json
- Updated all import statements to include `.js` extensions
- Set `skip_cjs = True` in Bazel build configuration
- Removed `main` field from package.json as it's not needed for ESM packages

### How to test?

1. Build the package with `yarn build`
2. Run tests to ensure functionality is preserved
3. Test importing the package in an ESM environment
4. Verify that the package works correctly in applications that use it, like the React examples

### Why make this change?

This change modernizes the `intl-datetimeformat` package by converting it to use native ECMAScript modules (ESM). This provides better compatibility with modern JavaScript tooling and environments that prefer or require ESM. It also aligns with the broader JavaScript ecosystem's move toward ESM as the standard module format.