### PR TITLE
build: port datetime skeleton parser to rust

### DIFF
--- a/packages/icu-skeleton-parser/rust/BUILD.bazel
+++ b/packages/icu-skeleton-parser/rust/BUILD.bazel
@@ -3,6 +3,8 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 rust_library(
     name = "icu_skeleton_parser",
     srcs = [
+        "datetime_format_options.rs",
+        "datetime_parser.rs",
         "lib.rs",
         "number_format_options.rs",
         "number_skeleton_token.rs",

--- a/packages/icu-skeleton-parser/rust/datetime_format_options.rs
+++ b/packages/icu-skeleton-parser/rust/datetime_format_options.rs
@@ -1,0 +1,390 @@
+use serde::{Deserialize, Serialize};
+
+/// Represents the era format in date-time formatting
+/// Corresponds to Intl.DateTimeFormatOptions.era
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DateTimeFormatEra {
+    Long,
+    Short,
+    Narrow,
+}
+
+/// Represents the year format in date-time formatting
+/// Corresponds to Intl.DateTimeFormatOptions.year
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum DateTimeFormatYear {
+    Numeric,
+    #[serde(rename = "2-digit")]
+    TwoDigit,
+}
+
+/// Represents the month format in date-time formatting
+/// Corresponds to Intl.DateTimeFormatOptions.month
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DateTimeFormatMonth {
+    Numeric,
+    #[serde(rename = "2-digit")]
+    TwoDigit,
+    Short,
+    Long,
+    Narrow,
+}
+
+/// Represents the day format in date-time formatting
+/// Corresponds to Intl.DateTimeFormatOptions.day
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DateTimeFormatDay {
+    Numeric,
+    #[serde(rename = "2-digit")]
+    TwoDigit,
+}
+
+/// Represents the weekday format in date-time formatting
+/// Corresponds to Intl.DateTimeFormatOptions.weekday
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DateTimeFormatWeekday {
+    Long,
+    Short,
+    Narrow,
+}
+
+/// Represents the hour format in date-time formatting
+/// Corresponds to Intl.DateTimeFormatOptions.hour
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DateTimeFormatHour {
+    Numeric,
+    #[serde(rename = "2-digit")]
+    TwoDigit,
+}
+
+/// Represents the hour cycle format in date-time formatting
+/// Corresponds to Intl.DateTimeFormatOptions.hourCycle
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DateTimeFormatHourCycle {
+    H11,
+    H12,
+    H23,
+    H24,
+}
+
+/// Represents the minute format in date-time formatting
+/// Corresponds to Intl.DateTimeFormatOptions.minute
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DateTimeFormatMinute {
+    Numeric,
+    #[serde(rename = "2-digit")]
+    TwoDigit,
+}
+
+/// Represents the second format in date-time formatting
+/// Corresponds to Intl.DateTimeFormatOptions.second
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DateTimeFormatSecond {
+    Numeric,
+    #[serde(rename = "2-digit")]
+    TwoDigit,
+}
+
+/// Represents the time zone name format in date-time formatting
+/// Corresponds to Intl.DateTimeFormatOptions.timeZoneName
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DateTimeFormatTimeZoneName {
+    Short,
+    Long,
+}
+
+/// Represents the date-time format options
+/// Corresponds to Intl.DateTimeFormatOptions
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DateTimeFormatOptions {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub era: Option<DateTimeFormatEra>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub year: Option<DateTimeFormatYear>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub month: Option<DateTimeFormatMonth>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub day: Option<DateTimeFormatDay>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub weekday: Option<DateTimeFormatWeekday>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hour: Option<DateTimeFormatHour>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hour12: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hour_cycle: Option<DateTimeFormatHourCycle>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub minute: Option<DateTimeFormatMinute>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub second: Option<DateTimeFormatSecond>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub time_zone_name: Option<DateTimeFormatTimeZoneName>,
+}
+
+impl DateTimeFormatOptions {
+    /// Create a new DateTimeFormatOptions with default values
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    // Getters
+    pub fn era(&self) -> Option<&DateTimeFormatEra> {
+        self.era.as_ref()
+    }
+
+    pub fn year(&self) -> Option<&DateTimeFormatYear> {
+        self.year.as_ref()
+    }
+
+    pub fn month(&self) -> Option<&DateTimeFormatMonth> {
+        self.month.as_ref()
+    }
+
+    pub fn day(&self) -> Option<&DateTimeFormatDay> {
+        self.day.as_ref()
+    }
+
+    pub fn weekday(&self) -> Option<&DateTimeFormatWeekday> {
+        self.weekday.as_ref()
+    }
+
+    pub fn hour(&self) -> Option<&DateTimeFormatHour> {
+        self.hour.as_ref()
+    }
+
+    pub fn hour12(&self) -> Option<bool> {
+        self.hour12
+    }
+
+    pub fn hour_cycle(&self) -> Option<&DateTimeFormatHourCycle> {
+        self.hour_cycle.as_ref()
+    }
+
+    pub fn minute(&self) -> Option<&DateTimeFormatMinute> {
+        self.minute.as_ref()
+    }
+
+    pub fn second(&self) -> Option<&DateTimeFormatSecond> {
+        self.second.as_ref()
+    }
+
+    pub fn time_zone_name(&self) -> Option<&DateTimeFormatTimeZoneName> {
+        self.time_zone_name.as_ref()
+    }
+
+    // Setters (builder pattern)
+    pub fn with_era(mut self, era: DateTimeFormatEra) -> Self {
+        self.era = Some(era);
+        self
+    }
+
+    pub fn with_year(mut self, year: DateTimeFormatYear) -> Self {
+        self.year = Some(year);
+        self
+    }
+
+    pub fn with_month(mut self, month: DateTimeFormatMonth) -> Self {
+        self.month = Some(month);
+        self
+    }
+
+    pub fn with_day(mut self, day: DateTimeFormatDay) -> Self {
+        self.day = Some(day);
+        self
+    }
+
+    pub fn with_weekday(mut self, weekday: DateTimeFormatWeekday) -> Self {
+        self.weekday = Some(weekday);
+        self
+    }
+
+    pub fn with_hour(mut self, hour: DateTimeFormatHour) -> Self {
+        self.hour = Some(hour);
+        self
+    }
+
+    pub fn with_hour12(mut self, hour12: bool) -> Self {
+        self.hour12 = Some(hour12);
+        self
+    }
+
+    pub fn with_hour_cycle(mut self, hour_cycle: DateTimeFormatHourCycle) -> Self {
+        self.hour_cycle = Some(hour_cycle);
+        self
+    }
+
+    pub fn with_minute(mut self, minute: DateTimeFormatMinute) -> Self {
+        self.minute = Some(minute);
+        self
+    }
+
+    pub fn with_second(mut self, second: DateTimeFormatSecond) -> Self {
+        self.second = Some(second);
+        self
+    }
+
+    pub fn with_time_zone_name(mut self, time_zone_name: DateTimeFormatTimeZoneName) -> Self {
+        self.time_zone_name = Some(time_zone_name);
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_datetime_format_options_creation() {
+        let options = DateTimeFormatOptions::new()
+            .with_year(DateTimeFormatYear::Numeric)
+            .with_month(DateTimeFormatMonth::Long)
+            .with_day(DateTimeFormatDay::TwoDigit);
+
+        assert_eq!(options.year(), Some(&DateTimeFormatYear::Numeric));
+        assert_eq!(options.month(), Some(&DateTimeFormatMonth::Long));
+        assert_eq!(options.day(), Some(&DateTimeFormatDay::TwoDigit));
+    }
+
+    #[test]
+    fn test_datetime_format_options_serialization() {
+        let options = DateTimeFormatOptions::new()
+            .with_year(DateTimeFormatYear::Numeric)
+            .with_month(DateTimeFormatMonth::Short)
+            .with_hour(DateTimeFormatHour::TwoDigit)
+            .with_hour_cycle(DateTimeFormatHourCycle::H23);
+
+        let json = serde_json::to_string(&options).unwrap();
+        assert!(json.contains("\"year\":\"numeric\""));
+        assert!(json.contains("\"month\":\"short\""));
+        assert!(json.contains("\"hour\":\"2-digit\""));
+        assert!(json.contains("\"hourCycle\":\"h23\""));
+    }
+
+    #[test]
+    fn test_datetime_format_options_deserialization() {
+        let json = r#"{"year":"2-digit","month":"long","day":"numeric"}"#;
+        let options: DateTimeFormatOptions = serde_json::from_str(json).unwrap();
+
+        assert_eq!(options.year(), Some(&DateTimeFormatYear::TwoDigit));
+        assert_eq!(options.month(), Some(&DateTimeFormatMonth::Long));
+        assert_eq!(options.day(), Some(&DateTimeFormatDay::Numeric));
+    }
+
+    #[test]
+    fn test_hour12_boolean() {
+        let options = DateTimeFormatOptions::new()
+            .with_hour12(true)
+            .with_hour(DateTimeFormatHour::Numeric);
+
+        assert_eq!(options.hour12(), Some(true));
+
+        let json = serde_json::to_string(&options).unwrap();
+        assert!(json.contains("\"hour12\":true"));
+    }
+
+    #[test]
+    fn test_hour_cycle_values() {
+        let h11 = DateTimeFormatOptions::new()
+            .with_hour_cycle(DateTimeFormatHourCycle::H11);
+        let h12 = DateTimeFormatOptions::new()
+            .with_hour_cycle(DateTimeFormatHourCycle::H12);
+        let h23 = DateTimeFormatOptions::new()
+            .with_hour_cycle(DateTimeFormatHourCycle::H23);
+        let h24 = DateTimeFormatOptions::new()
+            .with_hour_cycle(DateTimeFormatHourCycle::H24);
+
+        assert_eq!(h11.hour_cycle(), Some(&DateTimeFormatHourCycle::H11));
+        assert_eq!(h12.hour_cycle(), Some(&DateTimeFormatHourCycle::H12));
+        assert_eq!(h23.hour_cycle(), Some(&DateTimeFormatHourCycle::H23));
+        assert_eq!(h24.hour_cycle(), Some(&DateTimeFormatHourCycle::H24));
+    }
+
+    #[test]
+    fn test_weekday_values() {
+        let json_long = r#"{"weekday":"long"}"#;
+        let json_short = r#"{"weekday":"short"}"#;
+        let json_narrow = r#"{"weekday":"narrow"}"#;
+
+        let opts_long: DateTimeFormatOptions = serde_json::from_str(json_long).unwrap();
+        let opts_short: DateTimeFormatOptions = serde_json::from_str(json_short).unwrap();
+        let opts_narrow: DateTimeFormatOptions = serde_json::from_str(json_narrow).unwrap();
+
+        assert_eq!(opts_long.weekday(), Some(&DateTimeFormatWeekday::Long));
+        assert_eq!(opts_short.weekday(), Some(&DateTimeFormatWeekday::Short));
+        assert_eq!(opts_narrow.weekday(), Some(&DateTimeFormatWeekday::Narrow));
+    }
+
+    #[test]
+    fn test_time_zone_name() {
+        let options = DateTimeFormatOptions::new()
+            .with_time_zone_name(DateTimeFormatTimeZoneName::Long);
+
+        assert_eq!(
+            options.time_zone_name(),
+            Some(&DateTimeFormatTimeZoneName::Long)
+        );
+
+        let json = serde_json::to_string(&options).unwrap();
+        assert!(json.contains("\"timeZoneName\":\"long\""));
+    }
+
+    #[test]
+    fn test_era_values() {
+        let options = DateTimeFormatOptions::new()
+            .with_era(DateTimeFormatEra::Short);
+
+        assert_eq!(options.era(), Some(&DateTimeFormatEra::Short));
+    }
+
+    #[test]
+    fn test_default_empty() {
+        let options = DateTimeFormatOptions::default();
+
+        assert_eq!(options.era(), None);
+        assert_eq!(options.year(), None);
+        assert_eq!(options.month(), None);
+        assert_eq!(options.day(), None);
+        assert_eq!(options.weekday(), None);
+        assert_eq!(options.hour(), None);
+        assert_eq!(options.hour12(), None);
+        assert_eq!(options.hour_cycle(), None);
+        assert_eq!(options.minute(), None);
+        assert_eq!(options.second(), None);
+        assert_eq!(options.time_zone_name(), None);
+    }
+
+    #[test]
+    fn test_skip_serializing_none_fields() {
+        let options = DateTimeFormatOptions::new()
+            .with_year(DateTimeFormatYear::Numeric);
+
+        let json = serde_json::to_string(&options).unwrap();
+
+        // Should only contain year, not other None fields
+        assert!(json.contains("\"year\":\"numeric\""));
+        assert!(!json.contains("\"month\""));
+        assert!(!json.contains("\"day\""));
+        assert!(!json.contains("\"era\""));
+    }
+}

--- a/packages/icu-skeleton-parser/rust/datetime_parser.rs
+++ b/packages/icu-skeleton-parser/rust/datetime_parser.rs
@@ -1,0 +1,514 @@
+use once_cell::sync::Lazy;
+
+use crate::DateTimeFormatDay;
+use crate::DateTimeFormatEra;
+use crate::DateTimeFormatHour;
+use crate::DateTimeFormatHourCycle;
+use crate::DateTimeFormatMinute;
+use crate::DateTimeFormatMonth;
+use crate::DateTimeFormatOptions;
+use crate::DateTimeFormatSecond;
+use crate::DateTimeFormatTimeZoneName;
+use crate::DateTimeFormatWeekday;
+use crate::DateTimeFormatYear;
+
+/// Regex pattern for matching date-time skeleton tokens
+/// Based on Unicode TR35 Date Field Symbol Table
+/// https://unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table
+///
+/// Note: The original TypeScript regex includes a lookahead pattern to handle quoted strings,
+/// but for simplicity in Rust, we match the basic patterns without the lookahead.
+/// This should work fine for standard skeleton strings that don't contain quoted text.
+///
+/// We also include unsupported patterns (j, J, C, S, A) to explicitly error on them.
+static DATE_TIME_REGEX: Lazy<regex::Regex> = Lazy::new(|| {
+    regex::Regex::new(
+        r"[Eec]{1,6}|G{1,5}|[Qq]{1,5}|[yYur]+|U{1,5}|[ML]{1,5}|d{1,2}|D{1,3}|F{1}|[abB]{1,5}|[hkHKjJC]{1,2}|w{1,2}|W{1}|m{1,2}|[sSA]{1,2}|[zZOvVxX]{1,4}"
+    ).unwrap()
+});
+
+/// Parse a date-time skeleton string into DateTimeFormatOptions
+///
+/// Converts ICU date-time skeleton patterns to ECMA-402 DateTimeFormat options.
+/// Reference: https://unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table
+///
+/// # Arguments
+/// * `skeleton` - The ICU date-time skeleton string to parse
+///
+/// # Returns
+/// `Ok(DateTimeFormatOptions)` with the parsed settings,
+/// or `Err(String)` if the skeleton contains unsupported patterns
+///
+/// # Supported Patterns
+/// - `G` - Era (1-3: short, 4: long, 5: narrow)
+/// - `y` - Year (1+: numeric, 2: 2-digit)
+/// - `M`/`L` - Month (1: numeric, 2: 2-digit, 3: short, 4: long, 5: narrow)
+/// - `d` - Day (1: numeric, 2: 2-digit)
+/// - `E` - Weekday (1-3: short, 4: long, 5-6: narrow)
+/// - `e`/`c` - Weekday (4: short, 5: long, 6: narrow)
+/// - `a` - Period (sets hour12 to true)
+/// - `h` - Hour 1-12 (hourCycle: h12)
+/// - `H` - Hour 0-23 (hourCycle: h23)
+/// - `K` - Hour 0-11 (hourCycle: h11)
+/// - `k` - Hour 1-24 (hourCycle: h24)
+/// - `m` - Minute (1: numeric, 2: 2-digit)
+/// - `s` - Second (1: numeric, 2: 2-digit)
+/// - `z` - Time zone name (1-3: short, 4: long)
+///
+/// # Unsupported Patterns (will return error)
+/// - `Y`, `u`, `U`, `r` - Alternative year patterns
+/// - `q`, `Q` - Quarter patterns
+/// - `w`, `W` - Week patterns
+/// - `D`, `F`, `g` - Alternative day patterns
+/// - `b`, `B` - Alternative period patterns
+/// - `j`, `J`, `C` - Alternative hour patterns
+/// - `S`, `A` - Alternative second patterns
+/// - `Z`, `O`, `v`, `V`, `X`, `x` - Alternative timezone patterns
+///
+/// # Examples
+/// ```
+/// use icu_skeleton_parser::parse_date_time_skeleton;
+///
+/// // Parse a simple date skeleton
+/// let opts = parse_date_time_skeleton("yMMMd").unwrap();
+/// assert!(opts.year().is_some());
+/// assert!(opts.month().is_some());
+/// assert!(opts.day().is_some());
+///
+/// // Parse a time skeleton
+/// let opts = parse_date_time_skeleton("Hms").unwrap();
+/// assert!(opts.hour().is_some());
+/// assert!(opts.minute().is_some());
+/// assert!(opts.second().is_some());
+/// ```
+pub fn parse_date_time_skeleton(skeleton: &str) -> Result<DateTimeFormatOptions, String> {
+    let mut result = DateTimeFormatOptions::default();
+
+    for capture in DATE_TIME_REGEX.captures_iter(skeleton) {
+        if let Some(matched) = capture.get(0) {
+            let match_str = matched.as_str();
+            let len = match_str.len();
+            let first_char = match_str.chars().next().unwrap();
+
+            match first_char {
+                // Era
+                'G' => {
+                    result.era = Some(match len {
+                        4 => DateTimeFormatEra::Long,
+                        5 => DateTimeFormatEra::Narrow,
+                        _ => DateTimeFormatEra::Short,
+                    });
+                }
+                // Year
+                'y' => {
+                    result.year = Some(if len == 2 {
+                        DateTimeFormatYear::TwoDigit
+                    } else {
+                        DateTimeFormatYear::Numeric
+                    });
+                }
+                'Y' | 'u' | 'U' | 'r' => {
+                    return Err(
+                        "`Y/u/U/r` (year) patterns are not supported, use `y` instead".to_string(),
+                    );
+                }
+                // Quarter
+                'q' | 'Q' => {
+                    return Err("`q/Q` (quarter) patterns are not supported".to_string());
+                }
+                // Month
+                'M' | 'L' => {
+                    result.month = Some(match len {
+                        1 => DateTimeFormatMonth::Numeric,
+                        2 => DateTimeFormatMonth::TwoDigit,
+                        3 => DateTimeFormatMonth::Short,
+                        4 => DateTimeFormatMonth::Long,
+                        _ => DateTimeFormatMonth::Narrow, // 5+
+                    });
+                }
+                // Week
+                'w' | 'W' => {
+                    return Err("`w/W` (week) patterns are not supported".to_string());
+                }
+                // Day
+                'd' => {
+                    result.day = Some(if len == 1 {
+                        DateTimeFormatDay::Numeric
+                    } else {
+                        DateTimeFormatDay::TwoDigit
+                    });
+                }
+                'D' | 'F' | 'g' => {
+                    return Err(
+                        "`D/F/g` (day) patterns are not supported, use `d` instead".to_string()
+                    );
+                }
+                // Weekday
+                'E' => {
+                    result.weekday = Some(match len {
+                        4 => DateTimeFormatWeekday::Long,
+                        5..=6 => DateTimeFormatWeekday::Narrow,
+                        _ => DateTimeFormatWeekday::Short,
+                    });
+                }
+                'e' => {
+                    if len < 4 {
+                        return Err("`e..eee` (weekday) patterns are not supported".to_string());
+                    }
+                    result.weekday = Some(match len {
+                        4 => DateTimeFormatWeekday::Short,
+                        5 => DateTimeFormatWeekday::Long,
+                        6 => DateTimeFormatWeekday::Narrow,
+                        _ => DateTimeFormatWeekday::Short,
+                    });
+                }
+                'c' => {
+                    if len < 4 {
+                        return Err("`c..ccc` (weekday) patterns are not supported".to_string());
+                    }
+                    result.weekday = Some(match len {
+                        4 => DateTimeFormatWeekday::Short,
+                        5 => DateTimeFormatWeekday::Long,
+                        6 => DateTimeFormatWeekday::Narrow,
+                        _ => DateTimeFormatWeekday::Short,
+                    });
+                }
+                // Period
+                'a' => {
+                    // AM, PM
+                    result.hour12 = Some(true);
+                }
+                'b' | 'B' => {
+                    return Err(
+                        "`b/B` (period) patterns are not supported, use `a` instead".to_string()
+                    );
+                }
+                // Hour
+                'h' => {
+                    result.hour_cycle = Some(DateTimeFormatHourCycle::H12);
+                    result.hour = Some(if len == 1 {
+                        DateTimeFormatHour::Numeric
+                    } else {
+                        DateTimeFormatHour::TwoDigit
+                    });
+                }
+                'H' => {
+                    result.hour_cycle = Some(DateTimeFormatHourCycle::H23);
+                    result.hour = Some(if len == 1 {
+                        DateTimeFormatHour::Numeric
+                    } else {
+                        DateTimeFormatHour::TwoDigit
+                    });
+                }
+                'K' => {
+                    result.hour_cycle = Some(DateTimeFormatHourCycle::H11);
+                    result.hour = Some(if len == 1 {
+                        DateTimeFormatHour::Numeric
+                    } else {
+                        DateTimeFormatHour::TwoDigit
+                    });
+                }
+                'k' => {
+                    result.hour_cycle = Some(DateTimeFormatHourCycle::H24);
+                    result.hour = Some(if len == 1 {
+                        DateTimeFormatHour::Numeric
+                    } else {
+                        DateTimeFormatHour::TwoDigit
+                    });
+                }
+                'j' | 'J' | 'C' => {
+                    return Err(
+                        "`j/J/C` (hour) patterns are not supported, use `h/H/K/k` instead"
+                            .to_string(),
+                    );
+                }
+                // Minute
+                'm' => {
+                    result.minute = Some(if len == 1 {
+                        DateTimeFormatMinute::Numeric
+                    } else {
+                        DateTimeFormatMinute::TwoDigit
+                    });
+                }
+                // Second
+                's' => {
+                    result.second = Some(if len == 1 {
+                        DateTimeFormatSecond::Numeric
+                    } else {
+                        DateTimeFormatSecond::TwoDigit
+                    });
+                }
+                'S' | 'A' => {
+                    return Err(
+                        "`S/A` (second) patterns are not supported, use `s` instead".to_string()
+                    );
+                }
+                // Zone
+                'z' => {
+                    result.time_zone_name = Some(if len < 4 {
+                        DateTimeFormatTimeZoneName::Short
+                    } else {
+                        DateTimeFormatTimeZoneName::Long
+                    });
+                }
+                'Z' | 'O' | 'v' | 'V' | 'X' | 'x' => {
+                    return Err(
+                        "`Z/O/v/V/X/x` (timeZone) patterns are not supported, use `z` instead"
+                            .to_string(),
+                    );
+                }
+                _ => {
+                    // Ignore unrecognized patterns
+                }
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_year_numeric() {
+        let result = parse_date_time_skeleton("y").unwrap();
+        assert_eq!(result.year(), Some(&DateTimeFormatYear::Numeric));
+    }
+
+    #[test]
+    fn test_parse_year_two_digit() {
+        let result = parse_date_time_skeleton("yy").unwrap();
+        assert_eq!(result.year(), Some(&DateTimeFormatYear::TwoDigit));
+    }
+
+    #[test]
+    fn test_parse_month_formats() {
+        let numeric = parse_date_time_skeleton("M").unwrap();
+        assert_eq!(numeric.month(), Some(&DateTimeFormatMonth::Numeric));
+
+        let two_digit = parse_date_time_skeleton("MM").unwrap();
+        assert_eq!(two_digit.month(), Some(&DateTimeFormatMonth::TwoDigit));
+
+        let short = parse_date_time_skeleton("MMM").unwrap();
+        assert_eq!(short.month(), Some(&DateTimeFormatMonth::Short));
+
+        let long = parse_date_time_skeleton("MMMM").unwrap();
+        assert_eq!(long.month(), Some(&DateTimeFormatMonth::Long));
+
+        let narrow = parse_date_time_skeleton("MMMMM").unwrap();
+        assert_eq!(narrow.month(), Some(&DateTimeFormatMonth::Narrow));
+    }
+
+    #[test]
+    fn test_parse_day_formats() {
+        let numeric = parse_date_time_skeleton("d").unwrap();
+        assert_eq!(numeric.day(), Some(&DateTimeFormatDay::Numeric));
+
+        let two_digit = parse_date_time_skeleton("dd").unwrap();
+        assert_eq!(two_digit.day(), Some(&DateTimeFormatDay::TwoDigit));
+    }
+
+    #[test]
+    fn test_parse_weekday_e() {
+        let short = parse_date_time_skeleton("eeee").unwrap();
+        assert_eq!(short.weekday(), Some(&DateTimeFormatWeekday::Short));
+
+        let long = parse_date_time_skeleton("eeeee").unwrap();
+        assert_eq!(long.weekday(), Some(&DateTimeFormatWeekday::Long));
+
+        let narrow = parse_date_time_skeleton("eeeeee").unwrap();
+        assert_eq!(narrow.weekday(), Some(&DateTimeFormatWeekday::Narrow));
+    }
+
+    #[test]
+    fn test_parse_weekday_e_short_error() {
+        let result = parse_date_time_skeleton("e");
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("`e..eee` (weekday) patterns are not supported"));
+    }
+
+    #[test]
+    fn test_parse_weekday_capital_e() {
+        let short = parse_date_time_skeleton("E").unwrap();
+        assert_eq!(short.weekday(), Some(&DateTimeFormatWeekday::Short));
+
+        let long = parse_date_time_skeleton("EEEE").unwrap();
+        assert_eq!(long.weekday(), Some(&DateTimeFormatWeekday::Long));
+
+        let narrow = parse_date_time_skeleton("EEEEE").unwrap();
+        assert_eq!(narrow.weekday(), Some(&DateTimeFormatWeekday::Narrow));
+    }
+
+    #[test]
+    fn test_parse_era() {
+        let short = parse_date_time_skeleton("G").unwrap();
+        assert_eq!(short.era(), Some(&DateTimeFormatEra::Short));
+
+        let long = parse_date_time_skeleton("GGGG").unwrap();
+        assert_eq!(long.era(), Some(&DateTimeFormatEra::Long));
+
+        let narrow = parse_date_time_skeleton("GGGGG").unwrap();
+        assert_eq!(narrow.era(), Some(&DateTimeFormatEra::Narrow));
+    }
+
+    #[test]
+    fn test_parse_hour_cycles() {
+        let h12 = parse_date_time_skeleton("h").unwrap();
+        assert_eq!(h12.hour_cycle(), Some(&DateTimeFormatHourCycle::H12));
+        assert_eq!(h12.hour(), Some(&DateTimeFormatHour::Numeric));
+
+        let h23 = parse_date_time_skeleton("HH").unwrap();
+        assert_eq!(h23.hour_cycle(), Some(&DateTimeFormatHourCycle::H23));
+        assert_eq!(h23.hour(), Some(&DateTimeFormatHour::TwoDigit));
+
+        let h11 = parse_date_time_skeleton("K").unwrap();
+        assert_eq!(h11.hour_cycle(), Some(&DateTimeFormatHourCycle::H11));
+
+        let h24 = parse_date_time_skeleton("kk").unwrap();
+        assert_eq!(h24.hour_cycle(), Some(&DateTimeFormatHourCycle::H24));
+    }
+
+    #[test]
+    fn test_parse_hour12_with_period() {
+        let result = parse_date_time_skeleton("ha").unwrap();
+        assert_eq!(result.hour12(), Some(true));
+        assert_eq!(result.hour(), Some(&DateTimeFormatHour::Numeric));
+    }
+
+    #[test]
+    fn test_parse_minute_second() {
+        let result = parse_date_time_skeleton("m").unwrap();
+        assert_eq!(result.minute(), Some(&DateTimeFormatMinute::Numeric));
+
+        let result = parse_date_time_skeleton("mm").unwrap();
+        assert_eq!(result.minute(), Some(&DateTimeFormatMinute::TwoDigit));
+
+        let result = parse_date_time_skeleton("s").unwrap();
+        assert_eq!(result.second(), Some(&DateTimeFormatSecond::Numeric));
+
+        let result = parse_date_time_skeleton("ss").unwrap();
+        assert_eq!(result.second(), Some(&DateTimeFormatSecond::TwoDigit));
+    }
+
+    #[test]
+    fn test_parse_timezone() {
+        let short = parse_date_time_skeleton("z").unwrap();
+        assert_eq!(
+            short.time_zone_name(),
+            Some(&DateTimeFormatTimeZoneName::Short)
+        );
+
+        let long = parse_date_time_skeleton("zzzz").unwrap();
+        assert_eq!(
+            long.time_zone_name(),
+            Some(&DateTimeFormatTimeZoneName::Long)
+        );
+    }
+
+    #[test]
+    fn test_parse_complex_skeleton() {
+        let result = parse_date_time_skeleton("yMMMdHms").unwrap();
+        assert_eq!(result.year(), Some(&DateTimeFormatYear::Numeric));
+        assert_eq!(result.month(), Some(&DateTimeFormatMonth::Short));
+        assert_eq!(result.day(), Some(&DateTimeFormatDay::Numeric));
+        assert_eq!(result.hour(), Some(&DateTimeFormatHour::Numeric));
+        assert_eq!(result.minute(), Some(&DateTimeFormatMinute::Numeric));
+        assert_eq!(result.second(), Some(&DateTimeFormatSecond::Numeric));
+    }
+
+    #[test]
+    fn test_parse_full_datetime() {
+        let result = parse_date_time_skeleton("yyyyMMddHHmmss").unwrap();
+        assert_eq!(result.year(), Some(&DateTimeFormatYear::Numeric));
+        assert_eq!(result.month(), Some(&DateTimeFormatMonth::TwoDigit));
+        assert_eq!(result.day(), Some(&DateTimeFormatDay::TwoDigit));
+        assert_eq!(result.hour(), Some(&DateTimeFormatHour::TwoDigit));
+        assert_eq!(result.hour_cycle(), Some(&DateTimeFormatHourCycle::H23));
+        assert_eq!(result.minute(), Some(&DateTimeFormatMinute::TwoDigit));
+        assert_eq!(result.second(), Some(&DateTimeFormatSecond::TwoDigit));
+    }
+
+    #[test]
+    fn test_unsupported_year_pattern() {
+        let result = parse_date_time_skeleton("Y");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Y/u/U/r"));
+    }
+
+    #[test]
+    fn test_unsupported_quarter_pattern() {
+        let result = parse_date_time_skeleton("Q");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("q/Q"));
+    }
+
+    #[test]
+    fn test_unsupported_week_pattern() {
+        let result = parse_date_time_skeleton("w");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("w/W"));
+    }
+
+    #[test]
+    fn test_unsupported_day_pattern() {
+        let result = parse_date_time_skeleton("D");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("D/F/g"));
+    }
+
+    #[test]
+    fn test_unsupported_period_pattern() {
+        let result = parse_date_time_skeleton("b");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("b/B"));
+    }
+
+    #[test]
+    fn test_unsupported_hour_pattern() {
+        let result = parse_date_time_skeleton("j");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("j/J/C"));
+    }
+
+    #[test]
+    fn test_unsupported_second_pattern() {
+        let result = parse_date_time_skeleton("S");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("S/A"));
+    }
+
+    #[test]
+    fn test_unsupported_timezone_pattern() {
+        let result = parse_date_time_skeleton("Z");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Z/O/v/V/X/x"));
+    }
+
+    #[test]
+    fn test_empty_skeleton() {
+        let result = parse_date_time_skeleton("").unwrap();
+        assert_eq!(result.year(), None);
+        assert_eq!(result.month(), None);
+        assert_eq!(result.day(), None);
+    }
+
+    #[test]
+    fn test_month_standalone_l() {
+        // L is standalone month (same behavior as M)
+        let result = parse_date_time_skeleton("LLL").unwrap();
+        assert_eq!(result.month(), Some(&DateTimeFormatMonth::Short));
+    }
+
+    #[test]
+    fn test_weekday_c() {
+        let short = parse_date_time_skeleton("cccc").unwrap();
+        assert_eq!(short.weekday(), Some(&DateTimeFormatWeekday::Short));
+
+        let result = parse_date_time_skeleton("c");
+        assert!(result.is_err());
+    }
+}

