### PR TITLE
build: fix docs build

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -28,8 +28,8 @@ jobs:
         id: build
         run: |
           BAZEL_BIN=$(bazel info bazel-bin)
-          bazel build --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //website:build
-          echo BUILD_PATH="$BAZEL_BIN/website/build" >> $GITHUB_OUTPUTS
+          bazel build --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //website:dist
+          echo BUILD_PATH="$BAZEL_BIN/website/dist" >> $GITHUB_OUTPUTS
 
       # Deploy to Organization GitHub Pages Repository
       - name: Deploy


### PR DESCRIPTION
### TL;DR

Updated the website build target from `//website:build` to `//website:dist` in the GitHub workflow.

### What changed?

Modified the `.github/workflows/website.yml` file to use the `//website:dist` Bazel target instead of `//website:build`. Also updated the corresponding output path from `$BAZEL_BIN/website/build` to `$BAZEL_BIN/website/dist`.

### How to test?

1. Run the website GitHub workflow manually
2. Verify that the website builds successfully using the new target
3. Confirm that the deployment step can find the build artifacts in the new location

### Why make this change?

The website build target was likely renamed from `build` to `dist` in the Bazel configuration, and this PR updates the workflow to match the new target name. This ensures the website deployment process continues to work correctly.