### PR TITLE
fix(react-intl)!: wrap rich text with Fragment instead of clone, fix #5135

### DIFF
--- a/packages/react-intl/src/utils.tsx
+++ b/packages/react-intl/src/utils.tsx
@@ -39,11 +39,6 @@ export const DEFAULT_INTL_CONFIG: DefaultIntlConfig = {
   textComponent: React.Fragment,
 }
 
-const toKeyedReactNode = (reactNode: React.ReactNode, key: number) =>
-  React.isValidElement(reactNode)
-    ? React.cloneElement(reactNode, {key})
-    : reactNode
-
 /**
  * Builds an array of {@link React.ReactNode}s with index-based keys, similar to
  * {@link React.Children.toArray}. However, this function tells React that it
@@ -52,14 +47,21 @@ const toKeyedReactNode = (reactNode: React.ReactNode, key: number) =>
  * React doesn't recommend doing this because it makes reordering inefficient,
  * but we mostly need this for message chunks, which don't tend to reorder to
  * begin with.
+ *
  */
-export const toKeyedReactNodeArray: typeof React.Children.toArray = children =>
-  /**
-   * Note: {@link React.Children.map} will add its own index-based prefix to
-   * every key anyway, so the auto-injected one doesn't even have to be unique.
-   * This basically just tells React that it's explicit/intentional.
-   */
-  React.Children.map(children, toKeyedReactNode) ?? []
+export const toKeyedReactNodeArray: typeof React.Children.toArray =
+  children => {
+    const childrenArray = React.Children.toArray(children)
+
+    return childrenArray.map((child, index) => {
+      // For React elements, wrap in a keyed Fragment
+      // This creates a new element with a key rather than trying to add one after creation
+      if (React.isValidElement(child)) {
+        return <React.Fragment key={index}>{child}</React.Fragment>
+      }
+      return child
+    })
+  }
 
 /**
  * Takes a `formatXMLElementFn`, and composes it in function, which passes

--- a/packages/react-intl/tests/unit/react-19-key-warning.test.tsx
+++ b/packages/react-intl/tests/unit/react-19-key-warning.test.tsx
@@ -1,0 +1,143 @@
+import {render} from '@testing-library/react'
+import * as React from 'react'
+import FormattedMessage from '../../src/components/message'
+import IntlProvider from '../../src/components/provider'
+import type {IntlConfig} from '../../src/types'
+import {describe, expect, it, beforeEach, vi, afterEach} from 'vitest'
+import '@testing-library/jest-dom/vitest'
+
+describe('React 19 Key Warning Issue #5135', () => {
+  let providerProps: IntlConfig
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    providerProps = {
+      locale: 'en',
+      defaultLocale: 'en',
+      onError: () => {},
+    }
+    // Spy on console.error to catch React warnings (React logs warnings to console.error)
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('should not produce React 19 key warnings when using React elements as format argument values', () => {
+    const {container} = render(
+      <IntlProvider {...providerProps}>
+        <FormattedMessage
+          id="example"
+          defaultMessage="hello {test}"
+          values={{test: <span>world</span>}}
+        />
+      </IntlProvider>
+    )
+
+    expect(container).toHaveTextContent('hello world')
+
+    // Check for React key warnings
+    const keyWarnings = consoleErrorSpy.mock.calls.filter((call: any[]) =>
+      call.some((arg: any) => typeof arg === 'string' && arg.includes('key'))
+    )
+
+    expect(keyWarnings.length).toBe(0)
+  })
+
+  it('should not produce React 19 key warnings with rich text formatting using tag functions', () => {
+    const {container} = render(
+      <IntlProvider {...providerProps}>
+        <FormattedMessage
+          id="example"
+          defaultMessage="Lorem <b>ipsum</b>"
+          values={{b: (chunks: React.ReactNode) => <span>{chunks}</span>}}
+        />
+      </IntlProvider>
+    )
+
+    expect(container).toHaveTextContent('Lorem ipsum')
+
+    // Check for React key warnings
+    const keyWarnings = consoleErrorSpy.mock.calls.filter((call: any[]) =>
+      call.some((arg: any) => typeof arg === 'string' && arg.includes('key'))
+    )
+
+    expect(keyWarnings.length).toBe(0)
+  })
+
+  it('should not produce React 19 key warnings with nested rich text tags', () => {
+    const {container} = render(
+      <IntlProvider {...providerProps}>
+        <FormattedMessage
+          id="example"
+          defaultMessage="Hello, <b>{name}<i>!</i></b>"
+          values={{
+            name: 'Jest',
+            b: (chunks: React.ReactNode) => <b>{chunks}</b>,
+            i: (msg: React.ReactNode) => <i>{msg}</i>,
+          }}
+        />
+      </IntlProvider>
+    )
+
+    expect(container).toHaveTextContent('Hello, Jest!')
+
+    // Check for React key warnings
+    const keyWarnings = consoleErrorSpy.mock.calls.filter((call: any[]) =>
+      call.some((arg: any) => typeof arg === 'string' && arg.includes('key'))
+    )
+
+    expect(keyWarnings.length).toBe(0)
+  })
+
+  it('should not produce React 19 key warnings with defaultRichTextElements', () => {
+    const {container} = render(
+      <IntlProvider
+        {...providerProps}
+        defaultRichTextElements={{
+          b: (chunks: React.ReactNode) => <b>{chunks}</b>,
+        }}
+      >
+        <FormattedMessage
+          id="example"
+          defaultMessage="Hello, <b>{name}</b>!"
+          values={{name: 'Jest'}}
+        />
+      </IntlProvider>
+    )
+
+    expect(container).toHaveTextContent('Hello, Jest!')
+
+    // Check for React key warnings
+    const keyWarnings = consoleErrorSpy.mock.calls.filter((call: any[]) =>
+      call.some((arg: any) => typeof arg === 'string' && arg.includes('key'))
+    )
+
+    expect(keyWarnings.length).toBe(0)
+  })
+
+  it('should not produce React 19 key warnings with multiple React element values', () => {
+    const {container} = render(
+      <IntlProvider {...providerProps}>
+        <FormattedMessage
+          id="example"
+          defaultMessage="Click {button} or {link}"
+          values={{
+            button: <button>here</button>,
+            link: <a href="#">there</a>,
+          }}
+        />
+      </IntlProvider>
+    )
+
+    expect(container).toHaveTextContent('Click here or there')
+
+    // Check for React key warnings
+    const keyWarnings = consoleErrorSpy.mock.calls.filter((call: any[]) =>
+      call.some((arg: any) => typeof arg === 'string' && arg.includes('key'))
+    )
+
+    expect(keyWarnings.length).toBe(0)
+  })
+})


### PR DESCRIPTION
### TL;DR

Fixed React 19 key warnings by improving how React elements are handled in formatted messages.

### What changed?

- Replaced `utils.ts` with `utils.tsx` to properly handle JSX
- Reimplemented `toKeyedReactNodeArray` to wrap React elements in keyed fragments
- Removed the `toKeyedReactNode` helper function
- Added comprehensive tests to verify the fix works with various message formatting scenarios

### How to test?

Run the new test suite in `react-19-key-warning.test.tsx` which verifies:
- Basic element formatting
- Rich text formatting with tag functions
- Nested rich text tags
- Default rich text elements
- Multiple React element values

All tests should pass without any React key warnings in the console.

### Why make this change?

React 19 introduced stricter key requirements, causing warnings when using React elements in formatted messages. The previous implementation attempted to clone elements and add keys, but this approach doesn't work well with React 19's validation. The new implementation properly wraps elements in keyed fragments, ensuring compatibility with React 19 while maintaining the same functionality.