### PR TITLE
fix(@formatjs/utils): fix json ESM import

### DIFF
--- a/packages/icu-messageformat-parser/scripts/time-data-gen.ts
+++ b/packages/icu-messageformat-parser/scripts/time-data-gen.ts
@@ -1,4 +1,4 @@
-import * as rawTimeData from 'cldr-core/supplemental/timeData.json'
+import * as rawTimeData from 'cldr-core/supplemental/timeData.json' with {type: 'json'}
 import {outputFileSync} from 'fs-extra/esm'
 import minimist from 'minimist'
 import stringify from 'json-stable-stringify'

--- a/packages/intl-datetimeformat/scripts/extract-dates.ts
+++ b/packages/intl-datetimeformat/scripts/extract-dates.ts
@@ -5,16 +5,16 @@
  */
 'use strict'
 
-import * as DateFields from 'cldr-dates-full/main/en/ca-gregorian.json'
-import * as NumberFields from 'cldr-numbers-full/main/en/numbers.json'
+import * as DateFields from 'cldr-dates-full/main/en/ca-gregorian.json' with {type: 'json'}
+import * as NumberFields from 'cldr-numbers-full/main/en/numbers.json' with {type: 'json'}
 import {sync as globSync} from 'fast-glob'
 import {resolve, dirname} from 'path'
-import * as AVAILABLE_LOCALES from 'cldr-core/availableLocales.json'
+import * as AVAILABLE_LOCALES from 'cldr-core/availableLocales.json' with {type: 'json'}
 import {RawDateTimeLocaleInternalData, TimeZoneNameData} from '../src/types'
-import * as rawTimeData from 'cldr-core/supplemental/timeData.json'
-import * as rawCalendarPreferenceData from 'cldr-core/supplemental/calendarPreferenceData.json'
-import * as TimeZoneNames from 'cldr-dates-full/main/en/timeZoneNames.json'
-import * as metaZones from 'cldr-core/supplemental/metaZones.json'
+import * as rawTimeData from 'cldr-core/supplemental/timeData.json' with {type: 'json'}
+import * as rawCalendarPreferenceData from 'cldr-core/supplemental/calendarPreferenceData.json' with {type: 'json'}
+import * as TimeZoneNames from 'cldr-dates-full/main/en/timeZoneNames.json' with {type: 'json'}
+import * as metaZones from 'cldr-core/supplemental/metaZones.json' with {type: 'json'}
 import IntlLocale from '@formatjs/intl-locale'
 import {Formats} from '@formatjs/ecma402-abstract'
 import {parseDateTimeSkeleton} from '../src/abstract/skeleton'

--- a/packages/intl-datetimeformat/tests/benchmark.ts
+++ b/packages/intl-datetimeformat/tests/benchmark.ts
@@ -1,5 +1,5 @@
 import benchmark from 'benchmark'
-import * as en from './locale-data/en.json'
+import * as en from './locale-data/en.json' with {type: 'json'}
 import allData from '../src/data/all-tz'
 import {DateTimeFormat} from '../src/core'
 DateTimeFormat.__addTZData(allData)

--- a/packages/intl-datetimeformat/tests/format-range.test.ts
+++ b/packages/intl-datetimeformat/tests/format-range.test.ts
@@ -2,11 +2,11 @@ import '@formatjs/intl-getcanonicallocales/polyfill.js'
 import '@formatjs/intl-locale/polyfill.js'
 import {DateTimeFormat} from '../src/core'
 import allData from '../src/data/all-tz'
-import * as enGB from './locale-data/en-GB.json'
-import * as en from './locale-data/en.json'
-import * as fa from './locale-data/fa.json'
-import * as nl from './locale-data/nl.json'
-import * as zhHans from './locale-data/zh-Hans.json'
+import * as enGB from './locale-data/en-GB.json' with {type: 'json'}
+import * as en from './locale-data/en.json' with {type: 'json'}
+import * as fa from './locale-data/fa.json' with {type: 'json'}
+import * as nl from './locale-data/nl.json' with {type: 'json'}
+import * as zhHans from './locale-data/zh-Hans.json' with {type: 'json'}
 import {describe, expect, it, test} from 'vitest'
 // @ts-ignore
 DateTimeFormat.__addLocaleData(en, enGB, zhHans, fa, nl)

--- a/packages/intl-datetimeformat/tests/format.test.ts
+++ b/packages/intl-datetimeformat/tests/format.test.ts
@@ -5,9 +5,9 @@ import {
   toLocaleString,
   toLocaleTimeString,
 } from '../src/to_locale_string'
-import * as en from './locale-data/en.json'
-import * as ko from './locale-data/ko.json'
-import * as ru from './locale-data/ru.json'
+import * as en from './locale-data/en.json' with {type: 'json'}
+import * as ko from './locale-data/ko.json' with {type: 'json'}
+import * as ru from './locale-data/ru.json' with {type: 'json'}
 import {describe, expect, it} from 'vitest'
 // @ts-ignore
 DateTimeFormat.__addLocaleData(en, ko, ru)

--- a/packages/intl-datetimeformat/tests/ftp-main.test.ts
+++ b/packages/intl-datetimeformat/tests/ftp-main.test.ts
@@ -1,7 +1,7 @@
-import * as en from './locale-data/en.json'
-import * as pl from './locale-data/pl.json'
-import * as de from './locale-data/de.json'
-import * as ar from './locale-data/ar.json'
+import * as en from './locale-data/en.json' with {type: 'json'}
+import * as pl from './locale-data/pl.json' with {type: 'json'}
+import * as de from './locale-data/de.json' with {type: 'json'}
+import * as ar from './locale-data/ar.json' with {type: 'json'}
 import allData from '../src/data/all-tz'
 import {DateTimeFormat} from '../src/core'
 import {IntlDateTimeFormatPart} from '@formatjs/ecma402-abstract'

--- a/packages/intl-datetimeformat/tests/index.test.ts
+++ b/packages/intl-datetimeformat/tests/index.test.ts
@@ -2,11 +2,11 @@ import '@formatjs/intl-getcanonicallocales/polyfill.js'
 import '@formatjs/intl-locale/polyfill.js'
 import {DateTimeFormat} from '../src/core'
 import allData from '../src/data/all-tz'
-import * as enCA from './locale-data/en-CA.json'
-import * as enGB from './locale-data/en-GB.json'
-import * as en from './locale-data/en.json'
-import * as fa from './locale-data/fa.json'
-import * as zhHans from './locale-data/zh-Hans.json'
+import * as enCA from './locale-data/en-CA.json' with {type: 'json'}
+import * as enGB from './locale-data/en-GB.json' with {type: 'json'}
+import * as en from './locale-data/en.json' with {type: 'json'}
+import * as fa from './locale-data/fa.json' with {type: 'json'}
+import * as zhHans from './locale-data/zh-Hans.json' with {type: 'json'}
 import {describe, expect, it, afterEach} from 'vitest'
 // @ts-ignore
 DateTimeFormat.__addLocaleData(en, enGB, enCA, zhHans, fa)

