### PR TITLE
test(@formatjs/icu-messageformat-parser): add more tests

### DIFF
--- a/packages/icu-messageformat-parser/integration-tests/test_cases/expect_date_arg_skeleton_whitespace_only.txt
+++ b/packages/icu-messageformat-parser/integration-tests/test_cases/expect_date_arg_skeleton_whitespace_only.txt
@@ -1,0 +1,23 @@
+{0, date, ::   }
+---
+{}
+---
+{
+  "val": null,
+  "err": {
+    "kind": 10,
+    "message": "{0, date, ::   }",
+    "location": {
+      "start": {
+        "offset": 0,
+        "line": 1,
+        "column": 1
+      },
+      "end": {
+        "offset": 16,
+        "line": 1,
+        "column": 17
+      }
+    }
+  }
+}

--- a/packages/icu-messageformat-parser/integration-tests/test_cases/expect_number_arg_skeleton_double_slash.txt
+++ b/packages/icu-messageformat-parser/integration-tests/test_cases/expect_number_arg_skeleton_double_slash.txt
@@ -1,0 +1,23 @@
+{0, number, ::currency//USD}
+---
+{}
+---
+{
+  "val": null,
+  "err": {
+    "kind": 7,
+    "message": "{0, number, ::currency//USD}",
+    "location": {
+      "start": {
+        "offset": 12,
+        "line": 1,
+        "column": 13
+      },
+      "end": {
+        "offset": 27,
+        "line": 1,
+        "column": 28
+      }
+    }
+  }
+}

--- a/packages/icu-messageformat-parser/integration-tests/test_cases/expect_number_arg_skeleton_empty_stem.txt
+++ b/packages/icu-messageformat-parser/integration-tests/test_cases/expect_number_arg_skeleton_empty_stem.txt
@@ -1,0 +1,49 @@
+{0, number, ::/USD}
+---
+{}
+---
+{
+  "val": [
+    {
+      "type": 2,
+      "value": "0",
+      "location": {
+        "start": {
+          "offset": 0,
+          "line": 1,
+          "column": 1
+        },
+        "end": {
+          "offset": 19,
+          "line": 1,
+          "column": 20
+        }
+      },
+      "style": {
+        "type": 0,
+        "tokens": [
+          {
+            "stem": "",
+            "options": [
+              "USD"
+            ]
+          }
+        ],
+        "location": {
+          "start": {
+            "offset": 12,
+            "line": 1,
+            "column": 13
+          },
+          "end": {
+            "offset": 18,
+            "line": 1,
+            "column": 19
+          }
+        },
+        "parsedOptions": {}
+      }
+    }
+  ],
+  "err": null
+}

--- a/packages/icu-messageformat-parser/integration-tests/test_cases/expect_number_arg_skeleton_whitespace_only.txt
+++ b/packages/icu-messageformat-parser/integration-tests/test_cases/expect_number_arg_skeleton_whitespace_only.txt
@@ -1,0 +1,23 @@
+{0, number, ::   }
+---
+{}
+---
+{
+  "val": null,
+  "err": {
+    "kind": 7,
+    "message": "{0, number, ::   }",
+    "location": {
+      "start": {
+        "offset": 12,
+        "line": 1,
+        "column": 13
+      },
+      "end": {
+        "offset": 17,
+        "line": 1,
+        "column": 18
+      }
+    }
+  }
+}

--- a/packages/icu-messageformat-parser/integration-tests/test_cases/number_skeleton_with_tab.txt
+++ b/packages/icu-messageformat-parser/integration-tests/test_cases/number_skeleton_with_tab.txt
@@ -1,0 +1,53 @@
+{0, number, ::currency/USD	compact-short}
+---
+{}
+---
+{
+  "val": [
+    {
+      "type": 2,
+      "value": "0",
+      "location": {
+        "start": {
+          "offset": 0,
+          "line": 1,
+          "column": 1
+        },
+        "end": {
+          "offset": 41,
+          "line": 1,
+          "column": 42
+        }
+      },
+      "style": {
+        "type": 0,
+        "tokens": [
+          {
+            "stem": "currency",
+            "options": [
+              "USD"
+            ]
+          },
+          {
+            "stem": "compact-short",
+            "options": []
+          }
+        ],
+        "location": {
+          "start": {
+            "offset": 12,
+            "line": 1,
+            "column": 13
+          },
+          "end": {
+            "offset": 40,
+            "line": 1,
+            "column": 41
+          }
+        },
+        "parsedOptions": {}
+      }
+    }
+  ],
+  "err": null
+}

--- a/packages/icu-skeleton-parser/rust/number_skeleton_token.rs
+++ b/packages/icu-skeleton-parser/rust/number_skeleton_token.rs
@@ -76,7 +76,8 @@ impl NumberSkeletonToken {
 
         let options: Vec<String> = parts.map(|s| s.to_string()).collect();
 
-        // Validate that no option is empty
+        // Validate that no option is empty (e.g., "currency/" or "currency//USD")
+        // Note: Empty stem is allowed by the spec (e.g., "/USD")
         if options.iter().any(|opt| opt.is_empty()) {
             return Err("Invalid number skeleton".to_string());
         }


### PR DESCRIPTION
# Add test cases for ICU MessageFormat parser edge cases

### TL;DR

Added test cases for handling edge cases in ICU MessageFormat parser skeletons and fixed a comment in the number skeleton token parser.

### What changed?

- Added new test cases for date and number argument skeletons:
  - Empty stem handling (`::/USD`)
  - Whitespace-only skeletons (`::   `)
  - Double slash in skeletons (`::currency//USD`)
  - Tab character in skeletons (`::currency/USD\tcompact-short`)
- Updated a comment in `number_skeleton_token.rs` to clarify that empty stems are allowed by the spec (e.g., `/USD`), but empty options are not (e.g., `currency/` or `currency//USD`)

### How to test?

Run the integration tests to verify that the parser correctly handles these edge cases:
- Empty stems should be valid
- Whitespace-only skeletons should produce errors
- Double slashes should produce errors
- Tab characters should be properly handled as whitespace separators

### Why make this change?

These test cases ensure the parser correctly handles edge cases according to the ICU MessageFormat specification, improving robustness and preventing potential parsing issues in real-world usage scenarios.