### PR TITLE
test(@formatjs/icu-messageformat-parser): more edge cases from icu4c

### DIFF
--- a/packages/icu-messageformat-parser/integration-tests/test_cases/number_skeleton_many_tokens.txt
+++ b/packages/icu-messageformat-parser/integration-tests/test_cases/number_skeleton_many_tokens.txt
@@ -1,0 +1,55 @@
+{0, number, ::compact-short unit-width-narrow notation-scientific}
+---
+{}
+---
+{
+  "val": [
+    {
+      "type": 2,
+      "value": "0",
+      "location": {
+        "start": {
+          "offset": 0,
+          "line": 1,
+          "column": 1
+        },
+        "end": {
+          "offset": 66,
+          "line": 1,
+          "column": 67
+        }
+      },
+      "style": {
+        "type": 0,
+        "tokens": [
+          {
+            "stem": "compact-short",
+            "options": []
+          },
+          {
+            "stem": "unit-width-narrow",
+            "options": []
+          },
+          {
+            "stem": "notation-scientific",
+            "options": []
+          }
+        ],
+        "location": {
+          "start": {
+            "offset": 12,
+            "line": 1,
+            "column": 13
+          },
+          "end": {
+            "offset": 65,
+            "line": 1,
+            "column": 66
+          }
+        },
+        "parsedOptions": {}
+      }
+    }
+  ],
+  "err": null
+}

--- a/packages/icu-messageformat-parser/integration-tests/test_cases/number_skeleton_multiple_spaces.txt
+++ b/packages/icu-messageformat-parser/integration-tests/test_cases/number_skeleton_multiple_spaces.txt
@@ -1,0 +1,53 @@
+{0, number, ::   percent   scale/100   }
+---
+{}
+---
+{
+  "val": [
+    {
+      "type": 2,
+      "value": "0",
+      "location": {
+        "start": {
+          "offset": 0,
+          "line": 1,
+          "column": 1
+        },
+        "end": {
+          "offset": 40,
+          "line": 1,
+          "column": 41
+        }
+      },
+      "style": {
+        "type": 0,
+        "tokens": [
+          {
+            "stem": "percent",
+            "options": []
+          },
+          {
+            "stem": "scale",
+            "options": [
+              "100"
+            ]
+          }
+        ],
+        "location": {
+          "start": {
+            "offset": 12,
+            "line": 1,
+            "column": 13
+          },
+          "end": {
+            "offset": 39,
+            "line": 1,
+            "column": 40
+          }
+        },
+        "parsedOptions": {}
+      }
+    }
+  ],
+  "err": null
+}

--- a/packages/icu-messageformat-parser/integration-tests/test_cases/number_skeleton_trailing_slash.txt
+++ b/packages/icu-messageformat-parser/integration-tests/test_cases/number_skeleton_trailing_slash.txt
@@ -1,0 +1,23 @@
+{0, number, ::compact-short/}
+---
+{}
+---
+{
+  "val": null,
+  "err": {
+    "kind": 7,
+    "message": "{0, number, ::compact-short/}",
+    "location": {
+      "start": {
+        "offset": 12,
+        "line": 1,
+        "column": 13
+      },
+      "end": {
+        "offset": 28,
+        "line": 1,
+        "column": 29
+      }
+    }
+  }
+}

