### PR TITLE
fix(@formatjs/intl-numberformat): optimize decimal, perf 10x, fix #5023

### DIFF
--- a/packages/ecma402-abstract/NumberFormat/ComputeExponent.ts
+++ b/packages/ecma402-abstract/NumberFormat/ComputeExponent.ts
@@ -2,6 +2,8 @@ import {Decimal} from 'decimal.js'
 import {NumberFormatInternal} from '../types/number.js'
 import {ComputeExponentForMagnitude} from './ComputeExponentForMagnitude.js'
 import {FormatNumericToString} from './FormatNumericToString.js'
+import {getPowerOf10} from './decimal-cache.js'
+
 /**
  * The abstract operation ComputeExponent computes an exponent (power of ten) by which to scale x
  * according to the number formatting settings. It handles cases such as 999 rounding up to 1000,
@@ -19,15 +21,45 @@ export function ComputeExponent(
   if (x.isNegative()) {
     x = x.negated()
   }
-  const magnitude = x.log(10).floor()
+
+  // Fast path for simple numbers
+  // If x can be represented as a safe integer, use native Math.log10
+  const xNum = x.toNumber()
+  let magnitude: Decimal
+  if (
+    Number.isFinite(xNum) &&
+    Number.isSafeInteger(xNum) &&
+    xNum > 0 &&
+    xNum <= 999999
+  ) {
+    // Use fast native logarithm for simple positive integers
+    const magNum = Math.floor(Math.log10(xNum))
+    magnitude = new Decimal(magNum)
+  } else {
+    magnitude = x.log(10).floor()
+  }
   const exponent = ComputeExponentForMagnitude(internalSlots, magnitude)
   // Preserve more precision by doing multiplication when exponent is negative.
-  x = x.times(Decimal.pow(10, -exponent))
+  x = x.times(getPowerOf10(-exponent))
   const formatNumberResult = FormatNumericToString(internalSlots, x)
   if (formatNumberResult.roundedNumber.isZero()) {
     return [exponent, magnitude.toNumber()]
   }
-  const newMagnitude = formatNumberResult.roundedNumber.log(10).floor()
+
+  // Fast path for simple rounded numbers
+  const roundedNum = formatNumberResult.roundedNumber.toNumber()
+  let newMagnitude: Decimal
+  if (
+    Number.isFinite(roundedNum) &&
+    Number.isSafeInteger(roundedNum) &&
+    roundedNum > 0 &&
+    roundedNum <= 999999
+  ) {
+    const newMagNum = Math.floor(Math.log10(roundedNum))
+    newMagnitude = new Decimal(newMagNum)
+  } else {
+    newMagnitude = formatNumberResult.roundedNumber.log(10).floor()
+  }
   if (newMagnitude.eq(magnitude.minus(exponent))) {
     return [exponent, magnitude.toNumber()]
   }

--- a/packages/ecma402-abstract/NumberFormat/ComputeExponentForMagnitude.ts
+++ b/packages/ecma402-abstract/NumberFormat/ComputeExponentForMagnitude.ts
@@ -1,6 +1,7 @@
 import {Decimal} from 'decimal.js'
 import {DecimalFormatNum, NumberFormatInternal} from '../types/number.js'
 import {invariant} from '../utils.js'
+import {getPowerOf10} from './decimal-cache.js'
 Decimal.set({
   toExpPos: 100,
 })
@@ -43,7 +44,7 @@ export function ComputeExponentForMagnitude(
       if (!thresholdMap) {
         return 0
       }
-      const num = Decimal.pow(10, magnitude).toString() as DecimalFormatNum
+      const num = getPowerOf10(magnitude).toString() as DecimalFormatNum
       const thresholds = Object.keys(thresholdMap) as DecimalFormatNum[] // TODO: this can be pre-processed
       if (num < thresholds[0]) {
         return 0

--- a/packages/ecma402-abstract/NumberFormat/PartitionNumberPattern.ts
+++ b/packages/ecma402-abstract/NumberFormat/PartitionNumberPattern.ts
@@ -4,6 +4,7 @@ import {invariant} from '../utils.js'
 import {ComputeExponent} from './ComputeExponent.js'
 import formatToParts from './format_to_parts.js'
 import {FormatNumericToString} from './FormatNumericToString.js'
+import {getPowerOf10} from './decimal-cache.js'
 
 /**
  * https://tc39.es/ecma402/#sec-partitionnumberpattern
@@ -57,7 +58,7 @@ export function PartitionNumberPattern(
       ] = ComputeExponent(internalSlots, x)
 
       // 8.d. Let x be x × 10^(-exponent).
-      x = x.times(Decimal.pow(10, -exponent))
+      x = x.times(getPowerOf10(-exponent))
     }
 
     // 8.e. Let formatNumberResult be FormatNumericToString(internalSlots, x).

--- a/packages/ecma402-abstract/NumberFormat/ToRawFixed.ts
+++ b/packages/ecma402-abstract/NumberFormat/ToRawFixed.ts
@@ -5,6 +5,7 @@ import {
 } from '../types/number.js'
 import {repeat} from '../utils.js'
 import {ApplyUnsignedRoundingMode} from './ApplyUnsignedRoundingMode.js'
+import {getPowerOf10} from './decimal-cache.js'
 
 //IMPL: Setting Decimal configuration
 Decimal.set({
@@ -13,12 +14,12 @@ Decimal.set({
 
 //IMPL: Helper function to calculate raw fixed value
 function ToRawFixedFn(n: Decimal, f: number) {
-  return n.times(Decimal.pow(10, -f))
+  return n.times(getPowerOf10(-f))
 }
 
 //IMPL: Helper function to find n1 and r1
 function findN1R1(x: Decimal, f: number, roundingIncrement: number) {
-  const nx = x.times(Decimal.pow(10, f)).floor()
+  const nx = x.times(getPowerOf10(f)).floor()
   const n1 = nx.div(roundingIncrement).floor().times(roundingIncrement)
   const r1 = ToRawFixedFn(n1, f)
   return {
@@ -29,7 +30,7 @@ function findN1R1(x: Decimal, f: number, roundingIncrement: number) {
 
 //IMPL: Helper function to find n2 and r2
 function findN2R2(x: Decimal, f: number, roundingIncrement: number) {
-  const nx = x.times(Decimal.pow(10, f)).ceil()
+  const nx = x.times(getPowerOf10(f)).ceil()
   const n2 = nx.div(roundingIncrement).ceil().times(roundingIncrement)
   const r2 = ToRawFixedFn(n2, f)
   return {

--- a/packages/ecma402-abstract/NumberFormat/decimal-cache.ts
+++ b/packages/ecma402-abstract/NumberFormat/decimal-cache.ts
@@ -1,0 +1,18 @@
+import {Decimal} from 'decimal.js'
+import {memoize} from '@formatjs/fast-memoize'
+
+/**
+ * Cached function to compute powers of 10 for Decimal.js operations.
+ * This cache significantly reduces overhead in ComputeExponent and ToRawFixed
+ * by memoizing expensive Decimal.pow(10, n) calculations.
+ *
+ * Common exponents (e.g., -20 to 20) are used repeatedly in number formatting,
+ * so caching provides substantial performance benefits.
+ *
+ * @param exponent - Can be a number or Decimal. If Decimal, it will be converted to string for cache key.
+ */
+export const getPowerOf10: (exponent: number | Decimal) => Decimal = memoize(
+  (exponent: number | Decimal): Decimal => {
+    return Decimal.pow(10, exponent)
+  }
+)

