### PR TITLE
feat(@formatjs/ecma376)!: convert to ESM

### DIFF
--- a/packages/ecma376/BUILD.bazel
+++ b/packages/ecma376/BUILD.bazel
@@ -17,7 +17,6 @@ npm_package(
         "README.md",
         "package.json",
         ":dist",
-        ":dist-esm",
     ],
     package = "@formatjs/%s" % PACKAGE_NAME,
     visibility = ["//visibility:public"],
@@ -35,6 +34,7 @@ TESTS = glob(["tests/*"])
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
+    skip_cjs = True,
     skip_esm = False,
     deps = SRC_DEPS,
 )

--- a/packages/ecma376/package.json
+++ b/packages/ecma376/package.json
@@ -4,6 +4,11 @@
   "version": "0.3.16",
   "license": "ISC",
   "author": "Long Ho <holevietlong@gmail.com>",
+  "type": "module",
+  "types": "index.d.ts",
+  "exports": {
+    ".": "./index.js"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -18,7 +23,5 @@
     "intl",
     "numFmt"
   ],
-  "main": "index.js",
-  "module": "lib/index.js",
   "repository": "formatjs/formatjs.git"
 }

--- a/packages/ecma376/tests/index.test.ts
+++ b/packages/ecma376/tests/index.test.ts
@@ -1,4 +1,4 @@
-import {generateNumFmtPattern} from '../index'
+import {generateNumFmtPattern} from '../index.js'
 import {expect, test} from 'vitest'
 test.each`
   locale       | result


### PR DESCRIPTION
### TL;DR

Convert `@formatjs/ecma376` package to ESM-only format.

### What changed?

- Updated `package.json` to specify `"type": "module"` and use modern exports field
- Removed CommonJS output by setting `skip_cjs = True` in the Bazel build
- Removed `:dist-esm` from the npm package build
- Updated import in test file to use `.js` extension

### How to test?

1. Build the package with Bazel
2. Verify that the package can be imported in an ESM environment
3. Run existing tests to ensure functionality is maintained

### Why make this change?

This change modernizes the package to use ESM-only format, which aligns with the direction of the JavaScript ecosystem. Using native ESM improves tree-shaking capabilities and simplifies the package structure by maintaining a single module format.