### PR TITLE
docs: fix #5580

### DIFF
--- a/website/docs/guides/advanced-usage.md
+++ b/website/docs/guides/advanced-usage.md
@@ -31,7 +31,7 @@ module.exports = {
   resolve: {
     alias: {
       '@formatjs/icu-messageformat-parser':
-        '@formatjs/icu-messageformat-parser/no-parser',
+        '@formatjs/icu-messageformat-parser/no-parser.js',
     },
   },
 }
@@ -48,7 +48,7 @@ module.exports = {
     alias({
       entries: {
         '@formatjs/icu-messageformat-parser':
-          '@formatjs/icu-messageformat-parser/no-parser',
+          '@formatjs/icu-messageformat-parser/no-parser.js',
       },
     }),
   ],


### PR DESCRIPTION
### TL;DR

Fixed import paths for `@formatjs/icu-messageformat-parser/no-parser` by adding the `.js` extension.

### What changed?

Updated the import paths in the webpack and rollup configuration examples to include the `.js` extension when aliasing `@formatjs/icu-messageformat-parser/no-parser`. The paths now correctly point to `@formatjs/icu-messageformat-parser/no-parser.js`.

### How to test?

1. Verify that webpack and rollup builds work correctly with the updated alias paths
2. Confirm that the documentation examples can be copied and used without modification
3. Check that imports of `@formatjs/icu-messageformat-parser` are properly resolved to the no-parser version

### Why make this change?

The previous import paths were missing the `.js` extension, which could cause module resolution issues in certain build environments. This change ensures that the correct file is imported when using the no-parser optimization technique described in the advanced usage documentation.