--- a/packages/ecma402-abstract/NumberFormat/format_to_parts.ts
+++ b/packages/ecma402-abstract/NumberFormat/format_to_parts.ts
@@ -18,6 +18,7 @@ import {
   UnsignedRoundingModeType,
   UseGroupingType,
 } from '../types/number.js'
+import {getPowerOf10} from './decimal-cache.js'
 import {LDMLPluralRule} from '../types/plural-rules.js'
 import {digitMapping} from './digit-mapping.generated.js'
 import {GetUnsignedRoundingMode} from './GetUnsignedRoundingMode.js'
@@ -258,9 +259,7 @@ export default function formatToParts(
         if (currencyNameData) {
           unitName = selectPlural(
             pl,
-            numberResult.roundedNumber
-              .times(Decimal.pow(10, exponent))
-              .toNumber(),
+            numberResult.roundedNumber.times(getPowerOf10(exponent)).toNumber(),
             currencyNameData.displayName
           )
         } else {
@@ -302,9 +301,7 @@ export default function formatToParts(
         // Simple unit pattern
         unitPattern = selectPlural(
           pl,
-          numberResult.roundedNumber
-            .times(Decimal.pow(10, exponent))
-            .toNumber(),
+          numberResult.roundedNumber.times(getPowerOf10(exponent)).toNumber(),
           data.units.simple[unit!][unitDisplay!]
         )
       } else {
@@ -316,9 +313,7 @@ export default function formatToParts(
 
         const numeratorUnitPattern = selectPlural(
           pl,
-          numberResult.roundedNumber
-            .times(Decimal.pow(10, exponent))
-            .toNumber(),
+          numberResult.roundedNumber.times(getPowerOf10(exponent)).toNumber(),
           data.units.simple[numeratorUnit!][unitDisplay!]
         )
         const perUnitPattern =

--- a/packages/intl-numberformat/benchmark/BUILD.bazel
+++ b/packages/intl-numberformat/benchmark/BUILD.bazel
@@ -12,3 +12,36 @@ ts_binary(
     ],
     entry_point = "benchmark.ts",
 )
+
+ts_binary(
+    name = "profile",
+    data = [
+        "en.json",
+        ":node_modules/@formatjs/intl-numberformat",
+    ],
+    entry_point = "profile.ts",
+)
+
+ts_binary(
+    name = "profile_cpu",
+    data = [
+        "en.json",
+        ":node_modules/@formatjs/intl-numberformat",
+    ],
+    entry_point = "profile.ts",
+    node_options = [
+        "--cpu-prof",
+        "--cpu-prof-interval=100",
+        "--cpu-prof-dir=/tmp",
+    ],
+)
+
+ts_binary(
+    name = "analyze_profile",
+    data = [
+        "//:node_modules/@types/minimist",
+        "//:node_modules/@types/node",
+        "//:node_modules/minimist",
+    ],
+    entry_point = "analyze-profile.ts",
+)

--- a/packages/intl-numberformat/benchmark/PROFILE.md
+++ b/packages/intl-numberformat/benchmark/PROFILE.md
@@ -1,0 +1,261 @@
+# CPU Profiling Guide for IntlNumberFormat
+
+This guide explains how to profile and analyze the performance of `@formatjs/intl-numberformat` using Node.js's built-in CPU profiler.
+
+## Quick Start
+
+### 1. Generate CPU Profile
+
+```bash
+bazel run //packages/intl-numberformat/benchmark:profile_cpu
+```
+
+### 2. Analyze Results
+
+```bash
+bazel run //packages/intl-numberformat/benchmark:analyze_profile
+```
+
+## Detailed Workflow
+
+### Step 1: Run CPU Profiler
+
+```bash
+bazel run //packages/intl-numberformat/benchmark:profile_cpu
+```
+
+**What this does:**
+
+- Runs the profile script with Node's `--cpu-prof` flag enabled
+- Generates a `.cpuprofile` file in `/tmp/`
+- Samples stack traces every 100 microseconds
+- Executes 900,000 format() calls
+- Displays total execution time
+
+**Output:**
+
+```
+Starting profiling...
+Warming up...
+Running profiled iterations...
+Total time: 3.376s
+Completed 900000 format() calls
+```
+
+**Profile file location:** `/tmp/CPU.*.cpuprofile`
+
+### Step 2: Analyze the Profile
+
+#### Automatic Analysis (Latest Profile)
+
+```bash
+bazel run //packages/intl-numberformat/benchmark:analyze_profile
+```
+
+The analyzer will automatically find and analyze the most recent `.cpuprofile` file in `/tmp/`.
+
+#### Specify a Profile File
+
+```bash
+# Using positional argument
+bazel run //packages/intl-numberformat/benchmark:analyze_profile -- /tmp/CPU.20251222.230039.35420.0.001.cpuprofile
+
+# Using --profile flag
+bazel run //packages/intl-numberformat/benchmark:analyze_profile -- --profile /tmp/CPU.20251222.230039.35420.0.001.cpuprofile
+
+# Using -p shorthand
+bazel run //packages/intl-numberformat/benchmark:analyze_profile -- -p /tmp/CPU.20251222.230039.35420.0.001.cpuprofile
+```
+
+### Profile Analysis Output
+
+The analyzer provides two comprehensive views:
+
+#### 1. Top 40 Functions by CPU Time
+
+Shows individual functions sorted by CPU time:
+
+```
+Top 40 functions by CPU time (hit count):
+==========================================
+
+1. Decimal [decimal.js:4291]
+   Hit count: 6317
+   File: file:///Users/.../node_modules/decimal.js/decimal.js
+
+2. P.times.P.mul [decimal.js:1871]
+   Hit count: 4872
+   File: file:///Users/.../node_modules/decimal.js/decimal.js
+...
+```
+
+**What each field means:**
+
+- **Function name**: Name of the function (or `(anonymous)` for unnamed functions)
+- **File and line number**: Source location `[filename:line]`
+- **Hit count**: Number of times this function was sampled (higher = more CPU time)
+- **File path**: Full path to the source file
+
+#### 2. Top 20 Files by CPU Time
+
+Aggregated view showing which files consume the most CPU time:
+
+```
+Top 20 files by CPU time:
+=========================
+
+1. decimal.js/decimal.js: 21575 hits
+2. ecma402-abstract/NumberFormat/format_to_parts.ts: 3080 hits
+3. ecma402-abstract/NumberFormat/ToRawFixed.ts: 947 hits
+...
+```
+
+**Filters:**
+
+- Excludes Node.js internals (`node:internal`)
+- Only shows formatjs-related code
+
+## Alternative Analysis Tools
+
+### Chrome DevTools (Visual Analysis)
+
+1. Open Chrome and press F12 to open DevTools
+2. Navigate to the **Performance** tab
+3. Click the **Load profile** button (⬆️ icon)
+4. Select your `.cpuprofile` file from `/tmp/`
+5. Explore the flame graph and call tree
+
+**Benefits:**
+
+- Interactive flame graph visualization
+- Bottom-up and top-down views
+- Function-level drill-down
+- Time range selection
+
+### VS Code (IDE Integration)
+
+1. Install the **JavaScript Profiler** extension
+2. Open your `.cpuprofile` file in VS Code
+3. View the interactive profile
+
+**Benefits:**
+
+- Integrated with your code editor
+- Jump to source code directly
+- Filter and search capabilities
+
+### Command Line (Direct)
+
+```bash
+node packages/intl-numberformat/benchmark/analyze-profile.ts /tmp/CPU.*.cpuprofile
+```
+
+## Available Bazel Targets
+
+| Target            | Description                           |
+| ----------------- | ------------------------------------- |
+| `profile`         | Quick timing test without profiling   |
+| `profile_cpu`     | CPU profiling with .cpuprofile output |
+| `analyze_profile` | Analyze .cpuprofile files             |
+| `benchmark`       | Full benchmark suite                  |
+
+## Understanding the Results
+
+### Hit Counts
+
+- **Hit count** represents CPU sampling frequency
+- Higher hit count = more time spent in that function
+- Samples are taken every 100 microseconds
+- Total hits ≈ (execution time in seconds) × 10,000
+
+### Identifying Bottlenecks
+
+Look for:
+
+1. **High hit count functions** - These consume the most CPU time
+2. **Unexpected functions** - Functions that shouldn't be hot
+3. **Deep call stacks** - May indicate recursion or nested loops
+4. **External dependencies** - Library code that's unexpectedly slow
+
+### Optimization History
+
+After our optimizations:
+
+- **Decimal.js overhead**: Reduced from 270,631 hits to 21,575 hits (92% reduction)
+- **Logarithm operations**: Eliminated from hot path using native `Math.log10()`
+- **Power-of-10 caching**: Reduced `Decimal.pow()` calls
+
+## Troubleshooting
+
+### No profile files found
+
+```bash
+# Check if files exist
+ls -lth /tmp/CPU.*.cpuprofile | head -5
+
+# If empty, try running the profiler again
+bazel run //packages/intl-numberformat/benchmark:profile_cpu
+```
+
+### Profile files in wrong location
+
+The profiler writes to `/tmp/` by default. To change this:
+
+1. Edit `BUILD.bazel` and modify `--cpu-prof-dir=/tmp`
+2. Update the default path in `analyze-profile.ts` line 106
+
+### Bazel build errors
+
+```bash
+# Clean build cache
+bazel clean
+
+# Rebuild
+bazel build //packages/intl-numberformat/benchmark:all
+```
+
+### Permission errors
+
+If you can't write to `/tmp/`:
+
+```bash
+# Use a different directory
+mkdir -p ~/profiles
+# Then update BUILD.bazel: --cpu-prof-dir=$HOME/profiles
+```
+
+## Best Practices
+
+### Before Profiling
+
+1. Warm up the code (already done in profile.ts)
+2. Run enough iterations (900K provides good signal)
+3. Close other applications to reduce noise
+
+### During Analysis
+
+1. Focus on formatjs code, not Node.js internals
+2. Look for patterns across multiple runs
+3. Compare before/after optimization profiles
+
+### After Optimization
+
+1. Run the benchmark suite to measure improvement
+2. Verify correctness with unit tests
+3. Profile again to find the next bottleneck
+
+## Related Documentation
+
+- [Benchmark README](./README.md) - Full benchmark suite documentation
+- [Fast-path optimizations tests](../tests/fast-path-optimizations.test.ts)
+- [Node.js Profiling Guide](https://nodejs.org/en/docs/guides/simple-profiling)
+- [Chrome DevTools Profiling](https://developer.chrome.com/docs/devtools/performance/)
+
+## Contributing
+
+When adding profiling capabilities:
+
+1. Add new profiling scenarios to `profile.ts`
+2. Update this documentation
+3. Consider adding visualization tools
+4. Share interesting findings in PRs

--- a/packages/intl-numberformat/benchmark/README.md
+++ b/packages/intl-numberformat/benchmark/README.md
@@ -21,10 +21,12 @@ The benchmark includes the following scenarios:
 
 ## Running the Benchmark
 
+### Benchmark Suite
+
 Using Bazel:
 
 ```bash
-bazel run //packages/intl-numberformat/benchmark
+bazel run //packages/intl-numberformat/benchmark:benchmark
 ```
 
 Or using tsx directly from the root:
@@ -34,6 +36,10 @@ cd packages/intl-numberformat/benchmark
 pnpm install
 pnpm exec tsx benchmark.ts
 ```
+
+### CPU Profiling
+
+For detailed performance analysis and CPU profiling workflows, see **[PROFILE.md](./PROFILE.md)**.
 
 ## Interpreting Results
 
@@ -48,73 +54,88 @@ Look for significant differences in the "time values 0-59" and "significantDigit
 
 ## Benchmark Results
 
-### After ToRawPrecision Optimization (Direct Calculation)
+### After Fast-Path Logarithm Optimization
 
-Results from running on macOS (Apple Silicon) after implementing direct calculation in `ToRawPrecision`:
+Results from running on macOS (Apple Silicon) with Node.js v24.11.1:
 
 ```
-┌─────────┬────────────────────────────────────────────┬───────────────────┬────────────────────┬────────────────────────┬────────────────────────┬─────────┐
-│ (index) │ Task name                                  │ Latency avg (ns)  │ Latency med (ns)   │ Throughput avg (ops/s) │ Throughput med (ops/s) │ Samples │
-├─────────┼────────────────────────────────────────────┼───────────────────┼────────────────────┼────────────────────────┼────────────────────────┼─────────┤
-│ 0       │ 'format decimal (polyfill)'                │ '392234 ± 0.61%'  │ '371791 ± 8666.5'  │ '2591 ± 0.42%'         │ '2690 ± 64'            │ 2550    │
-│ 1       │ 'format decimal (native)'                  │ '1737.5 ± 0.30%'  │ '1667.0 ± 42.00'   │ '589316 ± 0.02%'       │ '599880 ± 15505'       │ 575545  │
-│ 2       │ 'format percent (polyfill)'                │ '396033 ± 2.51%'  │ '356770 ± 8479.5'  │ '2668 ± 0.54%'         │ '2803 ± 68'            │ 2526    │
-│ 3       │ 'format percent (native)'                  │ '1964.1 ± 0.27%'  │ '1917.0 ± 42.00'   │ '517270 ± 0.02%'       │ '521648 ± 11685'       │ 509139  │
-│ 4       │ 'format currency (polyfill)'               │ '387081 ± 0.76%'  │ '366395 ± 8186.5'  │ '2636 ± 0.42%'         │ '2729 ± 62'            │ 2584    │
-│ 5       │ 'format currency (native)'                 │ '1952.2 ± 0.53%'  │ '1875.0 ± 42.00'   │ '526284 ± 0.02%'       │ '533333 ± 11923'       │ 512251  │
-│ 6       │ 'format unit (polyfill)'                   │ '395679 ± 0.47%'  │ '379896 ± 8729.0'  │ '2554 ± 0.35%'         │ '2632 ± 61'            │ 2528    │
-│ 7       │ 'format with significantDigits (polyfill)' │ '1011253 ± 0.64%' │ '979416 ± 25082'   │ '996 ± 0.46%'          │ '1021 ± 26'            │ 989     │
-│ 8       │ 'format with fractionDigits (polyfill)'    │ '387999 ± 0.44%'  │ '373625 ± 9917.0'  │ '2603 ± 0.34%'         │ '2676 ± 72'            │ 2578    │
-│ 9       │ 'format time values 0-59 (polyfill)'       │ '4649196 ± 0.45%' │ '4629062 ± 103041' │ '215 ± 0.45%'          │ '216 ± 5'              │ 216     │
-│ 10      │ 'format time values 0-59 (native)'         │ '10834 ± 0.10%'   │ '10625 ± 167.00'   │ '93180 ± 0.05%'        │ '94118 ± 1503'         │ 92304   │
-│ 11      │ 'formatToParts decimal (polyfill)'         │ '387318 ± 0.54%'  │ '370125 ± 8042.0'  │ '2615 ± 0.37%'         │ '2702 ± 60'            │ 2583    │
-│ 12      │ 'formatToParts decimal (native)'           │ '6030.9 ± 0.24%'  │ '5833.0 ± 125.00'  │ '169098 ± 0.04%'       │ '171438 ± 3597'        │ 165813  │
-└─────────┴────────────────────────────────────────────┴───────────────────┴────────────────────┴────────────────────────┴────────────────────────┴─────────┘
+┌─────────┬────────────────────────────────────────────┬──────────────────┬───────────────────┬────────────────────────┬────────────────────────┬─────────┐
+│ (index) │ Task name                                  │ Latency avg (ns) │ Latency med (ns)  │ Throughput avg (ops/s) │ Throughput med (ops/s) │ Samples │
+├─────────┼────────────────────────────────────────────┼──────────────────┼───────────────────┼────────────────────────┼────────────────────────┼─────────┤
+│ 0       │ 'format decimal (polyfill)'                │ '35333 ± 0.36%'  │ '34000 ± 500.00'  │ '28938 ± 0.10%'        │ '29412 ± 439'          │ 28303   │
+│ 1       │ 'format decimal (native)'                  │ '1727.4 ± 0.19%' │ '1708.0 ± 42.00'  │ '589508 ± 0.02%'       │ '585480 ± 14400'       │ 578900  │
+│ 2       │ 'format percent (polyfill)'                │ '34461 ± 1.42%'  │ '32583 ± 333.00'  │ '30107 ± 0.10%'        │ '30691 ± 317'          │ 29020   │
+│ 3       │ 'format percent (native)'                  │ '1928.2 ± 0.11%' │ '1916.0 ± 41.00'  │ '522869 ± 0.01%'       │ '521921 ± 11413'       │ 518628  │
+│ 4       │ 'format currency (polyfill)'               │ '35661 ± 0.27%'  │ '34625 ± 375.00'  │ '28467 ± 0.09%'        │ '28881 ± 316'          │ 28043   │
+│ 5       │ 'format currency (native)'                 │ '1924.6 ± 0.13%' │ '1916.0 ± 41.00'  │ '524039 ± 0.02%'       │ '521921 ± 11413'       │ 519580  │
+│ 6       │ 'format unit (polyfill)'                   │ '40681 ± 0.37%'  │ '39167 ± 459.00'  │ '25083 ± 0.10%'        │ '25532 ± 303'          │ 24582   │
+│ 7       │ 'format with significantDigits (polyfill)' │ '649578 ± 0.36%' │ '632312 ± 6437.0' │ '1546 ± 0.30%'         │ '1581 ± 16'            │ 1540    │
+│ 8       │ 'format with fractionDigits (polyfill)'    │ '35427 ± 0.31%'  │ '34333 ± 542.00'  │ '28760 ± 0.09%'        │ '29126 ± 467'          │ 28227   │
+│ 9       │ 'format time values 0-59 (polyfill)'       │ '227776 ± 0.37%' │ '220458 ± 4167.0' │ '4436 ± 0.25%'         │ '4536 ± 86'            │ 4391    │
+│ 10      │ 'format time values 0-59 (native)'         │ '10743 ± 0.14%'  │ '10584 ± 168.00'  │ '93984 ± 0.04%'        │ '94482 ± 1524'         │ 93084   │
+│ 11      │ 'formatToParts decimal (polyfill)'         │ '36420 ± 0.62%'  │ '34500 ± 625.00'  │ '28434 ± 0.12%'        │ '28986 ± 516'          │ 27458   │
+│ 12      │ 'formatToParts decimal (native)'           │ '5870.1 ± 0.23%' │ '5750.0 ± 83.00'  │ '172230 ± 0.03%'       │ '173913 ± 2475'        │ 170356  │
+└─────────┴────────────────────────────────────────────┴──────────────────┴───────────────────┴────────────────────────┴────────────────────────┴─────────┘
 ```
 
 ### Performance Improvements
 
-Comparing before/after the `ToRawPrecision` optimization:
+Comparing before/after the fast-path logarithm optimization:
 
-| Benchmark                         | Before (ops/s) | After (ops/s) | Improvement |
-| --------------------------------- | -------------- | ------------- | ----------- |
-| **format with significantDigits** | 852            | 996           | **+17%** 🎉 |
-| format decimal                    | 2,398          | 2,591         | +8%         |
-| format time values 0-59           | 199            | 215           | +8%         |
+| Benchmark                     | Before (ops/s) | After (ops/s) | Improvement  |
+| ----------------------------- | -------------- | ------------- | ------------ |
+| **format decimal**            | 2,591          | **28,938**    | **11.2x** 🚀 |
+| **format time values 0-59**   | 215            | **4,436**     | **20.6x** 🚀 |
+| **formatToParts**             | 2,615          | **28,434**    | **10.9x** 🚀 |
+| format percent                | 2,668          | 30,107        | 11.3x        |
+| format currency               | 2,636          | 28,467        | 10.8x        |
+| format with fractionDigits    | 2,603          | 28,760        | 11.0x        |
+| format unit                   | 2,554          | 25,083        | 9.8x         |
+| format with significantDigits | 996            | 1,546         | 1.6x         |
 
-The optimization replaced iterative `while(true)` loops with direct mathematical calculations using logarithms, reducing algorithmic complexity from O(n) to O(1) in the common case.
+**Overall speedup: 10-20x faster for most common operations!**
 
 ### Key Observations
 
-1. **Native vs Polyfill Performance Gap:**
-   - Basic decimal formatting: Native is **~227x faster** (589k ops/s vs 2.6k ops/s)
-   - The polyfill takes ~392μs per format operation vs ~1.7μs for native
+1. **Dramatic Performance Improvement:**
+   - Basic decimal formatting: **11.2x faster** (~35μs vs ~386μs per operation)
+   - Time values 0-59 (issue #5023): **20.6x faster** (~228μs vs ~4.7ms per batch)
+   - formatToParts: **10.9x faster** (~36μs vs ~382μs per operation)
 
-2. **Significant Digits Improvement:**
-   - Formatting with `significantDigits` improved from 852 to **996 ops/s** (+17%)
-   - Still **~2.6x slower** than basic decimal formatting, but the gap has narrowed
-   - The direct calculation approach in `ToRawPrecision` eliminates most iteration overhead
+2. **Native vs Polyfill Gap (After Optimization):**
+   - Basic decimal: Native is ~20x faster (was ~227x)
+   - Time values 0-59: Native is ~21x faster (was ~433x)
+   - formatToParts: Native is ~6x faster (was ~65x)
+   - **The gap has been significantly reduced!**
 
-3. **Time Values 0-59 (Issue #5023 Scenario):**
-   - Polyfill: **215 ops/s** (~4.6ms per batch of 60 values)
-   - Native: **93,180 ops/s** (~10.8μs per batch of 60 values)
-   - Native is **~433x faster** for this real-world use case
-   - The optimization provides modest improvement (+8%), but the gap remains significant
+3. **CPU Time Reduction:**
+   - Decimal.js operations: Reduced from 270K hits to 21K hits (**92% reduction**)
+   - Logarithm operations: Eliminated from hot path for common integers (0-999,999)
 
-4. **formatToParts Performance:**
-   - Polyfill: 2,615 ops/s (~387μs per operation)
-   - Native: 169,098 ops/s (~6μs per operation)
-   - Native is **~65x faster**
+4. **Significant Digits Path:**
+   - Still slower (1,546 ops/s) due to complex precision calculations
+   - Improved by 1.6x from previous optimization
+   - Remains the slowest path but acceptable for specialized use cases
 
 ### Optimization Details
 
-The `ToRawPrecision` function was optimized by:
+The optimization uses a **hybrid fast/slow path approach**:
 
-1. **Replacing iterative search with direct calculation**: Using `floor(log10(x))` to compute the exponent directly instead of iterating
-2. **Adding boundary adjustment logic**: Handles edge cases near powers of 10 efficiently
-3. **Keeping fallback for safety**: Rare edge cases still use the original iterative approach
+1. **Fast path for simple integers (0-999,999)**:
+   - Uses native `Math.log10()` instead of Decimal.js logarithms
+   - Orders of magnitude faster for common values
+   - Applies to dates, times, counters, and most UI numbers
 
-This change maintains full correctness while improving performance for the common path.
+2. **Power-of-10 caching**:
+   - Caches `Decimal.pow(10, n)` results to avoid repeated calculations
+   - Reduces overhead in `ComputeExponent` and `ToRawFixed`
+
+3. **Maintains correctness**:
+   - Falls back to Decimal.js for complex cases (very large numbers, decimals, BigInt)
+   - All 50+ unit tests pass
+   - No breaking changes
+
+This change provides massive performance improvements for the common path while maintaining full correctness.
 
 ## Related Files
 

--- a/packages/intl-numberformat/benchmark/analyze-profile.ts
+++ b/packages/intl-numberformat/benchmark/analyze-profile.ts
@@ -1,0 +1,151 @@
+import minimist from 'minimist'
+import {existsSync, readdirSync, readFileSync} from 'fs'
+
+interface CallFrame {
+  functionName: string
+  url: string
+  lineNumber: number
+}
+
+interface ProfileNode {
+  callFrame: CallFrame
+  hitCount?: number
+}
+
+interface CPUProfile {
+  nodes: ProfileNode[]
+}
+
+interface FunctionStats {
+  hitCount: number
+  url: string
+}
+
+interface FunctionEntry {
+  name: string
+  hitCount: number
+  url: string
+}
+
+interface FileEntry {
+  name: string
+  hitCount: number
+}
+
+function analyzeProfile(profilePath: string): void {
+  // Read and parse the profile file
+  const profileData = readFileSync(profilePath, 'utf8')
+  const profile: CPUProfile = JSON.parse(profileData)
+
+  console.log(`Analyzing profile: ${profilePath}\n`)
+
+  // Aggregate time by function name
+  const timeByFunction = new Map<string, FunctionStats>()
+
+  profile.nodes.forEach(node => {
+    const funcName = node.callFrame.functionName || '(anonymous)'
+    const url = node.callFrame.url
+    const fileName = url.split('/').pop() || ''
+    const key = `${funcName} [${fileName}:${node.callFrame.lineNumber}]`
+
+    if (!timeByFunction.has(key)) {
+      timeByFunction.set(key, {hitCount: 0, url})
+    }
+
+    const data = timeByFunction.get(key)!
+    data.hitCount += node.hitCount || 0
+  })
+
+  // Sort by hit count
+  const sorted: FunctionEntry[] = Array.from(timeByFunction.entries())
+    .map(([name, data]) => ({name, ...data}))
+    .filter(item => item.hitCount > 0 && !item.url.includes('node:internal'))
+    .sort((a, b) => b.hitCount - a.hitCount)
+    .slice(0, 40)
+
+  console.log('Top 40 functions by CPU time (hit count):')
+  console.log('==========================================\n')
+  sorted.forEach((item, i) => {
+    console.log(`${i + 1}. ${item.name}`)
+    console.log(`   Hit count: ${item.hitCount}`)
+    console.log(`   File: ${item.url}`)
+    console.log('')
+  })
+
+  // Also group by file
+  const timeByFile = new Map<string, number>()
+  profile.nodes.forEach(node => {
+    const url = node.callFrame.url
+    if (url.includes('node:internal') || !url.includes('formatjs')) return
+
+    const fileName = url.split('/packages/').pop()
+    if (!fileName) return
+
+    if (!timeByFile.has(fileName)) {
+      timeByFile.set(fileName, 0)
+    }
+
+    timeByFile.set(fileName, timeByFile.get(fileName)! + (node.hitCount || 0))
+  })
+
+  const sortedByFile: FileEntry[] = Array.from(timeByFile.entries())
+    .map(([name, hitCount]) => ({name, hitCount}))
+    .sort((a, b) => b.hitCount - a.hitCount)
+    .slice(0, 20)
+
+  console.log('\n\nTop 20 files by CPU time:')
+  console.log('=========================\n')
+  sortedByFile.forEach((item, i) => {
+    console.log(`${i + 1}. ${item.name}: ${item.hitCount} hits`)
+  })
+}
+
+function main(): void {
+  const argv = minimist(process.argv.slice(2), {
+    string: ['profile', 'p'],
+    alias: {p: 'profile'},
+    default: {
+      profile: '/tmp/CPU.*.cpuprofile',
+    },
+  })
+
+  const profilePath = argv.profile || argv._[0]
+
+  if (!profilePath) {
+    console.error('Error: No profile path specified')
+    console.error('\nUsage:')
+    console.error('  analyze-profile <path-to-profile.cpuprofile>')
+    console.error('  analyze-profile --profile <path-to-profile.cpuprofile>')
+    console.error('  analyze-profile -p <path-to-profile.cpuprofile>')
+    process.exit(1)
+  }
+
+  // Handle glob pattern for /tmp/CPU.*.cpuprofile
+  if (profilePath.includes('*')) {
+    const dir = profilePath.substring(0, profilePath.lastIndexOf('/'))
+    const pattern = profilePath.substring(profilePath.lastIndexOf('/') + 1)
+    const files = readdirSync(dir)
+      .filter(f => f.match(pattern.replace('*', '.*')))
+      .sort()
+      .reverse() // Get most recent first
+
+    if (files.length === 0) {
+      console.error(`Error: No profile files found matching ${profilePath}`)
+      process.exit(1)
+    }
+
+    const latestProfile = `${dir}/${files[0]}`
+    console.log(`Using most recent profile: ${latestProfile}\n`)
+    analyzeProfile(latestProfile)
+    return
+  }
+
+  if (!existsSync(profilePath)) {
+    console.error(`Error: Profile file not found: ${profilePath}`)
+    process.exit(1)
+  }
+
+  analyzeProfile(profilePath)
+}
+
+main()

--- a/packages/intl-numberformat/benchmark/profile.ts
+++ b/packages/intl-numberformat/benchmark/profile.ts
@@ -1,0 +1,31 @@
+import {NumberFormat} from '@formatjs/intl-numberformat'
+// @ts-ignore
+import * as en from './en.json' with {type: 'json'}
+// @ts-ignore
+NumberFormat.__addLocaleData(en)
+
+// Test values matching the benchmark
+const testValues = [59, 0, 1, 2, 3, 42, 99, 100, 1000]
+
+// Create formatter
+const nf = new NumberFormat('en')
+
+console.log('Starting profiling...')
+console.log('Warming up...')
+
+// Warm up
+for (let i = 0; i < 1000; i++) {
+  testValues.forEach(val => nf.format(val))
+}
+
+console.log('Running profiled iterations...')
+console.time('Total time')
+
+// Run many iterations to get meaningful profile data
+const iterations = 100000
+for (let i = 0; i < iterations; i++) {
+  testValues.forEach(val => nf.format(val))
+}
+
+console.timeEnd('Total time')
+console.log(`Completed ${iterations * testValues.length} format() calls`)

--- a/packages/intl-numberformat/tests/fast-path-optimizations.test.ts
+++ b/packages/intl-numberformat/tests/fast-path-optimizations.test.ts
@@ -1,0 +1,196 @@
+import {describe, it, expect} from 'vitest'
+import {NumberFormat} from '../src/core'
+import * as en from './locale-data/en.json' with {type: 'json'}
+NumberFormat.__addLocaleData(en as any)
+
+describe('Fast-path optimizations', () => {
+  describe('Basic integer formatting (fast path)', () => {
+    const nf = new NumberFormat('en')
+
+    it('should format zero', () => {
+      expect(nf.format(0)).toBe('0')
+    })
+
+    it('should format single digits', () => {
+      expect(nf.format(1)).toBe('1')
+      expect(nf.format(9)).toBe('9')
+    })
+
+    it('should format two-digit numbers', () => {
+      expect(nf.format(42)).toBe('42')
+      expect(nf.format(99)).toBe('99')
+    })
+
+    it('should format three-digit numbers', () => {
+      expect(nf.format(100)).toBe('100')
+      expect(nf.format(999)).toBe('999')
+    })
+
+    it('should format four-digit numbers with grouping', () => {
+      expect(nf.format(1000)).toBe('1,000')
+      expect(nf.format(9999)).toBe('9,999')
+    })
+
+    it('should format large numbers within fast-path range', () => {
+      expect(nf.format(999999)).toBe('999,999')
+    })
+
+    it('should format negative numbers', () => {
+      expect(nf.format(-42)).toBe('-42')
+      expect(nf.format(-999)).toBe('-999')
+      expect(nf.format(-1000)).toBe('-1,000')
+    })
+  })
+
+  describe('formatToParts with fast path', () => {
+    const nf = new NumberFormat('en')
+
+    it('should produce correct parts for simple numbers', () => {
+      const parts = nf.formatToParts(1234)
+      const hasInteger = parts.some(p => p.type === 'integer')
+      const hasGroup = parts.some(p => p.type === 'group')
+      expect(hasInteger).toBe(true)
+      expect(hasGroup).toBe(true)
+    })
+
+    it('should produce correct parts for zero', () => {
+      const parts = nf.formatToParts(0)
+      expect(parts).toEqual([{type: 'integer', value: '0'}])
+    })
+
+    it('should produce correct parts for negative numbers', () => {
+      const parts = nf.formatToParts(-42)
+      expect(parts[0]).toEqual({type: 'minusSign', value: '-'})
+      expect(parts[1]).toEqual({type: 'integer', value: '42'})
+    })
+  })
+
+  describe('Currency formatting with fast path', () => {
+    const nfCurrency = new NumberFormat('en', {
+      style: 'currency',
+      currency: 'USD',
+    })
+
+    it('should format integer currency values', () => {
+      expect(nfCurrency.format(42)).toBe('$42.00')
+      expect(nfCurrency.format(0)).toBe('$0.00')
+      expect(nfCurrency.format(999)).toBe('$999.00')
+    })
+
+    it('should format negative currency values', () => {
+      expect(nfCurrency.format(-42)).toBe('-$42.00')
+    })
+
+    it('should format large currency values', () => {
+      expect(nfCurrency.format(999999)).toBe('$999,999.00')
+    })
+  })
+
+  describe('Percent formatting with fast path', () => {
+    const nfPercent = new NumberFormat('en', {style: 'percent'})
+
+    it('should format decimal as percent', () => {
+      expect(nfPercent.format(0.42)).toBe('42%')
+    })
+
+    it('should format zero percent', () => {
+      expect(nfPercent.format(0)).toBe('0%')
+    })
+
+    it('should format negative percent', () => {
+      expect(nfPercent.format(-0.5)).toBe('-50%')
+    })
+
+    it('should format 100%', () => {
+      expect(nfPercent.format(1)).toBe('100%')
+    })
+  })
+
+  describe('Edge cases that bypass fast path', () => {
+    const nf = new NumberFormat('en')
+
+    it('should handle NaN', () => {
+      expect(nf.format(NaN)).toBe('NaN')
+    })
+
+    it('should handle Infinity', () => {
+      expect(nf.format(Infinity)).toBe('∞')
+      expect(nf.format(-Infinity)).toBe('-∞')
+    })
+
+    it('should handle decimal numbers', () => {
+      expect(nf.format(0.123)).toBe('0.123')
+      expect(nf.format(1.5)).toBe('1.5')
+    })
+
+    it('should handle very large numbers', () => {
+      expect(nf.format(1e20)).toBe('100,000,000,000,000,000,000')
+    })
+
+    it('should handle numbers beyond fast-path range', () => {
+      expect(nf.format(1000000)).toBe('1,000,000')
+      expect(nf.format(10000000)).toBe('10,000,000')
+    })
+  })
+
+  describe('Fast path performance characteristics', () => {
+    const nf = new NumberFormat('en')
+
+    it('should format common time values efficiently (0-59)', () => {
+      // These should all hit the fast path
+      for (let i = 0; i < 60; i++) {
+        const result = nf.format(i)
+        expect(result).toBe(String(i))
+      }
+    })
+
+    it('should format common date values efficiently (1-31)', () => {
+      // Common day-of-month values
+      for (let i = 1; i <= 31; i++) {
+        const result = nf.format(i)
+        expect(result).toBe(String(i))
+      }
+    })
+
+    it('should format percentages efficiently', () => {
+      // Common percentage values from 0-100
+      for (let i = 0; i <= 100; i++) {
+        const result = nf.format(i)
+        expect(typeof result).toBe('string')
+        expect(result.length).toBeGreaterThan(0)
+      }
+    })
+  })
+
+  describe('Mixed fast and slow path in same formatter', () => {
+    const nf = new NumberFormat('en', {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    })
+
+    it('should handle both integer and decimal formatting', () => {
+      // Fast path integers
+      expect(nf.format(42)).toBe('42.00')
+      expect(nf.format(0)).toBe('0.00')
+
+      // Slow path decimals
+      expect(nf.format(42.5)).toBe('42.50')
+      expect(nf.format(0.123)).toBe('0.12')
+    })
+  })
+
+  describe('Grouping with fast path', () => {
+    it('should handle different grouping settings', () => {
+      const nfAlways = new NumberFormat('en', {useGrouping: 'always'})
+      expect(nfAlways.format(999)).toBe('999')
+      expect(nfAlways.format(1000)).toBe('1,000')
+
+      const nfMin2 = new NumberFormat('en', {useGrouping: 'min2'})
+      expect(nfMin2.format(1000)).toBe('1000')
+      expect(nfMin2.format(10000)).toBe('10,000')
+
+      const nfFalse = new NumberFormat('en', {useGrouping: false})
+      expect(nfFalse.format(1000000)).toBe('1000000')
+    })
+  })
+})

--- a/tools/index.bzl
+++ b/tools/index.bzl
@@ -72,7 +72,7 @@ def ts_compile(name, srcs, deps = [], skip_esm = True, skip_esm_esnext = True, v
         visibility = visibility,
     )
 
-def ts_binary(name, data = [], **kwargs):
+def ts_binary(name, data = [], node_options = [], **kwargs):
     """Create a TS binary with prefilled args.
 
     Args:
@@ -85,7 +85,7 @@ def ts_binary(name, data = [], **kwargs):
         data = data + [
             "//:node_modules/tsx",
         ],
-        node_options = [
+        node_options = node_options + [
             "--import",
             "tsx",
         ],


### PR DESCRIPTION
# Optimize NumberFormat performance with fast-path logarithm calculations

### TL;DR

Dramatically improves `@formatjs/intl-numberformat` performance by 10-20x for common number formatting operations through fast-path optimizations and power-of-10 caching.

### What changed?

- Added a fast path for simple integers (0-999,999) using native `Math.log10()` instead of Decimal.js logarithms
- Implemented a memoized `getPowerOf10()` function to cache expensive `Decimal.pow(10, n)` calculations
- Applied these optimizations across multiple number formatting operations
- Added comprehensive CPU profiling tools and documentation
- Created new tests specifically for fast-path optimizations

### How to test?

1. Run the benchmark suite:
   ```bash
   bazel run //packages/intl-numberformat/benchmark:benchmark
   ```

2. Run CPU profiling:
   ```bash
   bazel run //packages/intl-numberformat/benchmark:profile_cpu
   ```

3. Analyze profile results:
   ```bash
   bazel run //packages/intl-numberformat/benchmark:analyze_profile
   ```

4. Run the new fast-path tests:
   ```bash
   pnpm test packages/intl-numberformat/tests/fast-path-optimizations.test.ts
   ```

### Why make this change?

The polyfill was significantly slower than native Intl.NumberFormat, especially for common operations like formatting integers. This optimization:

1. Reduces CPU time spent in Decimal.js operations by 92%
2. Makes common number formatting 10-20x faster
3. Significantly improves performance for time/date formatting (issue #5023)
4. Maintains full correctness for all number ranges
5. Narrows the performance gap between polyfill and native implementations

The hybrid approach ensures we get maximum performance for common cases while maintaining precision for complex numbers.