### PR TITLE
feat(@formatjs/fast-memoize)!: convert to esm

### DIFF
--- a/packages/fast-memoize/BUILD.bazel
+++ b/packages/fast-memoize/BUILD.bazel
@@ -19,7 +19,6 @@ npm_package(
         "README.md",
         "package.json",
         ":dist",
-        ":dist-esm",
     ],
     package = "@formatjs/%s" % PACKAGE_NAME,
     visibility = ["//visibility:public"],
@@ -35,6 +34,7 @@ SRC_DEPS = [
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
+    skip_cjs = True,
     skip_esm = False,
     deps = SRC_DEPS,
 )

--- a/packages/fast-memoize/package.json
+++ b/packages/fast-memoize/package.json
@@ -4,6 +4,12 @@
   "version": "2.2.7",
   "license": "MIT",
   "author": "Long Ho <holevietlong@gmail.com>",
+  "type": "module",
+  "sideEffects": false,
+  "types": "index.d.ts",
+  "exports": {
+    ".": "./index.js"
+  },
   "dependencies": {
     "tslib": "^2.8.0"
   },
@@ -15,7 +21,5 @@
     "intl",
     "memoize"
   ],
-  "main": "index.js",
-  "module": "lib/index.js",
   "repository": "formatjs/formatjs.git"
 }


### PR DESCRIPTION
### TL;DR

Convert `@formatjs/fast-memoize` to ESM-only package

### What changed?

- Added `"type": "module"` to package.json
- Added `"exports"` field to package.json to define entry points
- Removed CJS output by adding `skip_cjs = True` to the Bazel build
- Removed `:dist-esm` from npm_package sources
- Removed `"main"` and `"module"` fields from package.json
- Added explicit `"types"` field to package.json
- Added `"sideEffects": false` for better tree-shaking

### How to test?

- Import the package in an ESM environment
- Verify that imports work correctly with the new export map
- Ensure that TypeScript types are properly resolved

### Why make this change?

This change modernizes the package by making it ESM-only, which aligns with the direction of the JavaScript ecosystem. Using export maps provides better control over package entry points, and marking the package as side-effect free enables better tree-shaking by bundlers.