### PR TITLE
feat(@formatjs/icu-skeleton-parser)!: convert to esm

### DIFF
--- a/packages/icu-skeleton-parser/BUILD.bazel
+++ b/packages/icu-skeleton-parser/BUILD.bazel
@@ -30,6 +30,7 @@ SRC_DEPS = [
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
+    skip_cjs = True,
     skip_esm = False,
     deps = SRC_DEPS,
 )

--- a/packages/icu-skeleton-parser/index.ts
+++ b/packages/icu-skeleton-parser/index.ts
@@ -1,2 +1,2 @@
-export * from './date-time'
-export * from './number'
+export * from './date-time.js'
+export * from './number.js'

--- a/packages/icu-skeleton-parser/number.ts
+++ b/packages/icu-skeleton-parser/number.ts
@@ -1,5 +1,5 @@
 import type {NumberFormatOptions} from '@formatjs/ecma402-abstract'
-import {WHITE_SPACE_REGEX} from './regex.generated'
+import {WHITE_SPACE_REGEX} from './regex.generated.js'
 
 export interface ExtendedNumberFormatOptions extends NumberFormatOptions {
   scale?: number

--- a/packages/icu-skeleton-parser/package.json
+++ b/packages/icu-skeleton-parser/package.json
@@ -2,13 +2,15 @@
   "name": "@formatjs/icu-skeleton-parser",
   "version": "1.8.16",
   "license": "MIT",
+  "type": "module",
   "types": "index.d.ts",
+  "exports": {
+    ".": "./index.js"
+  },
   "dependencies": {
     "@formatjs/ecma402-abstract": "workspace:*",
     "tslib": "^2.8.0"
   },
-  "main": "index.js",
-  "module": "lib/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/formatjs/formatjs.git",

--- a/packages/icu-skeleton-parser/tests/index.test.ts
+++ b/packages/icu-skeleton-parser/tests/index.test.ts
@@ -1,5 +1,5 @@
-import {parseDateTimeSkeleton, parseNumberSkeleton} from '..'
-import {parseNumberSkeletonFromString} from '../number'
+import {parseDateTimeSkeleton, parseNumberSkeleton} from '../index.js'
+import {parseNumberSkeletonFromString} from '../number.js'
 import {test, expect} from 'vitest'
 
 const dateTimeSkeletonResults = {


### PR DESCRIPTION
### TL;DR

Convert `icu-skeleton-parser` package to ESM-only format.

### What changed?

- Updated `package.json` to specify `"type": "module"` and configured exports
- Added `.js` extensions to all import statements
- Removed CommonJS output by setting `skip_cjs = True` in Bazel build
- Updated import paths in test files to use proper ESM syntax
- Removed the `main` and `module` fields from package.json

### How to test?

1. Build the package with `yarn build`
2. Run tests with `yarn test`
3. Verify that the package can be imported in an ESM environment
4. Ensure that dependent packages can properly import from this package

### Why make this change?

This change modernizes the package to use native ES modules, which aligns with the direction of the JavaScript ecosystem. Using ESM-only format simplifies the package structure, reduces bundle size, and provides better tree-shaking capabilities for consumers of the library.