### PR TITLE
feat(@formatjs/utils)!: convert to ESM

### DIFF
--- a/packages/utils/BUILD.bazel
+++ b/packages/utils/BUILD.bazel
@@ -21,7 +21,6 @@ npm_package(
         "README.md",
         "package.json",
         ":dist",
-        ":dist-esm",
     ],
     package = "@formatjs/%s" % PACKAGE_NAME,
     visibility = ["//visibility:public"],
@@ -39,6 +38,7 @@ SRC_DEPS = [
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
+    skip_cjs = True,
     skip_esm = False,
     deps = SRC_DEPS,
 )

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -1,8 +1,8 @@
-export {canonicalizeCountryCode} from './src/countryCodes'
+export {canonicalizeCountryCode} from './src/countryCodes.js'
 export {
   countriesUsingDefaultCurrency,
   defaultCurrency,
-} from './src/defaultCurrency'
-export {defaultLocale} from './src/defaultLocale'
-export {defaultTimezone} from './src/defaultTimezone'
-export {currencyMinorScale} from './src/iso4217'
+} from './src/defaultCurrency.js'
+export {defaultLocale} from './src/defaultLocale.js'
+export {defaultTimezone} from './src/defaultTimezone.js'
+export {currencyMinorScale} from './src/iso4217.js'

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -4,6 +4,11 @@
   "version": "1.9.4",
   "license": "MIT",
   "author": "Long Ho <holevietlong@gmail.com>",
+  "type": "module",
+  "types": "index.d.ts",
+  "exports": {
+    ".": "./index.js"
+  },
   "dependencies": {
     "@formatjs/fast-memoize": "workspace:*",
     "tslib": "^2.8.0"
@@ -19,7 +24,5 @@
     "memoize",
     "utils"
   ],
-  "main": "index.js",
-  "module": "lib/index.js",
   "repository": "formatjs/formatjs.git"
 }

--- a/packages/utils/src/defaultCurrency.ts
+++ b/packages/utils/src/defaultCurrency.ts
@@ -1,4 +1,4 @@
-import {canonicalizeCountryCode} from './countryCodes'
+import {canonicalizeCountryCode} from './countryCodes.js'
 import * as data from './defaultCurrencyData.generated.json'
 
 const COUNTRIES_BY_DEFAULT_CURRENCY = Object.keys(data).reduce<

--- a/packages/utils/src/defaultLocale.ts
+++ b/packages/utils/src/defaultLocale.ts
@@ -1,4 +1,4 @@
-import {canonicalizeCountryCode} from './countryCodes'
+import {canonicalizeCountryCode} from './countryCodes.js'
 import * as data from './defaultLocaleData.generated.json'
 
 /**


### PR DESCRIPTION
### TL;DR

Convert `@formatjs/utils` package to ESM format.

### What changed?

- Updated the package.json to specify `"type": "module"` and configured proper ESM exports
- Added `.js` extensions to all import statements to comply with ESM requirements
- Modified the Bazel build configuration to skip CommonJS output and only generate ESM
- Removed the `dist-esm` from npm package contents as it's no longer needed

### How to test?

1. Build the package with `bazel build //packages/utils:dist`
2. Verify that the package can be imported in an ESM environment
3. Test importing the package in a project that uses ESM modules

### Why make this change?

This change modernizes the `@formatjs/utils` package by converting it to use native ES modules, which aligns with the direction of the JavaScript ecosystem. ESM provides better tree-shaking capabilities and is the standard module format for modern JavaScript applications.