### PR TITLE
Treat the main fs-extra import as the CJS file that it is 

### DIFF
--- a/packages/cli-lib/src/cli.ts
+++ b/packages/cli-lib/src/cli.ts
@@ -6,8 +6,9 @@ import compileFolder from './compile_folder.js'
 import {debug} from './console_utils.js'
 import extract, {ExtractCLIOptions} from './extract.js'
 import {verify, VerifyOpts} from './verify/index.js'
-import {readFileSync} from 'fs-extra'
+import * as fsExtra from 'fs-extra'
 import {resolve} from 'path'
+const {readFileSync} = fsExtra;
 
 const KNOWN_COMMANDS = ['extract']
 

--- a/packages/cli-lib/src/compile.ts
+++ b/packages/cli-lib/src/compile.ts
@@ -1,5 +1,5 @@
 import {MessageFormatElement, parse} from '@formatjs/icu-messageformat-parser'
-import {outputFile, readJSON} from 'fs-extra'
+import * as fsExtra from 'fs-extra'
 import * as stringifyNs from 'json-stable-stringify'
 import {debug, warn, writeStdout} from './console_utils.js'
 import {Formatter, resolveBuiltinFormatter} from './formatters/index.js'
@@ -10,6 +10,8 @@ import {
   generateXXHA,
   generateXXLS,
 } from './pseudo_locale.js'
+
+const {outputFile, readJSON} = fsExtra;
 
 const stringify = (stringifyNs as any).default || stringifyNs
 

--- a/packages/cli-lib/src/compile_folder.ts
+++ b/packages/cli-lib/src/compile_folder.ts
@@ -1,6 +1,7 @@
-import {outputFile} from 'fs-extra'
+import * as fsExtra from 'fs-extra'
 import {basename, join} from 'path'
 import {Opts, compile} from './compile.js'
+const {outputFile} = fsExtra;
 export default async function compileFolder(
   files: string[],
   outFolder: string,

--- a/packages/cli-lib/src/extract.ts
+++ b/packages/cli-lib/src/extract.ts
@@ -3,7 +3,7 @@ import {
   Opts,
   interpolateName,
 } from '@formatjs/ts-transformer'
-import {outputFile, readFile} from 'fs-extra'
+import * as fsExtra from 'fs-extra'
 import {debug, getStdinAsString, warn, writeStdout} from './console_utils.js'
 import * as stringifyNs from 'json-stable-stringify'
 
@@ -13,6 +13,7 @@ import {printAST} from '@formatjs/icu-messageformat-parser/printer.js'
 import {Formatter, resolveBuiltinFormatter} from './formatters/index.js'
 import {parseScript} from './parse_script.js'
 
+const {outputFile, readFile} = fsExtra;
 const stringify = (stringifyNs as any).default || stringifyNs
 export interface ExtractionResult<M = Record<string, string>> {
   /**

--- a/packages/cli-lib/src/verify/index.ts
+++ b/packages/cli-lib/src/verify/index.ts
@@ -2,8 +2,9 @@ import {basename} from 'path'
 import {debug} from '../console_utils.js'
 import {checkMissingKeys} from './checkMissingKeys.js'
 import {checkExtraKeys} from './checkExtraKeys.js'
-import {readJSON} from 'fs-extra'
+import * as fsExtra from 'fs-extra'
 import {checkStructuralEquality} from './checkStructuralEquality.js'
+const {readJSON} = fsExtra;
 export interface VerifyOpts {
   sourceLocale: string
   missingKeys: boolean


### PR DESCRIPTION
Resolves https://github.com/formatjs/formatjs/issues/5569

Hopefully this gets folks moving off of v6

<img width="1780" height="1408" alt="image" src="https://github.com/user-attachments/assets/f95b0e2b-6f4c-43c5-912a-798057dea7f6" />

https://majors.nullvoxpopuli.com/q?minors=false&old=false&packages=%40formatjs%2Fcli-lib