### PR TITLE
feat(intl-messageformat)!: convert to esm

### DIFF
--- a/packages/intl-messageformat/BUILD.bazel
+++ b/packages/intl-messageformat/BUILD.bazel
@@ -48,6 +48,7 @@ TEST_DEPS = SRC_DEPS + [
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
+    skip_cjs = True,
     skip_esm = False,
     skip_esm_esnext = False,
     deps = SRC_DEPS,

--- a/packages/intl-messageformat/index.ts
+++ b/packages/intl-messageformat/index.ts
@@ -4,9 +4,9 @@ Copyrights licensed under the New BSD License.
 See the accompanying LICENSE file for terms.
 */
 
-import {IntlMessageFormat} from './src/core'
-export * from './src/core'
-export * from './src/error'
-export * from './src/formatters'
+import {IntlMessageFormat} from './src/core.js'
+export * from './src/core.js'
+export * from './src/error.js'
+export * from './src/formatters.js'
 export {IntlMessageFormat}
 export default IntlMessageFormat

--- a/packages/intl-messageformat/package.json
+++ b/packages/intl-messageformat/package.json
@@ -4,8 +4,12 @@
   "version": "10.7.18",
   "license": "BSD-3-Clause",
   "author": "Eric Ferraiuolo <eferraiuolo@gmail.com>",
+  "type": "module",
   "sideEffects": false,
   "types": "index.d.ts",
+  "exports": {
+    ".": "./index.js"
+  },
   "dependencies": {
     "@formatjs/ecma402-abstract": "workspace:*",
     "@formatjs/fast-memoize": "workspace:*",
@@ -32,7 +36,5 @@
     "parser",
     "plural"
   ],
-  "main": "index.js",
-  "module": "lib/index.js",
   "repository": "git@github.com:formatjs/formatjs.git"
 }

--- a/packages/intl-messageformat/src/core.ts
+++ b/packages/intl-messageformat/src/core.ts
@@ -19,7 +19,7 @@ import {
   MessageFormatPart,
   PART_TYPE,
   PrimitiveType,
-} from './formatters'
+} from './formatters.js'
 
 // -- MessageFormat --------------------------------------------------------
 

--- a/packages/intl-messageformat/src/formatters.ts
+++ b/packages/intl-messageformat/src/formatters.ts
@@ -20,7 +20,7 @@ import {
   InvalidValueError,
   InvalidValueTypeError,
   MissingValueError,
-} from './error'
+} from './error.js'
 
 declare global {
   namespace FormatjsIntl {

--- a/packages/intl-messageformat/tests/benchmark.ts
+++ b/packages/intl-messageformat/tests/benchmark.ts
@@ -1,5 +1,5 @@
 import {Suite, Event} from 'benchmark'
-import IntlMessageFormat, {Formatters} from '..'
+import IntlMessageFormat, {Formatters} from '../index.js'
 import '@formatjs/intl-pluralrules/polyfill.js'
 import '@formatjs/intl-pluralrules/locale-data/en'
 import {memoize} from '@formatjs/fast-memoize'

--- a/packages/intl-messageformat/tests/index.test.ts
+++ b/packages/intl-messageformat/tests/index.test.ts
@@ -3,9 +3,9 @@
  * Copyrights licensed under the New BSD License.
  * See the accompanying LICENSE file for terms.
  */
-import {IntlMessageFormat} from '../src/core'
-import {MissingValueError} from '../src/error'
-import {PART_TYPE} from '../src/formatters'
+import {IntlMessageFormat} from '../src/core.js'
+import {MissingValueError} from '../src/error.js'
+import {PART_TYPE} from '../src/formatters.js'
 import {parse} from '@formatjs/icu-messageformat-parser'
 import {describe, expect, it} from 'vitest'
 describe('IntlMessageFormat', function () {


### PR DESCRIPTION
### TL;DR

Convert `intl-messageformat` package to ESM-only format with proper `.js` extensions.

### What changed?

- Updated `package.json` to specify `"type": "module"` and added proper exports field
- Added explicit `.js` extensions to all import/export statements
- Removed CommonJS output by setting `skip_cjs = True` in Bazel build config
- Removed `main` and `module` fields from package.json as they're no longer needed

### How to test?

1. Build the package with `yarn build`
2. Import the package in an ESM environment to verify it works correctly
3. Run tests to ensure functionality remains the same
4. Verify that the package can be properly imported in projects using ESM

### Why make this change?

This change modernizes the package to use native ES modules, which provides better tree-shaking and aligns with the direction of the JavaScript ecosystem. Using explicit `.js` extensions in imports ensures compatibility with ESM's stricter module resolution rules, while removing CommonJS output simplifies the package structure and maintenance.