### PR TITLE
test(@formatjs/intl-numberformat): split test targets

### DIFF
--- a/packages/intl-numberformat/BUILD.bazel
+++ b/packages/intl-numberformat/BUILD.bazel
@@ -80,11 +80,6 @@ SRCS = glob(
     exclude = ["test*.*"],
 )
 
-TESTS = glob([
-    "tests/**/*.test.ts",
-    "tests/**/*Test.ts",
-])
-
 SRC_DEPS = [
     ":node_modules/@formatjs/ecma402-abstract",
     ":node_modules/@formatjs/intl-localematcher",
@@ -186,13 +181,30 @@ write_source_files(
 )
 
 vitest(
-    name = "unit_tests",
+    name = "misc_tests",
     size = "large",
-    srcs = [":srcs"] +
-           TEST_LOCALE_DATA +
-           TESTS,
+    srcs = glob([
+               "tests/*.test.ts",
+           ]) + [":srcs"] +
+           TEST_LOCALE_DATA,
     deps = TEST_DEPS,
 )
+
+[
+    vitest(
+        name = "%s_tests" % type,
+        size = "large",
+        srcs = [
+            "tests/%s/%s.generated.test.ts" % (type, locale)
+            for locale in UNIT_TEST_LOCALES
+        ] + [
+            ":srcs",
+            "tests/%s/%sTest.ts" % (type, type),
+        ] + TEST_LOCALE_DATA,
+        deps = TEST_DEPS,
+    )
+    for type in LOCALE_TEST_TYPES
+]
 
 # CLDR
 ALL_LOCALES = [


### PR DESCRIPTION
### TL;DR

Split Intl.NumberFormat tests into separate Vitest targets for better parallelization.

### What changed?

- Removed the global `TESTS` variable that included all test files
- Replaced the single `unit_tests` Vitest target with multiple targets:
  - `misc_tests` for general tests
  - Separate test targets for each locale test type (e.g., `currency_tests`, `decimal_tests`, etc.)
- Each locale test type now runs in its own Vitest instance, allowing tests to run in parallel

### How to test?

Run the Bazel tests to verify they still pass:
```
bazel test //packages/intl-numberformat:misc_tests
bazel test //packages/intl-numberformat:currency_tests
# etc. for other test types
```

### Why make this change?

This change improves build and test performance by allowing different test types to run in parallel rather than sequentially in a single Vitest instance. This is particularly beneficial for the Intl.NumberFormat tests which can be time-consuming due to the number of locales being tested.