### PR TITLE
feat(@formatjs/intl)!: convert to ESM

### DIFF
--- a/packages/intl/BUILD.bazel
+++ b/packages/intl/BUILD.bazel
@@ -18,7 +18,6 @@ npm_package(
         "README.md",
         "package.json",
         ":dist",
-        ":dist-esm",
     ],
     package = "@formatjs/%s" % PACKAGE_NAME,
     visibility = ["//visibility:public"],
@@ -45,6 +44,7 @@ TESTS = glob(
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
+    skip_cjs = True,
     skip_esm = False,
     deps = SRC_DEPS,
 )

--- a/packages/intl/index.ts
+++ b/packages/intl/index.ts
@@ -1,5 +1,5 @@
-import {MessageDescriptor} from './src/types'
-export * from './src/types'
+import {MessageDescriptor} from './src/types.js'
+export * from './src/types.js'
 
 export function defineMessages<
   K extends keyof any,
@@ -19,20 +19,20 @@ export {
   DEFAULT_INTL_CONFIG,
   createFormatters,
   getNamedFormat,
-} from './src/utils'
-export * from './src/error'
-export {formatMessage} from './src/message'
-export type {FormatMessageFn} from './src/message'
+} from './src/utils.js'
+export * from './src/error.js'
+export {formatMessage} from './src/message.js'
+export type {FormatMessageFn} from './src/message.js'
 export {
   formatDate,
   formatDateToParts,
   formatTime,
   formatTimeToParts,
-} from './src/dateTime'
-export {formatDisplayName} from './src/displayName'
-export {formatList} from './src/list'
-export {formatPlural} from './src/plural'
-export {formatRelativeTime} from './src/relativeTime'
-export {formatNumber, formatNumberToParts} from './src/number'
-export {createIntl} from './src/create-intl'
-export type {CreateIntlFn} from './src/create-intl'
+} from './src/dateTime.js'
+export {formatDisplayName} from './src/displayName.js'
+export {formatList} from './src/list.js'
+export {formatPlural} from './src/plural.js'
+export {formatRelativeTime} from './src/relativeTime.js'
+export {formatNumber, formatNumberToParts} from './src/number.js'
+export {createIntl} from './src/create-intl.js'
+export type {CreateIntlFn} from './src/create-intl.js'

--- a/packages/intl/package.json
+++ b/packages/intl/package.json
@@ -4,7 +4,12 @@
   "version": "3.1.8",
   "license": "MIT",
   "author": "Long Ho <holevietlong@gmail.com>",
+  "type": "module",
   "sideEffects": false,
+  "types": "index.d.ts",
+  "exports": {
+    ".": "./index.js"
+  },
   "dependencies": {
     "@formatjs/ecma402-abstract": "workspace:*",
     "@formatjs/fast-memoize": "workspace:*",
@@ -30,8 +35,6 @@
     "translate",
     "translation"
   ],
