### PR TITLE
test(@formatjs/icu-skeleton-parser): add more rust tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,7 +12,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu-skeleton-parser-rust"
+name = "icu-skeleton-parser"
 version = "0.1.0"
 dependencies = [
  "once_cell",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -4601,10 +4601,10 @@
         "bzlTransitiveDigest": "WtIoVC11ie4SZ/RJIy/93jgE8KMXiwLBVrk6qhzuTCI=",
         "usagesDigest": "+2oxp30n7U2iCRyiQVVvn9Dm9XZaeUlnwnAuV9gqyVs=",
         "recordedFileInputs": {
-          "@@//Cargo.lock": "32218533ffef2e0cc67194e571a0916642af657e627c2828e6bf611e959ecdec",
+          "@@//Cargo.lock": "779eba073dd28c75bc798f83af6e75bd21fc679aab834101305c9f644c3f025a",
           "@@//Cargo.toml": "6ce76bc37649afb0dd1591a48c1e5e1c11a80bfcdbbdebc36fd9bc13a4df0ea5",
           "@@//MODULE.bazel": "cccf8ed0309c698fec8d96d630baad229781fa5bc6546e0e322e64a5fe023c8a",
-          "@@//packages/icu-skeleton-parser/rust/Cargo.toml": "6f5b9abcf422690ce980a2567265737d6b2847639982bb17ff308da95e2de034",
+          "@@//packages/icu-skeleton-parser/rust/Cargo.toml": "44478cc45d33a4595250e491a0154ece735a6768e2b9ccfdce98ccfc55c0acdd",
           "@@rules_rust++rust_host_tools+rust_host_tools//rust_host_tools": "ENOENT"
         },
         "recordedDirentsInputs": {},

--- a/packages/icu-skeleton-parser/rust/BUILD.bazel
+++ b/packages/icu-skeleton-parser/rust/BUILD.bazel
@@ -7,8 +7,8 @@ rust_library(
         "datetime_parser.rs",
         "lib.rs",
         "number_format_options.rs",
+        "number_parser.rs",
         "number_skeleton_token.rs",
-        "parser.rs",
     ],
     crate_name = "icu_skeleton_parser",
     deps = [

--- a/packages/icu-skeleton-parser/rust/Cargo.toml
+++ b/packages/icu-skeleton-parser/rust/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "icu-skeleton-parser-rust"
+name = "icu-skeleton-parser"
 version = "0.1.0"
 edition = "2021"
 

--- a/packages/icu-skeleton-parser/rust/datetime_parser.rs
+++ b/packages/icu-skeleton-parser/rust/datetime_parser.rs
@@ -511,4 +511,65 @@ mod tests {
         let result = parse_date_time_skeleton("c");
         assert!(result.is_err());
     }
+
+    // Integration tests from TypeScript test suite
+    #[test]
+    fn test_integration_complex_skeleton_1() {
+        // "yyyy.MM.dd G 'at' HH:mm:ss zzzz"
+        // Note: Quoted text is not supported in Rust version, testing without it
+        let result = parse_date_time_skeleton("yyyy.MM.dd G HH:mm:ss zzzz").unwrap();
+        assert_eq!(result.year(), Some(&DateTimeFormatYear::Numeric));
+        assert_eq!(result.month(), Some(&DateTimeFormatMonth::TwoDigit));
+        assert_eq!(result.day(), Some(&DateTimeFormatDay::TwoDigit));
+        assert_eq!(result.era(), Some(&DateTimeFormatEra::Short));
+        assert_eq!(result.hour(), Some(&DateTimeFormatHour::TwoDigit));
+        assert_eq!(result.hour_cycle(), Some(&DateTimeFormatHourCycle::H23));
+        assert_eq!(result.minute(), Some(&DateTimeFormatMinute::TwoDigit));
+        assert_eq!(result.second(), Some(&DateTimeFormatSecond::TwoDigit));
+        assert_eq!(
+            result.time_zone_name(),
+            Some(&DateTimeFormatTimeZoneName::Long)
+        );
+    }
+
+    #[test]
+    fn test_integration_skeleton_2() {
+        // "EEE, MMM d, ''yy"
+        let result = parse_date_time_skeleton("EEE, MMM d, yy").unwrap();
+        assert_eq!(result.weekday(), Some(&DateTimeFormatWeekday::Short));
+        assert_eq!(result.month(), Some(&DateTimeFormatMonth::Short));
+        assert_eq!(result.day(), Some(&DateTimeFormatDay::Numeric));
+        assert_eq!(result.year(), Some(&DateTimeFormatYear::TwoDigit));
+    }
+
+    #[test]
+    fn test_integration_skeleton_3() {
+        // "EEEE, d MMMM yyyy"
+        let result = parse_date_time_skeleton("EEEE, d MMMM yyyy").unwrap();
+        assert_eq!(result.weekday(), Some(&DateTimeFormatWeekday::Long));
+        assert_eq!(result.day(), Some(&DateTimeFormatDay::Numeric));
+        assert_eq!(result.month(), Some(&DateTimeFormatMonth::Long));
+        assert_eq!(result.year(), Some(&DateTimeFormatYear::Numeric));
+    }
+
+    #[test]
+    fn test_integration_skeleton_4() {
+        // "h:mm a"
+        let result = parse_date_time_skeleton("h:mm a").unwrap();
+        assert_eq!(result.hour(), Some(&DateTimeFormatHour::Numeric));
+        assert_eq!(result.hour12(), Some(true));
+        assert_eq!(result.hour_cycle(), Some(&DateTimeFormatHourCycle::H12));
+        assert_eq!(result.minute(), Some(&DateTimeFormatMinute::TwoDigit));
+    }
+
+    #[test]
+    fn test_integration_empty_skeleton() {
+        let result = parse_date_time_skeleton("").unwrap();
+        assert_eq!(result.year(), None);
+        assert_eq!(result.month(), None);
+        assert_eq!(result.day(), None);
+        assert_eq!(result.hour(), None);
+        assert_eq!(result.minute(), None);
+        assert_eq!(result.second(), None);
+    }
 }

--- a/packages/icu-skeleton-parser/rust/lib.rs
+++ b/packages/icu-skeleton-parser/rust/lib.rs
@@ -1,8 +1,8 @@
 pub mod datetime_format_options;
 pub mod datetime_parser;
 pub mod number_format_options;
+pub mod number_parser;
 pub mod number_skeleton_token;
-pub mod parser;
 
 // Re-export commonly used types
 pub use datetime_format_options::{
@@ -18,5 +18,5 @@ pub use number_format_options::{
     NumberFormatOptionsUnitDisplay, RoundingModeType, RoundingPriorityType, TrailingZeroDisplay,
     UseGroupingString, UseGroupingType,
 };
+pub use number_parser::parse_number_skeleton;
 pub use number_skeleton_token::NumberSkeletonToken;
-pub use parser::parse_number_skeleton;

--- a/packages/icu-skeleton-parser/rust/number_parser.rs
+++ b/packages/icu-skeleton-parser/rust/number_parser.rs
@@ -1180,4 +1180,557 @@ mod tests {
         );
         assert_eq!(result.minimum_integer_digits(), Some(2));
     }
+
+    // Integration tests from TypeScript test suite
+    #[test]
+    fn test_integration_percent_max_fraction() {
+        // "percent .##"
+        let tokens = NumberSkeletonToken::parse_from_string("percent .##").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(result.style(), Some(&NumberFormatOptionsStyle::Percent));
+        assert_eq!(result.maximum_fraction_digits(), Some(2));
+    }
+
+    #[test]
+    fn test_integration_max_fraction_only() {
+        // ".##"
+        let tokens = NumberSkeletonToken::parse_from_string(".##").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(result.maximum_fraction_digits(), Some(2));
+    }
+
+    #[test]
+    fn test_integration_trailing_zero_display() {
+        // ".##/w"
+        let tokens = NumberSkeletonToken::parse_from_string(".##/w").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(result.maximum_fraction_digits(), Some(2));
+        assert_eq!(
+            result.trailing_zero_display(),
+            Some(&TrailingZeroDisplay::StripIfInteger)
+        );
+    }
+
+    #[test]
+    fn test_integration_precision_integer() {
+        // "."
+        let tokens = NumberSkeletonToken::parse_from_string(".").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(result.maximum_fraction_digits(), Some(0));
+    }
+
+    #[test]
+    fn test_integration_percent_shorthand() {
+        // "% .##"
+        let tokens = NumberSkeletonToken::parse_from_string("% .##").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(result.style(), Some(&NumberFormatOptionsStyle::Percent));
+        assert_eq!(result.maximum_fraction_digits(), Some(2));
+    }
+
+    #[test]
+    fn test_integration_rounding_priority_more() {
+        // ".##/@##r"
+        let tokens = NumberSkeletonToken::parse_from_string(".##/@##r").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(result.maximum_fraction_digits(), Some(2));
+        assert_eq!(result.minimum_significant_digits(), Some(1));
+        assert_eq!(result.maximum_significant_digits(), Some(3));
+        assert_eq!(
+            result.rounding_priority(),
+            Some(&RoundingPriorityType::MorePrecision)
+        );
+    }
+
+    #[test]
+    fn test_integration_rounding_priority_less() {
+        // ".##/@##s"
+        let tokens = NumberSkeletonToken::parse_from_string(".##/@##s").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(result.maximum_fraction_digits(), Some(2));
+        assert_eq!(result.minimum_significant_digits(), Some(1));
+        assert_eq!(result.maximum_significant_digits(), Some(3));
+        assert_eq!(
+            result.rounding_priority(),
+            Some(&RoundingPriorityType::LessPrecision)
+        );
+    }
+
+    #[test]
+    fn test_integration_single_sig_digit_rounding_floor() {
+        // "@ rounding-mode-floor"
+        let tokens = NumberSkeletonToken::parse_from_string("@ rounding-mode-floor").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(result.minimum_significant_digits(), Some(1));
+        assert_eq!(result.maximum_significant_digits(), Some(1));
+        assert_eq!(result.rounding_mode(), Some(&RoundingModeType::Floor));
+    }
+
+    #[test]
+    fn test_integration_percent_min_fraction() {
+        // "percent .000*"
+        let tokens = NumberSkeletonToken::parse_from_string("percent .000*").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(result.style(), Some(&NumberFormatOptionsStyle::Percent));
+        assert_eq!(result.minimum_fraction_digits(), Some(3));
+    }
+
+    #[test]
+    fn test_integration_percent_min_max_fraction() {
+        // "percent .0###"
+        let tokens = NumberSkeletonToken::parse_from_string("percent .0###").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(result.style(), Some(&NumberFormatOptionsStyle::Percent));
+        assert_eq!(result.minimum_fraction_digits(), Some(1));
+        assert_eq!(result.maximum_fraction_digits(), Some(4));
+    }
+
+    #[test]
+    fn test_integration_percent_fraction_sig_digits_1() {
+        // "percent .00/@##"
+        let tokens = NumberSkeletonToken::parse_from_string("percent .00/@##").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(result.style(), Some(&NumberFormatOptionsStyle::Percent));
+        assert_eq!(result.minimum_fraction_digits(), Some(2));
+        assert_eq!(result.maximum_fraction_digits(), Some(2));
+        assert_eq!(result.minimum_significant_digits(), Some(1));
+        assert_eq!(result.maximum_significant_digits(), Some(3));
+    }
+
+    #[test]
+    fn test_integration_percent_fraction_sig_digits_2() {
+        // "percent .00/@@@"
+        let tokens = NumberSkeletonToken::parse_from_string("percent .00/@@@").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(result.style(), Some(&NumberFormatOptionsStyle::Percent));
+        assert_eq!(result.minimum_fraction_digits(), Some(2));
+        assert_eq!(result.maximum_fraction_digits(), Some(2));
+        assert_eq!(result.minimum_significant_digits(), Some(3));
+        assert_eq!(result.maximum_significant_digits(), Some(3));
+    }
+
+    #[test]
+    fn test_integration_percent_scale() {
+        // "percent scale/0.01"
+        let tokens = NumberSkeletonToken::parse_from_string("percent scale/0.01").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(result.style(), Some(&NumberFormatOptionsStyle::Percent));
+        assert_eq!(result.scale(), Some(0.01));
+    }
+
+    #[test]
+    fn test_integration_currency_precision_integer() {
+        // "currency/CAD ."
+        let tokens = NumberSkeletonToken::parse_from_string("currency/CAD .").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(result.style(), Some(&NumberFormatOptionsStyle::Currency));
+        assert_eq!(result.currency(), Some("CAD"));
+        assert_eq!(result.maximum_fraction_digits(), Some(0));
+    }
+
+    #[test]
+    fn test_integration_currency_trailing_zero() {
+        // ".00/w currency/CAD"
+        let tokens = NumberSkeletonToken::parse_from_string(".00/w currency/CAD").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(result.style(), Some(&NumberFormatOptionsStyle::Currency));
+        assert_eq!(result.currency(), Some("CAD"));
+        assert_eq!(result.minimum_fraction_digits(), Some(2));
+        assert_eq!(result.maximum_fraction_digits(), Some(2));
+        assert_eq!(
+            result.trailing_zero_display(),
+            Some(&TrailingZeroDisplay::StripIfInteger)
+        );
+    }
+
+    #[test]
+    fn test_integration_currency_sig_digits_1() {
+        // "currency/GBP .0*/@@@"
+        let tokens = NumberSkeletonToken::parse_from_string("currency/GBP .0*/@@@").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(result.style(), Some(&NumberFormatOptionsStyle::Currency));
+        assert_eq!(result.currency(), Some("GBP"));
+        assert_eq!(result.minimum_fraction_digits(), Some(1));
+        assert_eq!(result.minimum_significant_digits(), Some(3));
+        assert_eq!(result.maximum_significant_digits(), Some(3));
+    }
+
+    #[test]
+    fn test_integration_currency_sig_digits_2() {
+        // "currency/GBP .00##/@@@"
+        let tokens = NumberSkeletonToken::parse_from_string("currency/GBP .00##/@@@").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(result.style(), Some(&NumberFormatOptionsStyle::Currency));
+        assert_eq!(result.currency(), Some("GBP"));
+        assert_eq!(result.minimum_fraction_digits(), Some(2));
+        assert_eq!(result.maximum_fraction_digits(), Some(4));
+        assert_eq!(result.minimum_significant_digits(), Some(3));
+        assert_eq!(result.maximum_significant_digits(), Some(3));
+    }
+
+    #[test]
+    fn test_integration_currency_full_name() {
+        // "currency/GBP .00##/@@@ unit-width-full-name"
+        let tokens =
+            NumberSkeletonToken::parse_from_string("currency/GBP .00##/@@@ unit-width-full-name")
+                .unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(result.style(), Some(&NumberFormatOptionsStyle::Currency));
+        assert_eq!(result.currency(), Some("GBP"));
+        assert_eq!(
+            result.currency_display(),
+            Some(&NumberFormatOptionsCurrencyDisplay::Name)
+        );
+        assert_eq!(result.minimum_fraction_digits(), Some(2));
+        assert_eq!(result.maximum_fraction_digits(), Some(4));
+        assert_eq!(result.minimum_significant_digits(), Some(3));
+        assert_eq!(result.maximum_significant_digits(), Some(3));
+        assert_eq!(
+            result.unit_display(),
+            Some(&NumberFormatOptionsUnitDisplay::Long)
+        );
+    }
+
+    #[test]
+    fn test_integration_unit_meter() {
+        // "measure-unit/length-meter .00##/@@@"
+        let tokens =
+            NumberSkeletonToken::parse_from_string("measure-unit/length-meter .00##/@@@").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(result.style(), Some(&NumberFormatOptionsStyle::Unit));
+        assert_eq!(result.unit(), Some("meter"));
+        assert_eq!(result.minimum_fraction_digits(), Some(2));
+        assert_eq!(result.maximum_fraction_digits(), Some(4));
+        assert_eq!(result.minimum_significant_digits(), Some(3));
+        assert_eq!(result.maximum_significant_digits(), Some(3));
+    }
+
+    #[test]
+    fn test_integration_unit_meter_full_name() {
+        // "measure-unit/length-meter .00##/@@@ unit-width-full-name"
+        let tokens = NumberSkeletonToken::parse_from_string(
+            "measure-unit/length-meter .00##/@@@ unit-width-full-name",
+        )
+        .unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(result.style(), Some(&NumberFormatOptionsStyle::Unit));
+        assert_eq!(result.unit(), Some("meter"));
+        assert_eq!(
+            result.currency_display(),
+            Some(&NumberFormatOptionsCurrencyDisplay::Name)
+        );
+        assert_eq!(result.minimum_fraction_digits(), Some(2));
+        assert_eq!(result.maximum_fraction_digits(), Some(4));
+        assert_eq!(result.minimum_significant_digits(), Some(3));
+        assert_eq!(result.maximum_significant_digits(), Some(3));
+        assert_eq!(
+            result.unit_display(),
+            Some(&NumberFormatOptionsUnitDisplay::Long)
+        );
+    }
+
+    #[test]
+    fn test_integration_compact_short() {
+        // "compact-short"
+        let tokens = NumberSkeletonToken::parse_from_string("compact-short").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(result.notation(), Some(&NumberFormatNotation::Compact));
+        assert_eq!(
+            result.compact_display(),
+            Some(&NumberFormatOptionsCompactDisplay::Short)
+        );
+    }
+
+    #[test]
+    fn test_integration_compact_long() {
+        // "compact-long"
+        let tokens = NumberSkeletonToken::parse_from_string("compact-long").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(result.notation(), Some(&NumberFormatNotation::Compact));
+        assert_eq!(
+            result.compact_display(),
+            Some(&NumberFormatOptionsCompactDisplay::Long)
+        );
+    }
+
+    #[test]
+    fn test_integration_scientific_notation() {
+        // "scientific"
+        let tokens = NumberSkeletonToken::parse_from_string("scientific").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(result.notation(), Some(&NumberFormatNotation::Scientific));
+    }
+
+    #[test]
+    fn test_integration_scientific_sign_always() {
+        // "scientific/sign-always"
+        let tokens = NumberSkeletonToken::parse_from_string("scientific/sign-always").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(result.notation(), Some(&NumberFormatNotation::Scientific));
+        assert_eq!(
+            result.sign_display(),
+            Some(&NumberFormatOptionsSignDisplay::Always)
+        );
+    }
+
+    #[test]
+    fn test_integration_scientific_sign_always_alternative() {
+        // "scientific/+ee/sign-always"
+        let tokens = NumberSkeletonToken::parse_from_string("scientific/+ee/sign-always").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(result.notation(), Some(&NumberFormatNotation::Scientific));
+        assert_eq!(
+            result.sign_display(),
+            Some(&NumberFormatOptionsSignDisplay::Always)
+        );
+    }
+
+    #[test]
+    fn test_integration_engineering_notation() {
+        // "engineering"
+        let tokens = NumberSkeletonToken::parse_from_string("engineering").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(result.notation(), Some(&NumberFormatNotation::Engineering));
+    }
+
+    #[test]
+    fn test_integration_engineering_except_zero() {
+        // "engineering/sign-except-zero"
+        let tokens =
+            NumberSkeletonToken::parse_from_string("engineering/sign-except-zero").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(result.notation(), Some(&NumberFormatNotation::Engineering));
+        assert_eq!(
+            result.sign_display(),
+            Some(&NumberFormatOptionsSignDisplay::ExceptZero)
+        );
+    }
+
+    #[test]
+    fn test_integration_notation_simple() {
+        // "notation-simple"
+        let tokens = NumberSkeletonToken::parse_from_string("notation-simple").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(result.notation(), Some(&NumberFormatNotation::Standard));
+    }
+
+    #[test]
+    fn test_integration_sign_auto() {
+        // "sign-auto"
+        let tokens = NumberSkeletonToken::parse_from_string("sign-auto").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(
+            result.sign_display(),
+            Some(&NumberFormatOptionsSignDisplay::Auto)
+        );
+    }
+
+    #[test]
+    fn test_integration_sign_always_long() {
+        // "sign-always"
+        let tokens = NumberSkeletonToken::parse_from_string("sign-always").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(
+            result.sign_display(),
+            Some(&NumberFormatOptionsSignDisplay::Always)
+        );
+    }
+
+    #[test]
+    fn test_integration_sign_always_shorthand() {
+        // "+!"
+        let tokens = NumberSkeletonToken::parse_from_string("+!").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(
+            result.sign_display(),
+            Some(&NumberFormatOptionsSignDisplay::Always)
+        );
+    }
+
+    #[test]
+    fn test_integration_sign_never_long() {
+        // "sign-never"
+        let tokens = NumberSkeletonToken::parse_from_string("sign-never").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(
+            result.sign_display(),
+            Some(&NumberFormatOptionsSignDisplay::Never)
+        );
+    }
+
+    #[test]
+    fn test_integration_sign_never_shorthand() {
+        // "+_"
+        let tokens = NumberSkeletonToken::parse_from_string("+_").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(
+            result.sign_display(),
+            Some(&NumberFormatOptionsSignDisplay::Never)
+        );
+    }
+
+    #[test]
+    fn test_integration_sign_accounting_long() {
+        // "sign-accounting"
+        let tokens = NumberSkeletonToken::parse_from_string("sign-accounting").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(
+            result.currency_sign(),
+            Some(&NumberFormatOptionsCurrencySign::Accounting)
+        );
+    }
+
+    #[test]
+    fn test_integration_sign_accounting_shorthand() {
+        // "()"
+        let tokens = NumberSkeletonToken::parse_from_string("()").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(
+            result.currency_sign(),
+            Some(&NumberFormatOptionsCurrencySign::Accounting)
+        );
+    }
+
+    #[test]
+    fn test_integration_sign_accounting_always_long() {
+        // "sign-accounting-always"
+        let tokens = NumberSkeletonToken::parse_from_string("sign-accounting-always").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(
+            result.currency_sign(),
+            Some(&NumberFormatOptionsCurrencySign::Accounting)
+        );
+        assert_eq!(
+            result.sign_display(),
+            Some(&NumberFormatOptionsSignDisplay::Always)
+        );
+    }
+
+    #[test]
+    fn test_integration_sign_accounting_always_shorthand() {
+        // "()!"
+        let tokens = NumberSkeletonToken::parse_from_string("()!").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(
+            result.currency_sign(),
+            Some(&NumberFormatOptionsCurrencySign::Accounting)
+        );
+        assert_eq!(
+            result.sign_display(),
+            Some(&NumberFormatOptionsSignDisplay::Always)
+        );
+    }
+
+    #[test]
+    fn test_integration_sign_except_zero_long() {
+        // "sign-except-zero"
+        let tokens = NumberSkeletonToken::parse_from_string("sign-except-zero").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(
+            result.sign_display(),
+            Some(&NumberFormatOptionsSignDisplay::ExceptZero)
+        );
+    }
+
+    #[test]
+    fn test_integration_sign_except_zero_shorthand() {
+        // "+?"
+        let tokens = NumberSkeletonToken::parse_from_string("+?").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(
+            result.sign_display(),
+            Some(&NumberFormatOptionsSignDisplay::ExceptZero)
+        );
+    }
+
+    #[test]
+    fn test_integration_sign_accounting_except_zero_long() {
+        // "sign-accounting-except-zero"
+        let tokens =
+            NumberSkeletonToken::parse_from_string("sign-accounting-except-zero").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(
+            result.currency_sign(),
+            Some(&NumberFormatOptionsCurrencySign::Accounting)
+        );
+        assert_eq!(
+            result.sign_display(),
+            Some(&NumberFormatOptionsSignDisplay::ExceptZero)
+        );
+    }
+
+    #[test]
+    fn test_integration_sign_accounting_except_zero_shorthand() {
+        // "()?
+        let tokens = NumberSkeletonToken::parse_from_string("()?").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(
+            result.currency_sign(),
+            Some(&NumberFormatOptionsCurrencySign::Accounting)
+        );
+        assert_eq!(
+            result.sign_display(),
+            Some(&NumberFormatOptionsSignDisplay::ExceptZero)
+        );
+    }
+
+    #[test]
+    fn test_integration_min_integer_digits_concise() {
+        // "000"
+        let tokens = NumberSkeletonToken::parse_from_string("000").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(result.minimum_integer_digits(), Some(3));
+    }
+
+    #[test]
+    fn test_integration_min_integer_digits_long() {
+        // "integer-width/*000"
+        let tokens = NumberSkeletonToken::parse_from_string("integer-width/*000").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(result.minimum_integer_digits(), Some(3));
+    }
+
+    #[test]
+    fn test_integration_scientific_concise_e0() {
+        // "E0"
+        let tokens = NumberSkeletonToken::parse_from_string("E0").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(result.notation(), Some(&NumberFormatNotation::Scientific));
+        assert_eq!(result.minimum_integer_digits(), Some(1));
+    }
+
+    #[test]
+    fn test_integration_scientific_concise_sign_width() {
+        // "E+!00"
+        let tokens = NumberSkeletonToken::parse_from_string("E+!00").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(result.notation(), Some(&NumberFormatNotation::Scientific));
+        assert_eq!(
+            result.sign_display(),
+            Some(&NumberFormatOptionsSignDisplay::Always)
+        );
+        assert_eq!(result.minimum_integer_digits(), Some(2));
+    }
+
+    #[test]
+    fn test_integration_engineering_concise_sign_width() {
+        // "EE+?000"
+        let tokens = NumberSkeletonToken::parse_from_string("EE+?000").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(result.notation(), Some(&NumberFormatNotation::Engineering));
+        assert_eq!(
+            result.sign_display(),
+            Some(&NumberFormatOptionsSignDisplay::ExceptZero)
+        );
+        assert_eq!(result.minimum_integer_digits(), Some(3));
+    }
+
+    #[test]
+    fn test_integration_percent_scaled() {
+        // "%x100"
+        let tokens = NumberSkeletonToken::parse_from_string("%x100").unwrap();
+        let result = parse_number_skeleton(&tokens).unwrap();
+        assert_eq!(result.style(), Some(&NumberFormatOptionsStyle::Percent));
+        assert_eq!(result.scale(), Some(100.0));
+    }
 }


### PR DESCRIPTION
### TL;DR

Renamed package from `icu-skeleton-parser-rust` to `icu-skeleton-parser` and added comprehensive integration tests for both datetime and number skeleton parsers.

### What changed?

- Renamed the package from `icu-skeleton-parser-rust` to `icu-skeleton-parser` in Cargo.toml and updated references in Cargo.lock
- Renamed `parser.rs` to `number_parser.rs` for better clarity on its purpose
- Updated imports and exports in `lib.rs` to reflect the file name change
- Added extensive integration tests to both parsers:
  - Added datetime parser tests for complex skeletons, various date/time formats, and empty skeletons
  - Added number parser tests for various formatting options including percentages, currencies, scientific notation, engineering notation, sign displays, and more

### How to test?

Run the test suite to verify all tests pass:

```bash
cargo test
```

The new integration tests cover a wide range of formatting scenarios that match the TypeScript test suite, ensuring compatibility between implementations.

### Why make this change?

- The package name change removes the redundant `-rust` suffix, making it more consistent with other packages
- The file renaming improves code organization by making the purpose of each module clearer
- The comprehensive integration tests ensure the Rust implementation matches the behavior of the TypeScript implementation, providing better test coverage and confidence in the parser's correctness across various formatting scenarios