### PR TITLE
feat(@formatjs/editor)!: convert to ESM

### DIFF
--- a/packages/editor/index.tsx
+++ b/packages/editor/index.tsx
@@ -21,10 +21,10 @@ import {
   ListItemText,
 } from '@material-ui/core'
 import {Menu, AddAlert, NotificationsOff} from '@material-ui/icons'
-import Header from './header'
+import Header from './header.js'
 import {IntlProvider, useIntl} from 'react-intl'
-import {TranslatedMessage} from './types'
-import Messages from './messages'
+import {TranslatedMessage} from './types.js'
+import Messages from './messages.js'
 
 const MESSAGES_COUNT = 50
 async function fetchData(): Promise<TranslatedMessage[]> {

--- a/packages/editor/main.tsx
+++ b/packages/editor/main.tsx
@@ -1,4 +1,4 @@
-import Main from '.'
+import Main from './index.js'
 import ReactDOM from 'react-dom'
 import React from 'react'
 

--- a/packages/editor/messages.tsx
+++ b/packages/editor/messages.tsx
@@ -2,8 +2,8 @@ import {List, ListItem, Box} from '@material-ui/core'
 import {CheckCircle} from '@material-ui/icons'
 import {Skeleton} from '@material-ui/lab'
 import React from 'react'
-import {TranslatedMessage} from './types'
-import Message from './message'
+import {TranslatedMessage} from './types.js'
+import Message from './message.js'
 export interface Props {
   messages: TranslatedMessage[]
   isLoading?: boolean

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -22,7 +22,11 @@
   "author": "Long Ho <holevietlong@gmail.com>",
   "homepage": "https://github.com/formatjs/formatjs",
   "license": "MIT",
-  "main": "index.js",
+  "type": "module",
+  "types": "index.d.ts",
+  "exports": {
+    ".": "./index.js"
+  },
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/formatjs/formatjs.git"


### PR DESCRIPTION
### TL;DR

Convert the editor package to use ES modules by adding explicit `.js` extensions to imports and updating package.json configuration.

### What changed?

- Added explicit `.js` extensions to all import statements in various files:
  - `index.tsx`: Updated imports for Header, TranslatedMessage, and Messages
  - `main.tsx`: Updated import for Main
  - `messages.tsx`: Updated imports for TranslatedMessage and Message
- Modified `package.json` to:
  - Add `"type": "module"` to specify ES modules
  - Add `"types": "index.d.ts"` for TypeScript type definitions
  - Replace `"main": "index.js"` with an exports field: `"exports": { ".": "./index.js" }`

### How to test?

1. Build the editor package
2. Verify that imports work correctly in both development and production environments
3. Check that TypeScript types are properly resolved
4. Ensure the application loads and functions as expected

### Why make this change?

This change modernizes the package to use ES modules, which provides better tree-shaking, more explicit imports, and better alignment with modern JavaScript practices. The explicit file extensions are required for proper ESM resolution, and the package.json changes ensure the package is correctly identified as an ES module by Node.js and bundlers.