### PR TITLE
fix: fix exports

### DIFF
--- a/packages/intl-displaynames/package.json
+++ b/packages/intl-displaynames/package.json
@@ -10,7 +10,8 @@
     ".": "./index.js",
     "./polyfill.js": "./polyfill.js",
     "./polyfill-force.js": "./polyfill-force.js",
-    "./should-polyfill.js": "./should-polyfill.js"
+    "./should-polyfill.js": "./should-polyfill.js",
+    "./locale-data/*": "./locale-data/*"
   },
   "dependencies": {
     "@formatjs/ecma402-abstract": "workspace:*",

--- a/packages/intl-listformat/package.json
+++ b/packages/intl-listformat/package.json
@@ -10,7 +10,8 @@
     ".": "./index.js",
     "./polyfill.js": "./polyfill.js",
     "./polyfill-force.js": "./polyfill-force.js",
-    "./should-polyfill.js": "./should-polyfill.js"
+    "./should-polyfill.js": "./should-polyfill.js",
+    "./locale-data/*": "./locale-data/*"
   },
   "dependencies": {
     "@formatjs/ecma402-abstract": "workspace:*",


### PR DESCRIPTION
### TL;DR

Added locale-data exports to package.json for intl-displaynames and intl-listformat packages.

### What changed?

Updated the `exports` field in package.json for both `intl-displaynames` and `intl-listformat` packages to include the locale-data directory, allowing direct imports of locale data files using the pattern `./locale-data/*`.

### How to test?

Try importing locale data directly in your application:

```js
// For intl-displaynames
import '@formatjs/intl-displaynames/locale-data/en';

// For intl-listformat
import '@formatjs/intl-listformat/locale-data/en';
```

### Why make this change?

This change ensures that locale data files are properly exposed through the package exports map, which is required for modern module resolution in environments that respect the `exports` field in package.json. Without this change, users may encounter errors when trying to import locale data directly.