--- a/packages/icu-messageformat-parser/integration-tests/test_cases/plural_with_number_skeleton.txt
+++ b/packages/icu-messageformat-parser/integration-tests/test_cases/plural_with_number_skeleton.txt
@@ -1,0 +1,173 @@
+{0, plural, one {You have {1, number, ::currency/USD}} other {You have {1, number, ::currency/USD}}}
+---
+{}
+---
+{
+  "val": [
+    {
+      "type": 6,
+      "value": "0",
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "You have ",
+              "location": {
+                "start": {
+                  "offset": 17,
+                  "line": 1,
+                  "column": 18
+                },
+                "end": {
+                  "offset": 26,
+                  "line": 1,
+                  "column": 27
+                }
+              }
+            },
+            {
+              "type": 2,
+              "value": "1",
+              "location": {
+                "start": {
+                  "offset": 26,
+                  "line": 1,
+                  "column": 27
+                },
+                "end": {
+                  "offset": 53,
+                  "line": 1,
+                  "column": 54
+                }
+              },
+              "style": {
+                "type": 0,
+                "tokens": [
+                  {
+                    "stem": "currency",
+                    "options": [
+                      "USD"
+                    ]
+                  }
+                ],
+                "location": {
+                  "start": {
+                    "offset": 38,
+                    "line": 1,
+                    "column": 39
+                  },
+                  "end": {
+                    "offset": 52,
+                    "line": 1,
+                    "column": 53
+                  }
+                },
+                "parsedOptions": {}
+              }
+            }
+          ],
+          "location": {
+            "start": {
+              "offset": 16,
+              "line": 1,
+              "column": 17
+            },
+            "end": {
+              "offset": 54,
+              "line": 1,
+              "column": 55
+            }
+          }
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "You have ",
+              "location": {
+                "start": {
+                  "offset": 62,
+                  "line": 1,
+                  "column": 63
+                },
+                "end": {
+                  "offset": 71,
+                  "line": 1,
+                  "column": 72
+                }
+              }
+            },
+            {
+              "type": 2,
+              "value": "1",
+              "location": {
+                "start": {
+                  "offset": 71,
+                  "line": 1,
+                  "column": 72
+                },
+                "end": {
+                  "offset": 98,
+                  "line": 1,
+                  "column": 99
+                }
+              },
+              "style": {
+                "type": 0,
+                "tokens": [
+                  {
+                    "stem": "currency",
+                    "options": [
+                      "USD"
+                    ]
+                  }
+                ],
+                "location": {
+                  "start": {
+                    "offset": 83,
+                    "line": 1,
+                    "column": 84
+                  },
+                  "end": {
+                    "offset": 97,
+                    "line": 1,
+                    "column": 98
+                  }
+                },
+                "parsedOptions": {}
+              }
+            }
+          ],
+          "location": {
+            "start": {
+              "offset": 61,
+              "line": 1,
+              "column": 62
+            },
+            "end": {
+              "offset": 99,
+              "line": 1,
+              "column": 100
+            }
+          }
+        }
+      },
+      "offset": 0,
+      "pluralType": "cardinal",
+      "location": {
+        "start": {
+          "offset": 0,
+          "line": 1,
+          "column": 1
+        },
+        "end": {
+          "offset": 100,
+          "line": 1,
+          "column": 101
+        }
+      }
+    }
+  ],
+  "err": null
+}

