### PR TITLE
feat(@formatjs/intl-localematcher)!: convert to esm

### DIFF
--- a/packages/intl-localematcher/BUILD.bazel
+++ b/packages/intl-localematcher/BUILD.bazel
@@ -32,6 +32,7 @@ SRC_DEPS = [
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
+    skip_cjs = True,
     skip_esm = False,
     deps = SRC_DEPS,
 )

--- a/packages/intl-localematcher/abstract/BestFitMatcher.ts
+++ b/packages/intl-localematcher/abstract/BestFitMatcher.ts
@@ -1,5 +1,5 @@
-import {LookupMatcherResult} from './types'
-import {UNICODE_EXTENSION_SEQUENCE_REGEX, findBestMatch} from './utils'
+import {LookupMatcherResult} from './types.js'
+import {UNICODE_EXTENSION_SEQUENCE_REGEX, findBestMatch} from './utils.js'
 
 /**
  * https://tc39.es/ecma402/#sec-bestfitmatcher

--- a/packages/intl-localematcher/abstract/CanonicalizeUValue.ts
+++ b/packages/intl-localematcher/abstract/CanonicalizeUValue.ts
@@ -1,4 +1,4 @@
-import {invariant} from './utils'
+import {invariant} from './utils.js'
 
 export function CanonicalizeUValue(ukey: string, uvalue: string): string {
   // TODO: Implement algorithm for CanonicalizeUValue per https://tc39.es/ecma402/#sec-canonicalizeuvalue

--- a/packages/intl-localematcher/abstract/InsertUnicodeExtensionAndCanonicalize.ts
+++ b/packages/intl-localematcher/abstract/InsertUnicodeExtensionAndCanonicalize.ts
@@ -1,6 +1,6 @@
-import {CanonicalizeUnicodeLocaleId} from './CanonicalizeUnicodeLocaleId'
-import {Keyword} from './types'
-import {invariant} from './utils'
+import {CanonicalizeUnicodeLocaleId} from './CanonicalizeUnicodeLocaleId.js'
+import {Keyword} from './types.js'
+import {invariant} from './utils.js'
 
 export function InsertUnicodeExtensionAndCanonicalize(
   locale: string,

--- a/packages/intl-localematcher/abstract/LookupMatcher.ts
+++ b/packages/intl-localematcher/abstract/LookupMatcher.ts
@@ -1,6 +1,6 @@
-import {BestAvailableLocale} from './BestAvailableLocale'
-import {LookupMatcherResult} from './types'
-import {UNICODE_EXTENSION_SEQUENCE_REGEX} from './utils'
+import {BestAvailableLocale} from './BestAvailableLocale.js'
+import {LookupMatcherResult} from './types.js'
+import {UNICODE_EXTENSION_SEQUENCE_REGEX} from './utils.js'
 
 /**
  * https://tc39.es/ecma402/#sec-lookupmatcher

--- a/packages/intl-localematcher/abstract/LookupSupportedLocales.ts
+++ b/packages/intl-localematcher/abstract/LookupSupportedLocales.ts
@@ -1,5 +1,5 @@
-import {BestAvailableLocale} from './BestAvailableLocale'
-import {UNICODE_EXTENSION_SEQUENCE_REGEX} from './utils'
+import {BestAvailableLocale} from './BestAvailableLocale.js'
+import {UNICODE_EXTENSION_SEQUENCE_REGEX} from './utils.js'
 
 /**
  * https://tc39.es/ecma402/#sec-lookupsupportedlocales

--- a/packages/intl-localematcher/abstract/ResolveLocale.ts
+++ b/packages/intl-localematcher/abstract/ResolveLocale.ts
@@ -1,10 +1,10 @@
-import {BestFitMatcher} from './BestFitMatcher'
-import {CanonicalizeUValue} from './CanonicalizeUValue'
-import {InsertUnicodeExtensionAndCanonicalize} from './InsertUnicodeExtensionAndCanonicalize'
-import {LookupMatcher} from './LookupMatcher'
-import {UnicodeExtensionComponents} from './UnicodeExtensionComponents'
-import {Keyword, LookupMatcherResult} from './types'
-import {invariant} from './utils'
+import {BestFitMatcher} from './BestFitMatcher.js'
+import {CanonicalizeUValue} from './CanonicalizeUValue.js'
+import {InsertUnicodeExtensionAndCanonicalize} from './InsertUnicodeExtensionAndCanonicalize.js'
+import {LookupMatcher} from './LookupMatcher.js'
+import {UnicodeExtensionComponents} from './UnicodeExtensionComponents.js'
+import {Keyword, LookupMatcherResult} from './types.js'
+import {invariant} from './utils.js'
 
 export interface ResolveLocaleResult {
   locale: string

--- a/packages/intl-localematcher/abstract/UnicodeExtensionComponents.ts
+++ b/packages/intl-localematcher/abstract/UnicodeExtensionComponents.ts
@@ -1,5 +1,5 @@
-import {Keyword} from './types'
-import {invariant} from './utils'
+import {Keyword} from './types.js'
+import {invariant} from './utils.js'
 
 export function UnicodeExtensionComponents(extension: string): {
   attributes: string[]

--- a/packages/intl-localematcher/abstract/UnicodeExtensionValue.ts
+++ b/packages/intl-localematcher/abstract/UnicodeExtensionValue.ts
@@ -1,4 +1,4 @@
-import {invariant} from './utils'
+import {invariant} from './utils.js'
 
 /**
  * https://tc39.es/ecma402/#sec-unicodeextensionvalue

--- a/packages/intl-localematcher/abstract/utils.ts
+++ b/packages/intl-localematcher/abstract/utils.ts
@@ -1,5 +1,5 @@
-import {data as jsonData} from './languageMatching'
-import {regions} from './regions.generated'
+import {data as jsonData} from './languageMatching.js'
+import {regions} from './regions.generated.js'
 export const UNICODE_EXTENSION_SEQUENCE_REGEX: RegExp =
   /-u(?:-[0-9a-z]{2,8})+/gi
 

--- a/packages/intl-localematcher/index.ts
+++ b/packages/intl-localematcher/index.ts
@@ -1,5 +1,5 @@
-import {CanonicalizeLocaleList} from './abstract/CanonicalizeLocaleList'
-import {ResolveLocale} from './abstract/ResolveLocale'
+import {CanonicalizeLocaleList} from './abstract/CanonicalizeLocaleList.js'
+import {ResolveLocale} from './abstract/ResolveLocale.js'
 
 export interface Opts {
   algorithm: 'lookup' | 'best fit'
@@ -23,5 +23,5 @@ export function match(
   ).locale
 }
 
-export {LookupSupportedLocales} from './abstract/LookupSupportedLocales'
-export {ResolveLocale} from './abstract/ResolveLocale'
+export {LookupSupportedLocales} from './abstract/LookupSupportedLocales.js'
+export {ResolveLocale} from './abstract/ResolveLocale.js'

--- a/packages/intl-localematcher/package.json
+++ b/packages/intl-localematcher/package.json
@@ -4,7 +4,12 @@
   "version": "0.6.2",
   "license": "MIT",
   "author": "Long Ho <holevietlong@gmail.com>",
+  "type": "module",
+  "sideEffects": false,
   "types": "index.d.ts",
+  "exports": {
+    ".": "./index.js"
+  },
   "dependencies": {
     "tslib": "^2.8.0"
   },
@@ -19,7 +24,5 @@
     "react-intl",
     "tc39"
   ],
-  "main": "index.js",
-  "module": "lib/index.js",
   "repository": "formatjs/formatjs.git"
 }

--- a/packages/intl-localematcher/tests/BestFitMatcher.test.ts
+++ b/packages/intl-localematcher/tests/BestFitMatcher.test.ts
@@ -1,4 +1,4 @@
-import {BestFitMatcher} from '../abstract/BestFitMatcher'
+import {BestFitMatcher} from '../abstract/BestFitMatcher.js'
 import {expect, test} from 'vitest'
 test('BestFitMatcher', function () {
   expect(BestFitMatcher(['fr', 'en'], ['fr-XX', 'en'], () => 'en')).toEqual({

--- a/packages/intl-localematcher/tests/LookupMatcher.test.ts
+++ b/packages/intl-localematcher/tests/LookupMatcher.test.ts
@@ -1,4 +1,4 @@
-import {LookupMatcher} from '../abstract/LookupMatcher'
+import {LookupMatcher} from '../abstract/LookupMatcher.js'
 import {expect, test} from 'vitest'
 test('LookupMatcher', function () {
   expect(LookupMatcher(['fr', 'en'], ['fr-XX', 'en'], () => 'en')).toEqual({

--- a/packages/intl-localematcher/tests/ResolveLocale.test.ts
+++ b/packages/intl-localematcher/tests/ResolveLocale.test.ts
@@ -1,4 +1,4 @@
-import {ResolveLocale} from '../abstract/ResolveLocale'
+import {ResolveLocale} from '../abstract/ResolveLocale.js'
 import {expect, test} from 'vitest'
 test('ResolveLocale', function () {
   expect(

--- a/packages/intl-localematcher/tests/utils.test.ts
+++ b/packages/intl-localematcher/tests/utils.test.ts
@@ -1,4 +1,4 @@
-import {findBestMatch, findMatchingDistance} from '../abstract/utils'
+import {findBestMatch, findMatchingDistance} from '../abstract/utils.js'
 import {expect, test} from 'vitest'
 test('findMatchingDistance', () => {
   expect(findMatchingDistance('es-CO', 'es')).toBe(49)


### PR DESCRIPTION
### TL;DR

Convert `intl-localematcher` package to ESM-only format with proper `.js` extensions in import paths.

### What changed?

- Updated all import statements to include `.js` extensions for proper ESM compatibility
- Modified `package.json` to specify `"type": "module"` and added proper exports configuration
- Removed CommonJS output by setting `skip_cjs = True` in the Bazel build configuration
- Removed `main` and `module` fields from `package.json` and added `exports` field
- Added `"sideEffects": false` to `package.json` for better tree-shaking

### How to test?

1. Build the package with `yarn build`
2. Verify that the package works correctly when imported in an ESM environment
3. Test importing the package in a project that uses ESM imports
4. Ensure that existing functionality continues to work as expected

### Why make this change?

This change modernizes the package to follow ESM best practices, which provides better compatibility with modern JavaScript tooling and bundlers. Using explicit `.js` extensions in import paths is required for proper ESM resolution without a bundler, and the package.json changes ensure the package is properly identified as an ES module. This change also helps with tree-shaking by marking the package as side-effect free.