### PR TITLE
feat(@formatjs/intl-locale)!: convert to esm

### DIFF
--- a/packages/intl-datetimeformat/tests/format-range.test.ts
+++ b/packages/intl-datetimeformat/tests/format-range.test.ts
@@ -1,5 +1,5 @@
 import '@formatjs/intl-getcanonicallocales/polyfill'
-import '@formatjs/intl-locale/polyfill'
+import '@formatjs/intl-locale/polyfill.js'
 import {DateTimeFormat} from '../src/core'
 import allData from '../src/data/all-tz'
 import * as enGB from './locale-data/en-GB.json'

--- a/packages/intl-datetimeformat/tests/index.test.ts
+++ b/packages/intl-datetimeformat/tests/index.test.ts
@@ -1,5 +1,5 @@
 import '@formatjs/intl-getcanonicallocales/polyfill'
-import '@formatjs/intl-locale/polyfill'
+import '@formatjs/intl-locale/polyfill.js'
 import {DateTimeFormat} from '../src/core'
 import allData from '../src/data/all-tz'
 import * as enCA from './locale-data/en-CA.json'

--- a/packages/intl-displaynames/tests/index.test.ts
+++ b/packages/intl-displaynames/tests/index.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import '@formatjs/intl-getcanonicallocales/polyfill'
-import '@formatjs/intl-locale/polyfill'
+import '@formatjs/intl-locale/polyfill.js'
 import {DisplayNames} from '../index.js'
 import {describe, expect, it} from 'vitest'
 

--- a/packages/intl-listformat/tests/index.test.ts
+++ b/packages/intl-listformat/tests/index.test.ts
@@ -1,5 +1,5 @@
 import '@formatjs/intl-getcanonicallocales/polyfill'
-import '@formatjs/intl-locale/polyfill'
+import '@formatjs/intl-locale/polyfill.js'
 import ListFormat from '../index.js'
 import * as en from './locale-data/en.json'
 import * as enAI from './locale-data/en-AI.json'

--- a/packages/intl-listformat/tests/supported-locales-of.test.ts
+++ b/packages/intl-listformat/tests/supported-locales-of.test.ts
@@ -1,5 +1,5 @@
 import '@formatjs/intl-getcanonicallocales/polyfill'
-import '@formatjs/intl-locale/polyfill'
+import '@formatjs/intl-locale/polyfill.js'
 import ListFormat from '../index.js'
 import * as en from './locale-data/en.json'
 import * as enAI from './locale-data/en-AI.json'

--- a/packages/intl-locale/BUILD.bazel
+++ b/packages/intl-locale/BUILD.bazel
@@ -38,6 +38,7 @@ SRC_DEPS = [
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
+    skip_cjs = True,
     skip_esm = False,
     deps = SRC_DEPS,
 )

--- a/packages/intl-locale/index.ts
+++ b/packages/intl-locale/index.ts
@@ -21,18 +21,18 @@ import {
   parseUnicodeLanguageId,
   parseUnicodeLocaleId,
 } from '@formatjs/intl-getcanonicallocales'
-import {characterOrders} from './character-orders.generated'
-import getInternalSlots from './get_internal_slots'
-import {numberingSystems} from './numbering-systems.generated'
+import {characterOrders} from './character-orders.generated.js'
+import getInternalSlots from './get_internal_slots.js'
+import {numberingSystems} from './numbering-systems.generated.js'
 import {
   getCalendarPreferenceDataForRegion,
   getHourCyclesPreferenceDataForLocaleOrRegion,
   getTimeZonePreferenceForRegion,
   getWeekDataForRegion,
-} from './preference-data'
+} from './preference-data.js'
 