--- a/packages/intl-displaynames/scripts/extract-displaynames.ts
+++ b/packages/intl-displaynames/scripts/extract-displaynames.ts
@@ -1,5 +1,5 @@
 import {DisplayNamesData} from '@formatjs/ecma402-abstract'
-import * as AVAILABLE_LOCALES from 'cldr-core/availableLocales.json'
+import * as AVAILABLE_LOCALES from 'cldr-core/availableLocales.json' with {type: 'json'}
 import glob from 'fast-glob'
 import {dirname, resolve} from 'path'
 

--- a/packages/intl-displaynames/tests/index.test.ts
+++ b/packages/intl-displaynames/tests/index.test.ts
@@ -4,8 +4,8 @@ import '@formatjs/intl-locale/polyfill.js'
 import {DisplayNames} from '../index.js'
 import {describe, expect, it} from 'vitest'
 
-import * as en from './locale-data/en.json'
-import * as zh from './locale-data/zh.json'
+import * as en from './locale-data/en.json' with {type: 'json'}
+import * as zh from './locale-data/zh.json' with {type: 'json'}
 DisplayNames.__addLocaleData(en, zh)
 
 describe('.of()', () => {

--- a/packages/intl-getcanonicallocales/scripts/aliases.ts
+++ b/packages/intl-getcanonicallocales/scripts/aliases.ts
@@ -1,5 +1,5 @@
 import {outputFileSync} from 'fs-extra/esm'
-import * as aliases from 'cldr-core/supplemental/aliases.json'
+import * as aliases from 'cldr-core/supplemental/aliases.json' with {type: 'json'}
 import minimist from 'minimist'
 import stringify from 'json-stable-stringify'
 

--- a/packages/intl-getcanonicallocales/scripts/likely-subtags.ts
+++ b/packages/intl-getcanonicallocales/scripts/likely-subtags.ts
@@ -1,6 +1,6 @@
 import {outputFileSync} from 'fs-extra/esm'
 import minimist from 'minimist'
-import * as likelySubtags from 'cldr-core/supplemental/likelySubtags.json'
+import * as likelySubtags from 'cldr-core/supplemental/likelySubtags.json' with {type: 'json'}
 import stringify from 'json-stable-stringify'
 function main({out}: minimist.ParsedArgs) {
   outputFileSync(

--- a/packages/intl-listformat/scripts/extract-list.ts
+++ b/packages/intl-listformat/scripts/extract-list.ts
@@ -4,7 +4,7 @@
  * See the accompanying LICENSE file for terms.
  */
 'use strict'
-import * as ListPatterns from 'cldr-misc-full/main/en/listPatterns.json'
+import * as ListPatterns from 'cldr-misc-full/main/en/listPatterns.json' with {type: 'json'}
 import glob from 'fast-glob'
 import {resolve, dirname} from 'path'
 import {ListPatternFieldsData, ListPattern} from '@formatjs/ecma402-abstract'

--- a/packages/intl-listformat/tests/index.test.ts
+++ b/packages/intl-listformat/tests/index.test.ts
@@ -1,11 +1,11 @@
 import '@formatjs/intl-getcanonicallocales/polyfill.js'
 import '@formatjs/intl-locale/polyfill.js'
 import ListFormat from '../index.js'
-import * as en from './locale-data/en.json'
-import * as enAI from './locale-data/en-AI.json'
-import * as zh from './locale-data/zh.json'
-import * as zhHant from './locale-data/zh-Hant.json'
-import * as zhHans from './locale-data/zh-Hans.json'
+import * as en from './locale-data/en.json' with {type: 'json'}
+import * as enAI from './locale-data/en-AI.json' with {type: 'json'}
+import * as zh from './locale-data/zh.json' with {type: 'json'}
+import * as zhHant from './locale-data/zh-Hant.json' with {type: 'json'}
+import * as zhHans from './locale-data/zh-Hans.json' with {type: 'json'}
 import {describe, expect, it} from 'vitest'
 ListFormat.__addLocaleData(en, enAI, zh, zhHans, zhHant)
 

--- a/packages/intl-listformat/tests/supported-locales-of.test.ts
+++ b/packages/intl-listformat/tests/supported-locales-of.test.ts
@@ -1,11 +1,11 @@
 import '@formatjs/intl-getcanonicallocales/polyfill.js'
 import '@formatjs/intl-locale/polyfill.js'
 import ListFormat from '../index.js'
-import * as en from './locale-data/en.json'
-import * as enAI from './locale-data/en-AI.json'
-import * as zh from './locale-data/zh.json'
-import * as zhHant from './locale-data/zh-Hant.json'
-import * as zhHans from './locale-data/zh-Hans.json'
+import * as en from './locale-data/en.json' with {type: 'json'}
+import * as enAI from './locale-data/en-AI.json' with {type: 'json'}
+import * as zh from './locale-data/zh.json' with {type: 'json'}
+import * as zhHant from './locale-data/zh-Hant.json' with {type: 'json'}
+import * as zhHans from './locale-data/zh-Hans.json' with {type: 'json'}
 import {describe, expect, it} from 'vitest'
 ListFormat.__addLocaleData(en, enAI, zh, zhHans, zhHant)
 

--- a/packages/intl-locale/scripts/calendars.ts
+++ b/packages/intl-locale/scripts/calendars.ts
@@ -1,7 +1,7 @@
 import minimist from 'minimist'
 import {outputFileSync} from 'fs-extra/esm'
 
-import * as rawCalendarPreferenceData from 'cldr-core/supplemental/calendarPreferenceData.json'
+import * as rawCalendarPreferenceData from 'cldr-core/supplemental/calendarPreferenceData.json' with {type: 'json'}
 
 import type {Args} from './common-types.js'
 import stringify from 'json-stable-stringify'

--- a/packages/intl-locale/scripts/hour-cycles.ts
+++ b/packages/intl-locale/scripts/hour-cycles.ts
@@ -1,7 +1,7 @@
 import minimist from 'minimist'
 import {outputFileSync} from 'fs-extra/esm'
 import stringify from 'json-stable-stringify'
-import * as rawTimeData from 'cldr-core/supplemental/timeData.json'
+import * as rawTimeData from 'cldr-core/supplemental/timeData.json' with {type: 'json'}
 
 import type {Args} from './common-types.js'
 

--- a/packages/intl-locale/scripts/timezones.ts
+++ b/packages/intl-locale/scripts/timezones.ts
@@ -1,7 +1,7 @@
 import minimist from 'minimist'
 import {outputFileSync} from 'fs-extra/esm'
 import stringify from 'json-stable-stringify'
-import * as rawTimezones from 'cldr-bcp47/bcp47/timezone.json'
+import * as rawTimezones from 'cldr-bcp47/bcp47/timezone.json' with {type: 'json'}
 
 import type {Args} from './common-types.js'
 

--- a/packages/intl-locale/scripts/week-data.ts
+++ b/packages/intl-locale/scripts/week-data.ts
@@ -1,8 +1,8 @@
 import {outputFileSync} from 'fs-extra/esm'
 import minimist from 'minimist'
 
-import * as rawTerritoryInfo from 'cldr-core/supplemental/territoryInfo.json'
-import * as rawWeekData from 'cldr-core/supplemental/weekData.json'
+import * as rawTerritoryInfo from 'cldr-core/supplemental/territoryInfo.json' with {type: 'json'}
+import * as rawWeekData from 'cldr-core/supplemental/weekData.json' with {type: 'json'}
 
 import stringify from 'json-stable-stringify'
 import type {Args} from './common-types.js'

--- a/packages/intl-numberformat/BUILD.bazel
+++ b/packages/intl-numberformat/BUILD.bazel
@@ -160,7 +160,7 @@ LOCALE_TEST_TYPES = [
         cmd = """
         echo 'import \"@formatjs/intl-pluralrules/locale-data/%s.js\"\n\
 import { test } from \"./%sTest\"\n\
-import * as localeData from \"../locale-data/%s.json\"\n\
+import * as localeData from \"../locale-data/%s.json\" with {type: '"'"'json'"'"'}\n\
 test(\"%s\", localeData);' > $@""" % (
             locale.split("-")[0],
             type,

--- a/packages/intl-numberformat/scripts/cldr-raw.ts
+++ b/packages/intl-numberformat/scripts/cldr-raw.ts
@@ -4,7 +4,7 @@ import {generateDataForLocales as extractNumbers} from './extract-numbers.js'
 import {join} from 'path'
 import {outputFileSync} from 'fs-extra/esm'
 import stringify from 'json-stable-stringify'
-import * as AVAILABLE_LOCALES from 'cldr-core/availableLocales.json'
+import * as AVAILABLE_LOCALES from 'cldr-core/availableLocales.json' with {type: 'json'}
 import minimist from 'minimist'
 
 async function main(args: minimist.ParsedArgs) {

--- a/packages/intl-numberformat/scripts/extract-currencies.ts
+++ b/packages/intl-numberformat/scripts/extract-currencies.ts
@@ -4,12 +4,12 @@
  * See the accompanying LICENSE file for terms.
  */
 'use strict'
-import * as CurrenciesData from 'cldr-numbers-full/main/en/currencies.json'
-import * as supplementalCurrencyData from 'cldr-core/supplemental/currencyData.json'
+import * as CurrenciesData from 'cldr-numbers-full/main/en/currencies.json' with {type: 'json'}
+import * as supplementalCurrencyData from 'cldr-core/supplemental/currencyData.json' with {type: 'json'}
 import {sync as globSync} from 'fast-glob'
 import {resolve, dirname} from 'path'
 import {CurrencyData, LDMLPluralRuleMap} from '@formatjs/ecma402-abstract'
-import * as AVAILABLE_LOCALES from 'cldr-core/availableLocales.json'
+import * as AVAILABLE_LOCALES from 'cldr-core/availableLocales.json' with {type: 'json'}
 import {collapseSingleValuePluralRule, PLURAL_RULES} from './utils.js'
 
 export type Currencies =

--- a/packages/intl-numberformat/scripts/extract-numbers.ts
+++ b/packages/intl-numberformat/scripts/extract-numbers.ts
@@ -3,8 +3,8 @@
  * Copyrights licensed under the New BSD License.
  * See the accompanying LICENSE file for terms.
  */
-import * as NumbersData from 'cldr-numbers-full/main/ar/numbers.json'
-import * as numberingSystems from 'cldr-core/supplemental/numberingSystems.json'
+import * as NumbersData from 'cldr-numbers-full/main/ar/numbers.json' with {type: 'json'}
+import * as numberingSystems from 'cldr-core/supplemental/numberingSystems.json' with {type: 'json'}
 import {
   RawNumberData,
   SymbolsData,
@@ -13,7 +13,7 @@ import {
   RawCurrencyData,
   invariant,
 } from '@formatjs/ecma402-abstract'
-import * as AVAILABLE_LOCALES from 'cldr-core/availableLocales.json'
+import * as AVAILABLE_LOCALES from 'cldr-core/availableLocales.json' with {type: 'json'}
 import {collapseSingleValuePluralRule, PLURAL_RULES} from './utils.js'
 
 export type Numbers = (typeof NumbersData)['main']['ar']['numbers']

--- a/packages/intl-numberformat/scripts/extract-units.ts
+++ b/packages/intl-numberformat/scripts/extract-units.ts
@@ -12,8 +12,8 @@ import {
   IsWellFormedUnitIdentifier,
   UnitData,
 } from '@formatjs/ecma402-abstract'
-import * as UnitsData from 'cldr-units-full/main/en/units.json'
-import * as AVAILABLE_LOCALES from 'cldr-core/availableLocales.json'
+import * as UnitsData from 'cldr-units-full/main/en/units.json' with {type: 'json'}
+import * as AVAILABLE_LOCALES from 'cldr-core/availableLocales.json' with {type: 'json'}
 import {collapseSingleValuePluralRule, PLURAL_RULES} from './utils.js'
 
 export type Units = (typeof UnitsData)['main']['en']['units']

--- a/packages/intl-numberformat/tests/currency-code.test.ts
+++ b/packages/intl-numberformat/tests/currency-code.test.ts
@@ -1,7 +1,7 @@
 import {it, expect} from 'vitest'
 import '@formatjs/intl-getcanonicallocales/polyfill.js'
 import '@formatjs/intl-locale/polyfill.js'
-import * as en from './locale-data/en.json'
+import * as en from './locale-data/en.json' with {type: 'json'}
 import {NumberFormat} from '../src/core'
 NumberFormat.__addLocaleData(en as any)
 

--- a/packages/intl-numberformat/tests/currency/da.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/da.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/da.js"
 import { test } from "./currencyTest"
-import * as localeData from "../locale-data/da.json"
+import * as localeData from "../locale-data/da.json" with {type: 'json'}
 test("da", localeData);

--- a/packages/intl-numberformat/tests/currency/de.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/de.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/de.js"
 import { test } from "./currencyTest"
-import * as localeData from "../locale-data/de.json"
+import * as localeData from "../locale-data/de.json" with {type: 'json'}
 test("de", localeData);

--- a/packages/intl-numberformat/tests/currency/en-BS.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/en-BS.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/en.js"
 import { test } from "./currencyTest"
-import * as localeData from "../locale-data/en-BS.json"
+import * as localeData from "../locale-data/en-BS.json" with {type: 'json'}
 test("en-BS", localeData);

--- a/packages/intl-numberformat/tests/currency/en-GB.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/en-GB.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/en.js"
 import { test } from "./currencyTest"
-import * as localeData from "../locale-data/en-GB.json"
+import * as localeData from "../locale-data/en-GB.json" with {type: 'json'}
 test("en-GB", localeData);

--- a/packages/intl-numberformat/tests/currency/en.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/en.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/en.js"
 import { test } from "./currencyTest"
-import * as localeData from "../locale-data/en.json"
+import * as localeData from "../locale-data/en.json" with {type: 'json'}
 test("en", localeData);

--- a/packages/intl-numberformat/tests/currency/es.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/es.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/es.js"
 import { test } from "./currencyTest"
-import * as localeData from "../locale-data/es.json"
+import * as localeData from "../locale-data/es.json" with {type: 'json'}
 test("es", localeData);

--- a/packages/intl-numberformat/tests/currency/fr.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/fr.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/fr.js"
 import { test } from "./currencyTest"
-import * as localeData from "../locale-data/fr.json"
+import * as localeData from "../locale-data/fr.json" with {type: 'json'}
 test("fr", localeData);

--- a/packages/intl-numberformat/tests/currency/id.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/id.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/id.js"
 import { test } from "./currencyTest"
-import * as localeData from "../locale-data/id.json"
+import * as localeData from "../locale-data/id.json" with {type: 'json'}
 test("id", localeData);

--- a/packages/intl-numberformat/tests/currency/it.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/it.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/it.js"
 import { test } from "./currencyTest"
-import * as localeData from "../locale-data/it.json"
+import * as localeData from "../locale-data/it.json" with {type: 'json'}
 test("it", localeData);

--- a/packages/intl-numberformat/tests/currency/ja.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/ja.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/ja.js"
 import { test } from "./currencyTest"
-import * as localeData from "../locale-data/ja.json"
+import * as localeData from "../locale-data/ja.json" with {type: 'json'}
 test("ja", localeData);

--- a/packages/intl-numberformat/tests/currency/ko.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/ko.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/ko.js"
 import { test } from "./currencyTest"
-import * as localeData from "../locale-data/ko.json"
+import * as localeData from "../locale-data/ko.json" with {type: 'json'}
 test("ko", localeData);

--- a/packages/intl-numberformat/tests/currency/ms.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/ms.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/ms.js"
 import { test } from "./currencyTest"
-import * as localeData from "../locale-data/ms.json"
+import * as localeData from "../locale-data/ms.json" with {type: 'json'}
 test("ms", localeData);

--- a/packages/intl-numberformat/tests/currency/nb.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/nb.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/nb.js"
 import { test } from "./currencyTest"
-import * as localeData from "../locale-data/nb.json"
+import * as localeData from "../locale-data/nb.json" with {type: 'json'}
 test("nb", localeData);

--- a/packages/intl-numberformat/tests/currency/nl.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/nl.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/nl.js"
 import { test } from "./currencyTest"
-import * as localeData from "../locale-data/nl.json"
+import * as localeData from "../locale-data/nl.json" with {type: 'json'}
 test("nl", localeData);

--- a/packages/intl-numberformat/tests/currency/pl.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/pl.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/pl.js"
 import { test } from "./currencyTest"
-import * as localeData from "../locale-data/pl.json"
+import * as localeData from "../locale-data/pl.json" with {type: 'json'}
 test("pl", localeData);

--- a/packages/intl-numberformat/tests/currency/pt.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/pt.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/pt.js"
 import { test } from "./currencyTest"
-import * as localeData from "../locale-data/pt.json"
+import * as localeData from "../locale-data/pt.json" with {type: 'json'}
 test("pt", localeData);

--- a/packages/intl-numberformat/tests/currency/ru.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/ru.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/ru.js"
 import { test } from "./currencyTest"
-import * as localeData from "../locale-data/ru.json"
+import * as localeData from "../locale-data/ru.json" with {type: 'json'}
 test("ru", localeData);

--- a/packages/intl-numberformat/tests/currency/sv.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/sv.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/sv.js"
 import { test } from "./currencyTest"
-import * as localeData from "../locale-data/sv.json"
+import * as localeData from "../locale-data/sv.json" with {type: 'json'}
 test("sv", localeData);

--- a/packages/intl-numberformat/tests/currency/th.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/th.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/th.js"
 import { test } from "./currencyTest"
-import * as localeData from "../locale-data/th.json"
+import * as localeData from "../locale-data/th.json" with {type: 'json'}
 test("th", localeData);

--- a/packages/intl-numberformat/tests/currency/tr.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/tr.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/tr.js"
 import { test } from "./currencyTest"
-import * as localeData from "../locale-data/tr.json"
+import * as localeData from "../locale-data/tr.json" with {type: 'json'}
 test("tr", localeData);

--- a/packages/intl-numberformat/tests/currency/uk.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/uk.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/uk.js"
 import { test } from "./currencyTest"
-import * as localeData from "../locale-data/uk.json"
+import * as localeData from "../locale-data/uk.json" with {type: 'json'}
 test("uk", localeData);

--- a/packages/intl-numberformat/tests/currency/zh.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/zh.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/zh.js"
 import { test } from "./currencyTest"
-import * as localeData from "../locale-data/zh.json"
+import * as localeData from "../locale-data/zh.json" with {type: 'json'}
 test("zh", localeData);

--- a/packages/intl-numberformat/tests/decimal/da.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/da.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/da.js"
 import { test } from "./decimalTest"
-import * as localeData from "../locale-data/da.json"
+import * as localeData from "../locale-data/da.json" with {type: 'json'}
 test("da", localeData);

--- a/packages/intl-numberformat/tests/decimal/de.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/de.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/de.js"
 import { test } from "./decimalTest"
-import * as localeData from "../locale-data/de.json"
+import * as localeData from "../locale-data/de.json" with {type: 'json'}
 test("de", localeData);

--- a/packages/intl-numberformat/tests/decimal/en-BS.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/en-BS.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/en.js"
 import { test } from "./decimalTest"
-import * as localeData from "../locale-data/en-BS.json"
+import * as localeData from "../locale-data/en-BS.json" with {type: 'json'}
 test("en-BS", localeData);

--- a/packages/intl-numberformat/tests/decimal/en-GB.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/en-GB.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/en.js"
 import { test } from "./decimalTest"
-import * as localeData from "../locale-data/en-GB.json"
+import * as localeData from "../locale-data/en-GB.json" with {type: 'json'}
 test("en-GB", localeData);

--- a/packages/intl-numberformat/tests/decimal/en.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/en.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/en.js"
 import { test } from "./decimalTest"
-import * as localeData from "../locale-data/en.json"
+import * as localeData from "../locale-data/en.json" with {type: 'json'}
 test("en", localeData);

--- a/packages/intl-numberformat/tests/decimal/es.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/es.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/es.js"
 import { test } from "./decimalTest"
-import * as localeData from "../locale-data/es.json"
+import * as localeData from "../locale-data/es.json" with {type: 'json'}
 test("es", localeData);

--- a/packages/intl-numberformat/tests/decimal/fr.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/fr.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/fr.js"
 import { test } from "./decimalTest"
-import * as localeData from "../locale-data/fr.json"
+import * as localeData from "../locale-data/fr.json" with {type: 'json'}
 test("fr", localeData);

--- a/packages/intl-numberformat/tests/decimal/id.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/id.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/id.js"
 import { test } from "./decimalTest"
-import * as localeData from "../locale-data/id.json"
+import * as localeData from "../locale-data/id.json" with {type: 'json'}
 test("id", localeData);

--- a/packages/intl-numberformat/tests/decimal/it.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/it.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/it.js"
 import { test } from "./decimalTest"
-import * as localeData from "../locale-data/it.json"
+import * as localeData from "../locale-data/it.json" with {type: 'json'}
 test("it", localeData);

--- a/packages/intl-numberformat/tests/decimal/ja.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/ja.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/ja.js"
 import { test } from "./decimalTest"
-import * as localeData from "../locale-data/ja.json"
+import * as localeData from "../locale-data/ja.json" with {type: 'json'}
 test("ja", localeData);

--- a/packages/intl-numberformat/tests/decimal/ko.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/ko.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/ko.js"
 import { test } from "./decimalTest"
-import * as localeData from "../locale-data/ko.json"
+import * as localeData from "../locale-data/ko.json" with {type: 'json'}
 test("ko", localeData);

--- a/packages/intl-numberformat/tests/decimal/ms.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/ms.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/ms.js"
 import { test } from "./decimalTest"
-import * as localeData from "../locale-data/ms.json"
+import * as localeData from "../locale-data/ms.json" with {type: 'json'}
 test("ms", localeData);

--- a/packages/intl-numberformat/tests/decimal/nb.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/nb.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/nb.js"
 import { test } from "./decimalTest"
-import * as localeData from "../locale-data/nb.json"
+import * as localeData from "../locale-data/nb.json" with {type: 'json'}
 test("nb", localeData);

--- a/packages/intl-numberformat/tests/decimal/nl.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/nl.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/nl.js"
 import { test } from "./decimalTest"
-import * as localeData from "../locale-data/nl.json"
+import * as localeData from "../locale-data/nl.json" with {type: 'json'}
 test("nl", localeData);

--- a/packages/intl-numberformat/tests/decimal/pl.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/pl.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/pl.js"
 import { test } from "./decimalTest"
-import * as localeData from "../locale-data/pl.json"
+import * as localeData from "../locale-data/pl.json" with {type: 'json'}
 test("pl", localeData);

--- a/packages/intl-numberformat/tests/decimal/pt.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/pt.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/pt.js"
 import { test } from "./decimalTest"
-import * as localeData from "../locale-data/pt.json"
+import * as localeData from "../locale-data/pt.json" with {type: 'json'}
 test("pt", localeData);

--- a/packages/intl-numberformat/tests/decimal/ru.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/ru.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/ru.js"
 import { test } from "./decimalTest"
-import * as localeData from "../locale-data/ru.json"
+import * as localeData from "../locale-data/ru.json" with {type: 'json'}
 test("ru", localeData);

--- a/packages/intl-numberformat/tests/decimal/sv.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/sv.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/sv.js"
 import { test } from "./decimalTest"
-import * as localeData from "../locale-data/sv.json"
+import * as localeData from "../locale-data/sv.json" with {type: 'json'}
 test("sv", localeData);

--- a/packages/intl-numberformat/tests/decimal/th.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/th.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/th.js"
 import { test } from "./decimalTest"
-import * as localeData from "../locale-data/th.json"
+import * as localeData from "../locale-data/th.json" with {type: 'json'}
 test("th", localeData);

--- a/packages/intl-numberformat/tests/decimal/tr.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/tr.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/tr.js"
 import { test } from "./decimalTest"
-import * as localeData from "../locale-data/tr.json"
+import * as localeData from "../locale-data/tr.json" with {type: 'json'}
 test("tr", localeData);

--- a/packages/intl-numberformat/tests/decimal/uk.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/uk.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/uk.js"
 import { test } from "./decimalTest"
-import * as localeData from "../locale-data/uk.json"
+import * as localeData from "../locale-data/uk.json" with {type: 'json'}
 test("uk", localeData);

--- a/packages/intl-numberformat/tests/decimal/zh.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/zh.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/zh.js"
 import { test } from "./decimalTest"
-import * as localeData from "../locale-data/zh.json"
+import * as localeData from "../locale-data/zh.json" with {type: 'json'}
 test("zh", localeData);

--- a/packages/intl-numberformat/tests/notation-compact-ko-KR.test.ts
+++ b/packages/intl-numberformat/tests/notation-compact-ko-KR.test.ts
@@ -3,7 +3,7 @@ import {NumberFormatPart} from '@formatjs/ecma402-abstract'
 import '@formatjs/intl-pluralrules/locale-data/ko'
 import '@formatjs/intl-pluralrules/polyfill.js'
 import {NumberFormat} from '../src/core'
-import * as ko from './locale-data/ko.json'
+import * as ko from './locale-data/ko.json' with {type: 'json'}
 NumberFormat.__addLocaleData(ko as any)
 
 const tests: Array<[number, NumberFormatPart[]]> = [

--- a/packages/intl-numberformat/tests/notation-compact-zh-TW.test.ts
+++ b/packages/intl-numberformat/tests/notation-compact-zh-TW.test.ts
@@ -4,8 +4,8 @@ import '@formatjs/intl-locale/polyfill.js'
 import '@formatjs/intl-pluralrules/polyfill.js'
 import '@formatjs/intl-pluralrules/locale-data/zh'
 import '@formatjs/intl-pluralrules/polyfill.js'
-import * as zh from './locale-data/zh.json'
-import * as zhHant from './locale-data/zh-Hant.json'
+import * as zh from './locale-data/zh.json' with {type: 'json'}
+import * as zhHant from './locale-data/zh-Hant.json' with {type: 'json'}
 import {NumberFormat} from '../src/core'
 NumberFormat.__addLocaleData(zh as any, zhHant as any)
 

--- a/packages/intl-numberformat/tests/percent/da.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/da.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/da.js"
 import { test } from "./percentTest"
-import * as localeData from "../locale-data/da.json"
+import * as localeData from "../locale-data/da.json" with {type: 'json'}
 test("da", localeData);

--- a/packages/intl-numberformat/tests/percent/de.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/de.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/de.js"
 import { test } from "./percentTest"
-import * as localeData from "../locale-data/de.json"
+import * as localeData from "../locale-data/de.json" with {type: 'json'}
 test("de", localeData);

--- a/packages/intl-numberformat/tests/percent/en-BS.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/en-BS.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/en.js"
 import { test } from "./percentTest"
-import * as localeData from "../locale-data/en-BS.json"
+import * as localeData from "../locale-data/en-BS.json" with {type: 'json'}
 test("en-BS", localeData);

--- a/packages/intl-numberformat/tests/percent/en-GB.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/en-GB.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/en.js"
 import { test } from "./percentTest"
-import * as localeData from "../locale-data/en-GB.json"
+import * as localeData from "../locale-data/en-GB.json" with {type: 'json'}
 test("en-GB", localeData);

--- a/packages/intl-numberformat/tests/percent/en.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/en.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/en.js"
 import { test } from "./percentTest"
-import * as localeData from "../locale-data/en.json"
+import * as localeData from "../locale-data/en.json" with {type: 'json'}
 test("en", localeData);

--- a/packages/intl-numberformat/tests/percent/es.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/es.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/es.js"
 import { test } from "./percentTest"
-import * as localeData from "../locale-data/es.json"
+import * as localeData from "../locale-data/es.json" with {type: 'json'}
 test("es", localeData);

--- a/packages/intl-numberformat/tests/percent/fr.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/fr.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/fr.js"
 import { test } from "./percentTest"
-import * as localeData from "../locale-data/fr.json"
+import * as localeData from "../locale-data/fr.json" with {type: 'json'}
 test("fr", localeData);

--- a/packages/intl-numberformat/tests/percent/id.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/id.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/id.js"
 import { test } from "./percentTest"
-import * as localeData from "../locale-data/id.json"
+import * as localeData from "../locale-data/id.json" with {type: 'json'}
 test("id", localeData);

--- a/packages/intl-numberformat/tests/percent/it.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/it.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/it.js"
 import { test } from "./percentTest"
-import * as localeData from "../locale-data/it.json"
+import * as localeData from "../locale-data/it.json" with {type: 'json'}
 test("it", localeData);

--- a/packages/intl-numberformat/tests/percent/ja.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/ja.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/ja.js"
 import { test } from "./percentTest"
-import * as localeData from "../locale-data/ja.json"
+import * as localeData from "../locale-data/ja.json" with {type: 'json'}
 test("ja", localeData);

--- a/packages/intl-numberformat/tests/percent/ko.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/ko.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/ko.js"
 import { test } from "./percentTest"
-import * as localeData from "../locale-data/ko.json"
+import * as localeData from "../locale-data/ko.json" with {type: 'json'}
 test("ko", localeData);

--- a/packages/intl-numberformat/tests/percent/ms.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/ms.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/ms.js"
 import { test } from "./percentTest"
-import * as localeData from "../locale-data/ms.json"
+import * as localeData from "../locale-data/ms.json" with {type: 'json'}
 test("ms", localeData);

--- a/packages/intl-numberformat/tests/percent/nb.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/nb.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/nb.js"
 import { test } from "./percentTest"
-import * as localeData from "../locale-data/nb.json"
+import * as localeData from "../locale-data/nb.json" with {type: 'json'}
 test("nb", localeData);

--- a/packages/intl-numberformat/tests/percent/nl.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/nl.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/nl.js"
 import { test } from "./percentTest"
-import * as localeData from "../locale-data/nl.json"
+import * as localeData from "../locale-data/nl.json" with {type: 'json'}
 test("nl", localeData);

--- a/packages/intl-numberformat/tests/percent/pl.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/pl.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/pl.js"
 import { test } from "./percentTest"
-import * as localeData from "../locale-data/pl.json"
+import * as localeData from "../locale-data/pl.json" with {type: 'json'}
 test("pl", localeData);

--- a/packages/intl-numberformat/tests/percent/pt.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/pt.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/pt.js"
 import { test } from "./percentTest"
-import * as localeData from "../locale-data/pt.json"
+import * as localeData from "../locale-data/pt.json" with {type: 'json'}
 test("pt", localeData);

--- a/packages/intl-numberformat/tests/percent/ru.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/ru.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/ru.js"
 import { test } from "./percentTest"
-import * as localeData from "../locale-data/ru.json"
+import * as localeData from "../locale-data/ru.json" with {type: 'json'}
 test("ru", localeData);

--- a/packages/intl-numberformat/tests/percent/sv.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/sv.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/sv.js"
 import { test } from "./percentTest"
-import * as localeData from "../locale-data/sv.json"
+import * as localeData from "../locale-data/sv.json" with {type: 'json'}
 test("sv", localeData);

--- a/packages/intl-numberformat/tests/percent/th.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/th.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/th.js"
 import { test } from "./percentTest"
-import * as localeData from "../locale-data/th.json"
+import * as localeData from "../locale-data/th.json" with {type: 'json'}
 test("th", localeData);

--- a/packages/intl-numberformat/tests/percent/tr.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/tr.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/tr.js"
 import { test } from "./percentTest"
-import * as localeData from "../locale-data/tr.json"
+import * as localeData from "../locale-data/tr.json" with {type: 'json'}
 test("tr", localeData);

--- a/packages/intl-numberformat/tests/percent/uk.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/uk.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/uk.js"
 import { test } from "./percentTest"
-import * as localeData from "../locale-data/uk.json"
+import * as localeData from "../locale-data/uk.json" with {type: 'json'}
 test("uk", localeData);

--- a/packages/intl-numberformat/tests/percent/zh.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/zh.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/zh.js"
 import { test } from "./percentTest"
-import * as localeData from "../locale-data/zh.json"
+import * as localeData from "../locale-data/zh.json" with {type: 'json'}
 test("zh", localeData);

--- a/packages/intl-numberformat/tests/signDisplay-currency-zh-TW.test.ts
+++ b/packages/intl-numberformat/tests/signDisplay-currency-zh-TW.test.ts
@@ -3,8 +3,8 @@ import '@formatjs/intl-getcanonicallocales/polyfill.js'
 import '@formatjs/intl-locale/polyfill.js'
 import '@formatjs/intl-pluralrules/polyfill.js'
 import '@formatjs/intl-pluralrules/locale-data/zh'
-import * as zh from './locale-data/zh.json'
-import * as zhHant from './locale-data/zh-Hant.json'
+import * as zh from './locale-data/zh.json' with {type: 'json'}
+import * as zhHant from './locale-data/zh-Hant.json' with {type: 'json'}
 import {NumberFormat} from '../src/core'
 NumberFormat.__addLocaleData(zh as any, zhHant as any)
 const tests = [

--- a/packages/intl-numberformat/tests/signDisplay-zh-TW.test.ts
+++ b/packages/intl-numberformat/tests/signDisplay-zh-TW.test.ts
@@ -3,8 +3,8 @@ import '@formatjs/intl-getcanonicallocales/polyfill.js'
 import '@formatjs/intl-locale/polyfill.js'
 import '@formatjs/intl-pluralrules/polyfill.js'
 import '@formatjs/intl-pluralrules/locale-data/zh'
-import * as zh from './locale-data/zh.json'
-import * as zhHant from './locale-data/zh-Hant.json'
+import * as zh from './locale-data/zh.json' with {type: 'json'}
+import * as zhHant from './locale-data/zh-Hant.json' with {type: 'json'}
 import {NumberFormat} from '../src/core'
 NumberFormat.__addLocaleData(zh as any, zhHant as any)
 

--- a/packages/intl-numberformat/tests/unit-zh-TW.test.ts
+++ b/packages/intl-numberformat/tests/unit-zh-TW.test.ts
@@ -4,8 +4,8 @@ import '@formatjs/intl-locale/polyfill.js'
 import '@formatjs/intl-pluralrules/locale-data/zh'
 import '@formatjs/intl-pluralrules/polyfill.js'
 import {NumberFormat} from '../src/core'
-import * as zhHant from './locale-data/zh-Hant.json'
-import * as zh from './locale-data/zh.json'
+import * as zhHant from './locale-data/zh-Hant.json' with {type: 'json'}
+import * as zh from './locale-data/zh.json' with {type: 'json'}
 NumberFormat.__addLocaleData(zh as any, zhHant as any)
 
 const tests: Array<

--- a/packages/intl-numberformat/tests/unit/da.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/da.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/da.js"
 import { test } from "./unitTest"
-import * as localeData from "../locale-data/da.json"
+import * as localeData from "../locale-data/da.json" with {type: 'json'}
 test("da", localeData);

--- a/packages/intl-numberformat/tests/unit/de.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/de.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/de.js"
 import { test } from "./unitTest"
-import * as localeData from "../locale-data/de.json"
+import * as localeData from "../locale-data/de.json" with {type: 'json'}
 test("de", localeData);

--- a/packages/intl-numberformat/tests/unit/en-BS.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/en-BS.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/en.js"
 import { test } from "./unitTest"
-import * as localeData from "../locale-data/en-BS.json"
+import * as localeData from "../locale-data/en-BS.json" with {type: 'json'}
 test("en-BS", localeData);

--- a/packages/intl-numberformat/tests/unit/en-GB.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/en-GB.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/en.js"
 import { test } from "./unitTest"
-import * as localeData from "../locale-data/en-GB.json"
+import * as localeData from "../locale-data/en-GB.json" with {type: 'json'}
 test("en-GB", localeData);

--- a/packages/intl-numberformat/tests/unit/en.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/en.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/en.js"
 import { test } from "./unitTest"
-import * as localeData from "../locale-data/en.json"
+import * as localeData from "../locale-data/en.json" with {type: 'json'}
 test("en", localeData);

--- a/packages/intl-numberformat/tests/unit/es.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/es.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/es.js"
 import { test } from "./unitTest"
-import * as localeData from "../locale-data/es.json"
+import * as localeData from "../locale-data/es.json" with {type: 'json'}
 test("es", localeData);

--- a/packages/intl-numberformat/tests/unit/fr.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/fr.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/fr.js"
 import { test } from "./unitTest"
-import * as localeData from "../locale-data/fr.json"
+import * as localeData from "../locale-data/fr.json" with {type: 'json'}
 test("fr", localeData);

--- a/packages/intl-numberformat/tests/unit/id.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/id.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/id.js"
 import { test } from "./unitTest"
-import * as localeData from "../locale-data/id.json"
+import * as localeData from "../locale-data/id.json" with {type: 'json'}
 test("id", localeData);

--- a/packages/intl-numberformat/tests/unit/it.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/it.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/it.js"
 import { test } from "./unitTest"
-import * as localeData from "../locale-data/it.json"
+import * as localeData from "../locale-data/it.json" with {type: 'json'}
 test("it", localeData);

--- a/packages/intl-numberformat/tests/unit/ja.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/ja.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/ja.js"
 import { test } from "./unitTest"
-import * as localeData from "../locale-data/ja.json"
+import * as localeData from "../locale-data/ja.json" with {type: 'json'}
 test("ja", localeData);

--- a/packages/intl-numberformat/tests/unit/ko.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/ko.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/ko.js"
 import { test } from "./unitTest"
-import * as localeData from "../locale-data/ko.json"
+import * as localeData from "../locale-data/ko.json" with {type: 'json'}
 test("ko", localeData);

--- a/packages/intl-numberformat/tests/unit/ms.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/ms.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/ms.js"
 import { test } from "./unitTest"
-import * as localeData from "../locale-data/ms.json"
+import * as localeData from "../locale-data/ms.json" with {type: 'json'}
 test("ms", localeData);

--- a/packages/intl-numberformat/tests/unit/nb.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/nb.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/nb.js"
 import { test } from "./unitTest"
-import * as localeData from "../locale-data/nb.json"
+import * as localeData from "../locale-data/nb.json" with {type: 'json'}
 test("nb", localeData);

--- a/packages/intl-numberformat/tests/unit/nl.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/nl.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/nl.js"
 import { test } from "./unitTest"
-import * as localeData from "../locale-data/nl.json"
+import * as localeData from "../locale-data/nl.json" with {type: 'json'}
 test("nl", localeData);

--- a/packages/intl-numberformat/tests/unit/pl.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/pl.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/pl.js"
 import { test } from "./unitTest"
-import * as localeData from "../locale-data/pl.json"
+import * as localeData from "../locale-data/pl.json" with {type: 'json'}
 test("pl", localeData);

--- a/packages/intl-numberformat/tests/unit/pt.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/pt.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/pt.js"
 import { test } from "./unitTest"
-import * as localeData from "../locale-data/pt.json"
+import * as localeData from "../locale-data/pt.json" with {type: 'json'}
 test("pt", localeData);

--- a/packages/intl-numberformat/tests/unit/ru.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/ru.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/ru.js"
 import { test } from "./unitTest"
-import * as localeData from "../locale-data/ru.json"
+import * as localeData from "../locale-data/ru.json" with {type: 'json'}
 test("ru", localeData);

--- a/packages/intl-numberformat/tests/unit/sv.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/sv.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/sv.js"
 import { test } from "./unitTest"
-import * as localeData from "../locale-data/sv.json"
+import * as localeData from "../locale-data/sv.json" with {type: 'json'}
 test("sv", localeData);

--- a/packages/intl-numberformat/tests/unit/th.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/th.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/th.js"
 import { test } from "./unitTest"
-import * as localeData from "../locale-data/th.json"
+import * as localeData from "../locale-data/th.json" with {type: 'json'}
 test("th", localeData);

--- a/packages/intl-numberformat/tests/unit/tr.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/tr.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/tr.js"
 import { test } from "./unitTest"
-import * as localeData from "../locale-data/tr.json"
+import * as localeData from "../locale-data/tr.json" with {type: 'json'}
 test("tr", localeData);

--- a/packages/intl-numberformat/tests/unit/uk.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/uk.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/uk.js"
 import { test } from "./unitTest"
-import * as localeData from "../locale-data/uk.json"
+import * as localeData from "../locale-data/uk.json" with {type: 'json'}
 test("uk", localeData);

--- a/packages/intl-numberformat/tests/unit/zh.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/zh.generated.test.ts
@@ -1,4 +1,4 @@
 import "@formatjs/intl-pluralrules/locale-data/zh.js"
 import { test } from "./unitTest"
-import * as localeData from "../locale-data/zh.json"
+import * as localeData from "../locale-data/zh.json" with {type: 'json'}
 test("zh", localeData);

--- a/packages/intl-numberformat/tests/value-tonumber.test.ts
+++ b/packages/intl-numberformat/tests/value-tonumber.test.ts
@@ -1,7 +1,7 @@
 import {describe, it, expect} from 'vitest'
 import '@formatjs/intl-pluralrules/polyfill.js'
 import '@formatjs/intl-pluralrules/locale-data/en'
-import * as en from './locale-data/en.json'
+import * as en from './locale-data/en.json' with {type: 'json'}
 import {NumberFormat} from '../src/core'
 NumberFormat.__addLocaleData(en as any)
 const toNumberResults = [

--- a/packages/intl-relativetimeformat/scripts/extract-relative.ts
+++ b/packages/intl-relativetimeformat/scripts/extract-relative.ts
@@ -5,12 +5,12 @@
  */
 'use strict'
 
-import * as DateFields from 'cldr-dates-full/main/en/dateFields.json'
-import * as NumberFields from 'cldr-numbers-full/main/en/numbers.json'
+import * as DateFields from 'cldr-dates-full/main/en/dateFields.json' with {type: 'json'}
+import * as NumberFields from 'cldr-numbers-full/main/en/numbers.json' with {type: 'json'}
 import glob from 'fast-glob'
 import {resolve, dirname} from 'path'
 import {FieldData, LocaleFieldsData} from '@formatjs/ecma402-abstract'
-import * as AVAILABLE_LOCALES from 'cldr-core/availableLocales.json'
+import * as AVAILABLE_LOCALES from 'cldr-core/availableLocales.json' with {type: 'json'}
 
 // The set of CLDR date field names that are used in FormatJS.
 const FIELD_NAMES = [

--- a/packages/intl-relativetimeformat/tests/index.test.ts
+++ b/packages/intl-relativetimeformat/tests/index.test.ts
@@ -3,11 +3,11 @@ import '@formatjs/intl-locale/polyfill.js'
 import '@formatjs/intl-pluralrules/polyfill.js'
 import '@formatjs/intl-pluralrules/locale-data/zh'
 import '@formatjs/intl-pluralrules/locale-data/en'
-import * as zh from './locale-data/zh.json'
-import * as zhHant from './locale-data/zh-Hant.json'
-import * as zhHans from './locale-data/zh-Hans.json'
-import * as en from './locale-data/en.json'
-import * as enAI from './locale-data/en-AI.json'
+import * as zh from './locale-data/zh.json' with {type: 'json'}
+import * as zhHant from './locale-data/zh-Hant.json' with {type: 'json'}
+import * as zhHans from './locale-data/zh-Hans.json' with {type: 'json'}
+import * as en from './locale-data/en.json' with {type: 'json'}
+import * as enAI from './locale-data/en-AI.json' with {type: 'json'}
 import RelativeTimeFormat from '../index.js'
 import {describe, expect, it} from 'vitest'
 RelativeTimeFormat.__addLocaleData(en, enAI, zh, zhHans, zhHant)

--- a/packages/intl-relativetimeformat/tests/supported-locales-of.test.ts
+++ b/packages/intl-relativetimeformat/tests/supported-locales-of.test.ts
@@ -3,11 +3,11 @@ import '@formatjs/intl-locale/polyfill.js'
 import '@formatjs/intl-pluralrules/polyfill.js'
 import '@formatjs/intl-pluralrules/locale-data/en'
 import '@formatjs/intl-pluralrules/locale-data/zh'
-import * as zh from './locale-data/zh.json'
-import * as zhHant from './locale-data/zh-Hant.json'
-import * as zhHans from './locale-data/zh-Hans.json'
-import * as en from './locale-data/en.json'
-import * as enAI from './locale-data/en-AI.json'
+import * as zh from './locale-data/zh.json' with {type: 'json'}
+import * as zhHant from './locale-data/zh-Hant.json' with {type: 'json'}
+import * as zhHans from './locale-data/zh-Hans.json' with {type: 'json'}
+import * as en from './locale-data/en.json' with {type: 'json'}
+import * as enAI from './locale-data/en-AI.json' with {type: 'json'}
 import RelativeTimeFormat from '../index.js'
 import {describe, expect, it} from 'vitest'
 RelativeTimeFormat.__addLocaleData(en, enAI, zh, zhHans, zhHant)

--- a/packages/react-intl/examples/StaticTypeSafetyAndCodeSplitting/intlHelpers.tsx
+++ b/packages/react-intl/examples/StaticTypeSafetyAndCodeSplitting/intlHelpers.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import {IntlProvider as IntlProvider_, useIntl} from 'react-intl'
 
 // "import type" ensures en messages aren't bundled by default
-import * as sourceOfTruth from './en.json'
+import * as sourceOfTruth from './en.json' with {type: 'json'}
 // Note: in order to use "import type" you'll need Babel >= 7.9.0 and/or TypeScript >= 3.8.
 // Otherwise, you can use a normal import and accept to always bundle one language + the user required one
 

--- a/packages/utils/src/countryCodes.ts
+++ b/packages/utils/src/countryCodes.ts
@@ -1,4 +1,4 @@
-import * as alpha3CountryCodes from './iso3166Alpha3CountryCodes.json'
+import * as alpha3CountryCodes from './iso3166Alpha3CountryCodes.json' with {type: 'json'}
 
 const COUNTRY_CODE_ALPHA2 = new Set(
   Object.keys(alpha3CountryCodes).map(

--- a/packages/utils/src/defaultCurrency.ts
+++ b/packages/utils/src/defaultCurrency.ts
@@ -1,5 +1,5 @@
 import {canonicalizeCountryCode} from './countryCodes.js'
-import * as data from './defaultCurrencyData.generated.json'
+import * as data from './defaultCurrencyData.generated.json' with {type: 'json'}
 
 const COUNTRIES_BY_DEFAULT_CURRENCY = Object.keys(data).reduce<
   Record<string, string[]>

--- a/packages/utils/src/defaultLocale.ts
+++ b/packages/utils/src/defaultLocale.ts
@@ -1,5 +1,5 @@
 import {canonicalizeCountryCode} from './countryCodes.js'
-import * as data from './defaultLocaleData.generated.json'
+import * as data from './defaultLocaleData.generated.json' with {type: 'json'}
 
 /**
  * Look up default locale for a country code.

--- a/packages/utils/src/iso4217.ts
+++ b/packages/utils/src/iso4217.ts
@@ -1,4 +1,4 @@
-import * as iso4217 from './currencyMinorUnits.generated.json'
+import * as iso4217 from './currencyMinorUnits.generated.json' with {type: 'json'}
 
 /**
  * Returns the number of minor units (decimal places) for a given currency code.

--- a/website/docs/guides/testing-with-react-intl.md
+++ b/website/docs/guides/testing-with-react-intl.md
@@ -158,7 +158,7 @@ We recommend using [`@testing-library/react`](https://testing-library.com/docs/r
 import React from 'react'
 import {render as rtlRender} from '@testing-library/react'
 import {IntlProvider} from 'react-intl'
-import messages from '../locales/en.json' with {type: 'json'}
+import * as messages from '../locales/en.json' with {type: 'json'}
 
 interface RenderOptions {
   locale?: string
@@ -310,7 +310,7 @@ You can use the same test helper function from the `@testing-library/react` sect
 import React from 'react'
 import {render as rtlRender} from '@testing-library/react'
 import {IntlProvider} from 'react-intl'
-import messages from '../locales/en.json' with {type: 'json'}
+import * as messages from '../locales/en.json' with {type: 'json'}
 
 interface RenderOptions {
   locale?: string


### PR DESCRIPTION
### TL;DR

Added `with {type: 'json'}` to all JSON imports to support the new import attributes syntax.

### What changed?

Updated all JSON imports across the codebase to use the new import attributes syntax by adding `with {type: 'json'}` to each import statement. This change affects multiple packages including:

- icu-messageformat-parser
- intl-datetimeformat
- intl-displaynames
- intl-getcanonicallocales
- intl-listformat
- intl-locale
- intl-numberformat
- intl-relativetimeformat
- react-intl
- utils

### How to test?

1. Run the test suite to ensure all tests pass with the new import syntax
2. Verify that the build process completes successfully
3. Check that the generated code correctly handles JSON imports

### Why make this change?

This change adopts the new ECMAScript import attributes syntax, which is the standardized way to specify how imported resources should be interpreted. The `with {type: 'json'}` attribute explicitly tells the JavaScript runtime that the imported file should be treated as JSON, improving type safety and compatibility with newer JavaScript runtimes and bundlers.