### PR TITLE
feat(@formatjs/intl-getcanonicallocales)!: convert to esm

### DIFF
--- a/packages/intl-datetimeformat/tests/format-range.test.ts
+++ b/packages/intl-datetimeformat/tests/format-range.test.ts
@@ -1,4 +1,4 @@
-import '@formatjs/intl-getcanonicallocales/polyfill'
+import '@formatjs/intl-getcanonicallocales/polyfill.js'
 import '@formatjs/intl-locale/polyfill.js'
 import {DateTimeFormat} from '../src/core'
 import allData from '../src/data/all-tz'

--- a/packages/intl-datetimeformat/tests/index.test.ts
+++ b/packages/intl-datetimeformat/tests/index.test.ts
@@ -1,4 +1,4 @@
-import '@formatjs/intl-getcanonicallocales/polyfill'
+import '@formatjs/intl-getcanonicallocales/polyfill.js'
 import '@formatjs/intl-locale/polyfill.js'
 import {DateTimeFormat} from '../src/core'
 import allData from '../src/data/all-tz'

--- a/packages/intl-displaynames/tests/index.test.ts
+++ b/packages/intl-displaynames/tests/index.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-import '@formatjs/intl-getcanonicallocales/polyfill'
+import '@formatjs/intl-getcanonicallocales/polyfill.js'
 import '@formatjs/intl-locale/polyfill.js'
 import {DisplayNames} from '../index.js'
 import {describe, expect, it} from 'vitest'

--- a/packages/intl-getcanonicallocales/BUILD.bazel
+++ b/packages/intl-getcanonicallocales/BUILD.bazel
@@ -50,6 +50,8 @@ TEST_DEPS = SRC_DEPS
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
+    skip_cjs = True,
+    skip_esm = False,
     deps = SRC_DEPS,
 )
 

