### PR TITLE
docs: update import paths

### DIFF
--- a/website/docs/polyfills/intl-datetimeformat.md
+++ b/website/docs/polyfills/intl-datetimeformat.md
@@ -71,15 +71,15 @@ You can use [polyfill-fastly.io URL Builder](https://polyfill-fastly.io/) to cre
 ### Simple
 
 ```tsx
-import '@formatjs/intl-datetimeformat/polyfill'
-import '@formatjs/intl-datetimeformat/locale-data/en' // locale-data for en
-import '@formatjs/intl-datetimeformat/add-all-tz' // Add ALL tz data
+import '@formatjs/intl-datetimeformat/polyfill.js'
+import '@formatjs/intl-datetimeformat/locale-data/en.js' // locale-data for en
+import '@formatjs/intl-datetimeformat/add-all-tz.js' // Add ALL tz data
 ```
 
 ### Dynamic import + capability detection
 
 ```tsx
-import {shouldPolyfill} from '@formatjs/intl-datetimeformat/should-polyfill'
+import {shouldPolyfill} from '@formatjs/intl-datetimeformat/should-polyfill.js'
 async function polyfill(locale: string) {
   const unsupportedLocale = shouldPolyfill(locale)
   // This locale is supported
@@ -87,12 +87,12 @@ async function polyfill(locale: string) {
     return
   }
   // Load the polyfill 1st BEFORE loading data
-  await import('@formatjs/intl-datetimeformat/polyfill-force')
+  await import('@formatjs/intl-datetimeformat/polyfill-force.js')
 
   // Parallelize CLDR data loading
   const dataPolyfills = [
-    import('@formatjs/intl-datetimeformat/add-all-tz'),
-    import(`@formatjs/intl-datetimeformat/locale-data/${unsupportedLocale}`),
+    import('@formatjs/intl-datetimeformat/add-all-tz.js'),
+    import(`@formatjs/intl-datetimeformat/locale-data/${unsupportedLocale}.js`),
   ]
   await Promise.all(dataPolyfills)
 }
@@ -105,15 +105,15 @@ We provide 2 pre-processed IANA Timezone:
 #### Full: contains ALL Timezone from IANA database
 
 ```tsx
-import '@formatjs/intl-datetimeformat/polyfill'
-import '@formatjs/intl-datetimeformat/add-all-tz'
+import '@formatjs/intl-datetimeformat/polyfill.js'
+import '@formatjs/intl-datetimeformat/add-all-tz.js'
 ```
 
 #### Golden: contains popular set of timezones from IANA database
 
 ```tsx
-import '@formatjs/intl-datetimeformat/polyfill'
-import '@formatjs/intl-datetimeformat/add-golden-tz'
+import '@formatjs/intl-datetimeformat/polyfill.js'
+import '@formatjs/intl-datetimeformat/add-golden-tz.js'
 ```
 
 ### Default Timezone
@@ -125,7 +125,7 @@ You can change this by either calling `__setDefaultTimeZone` or always explicitl
 Since `__setDefaultTimeZone` is not in the spec, you should make sure to check for its existence before calling it & after tz data has been loaded, e.g:
 
 ```tsx
-import '@formatjs/intl-datetimeformat/polyfill'
+import '@formatjs/intl-datetimeformat/polyfill.js'
 import '@formatjs/intl-datetimeformat/add-all-tz.js'
 
 if ('__setDefaultTimeZone' in Intl.DateTimeFormat) {

--- a/website/docs/polyfills/intl-displaynames.md
+++ b/website/docs/polyfills/intl-displaynames.md
@@ -59,14 +59,14 @@ You can use [polyfill-fastly.io URL Builder](https://polyfill-fastly.io/) to cre
 ### Simple
 
 ```tsx
-import '@formatjs/intl-displaynames/polyfill'
-import '@formatjs/intl-displaynames/locale-data/en' // locale-data for en
+import '@formatjs/intl-displaynames/polyfill.js'
+import '@formatjs/intl-displaynames/locale-data/en.js' // locale-data for en
 ```
 
 ### Dynamic import + capability detection
 
 ```tsx
-import {shouldPolyfill} from '@formatjs/intl-displaynames/should-polyfill'
+import {shouldPolyfill} from '@formatjs/intl-displaynames/should-polyfill.js'
 async function polyfill(locale: string) {
   const unsupportedLocale = shouldPolyfill(locale)
   // This locale is supported
@@ -74,7 +74,7 @@ async function polyfill(locale: string) {
     return
   }
   // Load the polyfill 1st BEFORE loading data
-  await import('@formatjs/intl-displaynames/polyfill-force')
-  await import(`@formatjs/intl-displaynames/locale-data/${locale}`)
+  await import('@formatjs/intl-displaynames/polyfill-force.js')
+  await import(`@formatjs/intl-displaynames/locale-data/${locale}.js`)
 }
 ```

--- a/website/docs/polyfills/intl-durationformat.md
+++ b/website/docs/polyfills/intl-durationformat.md
@@ -46,13 +46,13 @@ yarn add @formatjs/intl-durationformat
 ### Simple
 
 ```tsx
-import '@formatjs/intl-durationformat/polyfill'
+import '@formatjs/intl-durationformat/polyfill.js'
 ```
 
 ### Dynamic import + capability detection
 
 ```tsx
-import {shouldPolyfill} from '@formatjs/intl-durationformat/should-polyfill'
+import {shouldPolyfill} from '@formatjs/intl-durationformat/should-polyfill.js'
 async function polyfill(locale: string) {
   const unsupportedLocale = shouldPolyfill(locale)
   // This locale is supported
@@ -60,6 +60,6 @@ async function polyfill(locale: string) {
     return
   }
   // Load the polyfill 1st BEFORE loading data
-  await import('@formatjs/intl-durationformat/polyfill-force')
+  await import('@formatjs/intl-durationformat/polyfill-force.js')
 }
 ```

--- a/website/docs/polyfills/intl-getcanonicallocales.md
+++ b/website/docs/polyfills/intl-getcanonicallocales.md
@@ -50,20 +50,20 @@ You can use [polyfill-fastly.io URL Builder](https://polyfill-fastly.io/) to cre
 ### Simple
 
 ```tsx
-import '@formatjs/intl-getcanonicallocales/polyfill'
+import '@formatjs/intl-getcanonicallocales/polyfill.js'
 ```
 
 ### Dynamic import + capability detection
 
 ```tsx
-import {shouldPolyfill} from '@formatjs/intl-getcanonicallocales/should-polyfill'
+import {shouldPolyfill} from '@formatjs/intl-getcanonicallocales/should-polyfill.js'
 async function polyfill() {
   // This platform already supports Intl.getCanonicalLocales
   if (shouldPolyfill()) {
-    await import('@formatjs/intl-getcanonicallocales/polyfill')
+    await import('@formatjs/intl-getcanonicallocales/polyfill.js')
   }
   // Alternatively, force the polyfill regardless of support
-  await import('@formatjs/intl-getcanonicallocales/polyfill-force')
+  await import('@formatjs/intl-getcanonicallocales/polyfill-force.js')
 }
 ```
 

--- a/website/docs/polyfills/intl-listformat.md
+++ b/website/docs/polyfills/intl-listformat.md
@@ -55,14 +55,14 @@ You can use [polyfill-fastly.io URL Builder](https://polyfill-fastly.io/) to cre
 ### Simple
 
 ```tsx
-import '@formatjs/intl-listformat/polyfill'
-import '@formatjs/intl-listformat/locale-data/en' // locale-data for en
+import '@formatjs/intl-listformat/polyfill.js'
+import '@formatjs/intl-listformat/locale-data/en.js' // locale-data for en
 ```
 
 ### Dynamic import + capability detection
 
 ```tsx
-import {shouldPolyfill} from '@formatjs/intl-listformat/should-polyfill'
+import {shouldPolyfill} from '@formatjs/intl-listformat/should-polyfill.js'
 async function polyfill(locale: string) {
   const unsupportedLocale = shouldPolyfill(locale)
   // This locale is supported
@@ -70,8 +70,8 @@ async function polyfill(locale: string) {
     return
   }
   // Load the polyfill 1st BEFORE loading data
-  await import('@formatjs/intl-listformat/polyfill-force')
-  await import(`@formatjs/intl-listformat/locale-data/${unsupportedLocale}`)
+  await import('@formatjs/intl-listformat/polyfill-force.js')
+  await import(`@formatjs/intl-listformat/locale-data/${unsupportedLocale}.js`)
 }
 ```
 

--- a/website/docs/polyfills/intl-locale.md
+++ b/website/docs/polyfills/intl-locale.md
@@ -54,20 +54,20 @@ You can use [polyfill-fastly.io URL Builder](https://polyfill-fastly.io/) to cre
 ### Simple
 
 ```tsx
-import '@formatjs/intl-locale/polyfill'
+import '@formatjs/intl-locale/polyfill.js'
 ```
 
 ### Dynamic import + capability detection
 
 ```tsx
-import {shouldPolyfill} from '@formatjs/intl-locale/should-polyfill'
+import {shouldPolyfill} from '@formatjs/intl-locale/should-polyfill.js'
 async function polyfill() {
   // This platform already supports Intl.Locale
   if (shouldPolyfill()) {
-    await import('@formatjs/intl-locale/polyfill')
+    await import('@formatjs/intl-locale/polyfill.js')
   }
   // Alternatively, force the polyfill regardless of support
-  await import('@formatjs/intl-locale/polyfill-force')
+  await import('@formatjs/intl-locale/polyfill-force.js')
 }
 ```
 

--- a/website/docs/polyfills/intl-localematcher.md
+++ b/website/docs/polyfills/intl-localematcher.md
@@ -46,7 +46,7 @@ yarn add @formatjs/intl-localematcher
 ### Simple
 
 ```tsx
-import {match} from '@formatjs/intl-localematcher'
+import {match} from '@formatjs/intl-localematcher.js'
 
 match(['fr-XX', 'en'], ['fr', 'en'], 'en') // 'fr'
 

--- a/website/docs/polyfills/intl-numberformat.md
+++ b/website/docs/polyfills/intl-numberformat.md
@@ -72,14 +72,14 @@ Or if `Intl.PluralRules` needs to be polyfilled as well:
 ### Simple
 
 ```tsx
-import '@formatjs/intl-numberformat/polyfill'
-import '@formatjs/intl-numberformat/locale-data/en' // locale-data for en
+import '@formatjs/intl-numberformat/polyfill.js'
+import '@formatjs/intl-numberformat/locale-data/en.js' // locale-data for en
 ```
 
 ### Dynamic import + capability detection
 
 ```tsx
-import {shouldPolyfill} from '@formatjs/intl-numberformat/should-polyfill'
+import {shouldPolyfill} from '@formatjs/intl-numberformat/should-polyfill.js'
 async function polyfill(locale: string) {
   const unsupportedLocale = shouldPolyfill(locale)
   // This locale is supported
@@ -87,8 +87,10 @@ async function polyfill(locale: string) {
     return
   }
   // Load the polyfill 1st BEFORE loading data
-  await import('@formatjs/intl-numberformat/polyfill-force')
-  await import(`@formatjs/intl-numberformat/locale-data/${unsupportedLocale}`)
+  await import('@formatjs/intl-numberformat/polyfill-force.js')
+  await import(
+    `@formatjs/intl-numberformat/locale-data/${unsupportedLocale}.js`
+  )
 }
 ```
 

--- a/website/docs/polyfills/intl-pluralrules.md
+++ b/website/docs/polyfills/intl-pluralrules.md
@@ -55,8 +55,8 @@ You can use [polyfill-fastly.io URL Builder](https://polyfill-fastly.io/) to cre
 ### Simple
 
 ```tsx
-import '@formatjs/intl-pluralrules/polyfill'
-import '@formatjs/intl-pluralrules/locale-data/en' // locale-data for en
+import '@formatjs/intl-pluralrules/polyfill.js'
+import '@formatjs/intl-pluralrules/locale-data/en.js' // locale-data for en
 ```
 
 ### React Native
@@ -64,14 +64,14 @@ import '@formatjs/intl-pluralrules/locale-data/en' // locale-data for en
 The polyfill conditional detection code runs [very slowly on Android](https://github.com/formatjs/formatjs/issues/4463) and can slow down your app's startup time by seconds. Since React Native uses Hermes which does not support `Intl.PluralRules`, import `/polyfill-force` instead for much better performance:
 
 ```tsx
-import '@formatjs/intl-pluralrules/polyfill-force' // instead of /polyfill
-import '@formatjs/intl-pluralrules/locale-data/en'
+import '@formatjs/intl-pluralrules/polyfill-force.js' // instead of /polyfill
+import '@formatjs/intl-pluralrules/locale-data/en.js'
 ```
 
 ### Dynamic import + capability detection
 
 ```tsx
-import {shouldPolyfill} from '@formatjs/intl-pluralrules/should-polyfill'
+import {shouldPolyfill} from '@formatjs/intl-pluralrules/should-polyfill.js'
 async function polyfill(locale: string) {
   const unsupportedLocale = shouldPolyfill(locale)
   // This locale is supported
@@ -79,7 +79,7 @@ async function polyfill(locale: string) {
     return
   }
   // Load the polyfill 1st BEFORE loading data
-  await import('@formatjs/intl-pluralrules/polyfill-force')
-  await import(`@formatjs/intl-pluralrules/locale-data/${unsupportedLocale}`)
+  await import('@formatjs/intl-pluralrules/polyfill-force.js')
+  await import(`@formatjs/intl-pluralrules/locale-data/${unsupportedLocale}.js`)
 }
 ```

--- a/website/docs/polyfills/intl-relativetimeformat.md
+++ b/website/docs/polyfills/intl-relativetimeformat.md
@@ -43,7 +43,7 @@ This package requires the following capabilities:
 - [`Intl.getCanonicalLocales`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/getCanonicalLocales) or [polyfill](intl-getcanonicallocales.md)
 - [`Intl.Locale`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale) or [polyfill](intl-locale.md).
 - [`Intl.PluralRules`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/PluralRules) or [polyfill](intl-pluralrules.md).
-- If you need `formatToParts` and have to support IE11- or Node 10-, you'd need to polyfill using [`@formatjs/intl-numberformat`](intl-numberformat.md).
+- If you need `formatToParts` and have to support IE11- or Node 10-, you'd need to polyfill using [`@formatjs/intl-numberformat.js`](intl-numberformat.md).
 
 ## Usage
 
@@ -59,14 +59,14 @@ You can use [polyfill-fastly.io URL Builder](https://polyfill-fastly.io/) to cre
 ### Simple
 
 ```tsx
-import '@formatjs/intl-relativetimeformat/polyfill'
-import '@formatjs/intl-relativetimeformat/locale-data/en' // locale-data for en
+import '@formatjs/intl-relativetimeformat/polyfill.js'
+import '@formatjs/intl-relativetimeformat/locale-data/en.js' // locale-data for en
 ```
 
 ### Dynamic import + capability detection
 
 ```tsx
-import {shouldPolyfill} from '@formatjs/intl-relativetimeformat/should-polyfill'
+import {shouldPolyfill} from '@formatjs/intl-relativetimeformat/should-polyfill.js'
 async function polyfill(locale: string) {
   const unsupportedLocale = shouldPolyfill(locale)
   // This locale is supported
@@ -74,9 +74,9 @@ async function polyfill(locale: string) {
     return
   }
   // Load the polyfill 1st BEFORE loading data
-  await import('@formatjs/intl-relativetimeformat/polyfill-force')
+  await import('@formatjs/intl-relativetimeformat/polyfill-force.js')
   await import(
-    `@formatjs/intl-relativetimeformat/locale-data/${unsupportedLocale}`
+    `@formatjs/intl-relativetimeformat/locale-data/${unsupportedLocale}.js`
   )
 }
 ```

--- a/website/docs/polyfills/intl-segmenter.md
+++ b/website/docs/polyfills/intl-segmenter.md
@@ -45,16 +45,16 @@ Everything in [intl-segmenter proposal](https://tc39.es/proposal-intl-segmenter)
 ### Simple
 
 ```tsx
-import '@formatjs/intl-segmenter/polyfill'
+import '@formatjs/intl-segmenter/polyfill.js'
 ```
 
 ### Dynamic import + capability detection
 
 ```tsx
-import {shouldPolyfill} from '@formatjs/intl-segmenter/should-polyfill'
+import {shouldPolyfill} from '@formatjs/intl-segmenter/should-polyfill.js'
 async function polyfill(locale: string) {
   if (shouldPolyfill()) {
-    await import('@formatjs/intl-segmenter/polyfill-force')
+    await import('@formatjs/intl-segmenter/polyfill-force.js')
   }
 }
 ```

--- a/website/docs/polyfills/intl-supportedvaluesof.md
+++ b/website/docs/polyfills/intl-supportedvaluesof.md
@@ -47,20 +47,20 @@ yarn add @formatjs/intl-enumerator
 ### Simple
 
 ```tsx
-import '@formatjs/intl-enumerator/polyfill'
+import '@formatjs/intl-enumerator/polyfill.js'
 ```
 
 ### Dynamic import + capability detection
 
 ```tsx
-import {shouldPolyfill} from '@formatjs/intl-enumerator/should-polyfill'
+import {shouldPolyfill} from '@formatjs/intl-enumerator/should-polyfill.js'
 async function polyfill() {
   // This platform already supports Intl.supportedValuesOf
   if (shouldPolyfill()) {
-    await import('@formatjs/intl-enumerator/polyfill')
+    await import('@formatjs/intl-enumerator/polyfill.js')
   }
   // Alternatively, force the polyfill regardless of support
-  await import('@formatjs/intl-enumerator/polyfill-force')
+  await import('@formatjs/intl-enumerator/polyfill-force.js')
 }
 ```
 


### PR DESCRIPTION
### TL;DR

Added `.js` extensions to all import statements in polyfill documentation.

### What changed?

Updated all import statements in the polyfill documentation to include `.js` extensions. This change affects all polyfill documentation pages including:

- intl-datetimeformat
- intl-displaynames
- intl-durationformat
- intl-getcanonicallocales
- intl-listformat
- intl-locale
- intl-localematcher
- intl-numberformat
- intl-pluralrules
- intl-relativetimeformat
- intl-segmenter
- intl-supportedvaluesof (intl-enumerator)

### How to test?

1. Review the documentation pages to ensure all import statements now include `.js` extensions
2. Test the import statements in a project to verify they work correctly with the extensions

### Why make this change?

This change improves compatibility with ESM imports where file extensions are required. Modern bundlers and JavaScript runtimes that use strict ESM require explicit file extensions, and this update ensures the documentation reflects the correct import syntax for these environments.