--- a/packages/icu-skeleton-parser/rust/lib.rs
+++ b/packages/icu-skeleton-parser/rust/lib.rs
@@ -1,8 +1,16 @@
+pub mod datetime_format_options;
+pub mod datetime_parser;
 pub mod number_format_options;
 pub mod number_skeleton_token;
 pub mod parser;
 
 // Re-export commonly used types
+pub use datetime_format_options::{
+    DateTimeFormatDay, DateTimeFormatEra, DateTimeFormatHour, DateTimeFormatHourCycle,
+    DateTimeFormatMinute, DateTimeFormatMonth, DateTimeFormatOptions, DateTimeFormatSecond,
+    DateTimeFormatTimeZoneName, DateTimeFormatWeekday, DateTimeFormatYear,
+};
+pub use datetime_parser::parse_date_time_skeleton;
 pub use number_format_options::{
     ExtendedNumberFormatOptions, NumberFormatNotation, NumberFormatOptions,
     NumberFormatOptionsCompactDisplay, NumberFormatOptionsCurrencyDisplay,


### PR DESCRIPTION
### TL;DR

Add date-time skeleton parser for ICU format strings

### What changed?

- Added `DateTimeFormatOptions` struct and related enums to represent ECMA-402 date-time format options
- Implemented `parse_date_time_skeleton` function to convert ICU date-time skeleton patterns to format options
- Added comprehensive unit tests for all date-time formatting components
- Exposed new functionality through public exports in the library

### How to test?

```rust
use icu_skeleton_parser::parse_date_time_skeleton;

// Parse a date skeleton
let opts = parse_date_time_skeleton("yMMMd").unwrap();
assert!(opts.year().is_some());
assert!(opts.month().is_some());
assert!(opts.day().is_some());

// Parse a time skeleton
let opts = parse_date_time_skeleton("Hms").unwrap();
assert!(opts.hour().is_some());
assert!(opts.minute().is_some());
assert!(opts.second().is_some());
```

### Why make this change?

This implementation adds support for parsing ICU date-time skeleton patterns, which are commonly used in internationalization libraries. The parser converts these patterns to ECMA-402 compatible format options, enabling applications to use the more concise ICU syntax while maintaining compatibility with JavaScript's Intl.DateTimeFormat API. This complements the existing number skeleton parser functionality.