-  "main": "index.js",
-  "module": "lib/index.js",
   "peerDependenciesMeta": {
     "typescript": {
       "optional": true

--- a/packages/intl/src/create-intl.ts
+++ b/packages/intl/src/create-intl.ts
@@ -5,16 +5,16 @@ import {
   formatDateToParts,
   formatTime,
   formatTimeToParts,
-} from './dateTime'
-import {formatDisplayName} from './displayName'
-import {InvalidConfigError, MissingDataError} from './error'
-import {formatList, formatListToParts} from './list'
-import {formatMessage} from './message'
-import {formatNumber, formatNumberToParts} from './number'
-import {formatPlural} from './plural'
-import {formatRelativeTime} from './relativeTime'
-import {IntlCache, IntlConfig, IntlShape, ResolvedIntlConfig} from './types'
-import {createFormatters, DEFAULT_INTL_CONFIG} from './utils'
+} from './dateTime.js'
+import {formatDisplayName} from './displayName.js'
+import {InvalidConfigError, MissingDataError} from './error.js'
+import {formatList, formatListToParts} from './list.js'
+import {formatMessage} from './message.js'
+import {formatNumber, formatNumberToParts} from './number.js'
+import {formatPlural} from './plural.js'
+import {formatRelativeTime} from './relativeTime.js'
+import {IntlCache, IntlConfig, IntlShape, ResolvedIntlConfig} from './types.js'
+import {createFormatters, DEFAULT_INTL_CONFIG} from './utils.js'
 
 export interface CreateIntlFn<
   T = string,

--- a/packages/intl/src/dateTime.ts
+++ b/packages/intl/src/dateTime.ts
@@ -1,7 +1,7 @@
-import {CustomFormats, Formatters, IntlFormatters, OnErrorFn} from './types'
+import {CustomFormats, Formatters, IntlFormatters, OnErrorFn} from './types.js'
 
-import {IntlFormatError} from './error'
-import {filterProps, getNamedFormat} from './utils'
+import {IntlFormatError} from './error.js'
+import {filterProps, getNamedFormat} from './utils.js'
 
 const DATE_TIME_FORMAT_OPTIONS: Array<keyof Intl.DateTimeFormatOptions> = [
   'formatMatcher',

--- a/packages/intl/src/displayName.ts
+++ b/packages/intl/src/displayName.ts
@@ -1,8 +1,8 @@
-import {Formatters, IntlFormatters, OnErrorFn} from './types'
-import {filterProps} from './utils'
+import {Formatters, IntlFormatters, OnErrorFn} from './types.js'
+import {filterProps} from './utils.js'
 
 import {ErrorCode, FormatError} from 'intl-messageformat'
-import {IntlFormatError} from './error'
+import {IntlFormatError} from './error.js'
 
 const DISPLAY_NAMES_OPTONS: Array<keyof Intl.DisplayNamesOptions> = [
   'style',

--- a/packages/intl/src/error.ts
+++ b/packages/intl/src/error.ts
@@ -1,4 +1,4 @@
-import {MessageDescriptor} from './types'
+import {MessageDescriptor} from './types.js'
 
 export enum IntlErrorCode {
   FORMAT_ERROR = 'FORMAT_ERROR',

--- a/packages/intl/src/list.ts
+++ b/packages/intl/src/list.ts
@@ -1,7 +1,7 @@
 import {ErrorCode, FormatError} from 'intl-messageformat'
-import {IntlFormatError} from './error'
-import {Formatters, IntlFormatters, OnErrorFn, Part} from './types'
-import {filterProps} from './utils'
+import {IntlFormatError} from './error.js'
+import {Formatters, IntlFormatters, OnErrorFn, Part} from './types.js'
+import {filterProps} from './utils.js'
 
 const LIST_FORMAT_OPTIONS: Array<keyof Intl.ListFormatOptions> = [
   'type',

--- a/packages/intl/src/message.ts
+++ b/packages/intl/src/message.ts
@@ -1,4 +1,9 @@
-import {CustomFormats, Formatters, MessageDescriptor, OnErrorFn} from './types'
+import {
+  CustomFormats,
+  Formatters,
+  MessageDescriptor,
+  OnErrorFn,
+} from './types.js'
 
 import {MessageFormatElement, TYPE} from '@formatjs/icu-messageformat-parser'
 import {
@@ -8,8 +13,8 @@ import {
   Options,
   PrimitiveType,
 } from 'intl-messageformat'
-import {MessageFormatError, MissingTranslationError} from './error'
-import {invariant} from './utils'
+import {MessageFormatError, MissingTranslationError} from './error.js'
+import {invariant} from './utils.js'
 
 function setTimeZoneInOptions(
   opts: Record<string, Intl.DateTimeFormatOptions>,

--- a/packages/intl/src/number.ts
+++ b/packages/intl/src/number.ts
@@ -1,7 +1,7 @@
 import {NumberFormatOptions} from '@formatjs/ecma402-abstract'
-import {IntlFormatError} from './error'
-import {CustomFormats, Formatters, IntlFormatters, OnErrorFn} from './types'
-import {filterProps, getNamedFormat} from './utils'
+import {IntlFormatError} from './error.js'
+import {CustomFormats, Formatters, IntlFormatters, OnErrorFn} from './types.js'
+import {filterProps, getNamedFormat} from './utils.js'
 
 const NUMBER_FORMAT_OPTIONS: Array<keyof NumberFormatOptions> = [
   'style',

--- a/packages/intl/src/plural.ts
+++ b/packages/intl/src/plural.ts
@@ -1,7 +1,7 @@
 import {ErrorCode, FormatError} from 'intl-messageformat'
-import {IntlFormatError} from './error'
-import {Formatters, IntlFormatters, OnErrorFn} from './types'
-import {filterProps} from './utils'
+import {IntlFormatError} from './error.js'
+import {Formatters, IntlFormatters, OnErrorFn} from './types.js'
+import {filterProps} from './utils.js'
 
 const PLURAL_FORMAT_OPTIONS: Array<keyof Intl.PluralRulesOptions> = ['type']
 

--- a/packages/intl/src/relativeTime.ts
+++ b/packages/intl/src/relativeTime.ts
@@ -1,8 +1,8 @@
-import {IntlFormatters, Formatters, CustomFormats, OnErrorFn} from './types'
+import {IntlFormatters, Formatters, CustomFormats, OnErrorFn} from './types.js'
 
-import {getNamedFormat, filterProps} from './utils'
+import {getNamedFormat, filterProps} from './utils.js'
 import {FormatError, ErrorCode} from 'intl-messageformat'
-import {IntlFormatError} from './error'
+import {IntlFormatError} from './error.js'
 
 const RELATIVE_TIME_FORMAT_OPTIONS: Array<
   keyof Intl.RelativeTimeFormatOptions

--- a/packages/intl/src/types.ts
+++ b/packages/intl/src/types.ts
@@ -15,8 +15,8 @@ import {
   MissingDataError,
   MissingTranslationError,
   UnsupportedFormatterError,
-} from './error'
-import {DEFAULT_INTL_CONFIG} from './utils'
+} from './error.js'
+import {DEFAULT_INTL_CONFIG} from './utils.js'
 
 export interface Part<T = string> {
   type: 'element' | 'literal'

--- a/packages/intl/src/utils.ts
+++ b/packages/intl/src/utils.ts
@@ -1,7 +1,7 @@
 import {NumberFormatOptions} from '@formatjs/ecma402-abstract'
 import {Cache, memoize, strategies} from '@formatjs/fast-memoize'
 import {IntlMessageFormat} from 'intl-messageformat'
-import {UnsupportedFormatterError} from './error'
+import {UnsupportedFormatterError} from './error.js'
 import {
   CustomFormats,
   Formatters,
@@ -9,7 +9,7 @@ import {
   OnErrorFn,
   OnWarnFn,
   ResolvedIntlConfig,
-} from './types'
+} from './types.js'
 
 export function invariant(
   condition: boolean,


### PR DESCRIPTION
### TL;DR

Convert `@formatjs/intl` package to ESM format with proper `.js` extensions.

### What changed?

- Updated all import statements to include `.js` extensions
- Modified `package.json` to specify `"type": "module"` and updated exports configuration
- Removed CommonJS build by setting `skip_cjs = True` in Bazel build
- Removed `dist-esm` from npm package build
- Removed legacy `main` and `module` fields from package.json
- Added proper ESM exports configuration

### How to test?

1. Build the package with `yarn build`
2. Import the package in an ESM project
3. Verify that all imports work correctly with the `.js` extensions
4. Ensure that existing applications using this package continue to work

### Why make this change?

This change modernizes the package to use native ES modules, which provides better compatibility with modern JavaScript tooling and bundlers. Using explicit `.js` extensions in import paths is required for proper ESM resolution in Node.js and browsers. This change aligns with the broader JavaScript ecosystem's move toward ESM as the standard module format.