### PR TITLE
docs: fix docs

### DIFF
--- a/website/src/components/IcuEditor.tsx
+++ b/website/src/components/IcuEditor.tsx
@@ -31,7 +31,7 @@ export const IcuEditor = ({defaultMessage, defaultValues}: IcuEditorProps) => {
       const msg = new IntlMessageFormat(message).format(opts) as string
       setError(false)
       setResult(msg)
-    } catch {
+    } catch (err) {
       if (err instanceof Error) {
         setResult(err.message)
         setError(true)


### PR DESCRIPTION
### TL;DR

Fixed error handling in the IcuEditor component by properly capturing the error object.

Fix #5510

### What changed?

Updated the catch block in the IcuEditor component to properly capture the error object (`err`) instead of ignoring it. This allows the component to access the error message when an exception occurs during message formatting.

### How to test?

1. Navigate to the ICU Editor component in the website
2. Enter an invalid ICU message format
3. Verify that the proper error message is displayed instead of undefined behavior

### Why make this change?

The previous implementation had a catch block that didn't capture the error parameter, but then tried to use it within the block. This would cause a reference error when an exception occurred. This fix ensures that error messages are properly displayed to users when they input invalid ICU message formats.