--- a/packages/intl-getcanonicallocales/index.ts
+++ b/packages/intl-getcanonicallocales/index.ts
@@ -1,6 +1,6 @@
-import {CanonicalizeUnicodeLocaleId} from './src/canonicalizer'
-import {emitUnicodeLocaleId} from './src/emitter'
-import {parseUnicodeLocaleId} from './src/parser'
+import {CanonicalizeUnicodeLocaleId} from './src/canonicalizer.js'
+import {emitUnicodeLocaleId} from './src/emitter.js'
+import {parseUnicodeLocaleId} from './src/parser.js'
 
 /**
  * https://tc39.es/ecma402/#sec-canonicalizelocalelist
@@ -29,7 +29,7 @@ export function getCanonicalLocales(locales?: string[] | string): string[] {
   return CanonicalizeLocaleList(locales)
 }
 
-export * from './src/emitter'
+export * from './src/emitter.js'
 export {
   isStructurallyValidLanguageTag,
   isUnicodeLanguageSubtag,
@@ -37,7 +37,7 @@ export {
   isUnicodeScriptSubtag,
   parseUnicodeLanguageId,
   parseUnicodeLocaleId,
-} from './src/parser'
-export * from './src/types'
+} from './src/parser.js'
+export * from './src/types.js'
 
-export * from './src/likelySubtags.generated'
+export * from './src/likelySubtags.generated.js'

--- a/packages/intl-getcanonicallocales/package.json
+++ b/packages/intl-getcanonicallocales/package.json
@@ -4,7 +4,14 @@
   "version": "2.5.6",
   "license": "MIT",
   "author": "Long Ho <holevietlong@gmail.com>",
+  "type": "module",
   "types": "index.d.ts",
+  "exports": {
+    ".": "./index.js",
+    "./polyfill.js": "./polyfill.js",
+    "./polyfill-force.js": "./polyfill-force.js",
+    "./should-polyfill.js": "./should-polyfill.js"
+  },
   "dependencies": {
     "tslib": "^2.8.0"
   },
@@ -20,6 +27,5 @@
     "react-intl",
     "tc39"
   ],
-  "main": "index.js",
   "repository": "formatjs/formatjs.git"
 }

--- a/packages/intl-getcanonicallocales/polyfill-force.ts
+++ b/packages/intl-getcanonicallocales/polyfill-force.ts
@@ -1,4 +1,4 @@
-import {getCanonicalLocales} from './'
+import {getCanonicalLocales} from './index.js'
 if (typeof Intl === 'undefined') {
   if (typeof window !== 'undefined') {
     Object.defineProperty(window, 'Intl', {

--- a/packages/intl-getcanonicallocales/polyfill.ts
+++ b/packages/intl-getcanonicallocales/polyfill.ts
@@ -1,5 +1,5 @@
-import {getCanonicalLocales} from './'
-import {shouldPolyfill} from './should-polyfill'
+import {getCanonicalLocales} from './index.js'
+import {shouldPolyfill} from './should-polyfill.js'
 if (typeof Intl === 'undefined') {
   if (typeof window !== 'undefined') {
     Object.defineProperty(window, 'Intl', {

--- a/packages/intl-getcanonicallocales/src/canonicalizer.ts
+++ b/packages/intl-getcanonicallocales/src/canonicalizer.ts
@@ -3,16 +3,16 @@ import {
   scriptAlias,
   territoryAlias,
   variantAlias,
-} from './aliases.generated'
-import {emitUnicodeLanguageId} from './emitter'
-import {likelySubtags} from './likelySubtags.generated'
+} from './aliases.generated.js'
+import {emitUnicodeLanguageId} from './emitter.js'
+import {likelySubtags} from './likelySubtags.generated.js'
 import {
   isUnicodeLanguageSubtag,
   isUnicodeVariantSubtag,
   parseUnicodeLanguageId,
   SEPARATOR,
-} from './parser'
-import {Extension, KV, UnicodeLanguageId, UnicodeLocaleId} from './types'
+} from './parser.js'
+import {Extension, KV, UnicodeLanguageId, UnicodeLocaleId} from './types.js'
 
 function canonicalizeAttrs(strs: string[]): string[] {
   return Object.keys(

--- a/packages/intl-getcanonicallocales/src/emitter.ts
+++ b/packages/intl-getcanonicallocales/src/emitter.ts
@@ -1,4 +1,4 @@
-import {UnicodeLanguageId, UnicodeLocaleId} from './types'
+import {UnicodeLanguageId, UnicodeLocaleId} from './types.js'
 
 export function emitUnicodeLanguageId(lang?: UnicodeLanguageId): string {
   if (!lang) {

--- a/packages/intl-getcanonicallocales/src/parser.ts
+++ b/packages/intl-getcanonicallocales/src/parser.ts
@@ -6,7 +6,7 @@ import {
   PuExtension,
   OtherExtension,
   KV,
-} from './types'
+} from './types.js'
 
 const ALPHANUM_1_8 = /^[a-z0-9]{1,8}$/i
 const ALPHANUM_2_8 = /^[a-z0-9]{2,8}$/i

--- a/packages/intl-getcanonicallocales/tests/index.test.ts
+++ b/packages/intl-getcanonicallocales/tests/index.test.ts
@@ -1,4 +1,4 @@
-import {getCanonicalLocales} from '../'
+import {getCanonicalLocales} from '../index.js'
 import {describe, expect, it} from 'vitest'
 describe('Intl.getCanonicalLocales', () => {
   it('regular', function () {

--- a/packages/intl-getcanonicallocales/tests/parser.test.ts
+++ b/packages/intl-getcanonicallocales/tests/parser.test.ts
@@ -1,4 +1,4 @@
-import {parseUnicodeLocaleId} from '../src/parser'
+import {parseUnicodeLocaleId} from '../src/parser.js'
 import {describe, expect, it} from 'vitest'
 describe('parser', () => {
   const invalidLanguageTags = [

--- a/packages/intl-listformat/tests/index.test.ts
+++ b/packages/intl-listformat/tests/index.test.ts
@@ -1,4 +1,4 @@
-import '@formatjs/intl-getcanonicallocales/polyfill'
+import '@formatjs/intl-getcanonicallocales/polyfill.js'
 import '@formatjs/intl-locale/polyfill.js'
 import ListFormat from '../index.js'
 import * as en from './locale-data/en.json'

--- a/packages/intl-listformat/tests/supported-locales-of.test.ts
+++ b/packages/intl-listformat/tests/supported-locales-of.test.ts
@@ -1,4 +1,4 @@
-import '@formatjs/intl-getcanonicallocales/polyfill'
+import '@formatjs/intl-getcanonicallocales/polyfill.js'
 import '@formatjs/intl-locale/polyfill.js'
 import ListFormat from '../index.js'
 import * as en from './locale-data/en.json'

--- a/packages/intl-locale/BUILD.bazel
+++ b/packages/intl-locale/BUILD.bazel
@@ -92,6 +92,7 @@ esbuild(
     name = "polyfill.iife",
     srcs = [":srcs"],
     entry_point = "polyfill.ts",
+    target = "es6",
     deps = [
         "//:node_modules/tslib",
     ] + SRC_DEPS,

--- a/packages/intl-locale/tests/index.test.ts
+++ b/packages/intl-locale/tests/index.test.ts
@@ -1,4 +1,4 @@
-import '@formatjs/intl-getcanonicallocales/polyfill'
+import '@formatjs/intl-getcanonicallocales/polyfill.js'
 import {Locale} from '../'
 import {describe, expect, it, test} from 'vitest'
 describe('intl-locale', () => {

--- a/packages/intl-locale/tests/likely-subtags.test.ts
+++ b/packages/intl-locale/tests/likely-subtags.test.ts
@@ -1,4 +1,4 @@
-import '@formatjs/intl-getcanonicallocales/polyfill'
+import '@formatjs/intl-getcanonicallocales/polyfill.js'
 import {Locale} from '../'
 import {describe, expect, it} from 'vitest'
 const testDataMaximal: Record<string, string> = {

--- a/packages/intl-locale/tests/minimize.test.ts
+++ b/packages/intl-locale/tests/minimize.test.ts
@@ -1,4 +1,4 @@
-import '@formatjs/intl-getcanonicallocales/polyfill'
+import '@formatjs/intl-getcanonicallocales/polyfill.js'
 import {Locale} from '../'
 import {describe, expect, it} from 'vitest'
 const testDataMinimal: Record<string, string> = {

--- a/packages/intl-numberformat/tests/currency-code.test.ts
+++ b/packages/intl-numberformat/tests/currency-code.test.ts
@@ -1,5 +1,5 @@
 import {it, expect} from 'vitest'
-import '@formatjs/intl-getcanonicallocales/polyfill'
+import '@formatjs/intl-getcanonicallocales/polyfill.js'
 import '@formatjs/intl-locale/polyfill.js'
 import * as en from './locale-data/en.json'
 import {NumberFormat} from '../src/core'

--- a/packages/intl-numberformat/tests/notation-compact-zh-TW.test.ts
+++ b/packages/intl-numberformat/tests/notation-compact-zh-TW.test.ts
@@ -1,5 +1,5 @@
 import {describe, it, expect} from 'vitest'
-import '@formatjs/intl-getcanonicallocales/polyfill'
+import '@formatjs/intl-getcanonicallocales/polyfill.js'
 import '@formatjs/intl-locale/polyfill.js'
 import '@formatjs/intl-pluralrules/polyfill.js'
 import '@formatjs/intl-pluralrules/locale-data/zh'

--- a/packages/intl-numberformat/tests/signDisplay-currency-zh-TW.test.ts
+++ b/packages/intl-numberformat/tests/signDisplay-currency-zh-TW.test.ts
@@ -1,5 +1,5 @@
 import {describe, it, expect} from 'vitest'
-import '@formatjs/intl-getcanonicallocales/polyfill'
+import '@formatjs/intl-getcanonicallocales/polyfill.js'
 import '@formatjs/intl-locale/polyfill.js'
 import '@formatjs/intl-pluralrules/polyfill.js'
 import '@formatjs/intl-pluralrules/locale-data/zh'

--- a/packages/intl-numberformat/tests/signDisplay-zh-TW.test.ts
+++ b/packages/intl-numberformat/tests/signDisplay-zh-TW.test.ts
@@ -1,5 +1,5 @@
 import {describe, it, expect} from 'vitest'
-import '@formatjs/intl-getcanonicallocales/polyfill'
+import '@formatjs/intl-getcanonicallocales/polyfill.js'
 import '@formatjs/intl-locale/polyfill.js'
 import '@formatjs/intl-pluralrules/polyfill.js'
 import '@formatjs/intl-pluralrules/locale-data/zh'

--- a/packages/intl-numberformat/tests/unit-zh-TW.test.ts
+++ b/packages/intl-numberformat/tests/unit-zh-TW.test.ts
@@ -1,5 +1,5 @@
 import {describe, it, expect} from 'vitest'
-import '@formatjs/intl-getcanonicallocales/polyfill'
+import '@formatjs/intl-getcanonicallocales/polyfill.js'
 import '@formatjs/intl-locale/polyfill.js'
 import '@formatjs/intl-pluralrules/locale-data/zh'
 import '@formatjs/intl-pluralrules/polyfill.js'

--- a/packages/intl-pluralrules/tests/index.test.ts
+++ b/packages/intl-pluralrules/tests/index.test.ts
@@ -1,4 +1,4 @@
-import '@formatjs/intl-getcanonicallocales/polyfill'
+import '@formatjs/intl-getcanonicallocales/polyfill.js'
 import '@formatjs/intl-locale/polyfill.js'
 import {PluralRules} from '../'
 import {describe, expect, it} from 'vitest'

--- a/packages/intl-pluralrules/tests/supported-locales-of.test.ts
+++ b/packages/intl-pluralrules/tests/supported-locales-of.test.ts
@@ -1,4 +1,4 @@
-import '@formatjs/intl-getcanonicallocales/polyfill'
+import '@formatjs/intl-getcanonicallocales/polyfill.js'
 import '@formatjs/intl-locale/polyfill.js'
 import {PluralRules} from '../'
 import {describe, expect, it} from 'vitest'

--- a/packages/intl-relativetimeformat/tests/index.test.ts
+++ b/packages/intl-relativetimeformat/tests/index.test.ts
@@ -1,4 +1,4 @@
-import '@formatjs/intl-getcanonicallocales/polyfill'
+import '@formatjs/intl-getcanonicallocales/polyfill.js'
 import '@formatjs/intl-locale/polyfill.js'
 import '@formatjs/intl-pluralrules/polyfill.js'
 import '@formatjs/intl-pluralrules/locale-data/zh'

--- a/packages/intl-relativetimeformat/tests/supported-locales-of.test.ts
+++ b/packages/intl-relativetimeformat/tests/supported-locales-of.test.ts
@@ -1,4 +1,4 @@
-import '@formatjs/intl-getcanonicallocales/polyfill'
+import '@formatjs/intl-getcanonicallocales/polyfill.js'
 import '@formatjs/intl-locale/polyfill.js'
 import '@formatjs/intl-pluralrules/polyfill.js'
 import '@formatjs/intl-pluralrules/locale-data/en'

--- a/packages/react-intl/examples/index.tsx
+++ b/packages/react-intl/examples/index.tsx
@@ -10,7 +10,7 @@ import Messages from './Messages'
 import StaticTypeSafetyAndCodeSplitting from './StaticTypeSafetyAndCodeSplitting/StaticTypeSafetyAndCodeSplitting'
 import Timezone from './TimeZone'
 //polyfills
-import '@formatjs/intl-getcanonicallocales/polyfill'
+import '@formatjs/intl-getcanonicallocales/polyfill.js'
 import '@formatjs/intl-locale/polyfill.js'
 
 import '@formatjs/intl-pluralrules/locale-data/en.js' // locale-data for en


### PR DESCRIPTION
### TL;DR

Convert `intl-getcanonicallocales` package to ESM format.

### What changed?

- Added `"type": "module"` to package.json
- Updated import paths to include `.js` extensions
- Added `exports` field to package.json to define entry points
- Removed `main` field from package.json
- Added `skip_cjs = True` to the Bazel build configuration

### How to test?

1. Import the package in an ESM environment
2. Verify that all exports work correctly
3. Test the polyfill functionality
4. Run existing tests to ensure functionality is preserved

### Why make this change?

This change modernizes the package to use ES Modules format, which is the standard module system for JavaScript. This improves compatibility with modern tooling and bundlers while maintaining the same functionality. The explicit `.js` extensions in import paths and the `exports` field in package.json ensure proper resolution in ESM environments.