### PR TITLE
feat(@formatjs/icu-messageformat-parser)!: convert to esm

### DIFF
--- a/packages/cli-lib/src/extract.ts
+++ b/packages/cli-lib/src/extract.ts
@@ -8,8 +8,8 @@ import {debug, getStdinAsString, warn, writeStdout} from './console_utils.js'
 import * as stringifyNs from 'json-stable-stringify'
 
 import {parse} from '@formatjs/icu-messageformat-parser'
-import {hoistSelectors} from '@formatjs/icu-messageformat-parser/manipulator'
-import {printAST} from '@formatjs/icu-messageformat-parser/printer'
+import {hoistSelectors} from '@formatjs/icu-messageformat-parser/manipulator.js'
+import {printAST} from '@formatjs/icu-messageformat-parser/printer.js'
 import {Formatter, resolveBuiltinFormatter} from './formatters/index.js'
 import {parseScript} from './parse_script.js'
 

--- a/packages/icu-messageformat-parser/BUILD.bazel
+++ b/packages/icu-messageformat-parser/BUILD.bazel
@@ -36,6 +36,7 @@ SRC_DEPS = [
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
+    skip_cjs = True,
     skip_esm = False,
     deps = SRC_DEPS,
 )

--- a/packages/icu-messageformat-parser/date-time-pattern-generator.ts
+++ b/packages/icu-messageformat-parser/date-time-pattern-generator.ts
@@ -1,4 +1,4 @@
-import {timeData} from './time-data.generated'
+import {timeData} from './time-data.generated.js'
 
 /**
  * Returns the best matching date time pattern if a date time skeleton

--- a/packages/icu-messageformat-parser/error.ts
+++ b/packages/icu-messageformat-parser/error.ts
@@ -1,4 +1,4 @@
-import {Location} from './types'
+import {Location} from './types.js'
 
 export interface ParserError {
   kind: ErrorKind

--- a/packages/icu-messageformat-parser/index.ts
+++ b/packages/icu-messageformat-parser/index.ts
@@ -1,5 +1,5 @@
-import {ErrorKind} from './error'
-import {Parser, ParserOptions} from './parser'
+import {ErrorKind} from './error.js'
+import {Parser, ParserOptions} from './parser.js'
 import {
   isDateElement,
   isDateTimeSkeleton,
@@ -10,7 +10,7 @@ import {
   isTagElement,
   isTimeElement,
   MessageFormatElement,
-} from './types'
+} from './types.js'
 
 function pruneLocation(els: MessageFormatElement[]): void {
   els.forEach(el => {
@@ -57,8 +57,8 @@ export function parse(
   }
   return result.val
 }
-export * from './types'
+export * from './types.js'
 export type {ParserOptions}
 // only for testing
 export const _Parser: typeof Parser = Parser
-export {isStructurallySame} from './manipulator'
+export {isStructurallySame} from './manipulator.js'

--- a/packages/icu-messageformat-parser/manipulator.ts
+++ b/packages/icu-messageformat-parser/manipulator.ts
@@ -11,7 +11,7 @@ import {
   PluralOrSelectOption,
   SelectElement,
   TYPE,
-} from './types'
+} from './types.js'
 
 function cloneDeep<T>(obj: T): T {
   if (Array.isArray(obj)) {

--- a/packages/icu-messageformat-parser/no-parser.ts
+++ b/packages/icu-messageformat-parser/no-parser.ts
@@ -3,6 +3,6 @@ export function parse(): void {
     "You're trying to format an uncompiled message with react-intl without parser, please import from 'react-intl' instead"
   )
 }
-export * from './types'
+export * from './types.js'
 export const _Parser = undefined
-export {isStructurallySame} from './manipulator'
+export {isStructurallySame} from './manipulator.js'

--- a/packages/icu-messageformat-parser/package.json
+++ b/packages/icu-messageformat-parser/package.json
@@ -2,14 +2,19 @@
   "name": "@formatjs/icu-messageformat-parser",
   "version": "2.11.4",
   "license": "MIT",
+  "type": "module",
   "types": "index.d.ts",
+  "exports": {
+    ".": "./index.js",
+    "./no-parser.js": "./no-parser.js",
+    "./printer.js": "./printer.js",
+    "./manipulator.js": "./manipulator.js"
+  },
   "dependencies": {
     "@formatjs/ecma402-abstract": "workspace:*",
     "@formatjs/icu-skeleton-parser": "workspace:*",
     "tslib": "^2.8.0"
   },
-  "main": "index.js",
-  "module": "lib/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/formatjs/formatjs.git",

--- a/packages/icu-messageformat-parser/parser.ts
+++ b/packages/icu-messageformat-parser/parser.ts
@@ -1,4 +1,4 @@
-import {ErrorKind, ParserError} from './error'
+import {ErrorKind, ParserError} from './error.js'
 import {
   DateTimeSkeleton,
   LiteralElement,
@@ -9,15 +9,15 @@ import {
   SKELETON_TYPE,
   TagElement,
   TYPE,
-} from './types'
-import {SPACE_SEPARATOR_REGEX} from './regex.generated'
+} from './types.js'
+import {SPACE_SEPARATOR_REGEX} from './regex.generated.js'
 import {
   NumberSkeletonToken,
   parseNumberSkeleton,
   parseNumberSkeletonFromString,
   parseDateTimeSkeleton,
 } from '@formatjs/icu-skeleton-parser'
-import {getBestPattern} from './date-time-pattern-generator'
+import {getBestPattern} from './date-time-pattern-generator.js'
 
 const SPACE_SEPARATOR_START_REGEX = new RegExp(
   `^${SPACE_SEPARATOR_REGEX.source}*`

--- a/packages/icu-messageformat-parser/printer.ts
+++ b/packages/icu-messageformat-parser/printer.ts
@@ -22,7 +22,7 @@ import {
   TagElement,
   TimeElement,
   TYPE,
-} from './types'
+} from './types.js'
 
 export function printAST(ast: MessageFormatElement[]): string {
   return doPrintAST(ast, false)

--- a/packages/icu-messageformat-parser/tests/browser-smoke.test.ts
+++ b/packages/icu-messageformat-parser/tests/browser-smoke.test.ts
@@ -1,4 +1,4 @@
-import {Parser} from '../parser'
+import {Parser} from '../parser.js'
 import {describe, expect, it} from 'vitest'
 describe('@formatjs/icu-messageformat-parser', function () {
   it('plural_arg_2', () => {

--- a/packages/icu-messageformat-parser/tests/date-time-pattern-generator.test.ts
+++ b/packages/icu-messageformat-parser/tests/date-time-pattern-generator.test.ts
@@ -1,4 +1,4 @@
-import {getBestPattern} from '../date-time-pattern-generator'
+import {getBestPattern} from '../date-time-pattern-generator.js'
 import {describe, expect, it} from 'vitest'
 describe('date-time-pattern-generator', () => {
   // Test most commong 2 patterns

--- a/packages/icu-messageformat-parser/tests/manipulator.test.ts
+++ b/packages/icu-messageformat-parser/tests/manipulator.test.ts
@@ -1,6 +1,6 @@
-import {parse} from '..'
-import {hoistSelectors, isStructurallySame} from '../manipulator'
-import {printAST} from '../printer'
+import {parse} from '../index.js'
+import {hoistSelectors, isStructurallySame} from '../manipulator.js'
+import {printAST} from '../printer.js'
 import {expect, test} from 'vitest'
 test('should hoist 1 plural', function () {
   expect(

--- a/packages/icu-messageformat-parser/tests/no-parser.test.ts
+++ b/packages/icu-messageformat-parser/tests/no-parser.test.ts
@@ -1,5 +1,5 @@
-import * as noParser from '../no-parser'
-import * as withParser from '..'
+import * as noParser from '../no-parser.js'
+import * as withParser from '../index.js'
 import {test, expect} from 'vitest'
 test('no-parser should export everything that index does', function () {
   expect(Object.keys(noParser)).toEqual(Object.keys(withParser))

--- a/packages/icu-messageformat-parser/tests/printer.test.ts
+++ b/packages/icu-messageformat-parser/tests/printer.test.ts
@@ -1,5 +1,5 @@
-import {parse} from '..'
-import {printAST} from '../printer'
+import {parse} from '../index.js'
+import {printAST} from '../printer.js'
 import {expect, test} from 'vitest'
 test('should escape things properly', function () {
   expect(printAST(parse("Name: ''{name}''."))).toBe("Name: ''{name}''.")


### PR DESCRIPTION
### TL;DR

Convert `@formatjs/icu-messageformat-parser` to ESM-only package.

### What changed?

- Updated `package.json` to set `"type": "module"` and configured proper exports
- Added `.js` extensions to all imports/exports throughout the codebase
- Modified Bazel build configuration to skip CommonJS output (`skip_cjs = True`)
- Updated import paths in dependent packages to use the `.js` extension

### How to test?

1. Build the package with `yarn build`
2. Run tests to ensure functionality is maintained
3. Test integration with dependent packages like `cli-lib`
4. Verify that imports work correctly in ESM environments

### Why make this change?

This change modernizes the package by converting it to use native ES modules exclusively, which aligns with the direction of the JavaScript ecosystem. Using ESM provides better tree-shaking, more consistent import/export syntax, and better compatibility with modern tooling and environments.