-import type {CharacterOrder} from './character-orders.generated'
-import type {WeekInfoInternal} from './preference-data'
+import type {CharacterOrder} from './character-orders.generated.js'
+import type {WeekInfoInternal} from './preference-data.js'
 
 export interface IntlLocaleOptions {
   language?: string

--- a/packages/intl-locale/package.json
+++ b/packages/intl-locale/package.json
@@ -4,7 +4,14 @@
   "version": "4.2.13",
   "license": "MIT",
   "author": "Long Ho <holevietlong@gmail.com>",
+  "type": "module",
   "types": "index.d.ts",
+  "exports": {
+    ".": "./index.js",
+    "./polyfill.js": "./polyfill.js",
+    "./polyfill-force.js": "./polyfill-force.js",
+    "./should-polyfill.js": "./should-polyfill.js"
+  },
   "dependencies": {
     "@formatjs/ecma402-abstract": "workspace:*",
     "@formatjs/intl-enumerator": "workspace:*",
@@ -22,6 +29,5 @@
     "react-intl",
     "tc39"
   ],
-  "main": "index.js",
   "repository": "formatjs/formatjs.git"
 }

--- a/packages/intl-locale/polyfill-force.ts
+++ b/packages/intl-locale/polyfill-force.ts
@@ -1,4 +1,4 @@
-import {Locale} from './'
+import {Locale} from './index.js'
 
 Object.defineProperty(Intl, 'Locale', {
   value: Locale,

--- a/packages/intl-locale/polyfill.ts
+++ b/packages/intl-locale/polyfill.ts
@@ -1,5 +1,5 @@
-import {Locale} from './'
-import {shouldPolyfill} from './should-polyfill'
+import {Locale} from './index.js'
+import {shouldPolyfill} from './should-polyfill.js'
 if (shouldPolyfill()) {
   Object.defineProperty(Intl, 'Locale', {
     value: Locale,

--- a/packages/intl-locale/preference-data.ts
+++ b/packages/intl-locale/preference-data.ts
@@ -1,12 +1,12 @@
-import {timezones} from './timezones.generated'
-import {hourCycles} from './hour-cycles.generated'
-import {calendars} from './calendars.generated'
-import {weekData} from './week-data.generated'
+import {timezones} from './timezones.generated.js'
+import {hourCycles} from './hour-cycles.generated.js'
+import {calendars} from './calendars.generated.js'
+import {weekData} from './week-data.generated.js'
 
-import type {TimezonesTerritory} from './timezones.generated'
-import type {HourCyclesKey} from './hour-cycles.generated'
-import type {CalendarsKey} from './calendars.generated'
-import type {WeekDataKey, WeekInfoInternal} from './week-data.generated'
+import type {TimezonesTerritory} from './timezones.generated.js'
+import type {HourCyclesKey} from './hour-cycles.generated.js'
+import type {CalendarsKey} from './calendars.generated.js'
+import type {WeekDataKey, WeekInfoInternal} from './week-data.generated.js'
 
 export {WeekInfoInternal}
 

--- a/packages/intl-locale/scripts/calendars.ts
+++ b/packages/intl-locale/scripts/calendars.ts
@@ -3,7 +3,7 @@ import {outputFileSync} from 'fs-extra'
 
 import * as rawCalendarPreferenceData from 'cldr-core/supplemental/calendarPreferenceData.json'
 
-import type {Args} from './common-types'
+import type {Args} from './common-types.js'
 import stringify from 'json-stable-stringify'
 
 const {calendarPreferenceData} = rawCalendarPreferenceData.supplemental

--- a/packages/intl-locale/scripts/character-orders.ts
+++ b/packages/intl-locale/scripts/character-orders.ts
@@ -1,9 +1,9 @@
 import {outputFileSync} from 'fs-extra'
 import stringify from 'json-stable-stringify'
 import minimist from 'minimist'
-import {getAllLocales} from './utils'
+import {getAllLocales} from './utils.js'
 
-import type {Args} from './common-types'
+import type {Args} from './common-types.js'
 
 type CharacterOrder = 'left-to-right' | 'right-to-left'
 

--- a/packages/intl-locale/scripts/hour-cycles.ts
+++ b/packages/intl-locale/scripts/hour-cycles.ts
@@ -3,7 +3,7 @@ import {outputFileSync} from 'fs-extra'
 import stringify from 'json-stable-stringify'
 import * as rawTimeData from 'cldr-core/supplemental/timeData.json'
 
-import type {Args} from './common-types'
+import type {Args} from './common-types.js'
 
 const {timeData} = rawTimeData.supplemental
 

--- a/packages/intl-locale/scripts/numbering-systems.ts
+++ b/packages/intl-locale/scripts/numbering-systems.ts
@@ -2,9 +2,9 @@ import minimist from 'minimist'
 import {outputFileSync} from 'fs-extra'
 import stringify from 'json-stable-stringify'
 
-import {getAllLocales} from './utils'
+import {getAllLocales} from './utils.js'
 
-import type {Args} from './common-types'
+import type {Args} from './common-types.js'
 
 type CldrNumbersNumbers = {
   defaultNumberingSystem: string

--- a/packages/intl-locale/scripts/timezones.ts
+++ b/packages/intl-locale/scripts/timezones.ts
@@ -3,7 +3,7 @@ import {outputFileSync} from 'fs-extra'
 import stringify from 'json-stable-stringify'
 import * as rawTimezones from 'cldr-bcp47/bcp47/timezone.json'
 
-import type {Args} from './common-types'
+import type {Args} from './common-types.js'
 
 type Tz = typeof rawTimezones.keyword.u.tz & {
   _alias: never

--- a/packages/intl-locale/scripts/week-data.ts
+++ b/packages/intl-locale/scripts/week-data.ts
@@ -5,7 +5,7 @@ import * as rawTerritoryInfo from 'cldr-core/supplemental/territoryInfo.json'
 import * as rawWeekData from 'cldr-core/supplemental/weekData.json'
 
 import stringify from 'json-stable-stringify'
-import type {Args} from './common-types'
+import type {Args} from './common-types.js'
 
 type WeekInfoInternal = {
   firstDay: number

--- a/packages/intl-numberformat/tests/currency-code.test.ts
+++ b/packages/intl-numberformat/tests/currency-code.test.ts
@@ -1,6 +1,6 @@
 import {it, expect} from 'vitest'
 import '@formatjs/intl-getcanonicallocales/polyfill'
-import '@formatjs/intl-locale/polyfill'
+import '@formatjs/intl-locale/polyfill.js'
 import * as en from './locale-data/en.json'
 import {NumberFormat} from '../src/core'
 NumberFormat.__addLocaleData(en as any)

--- a/packages/intl-numberformat/tests/notation-compact-zh-TW.test.ts
+++ b/packages/intl-numberformat/tests/notation-compact-zh-TW.test.ts
@@ -1,6 +1,6 @@
 import {describe, it, expect} from 'vitest'
 import '@formatjs/intl-getcanonicallocales/polyfill'
-import '@formatjs/intl-locale/polyfill'
+import '@formatjs/intl-locale/polyfill.js'
 import '@formatjs/intl-pluralrules/polyfill'
 import '@formatjs/intl-pluralrules/locale-data/zh'
 import '@formatjs/intl-pluralrules/polyfill'

--- a/packages/intl-numberformat/tests/signDisplay-currency-zh-TW.test.ts
+++ b/packages/intl-numberformat/tests/signDisplay-currency-zh-TW.test.ts
@@ -1,6 +1,6 @@
 import {describe, it, expect} from 'vitest'
 import '@formatjs/intl-getcanonicallocales/polyfill'
-import '@formatjs/intl-locale/polyfill'
+import '@formatjs/intl-locale/polyfill.js'
 import '@formatjs/intl-pluralrules/polyfill'
 import '@formatjs/intl-pluralrules/locale-data/zh'
 import * as zh from './locale-data/zh.json'

--- a/packages/intl-numberformat/tests/signDisplay-zh-TW.test.ts
+++ b/packages/intl-numberformat/tests/signDisplay-zh-TW.test.ts
@@ -1,6 +1,6 @@
 import {describe, it, expect} from 'vitest'
 import '@formatjs/intl-getcanonicallocales/polyfill'
-import '@formatjs/intl-locale/polyfill'
+import '@formatjs/intl-locale/polyfill.js'
 import '@formatjs/intl-pluralrules/polyfill'
 import '@formatjs/intl-pluralrules/locale-data/zh'
 import * as zh from './locale-data/zh.json'

--- a/packages/intl-numberformat/tests/unit-zh-TW.test.ts
+++ b/packages/intl-numberformat/tests/unit-zh-TW.test.ts
@@ -1,6 +1,6 @@
 import {describe, it, expect} from 'vitest'
 import '@formatjs/intl-getcanonicallocales/polyfill'
-import '@formatjs/intl-locale/polyfill'
+import '@formatjs/intl-locale/polyfill.js'
 import '@formatjs/intl-pluralrules/locale-data/zh'
 import '@formatjs/intl-pluralrules/polyfill'
 import {NumberFormat} from '../src/core'

--- a/packages/intl-pluralrules/tests/index.test.ts
+++ b/packages/intl-pluralrules/tests/index.test.ts
@@ -1,5 +1,5 @@
 import '@formatjs/intl-getcanonicallocales/polyfill'
-import '@formatjs/intl-locale/polyfill'
+import '@formatjs/intl-locale/polyfill.js'
 import {PluralRules} from '../'
 import {describe, expect, it} from 'vitest'
 // @ts-ignore

--- a/packages/intl-pluralrules/tests/supported-locales-of.test.ts
+++ b/packages/intl-pluralrules/tests/supported-locales-of.test.ts
@@ -1,5 +1,5 @@
 import '@formatjs/intl-getcanonicallocales/polyfill'
-import '@formatjs/intl-locale/polyfill'
+import '@formatjs/intl-locale/polyfill.js'
 import {PluralRules} from '../'
 import {describe, expect, it} from 'vitest'
 // @ts-ignore

--- a/packages/intl-relativetimeformat/tests/index.test.ts
+++ b/packages/intl-relativetimeformat/tests/index.test.ts
@@ -1,5 +1,5 @@
 import '@formatjs/intl-getcanonicallocales/polyfill'
-import '@formatjs/intl-locale/polyfill'
+import '@formatjs/intl-locale/polyfill.js'
 import '@formatjs/intl-pluralrules/polyfill'
 import '@formatjs/intl-pluralrules/locale-data/zh'
 import '@formatjs/intl-pluralrules/locale-data/en'

--- a/packages/intl-relativetimeformat/tests/supported-locales-of.test.ts
+++ b/packages/intl-relativetimeformat/tests/supported-locales-of.test.ts
@@ -1,5 +1,5 @@
 import '@formatjs/intl-getcanonicallocales/polyfill'
-import '@formatjs/intl-locale/polyfill'
+import '@formatjs/intl-locale/polyfill.js'
 import '@formatjs/intl-pluralrules/polyfill'
 import '@formatjs/intl-pluralrules/locale-data/en'
 import '@formatjs/intl-pluralrules/locale-data/zh'

--- a/packages/react-intl/examples/index.tsx
+++ b/packages/react-intl/examples/index.tsx
@@ -11,7 +11,7 @@ import StaticTypeSafetyAndCodeSplitting from './StaticTypeSafetyAndCodeSplitting
 import Timezone from './TimeZone'
 //polyfills
 import '@formatjs/intl-getcanonicallocales/polyfill'
-import '@formatjs/intl-locale/polyfill'
+import '@formatjs/intl-locale/polyfill.js'
 
 import '@formatjs/intl-pluralrules/locale-data/en' // locale-data for en
 import '@formatjs/intl-pluralrules/polyfill'


### PR DESCRIPTION
### TL;DR

Convert `@formatjs/intl-locale` to ESM-only package.

### What changed?

- Updated `@formatjs/intl-locale` package to be ESM-only by adding `"type": "module"` to package.json
- Added proper exports configuration in package.json
- Updated all imports to use `.js` extension for proper ESM resolution
- Removed CommonJS build by adding `skip_cjs = True` in Bazel config
- Updated all imports of `@formatjs/intl-locale/polyfill` to `@formatjs/intl-locale/polyfill.js` across various packages

### How to test?

1. Build the project and verify that the `intl-locale` package works correctly as an ESM module
2. Run tests for all packages that depend on `intl-locale` to ensure they can properly import the polyfill
3. Verify that applications using `@formatjs/intl-locale` can still import it correctly with the new ESM format

### Why make this change?

This change modernizes the `intl-locale` package to use ESM format, which is the standard module system for JavaScript. This improves compatibility with modern bundlers and runtimes while ensuring proper static analysis and tree-shaking capabilities. The explicit `.js` extensions in imports are required for proper ESM resolution.