--- a/packages/icu-messageformat-parser/integration-tests/test_cases/select_with_number_skeleton.txt
+++ b/packages/icu-messageformat-parser/integration-tests/test_cases/select_with_number_skeleton.txt
@@ -1,0 +1,243 @@
+{0, select, female {{1, number, ::currency/EUR} paid} male {{1, number, ::currency/EUR} paid} other {{1, number, ::currency/EUR} paid}}
+---
+{}
+---
+{
+  "val": [
+    {
+      "type": 5,
+      "value": "0",
+      "options": {
+        "female": {
+          "value": [
+            {
+              "type": 2,
+              "value": "1",
+              "location": {
+                "start": {
+                  "offset": 20,
+                  "line": 1,
+                  "column": 21
+                },
+                "end": {
+                  "offset": 47,
+                  "line": 1,
+                  "column": 48
+                }
+              },
+              "style": {
+                "type": 0,
+                "tokens": [
+                  {
+                    "stem": "currency",
+                    "options": [
+                      "EUR"
+                    ]
+                  }
+                ],
+                "location": {
+                  "start": {
+                    "offset": 32,
+                    "line": 1,
+                    "column": 33
+                  },
+                  "end": {
+                    "offset": 46,
+                    "line": 1,
+                    "column": 47
+                  }
+                },
+                "parsedOptions": {}
+              }
+            },
+            {
+              "type": 0,
+              "value": " paid",
+              "location": {
+                "start": {
+                  "offset": 47,
+                  "line": 1,
+                  "column": 48
+                },
+                "end": {
+                  "offset": 52,
+                  "line": 1,
+                  "column": 53
+                }
+              }
+            }
+          ],
+          "location": {
+            "start": {
+              "offset": 19,
+              "line": 1,
+              "column": 20
+            },
+            "end": {
+              "offset": 53,
+              "line": 1,
+              "column": 54
+            }
+          }
+        },
+        "male": {
+          "value": [
+            {
+              "type": 2,
+              "value": "1",
+              "location": {
+                "start": {
+                  "offset": 60,
+                  "line": 1,
+                  "column": 61
+                },
+                "end": {
+                  "offset": 87,
+                  "line": 1,
+                  "column": 88
+                }
+              },
+              "style": {
+                "type": 0,
+                "tokens": [
+                  {
+                    "stem": "currency",
+                    "options": [
+                      "EUR"
+                    ]
+                  }
+                ],
+                "location": {
+                  "start": {
+                    "offset": 72,
+                    "line": 1,
+                    "column": 73
+                  },
+                  "end": {
+                    "offset": 86,
+                    "line": 1,
+                    "column": 87
+                  }
+                },
+                "parsedOptions": {}
+              }
+            },
+            {
+              "type": 0,
+              "value": " paid",
+              "location": {
+                "start": {
+                  "offset": 87,
+                  "line": 1,
+                  "column": 88
+                },
+                "end": {
+                  "offset": 92,
+                  "line": 1,
+                  "column": 93
+                }
+              }
+            }
+          ],
+          "location": {
+            "start": {
+              "offset": 59,
+              "line": 1,
+              "column": 60
+            },
+            "end": {
+              "offset": 93,
+              "line": 1,
+              "column": 94
+            }
+          }
+        },
+        "other": {
+          "value": [
+            {
+              "type": 2,
+              "value": "1",
+              "location": {
+                "start": {
+                  "offset": 101,
+                  "line": 1,
+                  "column": 102
+                },
+                "end": {
+                  "offset": 128,
+                  "line": 1,
+                  "column": 129
+                }
+              },
+              "style": {
+                "type": 0,
+                "tokens": [
+                  {
+                    "stem": "currency",
+                    "options": [
+                      "EUR"
+                    ]
+                  }
+                ],
+                "location": {
+                  "start": {
+                    "offset": 113,
+                    "line": 1,
+                    "column": 114
+                  },
+                  "end": {
+                    "offset": 127,
+                    "line": 1,
+                    "column": 128
+                  }
+                },
+                "parsedOptions": {}
+              }
+            },
+            {
+              "type": 0,
+              "value": " paid",
+              "location": {
+                "start": {
+                  "offset": 128,
+                  "line": 1,
+                  "column": 129
+                },
+                "end": {
+                  "offset": 133,
+                  "line": 1,
+                  "column": 134
+                }
+              }
+            }
+          ],
+          "location": {
+            "start": {
+              "offset": 100,
+              "line": 1,
+              "column": 101
+            },
+            "end": {
+              "offset": 134,
+              "line": 1,
+              "column": 135
+            }
+          }
+        }
+      },
+      "location": {
+        "start": {
+          "offset": 0,
+          "line": 1,
+          "column": 1
+        },
+        "end": {
+          "offset": 135,
+          "line": 1,
+          "column": 136
+        }
+      }
+    }
+  ],
+  "err": null
+}

--- a/packages/icu-messageformat-parser/integration-tests/test_cases/unclosed_quote_in_number_arg.txt
+++ b/packages/icu-messageformat-parser/integration-tests/test_cases/unclosed_quote_in_number_arg.txt
@@ -1,0 +1,23 @@
+{0, number, 'unclosed}
+---
+{}
+---
+{
+  "val": null,
+  "err": {
+    "kind": 11,
+    "message": "{0, number, 'unclosed}",
+    "location": {
+      "start": {
+        "offset": 13,
+        "line": 1,
+        "column": 14
+      },
+      "end": {
+        "offset": 22,
+        "line": 1,
+        "column": 23
+      }
+    }
+  }
+}


### PR DESCRIPTION
### TL;DR

Added test cases for number skeleton parsing in ICU MessageFormat.

### What changed?

Added six new test cases to validate number skeleton parsing functionality:
- `number_skeleton_many_tokens.txt`: Tests parsing multiple tokens in a number skeleton
- `number_skeleton_multiple_spaces.txt`: Tests handling of multiple spaces between tokens
- `number_skeleton_trailing_slash.txt`: Tests error handling for trailing slashes
- `plural_with_number_skeleton.txt`: Tests number skeletons within plural contexts
- `select_with_number_skeleton.txt`: Tests number skeletons within select contexts
- `unclosed_quote_in_number_arg.txt`: Tests error handling for unclosed quotes

### How to test?

Run the integration tests to verify that the parser correctly handles these number skeleton patterns:
```
cd packages/icu-messageformat-parser
npm test
```

### Why make this change?

These test cases ensure the parser correctly handles various number skeleton formats and edge cases, improving the robustness of the ICU MessageFormat parser. They validate both successful parsing scenarios and proper error handling for invalid inputs.