### PR TITLE
chore: clean up build

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -398,7 +398,7 @@
         "bzlTransitiveDigest": "PmSFl5de9ODJbC1xCNlhwlUaInXalJ08lhcxW297GX0=",
         "usagesDigest": "tsxRjH5DN8xUnGoUELCp/xuIp04EwwlFAtYpnGb6Y+4=",
         "recordedFileInputs": {
-          "@@//package.json": "03119861339f7fa9a32fa4358fac4083b7813558d8ca75ab9e07c77c270c781c"
+          "@@//package.json": "0310f0f719de9fd2ef80c79d0083d00f6ecc040cedee9e801c05e3d378025990"
         },
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@types/babel__traverse": "^7.20.6",
     "@types/benchmark": "^2.1.5",
     "@types/eslint": "^9.6.1",
+    "@types/eslint-scope": "^8.3.2",
     "@types/estree": "^1.0.6",
     "@types/fs-extra": "^11.0.4",
     "@types/lodash-es": "^4.17.12",

--- a/packages/babel-plugin-formatjs/BUILD.bazel
+++ b/packages/babel-plugin-formatjs/BUILD.bazel
@@ -42,7 +42,6 @@ SRC_DEPS = [
 ts_compile_node(
     name = "dist",
     srcs = [":srcs"],
-    skip_cjs = True,
     deps = SRC_DEPS,
 )
 

--- a/packages/cli-lib/BUILD.bazel
+++ b/packages/cli-lib/BUILD.bazel
@@ -61,7 +61,6 @@ SRC_DEPS = [
 ts_compile_node(
     name = "dist",
     srcs = [":srcs"],
-    skip_cjs = True,
     deps = SRC_DEPS,
 )
 

--- a/packages/cli/integration-tests/extract/duplicated/file1.tsx
+++ b/packages/cli/integration-tests/extract/duplicated/file1.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import {FormattedMessage} from 'react-intl'
 
 export function Foo() {

--- a/packages/cli/integration-tests/extract/duplicated/file2.tsx
+++ b/packages/cli/integration-tests/extract/duplicated/file2.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import {FormattedMessage} from 'react-intl'
 
 export function Bar() {

--- a/packages/cli/integration-tests/extract/inFile/file1.tsx
+++ b/packages/cli/integration-tests/extract/inFile/file1.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import {FormattedMessage} from 'react-intl'
 
 export function Foo() {

--- a/packages/cli/integration-tests/extract/inFile/file2.tsx
+++ b/packages/cli/integration-tests/extract/inFile/file2.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import {FormattedMessage} from 'react-intl'
 
 export function Bar() {

--- a/packages/cli/integration-tests/extract/nonDuplicated/file1.tsx
+++ b/packages/cli/integration-tests/extract/nonDuplicated/file1.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import {FormattedMessage} from 'react-intl'
 
 export function Foo() {

--- a/packages/cli/integration-tests/extract/nonDuplicated/file2.tsx
+++ b/packages/cli/integration-tests/extract/nonDuplicated/file2.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import {FormattedMessage} from 'react-intl'
 
 export function Bar() {

--- a/packages/ecma376/BUILD.bazel
+++ b/packages/ecma376/BUILD.bazel
@@ -34,7 +34,6 @@ TESTS = glob(["tests/*"])
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
-    skip_cjs = True,
     skip_esm = False,
     deps = SRC_DEPS,
 )

--- a/packages/ecma402-abstract/BUILD.bazel
+++ b/packages/ecma402-abstract/BUILD.bazel
@@ -40,7 +40,6 @@ SRC_DEPS = [
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
-    skip_cjs = True,
     skip_esm = False,
     deps = SRC_DEPS,
 )

--- a/packages/editor/header.tsx
+++ b/packages/editor/header.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import {Typography, Breadcrumbs, Link} from '@material-ui/core'
 
 function handleClick(event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) {

--- a/packages/editor/main.tsx
+++ b/packages/editor/main.tsx
@@ -1,5 +1,5 @@
 import Main from './index.js'
 import ReactDOM from 'react-dom'
-import React from 'react'
+import * as React from 'react'
 
 ReactDOM.render(<Main />, document.getElementById('main'))

--- a/packages/editor/message.tsx
+++ b/packages/editor/message.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import {Chip, Avatar} from '@material-ui/core'
 import {
   parse,

--- a/packages/editor/messages.tsx
+++ b/packages/editor/messages.tsx
@@ -1,7 +1,7 @@
 import {List, ListItem, Box} from '@material-ui/core'
 import {CheckCircle} from '@material-ui/icons'
 import {Skeleton} from '@material-ui/lab'
-import React from 'react'
+import * as React from 'react'
 import {TranslatedMessage} from './types.js'
 import Message from './message.js'
 export interface Props {

--- a/packages/eslint-plugin-formatjs/BUILD.bazel
+++ b/packages/eslint-plugin-formatjs/BUILD.bazel
@@ -45,7 +45,6 @@ SRC_DEPS = [
 ts_compile_node(
     name = "dist",
     srcs = [":srcs"],
-    skip_cjs = True,
     deps = SRC_DEPS,
 )
 
@@ -63,8 +62,8 @@ TEST_FILES = glob([
 vitest(
     name = "unit_test",
     srcs = TESTS_BASE_SRCS + TEST_FILES,
-    skip_typecheck = True,
     deps = SRC_DEPS + [
+        "//:node_modules/@types/eslint-scope",
         "//:node_modules/@typescript-eslint/parser",
         "//:node_modules/@typescript-eslint/rule-tester",
         "//:node_modules/vue-eslint-parser",

--- a/packages/eslint-plugin-formatjs/rules/blocklist-elements.ts
+++ b/packages/eslint-plugin-formatjs/rules/blocklist-elements.ts
@@ -131,7 +131,7 @@ const createRule = ESLintUtils.RuleCreator(
 
 export const rule: ESLintUtils.RuleModule<
   'blocklist',
-  [],
+  Element[][],
   unknown,
   ESLintUtils.RuleListener
 > = createRule({

--- a/packages/fast-memoize/BUILD.bazel
+++ b/packages/fast-memoize/BUILD.bazel
@@ -34,7 +34,6 @@ SRC_DEPS = [
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
-    skip_cjs = True,
     skip_esm = False,
     deps = SRC_DEPS,
 )

--- a/packages/icu-messageformat-parser/BUILD.bazel
+++ b/packages/icu-messageformat-parser/BUILD.bazel
@@ -36,7 +36,6 @@ SRC_DEPS = [
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
-    skip_cjs = True,
     skip_esm = False,
     deps = SRC_DEPS,
 )

--- a/packages/icu-skeleton-parser/BUILD.bazel
+++ b/packages/icu-skeleton-parser/BUILD.bazel
@@ -30,7 +30,6 @@ SRC_DEPS = [
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
-    skip_cjs = True,
     skip_esm = False,
     deps = SRC_DEPS,
 )

--- a/packages/intl-datetimeformat/BUILD.bazel
+++ b/packages/intl-datetimeformat/BUILD.bazel
@@ -74,7 +74,6 @@ TEST_DEPS = SRC_DEPS + [
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
-    skip_cjs = True,
     skip_esm = False,
     deps = SRC_DEPS,
 )

--- a/packages/intl-displaynames/BUILD.bazel
+++ b/packages/intl-displaynames/BUILD.bazel
@@ -58,7 +58,6 @@ TEST_DEPS = SRC_DEPS + [
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
-    skip_cjs = True,
     skip_esm = False,
     deps = SRC_DEPS,
 )

--- a/packages/intl-durationformat/BUILD.bazel
+++ b/packages/intl-durationformat/BUILD.bazel
@@ -34,7 +34,6 @@ SRC_DEPS = [
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
-    skip_cjs = True,
     skip_esm = False,
     deps = SRC_DEPS,
 )

--- a/packages/intl-enumerator/BUILD.bazel
+++ b/packages/intl-enumerator/BUILD.bazel
@@ -41,7 +41,6 @@ TESTS = glob([
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
-    skip_cjs = True,
     skip_esm = False,
     deps = SRC_DEPS,
 )

--- a/packages/intl-getcanonicallocales/BUILD.bazel
+++ b/packages/intl-getcanonicallocales/BUILD.bazel
@@ -50,7 +50,6 @@ TEST_DEPS = SRC_DEPS
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
-    skip_cjs = True,
     skip_esm = False,
     deps = SRC_DEPS,
 )

--- a/packages/intl-listformat/BUILD.bazel
+++ b/packages/intl-listformat/BUILD.bazel
@@ -61,7 +61,6 @@ TEST_DEPS = SRC_DEPS + [
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
-    skip_cjs = True,
     skip_esm = False,
     deps = SRC_DEPS,
 )

--- a/packages/intl-locale/BUILD.bazel
+++ b/packages/intl-locale/BUILD.bazel
@@ -38,7 +38,6 @@ SRC_DEPS = [
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
-    skip_cjs = True,
     skip_esm = False,
     deps = SRC_DEPS,
 )

--- a/packages/intl-localematcher/BUILD.bazel
+++ b/packages/intl-localematcher/BUILD.bazel
@@ -32,7 +32,6 @@ SRC_DEPS = [
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
-    skip_cjs = True,
     skip_esm = False,
     deps = SRC_DEPS,
 )

--- a/packages/intl-messageformat/BUILD.bazel
+++ b/packages/intl-messageformat/BUILD.bazel
@@ -48,7 +48,6 @@ TEST_DEPS = SRC_DEPS + [
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
-    skip_cjs = True,
     skip_esm = False,
     skip_esm_esnext = False,
     deps = SRC_DEPS,

--- a/packages/intl-numberformat/BUILD.bazel
+++ b/packages/intl-numberformat/BUILD.bazel
@@ -99,7 +99,6 @@ TEST_DEPS = SRC_DEPS + [
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
-    skip_cjs = True,
     skip_esm = False,
     deps = SRC_DEPS,
 )

--- a/packages/intl-pluralrules/BUILD.bazel
+++ b/packages/intl-pluralrules/BUILD.bazel
@@ -273,7 +273,6 @@ SRC_DEPS = [
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
-    skip_cjs = True,
     skip_esm = False,
     deps = SRC_DEPS,
 )
@@ -281,7 +280,6 @@ ts_compile(
 vitest(
     name = "unit_test",
     srcs = SRCS + TESTS + TEST_LOCALE_DATA,
-    skip_typecheck = True,
     deps = SRC_DEPS + [
         ":node_modules/@formatjs/intl-getcanonicallocales",
         ":node_modules/@formatjs/intl-locale",
@@ -342,7 +340,14 @@ ts_script(
     name = "tests-locale-data-%s" % locale,
     srcs = ["cldr-raw/%s.js" % locale],
     outs = ["tests-locale-data/%s.ts" % locale],
-    cmd = "printf \"%s %s\n\" \"/* @generated */\n// prettier-ignore\n// @ts-nocheck\nexport default\" \"$$(cat $<)\" > $@",
+    cmd = """
+    printf \"%s %s\nexport default data\" \"\
+/* @generated */\n\
+// prettier-ignore\n\
+// @ts-nocheck\n\
+type LocaleData = {data: {categories: {cardinal: string[]; ordinal: string[];}; fn: (n: number | string, ord?: boolean | undefined) => \"zero\" | \"one\" | \"two\" | \"few\" | \"many\" | \"other\";}; locale: string;};\n\
+const data:LocaleData = \" \"$$(cat $<)\" > $@
+    """,
 ) for locale in TEST_LOCALES]
 
 generate_src_file(

--- a/packages/intl-pluralrules/tests/locale-data/en.ts
+++ b/packages/intl-pluralrules/tests/locale-data/en.ts
@@ -1,7 +1,8 @@
 /* @generated */
 // prettier-ignore
 // @ts-nocheck
-export default {"data":{"categories":{"cardinal":["one","other"],"ordinal":["one","two","few","other"]},"fn":function(n, ord) {
+type LocaleData = {data: {categories: {cardinal: string[]; ordinal: string[];}; fn: (n: number | string, ord?: boolean | undefined) => zero | one | two | few | many | other;}; locale: string;};
+const data:LocaleData =  {"data":{"categories":{"cardinal":["one","other"],"ordinal":["one","two","few","other"]},"fn":function(n, ord) {
   var s = String(n).split('.'), v0 = !s[1], t0 = Number(s[0]) == n, n10 = t0 && s[0].slice(-1), n100 = t0 && s[0].slice(-2);
   if (ord) return n10 == 1 && n100 != 11 ? 'one'
     : n10 == 2 && n100 != 12 ? 'two'
@@ -9,3 +10,4 @@ export default {"data":{"categories":{"cardinal":["one","other"],"ordinal":["one
     : 'other';
   return n == 1 && v0 ? 'one' : 'other';
 }},"locale":"en"}
+export default data

--- a/packages/intl-pluralrules/tests/locale-data/fr.ts
+++ b/packages/intl-pluralrules/tests/locale-data/fr.ts
@@ -1,10 +1,12 @@
 /* @generated */
 // prettier-ignore
 // @ts-nocheck
-export default {"data":{"categories":{"cardinal":["one","many","other"],"ordinal":["one","other"]},"fn":function(n, ord) {
+type LocaleData = {data: {categories: {cardinal: string[]; ordinal: string[];}; fn: (n: number | string, ord?: boolean | undefined) => zero | one | two | few | many | other;}; locale: string;};
+const data:LocaleData =  {"data":{"categories":{"cardinal":["one","many","other"],"ordinal":["one","other"]},"fn":function(n, ord) {
   var _n = String(n), se = _n.split(/[ce]/), e = se[1] || 0, c = e, s = String(e ? Number(se[0]) * Math.pow(10, e) : _n).split("."), i = s[0], v0 = !s[1], i1000000 = i.slice(-6);
   if (ord) return n == 1 ? 'one' : 'other';
   return n >= 0 && n < 2 ? 'one'
     : e == 0 && i != 0 && i1000000 == 0 && v0 || (e < 0 || e > 5) ? 'many'
     : 'other';
 }},"locale":"fr"}
+export default data

--- a/packages/intl-pluralrules/tests/locale-data/zh.ts
+++ b/packages/intl-pluralrules/tests/locale-data/zh.ts
@@ -1,6 +1,8 @@
 /* @generated */
 // prettier-ignore
 // @ts-nocheck
-export default {"data":{"categories":{"cardinal":["other"],"ordinal":["other"]},"fn":function(n, ord) {
+type LocaleData = {data: {categories: {cardinal: string[]; ordinal: string[];}; fn: (n: number | string, ord?: boolean | undefined) => zero | one | two | few | many | other;}; locale: string;};
+const data:LocaleData =  {"data":{"categories":{"cardinal":["other"],"ordinal":["other"]},"fn":function(n, ord) {
   return 'other';
 }},"locale":"zh"}
+export default data

--- a/packages/intl-relativetimeformat/BUILD.bazel
+++ b/packages/intl-relativetimeformat/BUILD.bazel
@@ -56,7 +56,6 @@ SRC_DEPS = [
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
-    skip_cjs = True,
     skip_esm = False,
     deps = SRC_DEPS,
 )

--- a/packages/intl-segmenter/BUILD.bazel
+++ b/packages/intl-segmenter/BUILD.bazel
@@ -63,7 +63,6 @@ TESTS = glob([
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
-    skip_cjs = True,
     skip_esm = False,
     deps = SRC_DEPS,
 )

--- a/packages/intl/BUILD.bazel
+++ b/packages/intl/BUILD.bazel
@@ -44,7 +44,6 @@ TESTS = glob(
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
-    skip_cjs = True,
     skip_esm = False,
     deps = SRC_DEPS,
 )

--- a/packages/react-intl/BUILD.bazel
+++ b/packages/react-intl/BUILD.bazel
@@ -58,7 +58,6 @@ TEST_DEPS = SRC_DEPS + [
 ts_compile(
     name = "dist",
     srcs = SRCS,
-    skip_cjs = True,
     skip_esm = False,
     deps = SRC_DEPS,
 )
@@ -87,7 +86,6 @@ vitest(
     srcs = SRCS +
            TESTS,
     dom = True,
-    skip_typecheck = True,
     deps = TEST_DEPS,
 )
 

--- a/packages/react-intl/example-sandboxes/strict-locale-type/src/App.tsx
+++ b/packages/react-intl/example-sandboxes/strict-locale-type/src/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import './styles.css'
 import {IntlProvider, FormattedMessage, useIntl} from 'react-intl'
 

--- a/packages/react-intl/example-sandboxes/strict-locale-type/src/index.tsx
+++ b/packages/react-intl/example-sandboxes/strict-locale-type/src/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import ReactDOM from 'react-dom'
 
 import App from './App'

--- a/packages/react-intl/example-sandboxes/strict-message-types/src/App.tsx
+++ b/packages/react-intl/example-sandboxes/strict-message-types/src/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import './styles.css'
 import {IntlProvider, FormattedMessage} from 'react-intl'
 

--- a/packages/react-intl/example-sandboxes/strict-message-types/src/index.tsx
+++ b/packages/react-intl/example-sandboxes/strict-message-types/src/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import ReactDOM from 'react-dom'
 
 import App from './App'

--- a/packages/react-intl/examples/Bug2727.tsx
+++ b/packages/react-intl/examples/Bug2727.tsx
@@ -1,4 +1,5 @@
-import React, {useState} from 'react'
+import * as React from 'react'
+import {useState} from 'react'
 import {IntlProvider, FormattedRelativeTime, useIntl} from 'react-intl'
 
 const getRelativeTime = (date: Date) =>

--- a/packages/react-intl/examples/StaticTypeSafetyAndCodeSplitting/intlHelpers.tsx
+++ b/packages/react-intl/examples/StaticTypeSafetyAndCodeSplitting/intlHelpers.tsx
@@ -26,9 +26,9 @@ export function importMessages(
 ): Promise<LocaleMessages> {
   switch (locale) {
     case 'en':
-      return import('./en.json').then(p => p.default)
+      return import('./en.json') as Promise<LocaleMessages>
     case 'it':
-      return import('./it.json').then(p => p.default)
+      return import('./it.json') as Promise<LocaleMessages>
   }
 }
 

--- a/packages/react-intl/examples/advanced/Advanced.tsx
+++ b/packages/react-intl/examples/advanced/Advanced.tsx
@@ -66,5 +66,5 @@ export async function bootstrapApplication(
   locale: string
 ): Promise<React.JSX.Element> {
   const messages = await loadLocaleData(locale)
-  return <App locale={locale} messages={messages.default} />
+  return <App locale={locale} messages={messages} />
 }

--- a/packages/react-intl/integration-tests/format.test.tsx
+++ b/packages/react-intl/integration-tests/format.test.tsx
@@ -10,7 +10,7 @@ import {
 import {describe, expect, it, afterEach} from 'vitest'
 
 import {render, screen, cleanup} from '@testing-library/react'
-import React from 'react'
+import * as React from 'react'
 
 import '@testing-library/jest-dom/vitest'
 

--- a/packages/react-intl/src/components/injectIntl.tsx
+++ b/packages/react-intl/src/components/injectIntl.tsx
@@ -1,7 +1,10 @@
-import hoistNonReactStatics from 'hoist-non-react-statics'
+import * as hoistNonReactStaticsNs from 'hoist-non-react-statics'
 import * as React from 'react'
 import {IntlShape} from '../types.js'
 import {invariantIntlContext} from '../utils.js'
+
+const hoistNonReactStatics =
+  (hoistNonReactStaticsNs as any).default ?? hoistNonReactStaticsNs
 
 function getDisplayName(Component: React.ComponentType<any>): string {
   return Component.displayName || Component.name || 'Component'

--- a/packages/react-intl/tests/unit/types.test.tsx
+++ b/packages/react-intl/tests/unit/types.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import {defineMessages, injectIntl, IntlShape, useIntl} from '../../'
 import {describe, it} from 'vitest'
 describe('types', () => {

--- a/packages/ts-transformer/BUILD.bazel
+++ b/packages/ts-transformer/BUILD.bazel
@@ -44,7 +44,6 @@ SRC_DEPS = [
 ts_compile_node(
     name = "dist",
     srcs = [":srcs"],
-    skip_cjs = True,
     deps = SRC_DEPS,
 )
 

--- a/packages/ts-transformer/tests/fixtures/extractFromFormatMessageStateless.tsx
+++ b/packages/ts-transformer/tests/fixtures/extractFromFormatMessageStateless.tsx
@@ -1,6 +1,6 @@
 import {FormattedMessage, injectIntl, useIntl} from 'react-intl'
 
-import React from 'react'
+import * as React from 'react'
 
 function myFunction(param1, {formatMessage, formatDate}) {
   return (

--- a/packages/utils/BUILD.bazel
+++ b/packages/utils/BUILD.bazel
@@ -38,7 +38,6 @@ SRC_DEPS = [
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
-    skip_cjs = True,
     skip_esm = False,
     deps = SRC_DEPS,
 )

--- a/packages/vue-intl/BUILD.bazel
+++ b/packages/vue-intl/BUILD.bazel
@@ -31,7 +31,6 @@ SRC_DEPS = [
 ts_compile_node(
     name = "dist",
     srcs = [":srcs"],
-    skip_cjs = True,
     deps = SRC_DEPS,
 )
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       '@types/eslint':
         specifier: ^9.6.1
         version: 9.6.1
+      '@types/eslint-scope':
+        specifier: ^8.3.2
+        version: 8.3.2
       '@types/estree':
         specifier: ^1.0.6
         version: 1.0.8
@@ -3449,11 +3452,17 @@ packages:
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
 
+  '@types/eslint-scope@8.3.2':
+    resolution: {integrity: sha512-ygPtnKRQjbXB6LKQ+m6SLyZDMgFeQFVNCkjUK/HivS58Ce6JBjxpVzHbE1+RS6pC5fP4FQg4qh8lvVSm2oxYZw==}
+
   '@types/eslint@7.29.0':
     resolution: {integrity: sha512-VNcvioYDH8/FxaeTKkM4/TiTwt6pBV9E3OfGmvaw8tPl0rrHCJ4Ll15HRT+pMiFAf/MLQvAzC+6RzUMEL9Ceng==}
 
   '@types/eslint@9.6.1':
     resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
+
+  '@types/esrecurse@4.3.1':
+    resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
@@ -14321,6 +14330,13 @@ snapshots:
       '@types/eslint': 9.6.1
       '@types/estree': 1.0.8
 
+  '@types/eslint-scope@8.3.2':
+    dependencies:
+      '@types/eslint': 9.6.1
+      '@types/esrecurse': 4.3.1
+      '@types/estree': 1.0.8
+      eslint-visitor-keys: 4.2.1
+
   '@types/eslint@7.29.0':
     dependencies:
       '@types/estree': 1.0.8
@@ -14330,6 +14346,8 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
       '@types/json-schema': 7.0.15
+
+  '@types/esrecurse@4.3.1': {}
 
   '@types/estree-jsx@1.0.5':
     dependencies:
@@ -14493,13 +14511,13 @@ snapshots:
   '@types/react-router-dom@5.3.3':
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 19.1.8
+      '@types/react': 19.2.7
       '@types/react-router': 5.1.20
 
   '@types/react-router@5.1.20':
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 19.1.8
+      '@types/react': 19.2.7
 
   '@types/react@19.0.12':
     dependencies:

--- a/tools/tsconfig.bzl
+++ b/tools/tsconfig.bzl
@@ -3,8 +3,8 @@
 # Base tsconfig configuration (tsconfig.json)
 BASE_TSCONFIG = {
     "compilerOptions": {
-        "module": "NodeNext",
-        "moduleResolution": "NodeNext",
+        "module": "ESNext",
+        "moduleResolution": "Bundler",
         "target": "es5",
         "lib": [
             "dom",
@@ -27,7 +27,7 @@ BASE_TSCONFIG = {
         "esModuleInterop": True,
         "noUnusedParameters": True,
         "preserveConstEnums": True,
-        "allowSyntheticDefaultImports": True,
+        "allowSyntheticDefaultImports": False,
         "noFallthroughCasesInSwitch": True,
         "importHelpers": True,
         "isolatedDeclarations": True,
@@ -39,58 +39,14 @@ BASE_TSCONFIG = {
     ],
 }
 
-# Test configuration (tsconfig.test.json)
-TEST_TSCONFIG = {
-    "compilerOptions": {
-        "module": "ESNext",
-        "moduleResolution": "bundler",
+# ESM ESNext configuration (tsconfig.esm.esnext.json) - merges with base
+ESNEXT_TSCONFIG = BASE_TSCONFIG | {
+    "compilerOptions": BASE_TSCONFIG["compilerOptions"] | {
         "target": "ESNext",
         "lib": [
             "dom",
             "ESNext",
-            "ES2017.Intl",
-            "ES2018.Intl",
-            "ES2019.Intl",
-            "ES2020.Intl",
-            "ES2021.intl",
-            "ES2022.Intl",
-            "ESNext.Intl",
         ],
-        "baseUrl": ".",
-        "declaration": True,
-        "strict": True,
-        "resolveJsonModule": True,
-        "noUnusedLocals": True,
-        "esModuleInterop": True,
-        "noUnusedParameters": True,
-        "preserveConstEnums": True,
-        "allowSyntheticDefaultImports": True,
-        "noFallthroughCasesInSwitch": True,
-        "importHelpers": True,
-        "isolatedDeclarations": True,
-        "noEmit": True,
-        "jsx": "react",
-    },
-    "exclude": [
-        "packages/react-intl/example-sandboxes",
-        "**/*.test-d.ts",
-    ],
-}
-
-# ESM configuration (tsconfig.esm.json) - merges with base
-ESM_TSCONFIG = BASE_TSCONFIG | {
-    "compilerOptions": BASE_TSCONFIG["compilerOptions"] | {
-        "module": "ESNext",
-        "moduleResolution": "Bundler",
-    },
-}
-
-# ESM ESNext configuration (tsconfig.esm.esnext.json) - merges with base
-ESM_ESNEXT_TSCONFIG = BASE_TSCONFIG | {
-    "compilerOptions": BASE_TSCONFIG["compilerOptions"] | {
-        "target": "ESNext",
-        "module": "ESNext",
-        "moduleResolution": "Bundler",
     },
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,7 @@
     "esModuleInterop": true,
     "noUnusedParameters": true,
     "preserveConstEnums": true,
-    "allowSyntheticDefaultImports": true,
+    "allowSyntheticDefaultImports": false,
     "noFallthroughCasesInSwitch": true,
     "importHelpers": true,
     "isolatedDeclarations": true,


### PR DESCRIPTION
### TL;DR

Standardize TypeScript module resolution and React imports across the codebase.

### What changed?

- Removed `skip_cjs` flags from all Bazel build configurations
- Changed TypeScript module resolution from `NodeNext` to `Bundler` with `ESNext` modules
- Updated React imports from `import React from 'react'` to `import * as React from 'react'`
- Set `allowSyntheticDefaultImports` to `false` in TypeScript configurations
- Fixed import handling in various files to accommodate the new import style
- Updated the hoisting of non-React statics to handle both default and namespace imports

### How to test?

1. Build the project with Bazel to ensure all packages compile correctly
2. Run tests to verify that the changes don't break existing functionality
3. Test React components to ensure they render properly with the new import style

### Why make this change?

This change standardizes the module resolution strategy across the codebase, making it more consistent with modern TypeScript practices. Using `import * as React from 'react'` instead of default imports provides better type safety and compatibility with the new module resolution settings. Removing the `skip_cjs` flags simplifies the build process while the updated TypeScript configuration ensures a more consistent development experience.