### PR TITLE
fix(@formatjs/intl-datetimeformat): add synthetic range, fix #4535

### DIFF
--- a/packages/intl-datetimeformat/test262-main.ts
+++ b/packages/intl-datetimeformat/test262-main.ts
@@ -2599,6 +2599,1318 @@ Intl.DateTimeFormat.__addLocaleData({
       "yMMMM": {
         "M": "MMMM – MMMM y",
         "y": "MMMM y – MMMM y"
+      },
+      "EEEE، d MMMM y، Bh": {
+        "B": "EEEE، d MMMM y، h B – h B",
+        "h": "EEEE، d MMMM y، h–h B"
+      },
+      "d MMMM y، Bh": {
+        "B": "d MMMM y، h B – h B",
+        "h": "d MMMM y، h–h B"
+      },
+      "dd‏/MM‏/y، Bh": {
+        "B": "dd‏/MM‏/y، h B – h B",
+        "h": "dd‏/MM‏/y، h–h B"
+      },
+      "d‏/M‏/y، Bh": {
+        "B": "d‏/M‏/y، h B – h B",
+        "h": "d‏/M‏/y، h–h B"
+      },
+      "d، Bh": {
+        "B": "d، h B – h B",
+        "h": "d، h–h B"
+      },
+      "E، Bh": {
+        "B": "ccc، h B – h B",
+        "h": "ccc، h–h B"
+      },
+      "Ed، Bh": {
+        "B": "E، d، h B – h B",
+        "h": "E، d، h–h B"
+      },
+      "Gy، Bh": {
+        "B": "y G، h B – h B",
+        "h": "y G، h–h B"
+      },
+      "GyM، Bh": {
+        "B": "MM، y G، h B – h B",
+        "h": "MM، y G، h–h B"
+      },
+      "GyMd، Bh": {
+        "B": "dd-MM-y GGGGG، h B – h B",
+        "h": "dd-MM-y GGGGG، h–h B"
+      },
+      "GyMEd، Bh": {
+        "B": "E d/M/y G، h B – h B",
+        "h": "E d/M/y G، h–h B"
+      },
+      "GyMMM، Bh": {
+        "B": "MMM y G، h B – h B",
+        "h": "MMM y G، h–h B"
+      },
+      "GyMMMd، Bh": {
+        "B": "d MMM y G، h B – h B",
+        "h": "d MMM y G، h–h B"
+      },
+      "GyMMMEd، Bh": {
+        "B": "E، d MMM y G، h B – h B",
+        "h": "E، d MMM y G، h–h B"
+      },
+      "M، Bh": {
+        "B": "L، h B – h B",
+        "h": "L، h–h B"
+      },
+      "Md، Bh": {
+        "B": "d‏/M، h B – h B",
+        "h": "d‏/M، h–h B"
+      },
+      "MEd، Bh": {
+        "B": "E، d‏/M، h B – h B",
+        "h": "E، d‏/M، h–h B"
+      },
+      "MMdd، Bh": {
+        "B": "dd‏/MM، h B – h B",
+        "h": "dd‏/MM، h–h B"
+      },
+      "MMM، Bh": {
+        "B": "LLL، h B – h B",
+        "h": "LLL، h–h B"
+      },
+      "MMMd، Bh": {
+        "B": "d MMM، h B – h B",
+        "h": "d MMM، h–h B"
+      },
+      "MMMEd، Bh": {
+        "B": "E، d MMM، h B – h B",
+        "h": "E، d MMM، h–h B"
+      },
+      "MMMMd، Bh": {
+        "B": "d MMMM، h B – h B",
+        "h": "d MMMM، h–h B"
+      },
+      "MMMMEd، Bh": {
+        "B": "E، d MMMM، h B – h B",
+        "h": "E، d MMMM، h–h B"
+      },
+      "y، Bh": {
+        "B": "y، h B – h B",
+        "h": "y، h–h B"
+      },
+      "yM، Bh": {
+        "B": "M‏/y، h B – h B",
+        "h": "M‏/y، h–h B"
+      },
+      "yMd، Bh": {
+        "B": "d‏/M‏/y، h B – h B",
+        "h": "d‏/M‏/y، h–h B"
+      },
+      "yMEd، Bh": {
+        "B": "E، d‏/M‏/y، h B – h B",
+        "h": "E، d‏/M‏/y، h–h B"
+      },
+      "yMM، Bh": {
+        "B": "MM‏/y، h B – h B",
+        "h": "MM‏/y، h–h B"
+      },
+      "yMMM، Bh": {
+        "B": "MMM y، h B – h B",
+        "h": "MMM y، h–h B"
+      },
+      "yMMMd، Bh": {
+        "B": "d MMM y، h B – h B",
+        "h": "d MMM y، h–h B"
+      },
+      "yMMMEd، Bh": {
+        "B": "E، d MMM y، h B – h B",
+        "h": "E، d MMM y، h–h B"
+      },
+      "yMMMM، Bh": {
+        "B": "MMMM y، h B – h B",
+        "h": "MMMM y، h–h B"
+      },
+      "EEEE، d MMMM y، Bhm": {
+        "B": "EEEE، d MMMM y، h:mm B – h:mm B",
+        "h": "EEEE، d MMMM y، h:mm–h:mm B",
+        "m": "EEEE، d MMMM y، h:mm–h:mm B"
+      },
+      "d MMMM y، Bhm": {
+        "B": "d MMMM y، h:mm B – h:mm B",
+        "h": "d MMMM y، h:mm–h:mm B",
+        "m": "d MMMM y، h:mm–h:mm B"
+      },
+      "dd‏/MM‏/y، Bhm": {
+        "B": "dd‏/MM‏/y، h:mm B – h:mm B",
+        "h": "dd‏/MM‏/y، h:mm–h:mm B",
+        "m": "dd‏/MM‏/y، h:mm–h:mm B"
+      },
+      "d‏/M‏/y، Bhm": {
+        "B": "d‏/M‏/y، h:mm B – h:mm B",
+        "h": "d‏/M‏/y، h:mm–h:mm B",
+        "m": "d‏/M‏/y، h:mm–h:mm B"
+      },
+      "d، Bhm": {
+        "B": "d، h:mm B – h:mm B",
+        "h": "d، h:mm–h:mm B",
+        "m": "d، h:mm–h:mm B"
+      },
+      "E، Bhm": {
+        "B": "ccc، h:mm B – h:mm B",
+        "h": "ccc، h:mm–h:mm B",
+        "m": "ccc، h:mm–h:mm B"
+      },
+      "Ed، Bhm": {
+        "B": "E، d، h:mm B – h:mm B",
+        "h": "E، d، h:mm–h:mm B",
+        "m": "E، d، h:mm–h:mm B"
+      },
+      "Gy، Bhm": {
+        "B": "y G، h:mm B – h:mm B",
+        "h": "y G، h:mm–h:mm B",
+        "m": "y G، h:mm–h:mm B"
+      },
+      "GyM، Bhm": {
+        "B": "MM، y G، h:mm B – h:mm B",
+        "h": "MM، y G، h:mm–h:mm B",
+        "m": "MM، y G، h:mm–h:mm B"
+      },
+      "GyMd، Bhm": {
+        "B": "dd-MM-y GGGGG، h:mm B – h:mm B",
+        "h": "dd-MM-y GGGGG، h:mm–h:mm B",
+        "m": "dd-MM-y GGGGG، h:mm–h:mm B"
+      },
+      "GyMEd، Bhm": {
+        "B": "E d/M/y G، h:mm B – h:mm B",
+        "h": "E d/M/y G، h:mm–h:mm B",
+        "m": "E d/M/y G، h:mm–h:mm B"
+      },
+      "GyMMM، Bhm": {
+        "B": "MMM y G، h:mm B – h:mm B",
+        "h": "MMM y G، h:mm–h:mm B",
+        "m": "MMM y G، h:mm–h:mm B"
+      },
+      "GyMMMd، Bhm": {
+        "B": "d MMM y G، h:mm B – h:mm B",
+        "h": "d MMM y G، h:mm–h:mm B",
+        "m": "d MMM y G، h:mm–h:mm B"
+      },
+      "GyMMMEd، Bhm": {
+        "B": "E، d MMM y G، h:mm B – h:mm B",
+        "h": "E، d MMM y G، h:mm–h:mm B",
+        "m": "E، d MMM y G، h:mm–h:mm B"
+      },
+      "M، Bhm": {
+        "B": "L، h:mm B – h:mm B",
+        "h": "L، h:mm–h:mm B",
+        "m": "L، h:mm–h:mm B"
+      },
+      "Md، Bhm": {
+        "B": "d‏/M، h:mm B – h:mm B",
+        "h": "d‏/M، h:mm–h:mm B",
+        "m": "d‏/M، h:mm–h:mm B"
+      },
+      "MEd، Bhm": {
+        "B": "E، d‏/M، h:mm B – h:mm B",
+        "h": "E، d‏/M، h:mm–h:mm B",
+        "m": "E، d‏/M، h:mm–h:mm B"
+      },
+      "MMdd، Bhm": {
+        "B": "dd‏/MM، h:mm B – h:mm B",
+        "h": "dd‏/MM، h:mm–h:mm B",
+        "m": "dd‏/MM، h:mm–h:mm B"
+      },
+      "MMM، Bhm": {
+        "B": "LLL، h:mm B – h:mm B",
+        "h": "LLL، h:mm–h:mm B",
+        "m": "LLL، h:mm–h:mm B"
+      },
+      "MMMd، Bhm": {
+        "B": "d MMM، h:mm B – h:mm B",
+        "h": "d MMM، h:mm–h:mm B",
+        "m": "d MMM، h:mm–h:mm B"
+      },
+      "MMMEd، Bhm": {
+        "B": "E، d MMM، h:mm B – h:mm B",
+        "h": "E، d MMM، h:mm–h:mm B",
+        "m": "E، d MMM، h:mm–h:mm B"
+      },
+      "MMMMd، Bhm": {
+        "B": "d MMMM، h:mm B – h:mm B",
+        "h": "d MMMM، h:mm–h:mm B",
+        "m": "d MMMM، h:mm–h:mm B"
+      },
+      "MMMMEd، Bhm": {
+        "B": "E، d MMMM، h:mm B – h:mm B",
+        "h": "E، d MMMM، h:mm–h:mm B",
+        "m": "E، d MMMM، h:mm–h:mm B"
+      },
+      "y، Bhm": {
+        "B": "y، h:mm B – h:mm B",
+        "h": "y، h:mm–h:mm B",
+        "m": "y، h:mm–h:mm B"
+      },
+      "yM، Bhm": {
+        "B": "M‏/y، h:mm B – h:mm B",
+        "h": "M‏/y، h:mm–h:mm B",
+        "m": "M‏/y، h:mm–h:mm B"
+      },
+      "yMd، Bhm": {
+        "B": "d‏/M‏/y، h:mm B – h:mm B",
+        "h": "d‏/M‏/y، h:mm–h:mm B",
+        "m": "d‏/M‏/y، h:mm–h:mm B"
+      },
+      "yMEd، Bhm": {
+        "B": "E، d‏/M‏/y، h:mm B – h:mm B",
+        "h": "E، d‏/M‏/y، h:mm–h:mm B",
+        "m": "E، d‏/M‏/y، h:mm–h:mm B"
+      },
+      "yMM، Bhm": {
+        "B": "MM‏/y، h:mm B – h:mm B",
+        "h": "MM‏/y، h:mm–h:mm B",
+        "m": "MM‏/y، h:mm–h:mm B"
+      },
+      "yMMM، Bhm": {
+        "B": "MMM y، h:mm B – h:mm B",
+        "h": "MMM y، h:mm–h:mm B",
+        "m": "MMM y، h:mm–h:mm B"
+      },
+      "yMMMd، Bhm": {
+        "B": "d MMM y، h:mm B – h:mm B",
+        "h": "d MMM y، h:mm–h:mm B",
+        "m": "d MMM y، h:mm–h:mm B"
+      },
+      "yMMMEd، Bhm": {
+        "B": "E، d MMM y، h:mm B – h:mm B",
+        "h": "E، d MMM y، h:mm–h:mm B",
+        "m": "E، d MMM y، h:mm–h:mm B"
+      },
+      "yMMMM، Bhm": {
+        "B": "MMMM y، h:mm B – h:mm B",
+        "h": "MMMM y، h:mm–h:mm B",
+        "m": "MMMM y، h:mm–h:mm B"
+      },
+      "EEEE، d MMMM y، h": {
+        "a": "EEEE، d MMMM y، h a – h a",
+        "h": "EEEE، d MMMM y، h–h a"
+      },
+      "d MMMM y، h": {
+        "a": "d MMMM y، h a – h a",
+        "h": "d MMMM y، h–h a"
+      },
+      "dd‏/MM‏/y، h": {
+        "a": "dd‏/MM‏/y، h a – h a",
+        "h": "dd‏/MM‏/y، h–h a"
+      },
+      "d‏/M‏/y، h": {
+        "a": "d‏/M‏/y، h a – h a",
+        "h": "d‏/M‏/y، h–h a"
+      },
+      "d، h": {
+        "a": "d، h a – h a",
+        "h": "d، h–h a"
+      },
+      "E، h": {
+        "a": "ccc، h a – h a",
+        "h": "ccc، h–h a"
+      },
+      "Ed، h": {
+        "a": "E، d، h a – h a",
+        "h": "E، d، h–h a"
+      },
+      "Gy، h": {
+        "a": "y G، h a – h a",
+        "h": "y G، h–h a"
+      },
+      "GyM، h": {
+        "a": "MM، y G، h a – h a",
+        "h": "MM، y G، h–h a"
+      },
+      "GyMd، h": {
+        "a": "dd-MM-y GGGGG، h a – h a",
+        "h": "dd-MM-y GGGGG، h–h a"
+      },
+      "GyMEd، h": {
+        "a": "E d/M/y G، h a – h a",
+        "h": "E d/M/y G، h–h a"
+      },
+      "GyMMM، h": {
+        "a": "MMM y G، h a – h a",
+        "h": "MMM y G، h–h a"
+      },
+      "GyMMMd، h": {
+        "a": "d MMM y G، h a – h a",
+        "h": "d MMM y G، h–h a"
+      },
+      "GyMMMEd، h": {
+        "a": "E، d MMM y G، h a – h a",
+        "h": "E، d MMM y G، h–h a"
+      },
+      "M، h": {
+        "a": "L، h a – h a",
+        "h": "L، h–h a"
+      },
+      "Md، h": {
+        "a": "d‏/M، h a – h a",
+        "h": "d‏/M، h–h a"
+      },
+      "MEd، h": {
+        "a": "E، d‏/M، h a – h a",
+        "h": "E، d‏/M، h–h a"
+      },
+      "MMdd، h": {
+        "a": "dd‏/MM، h a – h a",
+        "h": "dd‏/MM، h–h a"
+      },
+      "MMM، h": {
+        "a": "LLL، h a – h a",
+        "h": "LLL، h–h a"
+      },
+      "MMMd، h": {
+        "a": "d MMM، h a – h a",
+        "h": "d MMM، h–h a"
+      },
+      "MMMEd، h": {
+        "a": "E، d MMM، h a – h a",
+        "h": "E، d MMM، h–h a"
+      },
+      "MMMMd، h": {
+        "a": "d MMMM، h a – h a",
+        "h": "d MMMM، h–h a"
+      },
+      "MMMMEd، h": {
+        "a": "E، d MMMM، h a – h a",
+        "h": "E، d MMMM، h–h a"
+      },
+      "y، h": {
+        "a": "y، h a – h a",
+        "h": "y، h–h a"
+      },
+      "yM، h": {
+        "a": "M‏/y، h a – h a",
+        "h": "M‏/y، h–h a"
+      },
+      "yMd، h": {
+        "a": "d‏/M‏/y، h a – h a",
+        "h": "d‏/M‏/y، h–h a"
+      },
+      "yMEd، h": {
+        "a": "E، d‏/M‏/y، h a – h a",
+        "h": "E، d‏/M‏/y، h–h a"
+      },
+      "yMM، h": {
+        "a": "MM‏/y، h a – h a",
+        "h": "MM‏/y، h–h a"
+      },
+      "yMMM، h": {
+        "a": "MMM y، h a – h a",
+        "h": "MMM y، h–h a"
+      },
+      "yMMMd، h": {
+        "a": "d MMM y، h a – h a",
+        "h": "d MMM y، h–h a"
+      },
+      "yMMMEd، h": {
+        "a": "E، d MMM y، h a – h a",
+        "h": "E، d MMM y، h–h a"
+      },
+      "yMMMM، h": {
+        "a": "MMMM y، h a – h a",
+        "h": "MMMM y، h–h a"
+      },
+      "EEEE، d MMMM y، H": {
+        "H": "EEEE، d MMMM y، HH–HH"
+      },
+      "d MMMM y، H": {
+        "H": "d MMMM y، HH–HH"
+      },
+      "dd‏/MM‏/y، H": {
+        "H": "dd‏/MM‏/y، HH–HH"
+      },
+      "d‏/M‏/y، H": {
+        "H": "d‏/M‏/y، HH–HH"
+      },
+      "d، H": {
+        "H": "d، HH–HH"
+      },
+      "E، H": {
+        "H": "ccc، HH–HH"
+      },
+      "Ed، H": {
+        "H": "E، d، HH–HH"
+      },
+      "Gy، H": {
+        "H": "y G، HH–HH"
+      },
+      "GyM، H": {
+        "H": "MM، y G، HH–HH"
+      },
+      "GyMd، H": {
+        "H": "dd-MM-y GGGGG، HH–HH"
+      },
+      "GyMEd، H": {
+        "H": "E d/M/y G، HH–HH"
+      },
+      "GyMMM، H": {
+        "H": "MMM y G، HH–HH"
+      },
+      "GyMMMd، H": {
+        "H": "d MMM y G، HH–HH"
+      },
+      "GyMMMEd، H": {
+        "H": "E، d MMM y G، HH–HH"
+      },
+      "M، H": {
+        "H": "L، HH–HH"
+      },
+      "Md، H": {
+        "H": "d‏/M، HH–HH"
+      },
+      "MEd، H": {
+        "H": "E، d‏/M، HH–HH"
+      },
+      "MMdd، H": {
+        "H": "dd‏/MM، HH–HH"
+      },
+      "MMM، H": {
+        "H": "LLL، HH–HH"
+      },
+      "MMMd، H": {
+        "H": "d MMM، HH–HH"
+      },
+      "MMMEd، H": {
+        "H": "E، d MMM، HH–HH"
+      },
+      "MMMMd، H": {
+        "H": "d MMMM، HH–HH"
+      },
+      "MMMMEd، H": {
+        "H": "E، d MMMM، HH–HH"
+      },
+      "y، H": {
+        "H": "y، HH–HH"
+      },
+      "yM، H": {
+        "H": "M‏/y، HH–HH"
+      },
+      "yMd، H": {
+        "H": "d‏/M‏/y، HH–HH"
+      },
+      "yMEd، H": {
+        "H": "E، d‏/M‏/y، HH–HH"
+      },
+      "yMM، H": {
+        "H": "MM‏/y، HH–HH"
+      },
+      "yMMM، H": {
+        "H": "MMM y، HH–HH"
+      },
+      "yMMMd، H": {
+        "H": "d MMM y، HH–HH"
+      },
+      "yMMMEd، H": {
+        "H": "E، d MMM y، HH–HH"
+      },
+      "yMMMM، H": {
+        "H": "MMMM y، HH–HH"
+      },
+      "EEEE، d MMMM y، hm": {
+        "a": "EEEE، d MMMM y، h:mm a – h:mm a",
+        "h": "EEEE، d MMMM y، h:mm–h:mm a",
+        "m": "EEEE، d MMMM y، h:mm–h:mm a"
+      },
+      "d MMMM y، hm": {
+        "a": "d MMMM y، h:mm a – h:mm a",
+        "h": "d MMMM y، h:mm–h:mm a",
+        "m": "d MMMM y، h:mm–h:mm a"
+      },
+      "dd‏/MM‏/y، hm": {
+        "a": "dd‏/MM‏/y، h:mm a – h:mm a",
+        "h": "dd‏/MM‏/y، h:mm–h:mm a",
+        "m": "dd‏/MM‏/y، h:mm–h:mm a"
+      },
+      "d‏/M‏/y، hm": {
+        "a": "d‏/M‏/y، h:mm a – h:mm a",
+        "h": "d‏/M‏/y، h:mm–h:mm a",
+        "m": "d‏/M‏/y، h:mm–h:mm a"
+      },
+      "d، hm": {
+        "a": "d، h:mm a – h:mm a",
+        "h": "d، h:mm–h:mm a",
+        "m": "d، h:mm–h:mm a"
+      },
+      "E، hm": {
+        "a": "ccc، h:mm a – h:mm a",
+        "h": "ccc، h:mm–h:mm a",
+        "m": "ccc، h:mm–h:mm a"
+      },
+      "Ed، hm": {
+        "a": "E، d، h:mm a – h:mm a",
+        "h": "E، d، h:mm–h:mm a",
+        "m": "E، d، h:mm–h:mm a"
+      },
+      "Gy، hm": {
+        "a": "y G، h:mm a – h:mm a",
+        "h": "y G، h:mm–h:mm a",
+        "m": "y G، h:mm–h:mm a"
+      },
+      "GyM، hm": {
+        "a": "MM، y G، h:mm a – h:mm a",
+        "h": "MM، y G، h:mm–h:mm a",
+        "m": "MM، y G، h:mm–h:mm a"
+      },
+      "GyMd، hm": {
+        "a": "dd-MM-y GGGGG، h:mm a – h:mm a",
+        "h": "dd-MM-y GGGGG، h:mm–h:mm a",
+        "m": "dd-MM-y GGGGG، h:mm–h:mm a"
+      },
+      "GyMEd، hm": {
+        "a": "E d/M/y G، h:mm a – h:mm a",
+        "h": "E d/M/y G، h:mm–h:mm a",
+        "m": "E d/M/y G، h:mm–h:mm a"
+      },
+      "GyMMM، hm": {
+        "a": "MMM y G، h:mm a – h:mm a",
+        "h": "MMM y G، h:mm–h:mm a",
+        "m": "MMM y G، h:mm–h:mm a"
+      },
+      "GyMMMd، hm": {
+        "a": "d MMM y G، h:mm a – h:mm a",
+        "h": "d MMM y G، h:mm–h:mm a",
+        "m": "d MMM y G، h:mm–h:mm a"
+      },
+      "GyMMMEd، hm": {
+        "a": "E، d MMM y G، h:mm a – h:mm a",
+        "h": "E، d MMM y G، h:mm–h:mm a",
+        "m": "E، d MMM y G، h:mm–h:mm a"
+      },
+      "M، hm": {
+        "a": "L، h:mm a – h:mm a",
+        "h": "L، h:mm–h:mm a",
+        "m": "L، h:mm–h:mm a"
+      },
+      "Md، hm": {
+        "a": "d‏/M، h:mm a – h:mm a",
+        "h": "d‏/M، h:mm–h:mm a",
+        "m": "d‏/M، h:mm–h:mm a"
+      },
+      "MEd، hm": {
+        "a": "E، d‏/M، h:mm a – h:mm a",
+        "h": "E، d‏/M، h:mm–h:mm a",
+        "m": "E، d‏/M، h:mm–h:mm a"
+      },
+      "MMdd، hm": {
+        "a": "dd‏/MM، h:mm a – h:mm a",
+        "h": "dd‏/MM، h:mm–h:mm a",
+        "m": "dd‏/MM، h:mm–h:mm a"
+      },
+      "MMM، hm": {
+        "a": "LLL، h:mm a – h:mm a",
+        "h": "LLL، h:mm–h:mm a",
+        "m": "LLL، h:mm–h:mm a"
+      },
+      "MMMd، hm": {
+        "a": "d MMM، h:mm a – h:mm a",
+        "h": "d MMM، h:mm–h:mm a",
+        "m": "d MMM، h:mm–h:mm a"
+      },
+      "MMMEd، hm": {
+        "a": "E، d MMM، h:mm a – h:mm a",
+        "h": "E، d MMM، h:mm–h:mm a",
+        "m": "E، d MMM، h:mm–h:mm a"
+      },
+      "MMMMd، hm": {
+        "a": "d MMMM، h:mm a – h:mm a",
+        "h": "d MMMM، h:mm–h:mm a",
+        "m": "d MMMM، h:mm–h:mm a"
+      },
+      "MMMMEd، hm": {
+        "a": "E، d MMMM، h:mm a – h:mm a",
+        "h": "E، d MMMM، h:mm–h:mm a",
+        "m": "E، d MMMM، h:mm–h:mm a"
+      },
+      "y، hm": {
+        "a": "y، h:mm a – h:mm a",
+        "h": "y، h:mm–h:mm a",
+        "m": "y، h:mm–h:mm a"
+      },
+      "yM، hm": {
+        "a": "M‏/y، h:mm a – h:mm a",
+        "h": "M‏/y، h:mm–h:mm a",
+        "m": "M‏/y، h:mm–h:mm a"
+      },
+      "yMd، hm": {
+        "a": "d‏/M‏/y، h:mm a – h:mm a",
+        "h": "d‏/M‏/y، h:mm–h:mm a",
+        "m": "d‏/M‏/y، h:mm–h:mm a"
+      },
+      "yMEd، hm": {
+        "a": "E، d‏/M‏/y، h:mm a – h:mm a",
+        "h": "E، d‏/M‏/y، h:mm–h:mm a",
+        "m": "E، d‏/M‏/y، h:mm–h:mm a"
+      },
+      "yMM، hm": {
+        "a": "MM‏/y، h:mm a – h:mm a",
+        "h": "MM‏/y، h:mm–h:mm a",
+        "m": "MM‏/y، h:mm–h:mm a"
+      },
+      "yMMM، hm": {
+        "a": "MMM y، h:mm a – h:mm a",
+        "h": "MMM y، h:mm–h:mm a",
+        "m": "MMM y، h:mm–h:mm a"
+      },
+      "yMMMd، hm": {
+        "a": "d MMM y، h:mm a – h:mm a",
+        "h": "d MMM y، h:mm–h:mm a",
+        "m": "d MMM y، h:mm–h:mm a"
+      },
+      "yMMMEd، hm": {
+        "a": "E، d MMM y، h:mm a – h:mm a",
+        "h": "E، d MMM y، h:mm–h:mm a",
+        "m": "E، d MMM y، h:mm–h:mm a"
+      },
+      "yMMMM، hm": {
+        "a": "MMMM y، h:mm a – h:mm a",
+        "h": "MMMM y، h:mm–h:mm a",
+        "m": "MMMM y، h:mm–h:mm a"
+      },
+      "EEEE، d MMMM y، Hm": {
+        "H": "EEEE، d MMMM y، HH:mm–HH:mm",
+        "m": "EEEE، d MMMM y، HH:mm–HH:mm"
+      },
+      "d MMMM y، Hm": {
+        "H": "d MMMM y، HH:mm–HH:mm",
+        "m": "d MMMM y، HH:mm–HH:mm"
+      },
+      "dd‏/MM‏/y، Hm": {
+        "H": "dd‏/MM‏/y، HH:mm–HH:mm",
+        "m": "dd‏/MM‏/y، HH:mm–HH:mm"
+      },
+      "d‏/M‏/y، Hm": {
+        "H": "d‏/M‏/y، HH:mm–HH:mm",
+        "m": "d‏/M‏/y، HH:mm–HH:mm"
+      },
+      "d، Hm": {
+        "H": "d، HH:mm–HH:mm",
+        "m": "d، HH:mm–HH:mm"
+      },
+      "E، Hm": {
+        "H": "ccc، HH:mm–HH:mm",
+        "m": "ccc، HH:mm–HH:mm"
+      },
+      "Ed، Hm": {
+        "H": "E، d، HH:mm–HH:mm",
+        "m": "E، d، HH:mm–HH:mm"
+      },
+      "Gy، Hm": {
+        "H": "y G، HH:mm–HH:mm",
+        "m": "y G، HH:mm–HH:mm"
+      },
+      "GyM، Hm": {
+        "H": "MM، y G، HH:mm–HH:mm",
+        "m": "MM، y G، HH:mm–HH:mm"
+      },
+      "GyMd، Hm": {
+        "H": "dd-MM-y GGGGG، HH:mm–HH:mm",
+        "m": "dd-MM-y GGGGG، HH:mm–HH:mm"
+      },
+      "GyMEd، Hm": {
+        "H": "E d/M/y G، HH:mm–HH:mm",
+        "m": "E d/M/y G، HH:mm–HH:mm"
+      },
+      "GyMMM، Hm": {
+        "H": "MMM y G، HH:mm–HH:mm",
+        "m": "MMM y G، HH:mm–HH:mm"
+      },
+      "GyMMMd، Hm": {
+        "H": "d MMM y G، HH:mm–HH:mm",
+        "m": "d MMM y G، HH:mm–HH:mm"
+      },
+      "GyMMMEd، Hm": {
+        "H": "E، d MMM y G، HH:mm–HH:mm",
+        "m": "E، d MMM y G، HH:mm–HH:mm"
+      },
+      "M، Hm": {
+        "H": "L، HH:mm–HH:mm",
+        "m": "L، HH:mm–HH:mm"
+      },
+      "Md، Hm": {
+        "H": "d‏/M، HH:mm–HH:mm",
+        "m": "d‏/M، HH:mm–HH:mm"
+      },
+      "MEd، Hm": {
+        "H": "E، d‏/M، HH:mm–HH:mm",
+        "m": "E، d‏/M، HH:mm–HH:mm"
+      },
+      "MMdd، Hm": {
+        "H": "dd‏/MM، HH:mm–HH:mm",
+        "m": "dd‏/MM، HH:mm–HH:mm"
+      },
+      "MMM، Hm": {
+        "H": "LLL، HH:mm–HH:mm",
+        "m": "LLL، HH:mm–HH:mm"
+      },
+      "MMMd، Hm": {
+        "H": "d MMM، HH:mm–HH:mm",
+        "m": "d MMM، HH:mm–HH:mm"
+      },
+      "MMMEd، Hm": {
+        "H": "E، d MMM، HH:mm–HH:mm",
+        "m": "E، d MMM، HH:mm–HH:mm"
+      },
+      "MMMMd، Hm": {
+        "H": "d MMMM، HH:mm–HH:mm",
+        "m": "d MMMM، HH:mm–HH:mm"
+      },
+      "MMMMEd، Hm": {
+        "H": "E، d MMMM، HH:mm–HH:mm",
+        "m": "E، d MMMM، HH:mm–HH:mm"
+      },
+      "y، Hm": {
+        "H": "y، HH:mm–HH:mm",
+        "m": "y، HH:mm–HH:mm"
+      },
+      "yM، Hm": {
+        "H": "M‏/y، HH:mm–HH:mm",
+        "m": "M‏/y، HH:mm–HH:mm"
+      },
+      "yMd، Hm": {
+        "H": "d‏/M‏/y، HH:mm–HH:mm",
+        "m": "d‏/M‏/y، HH:mm–HH:mm"
+      },
+      "yMEd، Hm": {
+        "H": "E، d‏/M‏/y، HH:mm–HH:mm",
+        "m": "E، d‏/M‏/y، HH:mm–HH:mm"
+      },
+      "yMM، Hm": {
+        "H": "MM‏/y، HH:mm–HH:mm",
+        "m": "MM‏/y، HH:mm–HH:mm"
+      },
+      "yMMM، Hm": {
+        "H": "MMM y، HH:mm–HH:mm",
+        "m": "MMM y، HH:mm–HH:mm"
+      },
+      "yMMMd، Hm": {
+        "H": "d MMM y، HH:mm–HH:mm",
+        "m": "d MMM y، HH:mm–HH:mm"
+      },
+      "yMMMEd، Hm": {
+        "H": "E، d MMM y، HH:mm–HH:mm",
+        "m": "E، d MMM y، HH:mm–HH:mm"
+      },
+      "yMMMM، Hm": {
+        "H": "MMMM y، HH:mm–HH:mm",
+        "m": "MMMM y، HH:mm–HH:mm"
+      },
+      "EEEE، d MMMM y، hmv": {
+        "a": "EEEE، d MMMM y، h:mm a – h:mm a v",
+        "h": "EEEE، d MMMM y، h:mm–h:mm a v",
+        "m": "EEEE، d MMMM y، h:mm–h:mm a v"
+      },
+      "d MMMM y، hmv": {
+        "a": "d MMMM y، h:mm a – h:mm a v",
+        "h": "d MMMM y، h:mm–h:mm a v",
+        "m": "d MMMM y، h:mm–h:mm a v"
+      },
+      "dd‏/MM‏/y، hmv": {
+        "a": "dd‏/MM‏/y، h:mm a – h:mm a v",
+        "h": "dd‏/MM‏/y، h:mm–h:mm a v",
+        "m": "dd‏/MM‏/y، h:mm–h:mm a v"
+      },
+      "d‏/M‏/y، hmv": {
+        "a": "d‏/M‏/y، h:mm a – h:mm a v",
+        "h": "d‏/M‏/y، h:mm–h:mm a v",
+        "m": "d‏/M‏/y، h:mm–h:mm a v"
+      },
+      "d، hmv": {
+        "a": "d، h:mm a – h:mm a v",
+        "h": "d، h:mm–h:mm a v",
+        "m": "d، h:mm–h:mm a v"
+      },
+      "E، hmv": {
+        "a": "ccc، h:mm a – h:mm a v",
+        "h": "ccc، h:mm–h:mm a v",
+        "m": "ccc، h:mm–h:mm a v"
+      },
+      "Ed، hmv": {
+        "a": "E، d، h:mm a – h:mm a v",
+        "h": "E، d، h:mm–h:mm a v",
+        "m": "E، d، h:mm–h:mm a v"
+      },
+      "Gy، hmv": {
+        "a": "y G، h:mm a – h:mm a v",
+        "h": "y G، h:mm–h:mm a v",
+        "m": "y G، h:mm–h:mm a v"
+      },
+      "GyM، hmv": {
+        "a": "MM، y G، h:mm a – h:mm a v",
+        "h": "MM، y G، h:mm–h:mm a v",
+        "m": "MM، y G، h:mm–h:mm a v"
+      },
+      "GyMd، hmv": {
+        "a": "dd-MM-y GGGGG، h:mm a – h:mm a v",
+        "h": "dd-MM-y GGGGG، h:mm–h:mm a v",
+        "m": "dd-MM-y GGGGG، h:mm–h:mm a v"
+      },
+      "GyMEd، hmv": {
+        "a": "E d/M/y G، h:mm a – h:mm a v",
+        "h": "E d/M/y G، h:mm–h:mm a v",
+        "m": "E d/M/y G، h:mm–h:mm a v"
+      },
+      "GyMMM، hmv": {
+        "a": "MMM y G، h:mm a – h:mm a v",
+        "h": "MMM y G، h:mm–h:mm a v",
+        "m": "MMM y G، h:mm–h:mm a v"
+      },
+      "GyMMMd، hmv": {
+        "a": "d MMM y G، h:mm a – h:mm a v",
+        "h": "d MMM y G، h:mm–h:mm a v",
+        "m": "d MMM y G، h:mm–h:mm a v"
+      },
+      "GyMMMEd، hmv": {
+        "a": "E، d MMM y G، h:mm a – h:mm a v",
+        "h": "E، d MMM y G، h:mm–h:mm a v",
+        "m": "E، d MMM y G، h:mm–h:mm a v"
+      },
+      "M، hmv": {
+        "a": "L، h:mm a – h:mm a v",
+        "h": "L، h:mm–h:mm a v",
+        "m": "L، h:mm–h:mm a v"
+      },
+      "Md، hmv": {
+        "a": "d‏/M، h:mm a – h:mm a v",
+        "h": "d‏/M، h:mm–h:mm a v",
+        "m": "d‏/M، h:mm–h:mm a v"
+      },
+      "MEd، hmv": {
+        "a": "E، d‏/M، h:mm a – h:mm a v",
+        "h": "E، d‏/M، h:mm–h:mm a v",
+        "m": "E، d‏/M، h:mm–h:mm a v"
+      },
+      "MMdd، hmv": {
+        "a": "dd‏/MM، h:mm a – h:mm a v",
+        "h": "dd‏/MM، h:mm–h:mm a v",
+        "m": "dd‏/MM، h:mm–h:mm a v"
+      },
+      "MMM، hmv": {
+        "a": "LLL، h:mm a – h:mm a v",
+        "h": "LLL، h:mm–h:mm a v",
+        "m": "LLL، h:mm–h:mm a v"
+      },
+      "MMMd، hmv": {
+        "a": "d MMM، h:mm a – h:mm a v",
+        "h": "d MMM، h:mm–h:mm a v",
+        "m": "d MMM، h:mm–h:mm a v"
+      },
+      "MMMEd، hmv": {
+        "a": "E، d MMM، h:mm a – h:mm a v",
+        "h": "E، d MMM، h:mm–h:mm a v",
+        "m": "E، d MMM، h:mm–h:mm a v"
+      },
+      "MMMMd، hmv": {
+        "a": "d MMMM، h:mm a – h:mm a v",
+        "h": "d MMMM، h:mm–h:mm a v",
+        "m": "d MMMM، h:mm–h:mm a v"
+      },
+      "MMMMEd، hmv": {
+        "a": "E، d MMMM، h:mm a – h:mm a v",
+        "h": "E، d MMMM، h:mm–h:mm a v",
+        "m": "E، d MMMM، h:mm–h:mm a v"
+      },
+      "y، hmv": {
+        "a": "y، h:mm a – h:mm a v",
+        "h": "y، h:mm–h:mm a v",
+        "m": "y، h:mm–h:mm a v"
+      },
+      "yM، hmv": {
+        "a": "M‏/y، h:mm a – h:mm a v",
+        "h": "M‏/y، h:mm–h:mm a v",
+        "m": "M‏/y، h:mm–h:mm a v"
+      },
+      "yMd، hmv": {
+        "a": "d‏/M‏/y، h:mm a – h:mm a v",
+        "h": "d‏/M‏/y، h:mm–h:mm a v",
+        "m": "d‏/M‏/y، h:mm–h:mm a v"
+      },
+      "yMEd، hmv": {
+        "a": "E، d‏/M‏/y، h:mm a – h:mm a v",
+        "h": "E، d‏/M‏/y، h:mm–h:mm a v",
+        "m": "E، d‏/M‏/y، h:mm–h:mm a v"
+      },
+      "yMM، hmv": {
+        "a": "MM‏/y، h:mm a – h:mm a v",
+        "h": "MM‏/y، h:mm–h:mm a v",
+        "m": "MM‏/y، h:mm–h:mm a v"
+      },
+      "yMMM، hmv": {
+        "a": "MMM y، h:mm a – h:mm a v",
+        "h": "MMM y، h:mm–h:mm a v",
+        "m": "MMM y، h:mm–h:mm a v"
+      },
+      "yMMMd، hmv": {
+        "a": "d MMM y، h:mm a – h:mm a v",
+        "h": "d MMM y، h:mm–h:mm a v",
+        "m": "d MMM y، h:mm–h:mm a v"
+      },
+      "yMMMEd، hmv": {
+        "a": "E، d MMM y، h:mm a – h:mm a v",
+        "h": "E، d MMM y، h:mm–h:mm a v",
+        "m": "E، d MMM y، h:mm–h:mm a v"
+      },
+      "yMMMM، hmv": {
+        "a": "MMMM y، h:mm a – h:mm a v",
+        "h": "MMMM y، h:mm–h:mm a v",
+        "m": "MMMM y، h:mm–h:mm a v"
+      },
+      "EEEE، d MMMM y، Hmv": {
+        "H": "EEEE، d MMMM y، HH:mm–HH:mm v",
+        "m": "EEEE، d MMMM y، HH:mm–HH:mm v"
+      },
+      "d MMMM y، Hmv": {
+        "H": "d MMMM y، HH:mm–HH:mm v",
+        "m": "d MMMM y، HH:mm–HH:mm v"
+      },
+      "dd‏/MM‏/y، Hmv": {
+        "H": "dd‏/MM‏/y، HH:mm–HH:mm v",
+        "m": "dd‏/MM‏/y، HH:mm–HH:mm v"
+      },
+      "d‏/M‏/y، Hmv": {
+        "H": "d‏/M‏/y، HH:mm–HH:mm v",
+        "m": "d‏/M‏/y، HH:mm–HH:mm v"
+      },
+      "d، Hmv": {
+        "H": "d، HH:mm–HH:mm v",
+        "m": "d، HH:mm–HH:mm v"
+      },
+      "E، Hmv": {
+        "H": "ccc، HH:mm–HH:mm v",
+        "m": "ccc، HH:mm–HH:mm v"
+      },
+      "Ed، Hmv": {
+        "H": "E، d، HH:mm–HH:mm v",
+        "m": "E، d، HH:mm–HH:mm v"
+      },
+      "Gy، Hmv": {
+        "H": "y G، HH:mm–HH:mm v",
+        "m": "y G، HH:mm–HH:mm v"
+      },
+      "GyM، Hmv": {
+        "H": "MM، y G، HH:mm–HH:mm v",
+        "m": "MM، y G، HH:mm–HH:mm v"
+      },
+      "GyMd، Hmv": {
+        "H": "dd-MM-y GGGGG، HH:mm–HH:mm v",
+        "m": "dd-MM-y GGGGG، HH:mm–HH:mm v"
+      },
+      "GyMEd، Hmv": {
+        "H": "E d/M/y G، HH:mm–HH:mm v",
+        "m": "E d/M/y G، HH:mm–HH:mm v"
+      },
+      "GyMMM، Hmv": {
+        "H": "MMM y G، HH:mm–HH:mm v",
+        "m": "MMM y G، HH:mm–HH:mm v"
+      },
+      "GyMMMd، Hmv": {
+        "H": "d MMM y G، HH:mm–HH:mm v",
+        "m": "d MMM y G، HH:mm–HH:mm v"
+      },
+      "GyMMMEd، Hmv": {
+        "H": "E، d MMM y G، HH:mm–HH:mm v",
+        "m": "E، d MMM y G، HH:mm–HH:mm v"
+      },
+      "M، Hmv": {
+        "H": "L، HH:mm–HH:mm v",
+        "m": "L، HH:mm–HH:mm v"
+      },
+      "Md، Hmv": {
+        "H": "d‏/M، HH:mm–HH:mm v",
+        "m": "d‏/M، HH:mm–HH:mm v"
+      },
+      "MEd، Hmv": {
+        "H": "E، d‏/M، HH:mm–HH:mm v",
+        "m": "E، d‏/M، HH:mm–HH:mm v"
+      },
+      "MMdd، Hmv": {
+        "H": "dd‏/MM، HH:mm–HH:mm v",
+        "m": "dd‏/MM، HH:mm–HH:mm v"
+      },
+      "MMM، Hmv": {
+        "H": "LLL، HH:mm–HH:mm v",
+        "m": "LLL، HH:mm–HH:mm v"
+      },
+      "MMMd، Hmv": {
+        "H": "d MMM، HH:mm–HH:mm v",
+        "m": "d MMM، HH:mm–HH:mm v"
+      },
+      "MMMEd، Hmv": {
+        "H": "E، d MMM، HH:mm–HH:mm v",
+        "m": "E، d MMM، HH:mm–HH:mm v"
+      },
+      "MMMMd، Hmv": {
+        "H": "d MMMM، HH:mm–HH:mm v",
+        "m": "d MMMM، HH:mm–HH:mm v"
+      },
+      "MMMMEd، Hmv": {
+        "H": "E، d MMMM، HH:mm–HH:mm v",
+        "m": "E، d MMMM، HH:mm–HH:mm v"
+      },
+      "y، Hmv": {
+        "H": "y، HH:mm–HH:mm v",
+        "m": "y، HH:mm–HH:mm v"
+      },
+      "yM، Hmv": {
+        "H": "M‏/y، HH:mm–HH:mm v",
+        "m": "M‏/y، HH:mm–HH:mm v"
+      },
+      "yMd، Hmv": {
+        "H": "d‏/M‏/y، HH:mm–HH:mm v",
+        "m": "d‏/M‏/y، HH:mm–HH:mm v"
+      },
+      "yMEd، Hmv": {
+        "H": "E، d‏/M‏/y، HH:mm–HH:mm v",
+        "m": "E، d‏/M‏/y، HH:mm–HH:mm v"
+      },
+      "yMM، Hmv": {
+        "H": "MM‏/y، HH:mm–HH:mm v",
+        "m": "MM‏/y، HH:mm–HH:mm v"
+      },
+      "yMMM، Hmv": {
+        "H": "MMM y، HH:mm–HH:mm v",
+        "m": "MMM y، HH:mm–HH:mm v"
+      },
+      "yMMMd، Hmv": {
+        "H": "d MMM y، HH:mm–HH:mm v",
+        "m": "d MMM y، HH:mm–HH:mm v"
+      },
+      "yMMMEd، Hmv": {
+        "H": "E، d MMM y، HH:mm–HH:mm v",
+        "m": "E، d MMM y، HH:mm–HH:mm v"
+      },
+      "yMMMM، Hmv": {
+        "H": "MMMM y، HH:mm–HH:mm v",
+        "m": "MMMM y، HH:mm–HH:mm v"
+      },
+      "EEEE، d MMMM y، hv": {
+        "a": "EEEE، d MMMM y، h a – h a v",
+        "h": "EEEE، d MMMM y، h–h a v"
+      },
+      "d MMMM y، hv": {
+        "a": "d MMMM y، h a – h a v",
+        "h": "d MMMM y، h–h a v"
+      },
+      "dd‏/MM‏/y، hv": {
+        "a": "dd‏/MM‏/y، h a – h a v",
+        "h": "dd‏/MM‏/y، h–h a v"
+      },
+      "d‏/M‏/y، hv": {
+        "a": "d‏/M‏/y، h a – h a v",
+        "h": "d‏/M‏/y، h–h a v"
+      },
+      "d، hv": {
+        "a": "d، h a – h a v",
+        "h": "d، h–h a v"
+      },
+      "E، hv": {
+        "a": "ccc، h a – h a v",
+        "h": "ccc، h–h a v"
+      },
+      "Ed، hv": {
+        "a": "E، d، h a – h a v",
+        "h": "E، d، h–h a v"
+      },
+      "Gy، hv": {
+        "a": "y G، h a – h a v",
+        "h": "y G، h–h a v"
+      },
+      "GyM، hv": {
+        "a": "MM، y G، h a – h a v",
+        "h": "MM، y G، h–h a v"
+      },
+      "GyMd، hv": {
+        "a": "dd-MM-y GGGGG، h a – h a v",
+        "h": "dd-MM-y GGGGG، h–h a v"
+      },
+      "GyMEd، hv": {
+        "a": "E d/M/y G، h a – h a v",
+        "h": "E d/M/y G، h–h a v"
+      },
+      "GyMMM، hv": {
+        "a": "MMM y G، h a – h a v",
+        "h": "MMM y G، h–h a v"
+      },
+      "GyMMMd، hv": {
+        "a": "d MMM y G، h a – h a v",
+        "h": "d MMM y G، h–h a v"
+      },
+      "GyMMMEd، hv": {
+        "a": "E، d MMM y G، h a – h a v",
+        "h": "E، d MMM y G، h–h a v"
+      },
+      "M، hv": {
+        "a": "L، h a – h a v",
+        "h": "L، h–h a v"
+      },
+      "Md، hv": {
+        "a": "d‏/M، h a – h a v",
+        "h": "d‏/M، h–h a v"
+      },
+      "MEd، hv": {
+        "a": "E، d‏/M، h a – h a v",
+        "h": "E، d‏/M، h–h a v"
+      },
+      "MMdd، hv": {
+        "a": "dd‏/MM، h a – h a v",
+        "h": "dd‏/MM، h–h a v"
+      },
+      "MMM، hv": {
+        "a": "LLL، h a – h a v",
+        "h": "LLL، h–h a v"
+      },
+      "MMMd، hv": {
+        "a": "d MMM، h a – h a v",
+        "h": "d MMM، h–h a v"
+      },
+      "MMMEd، hv": {
+        "a": "E، d MMM، h a – h a v",
+        "h": "E، d MMM، h–h a v"
+      },
+      "MMMMd، hv": {
+        "a": "d MMMM، h a – h a v",
+        "h": "d MMMM، h–h a v"
+      },
+      "MMMMEd، hv": {
+        "a": "E، d MMMM، h a – h a v",
+        "h": "E، d MMMM، h–h a v"
+      },
+      "y، hv": {
+        "a": "y، h a – h a v",
+        "h": "y، h–h a v"
+      },
+      "yM، hv": {
+        "a": "M‏/y، h a – h a v",
+        "h": "M‏/y، h–h a v"
+      },
+      "yMd، hv": {
+        "a": "d‏/M‏/y، h a – h a v",
+        "h": "d‏/M‏/y، h–h a v"
+      },
+      "yMEd، hv": {
+        "a": "E، d‏/M‏/y، h a – h a v",
+        "h": "E، d‏/M‏/y، h–h a v"
+      },
+      "yMM، hv": {
+        "a": "MM‏/y، h a – h a v",
+        "h": "MM‏/y، h–h a v"
+      },
+      "yMMM، hv": {
+        "a": "MMM y، h a – h a v",
+        "h": "MMM y، h–h a v"
+      },
+      "yMMMd، hv": {
+        "a": "d MMM y، h a – h a v",
+        "h": "d MMM y، h–h a v"
+      },
+      "yMMMEd، hv": {
+        "a": "E، d MMM y، h a – h a v",
+        "h": "E، d MMM y، h–h a v"
+      },
+      "yMMMM، hv": {
+        "a": "MMMM y، h a – h a v",
+        "h": "MMMM y، h–h a v"
+      },
+      "EEEE، d MMMM y، Hv": {
+        "H": "EEEE، d MMMM y، HH–HH v"
+      },
+      "d MMMM y، Hv": {
+        "H": "d MMMM y، HH–HH v"
+      },
+      "dd‏/MM‏/y، Hv": {
+        "H": "dd‏/MM‏/y، HH–HH v"
+      },
+      "d‏/M‏/y، Hv": {
+        "H": "d‏/M‏/y، HH–HH v"
+      },
+      "d، Hv": {
+        "H": "d، HH–HH v"
+      },
+      "E، Hv": {
+        "H": "ccc، HH–HH v"
+      },
+      "Ed، Hv": {
+        "H": "E، d، HH–HH v"
+      },
+      "Gy، Hv": {
+        "H": "y G، HH–HH v"
+      },
+      "GyM، Hv": {
+        "H": "MM، y G، HH–HH v"
+      },
+      "GyMd، Hv": {
+        "H": "dd-MM-y GGGGG، HH–HH v"
+      },
+      "GyMEd، Hv": {
+        "H": "E d/M/y G، HH–HH v"
+      },
+      "GyMMM، Hv": {
+        "H": "MMM y G، HH–HH v"
+      },
+      "GyMMMd، Hv": {
+        "H": "d MMM y G، HH–HH v"
+      },
+      "GyMMMEd، Hv": {
+        "H": "E، d MMM y G، HH–HH v"
+      },
+      "M، Hv": {
+        "H": "L، HH–HH v"
+      },
+      "Md، Hv": {
+        "H": "d‏/M، HH–HH v"
+      },
+      "MEd، Hv": {
+        "H": "E، d‏/M، HH–HH v"
+      },
+      "MMdd، Hv": {
+        "H": "dd‏/MM، HH–HH v"
+      },
+      "MMM، Hv": {
+        "H": "LLL، HH–HH v"
+      },
+      "MMMd، Hv": {
+        "H": "d MMM، HH–HH v"
+      },
+      "MMMEd، Hv": {
+        "H": "E، d MMM، HH–HH v"
+      },
+      "MMMMd، Hv": {
+        "H": "d MMMM، HH–HH v"
+      },
+      "MMMMEd، Hv": {
+        "H": "E، d MMMM، HH–HH v"
+      },
+      "y، Hv": {
+        "H": "y، HH–HH v"
+      },
+      "yM، Hv": {
+        "H": "M‏/y، HH–HH v"
+      },
+      "yMd، Hv": {
+        "H": "d‏/M‏/y، HH–HH v"
+      },
+      "yMEd، Hv": {
+        "H": "E، d‏/M‏/y، HH–HH v"
+      },
+      "yMM، Hv": {
+        "H": "MM‏/y، HH–HH v"
+      },
+      "yMMM، Hv": {
+        "H": "MMM y، HH–HH v"
+      },
+      "yMMMd، Hv": {
+        "H": "d MMM y، HH–HH v"
+      },
+      "yMMMEd، Hv": {
+        "H": "E، d MMM y، HH–HH v"
+      },
+      "yMMMM، Hv": {
+        "H": "MMMM y، HH–HH v"
       }
     },
     "hourCycle": "h12",
@@ -5508,6 +6820,1400 @@ Intl.DateTimeFormat.__addLocaleData({
       "yMMMM": {
         "M": "MMMM–MMMM y",
         "y": "MMMM y – MMMM y"
+      },
+      "EEEE, d. MMMM y, Bh": {
+        "B": "EEEE, d. MMMM y, h 'Uhr' B – h 'Uhr' B",
+        "h": "EEEE, d. MMMM y, h–h 'Uhr' B"
+      },
+      "d. MMMM y, Bh": {
+        "B": "d. MMMM y, h 'Uhr' B – h 'Uhr' B",
+        "h": "d. MMMM y, h–h 'Uhr' B"
+      },
+      "dd.MM.y, Bh": {
+        "B": "dd.MM.y, h 'Uhr' B – h 'Uhr' B",
+        "h": "dd.MM.y, h–h 'Uhr' B"
+      },
+      "dd.MM.yy, Bh": {
+        "B": "dd.MM.yy, h 'Uhr' B – h 'Uhr' B",
+        "h": "dd.MM.yy, h–h 'Uhr' B"
+      },
+      "d, Bh": {
+        "B": "d, h 'Uhr' B – h 'Uhr' B",
+        "h": "d, h–h 'Uhr' B"
+      },
+      "E, Bh": {
+        "B": "ccc, h 'Uhr' B – h 'Uhr' B",
+        "h": "ccc, h–h 'Uhr' B"
+      },
+      "Ed, Bh": {
+        "B": "E, d., h 'Uhr' B – h 'Uhr' B",
+        "h": "E, d., h–h 'Uhr' B"
+      },
+      "Gy, Bh": {
+        "B": "y G, h 'Uhr' B – h 'Uhr' B",
+        "h": "y G, h–h 'Uhr' B"
+      },
+      "GyM, Bh": {
+        "B": "MM/y G, h 'Uhr' B – h 'Uhr' B",
+        "h": "MM/y G, h–h 'Uhr' B"
+      },
+      "GyMd, Bh": {
+        "B": "dd.MM.y G, h 'Uhr' B – h 'Uhr' B",
+        "h": "dd.MM.y G, h–h 'Uhr' B"
+      },
+      "GyMEd, Bh": {
+        "B": "E, dd.MM.y G, h 'Uhr' B – h 'Uhr' B",
+        "h": "E, dd.MM.y G, h–h 'Uhr' B"
+      },
+      "GyMMM, Bh": {
+        "B": "MMM y G, h 'Uhr' B – h 'Uhr' B",
+        "h": "MMM y G, h–h 'Uhr' B"
+      },
+      "GyMMMd, Bh": {
+        "B": "d. MMM y G, h 'Uhr' B – h 'Uhr' B",
+        "h": "d. MMM y G, h–h 'Uhr' B"
+      },
+      "GyMMMEd, Bh": {
+        "B": "E, d. MMM y G, h 'Uhr' B – h 'Uhr' B",
+        "h": "E, d. MMM y G, h–h 'Uhr' B"
+      },
+      "M, Bh": {
+        "B": "L, h 'Uhr' B – h 'Uhr' B",
+        "h": "L, h–h 'Uhr' B"
+      },
+      "Md, Bh": {
+        "B": "d.M., h 'Uhr' B – h 'Uhr' B",
+        "h": "d.M., h–h 'Uhr' B"
+      },
+      "MEd, Bh": {
+        "B": "E, d.M., h 'Uhr' B – h 'Uhr' B",
+        "h": "E, d.M., h–h 'Uhr' B"
+      },
+      "MMd, Bh": {
+        "B": "dd.MM., h 'Uhr' B – h 'Uhr' B",
+        "h": "dd.MM., h–h 'Uhr' B"
+      },
+      "MMdd, Bh": {
+        "B": "dd.MM., h 'Uhr' B – h 'Uhr' B",
+        "h": "dd.MM., h–h 'Uhr' B"
+      },
+      "MMM, Bh": {
+        "B": "LLL, h 'Uhr' B – h 'Uhr' B",
+        "h": "LLL, h–h 'Uhr' B"
+      },
+      "MMMd, Bh": {
+        "B": "d. MMM, h 'Uhr' B – h 'Uhr' B",
+        "h": "d. MMM, h–h 'Uhr' B"
+      },
+      "MMMEd, Bh": {
+        "B": "E, d. MMM, h 'Uhr' B – h 'Uhr' B",
+        "h": "E, d. MMM, h–h 'Uhr' B"
+      },
+      "MMMMd, Bh": {
+        "B": "d. MMMM, h 'Uhr' B – h 'Uhr' B",
+        "h": "d. MMMM, h–h 'Uhr' B"
+      },
+      "MMMMEd, Bh": {
+        "B": "E, d. MMMM, h 'Uhr' B – h 'Uhr' B",
+        "h": "E, d. MMMM, h–h 'Uhr' B"
+      },
+      "y, Bh": {
+        "B": "y, h 'Uhr' B – h 'Uhr' B",
+        "h": "y, h–h 'Uhr' B"
+      },
+      "yM, Bh": {
+        "B": "M/y, h 'Uhr' B – h 'Uhr' B",
+        "h": "M/y, h–h 'Uhr' B"
+      },
+      "yMd, Bh": {
+        "B": "d.M.y, h 'Uhr' B – h 'Uhr' B",
+        "h": "d.M.y, h–h 'Uhr' B"
+      },
+      "yMEd, Bh": {
+        "B": "E, d.M.y, h 'Uhr' B – h 'Uhr' B",
+        "h": "E, d.M.y, h–h 'Uhr' B"
+      },
+      "yMM, Bh": {
+        "B": "MM/y, h 'Uhr' B – h 'Uhr' B",
+        "h": "MM/y, h–h 'Uhr' B"
+      },
+      "yMMdd, Bh": {
+        "B": "dd.MM.y, h 'Uhr' B – h 'Uhr' B",
+        "h": "dd.MM.y, h–h 'Uhr' B"
+      },
+      "yMMM, Bh": {
+        "B": "MMM y, h 'Uhr' B – h 'Uhr' B",
+        "h": "MMM y, h–h 'Uhr' B"
+      },
+      "yMMMd, Bh": {
+        "B": "d. MMM y, h 'Uhr' B – h 'Uhr' B",
+        "h": "d. MMM y, h–h 'Uhr' B"
+      },
+      "yMMMEd, Bh": {
+        "B": "E, d. MMM y, h 'Uhr' B – h 'Uhr' B",
+        "h": "E, d. MMM y, h–h 'Uhr' B"
+      },
+      "yMMMM, Bh": {
+        "B": "MMMM y, h 'Uhr' B – h 'Uhr' B",
+        "h": "MMMM y, h–h 'Uhr' B"
+      },
+      "EEEE, d. MMMM y, Bhm": {
+        "B": "EEEE, d. MMMM y, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "EEEE, d. MMMM y, h:mm – h:mm 'Uhr' B",
+        "m": "EEEE, d. MMMM y, h:mm – h:mm 'Uhr' B"
+      },
+      "d. MMMM y, Bhm": {
+        "B": "d. MMMM y, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "d. MMMM y, h:mm – h:mm 'Uhr' B",
+        "m": "d. MMMM y, h:mm – h:mm 'Uhr' B"
+      },
+      "dd.MM.y, Bhm": {
+        "B": "dd.MM.y, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "dd.MM.y, h:mm – h:mm 'Uhr' B",
+        "m": "dd.MM.y, h:mm – h:mm 'Uhr' B"
+      },
+      "dd.MM.yy, Bhm": {
+        "B": "dd.MM.yy, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "dd.MM.yy, h:mm – h:mm 'Uhr' B",
+        "m": "dd.MM.yy, h:mm – h:mm 'Uhr' B"
+      },
+      "d, Bhm": {
+        "B": "d, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "d, h:mm – h:mm 'Uhr' B",
+        "m": "d, h:mm – h:mm 'Uhr' B"
+      },
+      "E, Bhm": {
+        "B": "ccc, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "ccc, h:mm – h:mm 'Uhr' B",
+        "m": "ccc, h:mm – h:mm 'Uhr' B"
+      },
+      "Ed, Bhm": {
+        "B": "E, d., h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "E, d., h:mm – h:mm 'Uhr' B",
+        "m": "E, d., h:mm – h:mm 'Uhr' B"
+      },
+      "Gy, Bhm": {
+        "B": "y G, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "y G, h:mm – h:mm 'Uhr' B",
+        "m": "y G, h:mm – h:mm 'Uhr' B"
+      },
+      "GyM, Bhm": {
+        "B": "MM/y G, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "MM/y G, h:mm – h:mm 'Uhr' B",
+        "m": "MM/y G, h:mm – h:mm 'Uhr' B"
+      },
+      "GyMd, Bhm": {
+        "B": "dd.MM.y G, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "dd.MM.y G, h:mm – h:mm 'Uhr' B",
+        "m": "dd.MM.y G, h:mm – h:mm 'Uhr' B"
+      },
+      "GyMEd, Bhm": {
+        "B": "E, dd.MM.y G, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "E, dd.MM.y G, h:mm – h:mm 'Uhr' B",
+        "m": "E, dd.MM.y G, h:mm – h:mm 'Uhr' B"
+      },
+      "GyMMM, Bhm": {
+        "B": "MMM y G, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "MMM y G, h:mm – h:mm 'Uhr' B",
+        "m": "MMM y G, h:mm – h:mm 'Uhr' B"
+      },
+      "GyMMMd, Bhm": {
+        "B": "d. MMM y G, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "d. MMM y G, h:mm – h:mm 'Uhr' B",
+        "m": "d. MMM y G, h:mm – h:mm 'Uhr' B"
+      },
+      "GyMMMEd, Bhm": {
+        "B": "E, d. MMM y G, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "E, d. MMM y G, h:mm – h:mm 'Uhr' B",
+        "m": "E, d. MMM y G, h:mm – h:mm 'Uhr' B"
+      },
+      "M, Bhm": {
+        "B": "L, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "L, h:mm – h:mm 'Uhr' B",
+        "m": "L, h:mm – h:mm 'Uhr' B"
+      },
+      "Md, Bhm": {
+        "B": "d.M., h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "d.M., h:mm – h:mm 'Uhr' B",
+        "m": "d.M., h:mm – h:mm 'Uhr' B"
+      },
+      "MEd, Bhm": {
+        "B": "E, d.M., h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "E, d.M., h:mm – h:mm 'Uhr' B",
+        "m": "E, d.M., h:mm – h:mm 'Uhr' B"
+      },
+      "MMd, Bhm": {
+        "B": "dd.MM., h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "dd.MM., h:mm – h:mm 'Uhr' B",
+        "m": "dd.MM., h:mm – h:mm 'Uhr' B"
+      },
+      "MMdd, Bhm": {
+        "B": "dd.MM., h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "dd.MM., h:mm – h:mm 'Uhr' B",
+        "m": "dd.MM., h:mm – h:mm 'Uhr' B"
+      },
+      "MMM, Bhm": {
+        "B": "LLL, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "LLL, h:mm – h:mm 'Uhr' B",
+        "m": "LLL, h:mm – h:mm 'Uhr' B"
+      },
+      "MMMd, Bhm": {
+        "B": "d. MMM, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "d. MMM, h:mm – h:mm 'Uhr' B",
+        "m": "d. MMM, h:mm – h:mm 'Uhr' B"
+      },
+      "MMMEd, Bhm": {
+        "B": "E, d. MMM, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "E, d. MMM, h:mm – h:mm 'Uhr' B",
+        "m": "E, d. MMM, h:mm – h:mm 'Uhr' B"
+      },
+      "MMMMd, Bhm": {
+        "B": "d. MMMM, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "d. MMMM, h:mm – h:mm 'Uhr' B",
+        "m": "d. MMMM, h:mm – h:mm 'Uhr' B"
+      },
+      "MMMMEd, Bhm": {
+        "B": "E, d. MMMM, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "E, d. MMMM, h:mm – h:mm 'Uhr' B",
+        "m": "E, d. MMMM, h:mm – h:mm 'Uhr' B"
+      },
+      "y, Bhm": {
+        "B": "y, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "y, h:mm – h:mm 'Uhr' B",
+        "m": "y, h:mm – h:mm 'Uhr' B"
+      },
+      "yM, Bhm": {
+        "B": "M/y, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "M/y, h:mm – h:mm 'Uhr' B",
+        "m": "M/y, h:mm – h:mm 'Uhr' B"
+      },
+      "yMd, Bhm": {
+        "B": "d.M.y, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "d.M.y, h:mm – h:mm 'Uhr' B",
+        "m": "d.M.y, h:mm – h:mm 'Uhr' B"
+      },
+      "yMEd, Bhm": {
+        "B": "E, d.M.y, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "E, d.M.y, h:mm – h:mm 'Uhr' B",
+        "m": "E, d.M.y, h:mm – h:mm 'Uhr' B"
+      },
+      "yMM, Bhm": {
+        "B": "MM/y, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "MM/y, h:mm – h:mm 'Uhr' B",
+        "m": "MM/y, h:mm – h:mm 'Uhr' B"
+      },
+      "yMMdd, Bhm": {
+        "B": "dd.MM.y, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "dd.MM.y, h:mm – h:mm 'Uhr' B",
+        "m": "dd.MM.y, h:mm – h:mm 'Uhr' B"
+      },
+      "yMMM, Bhm": {
+        "B": "MMM y, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "MMM y, h:mm – h:mm 'Uhr' B",
+        "m": "MMM y, h:mm – h:mm 'Uhr' B"
+      },
+      "yMMMd, Bhm": {
+        "B": "d. MMM y, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "d. MMM y, h:mm – h:mm 'Uhr' B",
+        "m": "d. MMM y, h:mm – h:mm 'Uhr' B"
+      },
+      "yMMMEd, Bhm": {
+        "B": "E, d. MMM y, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "E, d. MMM y, h:mm – h:mm 'Uhr' B",
+        "m": "E, d. MMM y, h:mm – h:mm 'Uhr' B"
+      },
+      "yMMMM, Bhm": {
+        "B": "MMMM y, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "MMMM y, h:mm – h:mm 'Uhr' B",
+        "m": "MMMM y, h:mm – h:mm 'Uhr' B"
+      },
+      "EEEE, d. MMMM y, h": {
+        "a": "EEEE, d. MMMM y, h a – h a",
+        "h": "EEEE, d. MMMM y, h – h a"
+      },
+      "d. MMMM y, h": {
+        "a": "d. MMMM y, h a – h a",
+        "h": "d. MMMM y, h – h a"
+      },
+      "dd.MM.y, h": {
+        "a": "dd.MM.y, h a – h a",
+        "h": "dd.MM.y, h – h a"
+      },
+      "dd.MM.yy, h": {
+        "a": "dd.MM.yy, h a – h a",
+        "h": "dd.MM.yy, h – h a"
+      },
+      "d, h": {
+        "a": "d, h a – h a",
+        "h": "d, h – h a"
+      },
+      "E, h": {
+        "a": "ccc, h a – h a",
+        "h": "ccc, h – h a"
+      },
+      "Ed, h": {
+        "a": "E, d., h a – h a",
+        "h": "E, d., h – h a"
+      },
+      "Gy, h": {
+        "a": "y G, h a – h a",
+        "h": "y G, h – h a"
+      },
+      "GyM, h": {
+        "a": "MM/y G, h a – h a",
+        "h": "MM/y G, h – h a"
+      },
+      "GyMd, h": {
+        "a": "dd.MM.y G, h a – h a",
+        "h": "dd.MM.y G, h – h a"
+      },
+      "GyMEd, h": {
+        "a": "E, dd.MM.y G, h a – h a",
+        "h": "E, dd.MM.y G, h – h a"
+      },
+      "GyMMM, h": {
+        "a": "MMM y G, h a – h a",
+        "h": "MMM y G, h – h a"
+      },
+      "GyMMMd, h": {
+        "a": "d. MMM y G, h a – h a",
+        "h": "d. MMM y G, h – h a"
+      },
+      "GyMMMEd, h": {
+        "a": "E, d. MMM y G, h a – h a",
+        "h": "E, d. MMM y G, h – h a"
+      },
+      "M, h": {
+        "a": "L, h a – h a",
+        "h": "L, h – h a"
+      },
+      "Md, h": {
+        "a": "d.M., h a – h a",
+        "h": "d.M., h – h a"
+      },
+      "MEd, h": {
+        "a": "E, d.M., h a – h a",
+        "h": "E, d.M., h – h a"
+      },
+      "MMd, h": {
+        "a": "dd.MM., h a – h a",
+        "h": "dd.MM., h – h a"
+      },
+      "MMdd, h": {
+        "a": "dd.MM., h a – h a",
+        "h": "dd.MM., h – h a"
+      },
+      "MMM, h": {
+        "a": "LLL, h a – h a",
+        "h": "LLL, h – h a"
+      },
+      "MMMd, h": {
+        "a": "d. MMM, h a – h a",
+        "h": "d. MMM, h – h a"
+      },
+      "MMMEd, h": {
+        "a": "E, d. MMM, h a – h a",
+        "h": "E, d. MMM, h – h a"
+      },
+      "MMMMd, h": {
+        "a": "d. MMMM, h a – h a",
+        "h": "d. MMMM, h – h a"
+      },
+      "MMMMEd, h": {
+        "a": "E, d. MMMM, h a – h a",
+        "h": "E, d. MMMM, h – h a"
+      },
+      "y, h": {
+        "a": "y, h a – h a",
+        "h": "y, h – h a"
+      },
+      "yM, h": {
+        "a": "M/y, h a – h a",
+        "h": "M/y, h – h a"
+      },
+      "yMd, h": {
+        "a": "d.M.y, h a – h a",
+        "h": "d.M.y, h – h a"
+      },
+      "yMEd, h": {
+        "a": "E, d.M.y, h a – h a",
+        "h": "E, d.M.y, h – h a"
+      },
+      "yMM, h": {
+        "a": "MM/y, h a – h a",
+        "h": "MM/y, h – h a"
+      },
+      "yMMdd, h": {
+        "a": "dd.MM.y, h a – h a",
+        "h": "dd.MM.y, h – h a"
+      },
+      "yMMM, h": {
+        "a": "MMM y, h a – h a",
+        "h": "MMM y, h – h a"
+      },
+      "yMMMd, h": {
+        "a": "d. MMM y, h a – h a",
+        "h": "d. MMM y, h – h a"
+      },
+      "yMMMEd, h": {
+        "a": "E, d. MMM y, h a – h a",
+        "h": "E, d. MMM y, h – h a"
+      },
+      "yMMMM, h": {
+        "a": "MMMM y, h a – h a",
+        "h": "MMMM y, h – h a"
+      },
+      "EEEE, d. MMMM y, H": {
+        "H": "EEEE, d. MMMM y, HH–HH 'Uhr'"
+      },
+      "d. MMMM y, H": {
+        "H": "d. MMMM y, HH–HH 'Uhr'"
+      },
+      "dd.MM.y, H": {
+        "H": "dd.MM.y, HH–HH 'Uhr'"
+      },
+      "dd.MM.yy, H": {
+        "H": "dd.MM.yy, HH–HH 'Uhr'"
+      },
+      "d, H": {
+        "H": "d, HH–HH 'Uhr'"
+      },
+      "E, H": {
+        "H": "ccc, HH–HH 'Uhr'"
+      },
+      "Ed, H": {
+        "H": "E, d., HH–HH 'Uhr'"
+      },
+      "Gy, H": {
+        "H": "y G, HH–HH 'Uhr'"
+      },
+      "GyM, H": {
+        "H": "MM/y G, HH–HH 'Uhr'"
+      },
+      "GyMd, H": {
+        "H": "dd.MM.y G, HH–HH 'Uhr'"
+      },
+      "GyMEd, H": {
+        "H": "E, dd.MM.y G, HH–HH 'Uhr'"
+      },
+      "GyMMM, H": {
+        "H": "MMM y G, HH–HH 'Uhr'"
+      },
+      "GyMMMd, H": {
+        "H": "d. MMM y G, HH–HH 'Uhr'"
+      },
+      "GyMMMEd, H": {
+        "H": "E, d. MMM y G, HH–HH 'Uhr'"
+      },
+      "M, H": {
+        "H": "L, HH–HH 'Uhr'"
+      },
+      "Md, H": {
+        "H": "d.M., HH–HH 'Uhr'"
+      },
+      "MEd, H": {
+        "H": "E, d.M., HH–HH 'Uhr'"
+      },
+      "MMd, H": {
+        "H": "dd.MM., HH–HH 'Uhr'"
+      },
+      "MMdd, H": {
+        "H": "dd.MM., HH–HH 'Uhr'"
+      },
+      "MMM, H": {
+        "H": "LLL, HH–HH 'Uhr'"
+      },
+      "MMMd, H": {
+        "H": "d. MMM, HH–HH 'Uhr'"
+      },
+      "MMMEd, H": {
+        "H": "E, d. MMM, HH–HH 'Uhr'"
+      },
+      "MMMMd, H": {
+        "H": "d. MMMM, HH–HH 'Uhr'"
+      },
+      "MMMMEd, H": {
+        "H": "E, d. MMMM, HH–HH 'Uhr'"
+      },
+      "y, H": {
+        "H": "y, HH–HH 'Uhr'"
+      },
+      "yM, H": {
+        "H": "M/y, HH–HH 'Uhr'"
+      },
+      "yMd, H": {
+        "H": "d.M.y, HH–HH 'Uhr'"
+      },
+      "yMEd, H": {
+        "H": "E, d.M.y, HH–HH 'Uhr'"
+      },
+      "yMM, H": {
+        "H": "MM/y, HH–HH 'Uhr'"
+      },
+      "yMMdd, H": {
+        "H": "dd.MM.y, HH–HH 'Uhr'"
+      },
+      "yMMM, H": {
+        "H": "MMM y, HH–HH 'Uhr'"
+      },
+      "yMMMd, H": {
+        "H": "d. MMM y, HH–HH 'Uhr'"
+      },
+      "yMMMEd, H": {
+        "H": "E, d. MMM y, HH–HH 'Uhr'"
+      },
+      "yMMMM, H": {
+        "H": "MMMM y, HH–HH 'Uhr'"
+      },
+      "EEEE, d. MMMM y, hm": {
+        "a": "EEEE, d. MMMM y, h:mm a – h:mm a",
+        "h": "EEEE, d. MMMM y, h:mm–h:mm a",
+        "m": "EEEE, d. MMMM y, h:mm–h:mm a"
+      },
+      "d. MMMM y, hm": {
+        "a": "d. MMMM y, h:mm a – h:mm a",
+        "h": "d. MMMM y, h:mm–h:mm a",
+        "m": "d. MMMM y, h:mm–h:mm a"
+      },
+      "dd.MM.y, hm": {
+        "a": "dd.MM.y, h:mm a – h:mm a",
+        "h": "dd.MM.y, h:mm–h:mm a",
+        "m": "dd.MM.y, h:mm–h:mm a"
+      },
+      "dd.MM.yy, hm": {
+        "a": "dd.MM.yy, h:mm a – h:mm a",
+        "h": "dd.MM.yy, h:mm–h:mm a",
+        "m": "dd.MM.yy, h:mm–h:mm a"
+      },
+      "d, hm": {
+        "a": "d, h:mm a – h:mm a",
+        "h": "d, h:mm–h:mm a",
+        "m": "d, h:mm–h:mm a"
+      },
+      "E, hm": {
+        "a": "ccc, h:mm a – h:mm a",
+        "h": "ccc, h:mm–h:mm a",
+        "m": "ccc, h:mm–h:mm a"
+      },
+      "Ed, hm": {
+        "a": "E, d., h:mm a – h:mm a",
+        "h": "E, d., h:mm–h:mm a",
+        "m": "E, d., h:mm–h:mm a"
+      },
+      "Gy, hm": {
+        "a": "y G, h:mm a – h:mm a",
+        "h": "y G, h:mm–h:mm a",
+        "m": "y G, h:mm–h:mm a"
+      },
+      "GyM, hm": {
+        "a": "MM/y G, h:mm a – h:mm a",
+        "h": "MM/y G, h:mm–h:mm a",
+        "m": "MM/y G, h:mm–h:mm a"
+      },
+      "GyMd, hm": {
+        "a": "dd.MM.y G, h:mm a – h:mm a",
+        "h": "dd.MM.y G, h:mm–h:mm a",
+        "m": "dd.MM.y G, h:mm–h:mm a"
+      },
+      "GyMEd, hm": {
+        "a": "E, dd.MM.y G, h:mm a – h:mm a",
+        "h": "E, dd.MM.y G, h:mm–h:mm a",
+        "m": "E, dd.MM.y G, h:mm–h:mm a"
+      },
+      "GyMMM, hm": {
+        "a": "MMM y G, h:mm a – h:mm a",
+        "h": "MMM y G, h:mm–h:mm a",
+        "m": "MMM y G, h:mm–h:mm a"
+      },
+      "GyMMMd, hm": {
+        "a": "d. MMM y G, h:mm a – h:mm a",
+        "h": "d. MMM y G, h:mm–h:mm a",
+        "m": "d. MMM y G, h:mm–h:mm a"
+      },
+      "GyMMMEd, hm": {
+        "a": "E, d. MMM y G, h:mm a – h:mm a",
+        "h": "E, d. MMM y G, h:mm–h:mm a",
+        "m": "E, d. MMM y G, h:mm–h:mm a"
+      },
+      "M, hm": {
+        "a": "L, h:mm a – h:mm a",
+        "h": "L, h:mm–h:mm a",
+        "m": "L, h:mm–h:mm a"
+      },
+      "Md, hm": {
+        "a": "d.M., h:mm a – h:mm a",
+        "h": "d.M., h:mm–h:mm a",
+        "m": "d.M., h:mm–h:mm a"
+      },
+      "MEd, hm": {
+        "a": "E, d.M., h:mm a – h:mm a",
+        "h": "E, d.M., h:mm–h:mm a",
+        "m": "E, d.M., h:mm–h:mm a"
+      },
+      "MMd, hm": {
+        "a": "dd.MM., h:mm a – h:mm a",
+        "h": "dd.MM., h:mm–h:mm a",
+        "m": "dd.MM., h:mm–h:mm a"
+      },
+      "MMdd, hm": {
+        "a": "dd.MM., h:mm a – h:mm a",
+        "h": "dd.MM., h:mm–h:mm a",
+        "m": "dd.MM., h:mm–h:mm a"
+      },
+      "MMM, hm": {
+        "a": "LLL, h:mm a – h:mm a",
+        "h": "LLL, h:mm–h:mm a",
+        "m": "LLL, h:mm–h:mm a"
+      },
+      "MMMd, hm": {
+        "a": "d. MMM, h:mm a – h:mm a",
+        "h": "d. MMM, h:mm–h:mm a",
+        "m": "d. MMM, h:mm–h:mm a"
+      },
+      "MMMEd, hm": {
+        "a": "E, d. MMM, h:mm a – h:mm a",
+        "h": "E, d. MMM, h:mm–h:mm a",
+        "m": "E, d. MMM, h:mm–h:mm a"
+      },
+      "MMMMd, hm": {
+        "a": "d. MMMM, h:mm a – h:mm a",
+        "h": "d. MMMM, h:mm–h:mm a",
+        "m": "d. MMMM, h:mm–h:mm a"
+      },
+      "MMMMEd, hm": {
+        "a": "E, d. MMMM, h:mm a – h:mm a",
+        "h": "E, d. MMMM, h:mm–h:mm a",
+        "m": "E, d. MMMM, h:mm–h:mm a"
+      },
+      "y, hm": {
+        "a": "y, h:mm a – h:mm a",
+        "h": "y, h:mm–h:mm a",
+        "m": "y, h:mm–h:mm a"
+      },
+      "yM, hm": {
+        "a": "M/y, h:mm a – h:mm a",
+        "h": "M/y, h:mm–h:mm a",
+        "m": "M/y, h:mm–h:mm a"
+      },
+      "yMd, hm": {
+        "a": "d.M.y, h:mm a – h:mm a",
+        "h": "d.M.y, h:mm–h:mm a",
+        "m": "d.M.y, h:mm–h:mm a"
+      },
+      "yMEd, hm": {
+        "a": "E, d.M.y, h:mm a – h:mm a",
+        "h": "E, d.M.y, h:mm–h:mm a",
+        "m": "E, d.M.y, h:mm–h:mm a"
+      },
+      "yMM, hm": {
+        "a": "MM/y, h:mm a – h:mm a",
+        "h": "MM/y, h:mm–h:mm a",
+        "m": "MM/y, h:mm–h:mm a"
+      },
+      "yMMdd, hm": {
+        "a": "dd.MM.y, h:mm a – h:mm a",
+        "h": "dd.MM.y, h:mm–h:mm a",
+        "m": "dd.MM.y, h:mm–h:mm a"
+      },
+      "yMMM, hm": {
+        "a": "MMM y, h:mm a – h:mm a",
+        "h": "MMM y, h:mm–h:mm a",
+        "m": "MMM y, h:mm–h:mm a"
+      },
+      "yMMMd, hm": {
+        "a": "d. MMM y, h:mm a – h:mm a",
+        "h": "d. MMM y, h:mm–h:mm a",
+        "m": "d. MMM y, h:mm–h:mm a"
+      },
+      "yMMMEd, hm": {
+        "a": "E, d. MMM y, h:mm a – h:mm a",
+        "h": "E, d. MMM y, h:mm–h:mm a",
+        "m": "E, d. MMM y, h:mm–h:mm a"
+      },
+      "yMMMM, hm": {
+        "a": "MMMM y, h:mm a – h:mm a",
+        "h": "MMMM y, h:mm–h:mm a",
+        "m": "MMMM y, h:mm–h:mm a"
+      },
+      "EEEE, d. MMMM y, Hm": {
+        "H": "EEEE, d. MMMM y, HH:mm–HH:mm 'Uhr'",
+        "m": "EEEE, d. MMMM y, HH:mm–HH:mm 'Uhr'"
+      },
+      "d. MMMM y, Hm": {
+        "H": "d. MMMM y, HH:mm–HH:mm 'Uhr'",
+        "m": "d. MMMM y, HH:mm–HH:mm 'Uhr'"
+      },
+      "dd.MM.y, Hm": {
+        "H": "dd.MM.y, HH:mm–HH:mm 'Uhr'",
+        "m": "dd.MM.y, HH:mm–HH:mm 'Uhr'"
+      },
+      "dd.MM.yy, Hm": {
+        "H": "dd.MM.yy, HH:mm–HH:mm 'Uhr'",
+        "m": "dd.MM.yy, HH:mm–HH:mm 'Uhr'"
+      },
+      "d, Hm": {
+        "H": "d, HH:mm–HH:mm 'Uhr'",
+        "m": "d, HH:mm–HH:mm 'Uhr'"
+      },
+      "E, Hm": {
+        "H": "ccc, HH:mm–HH:mm 'Uhr'",
+        "m": "ccc, HH:mm–HH:mm 'Uhr'"
+      },
+      "Ed, Hm": {
+        "H": "E, d., HH:mm–HH:mm 'Uhr'",
+        "m": "E, d., HH:mm–HH:mm 'Uhr'"
+      },
+      "Gy, Hm": {
+        "H": "y G, HH:mm–HH:mm 'Uhr'",
+        "m": "y G, HH:mm–HH:mm 'Uhr'"
+      },
+      "GyM, Hm": {
+        "H": "MM/y G, HH:mm–HH:mm 'Uhr'",
+        "m": "MM/y G, HH:mm–HH:mm 'Uhr'"
+      },
+      "GyMd, Hm": {
+        "H": "dd.MM.y G, HH:mm–HH:mm 'Uhr'",
+        "m": "dd.MM.y G, HH:mm–HH:mm 'Uhr'"
+      },
+      "GyMEd, Hm": {
+        "H": "E, dd.MM.y G, HH:mm–HH:mm 'Uhr'",
+        "m": "E, dd.MM.y G, HH:mm–HH:mm 'Uhr'"
+      },
+      "GyMMM, Hm": {
+        "H": "MMM y G, HH:mm–HH:mm 'Uhr'",
+        "m": "MMM y G, HH:mm–HH:mm 'Uhr'"
+      },
+      "GyMMMd, Hm": {
+        "H": "d. MMM y G, HH:mm–HH:mm 'Uhr'",
+        "m": "d. MMM y G, HH:mm–HH:mm 'Uhr'"
+      },
+      "GyMMMEd, Hm": {
+        "H": "E, d. MMM y G, HH:mm–HH:mm 'Uhr'",
+        "m": "E, d. MMM y G, HH:mm–HH:mm 'Uhr'"
+      },
+      "M, Hm": {
+        "H": "L, HH:mm–HH:mm 'Uhr'",
+        "m": "L, HH:mm–HH:mm 'Uhr'"
+      },
+      "Md, Hm": {
+        "H": "d.M., HH:mm–HH:mm 'Uhr'",
+        "m": "d.M., HH:mm–HH:mm 'Uhr'"
+      },
+      "MEd, Hm": {
+        "H": "E, d.M., HH:mm–HH:mm 'Uhr'",
+        "m": "E, d.M., HH:mm–HH:mm 'Uhr'"
+      },
+      "MMd, Hm": {
+        "H": "dd.MM., HH:mm–HH:mm 'Uhr'",
+        "m": "dd.MM., HH:mm–HH:mm 'Uhr'"
+      },
+      "MMdd, Hm": {
+        "H": "dd.MM., HH:mm–HH:mm 'Uhr'",
+        "m": "dd.MM., HH:mm–HH:mm 'Uhr'"
+      },
+      "MMM, Hm": {
+        "H": "LLL, HH:mm–HH:mm 'Uhr'",
+        "m": "LLL, HH:mm–HH:mm 'Uhr'"
+      },
+      "MMMd, Hm": {
+        "H": "d. MMM, HH:mm–HH:mm 'Uhr'",
+        "m": "d. MMM, HH:mm–HH:mm 'Uhr'"
+      },
+      "MMMEd, Hm": {
+        "H": "E, d. MMM, HH:mm–HH:mm 'Uhr'",
+        "m": "E, d. MMM, HH:mm–HH:mm 'Uhr'"
+      },
+      "MMMMd, Hm": {
+        "H": "d. MMMM, HH:mm–HH:mm 'Uhr'",
+        "m": "d. MMMM, HH:mm–HH:mm 'Uhr'"
+      },
+      "MMMMEd, Hm": {
+        "H": "E, d. MMMM, HH:mm–HH:mm 'Uhr'",
+        "m": "E, d. MMMM, HH:mm–HH:mm 'Uhr'"
+      },
+      "y, Hm": {
+        "H": "y, HH:mm–HH:mm 'Uhr'",
+        "m": "y, HH:mm–HH:mm 'Uhr'"
+      },
+      "yM, Hm": {
+        "H": "M/y, HH:mm–HH:mm 'Uhr'",
+        "m": "M/y, HH:mm–HH:mm 'Uhr'"
+      },
+      "yMd, Hm": {
+        "H": "d.M.y, HH:mm–HH:mm 'Uhr'",
+        "m": "d.M.y, HH:mm–HH:mm 'Uhr'"
+      },
+      "yMEd, Hm": {
+        "H": "E, d.M.y, HH:mm–HH:mm 'Uhr'",
+        "m": "E, d.M.y, HH:mm–HH:mm 'Uhr'"
+      },
+      "yMM, Hm": {
+        "H": "MM/y, HH:mm–HH:mm 'Uhr'",
+        "m": "MM/y, HH:mm–HH:mm 'Uhr'"
+      },
+      "yMMdd, Hm": {
+        "H": "dd.MM.y, HH:mm–HH:mm 'Uhr'",
+        "m": "dd.MM.y, HH:mm–HH:mm 'Uhr'"
+      },
+      "yMMM, Hm": {
+        "H": "MMM y, HH:mm–HH:mm 'Uhr'",
+        "m": "MMM y, HH:mm–HH:mm 'Uhr'"
+      },
+      "yMMMd, Hm": {
+        "H": "d. MMM y, HH:mm–HH:mm 'Uhr'",
+        "m": "d. MMM y, HH:mm–HH:mm 'Uhr'"
+      },
+      "yMMMEd, Hm": {
+        "H": "E, d. MMM y, HH:mm–HH:mm 'Uhr'",
+        "m": "E, d. MMM y, HH:mm–HH:mm 'Uhr'"
+      },
+      "yMMMM, Hm": {
+        "H": "MMMM y, HH:mm–HH:mm 'Uhr'",
+        "m": "MMMM y, HH:mm–HH:mm 'Uhr'"
+      },
+      "EEEE, d. MMMM y, hmv": {
+        "a": "EEEE, d. MMMM y, h:mm a – h:mm a v",
+        "h": "EEEE, d. MMMM y, h:mm–h:mm a v",
+        "m": "EEEE, d. MMMM y, h:mm–h:mm a v"
+      },
+      "d. MMMM y, hmv": {
+        "a": "d. MMMM y, h:mm a – h:mm a v",
+        "h": "d. MMMM y, h:mm–h:mm a v",
+        "m": "d. MMMM y, h:mm–h:mm a v"
+      },
+      "dd.MM.y, hmv": {
+        "a": "dd.MM.y, h:mm a – h:mm a v",
+        "h": "dd.MM.y, h:mm–h:mm a v",
+        "m": "dd.MM.y, h:mm–h:mm a v"
+      },
+      "dd.MM.yy, hmv": {
+        "a": "dd.MM.yy, h:mm a – h:mm a v",
+        "h": "dd.MM.yy, h:mm–h:mm a v",
+        "m": "dd.MM.yy, h:mm–h:mm a v"
+      },
+      "d, hmv": {
+        "a": "d, h:mm a – h:mm a v",
+        "h": "d, h:mm–h:mm a v",
+        "m": "d, h:mm–h:mm a v"
+      },
+      "E, hmv": {
+        "a": "ccc, h:mm a – h:mm a v",
+        "h": "ccc, h:mm–h:mm a v",
+        "m": "ccc, h:mm–h:mm a v"
+      },
+      "Ed, hmv": {
+        "a": "E, d., h:mm a – h:mm a v",
+        "h": "E, d., h:mm–h:mm a v",
+        "m": "E, d., h:mm–h:mm a v"
+      },
+      "Gy, hmv": {
+        "a": "y G, h:mm a – h:mm a v",
+        "h": "y G, h:mm–h:mm a v",
+        "m": "y G, h:mm–h:mm a v"
+      },
+      "GyM, hmv": {
+        "a": "MM/y G, h:mm a – h:mm a v",
+        "h": "MM/y G, h:mm–h:mm a v",
+        "m": "MM/y G, h:mm–h:mm a v"
+      },
+      "GyMd, hmv": {
+        "a": "dd.MM.y G, h:mm a – h:mm a v",
+        "h": "dd.MM.y G, h:mm–h:mm a v",
+        "m": "dd.MM.y G, h:mm–h:mm a v"
+      },
+      "GyMEd, hmv": {
+        "a": "E, dd.MM.y G, h:mm a – h:mm a v",
+        "h": "E, dd.MM.y G, h:mm–h:mm a v",
+        "m": "E, dd.MM.y G, h:mm–h:mm a v"
+      },
+      "GyMMM, hmv": {
+        "a": "MMM y G, h:mm a – h:mm a v",
+        "h": "MMM y G, h:mm–h:mm a v",
+        "m": "MMM y G, h:mm–h:mm a v"
+      },
+      "GyMMMd, hmv": {
+        "a": "d. MMM y G, h:mm a – h:mm a v",
+        "h": "d. MMM y G, h:mm–h:mm a v",
+        "m": "d. MMM y G, h:mm–h:mm a v"
+      },
+      "GyMMMEd, hmv": {
+        "a": "E, d. MMM y G, h:mm a – h:mm a v",
+        "h": "E, d. MMM y G, h:mm–h:mm a v",
+        "m": "E, d. MMM y G, h:mm–h:mm a v"
+      },
+      "M, hmv": {
+        "a": "L, h:mm a – h:mm a v",
+        "h": "L, h:mm–h:mm a v",
+        "m": "L, h:mm–h:mm a v"
+      },
+      "Md, hmv": {
+        "a": "d.M., h:mm a – h:mm a v",
+        "h": "d.M., h:mm–h:mm a v",
+        "m": "d.M., h:mm–h:mm a v"
+      },
+      "MEd, hmv": {
+        "a": "E, d.M., h:mm a – h:mm a v",
+        "h": "E, d.M., h:mm–h:mm a v",
+        "m": "E, d.M., h:mm–h:mm a v"
+      },
+      "MMd, hmv": {
+        "a": "dd.MM., h:mm a – h:mm a v",
+        "h": "dd.MM., h:mm–h:mm a v",
+        "m": "dd.MM., h:mm–h:mm a v"
+      },
+      "MMdd, hmv": {
+        "a": "dd.MM., h:mm a – h:mm a v",
+        "h": "dd.MM., h:mm–h:mm a v",
+        "m": "dd.MM., h:mm–h:mm a v"
+      },
+      "MMM, hmv": {
+        "a": "LLL, h:mm a – h:mm a v",
+        "h": "LLL, h:mm–h:mm a v",
+        "m": "LLL, h:mm–h:mm a v"
+      },
+      "MMMd, hmv": {
+        "a": "d. MMM, h:mm a – h:mm a v",
+        "h": "d. MMM, h:mm–h:mm a v",
+        "m": "d. MMM, h:mm–h:mm a v"
+      },
+      "MMMEd, hmv": {
+        "a": "E, d. MMM, h:mm a – h:mm a v",
+        "h": "E, d. MMM, h:mm–h:mm a v",
+        "m": "E, d. MMM, h:mm–h:mm a v"
+      },
+      "MMMMd, hmv": {
+        "a": "d. MMMM, h:mm a – h:mm a v",
+        "h": "d. MMMM, h:mm–h:mm a v",
+        "m": "d. MMMM, h:mm–h:mm a v"
+      },
+      "MMMMEd, hmv": {
+        "a": "E, d. MMMM, h:mm a – h:mm a v",
+        "h": "E, d. MMMM, h:mm–h:mm a v",
+        "m": "E, d. MMMM, h:mm–h:mm a v"
+      },
+      "y, hmv": {
+        "a": "y, h:mm a – h:mm a v",
+        "h": "y, h:mm–h:mm a v",
+        "m": "y, h:mm–h:mm a v"
+      },
+      "yM, hmv": {
+        "a": "M/y, h:mm a – h:mm a v",
+        "h": "M/y, h:mm–h:mm a v",
+        "m": "M/y, h:mm–h:mm a v"
+      },
+      "yMd, hmv": {
+        "a": "d.M.y, h:mm a – h:mm a v",
+        "h": "d.M.y, h:mm–h:mm a v",
+        "m": "d.M.y, h:mm–h:mm a v"
+      },
+      "yMEd, hmv": {
+        "a": "E, d.M.y, h:mm a – h:mm a v",
+        "h": "E, d.M.y, h:mm–h:mm a v",
+        "m": "E, d.M.y, h:mm–h:mm a v"
+      },
+      "yMM, hmv": {
+        "a": "MM/y, h:mm a – h:mm a v",
+        "h": "MM/y, h:mm–h:mm a v",
+        "m": "MM/y, h:mm–h:mm a v"
+      },
+      "yMMdd, hmv": {
+        "a": "dd.MM.y, h:mm a – h:mm a v",
+        "h": "dd.MM.y, h:mm–h:mm a v",
+        "m": "dd.MM.y, h:mm–h:mm a v"
+      },
+      "yMMM, hmv": {
+        "a": "MMM y, h:mm a – h:mm a v",
+        "h": "MMM y, h:mm–h:mm a v",
+        "m": "MMM y, h:mm–h:mm a v"
+      },
+      "yMMMd, hmv": {
+        "a": "d. MMM y, h:mm a – h:mm a v",
+        "h": "d. MMM y, h:mm–h:mm a v",
+        "m": "d. MMM y, h:mm–h:mm a v"
+      },
+      "yMMMEd, hmv": {
+        "a": "E, d. MMM y, h:mm a – h:mm a v",
+        "h": "E, d. MMM y, h:mm–h:mm a v",
+        "m": "E, d. MMM y, h:mm–h:mm a v"
+      },
+      "yMMMM, hmv": {
+        "a": "MMMM y, h:mm a – h:mm a v",
+        "h": "MMMM y, h:mm–h:mm a v",
+        "m": "MMMM y, h:mm–h:mm a v"
+      },
+      "EEEE, d. MMMM y, Hmv": {
+        "H": "EEEE, d. MMMM y, HH:mm–HH:mm 'Uhr' v",
+        "m": "EEEE, d. MMMM y, HH:mm–HH:mm 'Uhr' v"
+      },
+      "d. MMMM y, Hmv": {
+        "H": "d. MMMM y, HH:mm–HH:mm 'Uhr' v",
+        "m": "d. MMMM y, HH:mm–HH:mm 'Uhr' v"
+      },
+      "dd.MM.y, Hmv": {
+        "H": "dd.MM.y, HH:mm–HH:mm 'Uhr' v",
+        "m": "dd.MM.y, HH:mm–HH:mm 'Uhr' v"
+      },
+      "dd.MM.yy, Hmv": {
+        "H": "dd.MM.yy, HH:mm–HH:mm 'Uhr' v",
+        "m": "dd.MM.yy, HH:mm–HH:mm 'Uhr' v"
+      },
+      "d, Hmv": {
+        "H": "d, HH:mm–HH:mm 'Uhr' v",
+        "m": "d, HH:mm–HH:mm 'Uhr' v"
+      },
+      "E, Hmv": {
+        "H": "ccc, HH:mm–HH:mm 'Uhr' v",
+        "m": "ccc, HH:mm–HH:mm 'Uhr' v"
+      },
+      "Ed, Hmv": {
+        "H": "E, d., HH:mm–HH:mm 'Uhr' v",
+        "m": "E, d., HH:mm–HH:mm 'Uhr' v"
+      },
+      "Gy, Hmv": {
+        "H": "y G, HH:mm–HH:mm 'Uhr' v",
+        "m": "y G, HH:mm–HH:mm 'Uhr' v"
+      },
+      "GyM, Hmv": {
+        "H": "MM/y G, HH:mm–HH:mm 'Uhr' v",
+        "m": "MM/y G, HH:mm–HH:mm 'Uhr' v"
+      },
+      "GyMd, Hmv": {
+        "H": "dd.MM.y G, HH:mm–HH:mm 'Uhr' v",
+        "m": "dd.MM.y G, HH:mm–HH:mm 'Uhr' v"
+      },
+      "GyMEd, Hmv": {
+        "H": "E, dd.MM.y G, HH:mm–HH:mm 'Uhr' v",
+        "m": "E, dd.MM.y G, HH:mm–HH:mm 'Uhr' v"
+      },
+      "GyMMM, Hmv": {
+        "H": "MMM y G, HH:mm–HH:mm 'Uhr' v",
+        "m": "MMM y G, HH:mm–HH:mm 'Uhr' v"
+      },
+      "GyMMMd, Hmv": {
+        "H": "d. MMM y G, HH:mm–HH:mm 'Uhr' v",
+        "m": "d. MMM y G, HH:mm–HH:mm 'Uhr' v"
+      },
+      "GyMMMEd, Hmv": {
+        "H": "E, d. MMM y G, HH:mm–HH:mm 'Uhr' v",
+        "m": "E, d. MMM y G, HH:mm–HH:mm 'Uhr' v"
+      },
+      "M, Hmv": {
+        "H": "L, HH:mm–HH:mm 'Uhr' v",
+        "m": "L, HH:mm–HH:mm 'Uhr' v"
+      },
+      "Md, Hmv": {
+        "H": "d.M., HH:mm–HH:mm 'Uhr' v",
+        "m": "d.M., HH:mm–HH:mm 'Uhr' v"
+      },
+      "MEd, Hmv": {
+        "H": "E, d.M., HH:mm–HH:mm 'Uhr' v",
+        "m": "E, d.M., HH:mm–HH:mm 'Uhr' v"
+      },
+      "MMd, Hmv": {
+        "H": "dd.MM., HH:mm–HH:mm 'Uhr' v",
+        "m": "dd.MM., HH:mm–HH:mm 'Uhr' v"
+      },
+      "MMdd, Hmv": {
+        "H": "dd.MM., HH:mm–HH:mm 'Uhr' v",
+        "m": "dd.MM., HH:mm–HH:mm 'Uhr' v"
+      },
+      "MMM, Hmv": {
+        "H": "LLL, HH:mm–HH:mm 'Uhr' v",
+        "m": "LLL, HH:mm–HH:mm 'Uhr' v"
+      },
+      "MMMd, Hmv": {
+        "H": "d. MMM, HH:mm–HH:mm 'Uhr' v",
+        "m": "d. MMM, HH:mm–HH:mm 'Uhr' v"
+      },
+      "MMMEd, Hmv": {
+        "H": "E, d. MMM, HH:mm–HH:mm 'Uhr' v",
+        "m": "E, d. MMM, HH:mm–HH:mm 'Uhr' v"
+      },
+      "MMMMd, Hmv": {
+        "H": "d. MMMM, HH:mm–HH:mm 'Uhr' v",
+        "m": "d. MMMM, HH:mm–HH:mm 'Uhr' v"
+      },
+      "MMMMEd, Hmv": {
+        "H": "E, d. MMMM, HH:mm–HH:mm 'Uhr' v",
+        "m": "E, d. MMMM, HH:mm–HH:mm 'Uhr' v"
+      },
+      "y, Hmv": {
+        "H": "y, HH:mm–HH:mm 'Uhr' v",
+        "m": "y, HH:mm–HH:mm 'Uhr' v"
+      },
+      "yM, Hmv": {
+        "H": "M/y, HH:mm–HH:mm 'Uhr' v",
+        "m": "M/y, HH:mm–HH:mm 'Uhr' v"
+      },
+      "yMd, Hmv": {
+        "H": "d.M.y, HH:mm–HH:mm 'Uhr' v",
+        "m": "d.M.y, HH:mm–HH:mm 'Uhr' v"
+      },
+      "yMEd, Hmv": {
+        "H": "E, d.M.y, HH:mm–HH:mm 'Uhr' v",
+        "m": "E, d.M.y, HH:mm–HH:mm 'Uhr' v"
+      },
+      "yMM, Hmv": {
+        "H": "MM/y, HH:mm–HH:mm 'Uhr' v",
+        "m": "MM/y, HH:mm–HH:mm 'Uhr' v"
+      },
+      "yMMdd, Hmv": {
+        "H": "dd.MM.y, HH:mm–HH:mm 'Uhr' v",
+        "m": "dd.MM.y, HH:mm–HH:mm 'Uhr' v"
+      },
+      "yMMM, Hmv": {
+        "H": "MMM y, HH:mm–HH:mm 'Uhr' v",
+        "m": "MMM y, HH:mm–HH:mm 'Uhr' v"
+      },
+      "yMMMd, Hmv": {
+        "H": "d. MMM y, HH:mm–HH:mm 'Uhr' v",
+        "m": "d. MMM y, HH:mm–HH:mm 'Uhr' v"
+      },
+      "yMMMEd, Hmv": {
+        "H": "E, d. MMM y, HH:mm–HH:mm 'Uhr' v",
+        "m": "E, d. MMM y, HH:mm–HH:mm 'Uhr' v"
+      },
+      "yMMMM, Hmv": {
+        "H": "MMMM y, HH:mm–HH:mm 'Uhr' v",
+        "m": "MMMM y, HH:mm–HH:mm 'Uhr' v"
+      },
+      "EEEE, d. MMMM y, hv": {
+        "a": "EEEE, d. MMMM y, h a – h a v",
+        "h": "EEEE, d. MMMM y, h–h a v"
+      },
+      "d. MMMM y, hv": {
+        "a": "d. MMMM y, h a – h a v",
+        "h": "d. MMMM y, h–h a v"
+      },
+      "dd.MM.y, hv": {
+        "a": "dd.MM.y, h a – h a v",
+        "h": "dd.MM.y, h–h a v"
+      },
+      "dd.MM.yy, hv": {
+        "a": "dd.MM.yy, h a – h a v",
+        "h": "dd.MM.yy, h–h a v"
+      },
+      "d, hv": {
+        "a": "d, h a – h a v",
+        "h": "d, h–h a v"
+      },
+      "E, hv": {
+        "a": "ccc, h a – h a v",
+        "h": "ccc, h–h a v"
+      },
+      "Ed, hv": {
+        "a": "E, d., h a – h a v",
+        "h": "E, d., h–h a v"
+      },
+      "Gy, hv": {
+        "a": "y G, h a – h a v",
+        "h": "y G, h–h a v"
+      },
+      "GyM, hv": {
+        "a": "MM/y G, h a – h a v",
+        "h": "MM/y G, h–h a v"
+      },
+      "GyMd, hv": {
+        "a": "dd.MM.y G, h a – h a v",
+        "h": "dd.MM.y G, h–h a v"
+      },
+      "GyMEd, hv": {
+        "a": "E, dd.MM.y G, h a – h a v",
+        "h": "E, dd.MM.y G, h–h a v"
+      },
+      "GyMMM, hv": {
+        "a": "MMM y G, h a – h a v",
+        "h": "MMM y G, h–h a v"
+      },
+      "GyMMMd, hv": {
+        "a": "d. MMM y G, h a – h a v",
+        "h": "d. MMM y G, h–h a v"
+      },
+      "GyMMMEd, hv": {
+        "a": "E, d. MMM y G, h a – h a v",
+        "h": "E, d. MMM y G, h–h a v"
+      },
+      "M, hv": {
+        "a": "L, h a – h a v",
+        "h": "L, h–h a v"
+      },
+      "Md, hv": {
+        "a": "d.M., h a – h a v",
+        "h": "d.M., h–h a v"
+      },
+      "MEd, hv": {
+        "a": "E, d.M., h a – h a v",
+        "h": "E, d.M., h–h a v"
+      },
+      "MMd, hv": {
+        "a": "dd.MM., h a – h a v",
+        "h": "dd.MM., h–h a v"
+      },
+      "MMdd, hv": {
+        "a": "dd.MM., h a – h a v",
+        "h": "dd.MM., h–h a v"
+      },
+      "MMM, hv": {
+        "a": "LLL, h a – h a v",
+        "h": "LLL, h–h a v"
+      },
+      "MMMd, hv": {
+        "a": "d. MMM, h a – h a v",
+        "h": "d. MMM, h–h a v"
+      },
+      "MMMEd, hv": {
+        "a": "E, d. MMM, h a – h a v",
+        "h": "E, d. MMM, h–h a v"
+      },
+      "MMMMd, hv": {
+        "a": "d. MMMM, h a – h a v",
+        "h": "d. MMMM, h–h a v"
+      },
+      "MMMMEd, hv": {
+        "a": "E, d. MMMM, h a – h a v",
+        "h": "E, d. MMMM, h–h a v"
+      },
+      "y, hv": {
+        "a": "y, h a – h a v",
+        "h": "y, h–h a v"
+      },
+      "yM, hv": {
+        "a": "M/y, h a – h a v",
+        "h": "M/y, h–h a v"
+      },
+      "yMd, hv": {
+        "a": "d.M.y, h a – h a v",
+        "h": "d.M.y, h–h a v"
+      },
+      "yMEd, hv": {
+        "a": "E, d.M.y, h a – h a v",
+        "h": "E, d.M.y, h–h a v"
+      },
+      "yMM, hv": {
+        "a": "MM/y, h a – h a v",
+        "h": "MM/y, h–h a v"
+      },
+      "yMMdd, hv": {
+        "a": "dd.MM.y, h a – h a v",
+        "h": "dd.MM.y, h–h a v"
+      },
+      "yMMM, hv": {
+        "a": "MMM y, h a – h a v",
+        "h": "MMM y, h–h a v"
+      },
+      "yMMMd, hv": {
+        "a": "d. MMM y, h a – h a v",
+        "h": "d. MMM y, h–h a v"
+      },
+      "yMMMEd, hv": {
+        "a": "E, d. MMM y, h a – h a v",
+        "h": "E, d. MMM y, h–h a v"
+      },
+      "yMMMM, hv": {
+        "a": "MMMM y, h a – h a v",
+        "h": "MMMM y, h–h a v"
+      },
+      "EEEE, d. MMMM y, Hv": {
+        "H": "EEEE, d. MMMM y, HH–HH 'Uhr' v"
+      },
+      "d. MMMM y, Hv": {
+        "H": "d. MMMM y, HH–HH 'Uhr' v"
+      },
+      "dd.MM.y, Hv": {
+        "H": "dd.MM.y, HH–HH 'Uhr' v"
+      },
+      "dd.MM.yy, Hv": {
+        "H": "dd.MM.yy, HH–HH 'Uhr' v"
+      },
+      "d, Hv": {
+        "H": "d, HH–HH 'Uhr' v"
+      },
+      "E, Hv": {
+        "H": "ccc, HH–HH 'Uhr' v"
+      },
+      "Ed, Hv": {
+        "H": "E, d., HH–HH 'Uhr' v"
+      },
+      "Gy, Hv": {
+        "H": "y G, HH–HH 'Uhr' v"
+      },
+      "GyM, Hv": {
+        "H": "MM/y G, HH–HH 'Uhr' v"
+      },
+      "GyMd, Hv": {
+        "H": "dd.MM.y G, HH–HH 'Uhr' v"
+      },
+      "GyMEd, Hv": {
+        "H": "E, dd.MM.y G, HH–HH 'Uhr' v"
+      },
+      "GyMMM, Hv": {
+        "H": "MMM y G, HH–HH 'Uhr' v"
+      },
+      "GyMMMd, Hv": {
+        "H": "d. MMM y G, HH–HH 'Uhr' v"
+      },
+      "GyMMMEd, Hv": {
+        "H": "E, d. MMM y G, HH–HH 'Uhr' v"
+      },
+      "M, Hv": {
+        "H": "L, HH–HH 'Uhr' v"
+      },
+      "Md, Hv": {
+        "H": "d.M., HH–HH 'Uhr' v"
+      },
+      "MEd, Hv": {
+        "H": "E, d.M., HH–HH 'Uhr' v"
+      },
+      "MMd, Hv": {
+        "H": "dd.MM., HH–HH 'Uhr' v"
+      },
+      "MMdd, Hv": {
+        "H": "dd.MM., HH–HH 'Uhr' v"
+      },
+      "MMM, Hv": {
+        "H": "LLL, HH–HH 'Uhr' v"
+      },
+      "MMMd, Hv": {
+        "H": "d. MMM, HH–HH 'Uhr' v"
+      },
+      "MMMEd, Hv": {
+        "H": "E, d. MMM, HH–HH 'Uhr' v"
+      },
+      "MMMMd, Hv": {
+        "H": "d. MMMM, HH–HH 'Uhr' v"
+      },
+      "MMMMEd, Hv": {
+        "H": "E, d. MMMM, HH–HH 'Uhr' v"
+      },
+      "y, Hv": {
+        "H": "y, HH–HH 'Uhr' v"
+      },
+      "yM, Hv": {
+        "H": "M/y, HH–HH 'Uhr' v"
+      },
+      "yMd, Hv": {
+        "H": "d.M.y, HH–HH 'Uhr' v"
+      },
+      "yMEd, Hv": {
+        "H": "E, d.M.y, HH–HH 'Uhr' v"
+      },
+      "yMM, Hv": {
+        "H": "MM/y, HH–HH 'Uhr' v"
+      },
+      "yMMdd, Hv": {
+        "H": "dd.MM.y, HH–HH 'Uhr' v"
+      },
+      "yMMM, Hv": {
+        "H": "MMM y, HH–HH 'Uhr' v"
+      },
+      "yMMMd, Hv": {
+        "H": "d. MMM y, HH–HH 'Uhr' v"
+      },
+      "yMMMEd, Hv": {
+        "H": "E, d. MMM y, HH–HH 'Uhr' v"
+      },
+      "yMMMM, Hv": {
+        "H": "MMMM y, HH–HH 'Uhr' v"
       }
     },
     "hourCycle": "h23",
@@ -8456,6 +11162,1195 @@ Intl.DateTimeFormat.__addLocaleData({
       "yMMMM": {
         "M": "MMMM – MMMM y",
         "y": "MMMM y – MMMM y"
+      },
+      "EEEE, MMMM d, y, Bh": {
+        "B": "EEEE, MMMM d, y, h B – h B",
+        "h": "EEEE, MMMM d, y, h – h B"
+      },
+      "MMMM d, y, Bh": {
+        "B": "MMMM d, y, h B – h B",
+        "h": "MMMM d, y, h – h B"
+      },
+      "MMM d, y, Bh": {
+        "B": "MMM d, y, h B – h B",
+        "h": "MMM d, y, h – h B"
+      },
+      "M/d/yy, Bh": {
+        "B": "M/d/yy, h B – h B",
+        "h": "M/d/yy, h – h B"
+      },
+      "d, Bh": {
+        "B": "d, h B – h B",
+        "h": "d, h – h B"
+      },
+      "E, Bh": {
+        "B": "ccc, h B – h B",
+        "h": "ccc, h – h B"
+      },
+      "Ed, Bh": {
+        "B": "d E, h B – h B",
+        "h": "d E, h – h B"
+      },
+      "Gy, Bh": {
+        "B": "y G, h B – h B",
+        "h": "y G, h – h B"
+      },
+      "GyM, Bh": {
+        "B": "M/y G, h B – h B",
+        "h": "M/y G, h – h B"
+      },
+      "GyMd, Bh": {
+        "B": "M/d/y G, h B – h B",
+        "h": "M/d/y G, h – h B"
+      },
+      "GyMEd, Bh": {
+        "B": "E, M/d/y G, h B – h B",
+        "h": "E, M/d/y G, h – h B"
+      },
+      "GyMMM, Bh": {
+        "B": "MMM y G, h B – h B",
+        "h": "MMM y G, h – h B"
+      },
+      "GyMMMd, Bh": {
+        "B": "MMM d, y G, h B – h B",
+        "h": "MMM d, y G, h – h B"
+      },
+      "GyMMMEd, Bh": {
+        "B": "E, MMM d, y G, h B – h B",
+        "h": "E, MMM d, y G, h – h B"
+      },
+      "M, Bh": {
+        "B": "L, h B – h B",
+        "h": "L, h – h B"
+      },
+      "Md, Bh": {
+        "B": "M/d, h B – h B",
+        "h": "M/d, h – h B"
+      },
+      "MEd, Bh": {
+        "B": "E, M/d, h B – h B",
+        "h": "E, M/d, h – h B"
+      },
+      "MMM, Bh": {
+        "B": "LLL, h B – h B",
+        "h": "LLL, h – h B"
+      },
+      "MMMd, Bh": {
+        "B": "MMM d, h B – h B",
+        "h": "MMM d, h – h B"
+      },
+      "MMMEd, Bh": {
+        "B": "E, MMM d, h B – h B",
+        "h": "E, MMM d, h – h B"
+      },
+      "MMMMd, Bh": {
+        "B": "MMMM d, h B – h B",
+        "h": "MMMM d, h – h B"
+      },
+      "y, Bh": {
+        "B": "y, h B – h B",
+        "h": "y, h – h B"
+      },
+      "yM, Bh": {
+        "B": "M/y, h B – h B",
+        "h": "M/y, h – h B"
+      },
+      "yMd, Bh": {
+        "B": "M/d/y, h B – h B",
+        "h": "M/d/y, h – h B"
+      },
+      "yMEd, Bh": {
+        "B": "E, M/d/y, h B – h B",
+        "h": "E, M/d/y, h – h B"
+      },
+      "yMMM, Bh": {
+        "B": "MMM y, h B – h B",
+        "h": "MMM y, h – h B"
+      },
+      "yMMMd, Bh": {
+        "B": "MMM d, y, h B – h B",
+        "h": "MMM d, y, h – h B"
+      },
+      "yMMMEd, Bh": {
+        "B": "E, MMM d, y, h B – h B",
+        "h": "E, MMM d, y, h – h B"
+      },
+      "yMMMM, Bh": {
+        "B": "MMMM y, h B – h B",
+        "h": "MMMM y, h – h B"
+      },
+      "EEEE, MMMM d, y, Bhm": {
+        "B": "EEEE, MMMM d, y, h:mm B – h:mm B",
+        "h": "EEEE, MMMM d, y, h:mm – h:mm B",
+        "m": "EEEE, MMMM d, y, h:mm – h:mm B"
+      },
+      "MMMM d, y, Bhm": {
+        "B": "MMMM d, y, h:mm B – h:mm B",
+        "h": "MMMM d, y, h:mm – h:mm B",
+        "m": "MMMM d, y, h:mm – h:mm B"
+      },
+      "MMM d, y, Bhm": {
+        "B": "MMM d, y, h:mm B – h:mm B",
+        "h": "MMM d, y, h:mm – h:mm B",
+        "m": "MMM d, y, h:mm – h:mm B"
+      },
+      "M/d/yy, Bhm": {
+        "B": "M/d/yy, h:mm B – h:mm B",
+        "h": "M/d/yy, h:mm – h:mm B",
+        "m": "M/d/yy, h:mm – h:mm B"
+      },
+      "d, Bhm": {
+        "B": "d, h:mm B – h:mm B",
+        "h": "d, h:mm – h:mm B",
+        "m": "d, h:mm – h:mm B"
+      },
+      "E, Bhm": {
+        "B": "ccc, h:mm B – h:mm B",
+        "h": "ccc, h:mm – h:mm B",
+        "m": "ccc, h:mm – h:mm B"
+      },
+      "Ed, Bhm": {
+        "B": "d E, h:mm B – h:mm B",
+        "h": "d E, h:mm – h:mm B",
+        "m": "d E, h:mm – h:mm B"
+      },
+      "Gy, Bhm": {
+        "B": "y G, h:mm B – h:mm B",
+        "h": "y G, h:mm – h:mm B",
+        "m": "y G, h:mm – h:mm B"
+      },
+      "GyM, Bhm": {
+        "B": "M/y G, h:mm B – h:mm B",
+        "h": "M/y G, h:mm – h:mm B",
+        "m": "M/y G, h:mm – h:mm B"
+      },
+      "GyMd, Bhm": {
+        "B": "M/d/y G, h:mm B – h:mm B",
+        "h": "M/d/y G, h:mm – h:mm B",
+        "m": "M/d/y G, h:mm – h:mm B"
+      },
+      "GyMEd, Bhm": {
+        "B": "E, M/d/y G, h:mm B – h:mm B",
+        "h": "E, M/d/y G, h:mm – h:mm B",
+        "m": "E, M/d/y G, h:mm – h:mm B"
+      },
+      "GyMMM, Bhm": {
+        "B": "MMM y G, h:mm B – h:mm B",
+        "h": "MMM y G, h:mm – h:mm B",
+        "m": "MMM y G, h:mm – h:mm B"
+      },
+      "GyMMMd, Bhm": {
+        "B": "MMM d, y G, h:mm B – h:mm B",
+        "h": "MMM d, y G, h:mm – h:mm B",
+        "m": "MMM d, y G, h:mm – h:mm B"
+      },
+      "GyMMMEd, Bhm": {
+        "B": "E, MMM d, y G, h:mm B – h:mm B",
+        "h": "E, MMM d, y G, h:mm – h:mm B",
+        "m": "E, MMM d, y G, h:mm – h:mm B"
+      },
+      "M, Bhm": {
+        "B": "L, h:mm B – h:mm B",
+        "h": "L, h:mm – h:mm B",
+        "m": "L, h:mm – h:mm B"
+      },
+      "Md, Bhm": {
+        "B": "M/d, h:mm B – h:mm B",
+        "h": "M/d, h:mm – h:mm B",
+        "m": "M/d, h:mm – h:mm B"
+      },
+      "MEd, Bhm": {
+        "B": "E, M/d, h:mm B – h:mm B",
+        "h": "E, M/d, h:mm – h:mm B",
+        "m": "E, M/d, h:mm – h:mm B"
+      },
+      "MMM, Bhm": {
+        "B": "LLL, h:mm B – h:mm B",
+        "h": "LLL, h:mm – h:mm B",
+        "m": "LLL, h:mm – h:mm B"
+      },
+      "MMMd, Bhm": {
+        "B": "MMM d, h:mm B – h:mm B",
+        "h": "MMM d, h:mm – h:mm B",
+        "m": "MMM d, h:mm – h:mm B"
+      },
+      "MMMEd, Bhm": {
+        "B": "E, MMM d, h:mm B – h:mm B",
+        "h": "E, MMM d, h:mm – h:mm B",
+        "m": "E, MMM d, h:mm – h:mm B"
+      },
+      "MMMMd, Bhm": {
+        "B": "MMMM d, h:mm B – h:mm B",
+        "h": "MMMM d, h:mm – h:mm B",
+        "m": "MMMM d, h:mm – h:mm B"
+      },
+      "y, Bhm": {
+        "B": "y, h:mm B – h:mm B",
+        "h": "y, h:mm – h:mm B",
+        "m": "y, h:mm – h:mm B"
+      },
+      "yM, Bhm": {
+        "B": "M/y, h:mm B – h:mm B",
+        "h": "M/y, h:mm – h:mm B",
+        "m": "M/y, h:mm – h:mm B"
+      },
+      "yMd, Bhm": {
+        "B": "M/d/y, h:mm B – h:mm B",
+        "h": "M/d/y, h:mm – h:mm B",
+        "m": "M/d/y, h:mm – h:mm B"
+      },
+      "yMEd, Bhm": {
+        "B": "E, M/d/y, h:mm B – h:mm B",
+        "h": "E, M/d/y, h:mm – h:mm B",
+        "m": "E, M/d/y, h:mm – h:mm B"
+      },
+      "yMMM, Bhm": {
+        "B": "MMM y, h:mm B – h:mm B",
+        "h": "MMM y, h:mm – h:mm B",
+        "m": "MMM y, h:mm – h:mm B"
+      },
+      "yMMMd, Bhm": {
+        "B": "MMM d, y, h:mm B – h:mm B",
+        "h": "MMM d, y, h:mm – h:mm B",
+        "m": "MMM d, y, h:mm – h:mm B"
+      },
+      "yMMMEd, Bhm": {
+        "B": "E, MMM d, y, h:mm B – h:mm B",
+        "h": "E, MMM d, y, h:mm – h:mm B",
+        "m": "E, MMM d, y, h:mm – h:mm B"
+      },
+      "yMMMM, Bhm": {
+        "B": "MMMM y, h:mm B – h:mm B",
+        "h": "MMMM y, h:mm – h:mm B",
+        "m": "MMMM y, h:mm – h:mm B"
+      },
+      "EEEE, MMMM d, y, h": {
+        "a": "EEEE, MMMM d, y, h a – h a",
+        "h": "EEEE, MMMM d, y, h – h a"
+      },
+      "MMMM d, y, h": {
+        "a": "MMMM d, y, h a – h a",
+        "h": "MMMM d, y, h – h a"
+      },
+      "MMM d, y, h": {
+        "a": "MMM d, y, h a – h a",
+        "h": "MMM d, y, h – h a"
+      },
+      "M/d/yy, h": {
+        "a": "M/d/yy, h a – h a",
+        "h": "M/d/yy, h – h a"
+      },
+      "d, h": {
+        "a": "d, h a – h a",
+        "h": "d, h – h a"
+      },
+      "E, h": {
+        "a": "ccc, h a – h a",
+        "h": "ccc, h – h a"
+      },
+      "Ed, h": {
+        "a": "d E, h a – h a",
+        "h": "d E, h – h a"
+      },
+      "Gy, h": {
+        "a": "y G, h a – h a",
+        "h": "y G, h – h a"
+      },
+      "GyM, h": {
+        "a": "M/y G, h a – h a",
+        "h": "M/y G, h – h a"
+      },
+      "GyMd, h": {
+        "a": "M/d/y G, h a – h a",
+        "h": "M/d/y G, h – h a"
+      },
+      "GyMEd, h": {
+        "a": "E, M/d/y G, h a – h a",
+        "h": "E, M/d/y G, h – h a"
+      },
+      "GyMMM, h": {
+        "a": "MMM y G, h a – h a",
+        "h": "MMM y G, h – h a"
+      },
+      "GyMMMd, h": {
+        "a": "MMM d, y G, h a – h a",
+        "h": "MMM d, y G, h – h a"
+      },
+      "GyMMMEd, h": {
+        "a": "E, MMM d, y G, h a – h a",
+        "h": "E, MMM d, y G, h – h a"
+      },
+      "M, h": {
+        "a": "L, h a – h a",
+        "h": "L, h – h a"
+      },
+      "Md, h": {
+        "a": "M/d, h a – h a",
+        "h": "M/d, h – h a"
+      },
+      "MEd, h": {
+        "a": "E, M/d, h a – h a",
+        "h": "E, M/d, h – h a"
+      },
+      "MMM, h": {
+        "a": "LLL, h a – h a",
+        "h": "LLL, h – h a"
+      },
+      "MMMd, h": {
+        "a": "MMM d, h a – h a",
+        "h": "MMM d, h – h a"
+      },
+      "MMMEd, h": {
+        "a": "E, MMM d, h a – h a",
+        "h": "E, MMM d, h – h a"
+      },
+      "MMMMd, h": {
+        "a": "MMMM d, h a – h a",
+        "h": "MMMM d, h – h a"
+      },
+      "y, h": {
+        "a": "y, h a – h a",
+        "h": "y, h – h a"
+      },
+      "yM, h": {
+        "a": "M/y, h a – h a",
+        "h": "M/y, h – h a"
+      },
+      "yMd, h": {
+        "a": "M/d/y, h a – h a",
+        "h": "M/d/y, h – h a"
+      },
+      "yMEd, h": {
+        "a": "E, M/d/y, h a – h a",
+        "h": "E, M/d/y, h – h a"
+      },
+      "yMMM, h": {
+        "a": "MMM y, h a – h a",
+        "h": "MMM y, h – h a"
+      },
+      "yMMMd, h": {
+        "a": "MMM d, y, h a – h a",
+        "h": "MMM d, y, h – h a"
+      },
+      "yMMMEd, h": {
+        "a": "E, MMM d, y, h a – h a",
+        "h": "E, MMM d, y, h – h a"
+      },
+      "yMMMM, h": {
+        "a": "MMMM y, h a – h a",
+        "h": "MMMM y, h – h a"
+      },
+      "EEEE, MMMM d, y, H": {
+        "H": "EEEE, MMMM d, y, HH – HH"
+      },
+      "MMMM d, y, H": {
+        "H": "MMMM d, y, HH – HH"
+      },
+      "MMM d, y, H": {
+        "H": "MMM d, y, HH – HH"
+      },
+      "M/d/yy, H": {
+        "H": "M/d/yy, HH – HH"
+      },
+      "d, H": {
+        "H": "d, HH – HH"
+      },
+      "E, H": {
+        "H": "ccc, HH – HH"
+      },
+      "Ed, H": {
+        "H": "d E, HH – HH"
+      },
+      "Gy, H": {
+        "H": "y G, HH – HH"
+      },
+      "GyM, H": {
+        "H": "M/y G, HH – HH"
+      },
+      "GyMd, H": {
+        "H": "M/d/y G, HH – HH"
+      },
+      "GyMEd, H": {
+        "H": "E, M/d/y G, HH – HH"
+      },
+      "GyMMM, H": {
+        "H": "MMM y G, HH – HH"
+      },
+      "GyMMMd, H": {
+        "H": "MMM d, y G, HH – HH"
+      },
+      "GyMMMEd, H": {
+        "H": "E, MMM d, y G, HH – HH"
+      },
+      "M, H": {
+        "H": "L, HH – HH"
+      },
+      "Md, H": {
+        "H": "M/d, HH – HH"
+      },
+      "MEd, H": {
+        "H": "E, M/d, HH – HH"
+      },
+      "MMM, H": {
+        "H": "LLL, HH – HH"
+      },
+      "MMMd, H": {
+        "H": "MMM d, HH – HH"
+      },
+      "MMMEd, H": {
+        "H": "E, MMM d, HH – HH"
+      },
+      "MMMMd, H": {
+        "H": "MMMM d, HH – HH"
+      },
+      "y, H": {
+        "H": "y, HH – HH"
+      },
+      "yM, H": {
+        "H": "M/y, HH – HH"
+      },
+      "yMd, H": {
+        "H": "M/d/y, HH – HH"
+      },
+      "yMEd, H": {
+        "H": "E, M/d/y, HH – HH"
+      },
+      "yMMM, H": {
+        "H": "MMM y, HH – HH"
+      },
+      "yMMMd, H": {
+        "H": "MMM d, y, HH – HH"
+      },
+      "yMMMEd, H": {
+        "H": "E, MMM d, y, HH – HH"
+      },
+      "yMMMM, H": {
+        "H": "MMMM y, HH – HH"
+      },
+      "EEEE, MMMM d, y, hm": {
+        "a": "EEEE, MMMM d, y, h:mm a – h:mm a",
+        "h": "EEEE, MMMM d, y, h:mm – h:mm a",
+        "m": "EEEE, MMMM d, y, h:mm – h:mm a"
+      },
+      "MMMM d, y, hm": {
+        "a": "MMMM d, y, h:mm a – h:mm a",
+        "h": "MMMM d, y, h:mm – h:mm a",
+        "m": "MMMM d, y, h:mm – h:mm a"
+      },
+      "MMM d, y, hm": {
+        "a": "MMM d, y, h:mm a – h:mm a",
+        "h": "MMM d, y, h:mm – h:mm a",
+        "m": "MMM d, y, h:mm – h:mm a"
+      },
+      "M/d/yy, hm": {
+        "a": "M/d/yy, h:mm a – h:mm a",
+        "h": "M/d/yy, h:mm – h:mm a",
+        "m": "M/d/yy, h:mm – h:mm a"
+      },
+      "d, hm": {
+        "a": "d, h:mm a – h:mm a",
+        "h": "d, h:mm – h:mm a",
+        "m": "d, h:mm – h:mm a"
+      },
+      "E, hm": {
+        "a": "ccc, h:mm a – h:mm a",
+        "h": "ccc, h:mm – h:mm a",
+        "m": "ccc, h:mm – h:mm a"
+      },
+      "Ed, hm": {
+        "a": "d E, h:mm a – h:mm a",
+        "h": "d E, h:mm – h:mm a",
+        "m": "d E, h:mm – h:mm a"
+      },
+      "Gy, hm": {
+        "a": "y G, h:mm a – h:mm a",
+        "h": "y G, h:mm – h:mm a",
+        "m": "y G, h:mm – h:mm a"
+      },
+      "GyM, hm": {
+        "a": "M/y G, h:mm a – h:mm a",
+        "h": "M/y G, h:mm – h:mm a",
+        "m": "M/y G, h:mm – h:mm a"
+      },
+      "GyMd, hm": {
+        "a": "M/d/y G, h:mm a – h:mm a",
+        "h": "M/d/y G, h:mm – h:mm a",
+        "m": "M/d/y G, h:mm – h:mm a"
+      },
+      "GyMEd, hm": {
+        "a": "E, M/d/y G, h:mm a – h:mm a",
+        "h": "E, M/d/y G, h:mm – h:mm a",
+        "m": "E, M/d/y G, h:mm – h:mm a"
+      },
+      "GyMMM, hm": {
+        "a": "MMM y G, h:mm a – h:mm a",
+        "h": "MMM y G, h:mm – h:mm a",
+        "m": "MMM y G, h:mm – h:mm a"
+      },
+      "GyMMMd, hm": {
+        "a": "MMM d, y G, h:mm a – h:mm a",
+        "h": "MMM d, y G, h:mm – h:mm a",
+        "m": "MMM d, y G, h:mm – h:mm a"
+      },
+      "GyMMMEd, hm": {
+        "a": "E, MMM d, y G, h:mm a – h:mm a",
+        "h": "E, MMM d, y G, h:mm – h:mm a",
+        "m": "E, MMM d, y G, h:mm – h:mm a"
+      },
+      "M, hm": {
+        "a": "L, h:mm a – h:mm a",
+        "h": "L, h:mm – h:mm a",
+        "m": "L, h:mm – h:mm a"
+      },
+      "Md, hm": {
+        "a": "M/d, h:mm a – h:mm a",
+        "h": "M/d, h:mm – h:mm a",
+        "m": "M/d, h:mm – h:mm a"
+      },
+      "MEd, hm": {
+        "a": "E, M/d, h:mm a – h:mm a",
+        "h": "E, M/d, h:mm – h:mm a",
+        "m": "E, M/d, h:mm – h:mm a"
+      },
+      "MMM, hm": {
+        "a": "LLL, h:mm a – h:mm a",
+        "h": "LLL, h:mm – h:mm a",
+        "m": "LLL, h:mm – h:mm a"
+      },
+      "MMMd, hm": {
+        "a": "MMM d, h:mm a – h:mm a",
+        "h": "MMM d, h:mm – h:mm a",
+        "m": "MMM d, h:mm – h:mm a"
+      },
+      "MMMEd, hm": {
+        "a": "E, MMM d, h:mm a – h:mm a",
+        "h": "E, MMM d, h:mm – h:mm a",
+        "m": "E, MMM d, h:mm – h:mm a"
+      },
+      "MMMMd, hm": {
+        "a": "MMMM d, h:mm a – h:mm a",
+        "h": "MMMM d, h:mm – h:mm a",
+        "m": "MMMM d, h:mm – h:mm a"
+      },
+      "y, hm": {
+        "a": "y, h:mm a – h:mm a",
+        "h": "y, h:mm – h:mm a",
+        "m": "y, h:mm – h:mm a"
+      },
+      "yM, hm": {
+        "a": "M/y, h:mm a – h:mm a",
+        "h": "M/y, h:mm – h:mm a",
+        "m": "M/y, h:mm – h:mm a"
+      },
+      "yMd, hm": {
+        "a": "M/d/y, h:mm a – h:mm a",
+        "h": "M/d/y, h:mm – h:mm a",
+        "m": "M/d/y, h:mm – h:mm a"
+      },
+      "yMEd, hm": {
+        "a": "E, M/d/y, h:mm a – h:mm a",
+        "h": "E, M/d/y, h:mm – h:mm a",
+        "m": "E, M/d/y, h:mm – h:mm a"
+      },
+      "yMMM, hm": {
+        "a": "MMM y, h:mm a – h:mm a",
+        "h": "MMM y, h:mm – h:mm a",
+        "m": "MMM y, h:mm – h:mm a"
+      },
+      "yMMMd, hm": {
+        "a": "MMM d, y, h:mm a – h:mm a",
+        "h": "MMM d, y, h:mm – h:mm a",
+        "m": "MMM d, y, h:mm – h:mm a"
+      },
+      "yMMMEd, hm": {
+        "a": "E, MMM d, y, h:mm a – h:mm a",
+        "h": "E, MMM d, y, h:mm – h:mm a",
+        "m": "E, MMM d, y, h:mm – h:mm a"
+      },
+      "yMMMM, hm": {
+        "a": "MMMM y, h:mm a – h:mm a",
+        "h": "MMMM y, h:mm – h:mm a",
+        "m": "MMMM y, h:mm – h:mm a"
+      },
+      "EEEE, MMMM d, y, Hm": {
+        "H": "EEEE, MMMM d, y, HH:mm – HH:mm",
+        "m": "EEEE, MMMM d, y, HH:mm – HH:mm"
+      },
+      "MMMM d, y, Hm": {
+        "H": "MMMM d, y, HH:mm – HH:mm",
+        "m": "MMMM d, y, HH:mm – HH:mm"
+      },
+      "MMM d, y, Hm": {
+        "H": "MMM d, y, HH:mm – HH:mm",
+        "m": "MMM d, y, HH:mm – HH:mm"
+      },
+      "M/d/yy, Hm": {
+        "H": "M/d/yy, HH:mm – HH:mm",
+        "m": "M/d/yy, HH:mm – HH:mm"
+      },
+      "d, Hm": {
+        "H": "d, HH:mm – HH:mm",
+        "m": "d, HH:mm – HH:mm"
+      },
+      "E, Hm": {
+        "H": "ccc, HH:mm – HH:mm",
+        "m": "ccc, HH:mm – HH:mm"
+      },
+      "Ed, Hm": {
+        "H": "d E, HH:mm – HH:mm",
+        "m": "d E, HH:mm – HH:mm"
+      },
+      "Gy, Hm": {
+        "H": "y G, HH:mm – HH:mm",
+        "m": "y G, HH:mm – HH:mm"
+      },
+      "GyM, Hm": {
+        "H": "M/y G, HH:mm – HH:mm",
+        "m": "M/y G, HH:mm – HH:mm"
+      },
+      "GyMd, Hm": {
+        "H": "M/d/y G, HH:mm – HH:mm",
+        "m": "M/d/y G, HH:mm – HH:mm"
+      },
+      "GyMEd, Hm": {
+        "H": "E, M/d/y G, HH:mm – HH:mm",
+        "m": "E, M/d/y G, HH:mm – HH:mm"
+      },
+      "GyMMM, Hm": {
+        "H": "MMM y G, HH:mm – HH:mm",
+        "m": "MMM y G, HH:mm – HH:mm"
+      },
+      "GyMMMd, Hm": {
+        "H": "MMM d, y G, HH:mm – HH:mm",
+        "m": "MMM d, y G, HH:mm – HH:mm"
+      },
+      "GyMMMEd, Hm": {
+        "H": "E, MMM d, y G, HH:mm – HH:mm",
+        "m": "E, MMM d, y G, HH:mm – HH:mm"
+      },
+      "M, Hm": {
+        "H": "L, HH:mm – HH:mm",
+        "m": "L, HH:mm – HH:mm"
+      },
+      "Md, Hm": {
+        "H": "M/d, HH:mm – HH:mm",
+        "m": "M/d, HH:mm – HH:mm"
+      },
+      "MEd, Hm": {
+        "H": "E, M/d, HH:mm – HH:mm",
+        "m": "E, M/d, HH:mm – HH:mm"
+      },
+      "MMM, Hm": {
+        "H": "LLL, HH:mm – HH:mm",
+        "m": "LLL, HH:mm – HH:mm"
+      },
+      "MMMd, Hm": {
+        "H": "MMM d, HH:mm – HH:mm",
+        "m": "MMM d, HH:mm – HH:mm"
+      },
+      "MMMEd, Hm": {
+        "H": "E, MMM d, HH:mm – HH:mm",
+        "m": "E, MMM d, HH:mm – HH:mm"
+      },
+      "MMMMd, Hm": {
+        "H": "MMMM d, HH:mm – HH:mm",
+        "m": "MMMM d, HH:mm – HH:mm"
+      },
+      "y, Hm": {
+        "H": "y, HH:mm – HH:mm",
+        "m": "y, HH:mm – HH:mm"
+      },
+      "yM, Hm": {
+        "H": "M/y, HH:mm – HH:mm",
+        "m": "M/y, HH:mm – HH:mm"
+      },
+      "yMd, Hm": {
+        "H": "M/d/y, HH:mm – HH:mm",
+        "m": "M/d/y, HH:mm – HH:mm"
+      },
+      "yMEd, Hm": {
+        "H": "E, M/d/y, HH:mm – HH:mm",
+        "m": "E, M/d/y, HH:mm – HH:mm"
+      },
+      "yMMM, Hm": {
+        "H": "MMM y, HH:mm – HH:mm",
+        "m": "MMM y, HH:mm – HH:mm"
+      },
+      "yMMMd, Hm": {
+        "H": "MMM d, y, HH:mm – HH:mm",
+        "m": "MMM d, y, HH:mm – HH:mm"
+      },
+      "yMMMEd, Hm": {
+        "H": "E, MMM d, y, HH:mm – HH:mm",
+        "m": "E, MMM d, y, HH:mm – HH:mm"
+      },
+      "yMMMM, Hm": {
+        "H": "MMMM y, HH:mm – HH:mm",
+        "m": "MMMM y, HH:mm – HH:mm"
+      },
+      "EEEE, MMMM d, y, hmv": {
+        "a": "EEEE, MMMM d, y, h:mm a – h:mm a v",
+        "h": "EEEE, MMMM d, y, h:mm – h:mm a v",
+        "m": "EEEE, MMMM d, y, h:mm – h:mm a v"
+      },
+      "MMMM d, y, hmv": {
+        "a": "MMMM d, y, h:mm a – h:mm a v",
+        "h": "MMMM d, y, h:mm – h:mm a v",
+        "m": "MMMM d, y, h:mm – h:mm a v"
+      },
+      "MMM d, y, hmv": {
+        "a": "MMM d, y, h:mm a – h:mm a v",
+        "h": "MMM d, y, h:mm – h:mm a v",
+        "m": "MMM d, y, h:mm – h:mm a v"
+      },
+      "M/d/yy, hmv": {
+        "a": "M/d/yy, h:mm a – h:mm a v",
+        "h": "M/d/yy, h:mm – h:mm a v",
+        "m": "M/d/yy, h:mm – h:mm a v"
+      },
+      "d, hmv": {
+        "a": "d, h:mm a – h:mm a v",
+        "h": "d, h:mm – h:mm a v",
+        "m": "d, h:mm – h:mm a v"
+      },
+      "E, hmv": {
+        "a": "ccc, h:mm a – h:mm a v",
+        "h": "ccc, h:mm – h:mm a v",
+        "m": "ccc, h:mm – h:mm a v"
+      },
+      "Ed, hmv": {
+        "a": "d E, h:mm a – h:mm a v",
+        "h": "d E, h:mm – h:mm a v",
+        "m": "d E, h:mm – h:mm a v"
+      },
+      "Gy, hmv": {
+        "a": "y G, h:mm a – h:mm a v",
+        "h": "y G, h:mm – h:mm a v",
+        "m": "y G, h:mm – h:mm a v"
+      },
+      "GyM, hmv": {
+        "a": "M/y G, h:mm a – h:mm a v",
+        "h": "M/y G, h:mm – h:mm a v",
+        "m": "M/y G, h:mm – h:mm a v"
+      },
+      "GyMd, hmv": {
+        "a": "M/d/y G, h:mm a – h:mm a v",
+        "h": "M/d/y G, h:mm – h:mm a v",
+        "m": "M/d/y G, h:mm – h:mm a v"
+      },
+      "GyMEd, hmv": {
+        "a": "E, M/d/y G, h:mm a – h:mm a v",
+        "h": "E, M/d/y G, h:mm – h:mm a v",
+        "m": "E, M/d/y G, h:mm – h:mm a v"
+      },
+      "GyMMM, hmv": {
+        "a": "MMM y G, h:mm a – h:mm a v",
+        "h": "MMM y G, h:mm – h:mm a v",
+        "m": "MMM y G, h:mm – h:mm a v"
+      },
+      "GyMMMd, hmv": {
+        "a": "MMM d, y G, h:mm a – h:mm a v",
+        "h": "MMM d, y G, h:mm – h:mm a v",
+        "m": "MMM d, y G, h:mm – h:mm a v"
+      },
+      "GyMMMEd, hmv": {
+        "a": "E, MMM d, y G, h:mm a – h:mm a v",
+        "h": "E, MMM d, y G, h:mm – h:mm a v",
+        "m": "E, MMM d, y G, h:mm – h:mm a v"
+      },
+      "M, hmv": {
+        "a": "L, h:mm a – h:mm a v",
+        "h": "L, h:mm – h:mm a v",
+        "m": "L, h:mm – h:mm a v"
+      },
+      "Md, hmv": {
+        "a": "M/d, h:mm a – h:mm a v",
+        "h": "M/d, h:mm – h:mm a v",
+        "m": "M/d, h:mm – h:mm a v"
+      },
+      "MEd, hmv": {
+        "a": "E, M/d, h:mm a – h:mm a v",
+        "h": "E, M/d, h:mm – h:mm a v",
+        "m": "E, M/d, h:mm – h:mm a v"
+      },
+      "MMM, hmv": {
+        "a": "LLL, h:mm a – h:mm a v",
+        "h": "LLL, h:mm – h:mm a v",
+        "m": "LLL, h:mm – h:mm a v"
+      },
+      "MMMd, hmv": {
+        "a": "MMM d, h:mm a – h:mm a v",
+        "h": "MMM d, h:mm – h:mm a v",
+        "m": "MMM d, h:mm – h:mm a v"
+      },
+      "MMMEd, hmv": {
+        "a": "E, MMM d, h:mm a – h:mm a v",
+        "h": "E, MMM d, h:mm – h:mm a v",
+        "m": "E, MMM d, h:mm – h:mm a v"
+      },
+      "MMMMd, hmv": {
+        "a": "MMMM d, h:mm a – h:mm a v",
+        "h": "MMMM d, h:mm – h:mm a v",
+        "m": "MMMM d, h:mm – h:mm a v"
+      },
+      "y, hmv": {
+        "a": "y, h:mm a – h:mm a v",
+        "h": "y, h:mm – h:mm a v",
+        "m": "y, h:mm – h:mm a v"
+      },
+      "yM, hmv": {
+        "a": "M/y, h:mm a – h:mm a v",
+        "h": "M/y, h:mm – h:mm a v",
+        "m": "M/y, h:mm – h:mm a v"
+      },
+      "yMd, hmv": {
+        "a": "M/d/y, h:mm a – h:mm a v",
+        "h": "M/d/y, h:mm – h:mm a v",
+        "m": "M/d/y, h:mm – h:mm a v"
+      },
+      "yMEd, hmv": {
+        "a": "E, M/d/y, h:mm a – h:mm a v",
+        "h": "E, M/d/y, h:mm – h:mm a v",
+        "m": "E, M/d/y, h:mm – h:mm a v"
+      },
+      "yMMM, hmv": {
+        "a": "MMM y, h:mm a – h:mm a v",
+        "h": "MMM y, h:mm – h:mm a v",
+        "m": "MMM y, h:mm – h:mm a v"
+      },
+      "yMMMd, hmv": {
+        "a": "MMM d, y, h:mm a – h:mm a v",
+        "h": "MMM d, y, h:mm – h:mm a v",
+        "m": "MMM d, y, h:mm – h:mm a v"
+      },
+      "yMMMEd, hmv": {
+        "a": "E, MMM d, y, h:mm a – h:mm a v",
+        "h": "E, MMM d, y, h:mm – h:mm a v",
+        "m": "E, MMM d, y, h:mm – h:mm a v"
+      },
+      "yMMMM, hmv": {
+        "a": "MMMM y, h:mm a – h:mm a v",
+        "h": "MMMM y, h:mm – h:mm a v",
+        "m": "MMMM y, h:mm – h:mm a v"
+      },
+      "EEEE, MMMM d, y, Hmv": {
+        "H": "EEEE, MMMM d, y, HH:mm – HH:mm v",
+        "m": "EEEE, MMMM d, y, HH:mm – HH:mm v"
+      },
+      "MMMM d, y, Hmv": {
+        "H": "MMMM d, y, HH:mm – HH:mm v",
+        "m": "MMMM d, y, HH:mm – HH:mm v"
+      },
+      "MMM d, y, Hmv": {
+        "H": "MMM d, y, HH:mm – HH:mm v",
+        "m": "MMM d, y, HH:mm – HH:mm v"
+      },
+      "M/d/yy, Hmv": {
+        "H": "M/d/yy, HH:mm – HH:mm v",
+        "m": "M/d/yy, HH:mm – HH:mm v"
+      },
+      "d, Hmv": {
+        "H": "d, HH:mm – HH:mm v",
+        "m": "d, HH:mm – HH:mm v"
+      },
+      "E, Hmv": {
+        "H": "ccc, HH:mm – HH:mm v",
+        "m": "ccc, HH:mm – HH:mm v"
+      },
+      "Ed, Hmv": {
+        "H": "d E, HH:mm – HH:mm v",
+        "m": "d E, HH:mm – HH:mm v"
+      },
+      "Gy, Hmv": {
+        "H": "y G, HH:mm – HH:mm v",
+        "m": "y G, HH:mm – HH:mm v"
+      },
+      "GyM, Hmv": {
+        "H": "M/y G, HH:mm – HH:mm v",
+        "m": "M/y G, HH:mm – HH:mm v"
+      },
+      "GyMd, Hmv": {
+        "H": "M/d/y G, HH:mm – HH:mm v",
+        "m": "M/d/y G, HH:mm – HH:mm v"
+      },
+      "GyMEd, Hmv": {
+        "H": "E, M/d/y G, HH:mm – HH:mm v",
+        "m": "E, M/d/y G, HH:mm – HH:mm v"
+      },
+      "GyMMM, Hmv": {
+        "H": "MMM y G, HH:mm – HH:mm v",
+        "m": "MMM y G, HH:mm – HH:mm v"
+      },
+      "GyMMMd, Hmv": {
+        "H": "MMM d, y G, HH:mm – HH:mm v",
+        "m": "MMM d, y G, HH:mm – HH:mm v"
+      },
+      "GyMMMEd, Hmv": {
+        "H": "E, MMM d, y G, HH:mm – HH:mm v",
+        "m": "E, MMM d, y G, HH:mm – HH:mm v"
+      },
+      "M, Hmv": {
+        "H": "L, HH:mm – HH:mm v",
+        "m": "L, HH:mm – HH:mm v"
+      },
+      "Md, Hmv": {
+        "H": "M/d, HH:mm – HH:mm v",
+        "m": "M/d, HH:mm – HH:mm v"
+      },
+      "MEd, Hmv": {
+        "H": "E, M/d, HH:mm – HH:mm v",
+        "m": "E, M/d, HH:mm – HH:mm v"
+      },
+      "MMM, Hmv": {
+        "H": "LLL, HH:mm – HH:mm v",
+        "m": "LLL, HH:mm – HH:mm v"
+      },
+      "MMMd, Hmv": {
+        "H": "MMM d, HH:mm – HH:mm v",
+        "m": "MMM d, HH:mm – HH:mm v"
+      },
+      "MMMEd, Hmv": {
+        "H": "E, MMM d, HH:mm – HH:mm v",
+        "m": "E, MMM d, HH:mm – HH:mm v"
+      },
+      "MMMMd, Hmv": {
+        "H": "MMMM d, HH:mm – HH:mm v",
+        "m": "MMMM d, HH:mm – HH:mm v"
+      },
+      "y, Hmv": {
+        "H": "y, HH:mm – HH:mm v",
+        "m": "y, HH:mm – HH:mm v"
+      },
+      "yM, Hmv": {
+        "H": "M/y, HH:mm – HH:mm v",
+        "m": "M/y, HH:mm – HH:mm v"
+      },
+      "yMd, Hmv": {
+        "H": "M/d/y, HH:mm – HH:mm v",
+        "m": "M/d/y, HH:mm – HH:mm v"
+      },
+      "yMEd, Hmv": {
+        "H": "E, M/d/y, HH:mm – HH:mm v",
+        "m": "E, M/d/y, HH:mm – HH:mm v"
+      },
+      "yMMM, Hmv": {
+        "H": "MMM y, HH:mm – HH:mm v",
+        "m": "MMM y, HH:mm – HH:mm v"
+      },
+      "yMMMd, Hmv": {
+        "H": "MMM d, y, HH:mm – HH:mm v",
+        "m": "MMM d, y, HH:mm – HH:mm v"
+      },
+      "yMMMEd, Hmv": {
+        "H": "E, MMM d, y, HH:mm – HH:mm v",
+        "m": "E, MMM d, y, HH:mm – HH:mm v"
+      },
+      "yMMMM, Hmv": {
+        "H": "MMMM y, HH:mm – HH:mm v",
+        "m": "MMMM y, HH:mm – HH:mm v"
+      },
+      "EEEE, MMMM d, y, hv": {
+        "a": "EEEE, MMMM d, y, h a – h a v",
+        "h": "EEEE, MMMM d, y, h – h a v"
+      },
+      "MMMM d, y, hv": {
+        "a": "MMMM d, y, h a – h a v",
+        "h": "MMMM d, y, h – h a v"
+      },
+      "MMM d, y, hv": {
+        "a": "MMM d, y, h a – h a v",
+        "h": "MMM d, y, h – h a v"
+      },
+      "M/d/yy, hv": {
+        "a": "M/d/yy, h a – h a v",
+        "h": "M/d/yy, h – h a v"
+      },
+      "d, hv": {
+        "a": "d, h a – h a v",
+        "h": "d, h – h a v"
+      },
+      "E, hv": {
+        "a": "ccc, h a – h a v",
+        "h": "ccc, h – h a v"
+      },
+      "Ed, hv": {
+        "a": "d E, h a – h a v",
+        "h": "d E, h – h a v"
+      },
+      "Gy, hv": {
+        "a": "y G, h a – h a v",
+        "h": "y G, h – h a v"
+      },
+      "GyM, hv": {
+        "a": "M/y G, h a – h a v",
+        "h": "M/y G, h – h a v"
+      },
+      "GyMd, hv": {
+        "a": "M/d/y G, h a – h a v",
+        "h": "M/d/y G, h – h a v"
+      },
+      "GyMEd, hv": {
+        "a": "E, M/d/y G, h a – h a v",
+        "h": "E, M/d/y G, h – h a v"
+      },
+      "GyMMM, hv": {
+        "a": "MMM y G, h a – h a v",
+        "h": "MMM y G, h – h a v"
+      },
+      "GyMMMd, hv": {
+        "a": "MMM d, y G, h a – h a v",
+        "h": "MMM d, y G, h – h a v"
+      },
+      "GyMMMEd, hv": {
+        "a": "E, MMM d, y G, h a – h a v",
+        "h": "E, MMM d, y G, h – h a v"
+      },
+      "M, hv": {
+        "a": "L, h a – h a v",
+        "h": "L, h – h a v"
+      },
+      "Md, hv": {
+        "a": "M/d, h a – h a v",
+        "h": "M/d, h – h a v"
+      },
+      "MEd, hv": {
+        "a": "E, M/d, h a – h a v",
+        "h": "E, M/d, h – h a v"
+      },
+      "MMM, hv": {
+        "a": "LLL, h a – h a v",
+        "h": "LLL, h – h a v"
+      },
+      "MMMd, hv": {
+        "a": "MMM d, h a – h a v",
+        "h": "MMM d, h – h a v"
+      },
+      "MMMEd, hv": {
+        "a": "E, MMM d, h a – h a v",
+        "h": "E, MMM d, h – h a v"
+      },
+      "MMMMd, hv": {
+        "a": "MMMM d, h a – h a v",
+        "h": "MMMM d, h – h a v"
+      },
+      "y, hv": {
+        "a": "y, h a – h a v",
+        "h": "y, h – h a v"
+      },
+      "yM, hv": {
+        "a": "M/y, h a – h a v",
+        "h": "M/y, h – h a v"
+      },
+      "yMd, hv": {
+        "a": "M/d/y, h a – h a v",
+        "h": "M/d/y, h – h a v"
+      },
+      "yMEd, hv": {
+        "a": "E, M/d/y, h a – h a v",
+        "h": "E, M/d/y, h – h a v"
+      },
+      "yMMM, hv": {
+        "a": "MMM y, h a – h a v",
+        "h": "MMM y, h – h a v"
+      },
+      "yMMMd, hv": {
+        "a": "MMM d, y, h a – h a v",
+        "h": "MMM d, y, h – h a v"
+      },
+      "yMMMEd, hv": {
+        "a": "E, MMM d, y, h a – h a v",
+        "h": "E, MMM d, y, h – h a v"
+      },
+      "yMMMM, hv": {
+        "a": "MMMM y, h a – h a v",
+        "h": "MMMM y, h – h a v"
+      },
+      "EEEE, MMMM d, y, Hv": {
+        "H": "EEEE, MMMM d, y, HH – HH v"
+      },
+      "MMMM d, y, Hv": {
+        "H": "MMMM d, y, HH – HH v"
+      },
+      "MMM d, y, Hv": {
+        "H": "MMM d, y, HH – HH v"
+      },
+      "M/d/yy, Hv": {
+        "H": "M/d/yy, HH – HH v"
+      },
+      "d, Hv": {
+        "H": "d, HH – HH v"
+      },
+      "E, Hv": {
+        "H": "ccc, HH – HH v"
+      },
+      "Ed, Hv": {
+        "H": "d E, HH – HH v"
+      },
+      "Gy, Hv": {
+        "H": "y G, HH – HH v"
+      },
+      "GyM, Hv": {
+        "H": "M/y G, HH – HH v"
+      },
+      "GyMd, Hv": {
+        "H": "M/d/y G, HH – HH v"
+      },
+      "GyMEd, Hv": {
+        "H": "E, M/d/y G, HH – HH v"
+      },
+      "GyMMM, Hv": {
+        "H": "MMM y G, HH – HH v"
+      },
+      "GyMMMd, Hv": {
+        "H": "MMM d, y G, HH – HH v"
+      },
+      "GyMMMEd, Hv": {
+        "H": "E, MMM d, y G, HH – HH v"
+      },
+      "M, Hv": {
+        "H": "L, HH – HH v"
+      },
+      "Md, Hv": {
+        "H": "M/d, HH – HH v"
+      },
+      "MEd, Hv": {
+        "H": "E, M/d, HH – HH v"
+      },
+      "MMM, Hv": {
+        "H": "LLL, HH – HH v"
+      },
+      "MMMd, Hv": {
+        "H": "MMM d, HH – HH v"
+      },
+      "MMMEd, Hv": {
+        "H": "E, MMM d, HH – HH v"
+      },
+      "MMMMd, Hv": {
+        "H": "MMMM d, HH – HH v"
+      },
+      "y, Hv": {
+        "H": "y, HH – HH v"
+      },
+      "yM, Hv": {
+        "H": "M/y, HH – HH v"
+      },
+      "yMd, Hv": {
+        "H": "M/d/y, HH – HH v"
+      },
+      "yMEd, Hv": {
+        "H": "E, M/d/y, HH – HH v"
+      },
+      "yMMM, Hv": {
+        "H": "MMM y, HH – HH v"
+      },
+      "yMMMd, Hv": {
+        "H": "MMM d, y, HH – HH v"
+      },
+      "yMMMEd, Hv": {
+        "H": "E, MMM d, y, HH – HH v"
+      },
+      "yMMMM, Hv": {
+        "H": "MMMM y, HH – HH v"
       }
     },
     "hourCycle": "h12",
@@ -11174,6 +15069,1441 @@ Intl.DateTimeFormat.__addLocaleData({
       "yMMMM": {
         "M": "y年M月～M月",
         "y": "y年M月～y年M月"
+      },
+      "y年M月d日EEEE Bh": {
+        "B": "y年M月d日EEEE BK時～BK時",
+        "h": "y年M月d日EEEE BK時～K時"
+      },
+      "y年M月d日 Bh": {
+        "B": "y年M月d日 BK時～BK時",
+        "h": "y年M月d日 BK時～K時"
+      },
+      "y/MM/dd Bh": {
+        "B": "y/MM/dd BK時～BK時",
+        "h": "y/MM/dd BK時～K時"
+      },
+      "d Bh": {
+        "B": "d日 BK時～BK時",
+        "h": "d日 BK時～K時"
+      },
+      "E Bh": {
+        "B": "ccc BK時～BK時",
+        "h": "ccc BK時～K時"
+      },
+      "Ed Bh": {
+        "B": "d日(E) BK時～BK時",
+        "h": "d日(E) BK時～K時"
+      },
+      "EEEEd Bh": {
+        "B": "d日EEEE BK時～BK時",
+        "h": "d日EEEE BK時～K時"
+      },
+      "Gy Bh": {
+        "B": "Gy年 BK時～BK時",
+        "h": "Gy年 BK時～K時"
+      },
+      "GyM Bh": {
+        "B": "Gy/M BK時～BK時",
+        "h": "Gy/M BK時～K時"
+      },
+      "GyMd Bh": {
+        "B": "Gy/M/d BK時～BK時",
+        "h": "Gy/M/d BK時～K時"
+      },
+      "GyMEd Bh": {
+        "B": "Gy/M/d(E) BK時～BK時",
+        "h": "Gy/M/d(E) BK時～K時"
+      },
+      "GyMMM Bh": {
+        "B": "Gy年M月 BK時～BK時",
+        "h": "Gy年M月 BK時～K時"
+      },
+      "GyMMMd Bh": {
+        "B": "Gy年M月d日 BK時～BK時",
+        "h": "Gy年M月d日 BK時～K時"
+      },
+      "GyMMMEd Bh": {
+        "B": "Gy年M月d日(E) BK時～BK時",
+        "h": "Gy年M月d日(E) BK時～K時"
+      },
+      "GyMMMEEEEd Bh": {
+        "B": "Gy年M月d日EEEE BK時～BK時",
+        "h": "Gy年M月d日EEEE BK時～K時"
+      },
+      "M Bh": {
+        "B": "M月 BK時～BK時",
+        "h": "M月 BK時～K時"
+      },
+      "Md Bh": {
+        "B": "M/d BK時～BK時",
+        "h": "M/d BK時～K時"
+      },
+      "MEd Bh": {
+        "B": "M/d(E) BK時～BK時",
+        "h": "M/d(E) BK時～K時"
+      },
+      "MEEEEd Bh": {
+        "B": "M/dEEEE BK時～BK時",
+        "h": "M/dEEEE BK時～K時"
+      },
+      "MMM Bh": {
+        "B": "M月 BK時～BK時",
+        "h": "M月 BK時～K時"
+      },
+      "MMMd Bh": {
+        "B": "M月d日 BK時～BK時",
+        "h": "M月d日 BK時～K時"
+      },
+      "MMMEd Bh": {
+        "B": "M月d日(E) BK時～BK時",
+        "h": "M月d日(E) BK時～K時"
+      },
+      "MMMEEEEd Bh": {
+        "B": "M月d日EEEE BK時～BK時",
+        "h": "M月d日EEEE BK時～K時"
+      },
+      "MMMMd Bh": {
+        "B": "M月d日 BK時～BK時",
+        "h": "M月d日 BK時～K時"
+      },
+      "y Bh": {
+        "B": "y年 BK時～BK時",
+        "h": "y年 BK時～K時"
+      },
+      "yM Bh": {
+        "B": "y/M BK時～BK時",
+        "h": "y/M BK時～K時"
+      },
+      "yMd Bh": {
+        "B": "y/M/d BK時～BK時",
+        "h": "y/M/d BK時～K時"
+      },
+      "yMEd Bh": {
+        "B": "y/M/d(E) BK時～BK時",
+        "h": "y/M/d(E) BK時～K時"
+      },
+      "yMEEEEd Bh": {
+        "B": "y/M/dEEEE BK時～BK時",
+        "h": "y/M/dEEEE BK時～K時"
+      },
+      "yMM Bh": {
+        "B": "y/MM BK時～BK時",
+        "h": "y/MM BK時～K時"
+      },
+      "yMMM Bh": {
+        "B": "y年M月 BK時～BK時",
+        "h": "y年M月 BK時～K時"
+      },
+      "yMMMd Bh": {
+        "B": "y年M月d日 BK時～BK時",
+        "h": "y年M月d日 BK時～K時"
+      },
+      "yMMMEd Bh": {
+        "B": "y年M月d日(E) BK時～BK時",
+        "h": "y年M月d日(E) BK時～K時"
+      },
+      "yMMMEEEEd Bh": {
+        "B": "y年M月d日EEEE BK時～BK時",
+        "h": "y年M月d日EEEE BK時～K時"
+      },
+      "yMMMM Bh": {
+        "B": "y年M月 BK時～BK時",
+        "h": "y年M月 BK時～K時"
+      },
+      "y年M月d日EEEE Bhm": {
+        "B": "y年M月d日EEEE BK:mm～BK:mm",
+        "h": "y年M月d日EEEE BK:mm～K:mm",
+        "m": "y年M月d日EEEE BK:mm～K:mm"
+      },
+      "y年M月d日 Bhm": {
+        "B": "y年M月d日 BK:mm～BK:mm",
+        "h": "y年M月d日 BK:mm～K:mm",
+        "m": "y年M月d日 BK:mm～K:mm"
+      },
+      "y/MM/dd Bhm": {
+        "B": "y/MM/dd BK:mm～BK:mm",
+        "h": "y/MM/dd BK:mm～K:mm",
+        "m": "y/MM/dd BK:mm～K:mm"
+      },
+      "d Bhm": {
+        "B": "d日 BK:mm～BK:mm",
+        "h": "d日 BK:mm～K:mm",
+        "m": "d日 BK:mm～K:mm"
+      },
+      "E Bhm": {
+        "B": "ccc BK:mm～BK:mm",
+        "h": "ccc BK:mm～K:mm",
+        "m": "ccc BK:mm～K:mm"
+      },
+      "Ed Bhm": {
+        "B": "d日(E) BK:mm～BK:mm",
+        "h": "d日(E) BK:mm～K:mm",
+        "m": "d日(E) BK:mm～K:mm"
+      },
+      "EEEEd Bhm": {
+        "B": "d日EEEE BK:mm～BK:mm",
+        "h": "d日EEEE BK:mm～K:mm",
+        "m": "d日EEEE BK:mm～K:mm"
+      },
+      "Gy Bhm": {
+        "B": "Gy年 BK:mm～BK:mm",
+        "h": "Gy年 BK:mm～K:mm",
+        "m": "Gy年 BK:mm～K:mm"
+      },
+      "GyM Bhm": {
+        "B": "Gy/M BK:mm～BK:mm",
+        "h": "Gy/M BK:mm～K:mm",
+        "m": "Gy/M BK:mm～K:mm"
+      },
+      "GyMd Bhm": {
+        "B": "Gy/M/d BK:mm～BK:mm",
+        "h": "Gy/M/d BK:mm～K:mm",
+        "m": "Gy/M/d BK:mm～K:mm"
+      },
+      "GyMEd Bhm": {
+        "B": "Gy/M/d(E) BK:mm～BK:mm",
+        "h": "Gy/M/d(E) BK:mm～K:mm",
+        "m": "Gy/M/d(E) BK:mm～K:mm"
+      },
+      "GyMMM Bhm": {
+        "B": "Gy年M月 BK:mm～BK:mm",
+        "h": "Gy年M月 BK:mm～K:mm",
+        "m": "Gy年M月 BK:mm～K:mm"
+      },
+      "GyMMMd Bhm": {
+        "B": "Gy年M月d日 BK:mm～BK:mm",
+        "h": "Gy年M月d日 BK:mm～K:mm",
+        "m": "Gy年M月d日 BK:mm～K:mm"
+      },
+      "GyMMMEd Bhm": {
+        "B": "Gy年M月d日(E) BK:mm～BK:mm",
+        "h": "Gy年M月d日(E) BK:mm～K:mm",
+        "m": "Gy年M月d日(E) BK:mm～K:mm"
+      },
+      "GyMMMEEEEd Bhm": {
+        "B": "Gy年M月d日EEEE BK:mm～BK:mm",
+        "h": "Gy年M月d日EEEE BK:mm～K:mm",
+        "m": "Gy年M月d日EEEE BK:mm～K:mm"
+      },
+      "M Bhm": {
+        "B": "M月 BK:mm～BK:mm",
+        "h": "M月 BK:mm～K:mm",
+        "m": "M月 BK:mm～K:mm"
+      },
+      "Md Bhm": {
+        "B": "M/d BK:mm～BK:mm",
+        "h": "M/d BK:mm～K:mm",
+        "m": "M/d BK:mm～K:mm"
+      },
+      "MEd Bhm": {
+        "B": "M/d(E) BK:mm～BK:mm",
+        "h": "M/d(E) BK:mm～K:mm",
+        "m": "M/d(E) BK:mm～K:mm"
+      },
+      "MEEEEd Bhm": {
+        "B": "M/dEEEE BK:mm～BK:mm",
+        "h": "M/dEEEE BK:mm～K:mm",
+        "m": "M/dEEEE BK:mm～K:mm"
+      },
+      "MMM Bhm": {
+        "B": "M月 BK:mm～BK:mm",
+        "h": "M月 BK:mm～K:mm",
+        "m": "M月 BK:mm～K:mm"
+      },
+      "MMMd Bhm": {
+        "B": "M月d日 BK:mm～BK:mm",
+        "h": "M月d日 BK:mm～K:mm",
+        "m": "M月d日 BK:mm～K:mm"
+      },
+      "MMMEd Bhm": {
+        "B": "M月d日(E) BK:mm～BK:mm",
+        "h": "M月d日(E) BK:mm～K:mm",
+        "m": "M月d日(E) BK:mm～K:mm"
+      },
+      "MMMEEEEd Bhm": {
+        "B": "M月d日EEEE BK:mm～BK:mm",
+        "h": "M月d日EEEE BK:mm～K:mm",
+        "m": "M月d日EEEE BK:mm～K:mm"
+      },
+      "MMMMd Bhm": {
+        "B": "M月d日 BK:mm～BK:mm",
+        "h": "M月d日 BK:mm～K:mm",
+        "m": "M月d日 BK:mm～K:mm"
+      },
+      "y Bhm": {
+        "B": "y年 BK:mm～BK:mm",
+        "h": "y年 BK:mm～K:mm",
+        "m": "y年 BK:mm～K:mm"
+      },
+      "yM Bhm": {
+        "B": "y/M BK:mm～BK:mm",
+        "h": "y/M BK:mm～K:mm",
+        "m": "y/M BK:mm～K:mm"
+      },
+      "yMd Bhm": {
+        "B": "y/M/d BK:mm～BK:mm",
+        "h": "y/M/d BK:mm～K:mm",
+        "m": "y/M/d BK:mm～K:mm"
+      },
+      "yMEd Bhm": {
+        "B": "y/M/d(E) BK:mm～BK:mm",
+        "h": "y/M/d(E) BK:mm～K:mm",
+        "m": "y/M/d(E) BK:mm～K:mm"
+      },
+      "yMEEEEd Bhm": {
+        "B": "y/M/dEEEE BK:mm～BK:mm",
+        "h": "y/M/dEEEE BK:mm～K:mm",
+        "m": "y/M/dEEEE BK:mm～K:mm"
+      },
+      "yMM Bhm": {
+        "B": "y/MM BK:mm～BK:mm",
+        "h": "y/MM BK:mm～K:mm",
+        "m": "y/MM BK:mm～K:mm"
+      },
+      "yMMM Bhm": {
+        "B": "y年M月 BK:mm～BK:mm",
+        "h": "y年M月 BK:mm～K:mm",
+        "m": "y年M月 BK:mm～K:mm"
+      },
+      "yMMMd Bhm": {
+        "B": "y年M月d日 BK:mm～BK:mm",
+        "h": "y年M月d日 BK:mm～K:mm",
+        "m": "y年M月d日 BK:mm～K:mm"
+      },
+      "yMMMEd Bhm": {
+        "B": "y年M月d日(E) BK:mm～BK:mm",
+        "h": "y年M月d日(E) BK:mm～K:mm",
+        "m": "y年M月d日(E) BK:mm～K:mm"
+      },
+      "yMMMEEEEd Bhm": {
+        "B": "y年M月d日EEEE BK:mm～BK:mm",
+        "h": "y年M月d日EEEE BK:mm～K:mm",
+        "m": "y年M月d日EEEE BK:mm～K:mm"
+      },
+      "yMMMM Bhm": {
+        "B": "y年M月 BK:mm～BK:mm",
+        "h": "y年M月 BK:mm～K:mm",
+        "m": "y年M月 BK:mm～K:mm"
+      },
+      "y年M月d日EEEE h": {
+        "a": "y年M月d日EEEE aK時～aK時",
+        "h": "y年M月d日EEEE aK時～K時"
+      },
+      "y年M月d日 h": {
+        "a": "y年M月d日 aK時～aK時",
+        "h": "y年M月d日 aK時～K時"
+      },
+      "y/MM/dd h": {
+        "a": "y/MM/dd aK時～aK時",
+        "h": "y/MM/dd aK時～K時"
+      },
+      "d h": {
+        "a": "d日 aK時～aK時",
+        "h": "d日 aK時～K時"
+      },
+      "E h": {
+        "a": "ccc aK時～aK時",
+        "h": "ccc aK時～K時"
+      },
+      "Ed h": {
+        "a": "d日(E) aK時～aK時",
+        "h": "d日(E) aK時～K時"
+      },
+      "EEEEd h": {
+        "a": "d日EEEE aK時～aK時",
+        "h": "d日EEEE aK時～K時"
+      },
+      "Gy h": {
+        "a": "Gy年 aK時～aK時",
+        "h": "Gy年 aK時～K時"
+      },
+      "GyM h": {
+        "a": "Gy/M aK時～aK時",
+        "h": "Gy/M aK時～K時"
+      },
+      "GyMd h": {
+        "a": "Gy/M/d aK時～aK時",
+        "h": "Gy/M/d aK時～K時"
+      },
+      "GyMEd h": {
+        "a": "Gy/M/d(E) aK時～aK時",
+        "h": "Gy/M/d(E) aK時～K時"
+      },
+      "GyMMM h": {
+        "a": "Gy年M月 aK時～aK時",
+        "h": "Gy年M月 aK時～K時"
+      },
+      "GyMMMd h": {
+        "a": "Gy年M月d日 aK時～aK時",
+        "h": "Gy年M月d日 aK時～K時"
+      },
+      "GyMMMEd h": {
+        "a": "Gy年M月d日(E) aK時～aK時",
+        "h": "Gy年M月d日(E) aK時～K時"
+      },
+      "GyMMMEEEEd h": {
+        "a": "Gy年M月d日EEEE aK時～aK時",
+        "h": "Gy年M月d日EEEE aK時～K時"
+      },
+      "M h": {
+        "a": "M月 aK時～aK時",
+        "h": "M月 aK時～K時"
+      },
+      "Md h": {
+        "a": "M/d aK時～aK時",
+        "h": "M/d aK時～K時"
+      },
+      "MEd h": {
+        "a": "M/d(E) aK時～aK時",
+        "h": "M/d(E) aK時～K時"
+      },
+      "MEEEEd h": {
+        "a": "M/dEEEE aK時～aK時",
+        "h": "M/dEEEE aK時～K時"
+      },
+      "MMM h": {
+        "a": "M月 aK時～aK時",
+        "h": "M月 aK時～K時"
+      },
+      "MMMd h": {
+        "a": "M月d日 aK時～aK時",
+        "h": "M月d日 aK時～K時"
+      },
+      "MMMEd h": {
+        "a": "M月d日(E) aK時～aK時",
+        "h": "M月d日(E) aK時～K時"
+      },
+      "MMMEEEEd h": {
+        "a": "M月d日EEEE aK時～aK時",
+        "h": "M月d日EEEE aK時～K時"
+      },
+      "MMMMd h": {
+        "a": "M月d日 aK時～aK時",
+        "h": "M月d日 aK時～K時"
+      },
+      "y h": {
+        "a": "y年 aK時～aK時",
+        "h": "y年 aK時～K時"
+      },
+      "yM h": {
+        "a": "y/M aK時～aK時",
+        "h": "y/M aK時～K時"
+      },
+      "yMd h": {
+        "a": "y/M/d aK時～aK時",
+        "h": "y/M/d aK時～K時"
+      },
+      "yMEd h": {
+        "a": "y/M/d(E) aK時～aK時",
+        "h": "y/M/d(E) aK時～K時"
+      },
+      "yMEEEEd h": {
+        "a": "y/M/dEEEE aK時～aK時",
+        "h": "y/M/dEEEE aK時～K時"
+      },
+      "yMM h": {
+        "a": "y/MM aK時～aK時",
+        "h": "y/MM aK時～K時"
+      },
+      "yMMM h": {
+        "a": "y年M月 aK時～aK時",
+        "h": "y年M月 aK時～K時"
+      },
+      "yMMMd h": {
+        "a": "y年M月d日 aK時～aK時",
+        "h": "y年M月d日 aK時～K時"
+      },
+      "yMMMEd h": {
+        "a": "y年M月d日(E) aK時～aK時",
+        "h": "y年M月d日(E) aK時～K時"
+      },
+      "yMMMEEEEd h": {
+        "a": "y年M月d日EEEE aK時～aK時",
+        "h": "y年M月d日EEEE aK時～K時"
+      },
+      "yMMMM h": {
+        "a": "y年M月 aK時～aK時",
+        "h": "y年M月 aK時～K時"
+      },
+      "y年M月d日EEEE H": {
+        "H": "y年M月d日EEEE H時～H時"
+      },
+      "y年M月d日 H": {
+        "H": "y年M月d日 H時～H時"
+      },
+      "y/MM/dd H": {
+        "H": "y/MM/dd H時～H時"
+      },
+      "d H": {
+        "H": "d日 H時～H時"
+      },
+      "E H": {
+        "H": "ccc H時～H時"
+      },
+      "Ed H": {
+        "H": "d日(E) H時～H時"
+      },
+      "EEEEd H": {
+        "H": "d日EEEE H時～H時"
+      },
+      "Gy H": {
+        "H": "Gy年 H時～H時"
+      },
+      "GyM H": {
+        "H": "Gy/M H時～H時"
+      },
+      "GyMd H": {
+        "H": "Gy/M/d H時～H時"
+      },
+      "GyMEd H": {
+        "H": "Gy/M/d(E) H時～H時"
+      },
+      "GyMMM H": {
+        "H": "Gy年M月 H時～H時"
+      },
+      "GyMMMd H": {
+        "H": "Gy年M月d日 H時～H時"
+      },
+      "GyMMMEd H": {
+        "H": "Gy年M月d日(E) H時～H時"
+      },
+      "GyMMMEEEEd H": {
+        "H": "Gy年M月d日EEEE H時～H時"
+      },
+      "M H": {
+        "H": "M月 H時～H時"
+      },
+      "Md H": {
+        "H": "M/d H時～H時"
+      },
+      "MEd H": {
+        "H": "M/d(E) H時～H時"
+      },
+      "MEEEEd H": {
+        "H": "M/dEEEE H時～H時"
+      },
+      "MMM H": {
+        "H": "M月 H時～H時"
+      },
+      "MMMd H": {
+        "H": "M月d日 H時～H時"
+      },
+      "MMMEd H": {
+        "H": "M月d日(E) H時～H時"
+      },
+      "MMMEEEEd H": {
+        "H": "M月d日EEEE H時～H時"
+      },
+      "MMMMd H": {
+        "H": "M月d日 H時～H時"
+      },
+      "y H": {
+        "H": "y年 H時～H時"
+      },
+      "yM H": {
+        "H": "y/M H時～H時"
+      },
+      "yMd H": {
+        "H": "y/M/d H時～H時"
+      },
+      "yMEd H": {
+        "H": "y/M/d(E) H時～H時"
+      },
+      "yMEEEEd H": {
+        "H": "y/M/dEEEE H時～H時"
+      },
+      "yMM H": {
+        "H": "y/MM H時～H時"
+      },
+      "yMMM H": {
+        "H": "y年M月 H時～H時"
+      },
+      "yMMMd H": {
+        "H": "y年M月d日 H時～H時"
+      },
+      "yMMMEd H": {
+        "H": "y年M月d日(E) H時～H時"
+      },
+      "yMMMEEEEd H": {
+        "H": "y年M月d日EEEE H時～H時"
+      },
+      "yMMMM H": {
+        "H": "y年M月 H時～H時"
+      },
+      "y年M月d日EEEE hm": {
+        "a": "y年M月d日EEEE aK時mm分～aK時mm分",
+        "h": "y年M月d日EEEE aK時mm分～K時mm分",
+        "m": "y年M月d日EEEE aK時mm分～K時mm分"
+      },
+      "y年M月d日 hm": {
+        "a": "y年M月d日 aK時mm分～aK時mm分",
+        "h": "y年M月d日 aK時mm分～K時mm分",
+        "m": "y年M月d日 aK時mm分～K時mm分"
+      },
+      "y/MM/dd hm": {
+        "a": "y/MM/dd aK時mm分～aK時mm分",
+        "h": "y/MM/dd aK時mm分～K時mm分",
+        "m": "y/MM/dd aK時mm分～K時mm分"
+      },
+      "d hm": {
+        "a": "d日 aK時mm分～aK時mm分",
+        "h": "d日 aK時mm分～K時mm分",
+        "m": "d日 aK時mm分～K時mm分"
+      },
+      "E hm": {
+        "a": "ccc aK時mm分～aK時mm分",
+        "h": "ccc aK時mm分～K時mm分",
+        "m": "ccc aK時mm分～K時mm分"
+      },
+      "Ed hm": {
+        "a": "d日(E) aK時mm分～aK時mm分",
+        "h": "d日(E) aK時mm分～K時mm分",
+        "m": "d日(E) aK時mm分～K時mm分"
+      },
+      "EEEEd hm": {
+        "a": "d日EEEE aK時mm分～aK時mm分",
+        "h": "d日EEEE aK時mm分～K時mm分",
+        "m": "d日EEEE aK時mm分～K時mm分"
+      },
+      "Gy hm": {
+        "a": "Gy年 aK時mm分～aK時mm分",
+        "h": "Gy年 aK時mm分～K時mm分",
+        "m": "Gy年 aK時mm分～K時mm分"
+      },
+      "GyM hm": {
+        "a": "Gy/M aK時mm分～aK時mm分",
+        "h": "Gy/M aK時mm分～K時mm分",
+        "m": "Gy/M aK時mm分～K時mm分"
+      },
+      "GyMd hm": {
+        "a": "Gy/M/d aK時mm分～aK時mm分",
+        "h": "Gy/M/d aK時mm分～K時mm分",
+        "m": "Gy/M/d aK時mm分～K時mm分"
+      },
+      "GyMEd hm": {
+        "a": "Gy/M/d(E) aK時mm分～aK時mm分",
+        "h": "Gy/M/d(E) aK時mm分～K時mm分",
+        "m": "Gy/M/d(E) aK時mm分～K時mm分"
+      },
+      "GyMMM hm": {
+        "a": "Gy年M月 aK時mm分～aK時mm分",
+        "h": "Gy年M月 aK時mm分～K時mm分",
+        "m": "Gy年M月 aK時mm分～K時mm分"
+      },
+      "GyMMMd hm": {
+        "a": "Gy年M月d日 aK時mm分～aK時mm分",
+        "h": "Gy年M月d日 aK時mm分～K時mm分",
+        "m": "Gy年M月d日 aK時mm分～K時mm分"
+      },
+      "GyMMMEd hm": {
+        "a": "Gy年M月d日(E) aK時mm分～aK時mm分",
+        "h": "Gy年M月d日(E) aK時mm分～K時mm分",
+        "m": "Gy年M月d日(E) aK時mm分～K時mm分"
+      },
+      "GyMMMEEEEd hm": {
+        "a": "Gy年M月d日EEEE aK時mm分～aK時mm分",
+        "h": "Gy年M月d日EEEE aK時mm分～K時mm分",
+        "m": "Gy年M月d日EEEE aK時mm分～K時mm分"
+      },
+      "M hm": {
+        "a": "M月 aK時mm分～aK時mm分",
+        "h": "M月 aK時mm分～K時mm分",
+        "m": "M月 aK時mm分～K時mm分"
+      },
+      "Md hm": {
+        "a": "M/d aK時mm分～aK時mm分",
+        "h": "M/d aK時mm分～K時mm分",
+        "m": "M/d aK時mm分～K時mm分"
+      },
+      "MEd hm": {
+        "a": "M/d(E) aK時mm分～aK時mm分",
+        "h": "M/d(E) aK時mm分～K時mm分",
+        "m": "M/d(E) aK時mm分～K時mm分"
+      },
+      "MEEEEd hm": {
+        "a": "M/dEEEE aK時mm分～aK時mm分",
+        "h": "M/dEEEE aK時mm分～K時mm分",
+        "m": "M/dEEEE aK時mm分～K時mm分"
+      },
+      "MMM hm": {
+        "a": "M月 aK時mm分～aK時mm分",
+        "h": "M月 aK時mm分～K時mm分",
+        "m": "M月 aK時mm分～K時mm分"
+      },
+      "MMMd hm": {
+        "a": "M月d日 aK時mm分～aK時mm分",
+        "h": "M月d日 aK時mm分～K時mm分",
+        "m": "M月d日 aK時mm分～K時mm分"
+      },
+      "MMMEd hm": {
+        "a": "M月d日(E) aK時mm分～aK時mm分",
+        "h": "M月d日(E) aK時mm分～K時mm分",
+        "m": "M月d日(E) aK時mm分～K時mm分"
+      },
+      "MMMEEEEd hm": {
+        "a": "M月d日EEEE aK時mm分～aK時mm分",
+        "h": "M月d日EEEE aK時mm分～K時mm分",
+        "m": "M月d日EEEE aK時mm分～K時mm分"
+      },
+      "MMMMd hm": {
+        "a": "M月d日 aK時mm分～aK時mm分",
+        "h": "M月d日 aK時mm分～K時mm分",
+        "m": "M月d日 aK時mm分～K時mm分"
+      },
+      "y hm": {
+        "a": "y年 aK時mm分～aK時mm分",
+        "h": "y年 aK時mm分～K時mm分",
+        "m": "y年 aK時mm分～K時mm分"
+      },
+      "yM hm": {
+        "a": "y/M aK時mm分～aK時mm分",
+        "h": "y/M aK時mm分～K時mm分",
+        "m": "y/M aK時mm分～K時mm分"
+      },
+      "yMd hm": {
+        "a": "y/M/d aK時mm分～aK時mm分",
+        "h": "y/M/d aK時mm分～K時mm分",
+        "m": "y/M/d aK時mm分～K時mm分"
+      },
+      "yMEd hm": {
+        "a": "y/M/d(E) aK時mm分～aK時mm分",
+        "h": "y/M/d(E) aK時mm分～K時mm分",
+        "m": "y/M/d(E) aK時mm分～K時mm分"
+      },
+      "yMEEEEd hm": {
+        "a": "y/M/dEEEE aK時mm分～aK時mm分",
+        "h": "y/M/dEEEE aK時mm分～K時mm分",
+        "m": "y/M/dEEEE aK時mm分～K時mm分"
+      },
+      "yMM hm": {
+        "a": "y/MM aK時mm分～aK時mm分",
+        "h": "y/MM aK時mm分～K時mm分",
+        "m": "y/MM aK時mm分～K時mm分"
+      },
+      "yMMM hm": {
+        "a": "y年M月 aK時mm分～aK時mm分",
+        "h": "y年M月 aK時mm分～K時mm分",
+        "m": "y年M月 aK時mm分～K時mm分"
+      },
+      "yMMMd hm": {
+        "a": "y年M月d日 aK時mm分～aK時mm分",
+        "h": "y年M月d日 aK時mm分～K時mm分",
+        "m": "y年M月d日 aK時mm分～K時mm分"
+      },
+      "yMMMEd hm": {
+        "a": "y年M月d日(E) aK時mm分～aK時mm分",
+        "h": "y年M月d日(E) aK時mm分～K時mm分",
+        "m": "y年M月d日(E) aK時mm分～K時mm分"
+      },
+      "yMMMEEEEd hm": {
+        "a": "y年M月d日EEEE aK時mm分～aK時mm分",
+        "h": "y年M月d日EEEE aK時mm分～K時mm分",
+        "m": "y年M月d日EEEE aK時mm分～K時mm分"
+      },
+      "yMMMM hm": {
+        "a": "y年M月 aK時mm分～aK時mm分",
+        "h": "y年M月 aK時mm分～K時mm分",
+        "m": "y年M月 aK時mm分～K時mm分"
+      },
+      "y年M月d日EEEE Hm": {
+        "H": "y年M月d日EEEE H時mm分～H時mm分",
+        "m": "y年M月d日EEEE H時mm分～H時mm分"
+      },
+      "y年M月d日 Hm": {
+        "H": "y年M月d日 H時mm分～H時mm分",
+        "m": "y年M月d日 H時mm分～H時mm分"
+      },
+      "y/MM/dd Hm": {
+        "H": "y/MM/dd H時mm分～H時mm分",
+        "m": "y/MM/dd H時mm分～H時mm分"
+      },
+      "d Hm": {
+        "H": "d日 H時mm分～H時mm分",
+        "m": "d日 H時mm分～H時mm分"
+      },
+      "E Hm": {
+        "H": "ccc H時mm分～H時mm分",
+        "m": "ccc H時mm分～H時mm分"
+      },
+      "Ed Hm": {
+        "H": "d日(E) H時mm分～H時mm分",
+        "m": "d日(E) H時mm分～H時mm分"
+      },
+      "EEEEd Hm": {
+        "H": "d日EEEE H時mm分～H時mm分",
+        "m": "d日EEEE H時mm分～H時mm分"
+      },
+      "Gy Hm": {
+        "H": "Gy年 H時mm分～H時mm分",
+        "m": "Gy年 H時mm分～H時mm分"
+      },
+      "GyM Hm": {
+        "H": "Gy/M H時mm分～H時mm分",
+        "m": "Gy/M H時mm分～H時mm分"
+      },
+      "GyMd Hm": {
+        "H": "Gy/M/d H時mm分～H時mm分",
+        "m": "Gy/M/d H時mm分～H時mm分"
+      },
+      "GyMEd Hm": {
+        "H": "Gy/M/d(E) H時mm分～H時mm分",
+        "m": "Gy/M/d(E) H時mm分～H時mm分"
+      },
+      "GyMMM Hm": {
+        "H": "Gy年M月 H時mm分～H時mm分",
+        "m": "Gy年M月 H時mm分～H時mm分"
+      },
+      "GyMMMd Hm": {
+        "H": "Gy年M月d日 H時mm分～H時mm分",
+        "m": "Gy年M月d日 H時mm分～H時mm分"
+      },
+      "GyMMMEd Hm": {
+        "H": "Gy年M月d日(E) H時mm分～H時mm分",
+        "m": "Gy年M月d日(E) H時mm分～H時mm分"
+      },
+      "GyMMMEEEEd Hm": {
+        "H": "Gy年M月d日EEEE H時mm分～H時mm分",
+        "m": "Gy年M月d日EEEE H時mm分～H時mm分"
+      },
+      "M Hm": {
+        "H": "M月 H時mm分～H時mm分",
+        "m": "M月 H時mm分～H時mm分"
+      },
+      "Md Hm": {
+        "H": "M/d H時mm分～H時mm分",
+        "m": "M/d H時mm分～H時mm分"
+      },
+      "MEd Hm": {
+        "H": "M/d(E) H時mm分～H時mm分",
+        "m": "M/d(E) H時mm分～H時mm分"
+      },
+      "MEEEEd Hm": {
+        "H": "M/dEEEE H時mm分～H時mm分",
+        "m": "M/dEEEE H時mm分～H時mm分"
+      },
+      "MMM Hm": {
+        "H": "M月 H時mm分～H時mm分",
+        "m": "M月 H時mm分～H時mm分"
+      },
+      "MMMd Hm": {
+        "H": "M月d日 H時mm分～H時mm分",
+        "m": "M月d日 H時mm分～H時mm分"
+      },
+      "MMMEd Hm": {
+        "H": "M月d日(E) H時mm分～H時mm分",
+        "m": "M月d日(E) H時mm分～H時mm分"
+      },
+      "MMMEEEEd Hm": {
+        "H": "M月d日EEEE H時mm分～H時mm分",
+        "m": "M月d日EEEE H時mm分～H時mm分"
+      },
+      "MMMMd Hm": {
+        "H": "M月d日 H時mm分～H時mm分",
+        "m": "M月d日 H時mm分～H時mm分"
+      },
+      "y Hm": {
+        "H": "y年 H時mm分～H時mm分",
+        "m": "y年 H時mm分～H時mm分"
+      },
+      "yM Hm": {
+        "H": "y/M H時mm分～H時mm分",
+        "m": "y/M H時mm分～H時mm分"
+      },
+      "yMd Hm": {
+        "H": "y/M/d H時mm分～H時mm分",
+        "m": "y/M/d H時mm分～H時mm分"
+      },
+      "yMEd Hm": {
+        "H": "y/M/d(E) H時mm分～H時mm分",
+        "m": "y/M/d(E) H時mm分～H時mm分"
+      },
+      "yMEEEEd Hm": {
+        "H": "y/M/dEEEE H時mm分～H時mm分",
+        "m": "y/M/dEEEE H時mm分～H時mm分"
+      },
+      "yMM Hm": {
+        "H": "y/MM H時mm分～H時mm分",
+        "m": "y/MM H時mm分～H時mm分"
+      },
+      "yMMM Hm": {
+        "H": "y年M月 H時mm分～H時mm分",
+        "m": "y年M月 H時mm分～H時mm分"
+      },
+      "yMMMd Hm": {
+        "H": "y年M月d日 H時mm分～H時mm分",
+        "m": "y年M月d日 H時mm分～H時mm分"
+      },
+      "yMMMEd Hm": {
+        "H": "y年M月d日(E) H時mm分～H時mm分",
+        "m": "y年M月d日(E) H時mm分～H時mm分"
+      },
+      "yMMMEEEEd Hm": {
+        "H": "y年M月d日EEEE H時mm分～H時mm分",
+        "m": "y年M月d日EEEE H時mm分～H時mm分"
+      },
+      "yMMMM Hm": {
+        "H": "y年M月 H時mm分～H時mm分",
+        "m": "y年M月 H時mm分～H時mm分"
+      },
+      "y年M月d日EEEE hmv": {
+        "a": "y年M月d日EEEE aK時mm分～aK時mm分(v)",
+        "h": "y年M月d日EEEE aK時mm分～K時mm分(v)",
+        "m": "y年M月d日EEEE aK時mm分～K時mm分(v)"
+      },
+      "y年M月d日 hmv": {
+        "a": "y年M月d日 aK時mm分～aK時mm分(v)",
+        "h": "y年M月d日 aK時mm分～K時mm分(v)",
+        "m": "y年M月d日 aK時mm分～K時mm分(v)"
+      },
+      "y/MM/dd hmv": {
+        "a": "y/MM/dd aK時mm分～aK時mm分(v)",
+        "h": "y/MM/dd aK時mm分～K時mm分(v)",
+        "m": "y/MM/dd aK時mm分～K時mm分(v)"
+      },
+      "d hmv": {
+        "a": "d日 aK時mm分～aK時mm分(v)",
+        "h": "d日 aK時mm分～K時mm分(v)",
+        "m": "d日 aK時mm分～K時mm分(v)"
+      },
+      "E hmv": {
+        "a": "ccc aK時mm分～aK時mm分(v)",
+        "h": "ccc aK時mm分～K時mm分(v)",
+        "m": "ccc aK時mm分～K時mm分(v)"
+      },
+      "Ed hmv": {
+        "a": "d日(E) aK時mm分～aK時mm分(v)",
+        "h": "d日(E) aK時mm分～K時mm分(v)",
+        "m": "d日(E) aK時mm分～K時mm分(v)"
+      },
+      "EEEEd hmv": {
+        "a": "d日EEEE aK時mm分～aK時mm分(v)",
+        "h": "d日EEEE aK時mm分～K時mm分(v)",
+        "m": "d日EEEE aK時mm分～K時mm分(v)"
+      },
+      "Gy hmv": {
+        "a": "Gy年 aK時mm分～aK時mm分(v)",
+        "h": "Gy年 aK時mm分～K時mm分(v)",
+        "m": "Gy年 aK時mm分～K時mm分(v)"
+      },
+      "GyM hmv": {
+        "a": "Gy/M aK時mm分～aK時mm分(v)",
+        "h": "Gy/M aK時mm分～K時mm分(v)",
+        "m": "Gy/M aK時mm分～K時mm分(v)"
+      },
+      "GyMd hmv": {
+        "a": "Gy/M/d aK時mm分～aK時mm分(v)",
+        "h": "Gy/M/d aK時mm分～K時mm分(v)",
+        "m": "Gy/M/d aK時mm分～K時mm分(v)"
+      },
+      "GyMEd hmv": {
+        "a": "Gy/M/d(E) aK時mm分～aK時mm分(v)",
+        "h": "Gy/M/d(E) aK時mm分～K時mm分(v)",
+        "m": "Gy/M/d(E) aK時mm分～K時mm分(v)"
+      },
+      "GyMMM hmv": {
+        "a": "Gy年M月 aK時mm分～aK時mm分(v)",
+        "h": "Gy年M月 aK時mm分～K時mm分(v)",
+        "m": "Gy年M月 aK時mm分～K時mm分(v)"
+      },
+      "GyMMMd hmv": {
+        "a": "Gy年M月d日 aK時mm分～aK時mm分(v)",
+        "h": "Gy年M月d日 aK時mm分～K時mm分(v)",
+        "m": "Gy年M月d日 aK時mm分～K時mm分(v)"
+      },
+      "GyMMMEd hmv": {
+        "a": "Gy年M月d日(E) aK時mm分～aK時mm分(v)",
+        "h": "Gy年M月d日(E) aK時mm分～K時mm分(v)",
+        "m": "Gy年M月d日(E) aK時mm分～K時mm分(v)"
+      },
+      "GyMMMEEEEd hmv": {
+        "a": "Gy年M月d日EEEE aK時mm分～aK時mm分(v)",
+        "h": "Gy年M月d日EEEE aK時mm分～K時mm分(v)",
+        "m": "Gy年M月d日EEEE aK時mm分～K時mm分(v)"
+      },
+      "M hmv": {
+        "a": "M月 aK時mm分～aK時mm分(v)",
+        "h": "M月 aK時mm分～K時mm分(v)",
+        "m": "M月 aK時mm分～K時mm分(v)"
+      },
+      "Md hmv": {
+        "a": "M/d aK時mm分～aK時mm分(v)",
+        "h": "M/d aK時mm分～K時mm分(v)",
+        "m": "M/d aK時mm分～K時mm分(v)"
+      },
+      "MEd hmv": {
+        "a": "M/d(E) aK時mm分～aK時mm分(v)",
+        "h": "M/d(E) aK時mm分～K時mm分(v)",
+        "m": "M/d(E) aK時mm分～K時mm分(v)"
+      },
+      "MEEEEd hmv": {
+        "a": "M/dEEEE aK時mm分～aK時mm分(v)",
+        "h": "M/dEEEE aK時mm分～K時mm分(v)",
+        "m": "M/dEEEE aK時mm分～K時mm分(v)"
+      },
+      "MMM hmv": {
+        "a": "M月 aK時mm分～aK時mm分(v)",
+        "h": "M月 aK時mm分～K時mm分(v)",
+        "m": "M月 aK時mm分～K時mm分(v)"
+      },
+      "MMMd hmv": {
+        "a": "M月d日 aK時mm分～aK時mm分(v)",
+        "h": "M月d日 aK時mm分～K時mm分(v)",
+        "m": "M月d日 aK時mm分～K時mm分(v)"
+      },
+      "MMMEd hmv": {
+        "a": "M月d日(E) aK時mm分～aK時mm分(v)",
+        "h": "M月d日(E) aK時mm分～K時mm分(v)",
+        "m": "M月d日(E) aK時mm分～K時mm分(v)"
+      },
+      "MMMEEEEd hmv": {
+        "a": "M月d日EEEE aK時mm分～aK時mm分(v)",
+        "h": "M月d日EEEE aK時mm分～K時mm分(v)",
+        "m": "M月d日EEEE aK時mm分～K時mm分(v)"
+      },
+      "MMMMd hmv": {
+        "a": "M月d日 aK時mm分～aK時mm分(v)",
+        "h": "M月d日 aK時mm分～K時mm分(v)",
+        "m": "M月d日 aK時mm分～K時mm分(v)"
+      },
+      "y hmv": {
+        "a": "y年 aK時mm分～aK時mm分(v)",
+        "h": "y年 aK時mm分～K時mm分(v)",
+        "m": "y年 aK時mm分～K時mm分(v)"
+      },
+      "yM hmv": {
+        "a": "y/M aK時mm分～aK時mm分(v)",
+        "h": "y/M aK時mm分～K時mm分(v)",
+        "m": "y/M aK時mm分～K時mm分(v)"
+      },
+      "yMd hmv": {
+        "a": "y/M/d aK時mm分～aK時mm分(v)",
+        "h": "y/M/d aK時mm分～K時mm分(v)",
+        "m": "y/M/d aK時mm分～K時mm分(v)"
+      },
+      "yMEd hmv": {
+        "a": "y/M/d(E) aK時mm分～aK時mm分(v)",
+        "h": "y/M/d(E) aK時mm分～K時mm分(v)",
+        "m": "y/M/d(E) aK時mm分～K時mm分(v)"
+      },
+      "yMEEEEd hmv": {
+        "a": "y/M/dEEEE aK時mm分～aK時mm分(v)",
+        "h": "y/M/dEEEE aK時mm分～K時mm分(v)",
+        "m": "y/M/dEEEE aK時mm分～K時mm分(v)"
+      },
+      "yMM hmv": {
+        "a": "y/MM aK時mm分～aK時mm分(v)",
+        "h": "y/MM aK時mm分～K時mm分(v)",
+        "m": "y/MM aK時mm分～K時mm分(v)"
+      },
+      "yMMM hmv": {
+        "a": "y年M月 aK時mm分～aK時mm分(v)",
+        "h": "y年M月 aK時mm分～K時mm分(v)",
+        "m": "y年M月 aK時mm分～K時mm分(v)"
+      },
+      "yMMMd hmv": {
+        "a": "y年M月d日 aK時mm分～aK時mm分(v)",
+        "h": "y年M月d日 aK時mm分～K時mm分(v)",
+        "m": "y年M月d日 aK時mm分～K時mm分(v)"
+      },
+      "yMMMEd hmv": {
+        "a": "y年M月d日(E) aK時mm分～aK時mm分(v)",
+        "h": "y年M月d日(E) aK時mm分～K時mm分(v)",
+        "m": "y年M月d日(E) aK時mm分～K時mm分(v)"
+      },
+      "yMMMEEEEd hmv": {
+        "a": "y年M月d日EEEE aK時mm分～aK時mm分(v)",
+        "h": "y年M月d日EEEE aK時mm分～K時mm分(v)",
+        "m": "y年M月d日EEEE aK時mm分～K時mm分(v)"
+      },
+      "yMMMM hmv": {
+        "a": "y年M月 aK時mm分～aK時mm分(v)",
+        "h": "y年M月 aK時mm分～K時mm分(v)",
+        "m": "y年M月 aK時mm分～K時mm分(v)"
+      },
+      "y年M月d日EEEE Hmv": {
+        "H": "y年M月d日EEEE H時mm分～H時mm分(v)",
+        "m": "y年M月d日EEEE H時mm分～H時mm分(v)"
+      },
+      "y年M月d日 Hmv": {
+        "H": "y年M月d日 H時mm分～H時mm分(v)",
+        "m": "y年M月d日 H時mm分～H時mm分(v)"
+      },
+      "y/MM/dd Hmv": {
+        "H": "y/MM/dd H時mm分～H時mm分(v)",
+        "m": "y/MM/dd H時mm分～H時mm分(v)"
+      },
+      "d Hmv": {
+        "H": "d日 H時mm分～H時mm分(v)",
+        "m": "d日 H時mm分～H時mm分(v)"
+      },
+      "E Hmv": {
+        "H": "ccc H時mm分～H時mm分(v)",
+        "m": "ccc H時mm分～H時mm分(v)"
+      },
+      "Ed Hmv": {
+        "H": "d日(E) H時mm分～H時mm分(v)",
+        "m": "d日(E) H時mm分～H時mm分(v)"
+      },
+      "EEEEd Hmv": {
+        "H": "d日EEEE H時mm分～H時mm分(v)",
+        "m": "d日EEEE H時mm分～H時mm分(v)"
+      },
+      "Gy Hmv": {
+        "H": "Gy年 H時mm分～H時mm分(v)",
+        "m": "Gy年 H時mm分～H時mm分(v)"
+      },
+      "GyM Hmv": {
+        "H": "Gy/M H時mm分～H時mm分(v)",
+        "m": "Gy/M H時mm分～H時mm分(v)"
+      },
+      "GyMd Hmv": {
+        "H": "Gy/M/d H時mm分～H時mm分(v)",
+        "m": "Gy/M/d H時mm分～H時mm分(v)"
+      },
+      "GyMEd Hmv": {
+        "H": "Gy/M/d(E) H時mm分～H時mm分(v)",
+        "m": "Gy/M/d(E) H時mm分～H時mm分(v)"
+      },
+      "GyMMM Hmv": {
+        "H": "Gy年M月 H時mm分～H時mm分(v)",
+        "m": "Gy年M月 H時mm分～H時mm分(v)"
+      },
+      "GyMMMd Hmv": {
+        "H": "Gy年M月d日 H時mm分～H時mm分(v)",
+        "m": "Gy年M月d日 H時mm分～H時mm分(v)"
+      },
+      "GyMMMEd Hmv": {
+        "H": "Gy年M月d日(E) H時mm分～H時mm分(v)",
+        "m": "Gy年M月d日(E) H時mm分～H時mm分(v)"
+      },
+      "GyMMMEEEEd Hmv": {
+        "H": "Gy年M月d日EEEE H時mm分～H時mm分(v)",
+        "m": "Gy年M月d日EEEE H時mm分～H時mm分(v)"
+      },
+      "M Hmv": {
+        "H": "M月 H時mm分～H時mm分(v)",
+        "m": "M月 H時mm分～H時mm分(v)"
+      },
+      "Md Hmv": {
+        "H": "M/d H時mm分～H時mm分(v)",
+        "m": "M/d H時mm分～H時mm分(v)"
+      },
+      "MEd Hmv": {
+        "H": "M/d(E) H時mm分～H時mm分(v)",
+        "m": "M/d(E) H時mm分～H時mm分(v)"
+      },
+      "MEEEEd Hmv": {
+        "H": "M/dEEEE H時mm分～H時mm分(v)",
+        "m": "M/dEEEE H時mm分～H時mm分(v)"
+      },
+      "MMM Hmv": {
+        "H": "M月 H時mm分～H時mm分(v)",
+        "m": "M月 H時mm分～H時mm分(v)"
+      },
+      "MMMd Hmv": {
+        "H": "M月d日 H時mm分～H時mm分(v)",
+        "m": "M月d日 H時mm分～H時mm分(v)"
+      },
+      "MMMEd Hmv": {
+        "H": "M月d日(E) H時mm分～H時mm分(v)",
+        "m": "M月d日(E) H時mm分～H時mm分(v)"
+      },
+      "MMMEEEEd Hmv": {
+        "H": "M月d日EEEE H時mm分～H時mm分(v)",
+        "m": "M月d日EEEE H時mm分～H時mm分(v)"
+      },
+      "MMMMd Hmv": {
+        "H": "M月d日 H時mm分～H時mm分(v)",
+        "m": "M月d日 H時mm分～H時mm分(v)"
+      },
+      "y Hmv": {
+        "H": "y年 H時mm分～H時mm分(v)",
+        "m": "y年 H時mm分～H時mm分(v)"
+      },
+      "yM Hmv": {
+        "H": "y/M H時mm分～H時mm分(v)",
+        "m": "y/M H時mm分～H時mm分(v)"
+      },
+      "yMd Hmv": {
+        "H": "y/M/d H時mm分～H時mm分(v)",
+        "m": "y/M/d H時mm分～H時mm分(v)"
+      },
+      "yMEd Hmv": {
+        "H": "y/M/d(E) H時mm分～H時mm分(v)",
+        "m": "y/M/d(E) H時mm分～H時mm分(v)"
+      },
+      "yMEEEEd Hmv": {
+        "H": "y/M/dEEEE H時mm分～H時mm分(v)",
+        "m": "y/M/dEEEE H時mm分～H時mm分(v)"
+      },
+      "yMM Hmv": {
+        "H": "y/MM H時mm分～H時mm分(v)",
+        "m": "y/MM H時mm分～H時mm分(v)"
+      },
+      "yMMM Hmv": {
+        "H": "y年M月 H時mm分～H時mm分(v)",
+        "m": "y年M月 H時mm分～H時mm分(v)"
+      },
+      "yMMMd Hmv": {
+        "H": "y年M月d日 H時mm分～H時mm分(v)",
+        "m": "y年M月d日 H時mm分～H時mm分(v)"
+      },
+      "yMMMEd Hmv": {
+        "H": "y年M月d日(E) H時mm分～H時mm分(v)",
+        "m": "y年M月d日(E) H時mm分～H時mm分(v)"
+      },
+      "yMMMEEEEd Hmv": {
+        "H": "y年M月d日EEEE H時mm分～H時mm分(v)",
+        "m": "y年M月d日EEEE H時mm分～H時mm分(v)"
+      },
+      "yMMMM Hmv": {
+        "H": "y年M月 H時mm分～H時mm分(v)",
+        "m": "y年M月 H時mm分～H時mm分(v)"
+      },
+      "y年M月d日EEEE hv": {
+        "a": "y年M月d日EEEE aK時～aK時(v)",
+        "h": "y年M月d日EEEE aK時～K時(v)"
+      },
+      "y年M月d日 hv": {
+        "a": "y年M月d日 aK時～aK時(v)",
+        "h": "y年M月d日 aK時～K時(v)"
+      },
+      "y/MM/dd hv": {
+        "a": "y/MM/dd aK時～aK時(v)",
+        "h": "y/MM/dd aK時～K時(v)"
+      },
+      "d hv": {
+        "a": "d日 aK時～aK時(v)",
+        "h": "d日 aK時～K時(v)"
+      },
+      "E hv": {
+        "a": "ccc aK時～aK時(v)",
+        "h": "ccc aK時～K時(v)"
+      },
+      "Ed hv": {
+        "a": "d日(E) aK時～aK時(v)",
+        "h": "d日(E) aK時～K時(v)"
+      },
+      "EEEEd hv": {
+        "a": "d日EEEE aK時～aK時(v)",
+        "h": "d日EEEE aK時～K時(v)"
+      },
+      "Gy hv": {
+        "a": "Gy年 aK時～aK時(v)",
+        "h": "Gy年 aK時～K時(v)"
+      },
+      "GyM hv": {
+        "a": "Gy/M aK時～aK時(v)",
+        "h": "Gy/M aK時～K時(v)"
+      },
+      "GyMd hv": {
+        "a": "Gy/M/d aK時～aK時(v)",
+        "h": "Gy/M/d aK時～K時(v)"
+      },
+      "GyMEd hv": {
+        "a": "Gy/M/d(E) aK時～aK時(v)",
+        "h": "Gy/M/d(E) aK時～K時(v)"
+      },
+      "GyMMM hv": {
+        "a": "Gy年M月 aK時～aK時(v)",
+        "h": "Gy年M月 aK時～K時(v)"
+      },
+      "GyMMMd hv": {
+        "a": "Gy年M月d日 aK時～aK時(v)",
+        "h": "Gy年M月d日 aK時～K時(v)"
+      },
+      "GyMMMEd hv": {
+        "a": "Gy年M月d日(E) aK時～aK時(v)",
+        "h": "Gy年M月d日(E) aK時～K時(v)"
+      },
+      "GyMMMEEEEd hv": {
+        "a": "Gy年M月d日EEEE aK時～aK時(v)",
+        "h": "Gy年M月d日EEEE aK時～K時(v)"
+      },
+      "M hv": {
+        "a": "M月 aK時～aK時(v)",
+        "h": "M月 aK時～K時(v)"
+      },
+      "Md hv": {
+        "a": "M/d aK時～aK時(v)",
+        "h": "M/d aK時～K時(v)"
+      },
+      "MEd hv": {
+        "a": "M/d(E) aK時～aK時(v)",
+        "h": "M/d(E) aK時～K時(v)"
+      },
+      "MEEEEd hv": {
+        "a": "M/dEEEE aK時～aK時(v)",
+        "h": "M/dEEEE aK時～K時(v)"
+      },
+      "MMM hv": {
+        "a": "M月 aK時～aK時(v)",
+        "h": "M月 aK時～K時(v)"
+      },
+      "MMMd hv": {
+        "a": "M月d日 aK時～aK時(v)",
+        "h": "M月d日 aK時～K時(v)"
+      },
+      "MMMEd hv": {
+        "a": "M月d日(E) aK時～aK時(v)",
+        "h": "M月d日(E) aK時～K時(v)"
+      },
+      "MMMEEEEd hv": {
+        "a": "M月d日EEEE aK時～aK時(v)",
+        "h": "M月d日EEEE aK時～K時(v)"
+      },
+      "MMMMd hv": {
+        "a": "M月d日 aK時～aK時(v)",
+        "h": "M月d日 aK時～K時(v)"
+      },
+      "y hv": {
+        "a": "y年 aK時～aK時(v)",
+        "h": "y年 aK時～K時(v)"
+      },
+      "yM hv": {
+        "a": "y/M aK時～aK時(v)",
+        "h": "y/M aK時～K時(v)"
+      },
+      "yMd hv": {
+        "a": "y/M/d aK時～aK時(v)",
+        "h": "y/M/d aK時～K時(v)"
+      },
+      "yMEd hv": {
+        "a": "y/M/d(E) aK時～aK時(v)",
+        "h": "y/M/d(E) aK時～K時(v)"
+      },
+      "yMEEEEd hv": {
+        "a": "y/M/dEEEE aK時～aK時(v)",
+        "h": "y/M/dEEEE aK時～K時(v)"
+      },
+      "yMM hv": {
+        "a": "y/MM aK時～aK時(v)",
+        "h": "y/MM aK時～K時(v)"
+      },
+      "yMMM hv": {
+        "a": "y年M月 aK時～aK時(v)",
+        "h": "y年M月 aK時～K時(v)"
+      },
+      "yMMMd hv": {
+        "a": "y年M月d日 aK時～aK時(v)",
+        "h": "y年M月d日 aK時～K時(v)"
+      },
+      "yMMMEd hv": {
+        "a": "y年M月d日(E) aK時～aK時(v)",
+        "h": "y年M月d日(E) aK時～K時(v)"
+      },
+      "yMMMEEEEd hv": {
+        "a": "y年M月d日EEEE aK時～aK時(v)",
+        "h": "y年M月d日EEEE aK時～K時(v)"
+      },
+      "yMMMM hv": {
+        "a": "y年M月 aK時～aK時(v)",
+        "h": "y年M月 aK時～K時(v)"
+      },
+      "y年M月d日EEEE Hv": {
+        "H": "y年M月d日EEEE H時～H時(v)"
+      },
+      "y年M月d日 Hv": {
+        "H": "y年M月d日 H時～H時(v)"
+      },
+      "y/MM/dd Hv": {
+        "H": "y/MM/dd H時～H時(v)"
+      },
+      "d Hv": {
+        "H": "d日 H時～H時(v)"
+      },
+      "E Hv": {
+        "H": "ccc H時～H時(v)"
+      },
+      "Ed Hv": {
+        "H": "d日(E) H時～H時(v)"
+      },
+      "EEEEd Hv": {
+        "H": "d日EEEE H時～H時(v)"
+      },
+      "Gy Hv": {
+        "H": "Gy年 H時～H時(v)"
+      },
+      "GyM Hv": {
+        "H": "Gy/M H時～H時(v)"
+      },
+      "GyMd Hv": {
+        "H": "Gy/M/d H時～H時(v)"
+      },
+      "GyMEd Hv": {
+        "H": "Gy/M/d(E) H時～H時(v)"
+      },
+      "GyMMM Hv": {
+        "H": "Gy年M月 H時～H時(v)"
+      },
+      "GyMMMd Hv": {
+        "H": "Gy年M月d日 H時～H時(v)"
+      },
+      "GyMMMEd Hv": {
+        "H": "Gy年M月d日(E) H時～H時(v)"
+      },
+      "GyMMMEEEEd Hv": {
+        "H": "Gy年M月d日EEEE H時～H時(v)"
+      },
+      "M Hv": {
+        "H": "M月 H時～H時(v)"
+      },
+      "Md Hv": {
+        "H": "M/d H時～H時(v)"
+      },
+      "MEd Hv": {
+        "H": "M/d(E) H時～H時(v)"
+      },
+      "MEEEEd Hv": {
+        "H": "M/dEEEE H時～H時(v)"
+      },
+      "MMM Hv": {
+        "H": "M月 H時～H時(v)"
+      },
+      "MMMd Hv": {
+        "H": "M月d日 H時～H時(v)"
+      },
+      "MMMEd Hv": {
+        "H": "M月d日(E) H時～H時(v)"
+      },
+      "MMMEEEEd Hv": {
+        "H": "M月d日EEEE H時～H時(v)"
+      },
+      "MMMMd Hv": {
+        "H": "M月d日 H時～H時(v)"
+      },
+      "y Hv": {
+        "H": "y年 H時～H時(v)"
+      },
+      "yM Hv": {
+        "H": "y/M H時～H時(v)"
+      },
+      "yMd Hv": {
+        "H": "y/M/d H時～H時(v)"
+      },
+      "yMEd Hv": {
+        "H": "y/M/d(E) H時～H時(v)"
+      },
+      "yMEEEEd Hv": {
+        "H": "y/M/dEEEE H時～H時(v)"
+      },
+      "yMM Hv": {
+        "H": "y/MM H時～H時(v)"
+      },
+      "yMMM Hv": {
+        "H": "y年M月 H時～H時(v)"
+      },
+      "yMMMd Hv": {
+        "H": "y年M月d日 H時～H時(v)"
+      },
+      "yMMMEd Hv": {
+        "H": "y年M月d日(E) H時～H時(v)"
+      },
+      "yMMMEEEEd Hv": {
+        "H": "y年M月d日EEEE H時～H時(v)"
+      },
+      "yMMMM Hv": {
+        "H": "y年M月 H時～H時(v)"
       }
     },
     "hourCycle": "h23",
@@ -13964,6 +19294,1482 @@ Intl.DateTimeFormat.__addLocaleData({
       "yMMMM": {
         "M": "y년 MMMM~MMMM",
         "y": "y년 MMMM~y년 MMMM"
+      },
+      "y년 MMMM d일 EEEE Bh": {
+        "B": "y년 MMMM d일 EEEE B h시 ~ B h시",
+        "h": "y년 MMMM d일 EEEE B h시~h시"
+      },
+      "y년 MMMM d일 Bh": {
+        "B": "y년 MMMM d일 B h시 ~ B h시",
+        "h": "y년 MMMM d일 B h시~h시"
+      },
+      "y. M. d. Bh": {
+        "B": "y. M. d. B h시 ~ B h시",
+        "h": "y. M. d. B h시~h시"
+      },
+      "yy. M. d. Bh": {
+        "B": "yy. M. d. B h시 ~ B h시",
+        "h": "yy. M. d. B h시~h시"
+      },
+      "d Bh": {
+        "B": "d일 B h시 ~ B h시",
+        "h": "d일 B h시~h시"
+      },
+      "E Bh": {
+        "B": "ccc B h시 ~ B h시",
+        "h": "ccc B h시~h시"
+      },
+      "Ed Bh": {
+        "B": "d일 (E) B h시 ~ B h시",
+        "h": "d일 (E) B h시~h시"
+      },
+      "EEEEd Bh": {
+        "B": "d일 EEEE B h시 ~ B h시",
+        "h": "d일 EEEE B h시~h시"
+      },
+      "Gy Bh": {
+        "B": "G y년 B h시 ~ B h시",
+        "h": "G y년 B h시~h시"
+      },
+      "GyM Bh": {
+        "B": "G y/M B h시 ~ B h시",
+        "h": "G y/M B h시~h시"
+      },
+      "GyMd Bh": {
+        "B": "GGGGG y/M/d B h시 ~ B h시",
+        "h": "GGGGG y/M/d B h시~h시"
+      },
+      "GyMEd Bh": {
+        "B": "G y/M/d (E) B h시 ~ B h시",
+        "h": "G y/M/d (E) B h시~h시"
+      },
+      "GyMMM Bh": {
+        "B": "G y년 MMM B h시 ~ B h시",
+        "h": "G y년 MMM B h시~h시"
+      },
+      "GyMMMd Bh": {
+        "B": "G y년 MMM d일 B h시 ~ B h시",
+        "h": "G y년 MMM d일 B h시~h시"
+      },
+      "GyMMMEd Bh": {
+        "B": "G y년 MMM d일 (E) B h시 ~ B h시",
+        "h": "G y년 MMM d일 (E) B h시~h시"
+      },
+      "GyMMMEEEEd Bh": {
+        "B": "G y년 MMM d일 EEEE B h시 ~ B h시",
+        "h": "G y년 MMM d일 EEEE B h시~h시"
+      },
+      "M Bh": {
+        "B": "M월 B h시 ~ B h시",
+        "h": "M월 B h시~h시"
+      },
+      "Md Bh": {
+        "B": "M. d. B h시 ~ B h시",
+        "h": "M. d. B h시~h시"
+      },
+      "MEd Bh": {
+        "B": "M. d. (E) B h시 ~ B h시",
+        "h": "M. d. (E) B h시~h시"
+      },
+      "MEEEEd Bh": {
+        "B": "M. d. EEEE B h시 ~ B h시",
+        "h": "M. d. EEEE B h시~h시"
+      },
+      "MMM Bh": {
+        "B": "LLL B h시 ~ B h시",
+        "h": "LLL B h시~h시"
+      },
+      "MMMd Bh": {
+        "B": "MMM d일 B h시 ~ B h시",
+        "h": "MMM d일 B h시~h시"
+      },
+      "MMMEd Bh": {
+        "B": "MMM d일 (E) B h시 ~ B h시",
+        "h": "MMM d일 (E) B h시~h시"
+      },
+      "MMMEEEEd Bh": {
+        "B": "MMM d일 EEEE B h시 ~ B h시",
+        "h": "MMM d일 EEEE B h시~h시"
+      },
+      "MMMMd Bh": {
+        "B": "MMMM d일 B h시 ~ B h시",
+        "h": "MMMM d일 B h시~h시"
+      },
+      "y Bh": {
+        "B": "y년 B h시 ~ B h시",
+        "h": "y년 B h시~h시"
+      },
+      "yM Bh": {
+        "B": "y. M. B h시 ~ B h시",
+        "h": "y. M. B h시~h시"
+      },
+      "yMd Bh": {
+        "B": "y. M. d. B h시 ~ B h시",
+        "h": "y. M. d. B h시~h시"
+      },
+      "yMEd Bh": {
+        "B": "y. M. d. (E) B h시 ~ B h시",
+        "h": "y. M. d. (E) B h시~h시"
+      },
+      "yMEEEEd Bh": {
+        "B": "y. M. d. EEEE B h시 ~ B h시",
+        "h": "y. M. d. EEEE B h시~h시"
+      },
+      "yMM Bh": {
+        "B": "y. M. B h시 ~ B h시",
+        "h": "y. M. B h시~h시"
+      },
+      "yMMM Bh": {
+        "B": "y년 MMM B h시 ~ B h시",
+        "h": "y년 MMM B h시~h시"
+      },
+      "yMMMd Bh": {
+        "B": "y년 MMM d일 B h시 ~ B h시",
+        "h": "y년 MMM d일 B h시~h시"
+      },
+      "yMMMEd Bh": {
+        "B": "y년 MMM d일 (E) B h시 ~ B h시",
+        "h": "y년 MMM d일 (E) B h시~h시"
+      },
+      "yMMMEEEEd Bh": {
+        "B": "y년 MMM d일 EEEE B h시 ~ B h시",
+        "h": "y년 MMM d일 EEEE B h시~h시"
+      },
+      "yMMMM Bh": {
+        "B": "y년 MMMM B h시 ~ B h시",
+        "h": "y년 MMMM B h시~h시"
+      },
+      "y년 MMMM d일 EEEE Bhm": {
+        "B": "y년 MMMM d일 EEEE B h:mm~B h:mm",
+        "h": "y년 MMMM d일 EEEE B h:mm ~ h:mm",
+        "m": "y년 MMMM d일 EEEE B h:mm ~ h:mm"
+      },
+      "y년 MMMM d일 Bhm": {
+        "B": "y년 MMMM d일 B h:mm~B h:mm",
+        "h": "y년 MMMM d일 B h:mm ~ h:mm",
+        "m": "y년 MMMM d일 B h:mm ~ h:mm"
+      },
+      "y. M. d. Bhm": {
+        "B": "y. M. d. B h:mm~B h:mm",
+        "h": "y. M. d. B h:mm ~ h:mm",
+        "m": "y. M. d. B h:mm ~ h:mm"
+      },
+      "yy. M. d. Bhm": {
+        "B": "yy. M. d. B h:mm~B h:mm",
+        "h": "yy. M. d. B h:mm ~ h:mm",
+        "m": "yy. M. d. B h:mm ~ h:mm"
+      },
+      "d Bhm": {
+        "B": "d일 B h:mm~B h:mm",
+        "h": "d일 B h:mm ~ h:mm",
+        "m": "d일 B h:mm ~ h:mm"
+      },
+      "E Bhm": {
+        "B": "ccc B h:mm~B h:mm",
+        "h": "ccc B h:mm ~ h:mm",
+        "m": "ccc B h:mm ~ h:mm"
+      },
+      "Ed Bhm": {
+        "B": "d일 (E) B h:mm~B h:mm",
+        "h": "d일 (E) B h:mm ~ h:mm",
+        "m": "d일 (E) B h:mm ~ h:mm"
+      },
+      "EEEEd Bhm": {
+        "B": "d일 EEEE B h:mm~B h:mm",
+        "h": "d일 EEEE B h:mm ~ h:mm",
+        "m": "d일 EEEE B h:mm ~ h:mm"
+      },
+      "Gy Bhm": {
+        "B": "G y년 B h:mm~B h:mm",
+        "h": "G y년 B h:mm ~ h:mm",
+        "m": "G y년 B h:mm ~ h:mm"
+      },
+      "GyM Bhm": {
+        "B": "G y/M B h:mm~B h:mm",
+        "h": "G y/M B h:mm ~ h:mm",
+        "m": "G y/M B h:mm ~ h:mm"
+      },
+      "GyMd Bhm": {
+        "B": "GGGGG y/M/d B h:mm~B h:mm",
+        "h": "GGGGG y/M/d B h:mm ~ h:mm",
+        "m": "GGGGG y/M/d B h:mm ~ h:mm"
+      },
+      "GyMEd Bhm": {
+        "B": "G y/M/d (E) B h:mm~B h:mm",
+        "h": "G y/M/d (E) B h:mm ~ h:mm",
+        "m": "G y/M/d (E) B h:mm ~ h:mm"
+      },
+      "GyMMM Bhm": {
+        "B": "G y년 MMM B h:mm~B h:mm",
+        "h": "G y년 MMM B h:mm ~ h:mm",
+        "m": "G y년 MMM B h:mm ~ h:mm"
+      },
+      "GyMMMd Bhm": {
+        "B": "G y년 MMM d일 B h:mm~B h:mm",
+        "h": "G y년 MMM d일 B h:mm ~ h:mm",
+        "m": "G y년 MMM d일 B h:mm ~ h:mm"
+      },
+      "GyMMMEd Bhm": {
+        "B": "G y년 MMM d일 (E) B h:mm~B h:mm",
+        "h": "G y년 MMM d일 (E) B h:mm ~ h:mm",
+        "m": "G y년 MMM d일 (E) B h:mm ~ h:mm"
+      },
+      "GyMMMEEEEd Bhm": {
+        "B": "G y년 MMM d일 EEEE B h:mm~B h:mm",
+        "h": "G y년 MMM d일 EEEE B h:mm ~ h:mm",
+        "m": "G y년 MMM d일 EEEE B h:mm ~ h:mm"
+      },
+      "M Bhm": {
+        "B": "M월 B h:mm~B h:mm",
+        "h": "M월 B h:mm ~ h:mm",
+        "m": "M월 B h:mm ~ h:mm"
+      },
+      "Md Bhm": {
+        "B": "M. d. B h:mm~B h:mm",
+        "h": "M. d. B h:mm ~ h:mm",
+        "m": "M. d. B h:mm ~ h:mm"
+      },
+      "MEd Bhm": {
+        "B": "M. d. (E) B h:mm~B h:mm",
+        "h": "M. d. (E) B h:mm ~ h:mm",
+        "m": "M. d. (E) B h:mm ~ h:mm"
+      },
+      "MEEEEd Bhm": {
+        "B": "M. d. EEEE B h:mm~B h:mm",
+        "h": "M. d. EEEE B h:mm ~ h:mm",
+        "m": "M. d. EEEE B h:mm ~ h:mm"
+      },
+      "MMM Bhm": {
+        "B": "LLL B h:mm~B h:mm",
+        "h": "LLL B h:mm ~ h:mm",
+        "m": "LLL B h:mm ~ h:mm"
+      },
+      "MMMd Bhm": {
+        "B": "MMM d일 B h:mm~B h:mm",
+        "h": "MMM d일 B h:mm ~ h:mm",
+        "m": "MMM d일 B h:mm ~ h:mm"
+      },
+      "MMMEd Bhm": {
+        "B": "MMM d일 (E) B h:mm~B h:mm",
+        "h": "MMM d일 (E) B h:mm ~ h:mm",
+        "m": "MMM d일 (E) B h:mm ~ h:mm"
+      },
+      "MMMEEEEd Bhm": {
+        "B": "MMM d일 EEEE B h:mm~B h:mm",
+        "h": "MMM d일 EEEE B h:mm ~ h:mm",
+        "m": "MMM d일 EEEE B h:mm ~ h:mm"
+      },
+      "MMMMd Bhm": {
+        "B": "MMMM d일 B h:mm~B h:mm",
+        "h": "MMMM d일 B h:mm ~ h:mm",
+        "m": "MMMM d일 B h:mm ~ h:mm"
+      },
+      "y Bhm": {
+        "B": "y년 B h:mm~B h:mm",
+        "h": "y년 B h:mm ~ h:mm",
+        "m": "y년 B h:mm ~ h:mm"
+      },
+      "yM Bhm": {
+        "B": "y. M. B h:mm~B h:mm",
+        "h": "y. M. B h:mm ~ h:mm",
+        "m": "y. M. B h:mm ~ h:mm"
+      },
+      "yMd Bhm": {
+        "B": "y. M. d. B h:mm~B h:mm",
+        "h": "y. M. d. B h:mm ~ h:mm",
+        "m": "y. M. d. B h:mm ~ h:mm"
+      },
+      "yMEd Bhm": {
+        "B": "y. M. d. (E) B h:mm~B h:mm",
+        "h": "y. M. d. (E) B h:mm ~ h:mm",
+        "m": "y. M. d. (E) B h:mm ~ h:mm"
+      },
+      "yMEEEEd Bhm": {
+        "B": "y. M. d. EEEE B h:mm~B h:mm",
+        "h": "y. M. d. EEEE B h:mm ~ h:mm",
+        "m": "y. M. d. EEEE B h:mm ~ h:mm"
+      },
+      "yMM Bhm": {
+        "B": "y. M. B h:mm~B h:mm",
+        "h": "y. M. B h:mm ~ h:mm",
+        "m": "y. M. B h:mm ~ h:mm"
+      },
+      "yMMM Bhm": {
+        "B": "y년 MMM B h:mm~B h:mm",
+        "h": "y년 MMM B h:mm ~ h:mm",
+        "m": "y년 MMM B h:mm ~ h:mm"
+      },
+      "yMMMd Bhm": {
+        "B": "y년 MMM d일 B h:mm~B h:mm",
+        "h": "y년 MMM d일 B h:mm ~ h:mm",
+        "m": "y년 MMM d일 B h:mm ~ h:mm"
+      },
+      "yMMMEd Bhm": {
+        "B": "y년 MMM d일 (E) B h:mm~B h:mm",
+        "h": "y년 MMM d일 (E) B h:mm ~ h:mm",
+        "m": "y년 MMM d일 (E) B h:mm ~ h:mm"
+      },
+      "yMMMEEEEd Bhm": {
+        "B": "y년 MMM d일 EEEE B h:mm~B h:mm",
+        "h": "y년 MMM d일 EEEE B h:mm ~ h:mm",
+        "m": "y년 MMM d일 EEEE B h:mm ~ h:mm"
+      },
+      "yMMMM Bhm": {
+        "B": "y년 MMMM B h:mm~B h:mm",
+        "h": "y년 MMMM B h:mm ~ h:mm",
+        "m": "y년 MMMM B h:mm ~ h:mm"
+      },
+      "y년 MMMM d일 EEEE h": {
+        "a": "y년 MMMM d일 EEEE a h시 ~ a h시",
+        "h": "y년 MMMM d일 EEEE a h시 ~ h시"
+      },
+      "y년 MMMM d일 h": {
+        "a": "y년 MMMM d일 a h시 ~ a h시",
+        "h": "y년 MMMM d일 a h시 ~ h시"
+      },
+      "y. M. d. h": {
+        "a": "y. M. d. a h시 ~ a h시",
+        "h": "y. M. d. a h시 ~ h시"
+      },
+      "yy. M. d. h": {
+        "a": "yy. M. d. a h시 ~ a h시",
+        "h": "yy. M. d. a h시 ~ h시"
+      },
+      "d h": {
+        "a": "d일 a h시 ~ a h시",
+        "h": "d일 a h시 ~ h시"
+      },
+      "E h": {
+        "a": "ccc a h시 ~ a h시",
+        "h": "ccc a h시 ~ h시"
+      },
+      "Ed h": {
+        "a": "d일 (E) a h시 ~ a h시",
+        "h": "d일 (E) a h시 ~ h시"
+      },
+      "EEEEd h": {
+        "a": "d일 EEEE a h시 ~ a h시",
+        "h": "d일 EEEE a h시 ~ h시"
+      },
+      "Gy h": {
+        "a": "G y년 a h시 ~ a h시",
+        "h": "G y년 a h시 ~ h시"
+      },
+      "GyM h": {
+        "a": "G y/M a h시 ~ a h시",
+        "h": "G y/M a h시 ~ h시"
+      },
+      "GyMd h": {
+        "a": "GGGGG y/M/d a h시 ~ a h시",
+        "h": "GGGGG y/M/d a h시 ~ h시"
+      },
+      "GyMEd h": {
+        "a": "G y/M/d (E) a h시 ~ a h시",
+        "h": "G y/M/d (E) a h시 ~ h시"
+      },
+      "GyMMM h": {
+        "a": "G y년 MMM a h시 ~ a h시",
+        "h": "G y년 MMM a h시 ~ h시"
+      },
+      "GyMMMd h": {
+        "a": "G y년 MMM d일 a h시 ~ a h시",
+        "h": "G y년 MMM d일 a h시 ~ h시"
+      },
+      "GyMMMEd h": {
+        "a": "G y년 MMM d일 (E) a h시 ~ a h시",
+        "h": "G y년 MMM d일 (E) a h시 ~ h시"
+      },
+      "GyMMMEEEEd h": {
+        "a": "G y년 MMM d일 EEEE a h시 ~ a h시",
+        "h": "G y년 MMM d일 EEEE a h시 ~ h시"
+      },
+      "M h": {
+        "a": "M월 a h시 ~ a h시",
+        "h": "M월 a h시 ~ h시"
+      },
+      "Md h": {
+        "a": "M. d. a h시 ~ a h시",
+        "h": "M. d. a h시 ~ h시"
+      },
+      "MEd h": {
+        "a": "M. d. (E) a h시 ~ a h시",
+        "h": "M. d. (E) a h시 ~ h시"
+      },
+      "MEEEEd h": {
+        "a": "M. d. EEEE a h시 ~ a h시",
+        "h": "M. d. EEEE a h시 ~ h시"
+      },
+      "MMM h": {
+        "a": "LLL a h시 ~ a h시",
+        "h": "LLL a h시 ~ h시"
+      },
+      "MMMd h": {
+        "a": "MMM d일 a h시 ~ a h시",
+        "h": "MMM d일 a h시 ~ h시"
+      },
+      "MMMEd h": {
+        "a": "MMM d일 (E) a h시 ~ a h시",
+        "h": "MMM d일 (E) a h시 ~ h시"
+      },
+      "MMMEEEEd h": {
+        "a": "MMM d일 EEEE a h시 ~ a h시",
+        "h": "MMM d일 EEEE a h시 ~ h시"
+      },
+      "MMMMd h": {
+        "a": "MMMM d일 a h시 ~ a h시",
+        "h": "MMMM d일 a h시 ~ h시"
+      },
+      "y h": {
+        "a": "y년 a h시 ~ a h시",
+        "h": "y년 a h시 ~ h시"
+      },
+      "yM h": {
+        "a": "y. M. a h시 ~ a h시",
+        "h": "y. M. a h시 ~ h시"
+      },
+      "yMd h": {
+        "a": "y. M. d. a h시 ~ a h시",
+        "h": "y. M. d. a h시 ~ h시"
+      },
+      "yMEd h": {
+        "a": "y. M. d. (E) a h시 ~ a h시",
+        "h": "y. M. d. (E) a h시 ~ h시"
+      },
+      "yMEEEEd h": {
+        "a": "y. M. d. EEEE a h시 ~ a h시",
+        "h": "y. M. d. EEEE a h시 ~ h시"
+      },
+      "yMM h": {
+        "a": "y. M. a h시 ~ a h시",
+        "h": "y. M. a h시 ~ h시"
+      },
+      "yMMM h": {
+        "a": "y년 MMM a h시 ~ a h시",
+        "h": "y년 MMM a h시 ~ h시"
+      },
+      "yMMMd h": {
+        "a": "y년 MMM d일 a h시 ~ a h시",
+        "h": "y년 MMM d일 a h시 ~ h시"
+      },
+      "yMMMEd h": {
+        "a": "y년 MMM d일 (E) a h시 ~ a h시",
+        "h": "y년 MMM d일 (E) a h시 ~ h시"
+      },
+      "yMMMEEEEd h": {
+        "a": "y년 MMM d일 EEEE a h시 ~ a h시",
+        "h": "y년 MMM d일 EEEE a h시 ~ h시"
+      },
+      "yMMMM h": {
+        "a": "y년 MMMM a h시 ~ a h시",
+        "h": "y년 MMMM a h시 ~ h시"
+      },
+      "y년 MMMM d일 EEEE H": {
+        "H": "y년 MMMM d일 EEEE H ~ H시"
+      },
+      "y년 MMMM d일 H": {
+        "H": "y년 MMMM d일 H ~ H시"
+      },
+      "y. M. d. H": {
+        "H": "y. M. d. H ~ H시"
+      },
+      "yy. M. d. H": {
+        "H": "yy. M. d. H ~ H시"
+      },
+      "d H": {
+        "H": "d일 H ~ H시"
+      },
+      "E H": {
+        "H": "ccc H ~ H시"
+      },
+      "Ed H": {
+        "H": "d일 (E) H ~ H시"
+      },
+      "EEEEd H": {
+        "H": "d일 EEEE H ~ H시"
+      },
+      "Gy H": {
+        "H": "G y년 H ~ H시"
+      },
+      "GyM H": {
+        "H": "G y/M H ~ H시"
+      },
+      "GyMd H": {
+        "H": "GGGGG y/M/d H ~ H시"
+      },
+      "GyMEd H": {
+        "H": "G y/M/d (E) H ~ H시"
+      },
+      "GyMMM H": {
+        "H": "G y년 MMM H ~ H시"
+      },
+      "GyMMMd H": {
+        "H": "G y년 MMM d일 H ~ H시"
+      },
+      "GyMMMEd H": {
+        "H": "G y년 MMM d일 (E) H ~ H시"
+      },
+      "GyMMMEEEEd H": {
+        "H": "G y년 MMM d일 EEEE H ~ H시"
+      },
+      "M H": {
+        "H": "M월 H ~ H시"
+      },
+      "Md H": {
+        "H": "M. d. H ~ H시"
+      },
+      "MEd H": {
+        "H": "M. d. (E) H ~ H시"
+      },
+      "MEEEEd H": {
+        "H": "M. d. EEEE H ~ H시"
+      },
+      "MMM H": {
+        "H": "LLL H ~ H시"
+      },
+      "MMMd H": {
+        "H": "MMM d일 H ~ H시"
+      },
+      "MMMEd H": {
+        "H": "MMM d일 (E) H ~ H시"
+      },
+      "MMMEEEEd H": {
+        "H": "MMM d일 EEEE H ~ H시"
+      },
+      "MMMMd H": {
+        "H": "MMMM d일 H ~ H시"
+      },
+      "y H": {
+        "H": "y년 H ~ H시"
+      },
+      "yM H": {
+        "H": "y. M. H ~ H시"
+      },
+      "yMd H": {
+        "H": "y. M. d. H ~ H시"
+      },
+      "yMEd H": {
+        "H": "y. M. d. (E) H ~ H시"
+      },
+      "yMEEEEd H": {
+        "H": "y. M. d. EEEE H ~ H시"
+      },
+      "yMM H": {
+        "H": "y. M. H ~ H시"
+      },
+      "yMMM H": {
+        "H": "y년 MMM H ~ H시"
+      },
+      "yMMMd H": {
+        "H": "y년 MMM d일 H ~ H시"
+      },
+      "yMMMEd H": {
+        "H": "y년 MMM d일 (E) H ~ H시"
+      },
+      "yMMMEEEEd H": {
+        "H": "y년 MMM d일 EEEE H ~ H시"
+      },
+      "yMMMM H": {
+        "H": "y년 MMMM H ~ H시"
+      },
+      "y년 MMMM d일 EEEE hm": {
+        "a": "y년 MMMM d일 EEEE a h:mm ~ a h:mm",
+        "h": "y년 MMMM d일 EEEE a h:mm~h:mm",
+        "m": "y년 MMMM d일 EEEE a h:mm~h:mm"
+      },
+      "y년 MMMM d일 hm": {
+        "a": "y년 MMMM d일 a h:mm ~ a h:mm",
+        "h": "y년 MMMM d일 a h:mm~h:mm",
+        "m": "y년 MMMM d일 a h:mm~h:mm"
+      },
+      "y. M. d. hm": {
+        "a": "y. M. d. a h:mm ~ a h:mm",
+        "h": "y. M. d. a h:mm~h:mm",
+        "m": "y. M. d. a h:mm~h:mm"
+      },
+      "yy. M. d. hm": {
+        "a": "yy. M. d. a h:mm ~ a h:mm",
+        "h": "yy. M. d. a h:mm~h:mm",
+        "m": "yy. M. d. a h:mm~h:mm"
+      },
+      "d hm": {
+        "a": "d일 a h:mm ~ a h:mm",
+        "h": "d일 a h:mm~h:mm",
+        "m": "d일 a h:mm~h:mm"
+      },
+      "E hm": {
+        "a": "ccc a h:mm ~ a h:mm",
+        "h": "ccc a h:mm~h:mm",
+        "m": "ccc a h:mm~h:mm"
+      },
+      "Ed hm": {
+        "a": "d일 (E) a h:mm ~ a h:mm",
+        "h": "d일 (E) a h:mm~h:mm",
+        "m": "d일 (E) a h:mm~h:mm"
+      },
+      "EEEEd hm": {
+        "a": "d일 EEEE a h:mm ~ a h:mm",
+        "h": "d일 EEEE a h:mm~h:mm",
+        "m": "d일 EEEE a h:mm~h:mm"
+      },
+      "Gy hm": {
+        "a": "G y년 a h:mm ~ a h:mm",
+        "h": "G y년 a h:mm~h:mm",
+        "m": "G y년 a h:mm~h:mm"
+      },
+      "GyM hm": {
+        "a": "G y/M a h:mm ~ a h:mm",
+        "h": "G y/M a h:mm~h:mm",
+        "m": "G y/M a h:mm~h:mm"
+      },
+      "GyMd hm": {
+        "a": "GGGGG y/M/d a h:mm ~ a h:mm",
+        "h": "GGGGG y/M/d a h:mm~h:mm",
+        "m": "GGGGG y/M/d a h:mm~h:mm"
+      },
+      "GyMEd hm": {
+        "a": "G y/M/d (E) a h:mm ~ a h:mm",
+        "h": "G y/M/d (E) a h:mm~h:mm",
+        "m": "G y/M/d (E) a h:mm~h:mm"
+      },
+      "GyMMM hm": {
+        "a": "G y년 MMM a h:mm ~ a h:mm",
+        "h": "G y년 MMM a h:mm~h:mm",
+        "m": "G y년 MMM a h:mm~h:mm"
+      },
+      "GyMMMd hm": {
+        "a": "G y년 MMM d일 a h:mm ~ a h:mm",
+        "h": "G y년 MMM d일 a h:mm~h:mm",
+        "m": "G y년 MMM d일 a h:mm~h:mm"
+      },
+      "GyMMMEd hm": {
+        "a": "G y년 MMM d일 (E) a h:mm ~ a h:mm",
+        "h": "G y년 MMM d일 (E) a h:mm~h:mm",
+        "m": "G y년 MMM d일 (E) a h:mm~h:mm"
+      },
+      "GyMMMEEEEd hm": {
+        "a": "G y년 MMM d일 EEEE a h:mm ~ a h:mm",
+        "h": "G y년 MMM d일 EEEE a h:mm~h:mm",
+        "m": "G y년 MMM d일 EEEE a h:mm~h:mm"
+      },
+      "M hm": {
+        "a": "M월 a h:mm ~ a h:mm",
+        "h": "M월 a h:mm~h:mm",
+        "m": "M월 a h:mm~h:mm"
+      },
+      "Md hm": {
+        "a": "M. d. a h:mm ~ a h:mm",
+        "h": "M. d. a h:mm~h:mm",
+        "m": "M. d. a h:mm~h:mm"
+      },
+      "MEd hm": {
+        "a": "M. d. (E) a h:mm ~ a h:mm",
+        "h": "M. d. (E) a h:mm~h:mm",
+        "m": "M. d. (E) a h:mm~h:mm"
+      },
+      "MEEEEd hm": {
+        "a": "M. d. EEEE a h:mm ~ a h:mm",
+        "h": "M. d. EEEE a h:mm~h:mm",
+        "m": "M. d. EEEE a h:mm~h:mm"
+      },
+      "MMM hm": {
+        "a": "LLL a h:mm ~ a h:mm",
+        "h": "LLL a h:mm~h:mm",
+        "m": "LLL a h:mm~h:mm"
+      },
+      "MMMd hm": {
+        "a": "MMM d일 a h:mm ~ a h:mm",
+        "h": "MMM d일 a h:mm~h:mm",
+        "m": "MMM d일 a h:mm~h:mm"
+      },
+      "MMMEd hm": {
+        "a": "MMM d일 (E) a h:mm ~ a h:mm",
+        "h": "MMM d일 (E) a h:mm~h:mm",
+        "m": "MMM d일 (E) a h:mm~h:mm"
+      },
+      "MMMEEEEd hm": {
+        "a": "MMM d일 EEEE a h:mm ~ a h:mm",
+        "h": "MMM d일 EEEE a h:mm~h:mm",
+        "m": "MMM d일 EEEE a h:mm~h:mm"
+      },
+      "MMMMd hm": {
+        "a": "MMMM d일 a h:mm ~ a h:mm",
+        "h": "MMMM d일 a h:mm~h:mm",
+        "m": "MMMM d일 a h:mm~h:mm"
+      },
+      "y hm": {
+        "a": "y년 a h:mm ~ a h:mm",
+        "h": "y년 a h:mm~h:mm",
+        "m": "y년 a h:mm~h:mm"
+      },
+      "yM hm": {
+        "a": "y. M. a h:mm ~ a h:mm",
+        "h": "y. M. a h:mm~h:mm",
+        "m": "y. M. a h:mm~h:mm"
+      },
+      "yMd hm": {
+        "a": "y. M. d. a h:mm ~ a h:mm",
+        "h": "y. M. d. a h:mm~h:mm",
+        "m": "y. M. d. a h:mm~h:mm"
+      },
+      "yMEd hm": {
+        "a": "y. M. d. (E) a h:mm ~ a h:mm",
+        "h": "y. M. d. (E) a h:mm~h:mm",
+        "m": "y. M. d. (E) a h:mm~h:mm"
+      },
+      "yMEEEEd hm": {
+        "a": "y. M. d. EEEE a h:mm ~ a h:mm",
+        "h": "y. M. d. EEEE a h:mm~h:mm",
+        "m": "y. M. d. EEEE a h:mm~h:mm"
+      },
+      "yMM hm": {
+        "a": "y. M. a h:mm ~ a h:mm",
+        "h": "y. M. a h:mm~h:mm",
+        "m": "y. M. a h:mm~h:mm"
+      },
+      "yMMM hm": {
+        "a": "y년 MMM a h:mm ~ a h:mm",
+        "h": "y년 MMM a h:mm~h:mm",
+        "m": "y년 MMM a h:mm~h:mm"
+      },
+      "yMMMd hm": {
+        "a": "y년 MMM d일 a h:mm ~ a h:mm",
+        "h": "y년 MMM d일 a h:mm~h:mm",
+        "m": "y년 MMM d일 a h:mm~h:mm"
+      },
+      "yMMMEd hm": {
+        "a": "y년 MMM d일 (E) a h:mm ~ a h:mm",
+        "h": "y년 MMM d일 (E) a h:mm~h:mm",
+        "m": "y년 MMM d일 (E) a h:mm~h:mm"
+      },
+      "yMMMEEEEd hm": {
+        "a": "y년 MMM d일 EEEE a h:mm ~ a h:mm",
+        "h": "y년 MMM d일 EEEE a h:mm~h:mm",
+        "m": "y년 MMM d일 EEEE a h:mm~h:mm"
+      },
+      "yMMMM hm": {
+        "a": "y년 MMMM a h:mm ~ a h:mm",
+        "h": "y년 MMMM a h:mm~h:mm",
+        "m": "y년 MMMM a h:mm~h:mm"
+      },
+      "y년 MMMM d일 EEEE Hm": {
+        "H": "y년 MMMM d일 EEEE HH:mm ~ HH:mm",
+        "m": "y년 MMMM d일 EEEE HH:mm ~ HH:mm"
+      },
+      "y년 MMMM d일 Hm": {
+        "H": "y년 MMMM d일 HH:mm ~ HH:mm",
+        "m": "y년 MMMM d일 HH:mm ~ HH:mm"
+      },
+      "y. M. d. Hm": {
+        "H": "y. M. d. HH:mm ~ HH:mm",
+        "m": "y. M. d. HH:mm ~ HH:mm"
+      },
+      "yy. M. d. Hm": {
+        "H": "yy. M. d. HH:mm ~ HH:mm",
+        "m": "yy. M. d. HH:mm ~ HH:mm"
+      },
+      "d Hm": {
+        "H": "d일 HH:mm ~ HH:mm",
+        "m": "d일 HH:mm ~ HH:mm"
+      },
+      "E Hm": {
+        "H": "ccc HH:mm ~ HH:mm",
+        "m": "ccc HH:mm ~ HH:mm"
+      },
+      "Ed Hm": {
+        "H": "d일 (E) HH:mm ~ HH:mm",
+        "m": "d일 (E) HH:mm ~ HH:mm"
+      },
+      "EEEEd Hm": {
+        "H": "d일 EEEE HH:mm ~ HH:mm",
+        "m": "d일 EEEE HH:mm ~ HH:mm"
+      },
+      "Gy Hm": {
+        "H": "G y년 HH:mm ~ HH:mm",
+        "m": "G y년 HH:mm ~ HH:mm"
+      },
+      "GyM Hm": {
+        "H": "G y/M HH:mm ~ HH:mm",
+        "m": "G y/M HH:mm ~ HH:mm"
+      },
+      "GyMd Hm": {
+        "H": "GGGGG y/M/d HH:mm ~ HH:mm",
+        "m": "GGGGG y/M/d HH:mm ~ HH:mm"
+      },
+      "GyMEd Hm": {
+        "H": "G y/M/d (E) HH:mm ~ HH:mm",
+        "m": "G y/M/d (E) HH:mm ~ HH:mm"
+      },
+      "GyMMM Hm": {
+        "H": "G y년 MMM HH:mm ~ HH:mm",
+        "m": "G y년 MMM HH:mm ~ HH:mm"
+      },
+      "GyMMMd Hm": {
+        "H": "G y년 MMM d일 HH:mm ~ HH:mm",
+        "m": "G y년 MMM d일 HH:mm ~ HH:mm"
+      },
+      "GyMMMEd Hm": {
+        "H": "G y년 MMM d일 (E) HH:mm ~ HH:mm",
+        "m": "G y년 MMM d일 (E) HH:mm ~ HH:mm"
+      },
+      "GyMMMEEEEd Hm": {
+        "H": "G y년 MMM d일 EEEE HH:mm ~ HH:mm",
+        "m": "G y년 MMM d일 EEEE HH:mm ~ HH:mm"
+      },
+      "M Hm": {
+        "H": "M월 HH:mm ~ HH:mm",
+        "m": "M월 HH:mm ~ HH:mm"
+      },
+      "Md Hm": {
+        "H": "M. d. HH:mm ~ HH:mm",
+        "m": "M. d. HH:mm ~ HH:mm"
+      },
+      "MEd Hm": {
+        "H": "M. d. (E) HH:mm ~ HH:mm",
+        "m": "M. d. (E) HH:mm ~ HH:mm"
+      },
+      "MEEEEd Hm": {
+        "H": "M. d. EEEE HH:mm ~ HH:mm",
+        "m": "M. d. EEEE HH:mm ~ HH:mm"
+      },
+      "MMM Hm": {
+        "H": "LLL HH:mm ~ HH:mm",
+        "m": "LLL HH:mm ~ HH:mm"
+      },
+      "MMMd Hm": {
+        "H": "MMM d일 HH:mm ~ HH:mm",
+        "m": "MMM d일 HH:mm ~ HH:mm"
+      },
+      "MMMEd Hm": {
+        "H": "MMM d일 (E) HH:mm ~ HH:mm",
+        "m": "MMM d일 (E) HH:mm ~ HH:mm"
+      },
+      "MMMEEEEd Hm": {
+        "H": "MMM d일 EEEE HH:mm ~ HH:mm",
+        "m": "MMM d일 EEEE HH:mm ~ HH:mm"
+      },
+      "MMMMd Hm": {
+        "H": "MMMM d일 HH:mm ~ HH:mm",
+        "m": "MMMM d일 HH:mm ~ HH:mm"
+      },
+      "y Hm": {
+        "H": "y년 HH:mm ~ HH:mm",
+        "m": "y년 HH:mm ~ HH:mm"
+      },
+      "yM Hm": {
+        "H": "y. M. HH:mm ~ HH:mm",
+        "m": "y. M. HH:mm ~ HH:mm"
+      },
+      "yMd Hm": {
+        "H": "y. M. d. HH:mm ~ HH:mm",
+        "m": "y. M. d. HH:mm ~ HH:mm"
+      },
+      "yMEd Hm": {
+        "H": "y. M. d. (E) HH:mm ~ HH:mm",
+        "m": "y. M. d. (E) HH:mm ~ HH:mm"
+      },
+      "yMEEEEd Hm": {
+        "H": "y. M. d. EEEE HH:mm ~ HH:mm",
+        "m": "y. M. d. EEEE HH:mm ~ HH:mm"
+      },
+      "yMM Hm": {
+        "H": "y. M. HH:mm ~ HH:mm",
+        "m": "y. M. HH:mm ~ HH:mm"
+      },
+      "yMMM Hm": {
+        "H": "y년 MMM HH:mm ~ HH:mm",
+        "m": "y년 MMM HH:mm ~ HH:mm"
+      },
+      "yMMMd Hm": {
+        "H": "y년 MMM d일 HH:mm ~ HH:mm",
+        "m": "y년 MMM d일 HH:mm ~ HH:mm"
+      },
+      "yMMMEd Hm": {
+        "H": "y년 MMM d일 (E) HH:mm ~ HH:mm",
+        "m": "y년 MMM d일 (E) HH:mm ~ HH:mm"
+      },
+      "yMMMEEEEd Hm": {
+        "H": "y년 MMM d일 EEEE HH:mm ~ HH:mm",
+        "m": "y년 MMM d일 EEEE HH:mm ~ HH:mm"
+      },
+      "yMMMM Hm": {
+        "H": "y년 MMMM HH:mm ~ HH:mm",
+        "m": "y년 MMMM HH:mm ~ HH:mm"
+      },
+      "y년 MMMM d일 EEEE hmv": {
+        "a": "y년 MMMM d일 EEEE a h:mm ~ a h:mm v",
+        "h": "y년 MMMM d일 EEEE a h:mm~h:mm v",
+        "m": "y년 MMMM d일 EEEE a h:mm~h:mm v"
+      },
+      "y년 MMMM d일 hmv": {
+        "a": "y년 MMMM d일 a h:mm ~ a h:mm v",
+        "h": "y년 MMMM d일 a h:mm~h:mm v",
+        "m": "y년 MMMM d일 a h:mm~h:mm v"
+      },
+      "y. M. d. hmv": {
+        "a": "y. M. d. a h:mm ~ a h:mm v",
+        "h": "y. M. d. a h:mm~h:mm v",
+        "m": "y. M. d. a h:mm~h:mm v"
+      },
+      "yy. M. d. hmv": {
+        "a": "yy. M. d. a h:mm ~ a h:mm v",
+        "h": "yy. M. d. a h:mm~h:mm v",
+        "m": "yy. M. d. a h:mm~h:mm v"
+      },
+      "d hmv": {
+        "a": "d일 a h:mm ~ a h:mm v",
+        "h": "d일 a h:mm~h:mm v",
+        "m": "d일 a h:mm~h:mm v"
+      },
+      "E hmv": {
+        "a": "ccc a h:mm ~ a h:mm v",
+        "h": "ccc a h:mm~h:mm v",
+        "m": "ccc a h:mm~h:mm v"
+      },
+      "Ed hmv": {
+        "a": "d일 (E) a h:mm ~ a h:mm v",
+        "h": "d일 (E) a h:mm~h:mm v",
+        "m": "d일 (E) a h:mm~h:mm v"
+      },
+      "EEEEd hmv": {
+        "a": "d일 EEEE a h:mm ~ a h:mm v",
+        "h": "d일 EEEE a h:mm~h:mm v",
+        "m": "d일 EEEE a h:mm~h:mm v"
+      },
+      "Gy hmv": {
+        "a": "G y년 a h:mm ~ a h:mm v",
+        "h": "G y년 a h:mm~h:mm v",
+        "m": "G y년 a h:mm~h:mm v"
+      },
+      "GyM hmv": {
+        "a": "G y/M a h:mm ~ a h:mm v",
+        "h": "G y/M a h:mm~h:mm v",
+        "m": "G y/M a h:mm~h:mm v"
+      },
+      "GyMd hmv": {
+        "a": "GGGGG y/M/d a h:mm ~ a h:mm v",
+        "h": "GGGGG y/M/d a h:mm~h:mm v",
+        "m": "GGGGG y/M/d a h:mm~h:mm v"
+      },
+      "GyMEd hmv": {
+        "a": "G y/M/d (E) a h:mm ~ a h:mm v",
+        "h": "G y/M/d (E) a h:mm~h:mm v",
+        "m": "G y/M/d (E) a h:mm~h:mm v"
+      },
+      "GyMMM hmv": {
+        "a": "G y년 MMM a h:mm ~ a h:mm v",
+        "h": "G y년 MMM a h:mm~h:mm v",
+        "m": "G y년 MMM a h:mm~h:mm v"
+      },
+      "GyMMMd hmv": {
+        "a": "G y년 MMM d일 a h:mm ~ a h:mm v",
+        "h": "G y년 MMM d일 a h:mm~h:mm v",
+        "m": "G y년 MMM d일 a h:mm~h:mm v"
+      },
+      "GyMMMEd hmv": {
+        "a": "G y년 MMM d일 (E) a h:mm ~ a h:mm v",
+        "h": "G y년 MMM d일 (E) a h:mm~h:mm v",
+        "m": "G y년 MMM d일 (E) a h:mm~h:mm v"
+      },
+      "GyMMMEEEEd hmv": {
+        "a": "G y년 MMM d일 EEEE a h:mm ~ a h:mm v",
+        "h": "G y년 MMM d일 EEEE a h:mm~h:mm v",
+        "m": "G y년 MMM d일 EEEE a h:mm~h:mm v"
+      },
+      "M hmv": {
+        "a": "M월 a h:mm ~ a h:mm v",
+        "h": "M월 a h:mm~h:mm v",
+        "m": "M월 a h:mm~h:mm v"
+      },
+      "Md hmv": {
+        "a": "M. d. a h:mm ~ a h:mm v",
+        "h": "M. d. a h:mm~h:mm v",
+        "m": "M. d. a h:mm~h:mm v"
+      },
+      "MEd hmv": {
+        "a": "M. d. (E) a h:mm ~ a h:mm v",
+        "h": "M. d. (E) a h:mm~h:mm v",
+        "m": "M. d. (E) a h:mm~h:mm v"
+      },
+      "MEEEEd hmv": {
+        "a": "M. d. EEEE a h:mm ~ a h:mm v",
+        "h": "M. d. EEEE a h:mm~h:mm v",
+        "m": "M. d. EEEE a h:mm~h:mm v"
+      },
+      "MMM hmv": {
+        "a": "LLL a h:mm ~ a h:mm v",
+        "h": "LLL a h:mm~h:mm v",
+        "m": "LLL a h:mm~h:mm v"
+      },
+      "MMMd hmv": {
+        "a": "MMM d일 a h:mm ~ a h:mm v",
+        "h": "MMM d일 a h:mm~h:mm v",
+        "m": "MMM d일 a h:mm~h:mm v"
+      },
+      "MMMEd hmv": {
+        "a": "MMM d일 (E) a h:mm ~ a h:mm v",
+        "h": "MMM d일 (E) a h:mm~h:mm v",
+        "m": "MMM d일 (E) a h:mm~h:mm v"
+      },
+      "MMMEEEEd hmv": {
+        "a": "MMM d일 EEEE a h:mm ~ a h:mm v",
+        "h": "MMM d일 EEEE a h:mm~h:mm v",
+        "m": "MMM d일 EEEE a h:mm~h:mm v"
+      },
+      "MMMMd hmv": {
+        "a": "MMMM d일 a h:mm ~ a h:mm v",
+        "h": "MMMM d일 a h:mm~h:mm v",
+        "m": "MMMM d일 a h:mm~h:mm v"
+      },
+      "y hmv": {
+        "a": "y년 a h:mm ~ a h:mm v",
+        "h": "y년 a h:mm~h:mm v",
+        "m": "y년 a h:mm~h:mm v"
+      },
+      "yM hmv": {
+        "a": "y. M. a h:mm ~ a h:mm v",
+        "h": "y. M. a h:mm~h:mm v",
+        "m": "y. M. a h:mm~h:mm v"
+      },
+      "yMd hmv": {
+        "a": "y. M. d. a h:mm ~ a h:mm v",
+        "h": "y. M. d. a h:mm~h:mm v",
+        "m": "y. M. d. a h:mm~h:mm v"
+      },
+      "yMEd hmv": {
+        "a": "y. M. d. (E) a h:mm ~ a h:mm v",
+        "h": "y. M. d. (E) a h:mm~h:mm v",
+        "m": "y. M. d. (E) a h:mm~h:mm v"
+      },
+      "yMEEEEd hmv": {
+        "a": "y. M. d. EEEE a h:mm ~ a h:mm v",
+        "h": "y. M. d. EEEE a h:mm~h:mm v",
+        "m": "y. M. d. EEEE a h:mm~h:mm v"
+      },
+      "yMM hmv": {
+        "a": "y. M. a h:mm ~ a h:mm v",
+        "h": "y. M. a h:mm~h:mm v",
+        "m": "y. M. a h:mm~h:mm v"
+      },
+      "yMMM hmv": {
+        "a": "y년 MMM a h:mm ~ a h:mm v",
+        "h": "y년 MMM a h:mm~h:mm v",
+        "m": "y년 MMM a h:mm~h:mm v"
+      },
+      "yMMMd hmv": {
+        "a": "y년 MMM d일 a h:mm ~ a h:mm v",
+        "h": "y년 MMM d일 a h:mm~h:mm v",
+        "m": "y년 MMM d일 a h:mm~h:mm v"
+      },
+      "yMMMEd hmv": {
+        "a": "y년 MMM d일 (E) a h:mm ~ a h:mm v",
+        "h": "y년 MMM d일 (E) a h:mm~h:mm v",
+        "m": "y년 MMM d일 (E) a h:mm~h:mm v"
+      },
+      "yMMMEEEEd hmv": {
+        "a": "y년 MMM d일 EEEE a h:mm ~ a h:mm v",
+        "h": "y년 MMM d일 EEEE a h:mm~h:mm v",
+        "m": "y년 MMM d일 EEEE a h:mm~h:mm v"
+      },
+      "yMMMM hmv": {
+        "a": "y년 MMMM a h:mm ~ a h:mm v",
+        "h": "y년 MMMM a h:mm~h:mm v",
+        "m": "y년 MMMM a h:mm~h:mm v"
+      },
+      "y년 MMMM d일 EEEE Hmv": {
+        "H": "y년 MMMM d일 EEEE HH:mm ~ HH:mm v",
+        "m": "y년 MMMM d일 EEEE HH:mm ~ HH:mm v"
+      },
+      "y년 MMMM d일 Hmv": {
+        "H": "y년 MMMM d일 HH:mm ~ HH:mm v",
+        "m": "y년 MMMM d일 HH:mm ~ HH:mm v"
+      },
+      "y. M. d. Hmv": {
+        "H": "y. M. d. HH:mm ~ HH:mm v",
+        "m": "y. M. d. HH:mm ~ HH:mm v"
+      },
+      "yy. M. d. Hmv": {
+        "H": "yy. M. d. HH:mm ~ HH:mm v",
+        "m": "yy. M. d. HH:mm ~ HH:mm v"
+      },
+      "d Hmv": {
+        "H": "d일 HH:mm ~ HH:mm v",
+        "m": "d일 HH:mm ~ HH:mm v"
+      },
+      "E Hmv": {
+        "H": "ccc HH:mm ~ HH:mm v",
+        "m": "ccc HH:mm ~ HH:mm v"
+      },
+      "Ed Hmv": {
+        "H": "d일 (E) HH:mm ~ HH:mm v",
+        "m": "d일 (E) HH:mm ~ HH:mm v"
+      },
+      "EEEEd Hmv": {
+        "H": "d일 EEEE HH:mm ~ HH:mm v",
+        "m": "d일 EEEE HH:mm ~ HH:mm v"
+      },
+      "Gy Hmv": {
+        "H": "G y년 HH:mm ~ HH:mm v",
+        "m": "G y년 HH:mm ~ HH:mm v"
+      },
+      "GyM Hmv": {
+        "H": "G y/M HH:mm ~ HH:mm v",
+        "m": "G y/M HH:mm ~ HH:mm v"
+      },
+      "GyMd Hmv": {
+        "H": "GGGGG y/M/d HH:mm ~ HH:mm v",
+        "m": "GGGGG y/M/d HH:mm ~ HH:mm v"
+      },
+      "GyMEd Hmv": {
+        "H": "G y/M/d (E) HH:mm ~ HH:mm v",
+        "m": "G y/M/d (E) HH:mm ~ HH:mm v"
+      },
+      "GyMMM Hmv": {
+        "H": "G y년 MMM HH:mm ~ HH:mm v",
+        "m": "G y년 MMM HH:mm ~ HH:mm v"
+      },
+      "GyMMMd Hmv": {
+        "H": "G y년 MMM d일 HH:mm ~ HH:mm v",
+        "m": "G y년 MMM d일 HH:mm ~ HH:mm v"
+      },
+      "GyMMMEd Hmv": {
+        "H": "G y년 MMM d일 (E) HH:mm ~ HH:mm v",
+        "m": "G y년 MMM d일 (E) HH:mm ~ HH:mm v"
+      },
+      "GyMMMEEEEd Hmv": {
+        "H": "G y년 MMM d일 EEEE HH:mm ~ HH:mm v",
+        "m": "G y년 MMM d일 EEEE HH:mm ~ HH:mm v"
+      },
+      "M Hmv": {
+        "H": "M월 HH:mm ~ HH:mm v",
+        "m": "M월 HH:mm ~ HH:mm v"
+      },
+      "Md Hmv": {
+        "H": "M. d. HH:mm ~ HH:mm v",
+        "m": "M. d. HH:mm ~ HH:mm v"
+      },
+      "MEd Hmv": {
+        "H": "M. d. (E) HH:mm ~ HH:mm v",
+        "m": "M. d. (E) HH:mm ~ HH:mm v"
+      },
+      "MEEEEd Hmv": {
+        "H": "M. d. EEEE HH:mm ~ HH:mm v",
+        "m": "M. d. EEEE HH:mm ~ HH:mm v"
+      },
+      "MMM Hmv": {
+        "H": "LLL HH:mm ~ HH:mm v",
+        "m": "LLL HH:mm ~ HH:mm v"
+      },
+      "MMMd Hmv": {
+        "H": "MMM d일 HH:mm ~ HH:mm v",
+        "m": "MMM d일 HH:mm ~ HH:mm v"
+      },
+      "MMMEd Hmv": {
+        "H": "MMM d일 (E) HH:mm ~ HH:mm v",
+        "m": "MMM d일 (E) HH:mm ~ HH:mm v"
+      },
+      "MMMEEEEd Hmv": {
+        "H": "MMM d일 EEEE HH:mm ~ HH:mm v",
+        "m": "MMM d일 EEEE HH:mm ~ HH:mm v"
+      },
+      "MMMMd Hmv": {
+        "H": "MMMM d일 HH:mm ~ HH:mm v",
+        "m": "MMMM d일 HH:mm ~ HH:mm v"
+      },
+      "y Hmv": {
+        "H": "y년 HH:mm ~ HH:mm v",
+        "m": "y년 HH:mm ~ HH:mm v"
+      },
+      "yM Hmv": {
+        "H": "y. M. HH:mm ~ HH:mm v",
+        "m": "y. M. HH:mm ~ HH:mm v"
+      },
+      "yMd Hmv": {
+        "H": "y. M. d. HH:mm ~ HH:mm v",
+        "m": "y. M. d. HH:mm ~ HH:mm v"
+      },
+      "yMEd Hmv": {
+        "H": "y. M. d. (E) HH:mm ~ HH:mm v",
+        "m": "y. M. d. (E) HH:mm ~ HH:mm v"
+      },
+      "yMEEEEd Hmv": {
+        "H": "y. M. d. EEEE HH:mm ~ HH:mm v",
+        "m": "y. M. d. EEEE HH:mm ~ HH:mm v"
+      },
+      "yMM Hmv": {
+        "H": "y. M. HH:mm ~ HH:mm v",
+        "m": "y. M. HH:mm ~ HH:mm v"
+      },
+      "yMMM Hmv": {
+        "H": "y년 MMM HH:mm ~ HH:mm v",
+        "m": "y년 MMM HH:mm ~ HH:mm v"
+      },
+      "yMMMd Hmv": {
+        "H": "y년 MMM d일 HH:mm ~ HH:mm v",
+        "m": "y년 MMM d일 HH:mm ~ HH:mm v"
+      },
+      "yMMMEd Hmv": {
+        "H": "y년 MMM d일 (E) HH:mm ~ HH:mm v",
+        "m": "y년 MMM d일 (E) HH:mm ~ HH:mm v"
+      },
+      "yMMMEEEEd Hmv": {
+        "H": "y년 MMM d일 EEEE HH:mm ~ HH:mm v",
+        "m": "y년 MMM d일 EEEE HH:mm ~ HH:mm v"
+      },
+      "yMMMM Hmv": {
+        "H": "y년 MMMM HH:mm ~ HH:mm v",
+        "m": "y년 MMMM HH:mm ~ HH:mm v"
+      },
+      "y년 MMMM d일 EEEE hv": {
+        "a": "y년 MMMM d일 EEEE a h시 ~ a h시(v)",
+        "h": "y년 MMMM d일 EEEE a h시 ~ h시(v)"
+      },
+      "y년 MMMM d일 hv": {
+        "a": "y년 MMMM d일 a h시 ~ a h시(v)",
+        "h": "y년 MMMM d일 a h시 ~ h시(v)"
+      },
+      "y. M. d. hv": {
+        "a": "y. M. d. a h시 ~ a h시(v)",
+        "h": "y. M. d. a h시 ~ h시(v)"
+      },
+      "yy. M. d. hv": {
+        "a": "yy. M. d. a h시 ~ a h시(v)",
+        "h": "yy. M. d. a h시 ~ h시(v)"
+      },
+      "d hv": {
+        "a": "d일 a h시 ~ a h시(v)",
+        "h": "d일 a h시 ~ h시(v)"
+      },
+      "E hv": {
+        "a": "ccc a h시 ~ a h시(v)",
+        "h": "ccc a h시 ~ h시(v)"
+      },
+      "Ed hv": {
+        "a": "d일 (E) a h시 ~ a h시(v)",
+        "h": "d일 (E) a h시 ~ h시(v)"
+      },
+      "EEEEd hv": {
+        "a": "d일 EEEE a h시 ~ a h시(v)",
+        "h": "d일 EEEE a h시 ~ h시(v)"
+      },
+      "Gy hv": {
+        "a": "G y년 a h시 ~ a h시(v)",
+        "h": "G y년 a h시 ~ h시(v)"
+      },
+      "GyM hv": {
+        "a": "G y/M a h시 ~ a h시(v)",
+        "h": "G y/M a h시 ~ h시(v)"
+      },
+      "GyMd hv": {
+        "a": "GGGGG y/M/d a h시 ~ a h시(v)",
+        "h": "GGGGG y/M/d a h시 ~ h시(v)"
+      },
+      "GyMEd hv": {
+        "a": "G y/M/d (E) a h시 ~ a h시(v)",
+        "h": "G y/M/d (E) a h시 ~ h시(v)"
+      },
+      "GyMMM hv": {
+        "a": "G y년 MMM a h시 ~ a h시(v)",
+        "h": "G y년 MMM a h시 ~ h시(v)"
+      },
+      "GyMMMd hv": {
+        "a": "G y년 MMM d일 a h시 ~ a h시(v)",
+        "h": "G y년 MMM d일 a h시 ~ h시(v)"
+      },
+      "GyMMMEd hv": {
+        "a": "G y년 MMM d일 (E) a h시 ~ a h시(v)",
+        "h": "G y년 MMM d일 (E) a h시 ~ h시(v)"
+      },
+      "GyMMMEEEEd hv": {
+        "a": "G y년 MMM d일 EEEE a h시 ~ a h시(v)",
+        "h": "G y년 MMM d일 EEEE a h시 ~ h시(v)"
+      },
+      "M hv": {
+        "a": "M월 a h시 ~ a h시(v)",
+        "h": "M월 a h시 ~ h시(v)"
+      },
+      "Md hv": {
+        "a": "M. d. a h시 ~ a h시(v)",
+        "h": "M. d. a h시 ~ h시(v)"
+      },
+      "MEd hv": {
+        "a": "M. d. (E) a h시 ~ a h시(v)",
+        "h": "M. d. (E) a h시 ~ h시(v)"
+      },
+      "MEEEEd hv": {
+        "a": "M. d. EEEE a h시 ~ a h시(v)",
+        "h": "M. d. EEEE a h시 ~ h시(v)"
+      },
+      "MMM hv": {
+        "a": "LLL a h시 ~ a h시(v)",
+        "h": "LLL a h시 ~ h시(v)"
+      },
+      "MMMd hv": {
+        "a": "MMM d일 a h시 ~ a h시(v)",
+        "h": "MMM d일 a h시 ~ h시(v)"
+      },
+      "MMMEd hv": {
+        "a": "MMM d일 (E) a h시 ~ a h시(v)",
+        "h": "MMM d일 (E) a h시 ~ h시(v)"
+      },
+      "MMMEEEEd hv": {
+        "a": "MMM d일 EEEE a h시 ~ a h시(v)",
+        "h": "MMM d일 EEEE a h시 ~ h시(v)"
+      },
+      "MMMMd hv": {
+        "a": "MMMM d일 a h시 ~ a h시(v)",
+        "h": "MMMM d일 a h시 ~ h시(v)"
+      },
+      "y hv": {
+        "a": "y년 a h시 ~ a h시(v)",
+        "h": "y년 a h시 ~ h시(v)"
+      },
+      "yM hv": {
+        "a": "y. M. a h시 ~ a h시(v)",
+        "h": "y. M. a h시 ~ h시(v)"
+      },
+      "yMd hv": {
+        "a": "y. M. d. a h시 ~ a h시(v)",
+        "h": "y. M. d. a h시 ~ h시(v)"
+      },
+      "yMEd hv": {
+        "a": "y. M. d. (E) a h시 ~ a h시(v)",
+        "h": "y. M. d. (E) a h시 ~ h시(v)"
+      },
+      "yMEEEEd hv": {
+        "a": "y. M. d. EEEE a h시 ~ a h시(v)",
+        "h": "y. M. d. EEEE a h시 ~ h시(v)"
+      },
+      "yMM hv": {
+        "a": "y. M. a h시 ~ a h시(v)",
+        "h": "y. M. a h시 ~ h시(v)"
+      },
+      "yMMM hv": {
+        "a": "y년 MMM a h시 ~ a h시(v)",
+        "h": "y년 MMM a h시 ~ h시(v)"
+      },
+      "yMMMd hv": {
+        "a": "y년 MMM d일 a h시 ~ a h시(v)",
+        "h": "y년 MMM d일 a h시 ~ h시(v)"
+      },
+      "yMMMEd hv": {
+        "a": "y년 MMM d일 (E) a h시 ~ a h시(v)",
+        "h": "y년 MMM d일 (E) a h시 ~ h시(v)"
+      },
+      "yMMMEEEEd hv": {
+        "a": "y년 MMM d일 EEEE a h시 ~ a h시(v)",
+        "h": "y년 MMM d일 EEEE a h시 ~ h시(v)"
+      },
+      "yMMMM hv": {
+        "a": "y년 MMMM a h시 ~ a h시(v)",
+        "h": "y년 MMMM a h시 ~ h시(v)"
+      },
+      "y년 MMMM d일 EEEE Hv": {
+        "H": "y년 MMMM d일 EEEE HH ~ HH시 v"
+      },
+      "y년 MMMM d일 Hv": {
+        "H": "y년 MMMM d일 HH ~ HH시 v"
+      },
+      "y. M. d. Hv": {
+        "H": "y. M. d. HH ~ HH시 v"
+      },
+      "yy. M. d. Hv": {
+        "H": "yy. M. d. HH ~ HH시 v"
+      },
+      "d Hv": {
+        "H": "d일 HH ~ HH시 v"
+      },
+      "E Hv": {
+        "H": "ccc HH ~ HH시 v"
+      },
+      "Ed Hv": {
+        "H": "d일 (E) HH ~ HH시 v"
+      },
+      "EEEEd Hv": {
+        "H": "d일 EEEE HH ~ HH시 v"
+      },
+      "Gy Hv": {
+        "H": "G y년 HH ~ HH시 v"
+      },
+      "GyM Hv": {
+        "H": "G y/M HH ~ HH시 v"
+      },
+      "GyMd Hv": {
+        "H": "GGGGG y/M/d HH ~ HH시 v"
+      },
+      "GyMEd Hv": {
+        "H": "G y/M/d (E) HH ~ HH시 v"
+      },
+      "GyMMM Hv": {
+        "H": "G y년 MMM HH ~ HH시 v"
+      },
+      "GyMMMd Hv": {
+        "H": "G y년 MMM d일 HH ~ HH시 v"
+      },
+      "GyMMMEd Hv": {
+        "H": "G y년 MMM d일 (E) HH ~ HH시 v"
+      },
+      "GyMMMEEEEd Hv": {
+        "H": "G y년 MMM d일 EEEE HH ~ HH시 v"
+      },
+      "M Hv": {
+        "H": "M월 HH ~ HH시 v"
+      },
+      "Md Hv": {
+        "H": "M. d. HH ~ HH시 v"
+      },
+      "MEd Hv": {
+        "H": "M. d. (E) HH ~ HH시 v"
+      },
+      "MEEEEd Hv": {
+        "H": "M. d. EEEE HH ~ HH시 v"
+      },
+      "MMM Hv": {
+        "H": "LLL HH ~ HH시 v"
+      },
+      "MMMd Hv": {
+        "H": "MMM d일 HH ~ HH시 v"
+      },
+      "MMMEd Hv": {
+        "H": "MMM d일 (E) HH ~ HH시 v"
+      },
+      "MMMEEEEd Hv": {
+        "H": "MMM d일 EEEE HH ~ HH시 v"
+      },
+      "MMMMd Hv": {
+        "H": "MMMM d일 HH ~ HH시 v"
+      },
+      "y Hv": {
+        "H": "y년 HH ~ HH시 v"
+      },
+      "yM Hv": {
+        "H": "y. M. HH ~ HH시 v"
+      },
+      "yMd Hv": {
+        "H": "y. M. d. HH ~ HH시 v"
+      },
+      "yMEd Hv": {
+        "H": "y. M. d. (E) HH ~ HH시 v"
+      },
+      "yMEEEEd Hv": {
+        "H": "y. M. d. EEEE HH ~ HH시 v"
+      },
+      "yMM Hv": {
+        "H": "y. M. HH ~ HH시 v"
+      },
+      "yMMM Hv": {
+        "H": "y년 MMM HH ~ HH시 v"
+      },
+      "yMMMd Hv": {
+        "H": "y년 MMM d일 HH ~ HH시 v"
+      },
+      "yMMMEd Hv": {
+        "H": "y년 MMM d일 (E) HH ~ HH시 v"
+      },
+      "yMMMEEEEd Hv": {
+        "H": "y년 MMM d일 EEEE HH ~ HH시 v"
+      },
+      "yMMMM Hv": {
+        "H": "y년 MMMM HH ~ HH시 v"
       }
     },
     "hourCycle": "h12",
@@ -16780,6 +23586,1523 @@ Intl.DateTimeFormat.__addLocaleData({
         "d": "EEEEที่ d – EEEEที่ d MMMM G y",
         "M": "EEEEที่ d MMMM – EEEEที่ d MMMM G y",
         "y": "EEEEที่ d MMMM G y – EEEEที่ d MMMM y"
+      },
+      "EEEEที่ d MMMM G y Bh": {
+        "B": "EEEEที่ d MMMM G y h B – h B",
+        "h": "EEEEที่ d MMMM G y h – h B"
+      },
+      "d MMMM G y Bh": {
+        "B": "d MMMM G y h B – h B",
+        "h": "d MMMM G y h – h B"
+      },
+      "d MMM y Bh": {
+        "B": "d MMM y h B – h B",
+        "h": "d MMM y h – h B"
+      },
+      "d/M/yy Bh": {
+        "B": "d/M/yy h B – h B",
+        "h": "d/M/yy h – h B"
+      },
+      "d Bh": {
+        "B": "d h B – h B",
+        "h": "d h – h B"
+      },
+      "E Bh": {
+        "B": "ccc h B – h B",
+        "h": "ccc h – h B"
+      },
+      "Ed Bh": {
+        "B": "E d h B – h B",
+        "h": "E d h – h B"
+      },
+      "Gy Bh": {
+        "B": "G y h B – h B",
+        "h": "G y h – h B"
+      },
+      "GyM Bh": {
+        "B": "G y-MM h B – h B",
+        "h": "G y-MM h – h B"
+      },
+      "GyMd Bh": {
+        "B": "d/M/GGGGG y h B – h B",
+        "h": "d/M/GGGGG y h – h B"
+      },
+      "GyMEd Bh": {
+        "B": "E d/M/G y h B – h B",
+        "h": "E d/M/G y h – h B"
+      },
+      "GyMMM Bh": {
+        "B": "MMM G y h B – h B",
+        "h": "MMM G y h – h B"
+      },
+      "GyMMMd Bh": {
+        "B": "d MMM G y h B – h B",
+        "h": "d MMM G y h – h B"
+      },
+      "GyMMMEd Bh": {
+        "B": "E d MMM G y h B – h B",
+        "h": "E d MMM G y h – h B"
+      },
+      "GyMMMEEEEd Bh": {
+        "B": "EEEEที่ d MMM G y h B – h B",
+        "h": "EEEEที่ d MMM G y h – h B"
+      },
+      "M Bh": {
+        "B": "L h B – h B",
+        "h": "L h – h B"
+      },
+      "Md Bh": {
+        "B": "d/M h B – h B",
+        "h": "d/M h – h B"
+      },
+      "MEd Bh": {
+        "B": "E d/M h B – h B",
+        "h": "E d/M h – h B"
+      },
+      "MMM Bh": {
+        "B": "LLL h B – h B",
+        "h": "LLL h – h B"
+      },
+      "MMMd Bh": {
+        "B": "d MMM h B – h B",
+        "h": "d MMM h – h B"
+      },
+      "MMMEd Bh": {
+        "B": "E d MMM h B – h B",
+        "h": "E d MMM h – h B"
+      },
+      "MMMEEEEd Bh": {
+        "B": "EEEEที่ d MMM h B – h B",
+        "h": "EEEEที่ d MMM h – h B"
+      },
+      "MMMMd Bh": {
+        "B": "d MMMM h B – h B",
+        "h": "d MMMM h – h B"
+      },
+      "MMMMEd Bh": {
+        "B": "E d MMMM h B – h B",
+        "h": "E d MMMM h – h B"
+      },
+      "MMMMEEEEd Bh": {
+        "B": "EEEEที่ d MMMM h B – h B",
+        "h": "EEEEที่ d MMMM h – h B"
+      },
+      "y Bh": {
+        "B": "y h B – h B",
+        "h": "y h – h B"
+      },
+      "yM Bh": {
+        "B": "M/y h B – h B",
+        "h": "M/y h – h B"
+      },
+      "yMd Bh": {
+        "B": "d/M/y h B – h B",
+        "h": "d/M/y h – h B"
+      },
+      "yMEd Bh": {
+        "B": "E d/M/y h B – h B",
+        "h": "E d/M/y h – h B"
+      },
+      "yMMM Bh": {
+        "B": "MMM y h B – h B",
+        "h": "MMM y h – h B"
+      },
+      "yMMMd Bh": {
+        "B": "d MMM y h B – h B",
+        "h": "d MMM y h – h B"
+      },
+      "yMMMEd Bh": {
+        "B": "E d MMM y h B – h B",
+        "h": "E d MMM y h – h B"
+      },
+      "yMMMEEEEd Bh": {
+        "B": "EEEEที่ d MMM y h B – h B",
+        "h": "EEEEที่ d MMM y h – h B"
+      },
+      "yMMMM Bh": {
+        "B": "MMMM y h B – h B",
+        "h": "MMMM y h – h B"
+      },
+      "yMMMMd Bh": {
+        "B": "d MMMM y h B – h B",
+        "h": "d MMMM y h – h B"
+      },
+      "yMMMMEd Bh": {
+        "B": "E d MMMM y h B – h B",
+        "h": "E d MMMM y h – h B"
+      },
+      "yMMMMEEEEd Bh": {
+        "B": "EEEEที่ d MMMM y h B – h B",
+        "h": "EEEEที่ d MMMM y h – h B"
+      },
+      "EEEEที่ d MMMM G y Bhm": {
+        "B": "EEEEที่ d MMMM G y h:mm B – h:mm B",
+        "h": "EEEEที่ d MMMM G y h:mm – h:mm B",
+        "m": "EEEEที่ d MMMM G y h:mm – h:mm B"
+      },
+      "d MMMM G y Bhm": {
+        "B": "d MMMM G y h:mm B – h:mm B",
+        "h": "d MMMM G y h:mm – h:mm B",
+        "m": "d MMMM G y h:mm – h:mm B"
+      },
+      "d MMM y Bhm": {
+        "B": "d MMM y h:mm B – h:mm B",
+        "h": "d MMM y h:mm – h:mm B",
+        "m": "d MMM y h:mm – h:mm B"
+      },
+      "d/M/yy Bhm": {
+        "B": "d/M/yy h:mm B – h:mm B",
+        "h": "d/M/yy h:mm – h:mm B",
+        "m": "d/M/yy h:mm – h:mm B"
+      },
+      "d Bhm": {
+        "B": "d h:mm B – h:mm B",
+        "h": "d h:mm – h:mm B",
+        "m": "d h:mm – h:mm B"
+      },
+      "E Bhm": {
+        "B": "ccc h:mm B – h:mm B",
+        "h": "ccc h:mm – h:mm B",
+        "m": "ccc h:mm – h:mm B"
+      },
+      "Ed Bhm": {
+        "B": "E d h:mm B – h:mm B",
+        "h": "E d h:mm – h:mm B",
+        "m": "E d h:mm – h:mm B"
+      },
+      "Gy Bhm": {
+        "B": "G y h:mm B – h:mm B",
+        "h": "G y h:mm – h:mm B",
+        "m": "G y h:mm – h:mm B"
+      },
+      "GyM Bhm": {
+        "B": "G y-MM h:mm B – h:mm B",
+        "h": "G y-MM h:mm – h:mm B",
+        "m": "G y-MM h:mm – h:mm B"
+      },
+      "GyMd Bhm": {
+        "B": "d/M/GGGGG y h:mm B – h:mm B",
+        "h": "d/M/GGGGG y h:mm – h:mm B",
+        "m": "d/M/GGGGG y h:mm – h:mm B"
+      },
+      "GyMEd Bhm": {
+        "B": "E d/M/G y h:mm B – h:mm B",
+        "h": "E d/M/G y h:mm – h:mm B",
+        "m": "E d/M/G y h:mm – h:mm B"
+      },
+      "GyMMM Bhm": {
+        "B": "MMM G y h:mm B – h:mm B",
+        "h": "MMM G y h:mm – h:mm B",
+        "m": "MMM G y h:mm – h:mm B"
+      },
+      "GyMMMd Bhm": {
+        "B": "d MMM G y h:mm B – h:mm B",
+        "h": "d MMM G y h:mm – h:mm B",
+        "m": "d MMM G y h:mm – h:mm B"
+      },
+      "GyMMMEd Bhm": {
+        "B": "E d MMM G y h:mm B – h:mm B",
+        "h": "E d MMM G y h:mm – h:mm B",
+        "m": "E d MMM G y h:mm – h:mm B"
+      },
+      "GyMMMEEEEd Bhm": {
+        "B": "EEEEที่ d MMM G y h:mm B – h:mm B",
+        "h": "EEEEที่ d MMM G y h:mm – h:mm B",
+        "m": "EEEEที่ d MMM G y h:mm – h:mm B"
+      },
+      "M Bhm": {
+        "B": "L h:mm B – h:mm B",
+        "h": "L h:mm – h:mm B",
+        "m": "L h:mm – h:mm B"
+      },
+      "Md Bhm": {
+        "B": "d/M h:mm B – h:mm B",
+        "h": "d/M h:mm – h:mm B",
+        "m": "d/M h:mm – h:mm B"
+      },
+      "MEd Bhm": {
+        "B": "E d/M h:mm B – h:mm B",
+        "h": "E d/M h:mm – h:mm B",
+        "m": "E d/M h:mm – h:mm B"
+      },
+      "MMM Bhm": {
+        "B": "LLL h:mm B – h:mm B",
+        "h": "LLL h:mm – h:mm B",
+        "m": "LLL h:mm – h:mm B"
+      },
+      "MMMd Bhm": {
+        "B": "d MMM h:mm B – h:mm B",
+        "h": "d MMM h:mm – h:mm B",
+        "m": "d MMM h:mm – h:mm B"
+      },
+      "MMMEd Bhm": {
+        "B": "E d MMM h:mm B – h:mm B",
+        "h": "E d MMM h:mm – h:mm B",
+        "m": "E d MMM h:mm – h:mm B"
+      },
+      "MMMEEEEd Bhm": {
+        "B": "EEEEที่ d MMM h:mm B – h:mm B",
+        "h": "EEEEที่ d MMM h:mm – h:mm B",
+        "m": "EEEEที่ d MMM h:mm – h:mm B"
+      },
+      "MMMMd Bhm": {
+        "B": "d MMMM h:mm B – h:mm B",
+        "h": "d MMMM h:mm – h:mm B",
+        "m": "d MMMM h:mm – h:mm B"
+      },
+      "MMMMEd Bhm": {
+        "B": "E d MMMM h:mm B – h:mm B",
+        "h": "E d MMMM h:mm – h:mm B",
+        "m": "E d MMMM h:mm – h:mm B"
+      },
+      "MMMMEEEEd Bhm": {
+        "B": "EEEEที่ d MMMM h:mm B – h:mm B",
+        "h": "EEEEที่ d MMMM h:mm – h:mm B",
+        "m": "EEEEที่ d MMMM h:mm – h:mm B"
+      },
+      "y Bhm": {
+        "B": "y h:mm B – h:mm B",
+        "h": "y h:mm – h:mm B",
+        "m": "y h:mm – h:mm B"
+      },
+      "yM Bhm": {
+        "B": "M/y h:mm B – h:mm B",
+        "h": "M/y h:mm – h:mm B",
+        "m": "M/y h:mm – h:mm B"
+      },
+      "yMd Bhm": {
+        "B": "d/M/y h:mm B – h:mm B",
+        "h": "d/M/y h:mm – h:mm B",
+        "m": "d/M/y h:mm – h:mm B"
+      },
+      "yMEd Bhm": {
+        "B": "E d/M/y h:mm B – h:mm B",
+        "h": "E d/M/y h:mm – h:mm B",
+        "m": "E d/M/y h:mm – h:mm B"
+      },
+      "yMMM Bhm": {
+        "B": "MMM y h:mm B – h:mm B",
+        "h": "MMM y h:mm – h:mm B",
+        "m": "MMM y h:mm – h:mm B"
+      },
+      "yMMMd Bhm": {
+        "B": "d MMM y h:mm B – h:mm B",
+        "h": "d MMM y h:mm – h:mm B",
+        "m": "d MMM y h:mm – h:mm B"
+      },
+      "yMMMEd Bhm": {
+        "B": "E d MMM y h:mm B – h:mm B",
+        "h": "E d MMM y h:mm – h:mm B",
+        "m": "E d MMM y h:mm – h:mm B"
+      },
+      "yMMMEEEEd Bhm": {
+        "B": "EEEEที่ d MMM y h:mm B – h:mm B",
+        "h": "EEEEที่ d MMM y h:mm – h:mm B",
+        "m": "EEEEที่ d MMM y h:mm – h:mm B"
+      },
+      "yMMMM Bhm": {
+        "B": "MMMM y h:mm B – h:mm B",
+        "h": "MMMM y h:mm – h:mm B",
+        "m": "MMMM y h:mm – h:mm B"
+      },
+      "yMMMMd Bhm": {
+        "B": "d MMMM y h:mm B – h:mm B",
+        "h": "d MMMM y h:mm – h:mm B",
+        "m": "d MMMM y h:mm – h:mm B"
+      },
+      "yMMMMEd Bhm": {
+        "B": "E d MMMM y h:mm B – h:mm B",
+        "h": "E d MMMM y h:mm – h:mm B",
+        "m": "E d MMMM y h:mm – h:mm B"
+      },
+      "yMMMMEEEEd Bhm": {
+        "B": "EEEEที่ d MMMM y h:mm B – h:mm B",
+        "h": "EEEEที่ d MMMM y h:mm – h:mm B",
+        "m": "EEEEที่ d MMMM y h:mm – h:mm B"
+      },
+      "EEEEที่ d MMMM G y h": {
+        "a": "EEEEที่ d MMMM G y h a – h a",
+        "h": "EEEEที่ d MMMM G y h–h a"
+      },
+      "d MMMM G y h": {
+        "a": "d MMMM G y h a – h a",
+        "h": "d MMMM G y h–h a"
+      },
+      "d MMM y h": {
+        "a": "d MMM y h a – h a",
+        "h": "d MMM y h–h a"
+      },
+      "d/M/yy h": {
+        "a": "d/M/yy h a – h a",
+        "h": "d/M/yy h–h a"
+      },
+      "d h": {
+        "a": "d h a – h a",
+        "h": "d h–h a"
+      },
+      "E h": {
+        "a": "ccc h a – h a",
+        "h": "ccc h–h a"
+      },
+      "Ed h": {
+        "a": "E d h a – h a",
+        "h": "E d h–h a"
+      },
+      "Gy h": {
+        "a": "G y h a – h a",
+        "h": "G y h–h a"
+      },
+      "GyM h": {
+        "a": "G y-MM h a – h a",
+        "h": "G y-MM h–h a"
+      },
+      "GyMd h": {
+        "a": "d/M/GGGGG y h a – h a",
+        "h": "d/M/GGGGG y h–h a"
+      },
+      "GyMEd h": {
+        "a": "E d/M/G y h a – h a",
+        "h": "E d/M/G y h–h a"
+      },
+      "GyMMM h": {
+        "a": "MMM G y h a – h a",
+        "h": "MMM G y h–h a"
+      },
+      "GyMMMd h": {
+        "a": "d MMM G y h a – h a",
+        "h": "d MMM G y h–h a"
+      },
+      "GyMMMEd h": {
+        "a": "E d MMM G y h a – h a",
+        "h": "E d MMM G y h–h a"
+      },
+      "GyMMMEEEEd h": {
+        "a": "EEEEที่ d MMM G y h a – h a",
+        "h": "EEEEที่ d MMM G y h–h a"
+      },
+      "M h": {
+        "a": "L h a – h a",
+        "h": "L h–h a"
+      },
+      "Md h": {
+        "a": "d/M h a – h a",
+        "h": "d/M h–h a"
+      },
+      "MEd h": {
+        "a": "E d/M h a – h a",
+        "h": "E d/M h–h a"
+      },
+      "MMM h": {
+        "a": "LLL h a – h a",
+        "h": "LLL h–h a"
+      },
+      "MMMd h": {
+        "a": "d MMM h a – h a",
+        "h": "d MMM h–h a"
+      },
+      "MMMEd h": {
+        "a": "E d MMM h a – h a",
+        "h": "E d MMM h–h a"
+      },
+      "MMMEEEEd h": {
+        "a": "EEEEที่ d MMM h a – h a",
+        "h": "EEEEที่ d MMM h–h a"
+      },
+      "MMMMd h": {
+        "a": "d MMMM h a – h a",
+        "h": "d MMMM h–h a"
+      },
+      "MMMMEd h": {
+        "a": "E d MMMM h a – h a",
+        "h": "E d MMMM h–h a"
+      },
+      "MMMMEEEEd h": {
+        "a": "EEEEที่ d MMMM h a – h a",
+        "h": "EEEEที่ d MMMM h–h a"
+      },
+      "y h": {
+        "a": "y h a – h a",
+        "h": "y h–h a"
+      },
+      "yM h": {
+        "a": "M/y h a – h a",
+        "h": "M/y h–h a"
+      },
+      "yMd h": {
+        "a": "d/M/y h a – h a",
+        "h": "d/M/y h–h a"
+      },
+      "yMEd h": {
+        "a": "E d/M/y h a – h a",
+        "h": "E d/M/y h–h a"
+      },
+      "yMMM h": {
+        "a": "MMM y h a – h a",
+        "h": "MMM y h–h a"
+      },
+      "yMMMd h": {
+        "a": "d MMM y h a – h a",
+        "h": "d MMM y h–h a"
+      },
+      "yMMMEd h": {
+        "a": "E d MMM y h a – h a",
+        "h": "E d MMM y h–h a"
+      },
+      "yMMMEEEEd h": {
+        "a": "EEEEที่ d MMM y h a – h a",
+        "h": "EEEEที่ d MMM y h–h a"
+      },
+      "yMMMM h": {
+        "a": "MMMM y h a – h a",
+        "h": "MMMM y h–h a"
+      },
+      "yMMMMd h": {
+        "a": "d MMMM y h a – h a",
+        "h": "d MMMM y h–h a"
+      },
+      "yMMMMEd h": {
+        "a": "E d MMMM y h a – h a",
+        "h": "E d MMMM y h–h a"
+      },
+      "yMMMMEEEEd h": {
+        "a": "EEEEที่ d MMMM y h a – h a",
+        "h": "EEEEที่ d MMMM y h–h a"
+      },
+      "EEEEที่ d MMMM G y H": {
+        "H": "EEEEที่ d MMMM G y HH–HH"
+      },
+      "d MMMM G y H": {
+        "H": "d MMMM G y HH–HH"
+      },
+      "d MMM y H": {
+        "H": "d MMM y HH–HH"
+      },
+      "d/M/yy H": {
+        "H": "d/M/yy HH–HH"
+      },
+      "d H": {
+        "H": "d HH–HH"
+      },
+      "E H": {
+        "H": "ccc HH–HH"
+      },
+      "Ed H": {
+        "H": "E d HH–HH"
+      },
+      "Gy H": {
+        "H": "G y HH–HH"
+      },
+      "GyM H": {
+        "H": "G y-MM HH–HH"
+      },
+      "GyMd H": {
+        "H": "d/M/GGGGG y HH–HH"
+      },
+      "GyMEd H": {
+        "H": "E d/M/G y HH–HH"
+      },
+      "GyMMM H": {
+        "H": "MMM G y HH–HH"
+      },
+      "GyMMMd H": {
+        "H": "d MMM G y HH–HH"
+      },
+      "GyMMMEd H": {
+        "H": "E d MMM G y HH–HH"
+      },
+      "GyMMMEEEEd H": {
+        "H": "EEEEที่ d MMM G y HH–HH"
+      },
+      "M H": {
+        "H": "L HH–HH"
+      },
+      "Md H": {
+        "H": "d/M HH–HH"
+      },
+      "MEd H": {
+        "H": "E d/M HH–HH"
+      },
+      "MMM H": {
+        "H": "LLL HH–HH"
+      },
+      "MMMd H": {
+        "H": "d MMM HH–HH"
+      },
+      "MMMEd H": {
+        "H": "E d MMM HH–HH"
+      },
+      "MMMEEEEd H": {
+        "H": "EEEEที่ d MMM HH–HH"
+      },
+      "MMMMd H": {
+        "H": "d MMMM HH–HH"
+      },
+      "MMMMEd H": {
+        "H": "E d MMMM HH–HH"
+      },
+      "MMMMEEEEd H": {
+        "H": "EEEEที่ d MMMM HH–HH"
+      },
+      "y H": {
+        "H": "y HH–HH"
+      },
+      "yM H": {
+        "H": "M/y HH–HH"
+      },
+      "yMd H": {
+        "H": "d/M/y HH–HH"
+      },
+      "yMEd H": {
+        "H": "E d/M/y HH–HH"
+      },
+      "yMMM H": {
+        "H": "MMM y HH–HH"
+      },
+      "yMMMd H": {
+        "H": "d MMM y HH–HH"
+      },
+      "yMMMEd H": {
+        "H": "E d MMM y HH–HH"
+      },
+      "yMMMEEEEd H": {
+        "H": "EEEEที่ d MMM y HH–HH"
+      },
+      "yMMMM H": {
+        "H": "MMMM y HH–HH"
+      },
+      "yMMMMd H": {
+        "H": "d MMMM y HH–HH"
+      },
+      "yMMMMEd H": {
+        "H": "E d MMMM y HH–HH"
+      },
+      "yMMMMEEEEd H": {
+        "H": "EEEEที่ d MMMM y HH–HH"
+      },
+      "EEEEที่ d MMMM G y hm": {
+        "a": "EEEEที่ d MMMM G y h:mm a – h:mm a",
+        "h": "EEEEที่ d MMMM G y h:mm–h:mm a",
+        "m": "EEEEที่ d MMMM G y h:mm–h:mm a"
+      },
+      "d MMMM G y hm": {
+        "a": "d MMMM G y h:mm a – h:mm a",
+        "h": "d MMMM G y h:mm–h:mm a",
+        "m": "d MMMM G y h:mm–h:mm a"
+      },
+      "d MMM y hm": {
+        "a": "d MMM y h:mm a – h:mm a",
+        "h": "d MMM y h:mm–h:mm a",
+        "m": "d MMM y h:mm–h:mm a"
+      },
+      "d/M/yy hm": {
+        "a": "d/M/yy h:mm a – h:mm a",
+        "h": "d/M/yy h:mm–h:mm a",
+        "m": "d/M/yy h:mm–h:mm a"
+      },
+      "d hm": {
+        "a": "d h:mm a – h:mm a",
+        "h": "d h:mm–h:mm a",
+        "m": "d h:mm–h:mm a"
+      },
+      "E hm": {
+        "a": "ccc h:mm a – h:mm a",
+        "h": "ccc h:mm–h:mm a",
+        "m": "ccc h:mm–h:mm a"
+      },
+      "Ed hm": {
+        "a": "E d h:mm a – h:mm a",
+        "h": "E d h:mm–h:mm a",
+        "m": "E d h:mm–h:mm a"
+      },
+      "Gy hm": {
+        "a": "G y h:mm a – h:mm a",
+        "h": "G y h:mm–h:mm a",
+        "m": "G y h:mm–h:mm a"
+      },
+      "GyM hm": {
+        "a": "G y-MM h:mm a – h:mm a",
+        "h": "G y-MM h:mm–h:mm a",
+        "m": "G y-MM h:mm–h:mm a"
+      },
+      "GyMd hm": {
+        "a": "d/M/GGGGG y h:mm a – h:mm a",
+        "h": "d/M/GGGGG y h:mm–h:mm a",
+        "m": "d/M/GGGGG y h:mm–h:mm a"
+      },
+      "GyMEd hm": {
+        "a": "E d/M/G y h:mm a – h:mm a",
+        "h": "E d/M/G y h:mm–h:mm a",
+        "m": "E d/M/G y h:mm–h:mm a"
+      },
+      "GyMMM hm": {
+        "a": "MMM G y h:mm a – h:mm a",
+        "h": "MMM G y h:mm–h:mm a",
+        "m": "MMM G y h:mm–h:mm a"
+      },
+      "GyMMMd hm": {
+        "a": "d MMM G y h:mm a – h:mm a",
+        "h": "d MMM G y h:mm–h:mm a",
+        "m": "d MMM G y h:mm–h:mm a"
+      },
+      "GyMMMEd hm": {
+        "a": "E d MMM G y h:mm a – h:mm a",
+        "h": "E d MMM G y h:mm–h:mm a",
+        "m": "E d MMM G y h:mm–h:mm a"
+      },
+      "GyMMMEEEEd hm": {
+        "a": "EEEEที่ d MMM G y h:mm a – h:mm a",
+        "h": "EEEEที่ d MMM G y h:mm–h:mm a",
+        "m": "EEEEที่ d MMM G y h:mm–h:mm a"
+      },
+      "M hm": {
+        "a": "L h:mm a – h:mm a",
+        "h": "L h:mm–h:mm a",
+        "m": "L h:mm–h:mm a"
+      },
+      "Md hm": {
+        "a": "d/M h:mm a – h:mm a",
+        "h": "d/M h:mm–h:mm a",
+        "m": "d/M h:mm–h:mm a"
+      },
+      "MEd hm": {
+        "a": "E d/M h:mm a – h:mm a",
+        "h": "E d/M h:mm–h:mm a",
+        "m": "E d/M h:mm–h:mm a"
+      },
+      "MMM hm": {
+        "a": "LLL h:mm a – h:mm a",
+        "h": "LLL h:mm–h:mm a",
+        "m": "LLL h:mm–h:mm a"
+      },
+      "MMMd hm": {
+        "a": "d MMM h:mm a – h:mm a",
+        "h": "d MMM h:mm–h:mm a",
+        "m": "d MMM h:mm–h:mm a"
+      },
+      "MMMEd hm": {
+        "a": "E d MMM h:mm a – h:mm a",
+        "h": "E d MMM h:mm–h:mm a",
+        "m": "E d MMM h:mm–h:mm a"
+      },
+      "MMMEEEEd hm": {
+        "a": "EEEEที่ d MMM h:mm a – h:mm a",
+        "h": "EEEEที่ d MMM h:mm–h:mm a",
+        "m": "EEEEที่ d MMM h:mm–h:mm a"
+      },
+      "MMMMd hm": {
+        "a": "d MMMM h:mm a – h:mm a",
+        "h": "d MMMM h:mm–h:mm a",
+        "m": "d MMMM h:mm–h:mm a"
+      },
+      "MMMMEd hm": {
+        "a": "E d MMMM h:mm a – h:mm a",
+        "h": "E d MMMM h:mm–h:mm a",
+        "m": "E d MMMM h:mm–h:mm a"
+      },
+      "MMMMEEEEd hm": {
+        "a": "EEEEที่ d MMMM h:mm a – h:mm a",
+        "h": "EEEEที่ d MMMM h:mm–h:mm a",
+        "m": "EEEEที่ d MMMM h:mm–h:mm a"
+      },
+      "y hm": {
+        "a": "y h:mm a – h:mm a",
+        "h": "y h:mm–h:mm a",
+        "m": "y h:mm–h:mm a"
+      },
+      "yM hm": {
+        "a": "M/y h:mm a – h:mm a",
+        "h": "M/y h:mm–h:mm a",
+        "m": "M/y h:mm–h:mm a"
+      },
+      "yMd hm": {
+        "a": "d/M/y h:mm a – h:mm a",
+        "h": "d/M/y h:mm–h:mm a",
+        "m": "d/M/y h:mm–h:mm a"
+      },
+      "yMEd hm": {
+        "a": "E d/M/y h:mm a – h:mm a",
+        "h": "E d/M/y h:mm–h:mm a",
+        "m": "E d/M/y h:mm–h:mm a"
+      },
+      "yMMM hm": {
+        "a": "MMM y h:mm a – h:mm a",
+        "h": "MMM y h:mm–h:mm a",
+        "m": "MMM y h:mm–h:mm a"
+      },
+      "yMMMd hm": {
+        "a": "d MMM y h:mm a – h:mm a",
+        "h": "d MMM y h:mm–h:mm a",
+        "m": "d MMM y h:mm–h:mm a"
+      },
+      "yMMMEd hm": {
+        "a": "E d MMM y h:mm a – h:mm a",
+        "h": "E d MMM y h:mm–h:mm a",
+        "m": "E d MMM y h:mm–h:mm a"
+      },
+      "yMMMEEEEd hm": {
+        "a": "EEEEที่ d MMM y h:mm a – h:mm a",
+        "h": "EEEEที่ d MMM y h:mm–h:mm a",
+        "m": "EEEEที่ d MMM y h:mm–h:mm a"
+      },
+      "yMMMM hm": {
+        "a": "MMMM y h:mm a – h:mm a",
+        "h": "MMMM y h:mm–h:mm a",
+        "m": "MMMM y h:mm–h:mm a"
+      },
+      "yMMMMd hm": {
+        "a": "d MMMM y h:mm a – h:mm a",
+        "h": "d MMMM y h:mm–h:mm a",
+        "m": "d MMMM y h:mm–h:mm a"
+      },
+      "yMMMMEd hm": {
+        "a": "E d MMMM y h:mm a – h:mm a",
+        "h": "E d MMMM y h:mm–h:mm a",
+        "m": "E d MMMM y h:mm–h:mm a"
+      },
+      "yMMMMEEEEd hm": {
+        "a": "EEEEที่ d MMMM y h:mm a – h:mm a",
+        "h": "EEEEที่ d MMMM y h:mm–h:mm a",
+        "m": "EEEEที่ d MMMM y h:mm–h:mm a"
+      },
+      "EEEEที่ d MMMM G y Hm": {
+        "H": "EEEEที่ d MMMM G y HH:mm น. – HH:mm น.",
+        "m": "EEEEที่ d MMMM G y HH:mm น. – HH:mm น."
+      },
+      "d MMMM G y Hm": {
+        "H": "d MMMM G y HH:mm น. – HH:mm น.",
+        "m": "d MMMM G y HH:mm น. – HH:mm น."
+      },
+      "d MMM y Hm": {
+        "H": "d MMM y HH:mm น. – HH:mm น.",
+        "m": "d MMM y HH:mm น. – HH:mm น."
+      },
+      "d/M/yy Hm": {
+        "H": "d/M/yy HH:mm น. – HH:mm น.",
+        "m": "d/M/yy HH:mm น. – HH:mm น."
+      },
+      "d Hm": {
+        "H": "d HH:mm น. – HH:mm น.",
+        "m": "d HH:mm น. – HH:mm น."
+      },
+      "E Hm": {
+        "H": "ccc HH:mm น. – HH:mm น.",
+        "m": "ccc HH:mm น. – HH:mm น."
+      },
+      "Ed Hm": {
+        "H": "E d HH:mm น. – HH:mm น.",
+        "m": "E d HH:mm น. – HH:mm น."
+      },
+      "Gy Hm": {
+        "H": "G y HH:mm น. – HH:mm น.",
+        "m": "G y HH:mm น. – HH:mm น."
+      },
+      "GyM Hm": {
+        "H": "G y-MM HH:mm น. – HH:mm น.",
+        "m": "G y-MM HH:mm น. – HH:mm น."
+      },
+      "GyMd Hm": {
+        "H": "d/M/GGGGG y HH:mm น. – HH:mm น.",
+        "m": "d/M/GGGGG y HH:mm น. – HH:mm น."
+      },
+      "GyMEd Hm": {
+        "H": "E d/M/G y HH:mm น. – HH:mm น.",
+        "m": "E d/M/G y HH:mm น. – HH:mm น."
+      },
+      "GyMMM Hm": {
+        "H": "MMM G y HH:mm น. – HH:mm น.",
+        "m": "MMM G y HH:mm น. – HH:mm น."
+      },
+      "GyMMMd Hm": {
+        "H": "d MMM G y HH:mm น. – HH:mm น.",
+        "m": "d MMM G y HH:mm น. – HH:mm น."
+      },
+      "GyMMMEd Hm": {
+        "H": "E d MMM G y HH:mm น. – HH:mm น.",
+        "m": "E d MMM G y HH:mm น. – HH:mm น."
+      },
+      "GyMMMEEEEd Hm": {
+        "H": "EEEEที่ d MMM G y HH:mm น. – HH:mm น.",
+        "m": "EEEEที่ d MMM G y HH:mm น. – HH:mm น."
+      },
+      "M Hm": {
+        "H": "L HH:mm น. – HH:mm น.",
+        "m": "L HH:mm น. – HH:mm น."
+      },
+      "Md Hm": {
+        "H": "d/M HH:mm น. – HH:mm น.",
+        "m": "d/M HH:mm น. – HH:mm น."
+      },
+      "MEd Hm": {
+        "H": "E d/M HH:mm น. – HH:mm น.",
+        "m": "E d/M HH:mm น. – HH:mm น."
+      },
+      "MMM Hm": {
+        "H": "LLL HH:mm น. – HH:mm น.",
+        "m": "LLL HH:mm น. – HH:mm น."
+      },
+      "MMMd Hm": {
+        "H": "d MMM HH:mm น. – HH:mm น.",
+        "m": "d MMM HH:mm น. – HH:mm น."
+      },
+      "MMMEd Hm": {
+        "H": "E d MMM HH:mm น. – HH:mm น.",
+        "m": "E d MMM HH:mm น. – HH:mm น."
+      },
+      "MMMEEEEd Hm": {
+        "H": "EEEEที่ d MMM HH:mm น. – HH:mm น.",
+        "m": "EEEEที่ d MMM HH:mm น. – HH:mm น."
+      },
+      "MMMMd Hm": {
+        "H": "d MMMM HH:mm น. – HH:mm น.",
+        "m": "d MMMM HH:mm น. – HH:mm น."
+      },
+      "MMMMEd Hm": {
+        "H": "E d MMMM HH:mm น. – HH:mm น.",
+        "m": "E d MMMM HH:mm น. – HH:mm น."
+      },
+      "MMMMEEEEd Hm": {
+        "H": "EEEEที่ d MMMM HH:mm น. – HH:mm น.",
+        "m": "EEEEที่ d MMMM HH:mm น. – HH:mm น."
+      },
+      "y Hm": {
+        "H": "y HH:mm น. – HH:mm น.",
+        "m": "y HH:mm น. – HH:mm น."
+      },
+      "yM Hm": {
+        "H": "M/y HH:mm น. – HH:mm น.",
+        "m": "M/y HH:mm น. – HH:mm น."
+      },
+      "yMd Hm": {
+        "H": "d/M/y HH:mm น. – HH:mm น.",
+        "m": "d/M/y HH:mm น. – HH:mm น."
+      },
+      "yMEd Hm": {
+        "H": "E d/M/y HH:mm น. – HH:mm น.",
+        "m": "E d/M/y HH:mm น. – HH:mm น."
+      },
+      "yMMM Hm": {
+        "H": "MMM y HH:mm น. – HH:mm น.",
+        "m": "MMM y HH:mm น. – HH:mm น."
+      },
+      "yMMMd Hm": {
+        "H": "d MMM y HH:mm น. – HH:mm น.",
+        "m": "d MMM y HH:mm น. – HH:mm น."
+      },
+      "yMMMEd Hm": {
+        "H": "E d MMM y HH:mm น. – HH:mm น.",
+        "m": "E d MMM y HH:mm น. – HH:mm น."
+      },
+      "yMMMEEEEd Hm": {
+        "H": "EEEEที่ d MMM y HH:mm น. – HH:mm น.",
+        "m": "EEEEที่ d MMM y HH:mm น. – HH:mm น."
+      },
+      "yMMMM Hm": {
+        "H": "MMMM y HH:mm น. – HH:mm น.",
+        "m": "MMMM y HH:mm น. – HH:mm น."
+      },
+      "yMMMMd Hm": {
+        "H": "d MMMM y HH:mm น. – HH:mm น.",
+        "m": "d MMMM y HH:mm น. – HH:mm น."
+      },
+      "yMMMMEd Hm": {
+        "H": "E d MMMM y HH:mm น. – HH:mm น.",
+        "m": "E d MMMM y HH:mm น. – HH:mm น."
+      },
+      "yMMMMEEEEd Hm": {
+        "H": "EEEEที่ d MMMM y HH:mm น. – HH:mm น.",
+        "m": "EEEEที่ d MMMM y HH:mm น. – HH:mm น."
+      },
+      "EEEEที่ d MMMM G y hmv": {
+        "a": "EEEEที่ d MMMM G y h:mm a – h:mm a v",
+        "h": "EEEEที่ d MMMM G y h:mm–h:mm a v",
+        "m": "EEEEที่ d MMMM G y h:mm–h:mm a v"
+      },
+      "d MMMM G y hmv": {
+        "a": "d MMMM G y h:mm a – h:mm a v",
+        "h": "d MMMM G y h:mm–h:mm a v",
+        "m": "d MMMM G y h:mm–h:mm a v"
+      },
+      "d MMM y hmv": {
+        "a": "d MMM y h:mm a – h:mm a v",
+        "h": "d MMM y h:mm–h:mm a v",
+        "m": "d MMM y h:mm–h:mm a v"
+      },
+      "d/M/yy hmv": {
+        "a": "d/M/yy h:mm a – h:mm a v",
+        "h": "d/M/yy h:mm–h:mm a v",
+        "m": "d/M/yy h:mm–h:mm a v"
+      },
+      "d hmv": {
+        "a": "d h:mm a – h:mm a v",
+        "h": "d h:mm–h:mm a v",
+        "m": "d h:mm–h:mm a v"
+      },
+      "E hmv": {
+        "a": "ccc h:mm a – h:mm a v",
+        "h": "ccc h:mm–h:mm a v",
+        "m": "ccc h:mm–h:mm a v"
+      },
+      "Ed hmv": {
+        "a": "E d h:mm a – h:mm a v",
+        "h": "E d h:mm–h:mm a v",
+        "m": "E d h:mm–h:mm a v"
+      },
+      "Gy hmv": {
+        "a": "G y h:mm a – h:mm a v",
+        "h": "G y h:mm–h:mm a v",
+        "m": "G y h:mm–h:mm a v"
+      },
+      "GyM hmv": {
+        "a": "G y-MM h:mm a – h:mm a v",
+        "h": "G y-MM h:mm–h:mm a v",
+        "m": "G y-MM h:mm–h:mm a v"
+      },
+      "GyMd hmv": {
+        "a": "d/M/GGGGG y h:mm a – h:mm a v",
+        "h": "d/M/GGGGG y h:mm–h:mm a v",
+        "m": "d/M/GGGGG y h:mm–h:mm a v"
+      },
+      "GyMEd hmv": {
+        "a": "E d/M/G y h:mm a – h:mm a v",
+        "h": "E d/M/G y h:mm–h:mm a v",
+        "m": "E d/M/G y h:mm–h:mm a v"
+      },
+      "GyMMM hmv": {
+        "a": "MMM G y h:mm a – h:mm a v",
+        "h": "MMM G y h:mm–h:mm a v",
+        "m": "MMM G y h:mm–h:mm a v"
+      },
+      "GyMMMd hmv": {
+        "a": "d MMM G y h:mm a – h:mm a v",
+        "h": "d MMM G y h:mm–h:mm a v",
+        "m": "d MMM G y h:mm–h:mm a v"
+      },
+      "GyMMMEd hmv": {
+        "a": "E d MMM G y h:mm a – h:mm a v",
+        "h": "E d MMM G y h:mm–h:mm a v",
+        "m": "E d MMM G y h:mm–h:mm a v"
+      },
+      "GyMMMEEEEd hmv": {
+        "a": "EEEEที่ d MMM G y h:mm a – h:mm a v",
+        "h": "EEEEที่ d MMM G y h:mm–h:mm a v",
+        "m": "EEEEที่ d MMM G y h:mm–h:mm a v"
+      },
+      "M hmv": {
+        "a": "L h:mm a – h:mm a v",
+        "h": "L h:mm–h:mm a v",
+        "m": "L h:mm–h:mm a v"
+      },
+      "Md hmv": {
+        "a": "d/M h:mm a – h:mm a v",
+        "h": "d/M h:mm–h:mm a v",
+        "m": "d/M h:mm–h:mm a v"
+      },
+      "MEd hmv": {
+        "a": "E d/M h:mm a – h:mm a v",
+        "h": "E d/M h:mm–h:mm a v",
+        "m": "E d/M h:mm–h:mm a v"
+      },
+      "MMM hmv": {
+        "a": "LLL h:mm a – h:mm a v",
+        "h": "LLL h:mm–h:mm a v",
+        "m": "LLL h:mm–h:mm a v"
+      },
+      "MMMd hmv": {
+        "a": "d MMM h:mm a – h:mm a v",
+        "h": "d MMM h:mm–h:mm a v",
+        "m": "d MMM h:mm–h:mm a v"
+      },
+      "MMMEd hmv": {
+        "a": "E d MMM h:mm a – h:mm a v",
+        "h": "E d MMM h:mm–h:mm a v",
+        "m": "E d MMM h:mm–h:mm a v"
+      },
+      "MMMEEEEd hmv": {
+        "a": "EEEEที่ d MMM h:mm a – h:mm a v",
+        "h": "EEEEที่ d MMM h:mm–h:mm a v",
+        "m": "EEEEที่ d MMM h:mm–h:mm a v"
+      },
+      "MMMMd hmv": {
+        "a": "d MMMM h:mm a – h:mm a v",
+        "h": "d MMMM h:mm–h:mm a v",
+        "m": "d MMMM h:mm–h:mm a v"
+      },
+      "MMMMEd hmv": {
+        "a": "E d MMMM h:mm a – h:mm a v",
+        "h": "E d MMMM h:mm–h:mm a v",
+        "m": "E d MMMM h:mm–h:mm a v"
+      },
+      "MMMMEEEEd hmv": {
+        "a": "EEEEที่ d MMMM h:mm a – h:mm a v",
+        "h": "EEEEที่ d MMMM h:mm–h:mm a v",
+        "m": "EEEEที่ d MMMM h:mm–h:mm a v"
+      },
+      "y hmv": {
+        "a": "y h:mm a – h:mm a v",
+        "h": "y h:mm–h:mm a v",
+        "m": "y h:mm–h:mm a v"
+      },
+      "yM hmv": {
+        "a": "M/y h:mm a – h:mm a v",
+        "h": "M/y h:mm–h:mm a v",
+        "m": "M/y h:mm–h:mm a v"
+      },
+      "yMd hmv": {
+        "a": "d/M/y h:mm a – h:mm a v",
+        "h": "d/M/y h:mm–h:mm a v",
+        "m": "d/M/y h:mm–h:mm a v"
+      },
+      "yMEd hmv": {
+        "a": "E d/M/y h:mm a – h:mm a v",
+        "h": "E d/M/y h:mm–h:mm a v",
+        "m": "E d/M/y h:mm–h:mm a v"
+      },
+      "yMMM hmv": {
+        "a": "MMM y h:mm a – h:mm a v",
+        "h": "MMM y h:mm–h:mm a v",
+        "m": "MMM y h:mm–h:mm a v"
+      },
+      "yMMMd hmv": {
+        "a": "d MMM y h:mm a – h:mm a v",
+        "h": "d MMM y h:mm–h:mm a v",
+        "m": "d MMM y h:mm–h:mm a v"
+      },
+      "yMMMEd hmv": {
+        "a": "E d MMM y h:mm a – h:mm a v",
+        "h": "E d MMM y h:mm–h:mm a v",
+        "m": "E d MMM y h:mm–h:mm a v"
+      },
+      "yMMMEEEEd hmv": {
+        "a": "EEEEที่ d MMM y h:mm a – h:mm a v",
+        "h": "EEEEที่ d MMM y h:mm–h:mm a v",
+        "m": "EEEEที่ d MMM y h:mm–h:mm a v"
+      },
+      "yMMMM hmv": {
+        "a": "MMMM y h:mm a – h:mm a v",
+        "h": "MMMM y h:mm–h:mm a v",
+        "m": "MMMM y h:mm–h:mm a v"
+      },
+      "yMMMMd hmv": {
+        "a": "d MMMM y h:mm a – h:mm a v",
+        "h": "d MMMM y h:mm–h:mm a v",
+        "m": "d MMMM y h:mm–h:mm a v"
+      },
+      "yMMMMEd hmv": {
+        "a": "E d MMMM y h:mm a – h:mm a v",
+        "h": "E d MMMM y h:mm–h:mm a v",
+        "m": "E d MMMM y h:mm–h:mm a v"
+      },
+      "yMMMMEEEEd hmv": {
+        "a": "EEEEที่ d MMMM y h:mm a – h:mm a v",
+        "h": "EEEEที่ d MMMM y h:mm–h:mm a v",
+        "m": "EEEEที่ d MMMM y h:mm–h:mm a v"
+      },
+      "EEEEที่ d MMMM G y Hmv": {
+        "H": "EEEEที่ d MMMM G y H:mm น. – H:mm น. v",
+        "m": "EEEEที่ d MMMM G y H:mm น. – H:mm น. v"
+      },
+      "d MMMM G y Hmv": {
+        "H": "d MMMM G y H:mm น. – H:mm น. v",
+        "m": "d MMMM G y H:mm น. – H:mm น. v"
+      },
+      "d MMM y Hmv": {
+        "H": "d MMM y H:mm น. – H:mm น. v",
+        "m": "d MMM y H:mm น. – H:mm น. v"
+      },
+      "d/M/yy Hmv": {
+        "H": "d/M/yy H:mm น. – H:mm น. v",
+        "m": "d/M/yy H:mm น. – H:mm น. v"
+      },
+      "d Hmv": {
+        "H": "d H:mm น. – H:mm น. v",
+        "m": "d H:mm น. – H:mm น. v"
+      },
+      "E Hmv": {
+        "H": "ccc H:mm น. – H:mm น. v",
+        "m": "ccc H:mm น. – H:mm น. v"
+      },
+      "Ed Hmv": {
+        "H": "E d H:mm น. – H:mm น. v",
+        "m": "E d H:mm น. – H:mm น. v"
+      },
+      "Gy Hmv": {
+        "H": "G y H:mm น. – H:mm น. v",
+        "m": "G y H:mm น. – H:mm น. v"
+      },
+      "GyM Hmv": {
+        "H": "G y-MM H:mm น. – H:mm น. v",
+        "m": "G y-MM H:mm น. – H:mm น. v"
+      },
+      "GyMd Hmv": {
+        "H": "d/M/GGGGG y H:mm น. – H:mm น. v",
+        "m": "d/M/GGGGG y H:mm น. – H:mm น. v"
+      },
+      "GyMEd Hmv": {
+        "H": "E d/M/G y H:mm น. – H:mm น. v",
+        "m": "E d/M/G y H:mm น. – H:mm น. v"
+      },
+      "GyMMM Hmv": {
+        "H": "MMM G y H:mm น. – H:mm น. v",
+        "m": "MMM G y H:mm น. – H:mm น. v"
+      },
+      "GyMMMd Hmv": {
+        "H": "d MMM G y H:mm น. – H:mm น. v",
+        "m": "d MMM G y H:mm น. – H:mm น. v"
+      },
+      "GyMMMEd Hmv": {
+        "H": "E d MMM G y H:mm น. – H:mm น. v",
+        "m": "E d MMM G y H:mm น. – H:mm น. v"
+      },
+      "GyMMMEEEEd Hmv": {
+        "H": "EEEEที่ d MMM G y H:mm น. – H:mm น. v",
+        "m": "EEEEที่ d MMM G y H:mm น. – H:mm น. v"
+      },
+      "M Hmv": {
+        "H": "L H:mm น. – H:mm น. v",
+        "m": "L H:mm น. – H:mm น. v"
+      },
+      "Md Hmv": {
+        "H": "d/M H:mm น. – H:mm น. v",
+        "m": "d/M H:mm น. – H:mm น. v"
+      },
+      "MEd Hmv": {
+        "H": "E d/M H:mm น. – H:mm น. v",
+        "m": "E d/M H:mm น. – H:mm น. v"
+      },
+      "MMM Hmv": {
+        "H": "LLL H:mm น. – H:mm น. v",
+        "m": "LLL H:mm น. – H:mm น. v"
+      },
+      "MMMd Hmv": {
+        "H": "d MMM H:mm น. – H:mm น. v",
+        "m": "d MMM H:mm น. – H:mm น. v"
+      },
+      "MMMEd Hmv": {
+        "H": "E d MMM H:mm น. – H:mm น. v",
+        "m": "E d MMM H:mm น. – H:mm น. v"
+      },
+      "MMMEEEEd Hmv": {
+        "H": "EEEEที่ d MMM H:mm น. – H:mm น. v",
+        "m": "EEEEที่ d MMM H:mm น. – H:mm น. v"
+      },
+      "MMMMd Hmv": {
+        "H": "d MMMM H:mm น. – H:mm น. v",
+        "m": "d MMMM H:mm น. – H:mm น. v"
+      },
+      "MMMMEd Hmv": {
+        "H": "E d MMMM H:mm น. – H:mm น. v",
+        "m": "E d MMMM H:mm น. – H:mm น. v"
+      },
+      "MMMMEEEEd Hmv": {
+        "H": "EEEEที่ d MMMM H:mm น. – H:mm น. v",
+        "m": "EEEEที่ d MMMM H:mm น. – H:mm น. v"
+      },
+      "y Hmv": {
+        "H": "y H:mm น. – H:mm น. v",
+        "m": "y H:mm น. – H:mm น. v"
+      },
+      "yM Hmv": {
+        "H": "M/y H:mm น. – H:mm น. v",
+        "m": "M/y H:mm น. – H:mm น. v"
+      },
+      "yMd Hmv": {
+        "H": "d/M/y H:mm น. – H:mm น. v",
+        "m": "d/M/y H:mm น. – H:mm น. v"
+      },
+      "yMEd Hmv": {
+        "H": "E d/M/y H:mm น. – H:mm น. v",
+        "m": "E d/M/y H:mm น. – H:mm น. v"
+      },
+      "yMMM Hmv": {
+        "H": "MMM y H:mm น. – H:mm น. v",
+        "m": "MMM y H:mm น. – H:mm น. v"
+      },
+      "yMMMd Hmv": {
+        "H": "d MMM y H:mm น. – H:mm น. v",
+        "m": "d MMM y H:mm น. – H:mm น. v"
+      },
+      "yMMMEd Hmv": {
+        "H": "E d MMM y H:mm น. – H:mm น. v",
+        "m": "E d MMM y H:mm น. – H:mm น. v"
+      },
+      "yMMMEEEEd Hmv": {
+        "H": "EEEEที่ d MMM y H:mm น. – H:mm น. v",
+        "m": "EEEEที่ d MMM y H:mm น. – H:mm น. v"
+      },
+      "yMMMM Hmv": {
+        "H": "MMMM y H:mm น. – H:mm น. v",
+        "m": "MMMM y H:mm น. – H:mm น. v"
+      },
+      "yMMMMd Hmv": {
+        "H": "d MMMM y H:mm น. – H:mm น. v",
+        "m": "d MMMM y H:mm น. – H:mm น. v"
+      },
+      "yMMMMEd Hmv": {
+        "H": "E d MMMM y H:mm น. – H:mm น. v",
+        "m": "E d MMMM y H:mm น. – H:mm น. v"
+      },
+      "yMMMMEEEEd Hmv": {
+        "H": "EEEEที่ d MMMM y H:mm น. – H:mm น. v",
+        "m": "EEEEที่ d MMMM y H:mm น. – H:mm น. v"
+      },
+      "EEEEที่ d MMMM G y hv": {
+        "a": "EEEEที่ d MMMM G y h a – h a v",
+        "h": "EEEEที่ d MMMM G y h–h a v"
+      },
+      "d MMMM G y hv": {
+        "a": "d MMMM G y h a – h a v",
+        "h": "d MMMM G y h–h a v"
+      },
+      "d MMM y hv": {
+        "a": "d MMM y h a – h a v",
+        "h": "d MMM y h–h a v"
+      },
+      "d/M/yy hv": {
+        "a": "d/M/yy h a – h a v",
+        "h": "d/M/yy h–h a v"
+      },
+      "d hv": {
+        "a": "d h a – h a v",
+        "h": "d h–h a v"
+      },
+      "E hv": {
+        "a": "ccc h a – h a v",
+        "h": "ccc h–h a v"
+      },
+      "Ed hv": {
+        "a": "E d h a – h a v",
+        "h": "E d h–h a v"
+      },
+      "Gy hv": {
+        "a": "G y h a – h a v",
+        "h": "G y h–h a v"
+      },
+      "GyM hv": {
+        "a": "G y-MM h a – h a v",
+        "h": "G y-MM h–h a v"
+      },
+      "GyMd hv": {
+        "a": "d/M/GGGGG y h a – h a v",
+        "h": "d/M/GGGGG y h–h a v"
+      },
+      "GyMEd hv": {
+        "a": "E d/M/G y h a – h a v",
+        "h": "E d/M/G y h–h a v"
+      },
+      "GyMMM hv": {
+        "a": "MMM G y h a – h a v",
+        "h": "MMM G y h–h a v"
+      },
+      "GyMMMd hv": {
+        "a": "d MMM G y h a – h a v",
+        "h": "d MMM G y h–h a v"
+      },
+      "GyMMMEd hv": {
+        "a": "E d MMM G y h a – h a v",
+        "h": "E d MMM G y h–h a v"
+      },
+      "GyMMMEEEEd hv": {
+        "a": "EEEEที่ d MMM G y h a – h a v",
+        "h": "EEEEที่ d MMM G y h–h a v"
+      },
+      "M hv": {
+        "a": "L h a – h a v",
+        "h": "L h–h a v"
+      },
+      "Md hv": {
+        "a": "d/M h a – h a v",
+        "h": "d/M h–h a v"
+      },
+      "MEd hv": {
+        "a": "E d/M h a – h a v",
+        "h": "E d/M h–h a v"
+      },
+      "MMM hv": {
+        "a": "LLL h a – h a v",
+        "h": "LLL h–h a v"
+      },
+      "MMMd hv": {
+        "a": "d MMM h a – h a v",
+        "h": "d MMM h–h a v"
+      },
+      "MMMEd hv": {
+        "a": "E d MMM h a – h a v",
+        "h": "E d MMM h–h a v"
+      },
+      "MMMEEEEd hv": {
+        "a": "EEEEที่ d MMM h a – h a v",
+        "h": "EEEEที่ d MMM h–h a v"
+      },
+      "MMMMd hv": {
+        "a": "d MMMM h a – h a v",
+        "h": "d MMMM h–h a v"
+      },
+      "MMMMEd hv": {
+        "a": "E d MMMM h a – h a v",
+        "h": "E d MMMM h–h a v"
+      },
+      "MMMMEEEEd hv": {
+        "a": "EEEEที่ d MMMM h a – h a v",
+        "h": "EEEEที่ d MMMM h–h a v"
+      },
+      "y hv": {
+        "a": "y h a – h a v",
+        "h": "y h–h a v"
+      },
+      "yM hv": {
+        "a": "M/y h a – h a v",
+        "h": "M/y h–h a v"
+      },
+      "yMd hv": {
+        "a": "d/M/y h a – h a v",
+        "h": "d/M/y h–h a v"
+      },
+      "yMEd hv": {
+        "a": "E d/M/y h a – h a v",
+        "h": "E d/M/y h–h a v"
+      },
+      "yMMM hv": {
+        "a": "MMM y h a – h a v",
+        "h": "MMM y h–h a v"
+      },
+      "yMMMd hv": {
+        "a": "d MMM y h a – h a v",
+        "h": "d MMM y h–h a v"
+      },
+      "yMMMEd hv": {
+        "a": "E d MMM y h a – h a v",
+        "h": "E d MMM y h–h a v"
+      },
+      "yMMMEEEEd hv": {
+        "a": "EEEEที่ d MMM y h a – h a v",
+        "h": "EEEEที่ d MMM y h–h a v"
+      },
+      "yMMMM hv": {
+        "a": "MMMM y h a – h a v",
+        "h": "MMMM y h–h a v"
+      },
+      "yMMMMd hv": {
+        "a": "d MMMM y h a – h a v",
+        "h": "d MMMM y h–h a v"
+      },
+      "yMMMMEd hv": {
+        "a": "E d MMMM y h a – h a v",
+        "h": "E d MMMM y h–h a v"
+      },
+      "yMMMMEEEEd hv": {
+        "a": "EEEEที่ d MMMM y h a – h a v",
+        "h": "EEEEที่ d MMMM y h–h a v"
+      },
+      "EEEEที่ d MMMM G y Hv": {
+        "H": "EEEEที่ d MMMM G y HH–HH v"
+      },
+      "d MMMM G y Hv": {
+        "H": "d MMMM G y HH–HH v"
+      },
+      "d MMM y Hv": {
+        "H": "d MMM y HH–HH v"
+      },
+      "d/M/yy Hv": {
+        "H": "d/M/yy HH–HH v"
+      },
+      "d Hv": {
+        "H": "d HH–HH v"
+      },
+      "E Hv": {
+        "H": "ccc HH–HH v"
+      },
+      "Ed Hv": {
+        "H": "E d HH–HH v"
+      },
+      "Gy Hv": {
+        "H": "G y HH–HH v"
+      },
+      "GyM Hv": {
+        "H": "G y-MM HH–HH v"
+      },
+      "GyMd Hv": {
+        "H": "d/M/GGGGG y HH–HH v"
+      },
+      "GyMEd Hv": {
+        "H": "E d/M/G y HH–HH v"
+      },
+      "GyMMM Hv": {
+        "H": "MMM G y HH–HH v"
+      },
+      "GyMMMd Hv": {
+        "H": "d MMM G y HH–HH v"
+      },
+      "GyMMMEd Hv": {
+        "H": "E d MMM G y HH–HH v"
+      },
+      "GyMMMEEEEd Hv": {
+        "H": "EEEEที่ d MMM G y HH–HH v"
+      },
+      "M Hv": {
+        "H": "L HH–HH v"
+      },
+      "Md Hv": {
+        "H": "d/M HH–HH v"
+      },
+      "MEd Hv": {
+        "H": "E d/M HH–HH v"
+      },
+      "MMM Hv": {
+        "H": "LLL HH–HH v"
+      },
+      "MMMd Hv": {
+        "H": "d MMM HH–HH v"
+      },
+      "MMMEd Hv": {
+        "H": "E d MMM HH–HH v"
+      },
+      "MMMEEEEd Hv": {
+        "H": "EEEEที่ d MMM HH–HH v"
+      },
+      "MMMMd Hv": {
+        "H": "d MMMM HH–HH v"
+      },
+      "MMMMEd Hv": {
+        "H": "E d MMMM HH–HH v"
+      },
+      "MMMMEEEEd Hv": {
+        "H": "EEEEที่ d MMMM HH–HH v"
+      },
+      "y Hv": {
+        "H": "y HH–HH v"
+      },
+      "yM Hv": {
+        "H": "M/y HH–HH v"
+      },
+      "yMd Hv": {
+        "H": "d/M/y HH–HH v"
+      },
+      "yMEd Hv": {
+        "H": "E d/M/y HH–HH v"
+      },
+      "yMMM Hv": {
+        "H": "MMM y HH–HH v"
+      },
+      "yMMMd Hv": {
+        "H": "d MMM y HH–HH v"
+      },
+      "yMMMEd Hv": {
+        "H": "E d MMM y HH–HH v"
+      },
+      "yMMMEEEEd Hv": {
+        "H": "EEEEที่ d MMM y HH–HH v"
+      },
+      "yMMMM Hv": {
+        "H": "MMMM y HH–HH v"
+      },
+      "yMMMMd Hv": {
+        "H": "d MMMM y HH–HH v"
+      },
+      "yMMMMEd Hv": {
+        "H": "E d MMMM y HH–HH v"
+      },
+      "yMMMMEEEEd Hv": {
+        "H": "EEEEที่ d MMMM y HH–HH v"
       }
     },
     "hourCycle": "h23",
@@ -19406,6 +27729,1277 @@ Intl.DateTimeFormat.__addLocaleData({
       "yMMMM": {
         "M": "y年M月 – M月",
         "y": "y年M月 – y年M月"
+      },
+      "y年M月d日EEEE Bh": {
+        "B": "y年M月d日EEEE Bh时至Bh时",
+        "h": "y年M月d日EEEE Bh时至h时"
+      },
+      "y年M月d日 Bh": {
+        "B": "y年M月d日 Bh时至Bh时",
+        "h": "y年M月d日 Bh时至h时"
+      },
+      "y/M/d Bh": {
+        "B": "y/M/d Bh时至Bh时",
+        "h": "y/M/d Bh时至h时"
+      },
+      "d Bh": {
+        "B": "d日 Bh时至Bh时",
+        "h": "d日 Bh时至h时"
+      },
+      "E Bh": {
+        "B": "ccc Bh时至Bh时",
+        "h": "ccc Bh时至h时"
+      },
+      "Ed Bh": {
+        "B": "d日E Bh时至Bh时",
+        "h": "d日E Bh时至h时"
+      },
+      "Gy Bh": {
+        "B": "Gy年 Bh时至Bh时",
+        "h": "Gy年 Bh时至h时"
+      },
+      "GyM Bh": {
+        "B": "Gy年M月 Bh时至Bh时",
+        "h": "Gy年M月 Bh时至h时"
+      },
+      "GyMd Bh": {
+        "B": "Gy-MM-dd Bh时至Bh时",
+        "h": "Gy-MM-dd Bh时至h时"
+      },
+      "GyMEd Bh": {
+        "B": "Gy-MM-ddE Bh时至Bh时",
+        "h": "Gy-MM-ddE Bh时至h时"
+      },
+      "GyMMM Bh": {
+        "B": "Gy年M月 Bh时至Bh时",
+        "h": "Gy年M月 Bh时至h时"
+      },
+      "GyMMMd Bh": {
+        "B": "Gy年M月d日 Bh时至Bh时",
+        "h": "Gy年M月d日 Bh时至h时"
+      },
+      "GyMMMEd Bh": {
+        "B": "Gy年M月d日E Bh时至Bh时",
+        "h": "Gy年M月d日E Bh时至h时"
+      },
+      "M Bh": {
+        "B": "M月 Bh时至Bh时",
+        "h": "M月 Bh时至h时"
+      },
+      "Md Bh": {
+        "B": "M/d Bh时至Bh时",
+        "h": "M/d Bh时至h时"
+      },
+      "MEd Bh": {
+        "B": "M/dE Bh时至Bh时",
+        "h": "M/dE Bh时至h时"
+      },
+      "MMdd Bh": {
+        "B": "MM/dd Bh时至Bh时",
+        "h": "MM/dd Bh时至h时"
+      },
+      "MMM Bh": {
+        "B": "LLL Bh时至Bh时",
+        "h": "LLL Bh时至h时"
+      },
+      "MMMd Bh": {
+        "B": "M月d日 Bh时至Bh时",
+        "h": "M月d日 Bh时至h时"
+      },
+      "MMMEd Bh": {
+        "B": "M月d日E Bh时至Bh时",
+        "h": "M月d日E Bh时至h时"
+      },
+      "MMMMd Bh": {
+        "B": "M月d日 Bh时至Bh时",
+        "h": "M月d日 Bh时至h时"
+      },
+      "y Bh": {
+        "B": "y年 Bh时至Bh时",
+        "h": "y年 Bh时至h时"
+      },
+      "yM Bh": {
+        "B": "y/M Bh时至Bh时",
+        "h": "y/M Bh时至h时"
+      },
+      "yMd Bh": {
+        "B": "y/M/d Bh时至Bh时",
+        "h": "y/M/d Bh时至h时"
+      },
+      "yMEd Bh": {
+        "B": "y/M/dE Bh时至Bh时",
+        "h": "y/M/dE Bh时至h时"
+      },
+      "yMEEEEd Bh": {
+        "B": "y年M月d日EEEE Bh时至Bh时",
+        "h": "y年M月d日EEEE Bh时至h时"
+      },
+      "yMM Bh": {
+        "B": "y年M月 Bh时至Bh时",
+        "h": "y年M月 Bh时至h时"
+      },
+      "yMMM Bh": {
+        "B": "y年M月 Bh时至Bh时",
+        "h": "y年M月 Bh时至h时"
+      },
+      "yMMMd Bh": {
+        "B": "y年M月d日 Bh时至Bh时",
+        "h": "y年M月d日 Bh时至h时"
+      },
+      "yMMMEd Bh": {
+        "B": "y年M月d日E Bh时至Bh时",
+        "h": "y年M月d日E Bh时至h时"
+      },
+      "yMMMM Bh": {
+        "B": "y年M月 Bh时至Bh时",
+        "h": "y年M月 Bh时至h时"
+      },
+      "y年M月d日EEEE Bhm": {
+        "B": "y年M月d日EEEE Bh:mm至Bh:mm",
+        "h": "y年M月d日EEEE Bh:mm至h:mm",
+        "m": "y年M月d日EEEE Bh:mm至h:mm"
+      },
+      "y年M月d日 Bhm": {
+        "B": "y年M月d日 Bh:mm至Bh:mm",
+        "h": "y年M月d日 Bh:mm至h:mm",
+        "m": "y年M月d日 Bh:mm至h:mm"
+      },
+      "y/M/d Bhm": {
+        "B": "y/M/d Bh:mm至Bh:mm",
+        "h": "y/M/d Bh:mm至h:mm",
+        "m": "y/M/d Bh:mm至h:mm"
+      },
+      "d Bhm": {
+        "B": "d日 Bh:mm至Bh:mm",
+        "h": "d日 Bh:mm至h:mm",
+        "m": "d日 Bh:mm至h:mm"
+      },
+      "E Bhm": {
+        "B": "ccc Bh:mm至Bh:mm",
+        "h": "ccc Bh:mm至h:mm",
+        "m": "ccc Bh:mm至h:mm"
+      },
+      "Ed Bhm": {
+        "B": "d日E Bh:mm至Bh:mm",
+        "h": "d日E Bh:mm至h:mm",
+        "m": "d日E Bh:mm至h:mm"
+      },
+      "Gy Bhm": {
+        "B": "Gy年 Bh:mm至Bh:mm",
+        "h": "Gy年 Bh:mm至h:mm",
+        "m": "Gy年 Bh:mm至h:mm"
+      },
+      "GyM Bhm": {
+        "B": "Gy年M月 Bh:mm至Bh:mm",
+        "h": "Gy年M月 Bh:mm至h:mm",
+        "m": "Gy年M月 Bh:mm至h:mm"
+      },
+      "GyMd Bhm": {
+        "B": "Gy-MM-dd Bh:mm至Bh:mm",
+        "h": "Gy-MM-dd Bh:mm至h:mm",
+        "m": "Gy-MM-dd Bh:mm至h:mm"
+      },
+      "GyMEd Bhm": {
+        "B": "Gy-MM-ddE Bh:mm至Bh:mm",
+        "h": "Gy-MM-ddE Bh:mm至h:mm",
+        "m": "Gy-MM-ddE Bh:mm至h:mm"
+      },
+      "GyMMM Bhm": {
+        "B": "Gy年M月 Bh:mm至Bh:mm",
+        "h": "Gy年M月 Bh:mm至h:mm",
+        "m": "Gy年M月 Bh:mm至h:mm"
+      },
+      "GyMMMd Bhm": {
+        "B": "Gy年M月d日 Bh:mm至Bh:mm",
+        "h": "Gy年M月d日 Bh:mm至h:mm",
+        "m": "Gy年M月d日 Bh:mm至h:mm"
+      },
+      "GyMMMEd Bhm": {
+        "B": "Gy年M月d日E Bh:mm至Bh:mm",
+        "h": "Gy年M月d日E Bh:mm至h:mm",
+        "m": "Gy年M月d日E Bh:mm至h:mm"
+      },
+      "M Bhm": {
+        "B": "M月 Bh:mm至Bh:mm",
+        "h": "M月 Bh:mm至h:mm",
+        "m": "M月 Bh:mm至h:mm"
+      },
+      "Md Bhm": {
+        "B": "M/d Bh:mm至Bh:mm",
+        "h": "M/d Bh:mm至h:mm",
+        "m": "M/d Bh:mm至h:mm"
+      },
+      "MEd Bhm": {
+        "B": "M/dE Bh:mm至Bh:mm",
+        "h": "M/dE Bh:mm至h:mm",
+        "m": "M/dE Bh:mm至h:mm"
+      },
+      "MMdd Bhm": {
+        "B": "MM/dd Bh:mm至Bh:mm",
+        "h": "MM/dd Bh:mm至h:mm",
+        "m": "MM/dd Bh:mm至h:mm"
+      },
+      "MMM Bhm": {
+        "B": "LLL Bh:mm至Bh:mm",
+        "h": "LLL Bh:mm至h:mm",
+        "m": "LLL Bh:mm至h:mm"
+      },
+      "MMMd Bhm": {
+        "B": "M月d日 Bh:mm至Bh:mm",
+        "h": "M月d日 Bh:mm至h:mm",
+        "m": "M月d日 Bh:mm至h:mm"
+      },
+      "MMMEd Bhm": {
+        "B": "M月d日E Bh:mm至Bh:mm",
+        "h": "M月d日E Bh:mm至h:mm",
+        "m": "M月d日E Bh:mm至h:mm"
+      },
+      "MMMMd Bhm": {
+        "B": "M月d日 Bh:mm至Bh:mm",
+        "h": "M月d日 Bh:mm至h:mm",
+        "m": "M月d日 Bh:mm至h:mm"
+      },
+      "y Bhm": {
+        "B": "y年 Bh:mm至Bh:mm",
+        "h": "y年 Bh:mm至h:mm",
+        "m": "y年 Bh:mm至h:mm"
+      },
+      "yM Bhm": {
+        "B": "y/M Bh:mm至Bh:mm",
+        "h": "y/M Bh:mm至h:mm",
+        "m": "y/M Bh:mm至h:mm"
+      },
+      "yMd Bhm": {
+        "B": "y/M/d Bh:mm至Bh:mm",
+        "h": "y/M/d Bh:mm至h:mm",
+        "m": "y/M/d Bh:mm至h:mm"
+      },
+      "yMEd Bhm": {
+        "B": "y/M/dE Bh:mm至Bh:mm",
+        "h": "y/M/dE Bh:mm至h:mm",
+        "m": "y/M/dE Bh:mm至h:mm"
+      },
+      "yMEEEEd Bhm": {
+        "B": "y年M月d日EEEE Bh:mm至Bh:mm",
+        "h": "y年M月d日EEEE Bh:mm至h:mm",
+        "m": "y年M月d日EEEE Bh:mm至h:mm"
+      },
+      "yMM Bhm": {
+        "B": "y年M月 Bh:mm至Bh:mm",
+        "h": "y年M月 Bh:mm至h:mm",
+        "m": "y年M月 Bh:mm至h:mm"
+      },
+      "yMMM Bhm": {
+        "B": "y年M月 Bh:mm至Bh:mm",
+        "h": "y年M月 Bh:mm至h:mm",
+        "m": "y年M月 Bh:mm至h:mm"
+      },
+      "yMMMd Bhm": {
+        "B": "y年M月d日 Bh:mm至Bh:mm",
+        "h": "y年M月d日 Bh:mm至h:mm",
+        "m": "y年M月d日 Bh:mm至h:mm"
+      },
+      "yMMMEd Bhm": {
+        "B": "y年M月d日E Bh:mm至Bh:mm",
+        "h": "y年M月d日E Bh:mm至h:mm",
+        "m": "y年M月d日E Bh:mm至h:mm"
+      },
+      "yMMMM Bhm": {
+        "B": "y年M月 Bh:mm至Bh:mm",
+        "h": "y年M月 Bh:mm至h:mm",
+        "m": "y年M月 Bh:mm至h:mm"
+      },
+      "y年M月d日EEEE h": {
+        "a": "y年M月d日EEEE ah时至ah时",
+        "h": "y年M月d日EEEE ah时至h时"
+      },
+      "y年M月d日 h": {
+        "a": "y年M月d日 ah时至ah时",
+        "h": "y年M月d日 ah时至h时"
+      },
+      "y/M/d h": {
+        "a": "y/M/d ah时至ah时",
+        "h": "y/M/d ah时至h时"
+      },
+      "d h": {
+        "a": "d日 ah时至ah时",
+        "h": "d日 ah时至h时"
+      },
+      "E h": {
+        "a": "ccc ah时至ah时",
+        "h": "ccc ah时至h时"
+      },
+      "Ed h": {
+        "a": "d日E ah时至ah时",
+        "h": "d日E ah时至h时"
+      },
+      "Gy h": {
+        "a": "Gy年 ah时至ah时",
+        "h": "Gy年 ah时至h时"
+      },
+      "GyM h": {
+        "a": "Gy年M月 ah时至ah时",
+        "h": "Gy年M月 ah时至h时"
+      },
+      "GyMd h": {
+        "a": "Gy-MM-dd ah时至ah时",
+        "h": "Gy-MM-dd ah时至h时"
+      },
+      "GyMEd h": {
+        "a": "Gy-MM-ddE ah时至ah时",
+        "h": "Gy-MM-ddE ah时至h时"
+      },
+      "GyMMM h": {
+        "a": "Gy年M月 ah时至ah时",
+        "h": "Gy年M月 ah时至h时"
+      },
+      "GyMMMd h": {
+        "a": "Gy年M月d日 ah时至ah时",
+        "h": "Gy年M月d日 ah时至h时"
+      },
+      "GyMMMEd h": {
+        "a": "Gy年M月d日E ah时至ah时",
+        "h": "Gy年M月d日E ah时至h时"
+      },
+      "M h": {
+        "a": "M月 ah时至ah时",
+        "h": "M月 ah时至h时"
+      },
+      "Md h": {
+        "a": "M/d ah时至ah时",
+        "h": "M/d ah时至h时"
+      },
+      "MEd h": {
+        "a": "M/dE ah时至ah时",
+        "h": "M/dE ah时至h时"
+      },
+      "MMdd h": {
+        "a": "MM/dd ah时至ah时",
+        "h": "MM/dd ah时至h时"
+      },
+      "MMM h": {
+        "a": "LLL ah时至ah时",
+        "h": "LLL ah时至h时"
+      },
+      "MMMd h": {
+        "a": "M月d日 ah时至ah时",
+        "h": "M月d日 ah时至h时"
+      },
+      "MMMEd h": {
+        "a": "M月d日E ah时至ah时",
+        "h": "M月d日E ah时至h时"
+      },
+      "MMMMd h": {
+        "a": "M月d日 ah时至ah时",
+        "h": "M月d日 ah时至h时"
+      },
+      "y h": {
+        "a": "y年 ah时至ah时",
+        "h": "y年 ah时至h时"
+      },
+      "yM h": {
+        "a": "y/M ah时至ah时",
+        "h": "y/M ah时至h时"
+      },
+      "yMd h": {
+        "a": "y/M/d ah时至ah时",
+        "h": "y/M/d ah时至h时"
+      },
+      "yMEd h": {
+        "a": "y/M/dE ah时至ah时",
+        "h": "y/M/dE ah时至h时"
+      },
+      "yMEEEEd h": {
+        "a": "y年M月d日EEEE ah时至ah时",
+        "h": "y年M月d日EEEE ah时至h时"
+      },
+      "yMM h": {
+        "a": "y年M月 ah时至ah时",
+        "h": "y年M月 ah时至h时"
+      },
+      "yMMM h": {
+        "a": "y年M月 ah时至ah时",
+        "h": "y年M月 ah时至h时"
+      },
+      "yMMMd h": {
+        "a": "y年M月d日 ah时至ah时",
+        "h": "y年M月d日 ah时至h时"
+      },
+      "yMMMEd h": {
+        "a": "y年M月d日E ah时至ah时",
+        "h": "y年M月d日E ah时至h时"
+      },
+      "yMMMM h": {
+        "a": "y年M月 ah时至ah时",
+        "h": "y年M月 ah时至h时"
+      },
+      "y年M月d日EEEE H": {
+        "H": "y年M月d日EEEE HH–HH"
+      },
+      "y年M月d日 H": {
+        "H": "y年M月d日 HH–HH"
+      },
+      "y/M/d H": {
+        "H": "y/M/d HH–HH"
+      },
+      "d H": {
+        "H": "d日 HH–HH"
+      },
+      "E H": {
+        "H": "ccc HH–HH"
+      },
+      "Ed H": {
+        "H": "d日E HH–HH"
+      },
+      "Gy H": {
+        "H": "Gy年 HH–HH"
+      },
+      "GyM H": {
+        "H": "Gy年M月 HH–HH"
+      },
+      "GyMd H": {
+        "H": "Gy-MM-dd HH–HH"
+      },
+      "GyMEd H": {
+        "H": "Gy-MM-ddE HH–HH"
+      },
+      "GyMMM H": {
+        "H": "Gy年M月 HH–HH"
+      },
+      "GyMMMd H": {
+        "H": "Gy年M月d日 HH–HH"
+      },
+      "GyMMMEd H": {
+        "H": "Gy年M月d日E HH–HH"
+      },
+      "M H": {
+        "H": "M月 HH–HH"
+      },
+      "Md H": {
+        "H": "M/d HH–HH"
+      },
+      "MEd H": {
+        "H": "M/dE HH–HH"
+      },
+      "MMdd H": {
+        "H": "MM/dd HH–HH"
+      },
+      "MMM H": {
+        "H": "LLL HH–HH"
+      },
+      "MMMd H": {
+        "H": "M月d日 HH–HH"
+      },
+      "MMMEd H": {
+        "H": "M月d日E HH–HH"
+      },
+      "MMMMd H": {
+        "H": "M月d日 HH–HH"
+      },
+      "y H": {
+        "H": "y年 HH–HH"
+      },
+      "yM H": {
+        "H": "y/M HH–HH"
+      },
+      "yMd H": {
+        "H": "y/M/d HH–HH"
+      },
+      "yMEd H": {
+        "H": "y/M/dE HH–HH"
+      },
+      "yMEEEEd H": {
+        "H": "y年M月d日EEEE HH–HH"
+      },
+      "yMM H": {
+        "H": "y年M月 HH–HH"
+      },
+      "yMMM H": {
+        "H": "y年M月 HH–HH"
+      },
+      "yMMMd H": {
+        "H": "y年M月d日 HH–HH"
+      },
+      "yMMMEd H": {
+        "H": "y年M月d日E HH–HH"
+      },
+      "yMMMM H": {
+        "H": "y年M月 HH–HH"
+      },
+      "y年M月d日EEEE hm": {
+        "a": "y年M月d日EEEE ah:mm至ah:mm",
+        "h": "y年M月d日EEEE ah:mm至h:mm",
+        "m": "y年M月d日EEEE ah:mm至h:mm"
+      },
+      "y年M月d日 hm": {
+        "a": "y年M月d日 ah:mm至ah:mm",
+        "h": "y年M月d日 ah:mm至h:mm",
+        "m": "y年M月d日 ah:mm至h:mm"
+      },
+      "y/M/d hm": {
+        "a": "y/M/d ah:mm至ah:mm",
+        "h": "y/M/d ah:mm至h:mm",
+        "m": "y/M/d ah:mm至h:mm"
+      },
+      "d hm": {
+        "a": "d日 ah:mm至ah:mm",
+        "h": "d日 ah:mm至h:mm",
+        "m": "d日 ah:mm至h:mm"
+      },
+      "E hm": {
+        "a": "ccc ah:mm至ah:mm",
+        "h": "ccc ah:mm至h:mm",
+        "m": "ccc ah:mm至h:mm"
+      },
+      "Ed hm": {
+        "a": "d日E ah:mm至ah:mm",
+        "h": "d日E ah:mm至h:mm",
+        "m": "d日E ah:mm至h:mm"
+      },
+      "Gy hm": {
+        "a": "Gy年 ah:mm至ah:mm",
+        "h": "Gy年 ah:mm至h:mm",
+        "m": "Gy年 ah:mm至h:mm"
+      },
+      "GyM hm": {
+        "a": "Gy年M月 ah:mm至ah:mm",
+        "h": "Gy年M月 ah:mm至h:mm",
+        "m": "Gy年M月 ah:mm至h:mm"
+      },
+      "GyMd hm": {
+        "a": "Gy-MM-dd ah:mm至ah:mm",
+        "h": "Gy-MM-dd ah:mm至h:mm",
+        "m": "Gy-MM-dd ah:mm至h:mm"
+      },
+      "GyMEd hm": {
+        "a": "Gy-MM-ddE ah:mm至ah:mm",
+        "h": "Gy-MM-ddE ah:mm至h:mm",
+        "m": "Gy-MM-ddE ah:mm至h:mm"
+      },
+      "GyMMM hm": {
+        "a": "Gy年M月 ah:mm至ah:mm",
+        "h": "Gy年M月 ah:mm至h:mm",
+        "m": "Gy年M月 ah:mm至h:mm"
+      },
+      "GyMMMd hm": {
+        "a": "Gy年M月d日 ah:mm至ah:mm",
+        "h": "Gy年M月d日 ah:mm至h:mm",
+        "m": "Gy年M月d日 ah:mm至h:mm"
+      },
+      "GyMMMEd hm": {
+        "a": "Gy年M月d日E ah:mm至ah:mm",
+        "h": "Gy年M月d日E ah:mm至h:mm",
+        "m": "Gy年M月d日E ah:mm至h:mm"
+      },
+      "M hm": {
+        "a": "M月 ah:mm至ah:mm",
+        "h": "M月 ah:mm至h:mm",
+        "m": "M月 ah:mm至h:mm"
+      },
+      "Md hm": {
+        "a": "M/d ah:mm至ah:mm",
+        "h": "M/d ah:mm至h:mm",
+        "m": "M/d ah:mm至h:mm"
+      },
+      "MEd hm": {
+        "a": "M/dE ah:mm至ah:mm",
+        "h": "M/dE ah:mm至h:mm",
+        "m": "M/dE ah:mm至h:mm"
+      },
+      "MMdd hm": {
+        "a": "MM/dd ah:mm至ah:mm",
+        "h": "MM/dd ah:mm至h:mm",
+        "m": "MM/dd ah:mm至h:mm"
+      },
+      "MMM hm": {
+        "a": "LLL ah:mm至ah:mm",
+        "h": "LLL ah:mm至h:mm",
+        "m": "LLL ah:mm至h:mm"
+      },
+      "MMMd hm": {
+        "a": "M月d日 ah:mm至ah:mm",
+        "h": "M月d日 ah:mm至h:mm",
+        "m": "M月d日 ah:mm至h:mm"
+      },
+      "MMMEd hm": {
+        "a": "M月d日E ah:mm至ah:mm",
+        "h": "M月d日E ah:mm至h:mm",
+        "m": "M月d日E ah:mm至h:mm"
+      },
+      "MMMMd hm": {
+        "a": "M月d日 ah:mm至ah:mm",
+        "h": "M月d日 ah:mm至h:mm",
+        "m": "M月d日 ah:mm至h:mm"
+      },
+      "y hm": {
+        "a": "y年 ah:mm至ah:mm",
+        "h": "y年 ah:mm至h:mm",
+        "m": "y年 ah:mm至h:mm"
+      },
+      "yM hm": {
+        "a": "y/M ah:mm至ah:mm",
+        "h": "y/M ah:mm至h:mm",
+        "m": "y/M ah:mm至h:mm"
+      },
+      "yMd hm": {
+        "a": "y/M/d ah:mm至ah:mm",
+        "h": "y/M/d ah:mm至h:mm",
+        "m": "y/M/d ah:mm至h:mm"
+      },
+      "yMEd hm": {
+        "a": "y/M/dE ah:mm至ah:mm",
+        "h": "y/M/dE ah:mm至h:mm",
+        "m": "y/M/dE ah:mm至h:mm"
+      },
+      "yMEEEEd hm": {
+        "a": "y年M月d日EEEE ah:mm至ah:mm",
+        "h": "y年M月d日EEEE ah:mm至h:mm",
+        "m": "y年M月d日EEEE ah:mm至h:mm"
+      },
+      "yMM hm": {
+        "a": "y年M月 ah:mm至ah:mm",
+        "h": "y年M月 ah:mm至h:mm",
+        "m": "y年M月 ah:mm至h:mm"
+      },
+      "yMMM hm": {
+        "a": "y年M月 ah:mm至ah:mm",
+        "h": "y年M月 ah:mm至h:mm",
+        "m": "y年M月 ah:mm至h:mm"
+      },
+      "yMMMd hm": {
+        "a": "y年M月d日 ah:mm至ah:mm",
+        "h": "y年M月d日 ah:mm至h:mm",
+        "m": "y年M月d日 ah:mm至h:mm"
+      },
+      "yMMMEd hm": {
+        "a": "y年M月d日E ah:mm至ah:mm",
+        "h": "y年M月d日E ah:mm至h:mm",
+        "m": "y年M月d日E ah:mm至h:mm"
+      },
+      "yMMMM hm": {
+        "a": "y年M月 ah:mm至ah:mm",
+        "h": "y年M月 ah:mm至h:mm",
+        "m": "y年M月 ah:mm至h:mm"
+      },
+      "y年M月d日EEEE Hm": {
+        "H": "y年M月d日EEEE HH:mm–HH:mm",
+        "m": "y年M月d日EEEE HH:mm–HH:mm"
+      },
+      "y年M月d日 Hm": {
+        "H": "y年M月d日 HH:mm–HH:mm",
+        "m": "y年M月d日 HH:mm–HH:mm"
+      },
+      "y/M/d Hm": {
+        "H": "y/M/d HH:mm–HH:mm",
+        "m": "y/M/d HH:mm–HH:mm"
+      },
+      "d Hm": {
+        "H": "d日 HH:mm–HH:mm",
+        "m": "d日 HH:mm–HH:mm"
+      },
+      "E Hm": {
+        "H": "ccc HH:mm–HH:mm",
+        "m": "ccc HH:mm–HH:mm"
+      },
+      "Ed Hm": {
+        "H": "d日E HH:mm–HH:mm",
+        "m": "d日E HH:mm–HH:mm"
+      },
+      "Gy Hm": {
+        "H": "Gy年 HH:mm–HH:mm",
+        "m": "Gy年 HH:mm–HH:mm"
+      },
+      "GyM Hm": {
+        "H": "Gy年M月 HH:mm–HH:mm",
+        "m": "Gy年M月 HH:mm–HH:mm"
+      },
+      "GyMd Hm": {
+        "H": "Gy-MM-dd HH:mm–HH:mm",
+        "m": "Gy-MM-dd HH:mm–HH:mm"
+      },
+      "GyMEd Hm": {
+        "H": "Gy-MM-ddE HH:mm–HH:mm",
+        "m": "Gy-MM-ddE HH:mm–HH:mm"
+      },
+      "GyMMM Hm": {
+        "H": "Gy年M月 HH:mm–HH:mm",
+        "m": "Gy年M月 HH:mm–HH:mm"
+      },
+      "GyMMMd Hm": {
+        "H": "Gy年M月d日 HH:mm–HH:mm",
+        "m": "Gy年M月d日 HH:mm–HH:mm"
+      },
+      "GyMMMEd Hm": {
+        "H": "Gy年M月d日E HH:mm–HH:mm",
+        "m": "Gy年M月d日E HH:mm–HH:mm"
+      },
+      "M Hm": {
+        "H": "M月 HH:mm–HH:mm",
+        "m": "M月 HH:mm–HH:mm"
+      },
+      "Md Hm": {
+        "H": "M/d HH:mm–HH:mm",
+        "m": "M/d HH:mm–HH:mm"
+      },
+      "MEd Hm": {
+        "H": "M/dE HH:mm–HH:mm",
+        "m": "M/dE HH:mm–HH:mm"
+      },
+      "MMdd Hm": {
+        "H": "MM/dd HH:mm–HH:mm",
+        "m": "MM/dd HH:mm–HH:mm"
+      },
+      "MMM Hm": {
+        "H": "LLL HH:mm–HH:mm",
+        "m": "LLL HH:mm–HH:mm"
+      },
+      "MMMd Hm": {
+        "H": "M月d日 HH:mm–HH:mm",
+        "m": "M月d日 HH:mm–HH:mm"
+      },
+      "MMMEd Hm": {
+        "H": "M月d日E HH:mm–HH:mm",
+        "m": "M月d日E HH:mm–HH:mm"
+      },
+      "MMMMd Hm": {
+        "H": "M月d日 HH:mm–HH:mm",
+        "m": "M月d日 HH:mm–HH:mm"
+      },
+      "y Hm": {
+        "H": "y年 HH:mm–HH:mm",
+        "m": "y年 HH:mm–HH:mm"
+      },
+      "yM Hm": {
+        "H": "y/M HH:mm–HH:mm",
+        "m": "y/M HH:mm–HH:mm"
+      },
+      "yMd Hm": {
+        "H": "y/M/d HH:mm–HH:mm",
+        "m": "y/M/d HH:mm–HH:mm"
+      },
+      "yMEd Hm": {
+        "H": "y/M/dE HH:mm–HH:mm",
+        "m": "y/M/dE HH:mm–HH:mm"
+      },
+      "yMEEEEd Hm": {
+        "H": "y年M月d日EEEE HH:mm–HH:mm",
+        "m": "y年M月d日EEEE HH:mm–HH:mm"
+      },
+      "yMM Hm": {
+        "H": "y年M月 HH:mm–HH:mm",
+        "m": "y年M月 HH:mm–HH:mm"
+      },
+      "yMMM Hm": {
+        "H": "y年M月 HH:mm–HH:mm",
+        "m": "y年M月 HH:mm–HH:mm"
+      },
+      "yMMMd Hm": {
+        "H": "y年M月d日 HH:mm–HH:mm",
+        "m": "y年M月d日 HH:mm–HH:mm"
+      },
+      "yMMMEd Hm": {
+        "H": "y年M月d日E HH:mm–HH:mm",
+        "m": "y年M月d日E HH:mm–HH:mm"
+      },
+      "yMMMM Hm": {
+        "H": "y年M月 HH:mm–HH:mm",
+        "m": "y年M月 HH:mm–HH:mm"
+      },
+      "y年M月d日EEEE hmv": {
+        "a": "y年M月d日EEEE vah:mm至ah:mm",
+        "h": "y年M月d日EEEE vah:mm至h:mm",
+        "m": "y年M月d日EEEE vah:mm至h:mm"
+      },
+      "y年M月d日 hmv": {
+        "a": "y年M月d日 vah:mm至ah:mm",
+        "h": "y年M月d日 vah:mm至h:mm",
+        "m": "y年M月d日 vah:mm至h:mm"
+      },
+      "y/M/d hmv": {
+        "a": "y/M/d vah:mm至ah:mm",
+        "h": "y/M/d vah:mm至h:mm",
+        "m": "y/M/d vah:mm至h:mm"
+      },
+      "d hmv": {
+        "a": "d日 vah:mm至ah:mm",
+        "h": "d日 vah:mm至h:mm",
+        "m": "d日 vah:mm至h:mm"
+      },
+      "E hmv": {
+        "a": "ccc vah:mm至ah:mm",
+        "h": "ccc vah:mm至h:mm",
+        "m": "ccc vah:mm至h:mm"
+      },
+      "Ed hmv": {
+        "a": "d日E vah:mm至ah:mm",
+        "h": "d日E vah:mm至h:mm",
+        "m": "d日E vah:mm至h:mm"
+      },
+      "Gy hmv": {
+        "a": "Gy年 vah:mm至ah:mm",
+        "h": "Gy年 vah:mm至h:mm",
+        "m": "Gy年 vah:mm至h:mm"
+      },
+      "GyM hmv": {
+        "a": "Gy年M月 vah:mm至ah:mm",
+        "h": "Gy年M月 vah:mm至h:mm",
+        "m": "Gy年M月 vah:mm至h:mm"
+      },
+      "GyMd hmv": {
+        "a": "Gy-MM-dd vah:mm至ah:mm",
+        "h": "Gy-MM-dd vah:mm至h:mm",
+        "m": "Gy-MM-dd vah:mm至h:mm"
+      },
+      "GyMEd hmv": {
+        "a": "Gy-MM-ddE vah:mm至ah:mm",
+        "h": "Gy-MM-ddE vah:mm至h:mm",
+        "m": "Gy-MM-ddE vah:mm至h:mm"
+      },
+      "GyMMM hmv": {
+        "a": "Gy年M月 vah:mm至ah:mm",
+        "h": "Gy年M月 vah:mm至h:mm",
+        "m": "Gy年M月 vah:mm至h:mm"
+      },
+      "GyMMMd hmv": {
+        "a": "Gy年M月d日 vah:mm至ah:mm",
+        "h": "Gy年M月d日 vah:mm至h:mm",
+        "m": "Gy年M月d日 vah:mm至h:mm"
+      },
+      "GyMMMEd hmv": {
+        "a": "Gy年M月d日E vah:mm至ah:mm",
+        "h": "Gy年M月d日E vah:mm至h:mm",
+        "m": "Gy年M月d日E vah:mm至h:mm"
+      },
+      "M hmv": {
+        "a": "M月 vah:mm至ah:mm",
+        "h": "M月 vah:mm至h:mm",
+        "m": "M月 vah:mm至h:mm"
+      },
+      "Md hmv": {
+        "a": "M/d vah:mm至ah:mm",
+        "h": "M/d vah:mm至h:mm",
+        "m": "M/d vah:mm至h:mm"
+      },
+      "MEd hmv": {
+        "a": "M/dE vah:mm至ah:mm",
+        "h": "M/dE vah:mm至h:mm",
+        "m": "M/dE vah:mm至h:mm"
+      },
+      "MMdd hmv": {
+        "a": "MM/dd vah:mm至ah:mm",
+        "h": "MM/dd vah:mm至h:mm",
+        "m": "MM/dd vah:mm至h:mm"
+      },
+      "MMM hmv": {
+        "a": "LLL vah:mm至ah:mm",
+        "h": "LLL vah:mm至h:mm",
+        "m": "LLL vah:mm至h:mm"
+      },
+      "MMMd hmv": {
+        "a": "M月d日 vah:mm至ah:mm",
+        "h": "M月d日 vah:mm至h:mm",
+        "m": "M月d日 vah:mm至h:mm"
+      },
+      "MMMEd hmv": {
+        "a": "M月d日E vah:mm至ah:mm",
+        "h": "M月d日E vah:mm至h:mm",
+        "m": "M月d日E vah:mm至h:mm"
+      },
+      "MMMMd hmv": {
+        "a": "M月d日 vah:mm至ah:mm",
+        "h": "M月d日 vah:mm至h:mm",
+        "m": "M月d日 vah:mm至h:mm"
+      },
+      "y hmv": {
+        "a": "y年 vah:mm至ah:mm",
+        "h": "y年 vah:mm至h:mm",
+        "m": "y年 vah:mm至h:mm"
+      },
+      "yM hmv": {
+        "a": "y/M vah:mm至ah:mm",
+        "h": "y/M vah:mm至h:mm",
+        "m": "y/M vah:mm至h:mm"
+      },
+      "yMd hmv": {
+        "a": "y/M/d vah:mm至ah:mm",
+        "h": "y/M/d vah:mm至h:mm",
+        "m": "y/M/d vah:mm至h:mm"
+      },
+      "yMEd hmv": {
+        "a": "y/M/dE vah:mm至ah:mm",
+        "h": "y/M/dE vah:mm至h:mm",
+        "m": "y/M/dE vah:mm至h:mm"
+      },
+      "yMEEEEd hmv": {
+        "a": "y年M月d日EEEE vah:mm至ah:mm",
+        "h": "y年M月d日EEEE vah:mm至h:mm",
+        "m": "y年M月d日EEEE vah:mm至h:mm"
+      },
+      "yMM hmv": {
+        "a": "y年M月 vah:mm至ah:mm",
+        "h": "y年M月 vah:mm至h:mm",
+        "m": "y年M月 vah:mm至h:mm"
+      },
+      "yMMM hmv": {
+        "a": "y年M月 vah:mm至ah:mm",
+        "h": "y年M月 vah:mm至h:mm",
+        "m": "y年M月 vah:mm至h:mm"
+      },
+      "yMMMd hmv": {
+        "a": "y年M月d日 vah:mm至ah:mm",
+        "h": "y年M月d日 vah:mm至h:mm",
+        "m": "y年M月d日 vah:mm至h:mm"
+      },
+      "yMMMEd hmv": {
+        "a": "y年M月d日E vah:mm至ah:mm",
+        "h": "y年M月d日E vah:mm至h:mm",
+        "m": "y年M月d日E vah:mm至h:mm"
+      },
+      "yMMMM hmv": {
+        "a": "y年M月 vah:mm至ah:mm",
+        "h": "y年M月 vah:mm至h:mm",
+        "m": "y年M月 vah:mm至h:mm"
+      },
+      "y年M月d日EEEE Hmv": {
+        "H": "y年M月d日EEEE v HH:mm–HH:mm",
+        "m": "y年M月d日EEEE v HH:mm–HH:mm"
+      },
+      "y年M月d日 Hmv": {
+        "H": "y年M月d日 v HH:mm–HH:mm",
+        "m": "y年M月d日 v HH:mm–HH:mm"
+      },
+      "y/M/d Hmv": {
+        "H": "y/M/d v HH:mm–HH:mm",
+        "m": "y/M/d v HH:mm–HH:mm"
+      },
+      "d Hmv": {
+        "H": "d日 v HH:mm–HH:mm",
+        "m": "d日 v HH:mm–HH:mm"
+      },
+      "E Hmv": {
+        "H": "ccc v HH:mm–HH:mm",
+        "m": "ccc v HH:mm–HH:mm"
+      },
+      "Ed Hmv": {
+        "H": "d日E v HH:mm–HH:mm",
+        "m": "d日E v HH:mm–HH:mm"
+      },
+      "Gy Hmv": {
+        "H": "Gy年 v HH:mm–HH:mm",
+        "m": "Gy年 v HH:mm–HH:mm"
+      },
+      "GyM Hmv": {
+        "H": "Gy年M月 v HH:mm–HH:mm",
+        "m": "Gy年M月 v HH:mm–HH:mm"
+      },
+      "GyMd Hmv": {
+        "H": "Gy-MM-dd v HH:mm–HH:mm",
+        "m": "Gy-MM-dd v HH:mm–HH:mm"
+      },
+      "GyMEd Hmv": {
+        "H": "Gy-MM-ddE v HH:mm–HH:mm",
+        "m": "Gy-MM-ddE v HH:mm–HH:mm"
+      },
+      "GyMMM Hmv": {
+        "H": "Gy年M月 v HH:mm–HH:mm",
+        "m": "Gy年M月 v HH:mm–HH:mm"
+      },
+      "GyMMMd Hmv": {
+        "H": "Gy年M月d日 v HH:mm–HH:mm",
+        "m": "Gy年M月d日 v HH:mm–HH:mm"
+      },
+      "GyMMMEd Hmv": {
+        "H": "Gy年M月d日E v HH:mm–HH:mm",
+        "m": "Gy年M月d日E v HH:mm–HH:mm"
+      },
+      "M Hmv": {
+        "H": "M月 v HH:mm–HH:mm",
+        "m": "M月 v HH:mm–HH:mm"
+      },
+      "Md Hmv": {
+        "H": "M/d v HH:mm–HH:mm",
+        "m": "M/d v HH:mm–HH:mm"
+      },
+      "MEd Hmv": {
+        "H": "M/dE v HH:mm–HH:mm",
+        "m": "M/dE v HH:mm–HH:mm"
+      },
+      "MMdd Hmv": {
+        "H": "MM/dd v HH:mm–HH:mm",
+        "m": "MM/dd v HH:mm–HH:mm"
+      },
+      "MMM Hmv": {
+        "H": "LLL v HH:mm–HH:mm",
+        "m": "LLL v HH:mm–HH:mm"
+      },
+      "MMMd Hmv": {
+        "H": "M月d日 v HH:mm–HH:mm",
+        "m": "M月d日 v HH:mm–HH:mm"
+      },
+      "MMMEd Hmv": {
+        "H": "M月d日E v HH:mm–HH:mm",
+        "m": "M月d日E v HH:mm–HH:mm"
+      },
+      "MMMMd Hmv": {
+        "H": "M月d日 v HH:mm–HH:mm",
+        "m": "M月d日 v HH:mm–HH:mm"
+      },
+      "y Hmv": {
+        "H": "y年 v HH:mm–HH:mm",
+        "m": "y年 v HH:mm–HH:mm"
+      },
+      "yM Hmv": {
+        "H": "y/M v HH:mm–HH:mm",
+        "m": "y/M v HH:mm–HH:mm"
+      },
+      "yMd Hmv": {
+        "H": "y/M/d v HH:mm–HH:mm",
+        "m": "y/M/d v HH:mm–HH:mm"
+      },
+      "yMEd Hmv": {
+        "H": "y/M/dE v HH:mm–HH:mm",
+        "m": "y/M/dE v HH:mm–HH:mm"
+      },
+      "yMEEEEd Hmv": {
+        "H": "y年M月d日EEEE v HH:mm–HH:mm",
+        "m": "y年M月d日EEEE v HH:mm–HH:mm"
+      },
+      "yMM Hmv": {
+        "H": "y年M月 v HH:mm–HH:mm",
+        "m": "y年M月 v HH:mm–HH:mm"
+      },
+      "yMMM Hmv": {
+        "H": "y年M月 v HH:mm–HH:mm",
+        "m": "y年M月 v HH:mm–HH:mm"
+      },
+      "yMMMd Hmv": {
+        "H": "y年M月d日 v HH:mm–HH:mm",
+        "m": "y年M月d日 v HH:mm–HH:mm"
+      },
+      "yMMMEd Hmv": {
+        "H": "y年M月d日E v HH:mm–HH:mm",
+        "m": "y年M月d日E v HH:mm–HH:mm"
+      },
+      "yMMMM Hmv": {
+        "H": "y年M月 v HH:mm–HH:mm",
+        "m": "y年M月 v HH:mm–HH:mm"
+      },
+      "y年M月d日EEEE hv": {
+        "a": "y年M月d日EEEE vah时至ah时",
+        "h": "y年M月d日EEEE vah时至h时"
+      },
+      "y年M月d日 hv": {
+        "a": "y年M月d日 vah时至ah时",
+        "h": "y年M月d日 vah时至h时"
+      },
+      "y/M/d hv": {
+        "a": "y/M/d vah时至ah时",
+        "h": "y/M/d vah时至h时"
+      },
+      "d hv": {
+        "a": "d日 vah时至ah时",
+        "h": "d日 vah时至h时"
+      },
+      "E hv": {
+        "a": "ccc vah时至ah时",
+        "h": "ccc vah时至h时"
+      },
+      "Ed hv": {
+        "a": "d日E vah时至ah时",
+        "h": "d日E vah时至h时"
+      },
+      "Gy hv": {
+        "a": "Gy年 vah时至ah时",
+        "h": "Gy年 vah时至h时"
+      },
+      "GyM hv": {
+        "a": "Gy年M月 vah时至ah时",
+        "h": "Gy年M月 vah时至h时"
+      },
+      "GyMd hv": {
+        "a": "Gy-MM-dd vah时至ah时",
+        "h": "Gy-MM-dd vah时至h时"
+      },
+      "GyMEd hv": {
+        "a": "Gy-MM-ddE vah时至ah时",
+        "h": "Gy-MM-ddE vah时至h时"
+      },
+      "GyMMM hv": {
+        "a": "Gy年M月 vah时至ah时",
+        "h": "Gy年M月 vah时至h时"
+      },
+      "GyMMMd hv": {
+        "a": "Gy年M月d日 vah时至ah时",
+        "h": "Gy年M月d日 vah时至h时"
+      },
+      "GyMMMEd hv": {
+        "a": "Gy年M月d日E vah时至ah时",
+        "h": "Gy年M月d日E vah时至h时"
+      },
+      "M hv": {
+        "a": "M月 vah时至ah时",
+        "h": "M月 vah时至h时"
+      },
+      "Md hv": {
+        "a": "M/d vah时至ah时",
+        "h": "M/d vah时至h时"
+      },
+      "MEd hv": {
+        "a": "M/dE vah时至ah时",
+        "h": "M/dE vah时至h时"
+      },
+      "MMdd hv": {
+        "a": "MM/dd vah时至ah时",
+        "h": "MM/dd vah时至h时"
+      },
+      "MMM hv": {
+        "a": "LLL vah时至ah时",
+        "h": "LLL vah时至h时"
+      },
+      "MMMd hv": {
+        "a": "M月d日 vah时至ah时",
+        "h": "M月d日 vah时至h时"
+      },
+      "MMMEd hv": {
+        "a": "M月d日E vah时至ah时",
+        "h": "M月d日E vah时至h时"
+      },
+      "MMMMd hv": {
+        "a": "M月d日 vah时至ah时",
+        "h": "M月d日 vah时至h时"
+      },
+      "y hv": {
+        "a": "y年 vah时至ah时",
+        "h": "y年 vah时至h时"
+      },
+      "yM hv": {
+        "a": "y/M vah时至ah时",
+        "h": "y/M vah时至h时"
+      },
+      "yMd hv": {
+        "a": "y/M/d vah时至ah时",
+        "h": "y/M/d vah时至h时"
+      },
+      "yMEd hv": {
+        "a": "y/M/dE vah时至ah时",
+        "h": "y/M/dE vah时至h时"
+      },
+      "yMEEEEd hv": {
+        "a": "y年M月d日EEEE vah时至ah时",
+        "h": "y年M月d日EEEE vah时至h时"
+      },
+      "yMM hv": {
+        "a": "y年M月 vah时至ah时",
+        "h": "y年M月 vah时至h时"
+      },
+      "yMMM hv": {
+        "a": "y年M月 vah时至ah时",
+        "h": "y年M月 vah时至h时"
+      },
+      "yMMMd hv": {
+        "a": "y年M月d日 vah时至ah时",
+        "h": "y年M月d日 vah时至h时"
+      },
+      "yMMMEd hv": {
+        "a": "y年M月d日E vah时至ah时",
+        "h": "y年M月d日E vah时至h时"
+      },
+      "yMMMM hv": {
+        "a": "y年M月 vah时至ah时",
+        "h": "y年M月 vah时至h时"
+      },
+      "y年M月d日EEEE Hv": {
+        "H": "y年M月d日EEEE v HH–HH"
+      },
+      "y年M月d日 Hv": {
+        "H": "y年M月d日 v HH–HH"
+      },
+      "y/M/d Hv": {
+        "H": "y/M/d v HH–HH"
+      },
+      "d Hv": {
+        "H": "d日 v HH–HH"
+      },
+      "E Hv": {
+        "H": "ccc v HH–HH"
+      },
+      "Ed Hv": {
+        "H": "d日E v HH–HH"
+      },
+      "Gy Hv": {
+        "H": "Gy年 v HH–HH"
+      },
+      "GyM Hv": {
+        "H": "Gy年M月 v HH–HH"
+      },
+      "GyMd Hv": {
+        "H": "Gy-MM-dd v HH–HH"
+      },
+      "GyMEd Hv": {
+        "H": "Gy-MM-ddE v HH–HH"
+      },
+      "GyMMM Hv": {
+        "H": "Gy年M月 v HH–HH"
+      },
+      "GyMMMd Hv": {
+        "H": "Gy年M月d日 v HH–HH"
+      },
+      "GyMMMEd Hv": {
+        "H": "Gy年M月d日E v HH–HH"
+      },
+      "M Hv": {
+        "H": "M月 v HH–HH"
+      },
+      "Md Hv": {
+        "H": "M/d v HH–HH"
+      },
+      "MEd Hv": {
+        "H": "M/dE v HH–HH"
+      },
+      "MMdd Hv": {
+        "H": "MM/dd v HH–HH"
+      },
+      "MMM Hv": {
+        "H": "LLL v HH–HH"
+      },
+      "MMMd Hv": {
+        "H": "M月d日 v HH–HH"
+      },
+      "MMMEd Hv": {
+        "H": "M月d日E v HH–HH"
+      },
+      "MMMMd Hv": {
+        "H": "M月d日 v HH–HH"
+      },
+      "y Hv": {
+        "H": "y年 v HH–HH"
+      },
+      "yM Hv": {
+        "H": "y/M v HH–HH"
+      },
+      "yMd Hv": {
+        "H": "y/M/d v HH–HH"
+      },
+      "yMEd Hv": {
+        "H": "y/M/dE v HH–HH"
+      },
+      "yMEEEEd Hv": {
+        "H": "y年M月d日EEEE v HH–HH"
+      },
+      "yMM Hv": {
+        "H": "y年M月 v HH–HH"
+      },
+      "yMMM Hv": {
+        "H": "y年M月 v HH–HH"
+      },
+      "yMMMd Hv": {
+        "H": "y年M月d日 v HH–HH"
+      },
+      "yMMMEd Hv": {
+        "H": "y年M月d日E v HH–HH"
+      },
+      "yMMMM Hv": {
+        "H": "y年M月 v HH–HH"
       }
     },
     "hourCycle": "h23",
@@ -22269,6 +31863,1401 @@ Intl.DateTimeFormat.__addLocaleData({
       "yMMMM": {
         "M": "y年M月至M月",
         "y": "y年M月至y年M月"
+      },
+      "y年M月d日 EEEEBh": {
+        "B": "y年M月d日 EEEEBh時 – Bh時",
+        "h": "y年M月d日 EEEEBh–h時"
+      },
+      "y年M月d日Bh": {
+        "B": "y年M月d日Bh時 – Bh時",
+        "h": "y年M月d日Bh–h時"
+      },
+      "y/M/dBh": {
+        "B": "y/M/dBh時 – Bh時",
+        "h": "y/M/dBh–h時"
+      },
+      "dBh": {
+        "B": "d日Bh時 – Bh時",
+        "h": "d日Bh–h時"
+      },
+      "EBh": {
+        "B": "cccBh時 – Bh時",
+        "h": "cccBh–h時"
+      },
+      "EdBh": {
+        "B": "d EBh時 – Bh時",
+        "h": "d EBh–h時"
+      },
+      "GyBh": {
+        "B": "Gy年Bh時 – Bh時",
+        "h": "Gy年Bh–h時"
+      },
+      "GyMBh": {
+        "B": "Gy/MBh時 – Bh時",
+        "h": "Gy/MBh–h時"
+      },
+      "GyMdBh": {
+        "B": "G y/M/dBh時 – Bh時",
+        "h": "G y/M/dBh–h時"
+      },
+      "GyMEdBh": {
+        "B": "Gy/M/d（E）Bh時 – Bh時",
+        "h": "Gy/M/d（E）Bh–h時"
+      },
+      "GyMMMBh": {
+        "B": "Gy年M月Bh時 – Bh時",
+        "h": "Gy年M月Bh–h時"
+      },
+      "GyMMMdBh": {
+        "B": "Gy年M月d日Bh時 – Bh時",
+        "h": "Gy年M月d日Bh–h時"
+      },
+      "GyMMMEdBh": {
+        "B": "Gy年M月d日 EBh時 – Bh時",
+        "h": "Gy年M月d日 EBh–h時"
+      },
+      "MBh": {
+        "B": "M月Bh時 – Bh時",
+        "h": "M月Bh–h時"
+      },
+      "MdBh": {
+        "B": "M/dBh時 – Bh時",
+        "h": "M/dBh–h時"
+      },
+      "MEdBh": {
+        "B": "M/d（E）Bh時 – Bh時",
+        "h": "M/d（E）Bh–h時"
+      },
+      "MMddBh": {
+        "B": "MM/ddBh時 – Bh時",
+        "h": "MM/ddBh–h時"
+      },
+      "MMMBh": {
+        "B": "LLLBh時 – Bh時",
+        "h": "LLLBh–h時"
+      },
+      "MMMdBh": {
+        "B": "M月d日Bh時 – Bh時",
+        "h": "M月d日Bh–h時"
+      },
+      "MMMEdBh": {
+        "B": "M月d日EBh時 – Bh時",
+        "h": "M月d日EBh–h時"
+      },
+      "MMMMdBh": {
+        "B": "M月d日Bh時 – Bh時",
+        "h": "M月d日Bh–h時"
+      },
+      "yBh": {
+        "B": "y年Bh時 – Bh時",
+        "h": "y年Bh–h時"
+      },
+      "yMBh": {
+        "B": "y/MBh時 – Bh時",
+        "h": "y/MBh–h時"
+      },
+      "yMdBh": {
+        "B": "y/M/dBh時 – Bh時",
+        "h": "y/M/dBh–h時"
+      },
+      "yMEdBh": {
+        "B": "y/M/d（E）Bh時 – Bh時",
+        "h": "y/M/d（E）Bh–h時"
+      },
+      "yMEEEEdBh": {
+        "B": "y年M月d日 EEEEBh時 – Bh時",
+        "h": "y年M月d日 EEEEBh–h時"
+      },
+      "yMMBh": {
+        "B": "y/MMBh時 – Bh時",
+        "h": "y/MMBh–h時"
+      },
+      "yMMMBh": {
+        "B": "y年M月Bh時 – Bh時",
+        "h": "y年M月Bh–h時"
+      },
+      "yMMMdBh": {
+        "B": "y年M月d日Bh時 – Bh時",
+        "h": "y年M月d日Bh–h時"
+      },
+      "yMMMEdBh": {
+        "B": "y年M月d日EBh時 – Bh時",
+        "h": "y年M月d日EBh–h時"
+      },
+      "yMMMMBh": {
+        "B": "y年M月Bh時 – Bh時",
+        "h": "y年M月Bh–h時"
+      },
+      "y年M月d日 EEEEBhm": {
+        "B": "y年M月d日 EEEEBh:mm – Bh:mm",
+        "h": "y年M月d日 EEEEBh:mm–h:mm",
+        "m": "y年M月d日 EEEEBh:mm–h:mm"
+      },
+      "y年M月d日Bhm": {
+        "B": "y年M月d日Bh:mm – Bh:mm",
+        "h": "y年M月d日Bh:mm–h:mm",
+        "m": "y年M月d日Bh:mm–h:mm"
+      },
+      "y/M/dBhm": {
+        "B": "y/M/dBh:mm – Bh:mm",
+        "h": "y/M/dBh:mm–h:mm",
+        "m": "y/M/dBh:mm–h:mm"
+      },
+      "dBhm": {
+        "B": "d日Bh:mm – Bh:mm",
+        "h": "d日Bh:mm–h:mm",
+        "m": "d日Bh:mm–h:mm"
+      },
+      "EBhm": {
+        "B": "cccBh:mm – Bh:mm",
+        "h": "cccBh:mm–h:mm",
+        "m": "cccBh:mm–h:mm"
+      },
+      "EdBhm": {
+        "B": "d EBh:mm – Bh:mm",
+        "h": "d EBh:mm–h:mm",
+        "m": "d EBh:mm–h:mm"
+      },
+      "GyBhm": {
+        "B": "Gy年Bh:mm – Bh:mm",
+        "h": "Gy年Bh:mm–h:mm",
+        "m": "Gy年Bh:mm–h:mm"
+      },
+      "GyMBhm": {
+        "B": "Gy/MBh:mm – Bh:mm",
+        "h": "Gy/MBh:mm–h:mm",
+        "m": "Gy/MBh:mm–h:mm"
+      },
+      "GyMdBhm": {
+        "B": "G y/M/dBh:mm – Bh:mm",
+        "h": "G y/M/dBh:mm–h:mm",
+        "m": "G y/M/dBh:mm–h:mm"
+      },
+      "GyMEdBhm": {
+        "B": "Gy/M/d（E）Bh:mm – Bh:mm",
+        "h": "Gy/M/d（E）Bh:mm–h:mm",
+        "m": "Gy/M/d（E）Bh:mm–h:mm"
+      },
+      "GyMMMBhm": {
+        "B": "Gy年M月Bh:mm – Bh:mm",
+        "h": "Gy年M月Bh:mm–h:mm",
+        "m": "Gy年M月Bh:mm–h:mm"
+      },
+      "GyMMMdBhm": {
+        "B": "Gy年M月d日Bh:mm – Bh:mm",
+        "h": "Gy年M月d日Bh:mm–h:mm",
+        "m": "Gy年M月d日Bh:mm–h:mm"
+      },
+      "GyMMMEdBhm": {
+        "B": "Gy年M月d日 EBh:mm – Bh:mm",
+        "h": "Gy年M月d日 EBh:mm–h:mm",
+        "m": "Gy年M月d日 EBh:mm–h:mm"
+      },
+      "MBhm": {
+        "B": "M月Bh:mm – Bh:mm",
+        "h": "M月Bh:mm–h:mm",
+        "m": "M月Bh:mm–h:mm"
+      },
+      "MdBhm": {
+        "B": "M/dBh:mm – Bh:mm",
+        "h": "M/dBh:mm–h:mm",
+        "m": "M/dBh:mm–h:mm"
+      },
+      "MEdBhm": {
+        "B": "M/d（E）Bh:mm – Bh:mm",
+        "h": "M/d（E）Bh:mm–h:mm",
+        "m": "M/d（E）Bh:mm–h:mm"
+      },
+      "MMddBhm": {
+        "B": "MM/ddBh:mm – Bh:mm",
+        "h": "MM/ddBh:mm–h:mm",
+        "m": "MM/ddBh:mm–h:mm"
+      },
+      "MMMBhm": {
+        "B": "LLLBh:mm – Bh:mm",
+        "h": "LLLBh:mm–h:mm",
+        "m": "LLLBh:mm–h:mm"
+      },
+      "MMMdBhm": {
+        "B": "M月d日Bh:mm – Bh:mm",
+        "h": "M月d日Bh:mm–h:mm",
+        "m": "M月d日Bh:mm–h:mm"
+      },
+      "MMMEdBhm": {
+        "B": "M月d日EBh:mm – Bh:mm",
+        "h": "M月d日EBh:mm–h:mm",
+        "m": "M月d日EBh:mm–h:mm"
+      },
+      "MMMMdBhm": {
+        "B": "M月d日Bh:mm – Bh:mm",
+        "h": "M月d日Bh:mm–h:mm",
+        "m": "M月d日Bh:mm–h:mm"
+      },
+      "yBhm": {
+        "B": "y年Bh:mm – Bh:mm",
+        "h": "y年Bh:mm–h:mm",
+        "m": "y年Bh:mm–h:mm"
+      },
+      "yMBhm": {
+        "B": "y/MBh:mm – Bh:mm",
+        "h": "y/MBh:mm–h:mm",
+        "m": "y/MBh:mm–h:mm"
+      },
+      "yMdBhm": {
+        "B": "y/M/dBh:mm – Bh:mm",
+        "h": "y/M/dBh:mm–h:mm",
+        "m": "y/M/dBh:mm–h:mm"
+      },
+      "yMEdBhm": {
+        "B": "y/M/d（E）Bh:mm – Bh:mm",
+        "h": "y/M/d（E）Bh:mm–h:mm",
+        "m": "y/M/d（E）Bh:mm–h:mm"
+      },
+      "yMEEEEdBhm": {
+        "B": "y年M月d日 EEEEBh:mm – Bh:mm",
+        "h": "y年M月d日 EEEEBh:mm–h:mm",
+        "m": "y年M月d日 EEEEBh:mm–h:mm"
+      },
+      "yMMBhm": {
+        "B": "y/MMBh:mm – Bh:mm",
+        "h": "y/MMBh:mm–h:mm",
+        "m": "y/MMBh:mm–h:mm"
+      },
+      "yMMMBhm": {
+        "B": "y年M月Bh:mm – Bh:mm",
+        "h": "y年M月Bh:mm–h:mm",
+        "m": "y年M月Bh:mm–h:mm"
+      },
+      "yMMMdBhm": {
+        "B": "y年M月d日Bh:mm – Bh:mm",
+        "h": "y年M月d日Bh:mm–h:mm",
+        "m": "y年M月d日Bh:mm–h:mm"
+      },
+      "yMMMEdBhm": {
+        "B": "y年M月d日EBh:mm – Bh:mm",
+        "h": "y年M月d日EBh:mm–h:mm",
+        "m": "y年M月d日EBh:mm–h:mm"
+      },
+      "yMMMMBhm": {
+        "B": "y年M月Bh:mm – Bh:mm",
+        "h": "y年M月Bh:mm–h:mm",
+        "m": "y年M月Bh:mm–h:mm"
+      },
+      "y年M月d日 EEEEh": {
+        "a": "y年M月d日 EEEEah時至ah時",
+        "B": "y年M月d日 EEEEBh時至Bh時",
+        "h": "y年M月d日 EEEEBh時至h時"
+      },
+      "y年M月d日h": {
+        "a": "y年M月d日ah時至ah時",
+        "B": "y年M月d日Bh時至Bh時",
+        "h": "y年M月d日Bh時至h時"
+      },
+      "y/M/dh": {
+        "a": "y/M/dah時至ah時",
+        "B": "y/M/dBh時至Bh時",
+        "h": "y/M/dBh時至h時"
+      },
+      "dh": {
+        "a": "d日ah時至ah時",
+        "B": "d日Bh時至Bh時",
+        "h": "d日Bh時至h時"
+      },
+      "Eh": {
+        "a": "cccah時至ah時",
+        "B": "cccBh時至Bh時",
+        "h": "cccBh時至h時"
+      },
+      "Edh": {
+        "a": "d Eah時至ah時",
+        "B": "d EBh時至Bh時",
+        "h": "d EBh時至h時"
+      },
+      "Gyh": {
+        "a": "Gy年ah時至ah時",
+        "B": "Gy年Bh時至Bh時",
+        "h": "Gy年Bh時至h時"
+      },
+      "GyMh": {
+        "a": "Gy/Mah時至ah時",
+        "B": "Gy/MBh時至Bh時",
+        "h": "Gy/MBh時至h時"
+      },
+      "GyMdh": {
+        "a": "G y/M/dah時至ah時",
+        "B": "G y/M/dBh時至Bh時",
+        "h": "G y/M/dBh時至h時"
+      },
+      "GyMEdh": {
+        "a": "Gy/M/d（E）ah時至ah時",
+        "B": "Gy/M/d（E）Bh時至Bh時",
+        "h": "Gy/M/d（E）Bh時至h時"
+      },
+      "GyMMMh": {
+        "a": "Gy年M月ah時至ah時",
+        "B": "Gy年M月Bh時至Bh時",
+        "h": "Gy年M月Bh時至h時"
+      },
+      "GyMMMdh": {
+        "a": "Gy年M月d日ah時至ah時",
+        "B": "Gy年M月d日Bh時至Bh時",
+        "h": "Gy年M月d日Bh時至h時"
+      },
+      "GyMMMEdh": {
+        "a": "Gy年M月d日 Eah時至ah時",
+        "B": "Gy年M月d日 EBh時至Bh時",
+        "h": "Gy年M月d日 EBh時至h時"
+      },
+      "Mh": {
+        "a": "M月ah時至ah時",
+        "B": "M月Bh時至Bh時",
+        "h": "M月Bh時至h時"
+      },
+      "Mdh": {
+        "a": "M/dah時至ah時",
+        "B": "M/dBh時至Bh時",
+        "h": "M/dBh時至h時"
+      },
+      "MEdh": {
+        "a": "M/d（E）ah時至ah時",
+        "B": "M/d（E）Bh時至Bh時",
+        "h": "M/d（E）Bh時至h時"
+      },
+      "MMddh": {
+        "a": "MM/ddah時至ah時",
+        "B": "MM/ddBh時至Bh時",
+        "h": "MM/ddBh時至h時"
+      },
+      "MMMh": {
+        "a": "LLLah時至ah時",
+        "B": "LLLBh時至Bh時",
+        "h": "LLLBh時至h時"
+      },
+      "MMMdh": {
+        "a": "M月d日ah時至ah時",
+        "B": "M月d日Bh時至Bh時",
+        "h": "M月d日Bh時至h時"
+      },
+      "MMMEdh": {
+        "a": "M月d日Eah時至ah時",
+        "B": "M月d日EBh時至Bh時",
+        "h": "M月d日EBh時至h時"
+      },
+      "MMMMdh": {
+        "a": "M月d日ah時至ah時",
+        "B": "M月d日Bh時至Bh時",
+        "h": "M月d日Bh時至h時"
+      },
+      "yh": {
+        "a": "y年ah時至ah時",
+        "B": "y年Bh時至Bh時",
+        "h": "y年Bh時至h時"
+      },
+      "yMh": {
+        "a": "y/Mah時至ah時",
+        "B": "y/MBh時至Bh時",
+        "h": "y/MBh時至h時"
+      },
+      "yMdh": {
+        "a": "y/M/dah時至ah時",
+        "B": "y/M/dBh時至Bh時",
+        "h": "y/M/dBh時至h時"
+      },
+      "yMEdh": {
+        "a": "y/M/d（E）ah時至ah時",
+        "B": "y/M/d（E）Bh時至Bh時",
+        "h": "y/M/d（E）Bh時至h時"
+      },
+      "yMEEEEdh": {
+        "a": "y年M月d日 EEEEah時至ah時",
+        "B": "y年M月d日 EEEEBh時至Bh時",
+        "h": "y年M月d日 EEEEBh時至h時"
+      },
+      "yMMh": {
+        "a": "y/MMah時至ah時",
+        "B": "y/MMBh時至Bh時",
+        "h": "y/MMBh時至h時"
+      },
+      "yMMMh": {
+        "a": "y年M月ah時至ah時",
+        "B": "y年M月Bh時至Bh時",
+        "h": "y年M月Bh時至h時"
+      },
+      "yMMMdh": {
+        "a": "y年M月d日ah時至ah時",
+        "B": "y年M月d日Bh時至Bh時",
+        "h": "y年M月d日Bh時至h時"
+      },
+      "yMMMEdh": {
+        "a": "y年M月d日Eah時至ah時",
+        "B": "y年M月d日EBh時至Bh時",
+        "h": "y年M月d日EBh時至h時"
+      },
+      "yMMMMh": {
+        "a": "y年M月ah時至ah時",
+        "B": "y年M月Bh時至Bh時",
+        "h": "y年M月Bh時至h時"
+      },
+      "y年M月d日 EEEEH": {
+        "H": "y年M月d日 EEEEHH – HH"
+      },
+      "y年M月d日H": {
+        "H": "y年M月d日HH – HH"
+      },
+      "y/M/dH": {
+        "H": "y/M/dHH – HH"
+      },
+      "dH": {
+        "H": "d日HH – HH"
+      },
+      "EH": {
+        "H": "cccHH – HH"
+      },
+      "EdH": {
+        "H": "d EHH – HH"
+      },
+      "GyH": {
+        "H": "Gy年HH – HH"
+      },
+      "GyMH": {
+        "H": "Gy/MHH – HH"
+      },
+      "GyMdH": {
+        "H": "G y/M/dHH – HH"
+      },
+      "GyMEdH": {
+        "H": "Gy/M/d（E）HH – HH"
+      },
+      "GyMMMH": {
+        "H": "Gy年M月HH – HH"
+      },
+      "GyMMMdH": {
+        "H": "Gy年M月d日HH – HH"
+      },
+      "GyMMMEdH": {
+        "H": "Gy年M月d日 EHH – HH"
+      },
+      "MH": {
+        "H": "M月HH – HH"
+      },
+      "MdH": {
+        "H": "M/dHH – HH"
+      },
+      "MEdH": {
+        "H": "M/d（E）HH – HH"
+      },
+      "MMddH": {
+        "H": "MM/ddHH – HH"
+      },
+      "MMMH": {
+        "H": "LLLHH – HH"
+      },
+      "MMMdH": {
+        "H": "M月d日HH – HH"
+      },
+      "MMMEdH": {
+        "H": "M月d日EHH – HH"
+      },
+      "MMMMdH": {
+        "H": "M月d日HH – HH"
+      },
+      "yH": {
+        "H": "y年HH – HH"
+      },
+      "yMH": {
+        "H": "y/MHH – HH"
+      },
+      "yMdH": {
+        "H": "y/M/dHH – HH"
+      },
+      "yMEdH": {
+        "H": "y/M/d（E）HH – HH"
+      },
+      "yMEEEEdH": {
+        "H": "y年M月d日 EEEEHH – HH"
+      },
+      "yMMH": {
+        "H": "y/MMHH – HH"
+      },
+      "yMMMH": {
+        "H": "y年M月HH – HH"
+      },
+      "yMMMdH": {
+        "H": "y年M月d日HH – HH"
+      },
+      "yMMMEdH": {
+        "H": "y年M月d日EHH – HH"
+      },
+      "yMMMMH": {
+        "H": "y年M月HH – HH"
+      },
+      "y年M月d日 EEEEhm": {
+        "a": "y年M月d日 EEEEah:mm至ah:mm",
+        "B": "y年M月d日 EEEEBh:mm至Bh:mm",
+        "h": "y年M月d日 EEEEBh:mm至h:mm",
+        "m": "y年M月d日 EEEEBh:mm至h:mm"
+      },
+      "y年M月d日hm": {
+        "a": "y年M月d日ah:mm至ah:mm",
+        "B": "y年M月d日Bh:mm至Bh:mm",
+        "h": "y年M月d日Bh:mm至h:mm",
+        "m": "y年M月d日Bh:mm至h:mm"
+      },
+      "y/M/dhm": {
+        "a": "y/M/dah:mm至ah:mm",
+        "B": "y/M/dBh:mm至Bh:mm",
+        "h": "y/M/dBh:mm至h:mm",
+        "m": "y/M/dBh:mm至h:mm"
+      },
+      "dhm": {
+        "a": "d日ah:mm至ah:mm",
+        "B": "d日Bh:mm至Bh:mm",
+        "h": "d日Bh:mm至h:mm",
+        "m": "d日Bh:mm至h:mm"
+      },
+      "Ehm": {
+        "a": "cccah:mm至ah:mm",
+        "B": "cccBh:mm至Bh:mm",
+        "h": "cccBh:mm至h:mm",
+        "m": "cccBh:mm至h:mm"
+      },
+      "Edhm": {
+        "a": "d Eah:mm至ah:mm",
+        "B": "d EBh:mm至Bh:mm",
+        "h": "d EBh:mm至h:mm",
+        "m": "d EBh:mm至h:mm"
+      },
+      "Gyhm": {
+        "a": "Gy年ah:mm至ah:mm",
+        "B": "Gy年Bh:mm至Bh:mm",
+        "h": "Gy年Bh:mm至h:mm",
+        "m": "Gy年Bh:mm至h:mm"
+      },
+      "GyMhm": {
+        "a": "Gy/Mah:mm至ah:mm",
+        "B": "Gy/MBh:mm至Bh:mm",
+        "h": "Gy/MBh:mm至h:mm",
+        "m": "Gy/MBh:mm至h:mm"
+      },
+      "GyMdhm": {
+        "a": "G y/M/dah:mm至ah:mm",
+        "B": "G y/M/dBh:mm至Bh:mm",
+        "h": "G y/M/dBh:mm至h:mm",
+        "m": "G y/M/dBh:mm至h:mm"
+      },
+      "GyMEdhm": {
+        "a": "Gy/M/d（E）ah:mm至ah:mm",
+        "B": "Gy/M/d（E）Bh:mm至Bh:mm",
+        "h": "Gy/M/d（E）Bh:mm至h:mm",
+        "m": "Gy/M/d（E）Bh:mm至h:mm"
+      },
+      "GyMMMhm": {
+        "a": "Gy年M月ah:mm至ah:mm",
+        "B": "Gy年M月Bh:mm至Bh:mm",
+        "h": "Gy年M月Bh:mm至h:mm",
+        "m": "Gy年M月Bh:mm至h:mm"
+      },
+      "GyMMMdhm": {
+        "a": "Gy年M月d日ah:mm至ah:mm",
+        "B": "Gy年M月d日Bh:mm至Bh:mm",
+        "h": "Gy年M月d日Bh:mm至h:mm",
+        "m": "Gy年M月d日Bh:mm至h:mm"
+      },
+      "GyMMMEdhm": {
+        "a": "Gy年M月d日 Eah:mm至ah:mm",
+        "B": "Gy年M月d日 EBh:mm至Bh:mm",
+        "h": "Gy年M月d日 EBh:mm至h:mm",
+        "m": "Gy年M月d日 EBh:mm至h:mm"
+      },
+      "Mhm": {
+        "a": "M月ah:mm至ah:mm",
+        "B": "M月Bh:mm至Bh:mm",
+        "h": "M月Bh:mm至h:mm",
+        "m": "M月Bh:mm至h:mm"
+      },
+      "Mdhm": {
+        "a": "M/dah:mm至ah:mm",
+        "B": "M/dBh:mm至Bh:mm",
+        "h": "M/dBh:mm至h:mm",
+        "m": "M/dBh:mm至h:mm"
+      },
+      "MEdhm": {
+        "a": "M/d（E）ah:mm至ah:mm",
+        "B": "M/d（E）Bh:mm至Bh:mm",
+        "h": "M/d（E）Bh:mm至h:mm",
+        "m": "M/d（E）Bh:mm至h:mm"
+      },
+      "MMddhm": {
+        "a": "MM/ddah:mm至ah:mm",
+        "B": "MM/ddBh:mm至Bh:mm",
+        "h": "MM/ddBh:mm至h:mm",
+        "m": "MM/ddBh:mm至h:mm"
+      },
+      "MMMhm": {
+        "a": "LLLah:mm至ah:mm",
+        "B": "LLLBh:mm至Bh:mm",
+        "h": "LLLBh:mm至h:mm",
+        "m": "LLLBh:mm至h:mm"
+      },
+      "MMMdhm": {
+        "a": "M月d日ah:mm至ah:mm",
+        "B": "M月d日Bh:mm至Bh:mm",
+        "h": "M月d日Bh:mm至h:mm",
+        "m": "M月d日Bh:mm至h:mm"
+      },
+      "MMMEdhm": {
+        "a": "M月d日Eah:mm至ah:mm",
+        "B": "M月d日EBh:mm至Bh:mm",
+        "h": "M月d日EBh:mm至h:mm",
+        "m": "M月d日EBh:mm至h:mm"
+      },
+      "MMMMdhm": {
+        "a": "M月d日ah:mm至ah:mm",
+        "B": "M月d日Bh:mm至Bh:mm",
+        "h": "M月d日Bh:mm至h:mm",
+        "m": "M月d日Bh:mm至h:mm"
+      },
+      "yhm": {
+        "a": "y年ah:mm至ah:mm",
+        "B": "y年Bh:mm至Bh:mm",
+        "h": "y年Bh:mm至h:mm",
+        "m": "y年Bh:mm至h:mm"
+      },
+      "yMhm": {
+        "a": "y/Mah:mm至ah:mm",
+        "B": "y/MBh:mm至Bh:mm",
+        "h": "y/MBh:mm至h:mm",
+        "m": "y/MBh:mm至h:mm"
+      },
+      "yMdhm": {
+        "a": "y/M/dah:mm至ah:mm",
+        "B": "y/M/dBh:mm至Bh:mm",
+        "h": "y/M/dBh:mm至h:mm",
+        "m": "y/M/dBh:mm至h:mm"
+      },
+      "yMEdhm": {
+        "a": "y/M/d（E）ah:mm至ah:mm",
+        "B": "y/M/d（E）Bh:mm至Bh:mm",
+        "h": "y/M/d（E）Bh:mm至h:mm",
+        "m": "y/M/d（E）Bh:mm至h:mm"
+      },
+      "yMEEEEdhm": {
+        "a": "y年M月d日 EEEEah:mm至ah:mm",
+        "B": "y年M月d日 EEEEBh:mm至Bh:mm",
+        "h": "y年M月d日 EEEEBh:mm至h:mm",
+        "m": "y年M月d日 EEEEBh:mm至h:mm"
+      },
+      "yMMhm": {
+        "a": "y/MMah:mm至ah:mm",
+        "B": "y/MMBh:mm至Bh:mm",
+        "h": "y/MMBh:mm至h:mm",
+        "m": "y/MMBh:mm至h:mm"
+      },
+      "yMMMhm": {
+        "a": "y年M月ah:mm至ah:mm",
+        "B": "y年M月Bh:mm至Bh:mm",
+        "h": "y年M月Bh:mm至h:mm",
+        "m": "y年M月Bh:mm至h:mm"
+      },
+      "yMMMdhm": {
+        "a": "y年M月d日ah:mm至ah:mm",
+        "B": "y年M月d日Bh:mm至Bh:mm",
+        "h": "y年M月d日Bh:mm至h:mm",
+        "m": "y年M月d日Bh:mm至h:mm"
+      },
+      "yMMMEdhm": {
+        "a": "y年M月d日Eah:mm至ah:mm",
+        "B": "y年M月d日EBh:mm至Bh:mm",
+        "h": "y年M月d日EBh:mm至h:mm",
+        "m": "y年M月d日EBh:mm至h:mm"
+      },
+      "yMMMMhm": {
+        "a": "y年M月ah:mm至ah:mm",
+        "B": "y年M月Bh:mm至Bh:mm",
+        "h": "y年M月Bh:mm至h:mm",
+        "m": "y年M月Bh:mm至h:mm"
+      },
+      "y年M月d日 EEEEHm": {
+        "H": "y年M月d日 EEEEHH:mm – HH:mm",
+        "m": "y年M月d日 EEEEHH:mm – HH:mm"
+      },
+      "y年M月d日Hm": {
+        "H": "y年M月d日HH:mm – HH:mm",
+        "m": "y年M月d日HH:mm – HH:mm"
+      },
+      "y/M/dHm": {
+        "H": "y/M/dHH:mm – HH:mm",
+        "m": "y/M/dHH:mm – HH:mm"
+      },
+      "dHm": {
+        "H": "d日HH:mm – HH:mm",
+        "m": "d日HH:mm – HH:mm"
+      },
+      "EHm": {
+        "H": "cccHH:mm – HH:mm",
+        "m": "cccHH:mm – HH:mm"
+      },
+      "EdHm": {
+        "H": "d EHH:mm – HH:mm",
+        "m": "d EHH:mm – HH:mm"
+      },
+      "GyHm": {
+        "H": "Gy年HH:mm – HH:mm",
+        "m": "Gy年HH:mm – HH:mm"
+      },
+      "GyMHm": {
+        "H": "Gy/MHH:mm – HH:mm",
+        "m": "Gy/MHH:mm – HH:mm"
+      },
+      "GyMdHm": {
+        "H": "G y/M/dHH:mm – HH:mm",
+        "m": "G y/M/dHH:mm – HH:mm"
+      },
+      "GyMEdHm": {
+        "H": "Gy/M/d（E）HH:mm – HH:mm",
+        "m": "Gy/M/d（E）HH:mm – HH:mm"
+      },
+      "GyMMMHm": {
+        "H": "Gy年M月HH:mm – HH:mm",
+        "m": "Gy年M月HH:mm – HH:mm"
+      },
+      "GyMMMdHm": {
+        "H": "Gy年M月d日HH:mm – HH:mm",
+        "m": "Gy年M月d日HH:mm – HH:mm"
+      },
+      "GyMMMEdHm": {
+        "H": "Gy年M月d日 EHH:mm – HH:mm",
+        "m": "Gy年M月d日 EHH:mm – HH:mm"
+      },
+      "MHm": {
+        "H": "M月HH:mm – HH:mm",
+        "m": "M月HH:mm – HH:mm"
+      },
+      "MdHm": {
+        "H": "M/dHH:mm – HH:mm",
+        "m": "M/dHH:mm – HH:mm"
+      },
+      "MEdHm": {
+        "H": "M/d（E）HH:mm – HH:mm",
+        "m": "M/d（E）HH:mm – HH:mm"
+      },
+      "MMddHm": {
+        "H": "MM/ddHH:mm – HH:mm",
+        "m": "MM/ddHH:mm – HH:mm"
+      },
+      "MMMHm": {
+        "H": "LLLHH:mm – HH:mm",
+        "m": "LLLHH:mm – HH:mm"
+      },
+      "MMMdHm": {
+        "H": "M月d日HH:mm – HH:mm",
+        "m": "M月d日HH:mm – HH:mm"
+      },
+      "MMMEdHm": {
+        "H": "M月d日EHH:mm – HH:mm",
+        "m": "M月d日EHH:mm – HH:mm"
+      },
+      "MMMMdHm": {
+        "H": "M月d日HH:mm – HH:mm",
+        "m": "M月d日HH:mm – HH:mm"
+      },
+      "yHm": {
+        "H": "y年HH:mm – HH:mm",
+        "m": "y年HH:mm – HH:mm"
+      },
+      "yMHm": {
+        "H": "y/MHH:mm – HH:mm",
+        "m": "y/MHH:mm – HH:mm"
+      },
+      "yMdHm": {
+        "H": "y/M/dHH:mm – HH:mm",
+        "m": "y/M/dHH:mm – HH:mm"
+      },
+      "yMEdHm": {
+        "H": "y/M/d（E）HH:mm – HH:mm",
+        "m": "y/M/d（E）HH:mm – HH:mm"
+      },
+      "yMEEEEdHm": {
+        "H": "y年M月d日 EEEEHH:mm – HH:mm",
+        "m": "y年M月d日 EEEEHH:mm – HH:mm"
+      },
+      "yMMHm": {
+        "H": "y/MMHH:mm – HH:mm",
+        "m": "y/MMHH:mm – HH:mm"
+      },
+      "yMMMHm": {
+        "H": "y年M月HH:mm – HH:mm",
+        "m": "y年M月HH:mm – HH:mm"
+      },
+      "yMMMdHm": {
+        "H": "y年M月d日HH:mm – HH:mm",
+        "m": "y年M月d日HH:mm – HH:mm"
+      },
+      "yMMMEdHm": {
+        "H": "y年M月d日EHH:mm – HH:mm",
+        "m": "y年M月d日EHH:mm – HH:mm"
+      },
+      "yMMMMHm": {
+        "H": "y年M月HH:mm – HH:mm",
+        "m": "y年M月HH:mm – HH:mm"
+      },
+      "y年M月d日 EEEEhmv": {
+        "a": "y年M月d日 EEEEah:mm至ah:mm [v]",
+        "B": "y年M月d日 EEEEBh:mm至Bh:mm [v]",
+        "h": "y年M月d日 EEEEBh:mm至h:mm [v]",
+        "m": "y年M月d日 EEEEBh:mm至h:mm [v]"
+      },
+      "y年M月d日hmv": {
+        "a": "y年M月d日ah:mm至ah:mm [v]",
+        "B": "y年M月d日Bh:mm至Bh:mm [v]",
+        "h": "y年M月d日Bh:mm至h:mm [v]",
+        "m": "y年M月d日Bh:mm至h:mm [v]"
+      },
+      "y/M/dhmv": {
+        "a": "y/M/dah:mm至ah:mm [v]",
+        "B": "y/M/dBh:mm至Bh:mm [v]",
+        "h": "y/M/dBh:mm至h:mm [v]",
+        "m": "y/M/dBh:mm至h:mm [v]"
+      },
+      "dhmv": {
+        "a": "d日ah:mm至ah:mm [v]",
+        "B": "d日Bh:mm至Bh:mm [v]",
+        "h": "d日Bh:mm至h:mm [v]",
+        "m": "d日Bh:mm至h:mm [v]"
+      },
+      "Ehmv": {
+        "a": "cccah:mm至ah:mm [v]",
+        "B": "cccBh:mm至Bh:mm [v]",
+        "h": "cccBh:mm至h:mm [v]",
+        "m": "cccBh:mm至h:mm [v]"
+      },
+      "Edhmv": {
+        "a": "d Eah:mm至ah:mm [v]",
+        "B": "d EBh:mm至Bh:mm [v]",
+        "h": "d EBh:mm至h:mm [v]",
+        "m": "d EBh:mm至h:mm [v]"
+      },
+      "Gyhmv": {
+        "a": "Gy年ah:mm至ah:mm [v]",
+        "B": "Gy年Bh:mm至Bh:mm [v]",
+        "h": "Gy年Bh:mm至h:mm [v]",
+        "m": "Gy年Bh:mm至h:mm [v]"
+      },
+      "GyMhmv": {
+        "a": "Gy/Mah:mm至ah:mm [v]",
+        "B": "Gy/MBh:mm至Bh:mm [v]",
+        "h": "Gy/MBh:mm至h:mm [v]",
+        "m": "Gy/MBh:mm至h:mm [v]"
+      },
+      "GyMdhmv": {
+        "a": "G y/M/dah:mm至ah:mm [v]",
+        "B": "G y/M/dBh:mm至Bh:mm [v]",
+        "h": "G y/M/dBh:mm至h:mm [v]",
+        "m": "G y/M/dBh:mm至h:mm [v]"
+      },
+      "GyMEdhmv": {
+        "a": "Gy/M/d（E）ah:mm至ah:mm [v]",
+        "B": "Gy/M/d（E）Bh:mm至Bh:mm [v]",
+        "h": "Gy/M/d（E）Bh:mm至h:mm [v]",
+        "m": "Gy/M/d（E）Bh:mm至h:mm [v]"
+      },
+      "GyMMMhmv": {
+        "a": "Gy年M月ah:mm至ah:mm [v]",
+        "B": "Gy年M月Bh:mm至Bh:mm [v]",
+        "h": "Gy年M月Bh:mm至h:mm [v]",
+        "m": "Gy年M月Bh:mm至h:mm [v]"
+      },
+      "GyMMMdhmv": {
+        "a": "Gy年M月d日ah:mm至ah:mm [v]",
+        "B": "Gy年M月d日Bh:mm至Bh:mm [v]",
+        "h": "Gy年M月d日Bh:mm至h:mm [v]",
+        "m": "Gy年M月d日Bh:mm至h:mm [v]"
+      },
+      "GyMMMEdhmv": {
+        "a": "Gy年M月d日 Eah:mm至ah:mm [v]",
+        "B": "Gy年M月d日 EBh:mm至Bh:mm [v]",
+        "h": "Gy年M月d日 EBh:mm至h:mm [v]",
+        "m": "Gy年M月d日 EBh:mm至h:mm [v]"
+      },
+      "Mhmv": {
+        "a": "M月ah:mm至ah:mm [v]",
+        "B": "M月Bh:mm至Bh:mm [v]",
+        "h": "M月Bh:mm至h:mm [v]",
+        "m": "M月Bh:mm至h:mm [v]"
+      },
+      "Mdhmv": {
+        "a": "M/dah:mm至ah:mm [v]",
+        "B": "M/dBh:mm至Bh:mm [v]",
+        "h": "M/dBh:mm至h:mm [v]",
+        "m": "M/dBh:mm至h:mm [v]"
+      },
+      "MEdhmv": {
+        "a": "M/d（E）ah:mm至ah:mm [v]",
+        "B": "M/d（E）Bh:mm至Bh:mm [v]",
+        "h": "M/d（E）Bh:mm至h:mm [v]",
+        "m": "M/d（E）Bh:mm至h:mm [v]"
+      },
+      "MMddhmv": {
+        "a": "MM/ddah:mm至ah:mm [v]",
+        "B": "MM/ddBh:mm至Bh:mm [v]",
+        "h": "MM/ddBh:mm至h:mm [v]",
+        "m": "MM/ddBh:mm至h:mm [v]"
+      },
+      "MMMhmv": {
+        "a": "LLLah:mm至ah:mm [v]",
+        "B": "LLLBh:mm至Bh:mm [v]",
+        "h": "LLLBh:mm至h:mm [v]",
+        "m": "LLLBh:mm至h:mm [v]"
+      },
+      "MMMdhmv": {
+        "a": "M月d日ah:mm至ah:mm [v]",
+        "B": "M月d日Bh:mm至Bh:mm [v]",
+        "h": "M月d日Bh:mm至h:mm [v]",
+        "m": "M月d日Bh:mm至h:mm [v]"
+      },
+      "MMMEdhmv": {
+        "a": "M月d日Eah:mm至ah:mm [v]",
+        "B": "M月d日EBh:mm至Bh:mm [v]",
+        "h": "M月d日EBh:mm至h:mm [v]",
+        "m": "M月d日EBh:mm至h:mm [v]"
+      },
+      "MMMMdhmv": {
+        "a": "M月d日ah:mm至ah:mm [v]",
+        "B": "M月d日Bh:mm至Bh:mm [v]",
+        "h": "M月d日Bh:mm至h:mm [v]",
+        "m": "M月d日Bh:mm至h:mm [v]"
+      },
+      "yhmv": {
+        "a": "y年ah:mm至ah:mm [v]",
+        "B": "y年Bh:mm至Bh:mm [v]",
+        "h": "y年Bh:mm至h:mm [v]",
+        "m": "y年Bh:mm至h:mm [v]"
+      },
+      "yMhmv": {
+        "a": "y/Mah:mm至ah:mm [v]",
+        "B": "y/MBh:mm至Bh:mm [v]",
+        "h": "y/MBh:mm至h:mm [v]",
+        "m": "y/MBh:mm至h:mm [v]"
+      },
+      "yMdhmv": {
+        "a": "y/M/dah:mm至ah:mm [v]",
+        "B": "y/M/dBh:mm至Bh:mm [v]",
+        "h": "y/M/dBh:mm至h:mm [v]",
+        "m": "y/M/dBh:mm至h:mm [v]"
+      },
+      "yMEdhmv": {
+        "a": "y/M/d（E）ah:mm至ah:mm [v]",
+        "B": "y/M/d（E）Bh:mm至Bh:mm [v]",
+        "h": "y/M/d（E）Bh:mm至h:mm [v]",
+        "m": "y/M/d（E）Bh:mm至h:mm [v]"
+      },
+      "yMEEEEdhmv": {
+        "a": "y年M月d日 EEEEah:mm至ah:mm [v]",
+        "B": "y年M月d日 EEEEBh:mm至Bh:mm [v]",
+        "h": "y年M月d日 EEEEBh:mm至h:mm [v]",
+        "m": "y年M月d日 EEEEBh:mm至h:mm [v]"
+      },
+      "yMMhmv": {
+        "a": "y/MMah:mm至ah:mm [v]",
+        "B": "y/MMBh:mm至Bh:mm [v]",
+        "h": "y/MMBh:mm至h:mm [v]",
+        "m": "y/MMBh:mm至h:mm [v]"
+      },
+      "yMMMhmv": {
+        "a": "y年M月ah:mm至ah:mm [v]",
+        "B": "y年M月Bh:mm至Bh:mm [v]",
+        "h": "y年M月Bh:mm至h:mm [v]",
+        "m": "y年M月Bh:mm至h:mm [v]"
+      },
+      "yMMMdhmv": {
+        "a": "y年M月d日ah:mm至ah:mm [v]",
+        "B": "y年M月d日Bh:mm至Bh:mm [v]",
+        "h": "y年M月d日Bh:mm至h:mm [v]",
+        "m": "y年M月d日Bh:mm至h:mm [v]"
+      },
+      "yMMMEdhmv": {
+        "a": "y年M月d日Eah:mm至ah:mm [v]",
+        "B": "y年M月d日EBh:mm至Bh:mm [v]",
+        "h": "y年M月d日EBh:mm至h:mm [v]",
+        "m": "y年M月d日EBh:mm至h:mm [v]"
+      },
+      "yMMMMhmv": {
+        "a": "y年M月ah:mm至ah:mm [v]",
+        "B": "y年M月Bh:mm至Bh:mm [v]",
+        "h": "y年M月Bh:mm至h:mm [v]",
+        "m": "y年M月Bh:mm至h:mm [v]"
+      },
+      "y年M月d日 EEEEHmv": {
+        "H": "y年M月d日 EEEEHH:mm – HH:mm [v]",
+        "m": "y年M月d日 EEEEHH:mm – HH:mm [v]"
+      },
+      "y年M月d日Hmv": {
+        "H": "y年M月d日HH:mm – HH:mm [v]",
+        "m": "y年M月d日HH:mm – HH:mm [v]"
+      },
+      "y/M/dHmv": {
+        "H": "y/M/dHH:mm – HH:mm [v]",
+        "m": "y/M/dHH:mm – HH:mm [v]"
+      },
+      "dHmv": {
+        "H": "d日HH:mm – HH:mm [v]",
+        "m": "d日HH:mm – HH:mm [v]"
+      },
+      "EHmv": {
+        "H": "cccHH:mm – HH:mm [v]",
+        "m": "cccHH:mm – HH:mm [v]"
+      },
+      "EdHmv": {
+        "H": "d EHH:mm – HH:mm [v]",
+        "m": "d EHH:mm – HH:mm [v]"
+      },
+      "GyHmv": {
+        "H": "Gy年HH:mm – HH:mm [v]",
+        "m": "Gy年HH:mm – HH:mm [v]"
+      },
+      "GyMHmv": {
+        "H": "Gy/MHH:mm – HH:mm [v]",
+        "m": "Gy/MHH:mm – HH:mm [v]"
+      },
+      "GyMdHmv": {
+        "H": "G y/M/dHH:mm – HH:mm [v]",
+        "m": "G y/M/dHH:mm – HH:mm [v]"
+      },
+      "GyMEdHmv": {
+        "H": "Gy/M/d（E）HH:mm – HH:mm [v]",
+        "m": "Gy/M/d（E）HH:mm – HH:mm [v]"
+      },
+      "GyMMMHmv": {
+        "H": "Gy年M月HH:mm – HH:mm [v]",
+        "m": "Gy年M月HH:mm – HH:mm [v]"
+      },
+      "GyMMMdHmv": {
+        "H": "Gy年M月d日HH:mm – HH:mm [v]",
+        "m": "Gy年M月d日HH:mm – HH:mm [v]"
+      },
+      "GyMMMEdHmv": {
+        "H": "Gy年M月d日 EHH:mm – HH:mm [v]",
+        "m": "Gy年M月d日 EHH:mm – HH:mm [v]"
+      },
+      "MHmv": {
+        "H": "M月HH:mm – HH:mm [v]",
+        "m": "M月HH:mm – HH:mm [v]"
+      },
+      "MdHmv": {
+        "H": "M/dHH:mm – HH:mm [v]",
+        "m": "M/dHH:mm – HH:mm [v]"
+      },
+      "MEdHmv": {
+        "H": "M/d（E）HH:mm – HH:mm [v]",
+        "m": "M/d（E）HH:mm – HH:mm [v]"
+      },
+      "MMddHmv": {
+        "H": "MM/ddHH:mm – HH:mm [v]",
+        "m": "MM/ddHH:mm – HH:mm [v]"
+      },
+      "MMMHmv": {
+        "H": "LLLHH:mm – HH:mm [v]",
+        "m": "LLLHH:mm – HH:mm [v]"
+      },
+      "MMMdHmv": {
+        "H": "M月d日HH:mm – HH:mm [v]",
+        "m": "M月d日HH:mm – HH:mm [v]"
+      },
+      "MMMEdHmv": {
+        "H": "M月d日EHH:mm – HH:mm [v]",
+        "m": "M月d日EHH:mm – HH:mm [v]"
+      },
+      "MMMMdHmv": {
+        "H": "M月d日HH:mm – HH:mm [v]",
+        "m": "M月d日HH:mm – HH:mm [v]"
+      },
+      "yHmv": {
+        "H": "y年HH:mm – HH:mm [v]",
+        "m": "y年HH:mm – HH:mm [v]"
+      },
+      "yMHmv": {
+        "H": "y/MHH:mm – HH:mm [v]",
+        "m": "y/MHH:mm – HH:mm [v]"
+      },
+      "yMdHmv": {
+        "H": "y/M/dHH:mm – HH:mm [v]",
+        "m": "y/M/dHH:mm – HH:mm [v]"
+      },
+      "yMEdHmv": {
+        "H": "y/M/d（E）HH:mm – HH:mm [v]",
+        "m": "y/M/d（E）HH:mm – HH:mm [v]"
+      },
+      "yMEEEEdHmv": {
+        "H": "y年M月d日 EEEEHH:mm – HH:mm [v]",
+        "m": "y年M月d日 EEEEHH:mm – HH:mm [v]"
+      },
+      "yMMHmv": {
+        "H": "y/MMHH:mm – HH:mm [v]",
+        "m": "y/MMHH:mm – HH:mm [v]"
+      },
+      "yMMMHmv": {
+        "H": "y年M月HH:mm – HH:mm [v]",
+        "m": "y年M月HH:mm – HH:mm [v]"
+      },
+      "yMMMdHmv": {
+        "H": "y年M月d日HH:mm – HH:mm [v]",
+        "m": "y年M月d日HH:mm – HH:mm [v]"
+      },
+      "yMMMEdHmv": {
+        "H": "y年M月d日EHH:mm – HH:mm [v]",
+        "m": "y年M月d日EHH:mm – HH:mm [v]"
+      },
+      "yMMMMHmv": {
+        "H": "y年M月HH:mm – HH:mm [v]",
+        "m": "y年M月HH:mm – HH:mm [v]"
+      },
+      "y年M月d日 EEEEhv": {
+        "a": "y年M月d日 EEEEah時至ah時 [v]",
+        "B": "y年M月d日 EEEEBh時至Bh時 [v]",
+        "h": "y年M月d日 EEEEBh時至h時 [v]"
+      },
+      "y年M月d日hv": {
+        "a": "y年M月d日ah時至ah時 [v]",
+        "B": "y年M月d日Bh時至Bh時 [v]",
+        "h": "y年M月d日Bh時至h時 [v]"
+      },
+      "y/M/dhv": {
+        "a": "y/M/dah時至ah時 [v]",
+        "B": "y/M/dBh時至Bh時 [v]",
+        "h": "y/M/dBh時至h時 [v]"
+      },
+      "dhv": {
+        "a": "d日ah時至ah時 [v]",
+        "B": "d日Bh時至Bh時 [v]",
+        "h": "d日Bh時至h時 [v]"
+      },
+      "Ehv": {
+        "a": "cccah時至ah時 [v]",
+        "B": "cccBh時至Bh時 [v]",
+        "h": "cccBh時至h時 [v]"
+      },
+      "Edhv": {
+        "a": "d Eah時至ah時 [v]",
+        "B": "d EBh時至Bh時 [v]",
+        "h": "d EBh時至h時 [v]"
+      },
+      "Gyhv": {
+        "a": "Gy年ah時至ah時 [v]",
+        "B": "Gy年Bh時至Bh時 [v]",
+        "h": "Gy年Bh時至h時 [v]"
+      },
+      "GyMhv": {
+        "a": "Gy/Mah時至ah時 [v]",
+        "B": "Gy/MBh時至Bh時 [v]",
+        "h": "Gy/MBh時至h時 [v]"
+      },
+      "GyMdhv": {
+        "a": "G y/M/dah時至ah時 [v]",
+        "B": "G y/M/dBh時至Bh時 [v]",
+        "h": "G y/M/dBh時至h時 [v]"
+      },
+      "GyMEdhv": {
+        "a": "Gy/M/d（E）ah時至ah時 [v]",
+        "B": "Gy/M/d（E）Bh時至Bh時 [v]",
+        "h": "Gy/M/d（E）Bh時至h時 [v]"
+      },
+      "GyMMMhv": {
+        "a": "Gy年M月ah時至ah時 [v]",
+        "B": "Gy年M月Bh時至Bh時 [v]",
+        "h": "Gy年M月Bh時至h時 [v]"
+      },
+      "GyMMMdhv": {
+        "a": "Gy年M月d日ah時至ah時 [v]",
+        "B": "Gy年M月d日Bh時至Bh時 [v]",
+        "h": "Gy年M月d日Bh時至h時 [v]"
+      },
+      "GyMMMEdhv": {
+        "a": "Gy年M月d日 Eah時至ah時 [v]",
+        "B": "Gy年M月d日 EBh時至Bh時 [v]",
+        "h": "Gy年M月d日 EBh時至h時 [v]"
+      },
+      "Mhv": {
+        "a": "M月ah時至ah時 [v]",
+        "B": "M月Bh時至Bh時 [v]",
+        "h": "M月Bh時至h時 [v]"
+      },
+      "Mdhv": {
+        "a": "M/dah時至ah時 [v]",
+        "B": "M/dBh時至Bh時 [v]",
+        "h": "M/dBh時至h時 [v]"
+      },
+      "MEdhv": {
+        "a": "M/d（E）ah時至ah時 [v]",
+        "B": "M/d（E）Bh時至Bh時 [v]",
+        "h": "M/d（E）Bh時至h時 [v]"
+      },
+      "MMddhv": {
+        "a": "MM/ddah時至ah時 [v]",
+        "B": "MM/ddBh時至Bh時 [v]",
+        "h": "MM/ddBh時至h時 [v]"
+      },
+      "MMMhv": {
+        "a": "LLLah時至ah時 [v]",
+        "B": "LLLBh時至Bh時 [v]",
+        "h": "LLLBh時至h時 [v]"
+      },
+      "MMMdhv": {
+        "a": "M月d日ah時至ah時 [v]",
+        "B": "M月d日Bh時至Bh時 [v]",
+        "h": "M月d日Bh時至h時 [v]"
+      },
+      "MMMEdhv": {
+        "a": "M月d日Eah時至ah時 [v]",
+        "B": "M月d日EBh時至Bh時 [v]",
+        "h": "M月d日EBh時至h時 [v]"
+      },
+      "MMMMdhv": {
+        "a": "M月d日ah時至ah時 [v]",
+        "B": "M月d日Bh時至Bh時 [v]",
+        "h": "M月d日Bh時至h時 [v]"
+      },
+      "yhv": {
+        "a": "y年ah時至ah時 [v]",
+        "B": "y年Bh時至Bh時 [v]",
+        "h": "y年Bh時至h時 [v]"
+      },
+      "yMhv": {
+        "a": "y/Mah時至ah時 [v]",
+        "B": "y/MBh時至Bh時 [v]",
+        "h": "y/MBh時至h時 [v]"
+      },
+      "yMdhv": {
+        "a": "y/M/dah時至ah時 [v]",
+        "B": "y/M/dBh時至Bh時 [v]",
+        "h": "y/M/dBh時至h時 [v]"
+      },
+      "yMEdhv": {
+        "a": "y/M/d（E）ah時至ah時 [v]",
+        "B": "y/M/d（E）Bh時至Bh時 [v]",
+        "h": "y/M/d（E）Bh時至h時 [v]"
+      },
+      "yMEEEEdhv": {
+        "a": "y年M月d日 EEEEah時至ah時 [v]",
+        "B": "y年M月d日 EEEEBh時至Bh時 [v]",
+        "h": "y年M月d日 EEEEBh時至h時 [v]"
+      },
+      "yMMhv": {
+        "a": "y/MMah時至ah時 [v]",
+        "B": "y/MMBh時至Bh時 [v]",
+        "h": "y/MMBh時至h時 [v]"
+      },
+      "yMMMhv": {
+        "a": "y年M月ah時至ah時 [v]",
+        "B": "y年M月Bh時至Bh時 [v]",
+        "h": "y年M月Bh時至h時 [v]"
+      },
+      "yMMMdhv": {
+        "a": "y年M月d日ah時至ah時 [v]",
+        "B": "y年M月d日Bh時至Bh時 [v]",
+        "h": "y年M月d日Bh時至h時 [v]"
+      },
+      "yMMMEdhv": {
+        "a": "y年M月d日Eah時至ah時 [v]",
+        "B": "y年M月d日EBh時至Bh時 [v]",
+        "h": "y年M月d日EBh時至h時 [v]"
+      },
+      "yMMMMhv": {
+        "a": "y年M月ah時至ah時 [v]",
+        "B": "y年M月Bh時至Bh時 [v]",
+        "h": "y年M月Bh時至h時 [v]"
+      },
+      "y年M月d日 EEEEHv": {
+        "H": "y年M月d日 EEEEHH – HH [v]"
+      },
+      "y年M月d日Hv": {
+        "H": "y年M月d日HH – HH [v]"
+      },
+      "y/M/dHv": {
+        "H": "y/M/dHH – HH [v]"
+      },
+      "dHv": {
+        "H": "d日HH – HH [v]"
+      },
+      "EHv": {
+        "H": "cccHH – HH [v]"
+      },
+      "EdHv": {
+        "H": "d EHH – HH [v]"
+      },
+      "GyHv": {
+        "H": "Gy年HH – HH [v]"
+      },
+      "GyMHv": {
+        "H": "Gy/MHH – HH [v]"
+      },
+      "GyMdHv": {
+        "H": "G y/M/dHH – HH [v]"
+      },
+      "GyMEdHv": {
+        "H": "Gy/M/d（E）HH – HH [v]"
+      },
+      "GyMMMHv": {
+        "H": "Gy年M月HH – HH [v]"
+      },
+      "GyMMMdHv": {
+        "H": "Gy年M月d日HH – HH [v]"
+      },
+      "GyMMMEdHv": {
+        "H": "Gy年M月d日 EHH – HH [v]"
+      },
+      "MHv": {
+        "H": "M月HH – HH [v]"
+      },
+      "MdHv": {
+        "H": "M/dHH – HH [v]"
+      },
+      "MEdHv": {
+        "H": "M/d（E）HH – HH [v]"
+      },
+      "MMddHv": {
+        "H": "MM/ddHH – HH [v]"
+      },
+      "MMMHv": {
+        "H": "LLLHH – HH [v]"
+      },
+      "MMMdHv": {
+        "H": "M月d日HH – HH [v]"
+      },
+      "MMMEdHv": {
+        "H": "M月d日EHH – HH [v]"
+      },
+      "MMMMdHv": {
+        "H": "M月d日HH – HH [v]"
+      },
+      "yHv": {
+        "H": "y年HH – HH [v]"
+      },
+      "yMHv": {
+        "H": "y/MHH – HH [v]"
+      },
+      "yMdHv": {
+        "H": "y/M/dHH – HH [v]"
+      },
+      "yMEdHv": {
+        "H": "y/M/d（E）HH – HH [v]"
+      },
+      "yMEEEEdHv": {
+        "H": "y年M月d日 EEEEHH – HH [v]"
+      },
+      "yMMHv": {
+        "H": "y/MMHH – HH [v]"
+      },
+      "yMMMHv": {
+        "H": "y年M月HH – HH [v]"
+      },
+      "yMMMdHv": {
+        "H": "y年M月d日HH – HH [v]"
+      },
+      "yMMMEdHv": {
+        "H": "y年M月d日EHH – HH [v]"
+      },
+      "yMMMMHv": {
+        "H": "y年M月HH – HH [v]"
       }
     },
     "hourCycle": "",
@@ -24898,6 +35887,1277 @@ Intl.DateTimeFormat.__addLocaleData({
       "yMMMM": {
         "M": "y年M月 – M月",
         "y": "y年M月 – y年M月"
+      },
+      "y年M月d日EEEE Bh": {
+        "B": "y年M月d日EEEE Bh时至Bh时",
+        "h": "y年M月d日EEEE Bh时至h时"
+      },
+      "y年M月d日 Bh": {
+        "B": "y年M月d日 Bh时至Bh时",
+        "h": "y年M月d日 Bh时至h时"
+      },
+      "y/M/d Bh": {
+        "B": "y/M/d Bh时至Bh时",
+        "h": "y/M/d Bh时至h时"
+      },
+      "d Bh": {
+        "B": "d日 Bh时至Bh时",
+        "h": "d日 Bh时至h时"
+      },
+      "E Bh": {
+        "B": "ccc Bh时至Bh时",
+        "h": "ccc Bh时至h时"
+      },
+      "Ed Bh": {
+        "B": "d日E Bh时至Bh时",
+        "h": "d日E Bh时至h时"
+      },
+      "Gy Bh": {
+        "B": "Gy年 Bh时至Bh时",
+        "h": "Gy年 Bh时至h时"
+      },
+      "GyM Bh": {
+        "B": "Gy年M月 Bh时至Bh时",
+        "h": "Gy年M月 Bh时至h时"
+      },
+      "GyMd Bh": {
+        "B": "Gy-MM-dd Bh时至Bh时",
+        "h": "Gy-MM-dd Bh时至h时"
+      },
+      "GyMEd Bh": {
+        "B": "Gy-MM-ddE Bh时至Bh时",
+        "h": "Gy-MM-ddE Bh时至h时"
+      },
+      "GyMMM Bh": {
+        "B": "Gy年M月 Bh时至Bh时",
+        "h": "Gy年M月 Bh时至h时"
+      },
+      "GyMMMd Bh": {
+        "B": "Gy年M月d日 Bh时至Bh时",
+        "h": "Gy年M月d日 Bh时至h时"
+      },
+      "GyMMMEd Bh": {
+        "B": "Gy年M月d日E Bh时至Bh时",
+        "h": "Gy年M月d日E Bh时至h时"
+      },
+      "M Bh": {
+        "B": "M月 Bh时至Bh时",
+        "h": "M月 Bh时至h时"
+      },
+      "Md Bh": {
+        "B": "M/d Bh时至Bh时",
+        "h": "M/d Bh时至h时"
+      },
+      "MEd Bh": {
+        "B": "M/dE Bh时至Bh时",
+        "h": "M/dE Bh时至h时"
+      },
+      "MMdd Bh": {
+        "B": "MM/dd Bh时至Bh时",
+        "h": "MM/dd Bh时至h时"
+      },
+      "MMM Bh": {
+        "B": "LLL Bh时至Bh时",
+        "h": "LLL Bh时至h时"
+      },
+      "MMMd Bh": {
+        "B": "M月d日 Bh时至Bh时",
+        "h": "M月d日 Bh时至h时"
+      },
+      "MMMEd Bh": {
+        "B": "M月d日E Bh时至Bh时",
+        "h": "M月d日E Bh时至h时"
+      },
+      "MMMMd Bh": {
+        "B": "M月d日 Bh时至Bh时",
+        "h": "M月d日 Bh时至h时"
+      },
+      "y Bh": {
+        "B": "y年 Bh时至Bh时",
+        "h": "y年 Bh时至h时"
+      },
+      "yM Bh": {
+        "B": "y/M Bh时至Bh时",
+        "h": "y/M Bh时至h时"
+      },
+      "yMd Bh": {
+        "B": "y/M/d Bh时至Bh时",
+        "h": "y/M/d Bh时至h时"
+      },
+      "yMEd Bh": {
+        "B": "y/M/dE Bh时至Bh时",
+        "h": "y/M/dE Bh时至h时"
+      },
+      "yMEEEEd Bh": {
+        "B": "y年M月d日EEEE Bh时至Bh时",
+        "h": "y年M月d日EEEE Bh时至h时"
+      },
+      "yMM Bh": {
+        "B": "y年M月 Bh时至Bh时",
+        "h": "y年M月 Bh时至h时"
+      },
+      "yMMM Bh": {
+        "B": "y年M月 Bh时至Bh时",
+        "h": "y年M月 Bh时至h时"
+      },
+      "yMMMd Bh": {
+        "B": "y年M月d日 Bh时至Bh时",
+        "h": "y年M月d日 Bh时至h时"
+      },
+      "yMMMEd Bh": {
+        "B": "y年M月d日E Bh时至Bh时",
+        "h": "y年M月d日E Bh时至h时"
+      },
+      "yMMMM Bh": {
+        "B": "y年M月 Bh时至Bh时",
+        "h": "y年M月 Bh时至h时"
+      },
+      "y年M月d日EEEE Bhm": {
+        "B": "y年M月d日EEEE Bh:mm至Bh:mm",
+        "h": "y年M月d日EEEE Bh:mm至h:mm",
+        "m": "y年M月d日EEEE Bh:mm至h:mm"
+      },
+      "y年M月d日 Bhm": {
+        "B": "y年M月d日 Bh:mm至Bh:mm",
+        "h": "y年M月d日 Bh:mm至h:mm",
+        "m": "y年M月d日 Bh:mm至h:mm"
+      },
+      "y/M/d Bhm": {
+        "B": "y/M/d Bh:mm至Bh:mm",
+        "h": "y/M/d Bh:mm至h:mm",
+        "m": "y/M/d Bh:mm至h:mm"
+      },
+      "d Bhm": {
+        "B": "d日 Bh:mm至Bh:mm",
+        "h": "d日 Bh:mm至h:mm",
+        "m": "d日 Bh:mm至h:mm"
+      },
+      "E Bhm": {
+        "B": "ccc Bh:mm至Bh:mm",
+        "h": "ccc Bh:mm至h:mm",
+        "m": "ccc Bh:mm至h:mm"
+      },
+      "Ed Bhm": {
+        "B": "d日E Bh:mm至Bh:mm",
+        "h": "d日E Bh:mm至h:mm",
+        "m": "d日E Bh:mm至h:mm"
+      },
+      "Gy Bhm": {
+        "B": "Gy年 Bh:mm至Bh:mm",
+        "h": "Gy年 Bh:mm至h:mm",
+        "m": "Gy年 Bh:mm至h:mm"
+      },
+      "GyM Bhm": {
+        "B": "Gy年M月 Bh:mm至Bh:mm",
+        "h": "Gy年M月 Bh:mm至h:mm",
+        "m": "Gy年M月 Bh:mm至h:mm"
+      },
+      "GyMd Bhm": {
+        "B": "Gy-MM-dd Bh:mm至Bh:mm",
+        "h": "Gy-MM-dd Bh:mm至h:mm",
+        "m": "Gy-MM-dd Bh:mm至h:mm"
+      },
+      "GyMEd Bhm": {
+        "B": "Gy-MM-ddE Bh:mm至Bh:mm",
+        "h": "Gy-MM-ddE Bh:mm至h:mm",
+        "m": "Gy-MM-ddE Bh:mm至h:mm"
+      },
+      "GyMMM Bhm": {
+        "B": "Gy年M月 Bh:mm至Bh:mm",
+        "h": "Gy年M月 Bh:mm至h:mm",
+        "m": "Gy年M月 Bh:mm至h:mm"
+      },
+      "GyMMMd Bhm": {
+        "B": "Gy年M月d日 Bh:mm至Bh:mm",
+        "h": "Gy年M月d日 Bh:mm至h:mm",
+        "m": "Gy年M月d日 Bh:mm至h:mm"
+      },
+      "GyMMMEd Bhm": {
+        "B": "Gy年M月d日E Bh:mm至Bh:mm",
+        "h": "Gy年M月d日E Bh:mm至h:mm",
+        "m": "Gy年M月d日E Bh:mm至h:mm"
+      },
+      "M Bhm": {
+        "B": "M月 Bh:mm至Bh:mm",
+        "h": "M月 Bh:mm至h:mm",
+        "m": "M月 Bh:mm至h:mm"
+      },
+      "Md Bhm": {
+        "B": "M/d Bh:mm至Bh:mm",
+        "h": "M/d Bh:mm至h:mm",
+        "m": "M/d Bh:mm至h:mm"
+      },
+      "MEd Bhm": {
+        "B": "M/dE Bh:mm至Bh:mm",
+        "h": "M/dE Bh:mm至h:mm",
+        "m": "M/dE Bh:mm至h:mm"
+      },
+      "MMdd Bhm": {
+        "B": "MM/dd Bh:mm至Bh:mm",
+        "h": "MM/dd Bh:mm至h:mm",
+        "m": "MM/dd Bh:mm至h:mm"
+      },
+      "MMM Bhm": {
+        "B": "LLL Bh:mm至Bh:mm",
+        "h": "LLL Bh:mm至h:mm",
+        "m": "LLL Bh:mm至h:mm"
+      },
+      "MMMd Bhm": {
+        "B": "M月d日 Bh:mm至Bh:mm",
+        "h": "M月d日 Bh:mm至h:mm",
+        "m": "M月d日 Bh:mm至h:mm"
+      },
+      "MMMEd Bhm": {
+        "B": "M月d日E Bh:mm至Bh:mm",
+        "h": "M月d日E Bh:mm至h:mm",
+        "m": "M月d日E Bh:mm至h:mm"
+      },
+      "MMMMd Bhm": {
+        "B": "M月d日 Bh:mm至Bh:mm",
+        "h": "M月d日 Bh:mm至h:mm",
+        "m": "M月d日 Bh:mm至h:mm"
+      },
+      "y Bhm": {
+        "B": "y年 Bh:mm至Bh:mm",
+        "h": "y年 Bh:mm至h:mm",
+        "m": "y年 Bh:mm至h:mm"
+      },
+      "yM Bhm": {
+        "B": "y/M Bh:mm至Bh:mm",
+        "h": "y/M Bh:mm至h:mm",
+        "m": "y/M Bh:mm至h:mm"
+      },
+      "yMd Bhm": {
+        "B": "y/M/d Bh:mm至Bh:mm",
+        "h": "y/M/d Bh:mm至h:mm",
+        "m": "y/M/d Bh:mm至h:mm"
+      },
+      "yMEd Bhm": {
+        "B": "y/M/dE Bh:mm至Bh:mm",
+        "h": "y/M/dE Bh:mm至h:mm",
+        "m": "y/M/dE Bh:mm至h:mm"
+      },
+      "yMEEEEd Bhm": {
+        "B": "y年M月d日EEEE Bh:mm至Bh:mm",
+        "h": "y年M月d日EEEE Bh:mm至h:mm",
+        "m": "y年M月d日EEEE Bh:mm至h:mm"
+      },
+      "yMM Bhm": {
+        "B": "y年M月 Bh:mm至Bh:mm",
+        "h": "y年M月 Bh:mm至h:mm",
+        "m": "y年M月 Bh:mm至h:mm"
+      },
+      "yMMM Bhm": {
+        "B": "y年M月 Bh:mm至Bh:mm",
+        "h": "y年M月 Bh:mm至h:mm",
+        "m": "y年M月 Bh:mm至h:mm"
+      },
+      "yMMMd Bhm": {
+        "B": "y年M月d日 Bh:mm至Bh:mm",
+        "h": "y年M月d日 Bh:mm至h:mm",
+        "m": "y年M月d日 Bh:mm至h:mm"
+      },
+      "yMMMEd Bhm": {
+        "B": "y年M月d日E Bh:mm至Bh:mm",
+        "h": "y年M月d日E Bh:mm至h:mm",
+        "m": "y年M月d日E Bh:mm至h:mm"
+      },
+      "yMMMM Bhm": {
+        "B": "y年M月 Bh:mm至Bh:mm",
+        "h": "y年M月 Bh:mm至h:mm",
+        "m": "y年M月 Bh:mm至h:mm"
+      },
+      "y年M月d日EEEE h": {
+        "a": "y年M月d日EEEE ah时至ah时",
+        "h": "y年M月d日EEEE ah时至h时"
+      },
+      "y年M月d日 h": {
+        "a": "y年M月d日 ah时至ah时",
+        "h": "y年M月d日 ah时至h时"
+      },
+      "y/M/d h": {
+        "a": "y/M/d ah时至ah时",
+        "h": "y/M/d ah时至h时"
+      },
+      "d h": {
+        "a": "d日 ah时至ah时",
+        "h": "d日 ah时至h时"
+      },
+      "E h": {
+        "a": "ccc ah时至ah时",
+        "h": "ccc ah时至h时"
+      },
+      "Ed h": {
+        "a": "d日E ah时至ah时",
+        "h": "d日E ah时至h时"
+      },
+      "Gy h": {
+        "a": "Gy年 ah时至ah时",
+        "h": "Gy年 ah时至h时"
+      },
+      "GyM h": {
+        "a": "Gy年M月 ah时至ah时",
+        "h": "Gy年M月 ah时至h时"
+      },
+      "GyMd h": {
+        "a": "Gy-MM-dd ah时至ah时",
+        "h": "Gy-MM-dd ah时至h时"
+      },
+      "GyMEd h": {
+        "a": "Gy-MM-ddE ah时至ah时",
+        "h": "Gy-MM-ddE ah时至h时"
+      },
+      "GyMMM h": {
+        "a": "Gy年M月 ah时至ah时",
+        "h": "Gy年M月 ah时至h时"
+      },
+      "GyMMMd h": {
+        "a": "Gy年M月d日 ah时至ah时",
+        "h": "Gy年M月d日 ah时至h时"
+      },
+      "GyMMMEd h": {
+        "a": "Gy年M月d日E ah时至ah时",
+        "h": "Gy年M月d日E ah时至h时"
+      },
+      "M h": {
+        "a": "M月 ah时至ah时",
+        "h": "M月 ah时至h时"
+      },
+      "Md h": {
+        "a": "M/d ah时至ah时",
+        "h": "M/d ah时至h时"
+      },
+      "MEd h": {
+        "a": "M/dE ah时至ah时",
+        "h": "M/dE ah时至h时"
+      },
+      "MMdd h": {
+        "a": "MM/dd ah时至ah时",
+        "h": "MM/dd ah时至h时"
+      },
+      "MMM h": {
+        "a": "LLL ah时至ah时",
+        "h": "LLL ah时至h时"
+      },
+      "MMMd h": {
+        "a": "M月d日 ah时至ah时",
+        "h": "M月d日 ah时至h时"
+      },
+      "MMMEd h": {
+        "a": "M月d日E ah时至ah时",
+        "h": "M月d日E ah时至h时"
+      },
+      "MMMMd h": {
+        "a": "M月d日 ah时至ah时",
+        "h": "M月d日 ah时至h时"
+      },
+      "y h": {
+        "a": "y年 ah时至ah时",
+        "h": "y年 ah时至h时"
+      },
+      "yM h": {
+        "a": "y/M ah时至ah时",
+        "h": "y/M ah时至h时"
+      },
+      "yMd h": {
+        "a": "y/M/d ah时至ah时",
+        "h": "y/M/d ah时至h时"
+      },
+      "yMEd h": {
+        "a": "y/M/dE ah时至ah时",
+        "h": "y/M/dE ah时至h时"
+      },
+      "yMEEEEd h": {
+        "a": "y年M月d日EEEE ah时至ah时",
+        "h": "y年M月d日EEEE ah时至h时"
+      },
+      "yMM h": {
+        "a": "y年M月 ah时至ah时",
+        "h": "y年M月 ah时至h时"
+      },
+      "yMMM h": {
+        "a": "y年M月 ah时至ah时",
+        "h": "y年M月 ah时至h时"
+      },
+      "yMMMd h": {
+        "a": "y年M月d日 ah时至ah时",
+        "h": "y年M月d日 ah时至h时"
+      },
+      "yMMMEd h": {
+        "a": "y年M月d日E ah时至ah时",
+        "h": "y年M月d日E ah时至h时"
+      },
+      "yMMMM h": {
+        "a": "y年M月 ah时至ah时",
+        "h": "y年M月 ah时至h时"
+      },
+      "y年M月d日EEEE H": {
+        "H": "y年M月d日EEEE HH–HH"
+      },
+      "y年M月d日 H": {
+        "H": "y年M月d日 HH–HH"
+      },
+      "y/M/d H": {
+        "H": "y/M/d HH–HH"
+      },
+      "d H": {
+        "H": "d日 HH–HH"
+      },
+      "E H": {
+        "H": "ccc HH–HH"
+      },
+      "Ed H": {
+        "H": "d日E HH–HH"
+      },
+      "Gy H": {
+        "H": "Gy年 HH–HH"
+      },
+      "GyM H": {
+        "H": "Gy年M月 HH–HH"
+      },
+      "GyMd H": {
+        "H": "Gy-MM-dd HH–HH"
+      },
+      "GyMEd H": {
+        "H": "Gy-MM-ddE HH–HH"
+      },
+      "GyMMM H": {
+        "H": "Gy年M月 HH–HH"
+      },
+      "GyMMMd H": {
+        "H": "Gy年M月d日 HH–HH"
+      },
+      "GyMMMEd H": {
+        "H": "Gy年M月d日E HH–HH"
+      },
+      "M H": {
+        "H": "M月 HH–HH"
+      },
+      "Md H": {
+        "H": "M/d HH–HH"
+      },
+      "MEd H": {
+        "H": "M/dE HH–HH"
+      },
+      "MMdd H": {
+        "H": "MM/dd HH–HH"
+      },
+      "MMM H": {
+        "H": "LLL HH–HH"
+      },
+      "MMMd H": {
+        "H": "M月d日 HH–HH"
+      },
+      "MMMEd H": {
+        "H": "M月d日E HH–HH"
+      },
+      "MMMMd H": {
+        "H": "M月d日 HH–HH"
+      },
+      "y H": {
+        "H": "y年 HH–HH"
+      },
+      "yM H": {
+        "H": "y/M HH–HH"
+      },
+      "yMd H": {
+        "H": "y/M/d HH–HH"
+      },
+      "yMEd H": {
+        "H": "y/M/dE HH–HH"
+      },
+      "yMEEEEd H": {
+        "H": "y年M月d日EEEE HH–HH"
+      },
+      "yMM H": {
+        "H": "y年M月 HH–HH"
+      },
+      "yMMM H": {
+        "H": "y年M月 HH–HH"
+      },
+      "yMMMd H": {
+        "H": "y年M月d日 HH–HH"
+      },
+      "yMMMEd H": {
+        "H": "y年M月d日E HH–HH"
+      },
+      "yMMMM H": {
+        "H": "y年M月 HH–HH"
+      },
+      "y年M月d日EEEE hm": {
+        "a": "y年M月d日EEEE ah:mm至ah:mm",
+        "h": "y年M月d日EEEE ah:mm至h:mm",
+        "m": "y年M月d日EEEE ah:mm至h:mm"
+      },
+      "y年M月d日 hm": {
+        "a": "y年M月d日 ah:mm至ah:mm",
+        "h": "y年M月d日 ah:mm至h:mm",
+        "m": "y年M月d日 ah:mm至h:mm"
+      },
+      "y/M/d hm": {
+        "a": "y/M/d ah:mm至ah:mm",
+        "h": "y/M/d ah:mm至h:mm",
+        "m": "y/M/d ah:mm至h:mm"
+      },
+      "d hm": {
+        "a": "d日 ah:mm至ah:mm",
+        "h": "d日 ah:mm至h:mm",
+        "m": "d日 ah:mm至h:mm"
+      },
+      "E hm": {
+        "a": "ccc ah:mm至ah:mm",
+        "h": "ccc ah:mm至h:mm",
+        "m": "ccc ah:mm至h:mm"
+      },
+      "Ed hm": {
+        "a": "d日E ah:mm至ah:mm",
+        "h": "d日E ah:mm至h:mm",
+        "m": "d日E ah:mm至h:mm"
+      },
+      "Gy hm": {
+        "a": "Gy年 ah:mm至ah:mm",
+        "h": "Gy年 ah:mm至h:mm",
+        "m": "Gy年 ah:mm至h:mm"
+      },
+      "GyM hm": {
+        "a": "Gy年M月 ah:mm至ah:mm",
+        "h": "Gy年M月 ah:mm至h:mm",
+        "m": "Gy年M月 ah:mm至h:mm"
+      },
+      "GyMd hm": {
+        "a": "Gy-MM-dd ah:mm至ah:mm",
+        "h": "Gy-MM-dd ah:mm至h:mm",
+        "m": "Gy-MM-dd ah:mm至h:mm"
+      },
+      "GyMEd hm": {
+        "a": "Gy-MM-ddE ah:mm至ah:mm",
+        "h": "Gy-MM-ddE ah:mm至h:mm",
+        "m": "Gy-MM-ddE ah:mm至h:mm"
+      },
+      "GyMMM hm": {
+        "a": "Gy年M月 ah:mm至ah:mm",
+        "h": "Gy年M月 ah:mm至h:mm",
+        "m": "Gy年M月 ah:mm至h:mm"
+      },
+      "GyMMMd hm": {
+        "a": "Gy年M月d日 ah:mm至ah:mm",
+        "h": "Gy年M月d日 ah:mm至h:mm",
+        "m": "Gy年M月d日 ah:mm至h:mm"
+      },
+      "GyMMMEd hm": {
+        "a": "Gy年M月d日E ah:mm至ah:mm",
+        "h": "Gy年M月d日E ah:mm至h:mm",
+        "m": "Gy年M月d日E ah:mm至h:mm"
+      },
+      "M hm": {
+        "a": "M月 ah:mm至ah:mm",
+        "h": "M月 ah:mm至h:mm",
+        "m": "M月 ah:mm至h:mm"
+      },
+      "Md hm": {
+        "a": "M/d ah:mm至ah:mm",
+        "h": "M/d ah:mm至h:mm",
+        "m": "M/d ah:mm至h:mm"
+      },
+      "MEd hm": {
+        "a": "M/dE ah:mm至ah:mm",
+        "h": "M/dE ah:mm至h:mm",
+        "m": "M/dE ah:mm至h:mm"
+      },
+      "MMdd hm": {
+        "a": "MM/dd ah:mm至ah:mm",
+        "h": "MM/dd ah:mm至h:mm",
+        "m": "MM/dd ah:mm至h:mm"
+      },
+      "MMM hm": {
+        "a": "LLL ah:mm至ah:mm",
+        "h": "LLL ah:mm至h:mm",
+        "m": "LLL ah:mm至h:mm"
+      },
+      "MMMd hm": {
+        "a": "M月d日 ah:mm至ah:mm",
+        "h": "M月d日 ah:mm至h:mm",
+        "m": "M月d日 ah:mm至h:mm"
+      },
+      "MMMEd hm": {
+        "a": "M月d日E ah:mm至ah:mm",
+        "h": "M月d日E ah:mm至h:mm",
+        "m": "M月d日E ah:mm至h:mm"
+      },
+      "MMMMd hm": {
+        "a": "M月d日 ah:mm至ah:mm",
+        "h": "M月d日 ah:mm至h:mm",
+        "m": "M月d日 ah:mm至h:mm"
+      },
+      "y hm": {
+        "a": "y年 ah:mm至ah:mm",
+        "h": "y年 ah:mm至h:mm",
+        "m": "y年 ah:mm至h:mm"
+      },
+      "yM hm": {
+        "a": "y/M ah:mm至ah:mm",
+        "h": "y/M ah:mm至h:mm",
+        "m": "y/M ah:mm至h:mm"
+      },
+      "yMd hm": {
+        "a": "y/M/d ah:mm至ah:mm",
+        "h": "y/M/d ah:mm至h:mm",
+        "m": "y/M/d ah:mm至h:mm"
+      },
+      "yMEd hm": {
+        "a": "y/M/dE ah:mm至ah:mm",
+        "h": "y/M/dE ah:mm至h:mm",
+        "m": "y/M/dE ah:mm至h:mm"
+      },
+      "yMEEEEd hm": {
+        "a": "y年M月d日EEEE ah:mm至ah:mm",
+        "h": "y年M月d日EEEE ah:mm至h:mm",
+        "m": "y年M月d日EEEE ah:mm至h:mm"
+      },
+      "yMM hm": {
+        "a": "y年M月 ah:mm至ah:mm",
+        "h": "y年M月 ah:mm至h:mm",
+        "m": "y年M月 ah:mm至h:mm"
+      },
+      "yMMM hm": {
+        "a": "y年M月 ah:mm至ah:mm",
+        "h": "y年M月 ah:mm至h:mm",
+        "m": "y年M月 ah:mm至h:mm"
+      },
+      "yMMMd hm": {
+        "a": "y年M月d日 ah:mm至ah:mm",
+        "h": "y年M月d日 ah:mm至h:mm",
+        "m": "y年M月d日 ah:mm至h:mm"
+      },
+      "yMMMEd hm": {
+        "a": "y年M月d日E ah:mm至ah:mm",
+        "h": "y年M月d日E ah:mm至h:mm",
+        "m": "y年M月d日E ah:mm至h:mm"
+      },
+      "yMMMM hm": {
+        "a": "y年M月 ah:mm至ah:mm",
+        "h": "y年M月 ah:mm至h:mm",
+        "m": "y年M月 ah:mm至h:mm"
+      },
+      "y年M月d日EEEE Hm": {
+        "H": "y年M月d日EEEE HH:mm–HH:mm",
+        "m": "y年M月d日EEEE HH:mm–HH:mm"
+      },
+      "y年M月d日 Hm": {
+        "H": "y年M月d日 HH:mm–HH:mm",
+        "m": "y年M月d日 HH:mm–HH:mm"
+      },
+      "y/M/d Hm": {
+        "H": "y/M/d HH:mm–HH:mm",
+        "m": "y/M/d HH:mm–HH:mm"
+      },
+      "d Hm": {
+        "H": "d日 HH:mm–HH:mm",
+        "m": "d日 HH:mm–HH:mm"
+      },
+      "E Hm": {
+        "H": "ccc HH:mm–HH:mm",
+        "m": "ccc HH:mm–HH:mm"
+      },
+      "Ed Hm": {
+        "H": "d日E HH:mm–HH:mm",
+        "m": "d日E HH:mm–HH:mm"
+      },
+      "Gy Hm": {
+        "H": "Gy年 HH:mm–HH:mm",
+        "m": "Gy年 HH:mm–HH:mm"
+      },
+      "GyM Hm": {
+        "H": "Gy年M月 HH:mm–HH:mm",
+        "m": "Gy年M月 HH:mm–HH:mm"
+      },
+      "GyMd Hm": {
+        "H": "Gy-MM-dd HH:mm–HH:mm",
+        "m": "Gy-MM-dd HH:mm–HH:mm"
+      },
+      "GyMEd Hm": {
+        "H": "Gy-MM-ddE HH:mm–HH:mm",
+        "m": "Gy-MM-ddE HH:mm–HH:mm"
+      },
+      "GyMMM Hm": {
+        "H": "Gy年M月 HH:mm–HH:mm",
+        "m": "Gy年M月 HH:mm–HH:mm"
+      },
+      "GyMMMd Hm": {
+        "H": "Gy年M月d日 HH:mm–HH:mm",
+        "m": "Gy年M月d日 HH:mm–HH:mm"
+      },
+      "GyMMMEd Hm": {
+        "H": "Gy年M月d日E HH:mm–HH:mm",
+        "m": "Gy年M月d日E HH:mm–HH:mm"
+      },
+      "M Hm": {
+        "H": "M月 HH:mm–HH:mm",
+        "m": "M月 HH:mm–HH:mm"
+      },
+      "Md Hm": {
+        "H": "M/d HH:mm–HH:mm",
+        "m": "M/d HH:mm–HH:mm"
+      },
+      "MEd Hm": {
+        "H": "M/dE HH:mm–HH:mm",
+        "m": "M/dE HH:mm–HH:mm"
+      },
+      "MMdd Hm": {
+        "H": "MM/dd HH:mm–HH:mm",
+        "m": "MM/dd HH:mm–HH:mm"
+      },
+      "MMM Hm": {
+        "H": "LLL HH:mm–HH:mm",
+        "m": "LLL HH:mm–HH:mm"
+      },
+      "MMMd Hm": {
+        "H": "M月d日 HH:mm–HH:mm",
+        "m": "M月d日 HH:mm–HH:mm"
+      },
+      "MMMEd Hm": {
+        "H": "M月d日E HH:mm–HH:mm",
+        "m": "M月d日E HH:mm–HH:mm"
+      },
+      "MMMMd Hm": {
+        "H": "M月d日 HH:mm–HH:mm",
+        "m": "M月d日 HH:mm–HH:mm"
+      },
+      "y Hm": {
+        "H": "y年 HH:mm–HH:mm",
+        "m": "y年 HH:mm–HH:mm"
+      },
+      "yM Hm": {
+        "H": "y/M HH:mm–HH:mm",
+        "m": "y/M HH:mm–HH:mm"
+      },
+      "yMd Hm": {
+        "H": "y/M/d HH:mm–HH:mm",
+        "m": "y/M/d HH:mm–HH:mm"
+      },
+      "yMEd Hm": {
+        "H": "y/M/dE HH:mm–HH:mm",
+        "m": "y/M/dE HH:mm–HH:mm"
+      },
+      "yMEEEEd Hm": {
+        "H": "y年M月d日EEEE HH:mm–HH:mm",
+        "m": "y年M月d日EEEE HH:mm–HH:mm"
+      },
+      "yMM Hm": {
+        "H": "y年M月 HH:mm–HH:mm",
+        "m": "y年M月 HH:mm–HH:mm"
+      },
+      "yMMM Hm": {
+        "H": "y年M月 HH:mm–HH:mm",
+        "m": "y年M月 HH:mm–HH:mm"
+      },
+      "yMMMd Hm": {
+        "H": "y年M月d日 HH:mm–HH:mm",
+        "m": "y年M月d日 HH:mm–HH:mm"
+      },
+      "yMMMEd Hm": {
+        "H": "y年M月d日E HH:mm–HH:mm",
+        "m": "y年M月d日E HH:mm–HH:mm"
+      },
+      "yMMMM Hm": {
+        "H": "y年M月 HH:mm–HH:mm",
+        "m": "y年M月 HH:mm–HH:mm"
+      },
+      "y年M月d日EEEE hmv": {
+        "a": "y年M月d日EEEE vah:mm至ah:mm",
+        "h": "y年M月d日EEEE vah:mm至h:mm",
+        "m": "y年M月d日EEEE vah:mm至h:mm"
+      },
+      "y年M月d日 hmv": {
+        "a": "y年M月d日 vah:mm至ah:mm",
+        "h": "y年M月d日 vah:mm至h:mm",
+        "m": "y年M月d日 vah:mm至h:mm"
+      },
+      "y/M/d hmv": {
+        "a": "y/M/d vah:mm至ah:mm",
+        "h": "y/M/d vah:mm至h:mm",
+        "m": "y/M/d vah:mm至h:mm"
+      },
+      "d hmv": {
+        "a": "d日 vah:mm至ah:mm",
+        "h": "d日 vah:mm至h:mm",
+        "m": "d日 vah:mm至h:mm"
+      },
+      "E hmv": {
+        "a": "ccc vah:mm至ah:mm",
+        "h": "ccc vah:mm至h:mm",
+        "m": "ccc vah:mm至h:mm"
+      },
+      "Ed hmv": {
+        "a": "d日E vah:mm至ah:mm",
+        "h": "d日E vah:mm至h:mm",
+        "m": "d日E vah:mm至h:mm"
+      },
+      "Gy hmv": {
+        "a": "Gy年 vah:mm至ah:mm",
+        "h": "Gy年 vah:mm至h:mm",
+        "m": "Gy年 vah:mm至h:mm"
+      },
+      "GyM hmv": {
+        "a": "Gy年M月 vah:mm至ah:mm",
+        "h": "Gy年M月 vah:mm至h:mm",
+        "m": "Gy年M月 vah:mm至h:mm"
+      },
+      "GyMd hmv": {
+        "a": "Gy-MM-dd vah:mm至ah:mm",
+        "h": "Gy-MM-dd vah:mm至h:mm",
+        "m": "Gy-MM-dd vah:mm至h:mm"
+      },
+      "GyMEd hmv": {
+        "a": "Gy-MM-ddE vah:mm至ah:mm",
+        "h": "Gy-MM-ddE vah:mm至h:mm",
+        "m": "Gy-MM-ddE vah:mm至h:mm"
+      },
+      "GyMMM hmv": {
+        "a": "Gy年M月 vah:mm至ah:mm",
+        "h": "Gy年M月 vah:mm至h:mm",
+        "m": "Gy年M月 vah:mm至h:mm"
+      },
+      "GyMMMd hmv": {
+        "a": "Gy年M月d日 vah:mm至ah:mm",
+        "h": "Gy年M月d日 vah:mm至h:mm",
+        "m": "Gy年M月d日 vah:mm至h:mm"
+      },
+      "GyMMMEd hmv": {
+        "a": "Gy年M月d日E vah:mm至ah:mm",
+        "h": "Gy年M月d日E vah:mm至h:mm",
+        "m": "Gy年M月d日E vah:mm至h:mm"
+      },
+      "M hmv": {
+        "a": "M月 vah:mm至ah:mm",
+        "h": "M月 vah:mm至h:mm",
+        "m": "M月 vah:mm至h:mm"
+      },
+      "Md hmv": {
+        "a": "M/d vah:mm至ah:mm",
+        "h": "M/d vah:mm至h:mm",
+        "m": "M/d vah:mm至h:mm"
+      },
+      "MEd hmv": {
+        "a": "M/dE vah:mm至ah:mm",
+        "h": "M/dE vah:mm至h:mm",
+        "m": "M/dE vah:mm至h:mm"
+      },
+      "MMdd hmv": {
+        "a": "MM/dd vah:mm至ah:mm",
+        "h": "MM/dd vah:mm至h:mm",
+        "m": "MM/dd vah:mm至h:mm"
+      },
+      "MMM hmv": {
+        "a": "LLL vah:mm至ah:mm",
+        "h": "LLL vah:mm至h:mm",
+        "m": "LLL vah:mm至h:mm"
+      },
+      "MMMd hmv": {
+        "a": "M月d日 vah:mm至ah:mm",
+        "h": "M月d日 vah:mm至h:mm",
+        "m": "M月d日 vah:mm至h:mm"
+      },
+      "MMMEd hmv": {
+        "a": "M月d日E vah:mm至ah:mm",
+        "h": "M月d日E vah:mm至h:mm",
+        "m": "M月d日E vah:mm至h:mm"
+      },
+      "MMMMd hmv": {
+        "a": "M月d日 vah:mm至ah:mm",
+        "h": "M月d日 vah:mm至h:mm",
+        "m": "M月d日 vah:mm至h:mm"
+      },
+      "y hmv": {
+        "a": "y年 vah:mm至ah:mm",
+        "h": "y年 vah:mm至h:mm",
+        "m": "y年 vah:mm至h:mm"
+      },
+      "yM hmv": {
+        "a": "y/M vah:mm至ah:mm",
+        "h": "y/M vah:mm至h:mm",
+        "m": "y/M vah:mm至h:mm"
+      },
+      "yMd hmv": {
+        "a": "y/M/d vah:mm至ah:mm",
+        "h": "y/M/d vah:mm至h:mm",
+        "m": "y/M/d vah:mm至h:mm"
+      },
+      "yMEd hmv": {
+        "a": "y/M/dE vah:mm至ah:mm",
+        "h": "y/M/dE vah:mm至h:mm",
+        "m": "y/M/dE vah:mm至h:mm"
+      },
+      "yMEEEEd hmv": {
+        "a": "y年M月d日EEEE vah:mm至ah:mm",
+        "h": "y年M月d日EEEE vah:mm至h:mm",
+        "m": "y年M月d日EEEE vah:mm至h:mm"
+      },
+      "yMM hmv": {
+        "a": "y年M月 vah:mm至ah:mm",
+        "h": "y年M月 vah:mm至h:mm",
+        "m": "y年M月 vah:mm至h:mm"
+      },
+      "yMMM hmv": {
+        "a": "y年M月 vah:mm至ah:mm",
+        "h": "y年M月 vah:mm至h:mm",
+        "m": "y年M月 vah:mm至h:mm"
+      },
+      "yMMMd hmv": {
+        "a": "y年M月d日 vah:mm至ah:mm",
+        "h": "y年M月d日 vah:mm至h:mm",
+        "m": "y年M月d日 vah:mm至h:mm"
+      },
+      "yMMMEd hmv": {
+        "a": "y年M月d日E vah:mm至ah:mm",
+        "h": "y年M月d日E vah:mm至h:mm",
+        "m": "y年M月d日E vah:mm至h:mm"
+      },
+      "yMMMM hmv": {
+        "a": "y年M月 vah:mm至ah:mm",
+        "h": "y年M月 vah:mm至h:mm",
+        "m": "y年M月 vah:mm至h:mm"
+      },
+      "y年M月d日EEEE Hmv": {
+        "H": "y年M月d日EEEE v HH:mm–HH:mm",
+        "m": "y年M月d日EEEE v HH:mm–HH:mm"
+      },
+      "y年M月d日 Hmv": {
+        "H": "y年M月d日 v HH:mm–HH:mm",
+        "m": "y年M月d日 v HH:mm–HH:mm"
+      },
+      "y/M/d Hmv": {
+        "H": "y/M/d v HH:mm–HH:mm",
+        "m": "y/M/d v HH:mm–HH:mm"
+      },
+      "d Hmv": {
+        "H": "d日 v HH:mm–HH:mm",
+        "m": "d日 v HH:mm–HH:mm"
+      },
+      "E Hmv": {
+        "H": "ccc v HH:mm–HH:mm",
+        "m": "ccc v HH:mm–HH:mm"
+      },
+      "Ed Hmv": {
+        "H": "d日E v HH:mm–HH:mm",
+        "m": "d日E v HH:mm–HH:mm"
+      },
+      "Gy Hmv": {
+        "H": "Gy年 v HH:mm–HH:mm",
+        "m": "Gy年 v HH:mm–HH:mm"
+      },
+      "GyM Hmv": {
+        "H": "Gy年M月 v HH:mm–HH:mm",
+        "m": "Gy年M月 v HH:mm–HH:mm"
+      },
+      "GyMd Hmv": {
+        "H": "Gy-MM-dd v HH:mm–HH:mm",
+        "m": "Gy-MM-dd v HH:mm–HH:mm"
+      },
+      "GyMEd Hmv": {
+        "H": "Gy-MM-ddE v HH:mm–HH:mm",
+        "m": "Gy-MM-ddE v HH:mm–HH:mm"
+      },
+      "GyMMM Hmv": {
+        "H": "Gy年M月 v HH:mm–HH:mm",
+        "m": "Gy年M月 v HH:mm–HH:mm"
+      },
+      "GyMMMd Hmv": {
+        "H": "Gy年M月d日 v HH:mm–HH:mm",
+        "m": "Gy年M月d日 v HH:mm–HH:mm"
+      },
+      "GyMMMEd Hmv": {
+        "H": "Gy年M月d日E v HH:mm–HH:mm",
+        "m": "Gy年M月d日E v HH:mm–HH:mm"
+      },
+      "M Hmv": {
+        "H": "M月 v HH:mm–HH:mm",
+        "m": "M月 v HH:mm–HH:mm"
+      },
+      "Md Hmv": {
+        "H": "M/d v HH:mm–HH:mm",
+        "m": "M/d v HH:mm–HH:mm"
+      },
+      "MEd Hmv": {
+        "H": "M/dE v HH:mm–HH:mm",
+        "m": "M/dE v HH:mm–HH:mm"
+      },
+      "MMdd Hmv": {
+        "H": "MM/dd v HH:mm–HH:mm",
+        "m": "MM/dd v HH:mm–HH:mm"
+      },
+      "MMM Hmv": {
+        "H": "LLL v HH:mm–HH:mm",
+        "m": "LLL v HH:mm–HH:mm"
+      },
+      "MMMd Hmv": {
+        "H": "M月d日 v HH:mm–HH:mm",
+        "m": "M月d日 v HH:mm–HH:mm"
+      },
+      "MMMEd Hmv": {
+        "H": "M月d日E v HH:mm–HH:mm",
+        "m": "M月d日E v HH:mm–HH:mm"
+      },
+      "MMMMd Hmv": {
+        "H": "M月d日 v HH:mm–HH:mm",
+        "m": "M月d日 v HH:mm–HH:mm"
+      },
+      "y Hmv": {
+        "H": "y年 v HH:mm–HH:mm",
+        "m": "y年 v HH:mm–HH:mm"
+      },
+      "yM Hmv": {
+        "H": "y/M v HH:mm–HH:mm",
+        "m": "y/M v HH:mm–HH:mm"
+      },
+      "yMd Hmv": {
+        "H": "y/M/d v HH:mm–HH:mm",
+        "m": "y/M/d v HH:mm–HH:mm"
+      },
+      "yMEd Hmv": {
+        "H": "y/M/dE v HH:mm–HH:mm",
+        "m": "y/M/dE v HH:mm–HH:mm"
+      },
+      "yMEEEEd Hmv": {
+        "H": "y年M月d日EEEE v HH:mm–HH:mm",
+        "m": "y年M月d日EEEE v HH:mm–HH:mm"
+      },
+      "yMM Hmv": {
+        "H": "y年M月 v HH:mm–HH:mm",
+        "m": "y年M月 v HH:mm–HH:mm"
+      },
+      "yMMM Hmv": {
+        "H": "y年M月 v HH:mm–HH:mm",
+        "m": "y年M月 v HH:mm–HH:mm"
+      },
+      "yMMMd Hmv": {
+        "H": "y年M月d日 v HH:mm–HH:mm",
+        "m": "y年M月d日 v HH:mm–HH:mm"
+      },
+      "yMMMEd Hmv": {
+        "H": "y年M月d日E v HH:mm–HH:mm",
+        "m": "y年M月d日E v HH:mm–HH:mm"
+      },
+      "yMMMM Hmv": {
+        "H": "y年M月 v HH:mm–HH:mm",
+        "m": "y年M月 v HH:mm–HH:mm"
+      },
+      "y年M月d日EEEE hv": {
+        "a": "y年M月d日EEEE vah时至ah时",
+        "h": "y年M月d日EEEE vah时至h时"
+      },
+      "y年M月d日 hv": {
+        "a": "y年M月d日 vah时至ah时",
+        "h": "y年M月d日 vah时至h时"
+      },
+      "y/M/d hv": {
+        "a": "y/M/d vah时至ah时",
+        "h": "y/M/d vah时至h时"
+      },
+      "d hv": {
+        "a": "d日 vah时至ah时",
+        "h": "d日 vah时至h时"
+      },
+      "E hv": {
+        "a": "ccc vah时至ah时",
+        "h": "ccc vah时至h时"
+      },
+      "Ed hv": {
+        "a": "d日E vah时至ah时",
+        "h": "d日E vah时至h时"
+      },
+      "Gy hv": {
+        "a": "Gy年 vah时至ah时",
+        "h": "Gy年 vah时至h时"
+      },
+      "GyM hv": {
+        "a": "Gy年M月 vah时至ah时",
+        "h": "Gy年M月 vah时至h时"
+      },
+      "GyMd hv": {
+        "a": "Gy-MM-dd vah时至ah时",
+        "h": "Gy-MM-dd vah时至h时"
+      },
+      "GyMEd hv": {
+        "a": "Gy-MM-ddE vah时至ah时",
+        "h": "Gy-MM-ddE vah时至h时"
+      },
+      "GyMMM hv": {
+        "a": "Gy年M月 vah时至ah时",
+        "h": "Gy年M月 vah时至h时"
+      },
+      "GyMMMd hv": {
+        "a": "Gy年M月d日 vah时至ah时",
+        "h": "Gy年M月d日 vah时至h时"
+      },
+      "GyMMMEd hv": {
+        "a": "Gy年M月d日E vah时至ah时",
+        "h": "Gy年M月d日E vah时至h时"
+      },
+      "M hv": {
+        "a": "M月 vah时至ah时",
+        "h": "M月 vah时至h时"
+      },
+      "Md hv": {
+        "a": "M/d vah时至ah时",
+        "h": "M/d vah时至h时"
+      },
+      "MEd hv": {
+        "a": "M/dE vah时至ah时",
+        "h": "M/dE vah时至h时"
+      },
+      "MMdd hv": {
+        "a": "MM/dd vah时至ah时",
+        "h": "MM/dd vah时至h时"
+      },
+      "MMM hv": {
+        "a": "LLL vah时至ah时",
+        "h": "LLL vah时至h时"
+      },
+      "MMMd hv": {
+        "a": "M月d日 vah时至ah时",
+        "h": "M月d日 vah时至h时"
+      },
+      "MMMEd hv": {
+        "a": "M月d日E vah时至ah时",
+        "h": "M月d日E vah时至h时"
+      },
+      "MMMMd hv": {
+        "a": "M月d日 vah时至ah时",
+        "h": "M月d日 vah时至h时"
+      },
+      "y hv": {
+        "a": "y年 vah时至ah时",
+        "h": "y年 vah时至h时"
+      },
+      "yM hv": {
+        "a": "y/M vah时至ah时",
+        "h": "y/M vah时至h时"
+      },
+      "yMd hv": {
+        "a": "y/M/d vah时至ah时",
+        "h": "y/M/d vah时至h时"
+      },
+      "yMEd hv": {
+        "a": "y/M/dE vah时至ah时",
+        "h": "y/M/dE vah时至h时"
+      },
+      "yMEEEEd hv": {
+        "a": "y年M月d日EEEE vah时至ah时",
+        "h": "y年M月d日EEEE vah时至h时"
+      },
+      "yMM hv": {
+        "a": "y年M月 vah时至ah时",
+        "h": "y年M月 vah时至h时"
+      },
+      "yMMM hv": {
+        "a": "y年M月 vah时至ah时",
+        "h": "y年M月 vah时至h时"
+      },
+      "yMMMd hv": {
+        "a": "y年M月d日 vah时至ah时",
+        "h": "y年M月d日 vah时至h时"
+      },
+      "yMMMEd hv": {
+        "a": "y年M月d日E vah时至ah时",
+        "h": "y年M月d日E vah时至h时"
+      },
+      "yMMMM hv": {
+        "a": "y年M月 vah时至ah时",
+        "h": "y年M月 vah时至h时"
+      },
+      "y年M月d日EEEE Hv": {
+        "H": "y年M月d日EEEE v HH–HH"
+      },
+      "y年M月d日 Hv": {
+        "H": "y年M月d日 v HH–HH"
+      },
+      "y/M/d Hv": {
+        "H": "y/M/d v HH–HH"
+      },
+      "d Hv": {
+        "H": "d日 v HH–HH"
+      },
+      "E Hv": {
+        "H": "ccc v HH–HH"
+      },
+      "Ed Hv": {
+        "H": "d日E v HH–HH"
+      },
+      "Gy Hv": {
+        "H": "Gy年 v HH–HH"
+      },
+      "GyM Hv": {
+        "H": "Gy年M月 v HH–HH"
+      },
+      "GyMd Hv": {
+        "H": "Gy-MM-dd v HH–HH"
+      },
+      "GyMEd Hv": {
+        "H": "Gy-MM-ddE v HH–HH"
+      },
+      "GyMMM Hv": {
+        "H": "Gy年M月 v HH–HH"
+      },
+      "GyMMMd Hv": {
+        "H": "Gy年M月d日 v HH–HH"
+      },
+      "GyMMMEd Hv": {
+        "H": "Gy年M月d日E v HH–HH"
+      },
+      "M Hv": {
+        "H": "M月 v HH–HH"
+      },
+      "Md Hv": {
+        "H": "M/d v HH–HH"
+      },
+      "MEd Hv": {
+        "H": "M/dE v HH–HH"
+      },
+      "MMdd Hv": {
+        "H": "MM/dd v HH–HH"
+      },
+      "MMM Hv": {
+        "H": "LLL v HH–HH"
+      },
+      "MMMd Hv": {
+        "H": "M月d日 v HH–HH"
+      },
+      "MMMEd Hv": {
+        "H": "M月d日E v HH–HH"
+      },
+      "MMMMd Hv": {
+        "H": "M月d日 v HH–HH"
+      },
+      "y Hv": {
+        "H": "y年 v HH–HH"
+      },
+      "yM Hv": {
+        "H": "y/M v HH–HH"
+      },
+      "yMd Hv": {
+        "H": "y/M/d v HH–HH"
+      },
+      "yMEd Hv": {
+        "H": "y/M/dE v HH–HH"
+      },
+      "yMEEEEd Hv": {
+        "H": "y年M月d日EEEE v HH–HH"
+      },
+      "yMM Hv": {
+        "H": "y年M月 v HH–HH"
+      },
+      "yMMM Hv": {
+        "H": "y年M月 v HH–HH"
+      },
+      "yMMMd Hv": {
+        "H": "y年M月d日 v HH–HH"
+      },
+      "yMMMEd Hv": {
+        "H": "y年M月d日E v HH–HH"
+      },
+      "yMMMM Hv": {
+        "H": "y年M月 v HH–HH"
       }
     },
     "hourCycle": "h23",

--- a/packages/intl-datetimeformat/tests/format-range.test.ts
+++ b/packages/intl-datetimeformat/tests/format-range.test.ts
@@ -420,3 +420,32 @@ test('GH issue #4168', function () {
     )
   ).toBe('16 okt 2023, 10:00:00 – 16 okt 2023, 14:00:00')
 })
+
+test('GH issue #4535 - same day range should not duplicate date', function () {
+  // Fixed: When formatting a date range on the same day with different times,
+  // the date should only appear once, not twice
+  const dtf = new DateTimeFormat('en-GB', {
+    weekday: 'short',
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+  })
+
+  // Same day (Sept 22, 2024), different times (14:00 to 16:00)
+  const result = dtf.formatRange(
+    new Date('2024-09-22T14:00:00'),
+    new Date('2024-09-22T16:00:00')
+  )
+
+  // Expected behavior: show date once with time range
+  // The date "Sun, 22 Sept 2024" should only appear once
+  // Note: CLDR uses en dash (–) without spaces for time intervals
+  expect(result).toBe('Sun, 22 Sept 2024, 14:00–16:00')
+
+  // Verify the date appears only once
+  const dateString = 'Sun, 22 Sept 2024'
+  const occurrences = (result.match(new RegExp(dateString, 'g')) || []).length
+  expect(occurrences).toBe(1)
+})

--- a/packages/intl-datetimeformat/tests/locale-data/ar.json
+++ b/packages/intl-datetimeformat/tests/locale-data/ar.json
@@ -2594,6 +2594,1318 @@
       "yMMMM": {
         "M": "MMMM – MMMM y",
         "y": "MMMM y – MMMM y"
+      },
+      "EEEE، d MMMM y، Bh": {
+        "B": "EEEE، d MMMM y، h B – h B",
+        "h": "EEEE، d MMMM y، h–h B"
+      },
+      "d MMMM y، Bh": {
+        "B": "d MMMM y، h B – h B",
+        "h": "d MMMM y، h–h B"
+      },
+      "dd‏/MM‏/y، Bh": {
+        "B": "dd‏/MM‏/y، h B – h B",
+        "h": "dd‏/MM‏/y، h–h B"
+      },
+      "d‏/M‏/y، Bh": {
+        "B": "d‏/M‏/y، h B – h B",
+        "h": "d‏/M‏/y، h–h B"
+      },
+      "d، Bh": {
+        "B": "d، h B – h B",
+        "h": "d، h–h B"
+      },
+      "E، Bh": {
+        "B": "ccc، h B – h B",
+        "h": "ccc، h–h B"
+      },
+      "Ed، Bh": {
+        "B": "E، d، h B – h B",
+        "h": "E، d، h–h B"
+      },
+      "Gy، Bh": {
+        "B": "y G، h B – h B",
+        "h": "y G، h–h B"
+      },
+      "GyM، Bh": {
+        "B": "MM، y G، h B – h B",
+        "h": "MM، y G، h–h B"
+      },
+      "GyMd، Bh": {
+        "B": "dd-MM-y GGGGG، h B – h B",
+        "h": "dd-MM-y GGGGG، h–h B"
+      },
+      "GyMEd، Bh": {
+        "B": "E d/M/y G، h B – h B",
+        "h": "E d/M/y G، h–h B"
+      },
+      "GyMMM، Bh": {
+        "B": "MMM y G، h B – h B",
+        "h": "MMM y G، h–h B"
+      },
+      "GyMMMd، Bh": {
+        "B": "d MMM y G، h B – h B",
+        "h": "d MMM y G، h–h B"
+      },
+      "GyMMMEd، Bh": {
+        "B": "E، d MMM y G، h B – h B",
+        "h": "E، d MMM y G، h–h B"
+      },
+      "M، Bh": {
+        "B": "L، h B – h B",
+        "h": "L، h–h B"
+      },
+      "Md، Bh": {
+        "B": "d‏/M، h B – h B",
+        "h": "d‏/M، h–h B"
+      },
+      "MEd، Bh": {
+        "B": "E، d‏/M، h B – h B",
+        "h": "E، d‏/M، h–h B"
+      },
+      "MMdd، Bh": {
+        "B": "dd‏/MM، h B – h B",
+        "h": "dd‏/MM، h–h B"
+      },
+      "MMM، Bh": {
+        "B": "LLL، h B – h B",
+        "h": "LLL، h–h B"
+      },
+      "MMMd، Bh": {
+        "B": "d MMM، h B – h B",
+        "h": "d MMM، h–h B"
+      },
+      "MMMEd، Bh": {
+        "B": "E، d MMM، h B – h B",
+        "h": "E، d MMM، h–h B"
+      },
+      "MMMMd، Bh": {
+        "B": "d MMMM، h B – h B",
+        "h": "d MMMM، h–h B"
+      },
+      "MMMMEd، Bh": {
+        "B": "E، d MMMM، h B – h B",
+        "h": "E، d MMMM، h–h B"
+      },
+      "y، Bh": {
+        "B": "y، h B – h B",
+        "h": "y، h–h B"
+      },
+      "yM، Bh": {
+        "B": "M‏/y، h B – h B",
+        "h": "M‏/y، h–h B"
+      },
+      "yMd، Bh": {
+        "B": "d‏/M‏/y، h B – h B",
+        "h": "d‏/M‏/y، h–h B"
+      },
+      "yMEd، Bh": {
+        "B": "E، d‏/M‏/y، h B – h B",
+        "h": "E، d‏/M‏/y، h–h B"
+      },
+      "yMM، Bh": {
+        "B": "MM‏/y، h B – h B",
+        "h": "MM‏/y، h–h B"
+      },
+      "yMMM، Bh": {
+        "B": "MMM y، h B – h B",
+        "h": "MMM y، h–h B"
+      },
+      "yMMMd، Bh": {
+        "B": "d MMM y، h B – h B",
+        "h": "d MMM y، h–h B"
+      },
+      "yMMMEd، Bh": {
+        "B": "E، d MMM y، h B – h B",
+        "h": "E، d MMM y، h–h B"
+      },
+      "yMMMM، Bh": {
+        "B": "MMMM y، h B – h B",
+        "h": "MMMM y، h–h B"
+      },
+      "EEEE، d MMMM y، Bhm": {
+        "B": "EEEE، d MMMM y، h:mm B – h:mm B",
+        "h": "EEEE، d MMMM y، h:mm–h:mm B",
+        "m": "EEEE، d MMMM y، h:mm–h:mm B"
+      },
+      "d MMMM y، Bhm": {
+        "B": "d MMMM y، h:mm B – h:mm B",
+        "h": "d MMMM y، h:mm–h:mm B",
+        "m": "d MMMM y، h:mm–h:mm B"
+      },
+      "dd‏/MM‏/y، Bhm": {
+        "B": "dd‏/MM‏/y، h:mm B – h:mm B",
+        "h": "dd‏/MM‏/y، h:mm–h:mm B",
+        "m": "dd‏/MM‏/y، h:mm–h:mm B"
+      },
+      "d‏/M‏/y، Bhm": {
+        "B": "d‏/M‏/y، h:mm B – h:mm B",
+        "h": "d‏/M‏/y، h:mm–h:mm B",
+        "m": "d‏/M‏/y، h:mm–h:mm B"
+      },
+      "d، Bhm": {
+        "B": "d، h:mm B – h:mm B",
+        "h": "d، h:mm–h:mm B",
+        "m": "d، h:mm–h:mm B"
+      },
+      "E، Bhm": {
+        "B": "ccc، h:mm B – h:mm B",
+        "h": "ccc، h:mm–h:mm B",
+        "m": "ccc، h:mm–h:mm B"
+      },
+      "Ed، Bhm": {
+        "B": "E، d، h:mm B – h:mm B",
+        "h": "E، d، h:mm–h:mm B",
+        "m": "E، d، h:mm–h:mm B"
+      },
+      "Gy، Bhm": {
+        "B": "y G، h:mm B – h:mm B",
+        "h": "y G، h:mm–h:mm B",
+        "m": "y G، h:mm–h:mm B"
+      },
+      "GyM، Bhm": {
+        "B": "MM، y G، h:mm B – h:mm B",
+        "h": "MM، y G، h:mm–h:mm B",
+        "m": "MM، y G، h:mm–h:mm B"
+      },
+      "GyMd، Bhm": {
+        "B": "dd-MM-y GGGGG، h:mm B – h:mm B",
+        "h": "dd-MM-y GGGGG، h:mm–h:mm B",
+        "m": "dd-MM-y GGGGG، h:mm–h:mm B"
+      },
+      "GyMEd، Bhm": {
+        "B": "E d/M/y G، h:mm B – h:mm B",
+        "h": "E d/M/y G، h:mm–h:mm B",
+        "m": "E d/M/y G، h:mm–h:mm B"
+      },
+      "GyMMM، Bhm": {
+        "B": "MMM y G، h:mm B – h:mm B",
+        "h": "MMM y G، h:mm–h:mm B",
+        "m": "MMM y G، h:mm–h:mm B"
+      },
+      "GyMMMd، Bhm": {
+        "B": "d MMM y G، h:mm B – h:mm B",
+        "h": "d MMM y G، h:mm–h:mm B",
+        "m": "d MMM y G، h:mm–h:mm B"
+      },
+      "GyMMMEd، Bhm": {
+        "B": "E، d MMM y G، h:mm B – h:mm B",
+        "h": "E، d MMM y G، h:mm–h:mm B",
+        "m": "E، d MMM y G، h:mm–h:mm B"
+      },
+      "M، Bhm": {
+        "B": "L، h:mm B – h:mm B",
+        "h": "L، h:mm–h:mm B",
+        "m": "L، h:mm–h:mm B"
+      },
+      "Md، Bhm": {
+        "B": "d‏/M، h:mm B – h:mm B",
+        "h": "d‏/M، h:mm–h:mm B",
+        "m": "d‏/M، h:mm–h:mm B"
+      },
+      "MEd، Bhm": {
+        "B": "E، d‏/M، h:mm B – h:mm B",
+        "h": "E، d‏/M، h:mm–h:mm B",
+        "m": "E، d‏/M، h:mm–h:mm B"
+      },
+      "MMdd، Bhm": {
+        "B": "dd‏/MM، h:mm B – h:mm B",
+        "h": "dd‏/MM، h:mm–h:mm B",
+        "m": "dd‏/MM، h:mm–h:mm B"
+      },
+      "MMM، Bhm": {
+        "B": "LLL، h:mm B – h:mm B",
+        "h": "LLL، h:mm–h:mm B",
+        "m": "LLL، h:mm–h:mm B"
+      },
+      "MMMd، Bhm": {
+        "B": "d MMM، h:mm B – h:mm B",
+        "h": "d MMM، h:mm–h:mm B",
+        "m": "d MMM، h:mm–h:mm B"
+      },
+      "MMMEd، Bhm": {
+        "B": "E، d MMM، h:mm B – h:mm B",
+        "h": "E، d MMM، h:mm–h:mm B",
+        "m": "E، d MMM، h:mm–h:mm B"
+      },
+      "MMMMd، Bhm": {
+        "B": "d MMMM، h:mm B – h:mm B",
+        "h": "d MMMM، h:mm–h:mm B",
+        "m": "d MMMM، h:mm–h:mm B"
+      },
+      "MMMMEd، Bhm": {
+        "B": "E، d MMMM، h:mm B – h:mm B",
+        "h": "E، d MMMM، h:mm–h:mm B",
+        "m": "E، d MMMM، h:mm–h:mm B"
+      },
+      "y، Bhm": {
+        "B": "y، h:mm B – h:mm B",
+        "h": "y، h:mm–h:mm B",
+        "m": "y، h:mm–h:mm B"
+      },
+      "yM، Bhm": {
+        "B": "M‏/y، h:mm B – h:mm B",
+        "h": "M‏/y، h:mm–h:mm B",
+        "m": "M‏/y، h:mm–h:mm B"
+      },
+      "yMd، Bhm": {
+        "B": "d‏/M‏/y، h:mm B – h:mm B",
+        "h": "d‏/M‏/y، h:mm–h:mm B",
+        "m": "d‏/M‏/y، h:mm–h:mm B"
+      },
+      "yMEd، Bhm": {
+        "B": "E، d‏/M‏/y، h:mm B – h:mm B",
+        "h": "E، d‏/M‏/y، h:mm–h:mm B",
+        "m": "E، d‏/M‏/y، h:mm–h:mm B"
+      },
+      "yMM، Bhm": {
+        "B": "MM‏/y، h:mm B – h:mm B",
+        "h": "MM‏/y، h:mm–h:mm B",
+        "m": "MM‏/y، h:mm–h:mm B"
+      },
+      "yMMM، Bhm": {
+        "B": "MMM y، h:mm B – h:mm B",
+        "h": "MMM y، h:mm–h:mm B",
+        "m": "MMM y، h:mm–h:mm B"
+      },
+      "yMMMd، Bhm": {
+        "B": "d MMM y، h:mm B – h:mm B",
+        "h": "d MMM y، h:mm–h:mm B",
+        "m": "d MMM y، h:mm–h:mm B"
+      },
+      "yMMMEd، Bhm": {
+        "B": "E، d MMM y، h:mm B – h:mm B",
+        "h": "E، d MMM y، h:mm–h:mm B",
+        "m": "E، d MMM y، h:mm–h:mm B"
+      },
+      "yMMMM، Bhm": {
+        "B": "MMMM y، h:mm B – h:mm B",
+        "h": "MMMM y، h:mm–h:mm B",
+        "m": "MMMM y، h:mm–h:mm B"
+      },
+      "EEEE، d MMMM y، h": {
+        "a": "EEEE، d MMMM y، h a – h a",
+        "h": "EEEE، d MMMM y، h–h a"
+      },
+      "d MMMM y، h": {
+        "a": "d MMMM y، h a – h a",
+        "h": "d MMMM y، h–h a"
+      },
+      "dd‏/MM‏/y، h": {
+        "a": "dd‏/MM‏/y، h a – h a",
+        "h": "dd‏/MM‏/y، h–h a"
+      },
+      "d‏/M‏/y، h": {
+        "a": "d‏/M‏/y، h a – h a",
+        "h": "d‏/M‏/y، h–h a"
+      },
+      "d، h": {
+        "a": "d، h a – h a",
+        "h": "d، h–h a"
+      },
+      "E، h": {
+        "a": "ccc، h a – h a",
+        "h": "ccc، h–h a"
+      },
+      "Ed، h": {
+        "a": "E، d، h a – h a",
+        "h": "E، d، h–h a"
+      },
+      "Gy، h": {
+        "a": "y G، h a – h a",
+        "h": "y G، h–h a"
+      },
+      "GyM، h": {
+        "a": "MM، y G، h a – h a",
+        "h": "MM، y G، h–h a"
+      },
+      "GyMd، h": {
+        "a": "dd-MM-y GGGGG، h a – h a",
+        "h": "dd-MM-y GGGGG، h–h a"
+      },
+      "GyMEd، h": {
+        "a": "E d/M/y G، h a – h a",
+        "h": "E d/M/y G، h–h a"
+      },
+      "GyMMM، h": {
+        "a": "MMM y G، h a – h a",
+        "h": "MMM y G، h–h a"
+      },
+      "GyMMMd، h": {
+        "a": "d MMM y G، h a – h a",
+        "h": "d MMM y G، h–h a"
+      },
+      "GyMMMEd، h": {
+        "a": "E، d MMM y G، h a – h a",
+        "h": "E، d MMM y G، h–h a"
+      },
+      "M، h": {
+        "a": "L، h a – h a",
+        "h": "L، h–h a"
+      },
+      "Md، h": {
+        "a": "d‏/M، h a – h a",
+        "h": "d‏/M، h–h a"
+      },
+      "MEd، h": {
+        "a": "E، d‏/M، h a – h a",
+        "h": "E، d‏/M، h–h a"
+      },
+      "MMdd، h": {
+        "a": "dd‏/MM، h a – h a",
+        "h": "dd‏/MM، h–h a"
+      },
+      "MMM، h": {
+        "a": "LLL، h a – h a",
+        "h": "LLL، h–h a"
+      },
+      "MMMd، h": {
+        "a": "d MMM، h a – h a",
+        "h": "d MMM، h–h a"
+      },
+      "MMMEd، h": {
+        "a": "E، d MMM، h a – h a",
+        "h": "E، d MMM، h–h a"
+      },
+      "MMMMd، h": {
+        "a": "d MMMM، h a – h a",
+        "h": "d MMMM، h–h a"
+      },
+      "MMMMEd، h": {
+        "a": "E، d MMMM، h a – h a",
+        "h": "E، d MMMM، h–h a"
+      },
+      "y، h": {
+        "a": "y، h a – h a",
+        "h": "y، h–h a"
+      },
+      "yM، h": {
+        "a": "M‏/y، h a – h a",
+        "h": "M‏/y، h–h a"
+      },
+      "yMd، h": {
+        "a": "d‏/M‏/y، h a – h a",
+        "h": "d‏/M‏/y، h–h a"
+      },
+      "yMEd، h": {
+        "a": "E، d‏/M‏/y، h a – h a",
+        "h": "E، d‏/M‏/y، h–h a"
+      },
+      "yMM، h": {
+        "a": "MM‏/y، h a – h a",
+        "h": "MM‏/y، h–h a"
+      },
+      "yMMM، h": {
+        "a": "MMM y، h a – h a",
+        "h": "MMM y، h–h a"
+      },
+      "yMMMd، h": {
+        "a": "d MMM y، h a – h a",
+        "h": "d MMM y، h–h a"
+      },
+      "yMMMEd، h": {
+        "a": "E، d MMM y، h a – h a",
+        "h": "E، d MMM y، h–h a"
+      },
+      "yMMMM، h": {
+        "a": "MMMM y، h a – h a",
+        "h": "MMMM y، h–h a"
+      },
+      "EEEE، d MMMM y، H": {
+        "H": "EEEE، d MMMM y، HH–HH"
+      },
+      "d MMMM y، H": {
+        "H": "d MMMM y، HH–HH"
+      },
+      "dd‏/MM‏/y، H": {
+        "H": "dd‏/MM‏/y، HH–HH"
+      },
+      "d‏/M‏/y، H": {
+        "H": "d‏/M‏/y، HH–HH"
+      },
+      "d، H": {
+        "H": "d، HH–HH"
+      },
+      "E، H": {
+        "H": "ccc، HH–HH"
+      },
+      "Ed، H": {
+        "H": "E، d، HH–HH"
+      },
+      "Gy، H": {
+        "H": "y G، HH–HH"
+      },
+      "GyM، H": {
+        "H": "MM، y G، HH–HH"
+      },
+      "GyMd، H": {
+        "H": "dd-MM-y GGGGG، HH–HH"
+      },
+      "GyMEd، H": {
+        "H": "E d/M/y G، HH–HH"
+      },
+      "GyMMM، H": {
+        "H": "MMM y G، HH–HH"
+      },
+      "GyMMMd، H": {
+        "H": "d MMM y G، HH–HH"
+      },
+      "GyMMMEd، H": {
+        "H": "E، d MMM y G، HH–HH"
+      },
+      "M، H": {
+        "H": "L، HH–HH"
+      },
+      "Md، H": {
+        "H": "d‏/M، HH–HH"
+      },
+      "MEd، H": {
+        "H": "E، d‏/M، HH–HH"
+      },
+      "MMdd، H": {
+        "H": "dd‏/MM، HH–HH"
+      },
+      "MMM، H": {
+        "H": "LLL، HH–HH"
+      },
+      "MMMd، H": {
+        "H": "d MMM، HH–HH"
+      },
+      "MMMEd، H": {
+        "H": "E، d MMM، HH–HH"
+      },
+      "MMMMd، H": {
+        "H": "d MMMM، HH–HH"
+      },
+      "MMMMEd، H": {
+        "H": "E، d MMMM، HH–HH"
+      },
+      "y، H": {
+        "H": "y، HH–HH"
+      },
+      "yM، H": {
+        "H": "M‏/y، HH–HH"
+      },
+      "yMd، H": {
+        "H": "d‏/M‏/y، HH–HH"
+      },
+      "yMEd، H": {
+        "H": "E، d‏/M‏/y، HH–HH"
+      },
+      "yMM، H": {
+        "H": "MM‏/y، HH–HH"
+      },
+      "yMMM، H": {
+        "H": "MMM y، HH–HH"
+      },
+      "yMMMd، H": {
+        "H": "d MMM y، HH–HH"
+      },
+      "yMMMEd، H": {
+        "H": "E، d MMM y، HH–HH"
+      },
+      "yMMMM، H": {
+        "H": "MMMM y، HH–HH"
+      },
+      "EEEE، d MMMM y، hm": {
+        "a": "EEEE، d MMMM y، h:mm a – h:mm a",
+        "h": "EEEE، d MMMM y، h:mm–h:mm a",
+        "m": "EEEE، d MMMM y، h:mm–h:mm a"
+      },
+      "d MMMM y، hm": {
+        "a": "d MMMM y، h:mm a – h:mm a",
+        "h": "d MMMM y، h:mm–h:mm a",
+        "m": "d MMMM y، h:mm–h:mm a"
+      },
+      "dd‏/MM‏/y، hm": {
+        "a": "dd‏/MM‏/y، h:mm a – h:mm a",
+        "h": "dd‏/MM‏/y، h:mm–h:mm a",
+        "m": "dd‏/MM‏/y، h:mm–h:mm a"
+      },
+      "d‏/M‏/y، hm": {
+        "a": "d‏/M‏/y، h:mm a – h:mm a",
+        "h": "d‏/M‏/y، h:mm–h:mm a",
+        "m": "d‏/M‏/y، h:mm–h:mm a"
+      },
+      "d، hm": {
+        "a": "d، h:mm a – h:mm a",
+        "h": "d، h:mm–h:mm a",
+        "m": "d، h:mm–h:mm a"
+      },
+      "E، hm": {
+        "a": "ccc، h:mm a – h:mm a",
+        "h": "ccc، h:mm–h:mm a",
+        "m": "ccc، h:mm–h:mm a"
+      },
+      "Ed، hm": {
+        "a": "E، d، h:mm a – h:mm a",
+        "h": "E، d، h:mm–h:mm a",
+        "m": "E، d، h:mm–h:mm a"
+      },
+      "Gy، hm": {
+        "a": "y G، h:mm a – h:mm a",
+        "h": "y G، h:mm–h:mm a",
+        "m": "y G، h:mm–h:mm a"
+      },
+      "GyM، hm": {
+        "a": "MM، y G، h:mm a – h:mm a",
+        "h": "MM، y G، h:mm–h:mm a",
+        "m": "MM، y G، h:mm–h:mm a"
+      },
+      "GyMd، hm": {
+        "a": "dd-MM-y GGGGG، h:mm a – h:mm a",
+        "h": "dd-MM-y GGGGG، h:mm–h:mm a",
+        "m": "dd-MM-y GGGGG، h:mm–h:mm a"
+      },
+      "GyMEd، hm": {
+        "a": "E d/M/y G، h:mm a – h:mm a",
+        "h": "E d/M/y G، h:mm–h:mm a",
+        "m": "E d/M/y G، h:mm–h:mm a"
+      },
+      "GyMMM، hm": {
+        "a": "MMM y G، h:mm a – h:mm a",
+        "h": "MMM y G، h:mm–h:mm a",
+        "m": "MMM y G، h:mm–h:mm a"
+      },
+      "GyMMMd، hm": {
+        "a": "d MMM y G، h:mm a – h:mm a",
+        "h": "d MMM y G، h:mm–h:mm a",
+        "m": "d MMM y G، h:mm–h:mm a"
+      },
+      "GyMMMEd، hm": {
+        "a": "E، d MMM y G، h:mm a – h:mm a",
+        "h": "E، d MMM y G، h:mm–h:mm a",
+        "m": "E، d MMM y G، h:mm–h:mm a"
+      },
+      "M، hm": {
+        "a": "L، h:mm a – h:mm a",
+        "h": "L، h:mm–h:mm a",
+        "m": "L، h:mm–h:mm a"
+      },
+      "Md، hm": {
+        "a": "d‏/M، h:mm a – h:mm a",
+        "h": "d‏/M، h:mm–h:mm a",
+        "m": "d‏/M، h:mm–h:mm a"
+      },
+      "MEd، hm": {
+        "a": "E، d‏/M، h:mm a – h:mm a",
+        "h": "E، d‏/M، h:mm–h:mm a",
+        "m": "E، d‏/M، h:mm–h:mm a"
+      },
+      "MMdd، hm": {
+        "a": "dd‏/MM، h:mm a – h:mm a",
+        "h": "dd‏/MM، h:mm–h:mm a",
+        "m": "dd‏/MM، h:mm–h:mm a"
+      },
+      "MMM، hm": {
+        "a": "LLL، h:mm a – h:mm a",
+        "h": "LLL، h:mm–h:mm a",
+        "m": "LLL، h:mm–h:mm a"
+      },
+      "MMMd، hm": {
+        "a": "d MMM، h:mm a – h:mm a",
+        "h": "d MMM، h:mm–h:mm a",
+        "m": "d MMM، h:mm–h:mm a"
+      },
+      "MMMEd، hm": {
+        "a": "E، d MMM، h:mm a – h:mm a",
+        "h": "E، d MMM، h:mm–h:mm a",
+        "m": "E، d MMM، h:mm–h:mm a"
+      },
+      "MMMMd، hm": {
+        "a": "d MMMM، h:mm a – h:mm a",
+        "h": "d MMMM، h:mm–h:mm a",
+        "m": "d MMMM، h:mm–h:mm a"
+      },
+      "MMMMEd، hm": {
+        "a": "E، d MMMM، h:mm a – h:mm a",
+        "h": "E، d MMMM، h:mm–h:mm a",
+        "m": "E، d MMMM، h:mm–h:mm a"
+      },
+      "y، hm": {
+        "a": "y، h:mm a – h:mm a",
+        "h": "y، h:mm–h:mm a",
+        "m": "y، h:mm–h:mm a"
+      },
+      "yM، hm": {
+        "a": "M‏/y، h:mm a – h:mm a",
+        "h": "M‏/y، h:mm–h:mm a",
+        "m": "M‏/y، h:mm–h:mm a"
+      },
+      "yMd، hm": {
+        "a": "d‏/M‏/y، h:mm a – h:mm a",
+        "h": "d‏/M‏/y، h:mm–h:mm a",
+        "m": "d‏/M‏/y، h:mm–h:mm a"
+      },
+      "yMEd، hm": {
+        "a": "E، d‏/M‏/y، h:mm a – h:mm a",
+        "h": "E، d‏/M‏/y، h:mm–h:mm a",
+        "m": "E، d‏/M‏/y، h:mm–h:mm a"
+      },
+      "yMM، hm": {
+        "a": "MM‏/y، h:mm a – h:mm a",
+        "h": "MM‏/y، h:mm–h:mm a",
+        "m": "MM‏/y، h:mm–h:mm a"
+      },
+      "yMMM، hm": {
+        "a": "MMM y، h:mm a – h:mm a",
+        "h": "MMM y، h:mm–h:mm a",
+        "m": "MMM y، h:mm–h:mm a"
+      },
+      "yMMMd، hm": {
+        "a": "d MMM y، h:mm a – h:mm a",
+        "h": "d MMM y، h:mm–h:mm a",
+        "m": "d MMM y، h:mm–h:mm a"
+      },
+      "yMMMEd، hm": {
+        "a": "E، d MMM y، h:mm a – h:mm a",
+        "h": "E، d MMM y، h:mm–h:mm a",
+        "m": "E، d MMM y، h:mm–h:mm a"
+      },
+      "yMMMM، hm": {
+        "a": "MMMM y، h:mm a – h:mm a",
+        "h": "MMMM y، h:mm–h:mm a",
+        "m": "MMMM y، h:mm–h:mm a"
+      },
+      "EEEE، d MMMM y، Hm": {
+        "H": "EEEE، d MMMM y، HH:mm–HH:mm",
+        "m": "EEEE، d MMMM y، HH:mm–HH:mm"
+      },
+      "d MMMM y، Hm": {
+        "H": "d MMMM y، HH:mm–HH:mm",
+        "m": "d MMMM y، HH:mm–HH:mm"
+      },
+      "dd‏/MM‏/y، Hm": {
+        "H": "dd‏/MM‏/y، HH:mm–HH:mm",
+        "m": "dd‏/MM‏/y، HH:mm–HH:mm"
+      },
+      "d‏/M‏/y، Hm": {
+        "H": "d‏/M‏/y، HH:mm–HH:mm",
+        "m": "d‏/M‏/y، HH:mm–HH:mm"
+      },
+      "d، Hm": {
+        "H": "d، HH:mm–HH:mm",
+        "m": "d، HH:mm–HH:mm"
+      },
+      "E، Hm": {
+        "H": "ccc، HH:mm–HH:mm",
+        "m": "ccc، HH:mm–HH:mm"
+      },
+      "Ed، Hm": {
+        "H": "E، d، HH:mm–HH:mm",
+        "m": "E، d، HH:mm–HH:mm"
+      },
+      "Gy، Hm": {
+        "H": "y G، HH:mm–HH:mm",
+        "m": "y G، HH:mm–HH:mm"
+      },
+      "GyM، Hm": {
+        "H": "MM، y G، HH:mm–HH:mm",
+        "m": "MM، y G، HH:mm–HH:mm"
+      },
+      "GyMd، Hm": {
+        "H": "dd-MM-y GGGGG، HH:mm–HH:mm",
+        "m": "dd-MM-y GGGGG، HH:mm–HH:mm"
+      },
+      "GyMEd، Hm": {
+        "H": "E d/M/y G، HH:mm–HH:mm",
+        "m": "E d/M/y G، HH:mm–HH:mm"
+      },
+      "GyMMM، Hm": {
+        "H": "MMM y G، HH:mm–HH:mm",
+        "m": "MMM y G، HH:mm–HH:mm"
+      },
+      "GyMMMd، Hm": {
+        "H": "d MMM y G، HH:mm–HH:mm",
+        "m": "d MMM y G، HH:mm–HH:mm"
+      },
+      "GyMMMEd، Hm": {
+        "H": "E، d MMM y G، HH:mm–HH:mm",
+        "m": "E، d MMM y G، HH:mm–HH:mm"
+      },
+      "M، Hm": {
+        "H": "L، HH:mm–HH:mm",
+        "m": "L، HH:mm–HH:mm"
+      },
+      "Md، Hm": {
+        "H": "d‏/M، HH:mm–HH:mm",
+        "m": "d‏/M، HH:mm–HH:mm"
+      },
+      "MEd، Hm": {
+        "H": "E، d‏/M، HH:mm–HH:mm",
+        "m": "E، d‏/M، HH:mm–HH:mm"
+      },
+      "MMdd، Hm": {
+        "H": "dd‏/MM، HH:mm–HH:mm",
+        "m": "dd‏/MM، HH:mm–HH:mm"
+      },
+      "MMM، Hm": {
+        "H": "LLL، HH:mm–HH:mm",
+        "m": "LLL، HH:mm–HH:mm"
+      },
+      "MMMd، Hm": {
+        "H": "d MMM، HH:mm–HH:mm",
+        "m": "d MMM، HH:mm–HH:mm"
+      },
+      "MMMEd، Hm": {
+        "H": "E، d MMM، HH:mm–HH:mm",
+        "m": "E، d MMM، HH:mm–HH:mm"
+      },
+      "MMMMd، Hm": {
+        "H": "d MMMM، HH:mm–HH:mm",
+        "m": "d MMMM، HH:mm–HH:mm"
+      },
+      "MMMMEd، Hm": {
+        "H": "E، d MMMM، HH:mm–HH:mm",
+        "m": "E، d MMMM، HH:mm–HH:mm"
+      },
+      "y، Hm": {
+        "H": "y، HH:mm–HH:mm",
+        "m": "y، HH:mm–HH:mm"
+      },
+      "yM، Hm": {
+        "H": "M‏/y، HH:mm–HH:mm",
+        "m": "M‏/y، HH:mm–HH:mm"
+      },
+      "yMd، Hm": {
+        "H": "d‏/M‏/y، HH:mm–HH:mm",
+        "m": "d‏/M‏/y، HH:mm–HH:mm"
+      },
+      "yMEd، Hm": {
+        "H": "E، d‏/M‏/y، HH:mm–HH:mm",
+        "m": "E، d‏/M‏/y، HH:mm–HH:mm"
+      },
+      "yMM، Hm": {
+        "H": "MM‏/y، HH:mm–HH:mm",
+        "m": "MM‏/y، HH:mm–HH:mm"
+      },
+      "yMMM، Hm": {
+        "H": "MMM y، HH:mm–HH:mm",
+        "m": "MMM y، HH:mm–HH:mm"
+      },
+      "yMMMd، Hm": {
+        "H": "d MMM y، HH:mm–HH:mm",
+        "m": "d MMM y، HH:mm–HH:mm"
+      },
+      "yMMMEd، Hm": {
+        "H": "E، d MMM y، HH:mm–HH:mm",
+        "m": "E، d MMM y، HH:mm–HH:mm"
+      },
+      "yMMMM، Hm": {
+        "H": "MMMM y، HH:mm–HH:mm",
+        "m": "MMMM y، HH:mm–HH:mm"
+      },
+      "EEEE، d MMMM y، hmv": {
+        "a": "EEEE، d MMMM y، h:mm a – h:mm a v",
+        "h": "EEEE، d MMMM y، h:mm–h:mm a v",
+        "m": "EEEE، d MMMM y، h:mm–h:mm a v"
+      },
+      "d MMMM y، hmv": {
+        "a": "d MMMM y، h:mm a – h:mm a v",
+        "h": "d MMMM y، h:mm–h:mm a v",
+        "m": "d MMMM y، h:mm–h:mm a v"
+      },
+      "dd‏/MM‏/y، hmv": {
+        "a": "dd‏/MM‏/y، h:mm a – h:mm a v",
+        "h": "dd‏/MM‏/y، h:mm–h:mm a v",
+        "m": "dd‏/MM‏/y، h:mm–h:mm a v"
+      },
+      "d‏/M‏/y، hmv": {
+        "a": "d‏/M‏/y، h:mm a – h:mm a v",
+        "h": "d‏/M‏/y، h:mm–h:mm a v",
+        "m": "d‏/M‏/y، h:mm–h:mm a v"
+      },
+      "d، hmv": {
+        "a": "d، h:mm a – h:mm a v",
+        "h": "d، h:mm–h:mm a v",
+        "m": "d، h:mm–h:mm a v"
+      },
+      "E، hmv": {
+        "a": "ccc، h:mm a – h:mm a v",
+        "h": "ccc، h:mm–h:mm a v",
+        "m": "ccc، h:mm–h:mm a v"
+      },
+      "Ed، hmv": {
+        "a": "E، d، h:mm a – h:mm a v",
+        "h": "E، d، h:mm–h:mm a v",
+        "m": "E، d، h:mm–h:mm a v"
+      },
+      "Gy، hmv": {
+        "a": "y G، h:mm a – h:mm a v",
+        "h": "y G، h:mm–h:mm a v",
+        "m": "y G، h:mm–h:mm a v"
+      },
+      "GyM، hmv": {
+        "a": "MM، y G، h:mm a – h:mm a v",
+        "h": "MM، y G، h:mm–h:mm a v",
+        "m": "MM، y G، h:mm–h:mm a v"
+      },
+      "GyMd، hmv": {
+        "a": "dd-MM-y GGGGG، h:mm a – h:mm a v",
+        "h": "dd-MM-y GGGGG، h:mm–h:mm a v",
+        "m": "dd-MM-y GGGGG، h:mm–h:mm a v"
+      },
+      "GyMEd، hmv": {
+        "a": "E d/M/y G، h:mm a – h:mm a v",
+        "h": "E d/M/y G، h:mm–h:mm a v",
+        "m": "E d/M/y G، h:mm–h:mm a v"
+      },
+      "GyMMM، hmv": {
+        "a": "MMM y G، h:mm a – h:mm a v",
+        "h": "MMM y G، h:mm–h:mm a v",
+        "m": "MMM y G، h:mm–h:mm a v"
+      },
+      "GyMMMd، hmv": {
+        "a": "d MMM y G، h:mm a – h:mm a v",
+        "h": "d MMM y G، h:mm–h:mm a v",
+        "m": "d MMM y G، h:mm–h:mm a v"
+      },
+      "GyMMMEd، hmv": {
+        "a": "E، d MMM y G، h:mm a – h:mm a v",
+        "h": "E، d MMM y G، h:mm–h:mm a v",
+        "m": "E، d MMM y G، h:mm–h:mm a v"
+      },
+      "M، hmv": {
+        "a": "L، h:mm a – h:mm a v",
+        "h": "L، h:mm–h:mm a v",
+        "m": "L، h:mm–h:mm a v"
+      },
+      "Md، hmv": {
+        "a": "d‏/M، h:mm a – h:mm a v",
+        "h": "d‏/M، h:mm–h:mm a v",
+        "m": "d‏/M، h:mm–h:mm a v"
+      },
+      "MEd، hmv": {
+        "a": "E، d‏/M، h:mm a – h:mm a v",
+        "h": "E، d‏/M، h:mm–h:mm a v",
+        "m": "E، d‏/M، h:mm–h:mm a v"
+      },
+      "MMdd، hmv": {
+        "a": "dd‏/MM، h:mm a – h:mm a v",
+        "h": "dd‏/MM، h:mm–h:mm a v",
+        "m": "dd‏/MM، h:mm–h:mm a v"
+      },
+      "MMM، hmv": {
+        "a": "LLL، h:mm a – h:mm a v",
+        "h": "LLL، h:mm–h:mm a v",
+        "m": "LLL، h:mm–h:mm a v"
+      },
+      "MMMd، hmv": {
+        "a": "d MMM، h:mm a – h:mm a v",
+        "h": "d MMM، h:mm–h:mm a v",
+        "m": "d MMM، h:mm–h:mm a v"
+      },
+      "MMMEd، hmv": {
+        "a": "E، d MMM، h:mm a – h:mm a v",
+        "h": "E، d MMM، h:mm–h:mm a v",
+        "m": "E، d MMM، h:mm–h:mm a v"
+      },
+      "MMMMd، hmv": {
+        "a": "d MMMM، h:mm a – h:mm a v",
+        "h": "d MMMM، h:mm–h:mm a v",
+        "m": "d MMMM، h:mm–h:mm a v"
+      },
+      "MMMMEd، hmv": {
+        "a": "E، d MMMM، h:mm a – h:mm a v",
+        "h": "E، d MMMM، h:mm–h:mm a v",
+        "m": "E، d MMMM، h:mm–h:mm a v"
+      },
+      "y، hmv": {
+        "a": "y، h:mm a – h:mm a v",
+        "h": "y، h:mm–h:mm a v",
+        "m": "y، h:mm–h:mm a v"
+      },
+      "yM، hmv": {
+        "a": "M‏/y، h:mm a – h:mm a v",
+        "h": "M‏/y، h:mm–h:mm a v",
+        "m": "M‏/y، h:mm–h:mm a v"
+      },
+      "yMd، hmv": {
+        "a": "d‏/M‏/y، h:mm a – h:mm a v",
+        "h": "d‏/M‏/y، h:mm–h:mm a v",
+        "m": "d‏/M‏/y، h:mm–h:mm a v"
+      },
+      "yMEd، hmv": {
+        "a": "E، d‏/M‏/y، h:mm a – h:mm a v",
+        "h": "E، d‏/M‏/y، h:mm–h:mm a v",
+        "m": "E، d‏/M‏/y، h:mm–h:mm a v"
+      },
+      "yMM، hmv": {
+        "a": "MM‏/y، h:mm a – h:mm a v",
+        "h": "MM‏/y، h:mm–h:mm a v",
+        "m": "MM‏/y، h:mm–h:mm a v"
+      },
+      "yMMM، hmv": {
+        "a": "MMM y، h:mm a – h:mm a v",
+        "h": "MMM y، h:mm–h:mm a v",
+        "m": "MMM y، h:mm–h:mm a v"
+      },
+      "yMMMd، hmv": {
+        "a": "d MMM y، h:mm a – h:mm a v",
+        "h": "d MMM y، h:mm–h:mm a v",
+        "m": "d MMM y، h:mm–h:mm a v"
+      },
+      "yMMMEd، hmv": {
+        "a": "E، d MMM y، h:mm a – h:mm a v",
+        "h": "E، d MMM y، h:mm–h:mm a v",
+        "m": "E، d MMM y، h:mm–h:mm a v"
+      },
+      "yMMMM، hmv": {
+        "a": "MMMM y، h:mm a – h:mm a v",
+        "h": "MMMM y، h:mm–h:mm a v",
+        "m": "MMMM y، h:mm–h:mm a v"
+      },
+      "EEEE، d MMMM y، Hmv": {
+        "H": "EEEE، d MMMM y، HH:mm–HH:mm v",
+        "m": "EEEE، d MMMM y، HH:mm–HH:mm v"
+      },
+      "d MMMM y، Hmv": {
+        "H": "d MMMM y، HH:mm–HH:mm v",
+        "m": "d MMMM y، HH:mm–HH:mm v"
+      },
+      "dd‏/MM‏/y، Hmv": {
+        "H": "dd‏/MM‏/y، HH:mm–HH:mm v",
+        "m": "dd‏/MM‏/y، HH:mm–HH:mm v"
+      },
+      "d‏/M‏/y، Hmv": {
+        "H": "d‏/M‏/y، HH:mm–HH:mm v",
+        "m": "d‏/M‏/y، HH:mm–HH:mm v"
+      },
+      "d، Hmv": {
+        "H": "d، HH:mm–HH:mm v",
+        "m": "d، HH:mm–HH:mm v"
+      },
+      "E، Hmv": {
+        "H": "ccc، HH:mm–HH:mm v",
+        "m": "ccc، HH:mm–HH:mm v"
+      },
+      "Ed، Hmv": {
+        "H": "E، d، HH:mm–HH:mm v",
+        "m": "E، d، HH:mm–HH:mm v"
+      },
+      "Gy، Hmv": {
+        "H": "y G، HH:mm–HH:mm v",
+        "m": "y G، HH:mm–HH:mm v"
+      },
+      "GyM، Hmv": {
+        "H": "MM، y G، HH:mm–HH:mm v",
+        "m": "MM، y G، HH:mm–HH:mm v"
+      },
+      "GyMd، Hmv": {
+        "H": "dd-MM-y GGGGG، HH:mm–HH:mm v",
+        "m": "dd-MM-y GGGGG، HH:mm–HH:mm v"
+      },
+      "GyMEd، Hmv": {
+        "H": "E d/M/y G، HH:mm–HH:mm v",
+        "m": "E d/M/y G، HH:mm–HH:mm v"
+      },
+      "GyMMM، Hmv": {
+        "H": "MMM y G، HH:mm–HH:mm v",
+        "m": "MMM y G، HH:mm–HH:mm v"
+      },
+      "GyMMMd، Hmv": {
+        "H": "d MMM y G، HH:mm–HH:mm v",
+        "m": "d MMM y G، HH:mm–HH:mm v"
+      },
+      "GyMMMEd، Hmv": {
+        "H": "E، d MMM y G، HH:mm–HH:mm v",
+        "m": "E، d MMM y G، HH:mm–HH:mm v"
+      },
+      "M، Hmv": {
+        "H": "L، HH:mm–HH:mm v",
+        "m": "L، HH:mm–HH:mm v"
+      },
+      "Md، Hmv": {
+        "H": "d‏/M، HH:mm–HH:mm v",
+        "m": "d‏/M، HH:mm–HH:mm v"
+      },
+      "MEd، Hmv": {
+        "H": "E، d‏/M، HH:mm–HH:mm v",
+        "m": "E، d‏/M، HH:mm–HH:mm v"
+      },
+      "MMdd، Hmv": {
+        "H": "dd‏/MM، HH:mm–HH:mm v",
+        "m": "dd‏/MM، HH:mm–HH:mm v"
+      },
+      "MMM، Hmv": {
+        "H": "LLL، HH:mm–HH:mm v",
+        "m": "LLL، HH:mm–HH:mm v"
+      },
+      "MMMd، Hmv": {
+        "H": "d MMM، HH:mm–HH:mm v",
+        "m": "d MMM، HH:mm–HH:mm v"
+      },
+      "MMMEd، Hmv": {
+        "H": "E، d MMM، HH:mm–HH:mm v",
+        "m": "E، d MMM، HH:mm–HH:mm v"
+      },
+      "MMMMd، Hmv": {
+        "H": "d MMMM، HH:mm–HH:mm v",
+        "m": "d MMMM، HH:mm–HH:mm v"
+      },
+      "MMMMEd، Hmv": {
+        "H": "E، d MMMM، HH:mm–HH:mm v",
+        "m": "E، d MMMM، HH:mm–HH:mm v"
+      },
+      "y، Hmv": {
+        "H": "y، HH:mm–HH:mm v",
+        "m": "y، HH:mm–HH:mm v"
+      },
+      "yM، Hmv": {
+        "H": "M‏/y، HH:mm–HH:mm v",
+        "m": "M‏/y، HH:mm–HH:mm v"
+      },
+      "yMd، Hmv": {
+        "H": "d‏/M‏/y، HH:mm–HH:mm v",
+        "m": "d‏/M‏/y، HH:mm–HH:mm v"
+      },
+      "yMEd، Hmv": {
+        "H": "E، d‏/M‏/y، HH:mm–HH:mm v",
+        "m": "E، d‏/M‏/y، HH:mm–HH:mm v"
+      },
+      "yMM، Hmv": {
+        "H": "MM‏/y، HH:mm–HH:mm v",
+        "m": "MM‏/y، HH:mm–HH:mm v"
+      },
+      "yMMM، Hmv": {
+        "H": "MMM y، HH:mm–HH:mm v",
+        "m": "MMM y، HH:mm–HH:mm v"
+      },
+      "yMMMd، Hmv": {
+        "H": "d MMM y، HH:mm–HH:mm v",
+        "m": "d MMM y، HH:mm–HH:mm v"
+      },
+      "yMMMEd، Hmv": {
+        "H": "E، d MMM y، HH:mm–HH:mm v",
+        "m": "E، d MMM y، HH:mm–HH:mm v"
+      },
+      "yMMMM، Hmv": {
+        "H": "MMMM y، HH:mm–HH:mm v",
+        "m": "MMMM y، HH:mm–HH:mm v"
+      },
+      "EEEE، d MMMM y، hv": {
+        "a": "EEEE، d MMMM y، h a – h a v",
+        "h": "EEEE، d MMMM y، h–h a v"
+      },
+      "d MMMM y، hv": {
+        "a": "d MMMM y، h a – h a v",
+        "h": "d MMMM y، h–h a v"
+      },
+      "dd‏/MM‏/y، hv": {
+        "a": "dd‏/MM‏/y، h a – h a v",
+        "h": "dd‏/MM‏/y، h–h a v"
+      },
+      "d‏/M‏/y، hv": {
+        "a": "d‏/M‏/y، h a – h a v",
+        "h": "d‏/M‏/y، h–h a v"
+      },
+      "d، hv": {
+        "a": "d، h a – h a v",
+        "h": "d، h–h a v"
+      },
+      "E، hv": {
+        "a": "ccc، h a – h a v",
+        "h": "ccc، h–h a v"
+      },
+      "Ed، hv": {
+        "a": "E، d، h a – h a v",
+        "h": "E، d، h–h a v"
+      },
+      "Gy، hv": {
+        "a": "y G، h a – h a v",
+        "h": "y G، h–h a v"
+      },
+      "GyM، hv": {
+        "a": "MM، y G، h a – h a v",
+        "h": "MM، y G، h–h a v"
+      },
+      "GyMd، hv": {
+        "a": "dd-MM-y GGGGG، h a – h a v",
+        "h": "dd-MM-y GGGGG، h–h a v"
+      },
+      "GyMEd، hv": {
+        "a": "E d/M/y G، h a – h a v",
+        "h": "E d/M/y G، h–h a v"
+      },
+      "GyMMM، hv": {
+        "a": "MMM y G، h a – h a v",
+        "h": "MMM y G، h–h a v"
+      },
+      "GyMMMd، hv": {
+        "a": "d MMM y G، h a – h a v",
+        "h": "d MMM y G، h–h a v"
+      },
+      "GyMMMEd، hv": {
+        "a": "E، d MMM y G، h a – h a v",
+        "h": "E، d MMM y G، h–h a v"
+      },
+      "M، hv": {
+        "a": "L، h a – h a v",
+        "h": "L، h–h a v"
+      },
+      "Md، hv": {
+        "a": "d‏/M، h a – h a v",
+        "h": "d‏/M، h–h a v"
+      },
+      "MEd، hv": {
+        "a": "E، d‏/M، h a – h a v",
+        "h": "E، d‏/M، h–h a v"
+      },
+      "MMdd، hv": {
+        "a": "dd‏/MM، h a – h a v",
+        "h": "dd‏/MM، h–h a v"
+      },
+      "MMM، hv": {
+        "a": "LLL، h a – h a v",
+        "h": "LLL، h–h a v"
+      },
+      "MMMd، hv": {
+        "a": "d MMM، h a – h a v",
+        "h": "d MMM، h–h a v"
+      },
+      "MMMEd، hv": {
+        "a": "E، d MMM، h a – h a v",
+        "h": "E، d MMM، h–h a v"
+      },
+      "MMMMd، hv": {
+        "a": "d MMMM، h a – h a v",
+        "h": "d MMMM، h–h a v"
+      },
+      "MMMMEd، hv": {
+        "a": "E، d MMMM، h a – h a v",
+        "h": "E، d MMMM، h–h a v"
+      },
+      "y، hv": {
+        "a": "y، h a – h a v",
+        "h": "y، h–h a v"
+      },
+      "yM، hv": {
+        "a": "M‏/y، h a – h a v",
+        "h": "M‏/y، h–h a v"
+      },
+      "yMd، hv": {
+        "a": "d‏/M‏/y، h a – h a v",
+        "h": "d‏/M‏/y، h–h a v"
+      },
+      "yMEd، hv": {
+        "a": "E، d‏/M‏/y، h a – h a v",
+        "h": "E، d‏/M‏/y، h–h a v"
+      },
+      "yMM، hv": {
+        "a": "MM‏/y، h a – h a v",
+        "h": "MM‏/y، h–h a v"
+      },
+      "yMMM، hv": {
+        "a": "MMM y، h a – h a v",
+        "h": "MMM y، h–h a v"
+      },
+      "yMMMd، hv": {
+        "a": "d MMM y، h a – h a v",
+        "h": "d MMM y، h–h a v"
+      },
+      "yMMMEd، hv": {
+        "a": "E، d MMM y، h a – h a v",
+        "h": "E، d MMM y، h–h a v"
+      },
+      "yMMMM، hv": {
+        "a": "MMMM y، h a – h a v",
+        "h": "MMMM y، h–h a v"
+      },
+      "EEEE، d MMMM y، Hv": {
+        "H": "EEEE، d MMMM y، HH–HH v"
+      },
+      "d MMMM y، Hv": {
+        "H": "d MMMM y، HH–HH v"
+      },
+      "dd‏/MM‏/y، Hv": {
+        "H": "dd‏/MM‏/y، HH–HH v"
+      },
+      "d‏/M‏/y، Hv": {
+        "H": "d‏/M‏/y، HH–HH v"
+      },
+      "d، Hv": {
+        "H": "d، HH–HH v"
+      },
+      "E، Hv": {
+        "H": "ccc، HH–HH v"
+      },
+      "Ed، Hv": {
+        "H": "E، d، HH–HH v"
+      },
+      "Gy، Hv": {
+        "H": "y G، HH–HH v"
+      },
+      "GyM، Hv": {
+        "H": "MM، y G، HH–HH v"
+      },
+      "GyMd، Hv": {
+        "H": "dd-MM-y GGGGG، HH–HH v"
+      },
+      "GyMEd، Hv": {
+        "H": "E d/M/y G، HH–HH v"
+      },
+      "GyMMM، Hv": {
+        "H": "MMM y G، HH–HH v"
+      },
+      "GyMMMd، Hv": {
+        "H": "d MMM y G، HH–HH v"
+      },
+      "GyMMMEd، Hv": {
+        "H": "E، d MMM y G، HH–HH v"
+      },
+      "M، Hv": {
+        "H": "L، HH–HH v"
+      },
+      "Md، Hv": {
+        "H": "d‏/M، HH–HH v"
+      },
+      "MEd، Hv": {
+        "H": "E، d‏/M، HH–HH v"
+      },
+      "MMdd، Hv": {
+        "H": "dd‏/MM، HH–HH v"
+      },
+      "MMM، Hv": {
+        "H": "LLL، HH–HH v"
+      },
+      "MMMd، Hv": {
+        "H": "d MMM، HH–HH v"
+      },
+      "MMMEd، Hv": {
+        "H": "E، d MMM، HH–HH v"
+      },
+      "MMMMd، Hv": {
+        "H": "d MMMM، HH–HH v"
+      },
+      "MMMMEd، Hv": {
+        "H": "E، d MMMM، HH–HH v"
+      },
+      "y، Hv": {
+        "H": "y، HH–HH v"
+      },
+      "yM، Hv": {
+        "H": "M‏/y، HH–HH v"
+      },
+      "yMd، Hv": {
+        "H": "d‏/M‏/y، HH–HH v"
+      },
+      "yMEd، Hv": {
+        "H": "E، d‏/M‏/y، HH–HH v"
+      },
+      "yMM، Hv": {
+        "H": "MM‏/y، HH–HH v"
+      },
+      "yMMM، Hv": {
+        "H": "MMM y، HH–HH v"
+      },
+      "yMMMd، Hv": {
+        "H": "d MMM y، HH–HH v"
+      },
+      "yMMMEd، Hv": {
+        "H": "E، d MMM y، HH–HH v"
+      },
+      "yMMMM، Hv": {
+        "H": "MMMM y، HH–HH v"
       }
     },
     "hourCycle": "h12",

--- a/packages/intl-datetimeformat/tests/locale-data/de.json
+++ b/packages/intl-datetimeformat/tests/locale-data/de.json
@@ -2884,6 +2884,1400 @@
       "yMMMM": {
         "M": "MMMM–MMMM y",
         "y": "MMMM y – MMMM y"
+      },
+      "EEEE, d. MMMM y, Bh": {
+        "B": "EEEE, d. MMMM y, h 'Uhr' B – h 'Uhr' B",
+        "h": "EEEE, d. MMMM y, h–h 'Uhr' B"
+      },
+      "d. MMMM y, Bh": {
+        "B": "d. MMMM y, h 'Uhr' B – h 'Uhr' B",
+        "h": "d. MMMM y, h–h 'Uhr' B"
+      },
+      "dd.MM.y, Bh": {
+        "B": "dd.MM.y, h 'Uhr' B – h 'Uhr' B",
+        "h": "dd.MM.y, h–h 'Uhr' B"
+      },
+      "dd.MM.yy, Bh": {
+        "B": "dd.MM.yy, h 'Uhr' B – h 'Uhr' B",
+        "h": "dd.MM.yy, h–h 'Uhr' B"
+      },
+      "d, Bh": {
+        "B": "d, h 'Uhr' B – h 'Uhr' B",
+        "h": "d, h–h 'Uhr' B"
+      },
+      "E, Bh": {
+        "B": "ccc, h 'Uhr' B – h 'Uhr' B",
+        "h": "ccc, h–h 'Uhr' B"
+      },
+      "Ed, Bh": {
+        "B": "E, d., h 'Uhr' B – h 'Uhr' B",
+        "h": "E, d., h–h 'Uhr' B"
+      },
+      "Gy, Bh": {
+        "B": "y G, h 'Uhr' B – h 'Uhr' B",
+        "h": "y G, h–h 'Uhr' B"
+      },
+      "GyM, Bh": {
+        "B": "MM/y G, h 'Uhr' B – h 'Uhr' B",
+        "h": "MM/y G, h–h 'Uhr' B"
+      },
+      "GyMd, Bh": {
+        "B": "dd.MM.y G, h 'Uhr' B – h 'Uhr' B",
+        "h": "dd.MM.y G, h–h 'Uhr' B"
+      },
+      "GyMEd, Bh": {
+        "B": "E, dd.MM.y G, h 'Uhr' B – h 'Uhr' B",
+        "h": "E, dd.MM.y G, h–h 'Uhr' B"
+      },
+      "GyMMM, Bh": {
+        "B": "MMM y G, h 'Uhr' B – h 'Uhr' B",
+        "h": "MMM y G, h–h 'Uhr' B"
+      },
+      "GyMMMd, Bh": {
+        "B": "d. MMM y G, h 'Uhr' B – h 'Uhr' B",
+        "h": "d. MMM y G, h–h 'Uhr' B"
+      },
+      "GyMMMEd, Bh": {
+        "B": "E, d. MMM y G, h 'Uhr' B – h 'Uhr' B",
+        "h": "E, d. MMM y G, h–h 'Uhr' B"
+      },
+      "M, Bh": {
+        "B": "L, h 'Uhr' B – h 'Uhr' B",
+        "h": "L, h–h 'Uhr' B"
+      },
+      "Md, Bh": {
+        "B": "d.M., h 'Uhr' B – h 'Uhr' B",
+        "h": "d.M., h–h 'Uhr' B"
+      },
+      "MEd, Bh": {
+        "B": "E, d.M., h 'Uhr' B – h 'Uhr' B",
+        "h": "E, d.M., h–h 'Uhr' B"
+      },
+      "MMd, Bh": {
+        "B": "dd.MM., h 'Uhr' B – h 'Uhr' B",
+        "h": "dd.MM., h–h 'Uhr' B"
+      },
+      "MMdd, Bh": {
+        "B": "dd.MM., h 'Uhr' B – h 'Uhr' B",
+        "h": "dd.MM., h–h 'Uhr' B"
+      },
+      "MMM, Bh": {
+        "B": "LLL, h 'Uhr' B – h 'Uhr' B",
+        "h": "LLL, h–h 'Uhr' B"
+      },
+      "MMMd, Bh": {
+        "B": "d. MMM, h 'Uhr' B – h 'Uhr' B",
+        "h": "d. MMM, h–h 'Uhr' B"
+      },
+      "MMMEd, Bh": {
+        "B": "E, d. MMM, h 'Uhr' B – h 'Uhr' B",
+        "h": "E, d. MMM, h–h 'Uhr' B"
+      },
+      "MMMMd, Bh": {
+        "B": "d. MMMM, h 'Uhr' B – h 'Uhr' B",
+        "h": "d. MMMM, h–h 'Uhr' B"
+      },
+      "MMMMEd, Bh": {
+        "B": "E, d. MMMM, h 'Uhr' B – h 'Uhr' B",
+        "h": "E, d. MMMM, h–h 'Uhr' B"
+      },
+      "y, Bh": {
+        "B": "y, h 'Uhr' B – h 'Uhr' B",
+        "h": "y, h–h 'Uhr' B"
+      },
+      "yM, Bh": {
+        "B": "M/y, h 'Uhr' B – h 'Uhr' B",
+        "h": "M/y, h–h 'Uhr' B"
+      },
+      "yMd, Bh": {
+        "B": "d.M.y, h 'Uhr' B – h 'Uhr' B",
+        "h": "d.M.y, h–h 'Uhr' B"
+      },
+      "yMEd, Bh": {
+        "B": "E, d.M.y, h 'Uhr' B – h 'Uhr' B",
+        "h": "E, d.M.y, h–h 'Uhr' B"
+      },
+      "yMM, Bh": {
+        "B": "MM/y, h 'Uhr' B – h 'Uhr' B",
+        "h": "MM/y, h–h 'Uhr' B"
+      },
+      "yMMdd, Bh": {
+        "B": "dd.MM.y, h 'Uhr' B – h 'Uhr' B",
+        "h": "dd.MM.y, h–h 'Uhr' B"
+      },
+      "yMMM, Bh": {
+        "B": "MMM y, h 'Uhr' B – h 'Uhr' B",
+        "h": "MMM y, h–h 'Uhr' B"
+      },
+      "yMMMd, Bh": {
+        "B": "d. MMM y, h 'Uhr' B – h 'Uhr' B",
+        "h": "d. MMM y, h–h 'Uhr' B"
+      },
+      "yMMMEd, Bh": {
+        "B": "E, d. MMM y, h 'Uhr' B – h 'Uhr' B",
+        "h": "E, d. MMM y, h–h 'Uhr' B"
+      },
+      "yMMMM, Bh": {
+        "B": "MMMM y, h 'Uhr' B – h 'Uhr' B",
+        "h": "MMMM y, h–h 'Uhr' B"
+      },
+      "EEEE, d. MMMM y, Bhm": {
+        "B": "EEEE, d. MMMM y, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "EEEE, d. MMMM y, h:mm – h:mm 'Uhr' B",
+        "m": "EEEE, d. MMMM y, h:mm – h:mm 'Uhr' B"
+      },
+      "d. MMMM y, Bhm": {
+        "B": "d. MMMM y, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "d. MMMM y, h:mm – h:mm 'Uhr' B",
+        "m": "d. MMMM y, h:mm – h:mm 'Uhr' B"
+      },
+      "dd.MM.y, Bhm": {
+        "B": "dd.MM.y, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "dd.MM.y, h:mm – h:mm 'Uhr' B",
+        "m": "dd.MM.y, h:mm – h:mm 'Uhr' B"
+      },
+      "dd.MM.yy, Bhm": {
+        "B": "dd.MM.yy, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "dd.MM.yy, h:mm – h:mm 'Uhr' B",
+        "m": "dd.MM.yy, h:mm – h:mm 'Uhr' B"
+      },
+      "d, Bhm": {
+        "B": "d, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "d, h:mm – h:mm 'Uhr' B",
+        "m": "d, h:mm – h:mm 'Uhr' B"
+      },
+      "E, Bhm": {
+        "B": "ccc, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "ccc, h:mm – h:mm 'Uhr' B",
+        "m": "ccc, h:mm – h:mm 'Uhr' B"
+      },
+      "Ed, Bhm": {
+        "B": "E, d., h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "E, d., h:mm – h:mm 'Uhr' B",
+        "m": "E, d., h:mm – h:mm 'Uhr' B"
+      },
+      "Gy, Bhm": {
+        "B": "y G, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "y G, h:mm – h:mm 'Uhr' B",
+        "m": "y G, h:mm – h:mm 'Uhr' B"
+      },
+      "GyM, Bhm": {
+        "B": "MM/y G, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "MM/y G, h:mm – h:mm 'Uhr' B",
+        "m": "MM/y G, h:mm – h:mm 'Uhr' B"
+      },
+      "GyMd, Bhm": {
+        "B": "dd.MM.y G, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "dd.MM.y G, h:mm – h:mm 'Uhr' B",
+        "m": "dd.MM.y G, h:mm – h:mm 'Uhr' B"
+      },
+      "GyMEd, Bhm": {
+        "B": "E, dd.MM.y G, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "E, dd.MM.y G, h:mm – h:mm 'Uhr' B",
+        "m": "E, dd.MM.y G, h:mm – h:mm 'Uhr' B"
+      },
+      "GyMMM, Bhm": {
+        "B": "MMM y G, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "MMM y G, h:mm – h:mm 'Uhr' B",
+        "m": "MMM y G, h:mm – h:mm 'Uhr' B"
+      },
+      "GyMMMd, Bhm": {
+        "B": "d. MMM y G, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "d. MMM y G, h:mm – h:mm 'Uhr' B",
+        "m": "d. MMM y G, h:mm – h:mm 'Uhr' B"
+      },
+      "GyMMMEd, Bhm": {
+        "B": "E, d. MMM y G, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "E, d. MMM y G, h:mm – h:mm 'Uhr' B",
+        "m": "E, d. MMM y G, h:mm – h:mm 'Uhr' B"
+      },
+      "M, Bhm": {
+        "B": "L, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "L, h:mm – h:mm 'Uhr' B",
+        "m": "L, h:mm – h:mm 'Uhr' B"
+      },
+      "Md, Bhm": {
+        "B": "d.M., h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "d.M., h:mm – h:mm 'Uhr' B",
+        "m": "d.M., h:mm – h:mm 'Uhr' B"
+      },
+      "MEd, Bhm": {
+        "B": "E, d.M., h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "E, d.M., h:mm – h:mm 'Uhr' B",
+        "m": "E, d.M., h:mm – h:mm 'Uhr' B"
+      },
+      "MMd, Bhm": {
+        "B": "dd.MM., h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "dd.MM., h:mm – h:mm 'Uhr' B",
+        "m": "dd.MM., h:mm – h:mm 'Uhr' B"
+      },
+      "MMdd, Bhm": {
+        "B": "dd.MM., h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "dd.MM., h:mm – h:mm 'Uhr' B",
+        "m": "dd.MM., h:mm – h:mm 'Uhr' B"
+      },
+      "MMM, Bhm": {
+        "B": "LLL, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "LLL, h:mm – h:mm 'Uhr' B",
+        "m": "LLL, h:mm – h:mm 'Uhr' B"
+      },
+      "MMMd, Bhm": {
+        "B": "d. MMM, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "d. MMM, h:mm – h:mm 'Uhr' B",
+        "m": "d. MMM, h:mm – h:mm 'Uhr' B"
+      },
+      "MMMEd, Bhm": {
+        "B": "E, d. MMM, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "E, d. MMM, h:mm – h:mm 'Uhr' B",
+        "m": "E, d. MMM, h:mm – h:mm 'Uhr' B"
+      },
+      "MMMMd, Bhm": {
+        "B": "d. MMMM, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "d. MMMM, h:mm – h:mm 'Uhr' B",
+        "m": "d. MMMM, h:mm – h:mm 'Uhr' B"
+      },
+      "MMMMEd, Bhm": {
+        "B": "E, d. MMMM, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "E, d. MMMM, h:mm – h:mm 'Uhr' B",
+        "m": "E, d. MMMM, h:mm – h:mm 'Uhr' B"
+      },
+      "y, Bhm": {
+        "B": "y, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "y, h:mm – h:mm 'Uhr' B",
+        "m": "y, h:mm – h:mm 'Uhr' B"
+      },
+      "yM, Bhm": {
+        "B": "M/y, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "M/y, h:mm – h:mm 'Uhr' B",
+        "m": "M/y, h:mm – h:mm 'Uhr' B"
+      },
+      "yMd, Bhm": {
+        "B": "d.M.y, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "d.M.y, h:mm – h:mm 'Uhr' B",
+        "m": "d.M.y, h:mm – h:mm 'Uhr' B"
+      },
+      "yMEd, Bhm": {
+        "B": "E, d.M.y, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "E, d.M.y, h:mm – h:mm 'Uhr' B",
+        "m": "E, d.M.y, h:mm – h:mm 'Uhr' B"
+      },
+      "yMM, Bhm": {
+        "B": "MM/y, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "MM/y, h:mm – h:mm 'Uhr' B",
+        "m": "MM/y, h:mm – h:mm 'Uhr' B"
+      },
+      "yMMdd, Bhm": {
+        "B": "dd.MM.y, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "dd.MM.y, h:mm – h:mm 'Uhr' B",
+        "m": "dd.MM.y, h:mm – h:mm 'Uhr' B"
+      },
+      "yMMM, Bhm": {
+        "B": "MMM y, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "MMM y, h:mm – h:mm 'Uhr' B",
+        "m": "MMM y, h:mm – h:mm 'Uhr' B"
+      },
+      "yMMMd, Bhm": {
+        "B": "d. MMM y, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "d. MMM y, h:mm – h:mm 'Uhr' B",
+        "m": "d. MMM y, h:mm – h:mm 'Uhr' B"
+      },
+      "yMMMEd, Bhm": {
+        "B": "E, d. MMM y, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "E, d. MMM y, h:mm – h:mm 'Uhr' B",
+        "m": "E, d. MMM y, h:mm – h:mm 'Uhr' B"
+      },
+      "yMMMM, Bhm": {
+        "B": "MMMM y, h:mm 'Uhr' B – h:mm 'Uhr' B",
+        "h": "MMMM y, h:mm – h:mm 'Uhr' B",
+        "m": "MMMM y, h:mm – h:mm 'Uhr' B"
+      },
+      "EEEE, d. MMMM y, h": {
+        "a": "EEEE, d. MMMM y, h a – h a",
+        "h": "EEEE, d. MMMM y, h – h a"
+      },
+      "d. MMMM y, h": {
+        "a": "d. MMMM y, h a – h a",
+        "h": "d. MMMM y, h – h a"
+      },
+      "dd.MM.y, h": {
+        "a": "dd.MM.y, h a – h a",
+        "h": "dd.MM.y, h – h a"
+      },
+      "dd.MM.yy, h": {
+        "a": "dd.MM.yy, h a – h a",
+        "h": "dd.MM.yy, h – h a"
+      },
+      "d, h": {
+        "a": "d, h a – h a",
+        "h": "d, h – h a"
+      },
+      "E, h": {
+        "a": "ccc, h a – h a",
+        "h": "ccc, h – h a"
+      },
+      "Ed, h": {
+        "a": "E, d., h a – h a",
+        "h": "E, d., h – h a"
+      },
+      "Gy, h": {
+        "a": "y G, h a – h a",
+        "h": "y G, h – h a"
+      },
+      "GyM, h": {
+        "a": "MM/y G, h a – h a",
+        "h": "MM/y G, h – h a"
+      },
+      "GyMd, h": {
+        "a": "dd.MM.y G, h a – h a",
+        "h": "dd.MM.y G, h – h a"
+      },
+      "GyMEd, h": {
+        "a": "E, dd.MM.y G, h a – h a",
+        "h": "E, dd.MM.y G, h – h a"
+      },
+      "GyMMM, h": {
+        "a": "MMM y G, h a – h a",
+        "h": "MMM y G, h – h a"
+      },
+      "GyMMMd, h": {
+        "a": "d. MMM y G, h a – h a",
+        "h": "d. MMM y G, h – h a"
+      },
+      "GyMMMEd, h": {
+        "a": "E, d. MMM y G, h a – h a",
+        "h": "E, d. MMM y G, h – h a"
+      },
+      "M, h": {
+        "a": "L, h a – h a",
+        "h": "L, h – h a"
+      },
+      "Md, h": {
+        "a": "d.M., h a – h a",
+        "h": "d.M., h – h a"
+      },
+      "MEd, h": {
+        "a": "E, d.M., h a – h a",
+        "h": "E, d.M., h – h a"
+      },
+      "MMd, h": {
+        "a": "dd.MM., h a – h a",
+        "h": "dd.MM., h – h a"
+      },
+      "MMdd, h": {
+        "a": "dd.MM., h a – h a",
+        "h": "dd.MM., h – h a"
+      },
+      "MMM, h": {
+        "a": "LLL, h a – h a",
+        "h": "LLL, h – h a"
+      },
+      "MMMd, h": {
+        "a": "d. MMM, h a – h a",
+        "h": "d. MMM, h – h a"
+      },
+      "MMMEd, h": {
+        "a": "E, d. MMM, h a – h a",
+        "h": "E, d. MMM, h – h a"
+      },
+      "MMMMd, h": {
+        "a": "d. MMMM, h a – h a",
+        "h": "d. MMMM, h – h a"
+      },
+      "MMMMEd, h": {
+        "a": "E, d. MMMM, h a – h a",
+        "h": "E, d. MMMM, h – h a"
+      },
+      "y, h": {
+        "a": "y, h a – h a",
+        "h": "y, h – h a"
+      },
+      "yM, h": {
+        "a": "M/y, h a – h a",
+        "h": "M/y, h – h a"
+      },
+      "yMd, h": {
+        "a": "d.M.y, h a – h a",
+        "h": "d.M.y, h – h a"
+      },
+      "yMEd, h": {
+        "a": "E, d.M.y, h a – h a",
+        "h": "E, d.M.y, h – h a"
+      },
+      "yMM, h": {
+        "a": "MM/y, h a – h a",
+        "h": "MM/y, h – h a"
+      },
+      "yMMdd, h": {
+        "a": "dd.MM.y, h a – h a",
+        "h": "dd.MM.y, h – h a"
+      },
+      "yMMM, h": {
+        "a": "MMM y, h a – h a",
+        "h": "MMM y, h – h a"
+      },
+      "yMMMd, h": {
+        "a": "d. MMM y, h a – h a",
+        "h": "d. MMM y, h – h a"
+      },
+      "yMMMEd, h": {
+        "a": "E, d. MMM y, h a – h a",
+        "h": "E, d. MMM y, h – h a"
+      },
+      "yMMMM, h": {
+        "a": "MMMM y, h a – h a",
+        "h": "MMMM y, h – h a"
+      },
+      "EEEE, d. MMMM y, H": {
+        "H": "EEEE, d. MMMM y, HH–HH 'Uhr'"
+      },
+      "d. MMMM y, H": {
+        "H": "d. MMMM y, HH–HH 'Uhr'"
+      },
+      "dd.MM.y, H": {
+        "H": "dd.MM.y, HH–HH 'Uhr'"
+      },
+      "dd.MM.yy, H": {
+        "H": "dd.MM.yy, HH–HH 'Uhr'"
+      },
+      "d, H": {
+        "H": "d, HH–HH 'Uhr'"
+      },
+      "E, H": {
+        "H": "ccc, HH–HH 'Uhr'"
+      },
+      "Ed, H": {
+        "H": "E, d., HH–HH 'Uhr'"
+      },
+      "Gy, H": {
+        "H": "y G, HH–HH 'Uhr'"
+      },
+      "GyM, H": {
+        "H": "MM/y G, HH–HH 'Uhr'"
+      },
+      "GyMd, H": {
+        "H": "dd.MM.y G, HH–HH 'Uhr'"
+      },
+      "GyMEd, H": {
+        "H": "E, dd.MM.y G, HH–HH 'Uhr'"
+      },
+      "GyMMM, H": {
+        "H": "MMM y G, HH–HH 'Uhr'"
+      },
+      "GyMMMd, H": {
+        "H": "d. MMM y G, HH–HH 'Uhr'"
+      },
+      "GyMMMEd, H": {
+        "H": "E, d. MMM y G, HH–HH 'Uhr'"
+      },
+      "M, H": {
+        "H": "L, HH–HH 'Uhr'"
+      },
+      "Md, H": {
+        "H": "d.M., HH–HH 'Uhr'"
+      },
+      "MEd, H": {
+        "H": "E, d.M., HH–HH 'Uhr'"
+      },
+      "MMd, H": {
+        "H": "dd.MM., HH–HH 'Uhr'"
+      },
+      "MMdd, H": {
+        "H": "dd.MM., HH–HH 'Uhr'"
+      },
+      "MMM, H": {
+        "H": "LLL, HH–HH 'Uhr'"
+      },
+      "MMMd, H": {
+        "H": "d. MMM, HH–HH 'Uhr'"
+      },
+      "MMMEd, H": {
+        "H": "E, d. MMM, HH–HH 'Uhr'"
+      },
+      "MMMMd, H": {
+        "H": "d. MMMM, HH–HH 'Uhr'"
+      },
+      "MMMMEd, H": {
+        "H": "E, d. MMMM, HH–HH 'Uhr'"
+      },
+      "y, H": {
+        "H": "y, HH–HH 'Uhr'"
+      },
+      "yM, H": {
+        "H": "M/y, HH–HH 'Uhr'"
+      },
+      "yMd, H": {
+        "H": "d.M.y, HH–HH 'Uhr'"
+      },
+      "yMEd, H": {
+        "H": "E, d.M.y, HH–HH 'Uhr'"
+      },
+      "yMM, H": {
+        "H": "MM/y, HH–HH 'Uhr'"
+      },
+      "yMMdd, H": {
+        "H": "dd.MM.y, HH–HH 'Uhr'"
+      },
+      "yMMM, H": {
+        "H": "MMM y, HH–HH 'Uhr'"
+      },
+      "yMMMd, H": {
+        "H": "d. MMM y, HH–HH 'Uhr'"
+      },
+      "yMMMEd, H": {
+        "H": "E, d. MMM y, HH–HH 'Uhr'"
+      },
+      "yMMMM, H": {
+        "H": "MMMM y, HH–HH 'Uhr'"
+      },
+      "EEEE, d. MMMM y, hm": {
+        "a": "EEEE, d. MMMM y, h:mm a – h:mm a",
+        "h": "EEEE, d. MMMM y, h:mm–h:mm a",
+        "m": "EEEE, d. MMMM y, h:mm–h:mm a"
+      },
+      "d. MMMM y, hm": {
+        "a": "d. MMMM y, h:mm a – h:mm a",
+        "h": "d. MMMM y, h:mm–h:mm a",
+        "m": "d. MMMM y, h:mm–h:mm a"
+      },
+      "dd.MM.y, hm": {
+        "a": "dd.MM.y, h:mm a – h:mm a",
+        "h": "dd.MM.y, h:mm–h:mm a",
+        "m": "dd.MM.y, h:mm–h:mm a"
+      },
+      "dd.MM.yy, hm": {
+        "a": "dd.MM.yy, h:mm a – h:mm a",
+        "h": "dd.MM.yy, h:mm–h:mm a",
+        "m": "dd.MM.yy, h:mm–h:mm a"
+      },
+      "d, hm": {
+        "a": "d, h:mm a – h:mm a",
+        "h": "d, h:mm–h:mm a",
+        "m": "d, h:mm–h:mm a"
+      },
+      "E, hm": {
+        "a": "ccc, h:mm a – h:mm a",
+        "h": "ccc, h:mm–h:mm a",
+        "m": "ccc, h:mm–h:mm a"
+      },
+      "Ed, hm": {
+        "a": "E, d., h:mm a – h:mm a",
+        "h": "E, d., h:mm–h:mm a",
+        "m": "E, d., h:mm–h:mm a"
+      },
+      "Gy, hm": {
+        "a": "y G, h:mm a – h:mm a",
+        "h": "y G, h:mm–h:mm a",
+        "m": "y G, h:mm–h:mm a"
+      },
+      "GyM, hm": {
+        "a": "MM/y G, h:mm a – h:mm a",
+        "h": "MM/y G, h:mm–h:mm a",
+        "m": "MM/y G, h:mm–h:mm a"
+      },
+      "GyMd, hm": {
+        "a": "dd.MM.y G, h:mm a – h:mm a",
+        "h": "dd.MM.y G, h:mm–h:mm a",
+        "m": "dd.MM.y G, h:mm–h:mm a"
+      },
+      "GyMEd, hm": {
+        "a": "E, dd.MM.y G, h:mm a – h:mm a",
+        "h": "E, dd.MM.y G, h:mm–h:mm a",
+        "m": "E, dd.MM.y G, h:mm–h:mm a"
+      },
+      "GyMMM, hm": {
+        "a": "MMM y G, h:mm a – h:mm a",
+        "h": "MMM y G, h:mm–h:mm a",
+        "m": "MMM y G, h:mm–h:mm a"
+      },
+      "GyMMMd, hm": {
+        "a": "d. MMM y G, h:mm a – h:mm a",
+        "h": "d. MMM y G, h:mm–h:mm a",
+        "m": "d. MMM y G, h:mm–h:mm a"
+      },
+      "GyMMMEd, hm": {
+        "a": "E, d. MMM y G, h:mm a – h:mm a",
+        "h": "E, d. MMM y G, h:mm–h:mm a",
+        "m": "E, d. MMM y G, h:mm–h:mm a"
+      },
+      "M, hm": {
+        "a": "L, h:mm a – h:mm a",
+        "h": "L, h:mm–h:mm a",
+        "m": "L, h:mm–h:mm a"
+      },
+      "Md, hm": {
+        "a": "d.M., h:mm a – h:mm a",
+        "h": "d.M., h:mm–h:mm a",
+        "m": "d.M., h:mm–h:mm a"
+      },
+      "MEd, hm": {
+        "a": "E, d.M., h:mm a – h:mm a",
+        "h": "E, d.M., h:mm–h:mm a",
+        "m": "E, d.M., h:mm–h:mm a"
+      },
+      "MMd, hm": {
+        "a": "dd.MM., h:mm a – h:mm a",
+        "h": "dd.MM., h:mm–h:mm a",
+        "m": "dd.MM., h:mm–h:mm a"
+      },
+      "MMdd, hm": {
+        "a": "dd.MM., h:mm a – h:mm a",
+        "h": "dd.MM., h:mm–h:mm a",
+        "m": "dd.MM., h:mm–h:mm a"
+      },
+      "MMM, hm": {
+        "a": "LLL, h:mm a – h:mm a",
+        "h": "LLL, h:mm–h:mm a",
+        "m": "LLL, h:mm–h:mm a"
+      },
+      "MMMd, hm": {
+        "a": "d. MMM, h:mm a – h:mm a",
+        "h": "d. MMM, h:mm–h:mm a",
+        "m": "d. MMM, h:mm–h:mm a"
+      },
+      "MMMEd, hm": {
+        "a": "E, d. MMM, h:mm a – h:mm a",
+        "h": "E, d. MMM, h:mm–h:mm a",
+        "m": "E, d. MMM, h:mm–h:mm a"
+      },
+      "MMMMd, hm": {
+        "a": "d. MMMM, h:mm a – h:mm a",
+        "h": "d. MMMM, h:mm–h:mm a",
+        "m": "d. MMMM, h:mm–h:mm a"
+      },
+      "MMMMEd, hm": {
+        "a": "E, d. MMMM, h:mm a – h:mm a",
+        "h": "E, d. MMMM, h:mm–h:mm a",
+        "m": "E, d. MMMM, h:mm–h:mm a"
+      },
+      "y, hm": {
+        "a": "y, h:mm a – h:mm a",
+        "h": "y, h:mm–h:mm a",
+        "m": "y, h:mm–h:mm a"
+      },
+      "yM, hm": {
+        "a": "M/y, h:mm a – h:mm a",
+        "h": "M/y, h:mm–h:mm a",
+        "m": "M/y, h:mm–h:mm a"
+      },
+      "yMd, hm": {
+        "a": "d.M.y, h:mm a – h:mm a",
+        "h": "d.M.y, h:mm–h:mm a",
+        "m": "d.M.y, h:mm–h:mm a"
+      },
+      "yMEd, hm": {
+        "a": "E, d.M.y, h:mm a – h:mm a",
+        "h": "E, d.M.y, h:mm–h:mm a",
+        "m": "E, d.M.y, h:mm–h:mm a"
+      },
+      "yMM, hm": {
+        "a": "MM/y, h:mm a – h:mm a",
+        "h": "MM/y, h:mm–h:mm a",
+        "m": "MM/y, h:mm–h:mm a"
+      },
+      "yMMdd, hm": {
+        "a": "dd.MM.y, h:mm a – h:mm a",
+        "h": "dd.MM.y, h:mm–h:mm a",
+        "m": "dd.MM.y, h:mm–h:mm a"
+      },
+      "yMMM, hm": {
+        "a": "MMM y, h:mm a – h:mm a",
+        "h": "MMM y, h:mm–h:mm a",
+        "m": "MMM y, h:mm–h:mm a"
+      },
+      "yMMMd, hm": {
+        "a": "d. MMM y, h:mm a – h:mm a",
+        "h": "d. MMM y, h:mm–h:mm a",
+        "m": "d. MMM y, h:mm–h:mm a"
+      },
+      "yMMMEd, hm": {
+        "a": "E, d. MMM y, h:mm a – h:mm a",
+        "h": "E, d. MMM y, h:mm–h:mm a",
+        "m": "E, d. MMM y, h:mm–h:mm a"
+      },
+      "yMMMM, hm": {
+        "a": "MMMM y, h:mm a – h:mm a",
+        "h": "MMMM y, h:mm–h:mm a",
+        "m": "MMMM y, h:mm–h:mm a"
+      },
+      "EEEE, d. MMMM y, Hm": {
+        "H": "EEEE, d. MMMM y, HH:mm–HH:mm 'Uhr'",
+        "m": "EEEE, d. MMMM y, HH:mm–HH:mm 'Uhr'"
+      },
+      "d. MMMM y, Hm": {
+        "H": "d. MMMM y, HH:mm–HH:mm 'Uhr'",
+        "m": "d. MMMM y, HH:mm–HH:mm 'Uhr'"
+      },
+      "dd.MM.y, Hm": {
+        "H": "dd.MM.y, HH:mm–HH:mm 'Uhr'",
+        "m": "dd.MM.y, HH:mm–HH:mm 'Uhr'"
+      },
+      "dd.MM.yy, Hm": {
+        "H": "dd.MM.yy, HH:mm–HH:mm 'Uhr'",
+        "m": "dd.MM.yy, HH:mm–HH:mm 'Uhr'"
+      },
+      "d, Hm": {
+        "H": "d, HH:mm–HH:mm 'Uhr'",
+        "m": "d, HH:mm–HH:mm 'Uhr'"
+      },
+      "E, Hm": {
+        "H": "ccc, HH:mm–HH:mm 'Uhr'",
+        "m": "ccc, HH:mm–HH:mm 'Uhr'"
+      },
+      "Ed, Hm": {
+        "H": "E, d., HH:mm–HH:mm 'Uhr'",
+        "m": "E, d., HH:mm–HH:mm 'Uhr'"
+      },
+      "Gy, Hm": {
+        "H": "y G, HH:mm–HH:mm 'Uhr'",
+        "m": "y G, HH:mm–HH:mm 'Uhr'"
+      },
+      "GyM, Hm": {
+        "H": "MM/y G, HH:mm–HH:mm 'Uhr'",
+        "m": "MM/y G, HH:mm–HH:mm 'Uhr'"
+      },
+      "GyMd, Hm": {
+        "H": "dd.MM.y G, HH:mm–HH:mm 'Uhr'",
+        "m": "dd.MM.y G, HH:mm–HH:mm 'Uhr'"
+      },
+      "GyMEd, Hm": {
+        "H": "E, dd.MM.y G, HH:mm–HH:mm 'Uhr'",
+        "m": "E, dd.MM.y G, HH:mm–HH:mm 'Uhr'"
+      },
+      "GyMMM, Hm": {
+        "H": "MMM y G, HH:mm–HH:mm 'Uhr'",
+        "m": "MMM y G, HH:mm–HH:mm 'Uhr'"
+      },
+      "GyMMMd, Hm": {
+        "H": "d. MMM y G, HH:mm–HH:mm 'Uhr'",
+        "m": "d. MMM y G, HH:mm–HH:mm 'Uhr'"
+      },
+      "GyMMMEd, Hm": {
+        "H": "E, d. MMM y G, HH:mm–HH:mm 'Uhr'",
+        "m": "E, d. MMM y G, HH:mm–HH:mm 'Uhr'"
+      },
+      "M, Hm": {
+        "H": "L, HH:mm–HH:mm 'Uhr'",
+        "m": "L, HH:mm–HH:mm 'Uhr'"
+      },
+      "Md, Hm": {
+        "H": "d.M., HH:mm–HH:mm 'Uhr'",
+        "m": "d.M., HH:mm–HH:mm 'Uhr'"
+      },
+      "MEd, Hm": {
+        "H": "E, d.M., HH:mm–HH:mm 'Uhr'",
+        "m": "E, d.M., HH:mm–HH:mm 'Uhr'"
+      },
+      "MMd, Hm": {
+        "H": "dd.MM., HH:mm–HH:mm 'Uhr'",
+        "m": "dd.MM., HH:mm–HH:mm 'Uhr'"
+      },
+      "MMdd, Hm": {
+        "H": "dd.MM., HH:mm–HH:mm 'Uhr'",
+        "m": "dd.MM., HH:mm–HH:mm 'Uhr'"
+      },
+      "MMM, Hm": {
+        "H": "LLL, HH:mm–HH:mm 'Uhr'",
+        "m": "LLL, HH:mm–HH:mm 'Uhr'"
+      },
+      "MMMd, Hm": {
+        "H": "d. MMM, HH:mm–HH:mm 'Uhr'",
+        "m": "d. MMM, HH:mm–HH:mm 'Uhr'"
+      },
+      "MMMEd, Hm": {
+        "H": "E, d. MMM, HH:mm–HH:mm 'Uhr'",
+        "m": "E, d. MMM, HH:mm–HH:mm 'Uhr'"
+      },
+      "MMMMd, Hm": {
+        "H": "d. MMMM, HH:mm–HH:mm 'Uhr'",
+        "m": "d. MMMM, HH:mm–HH:mm 'Uhr'"
+      },
+      "MMMMEd, Hm": {
+        "H": "E, d. MMMM, HH:mm–HH:mm 'Uhr'",
+        "m": "E, d. MMMM, HH:mm–HH:mm 'Uhr'"
+      },
+      "y, Hm": {
+        "H": "y, HH:mm–HH:mm 'Uhr'",
+        "m": "y, HH:mm–HH:mm 'Uhr'"
+      },
+      "yM, Hm": {
+        "H": "M/y, HH:mm–HH:mm 'Uhr'",
+        "m": "M/y, HH:mm–HH:mm 'Uhr'"
+      },
+      "yMd, Hm": {
+        "H": "d.M.y, HH:mm–HH:mm 'Uhr'",
+        "m": "d.M.y, HH:mm–HH:mm 'Uhr'"
+      },
+      "yMEd, Hm": {
+        "H": "E, d.M.y, HH:mm–HH:mm 'Uhr'",
+        "m": "E, d.M.y, HH:mm–HH:mm 'Uhr'"
+      },
+      "yMM, Hm": {
+        "H": "MM/y, HH:mm–HH:mm 'Uhr'",
+        "m": "MM/y, HH:mm–HH:mm 'Uhr'"
+      },
+      "yMMdd, Hm": {
+        "H": "dd.MM.y, HH:mm–HH:mm 'Uhr'",
+        "m": "dd.MM.y, HH:mm–HH:mm 'Uhr'"
+      },
+      "yMMM, Hm": {
+        "H": "MMM y, HH:mm–HH:mm 'Uhr'",
+        "m": "MMM y, HH:mm–HH:mm 'Uhr'"
+      },
+      "yMMMd, Hm": {
+        "H": "d. MMM y, HH:mm–HH:mm 'Uhr'",
+        "m": "d. MMM y, HH:mm–HH:mm 'Uhr'"
+      },
+      "yMMMEd, Hm": {
+        "H": "E, d. MMM y, HH:mm–HH:mm 'Uhr'",
+        "m": "E, d. MMM y, HH:mm–HH:mm 'Uhr'"
+      },
+      "yMMMM, Hm": {
+        "H": "MMMM y, HH:mm–HH:mm 'Uhr'",
+        "m": "MMMM y, HH:mm–HH:mm 'Uhr'"
+      },
+      "EEEE, d. MMMM y, hmv": {
+        "a": "EEEE, d. MMMM y, h:mm a – h:mm a v",
+        "h": "EEEE, d. MMMM y, h:mm–h:mm a v",
+        "m": "EEEE, d. MMMM y, h:mm–h:mm a v"
+      },
+      "d. MMMM y, hmv": {
+        "a": "d. MMMM y, h:mm a – h:mm a v",
+        "h": "d. MMMM y, h:mm–h:mm a v",
+        "m": "d. MMMM y, h:mm–h:mm a v"
+      },
+      "dd.MM.y, hmv": {
+        "a": "dd.MM.y, h:mm a – h:mm a v",
+        "h": "dd.MM.y, h:mm–h:mm a v",
+        "m": "dd.MM.y, h:mm–h:mm a v"
+      },
+      "dd.MM.yy, hmv": {
+        "a": "dd.MM.yy, h:mm a – h:mm a v",
+        "h": "dd.MM.yy, h:mm–h:mm a v",
+        "m": "dd.MM.yy, h:mm–h:mm a v"
+      },
+      "d, hmv": {
+        "a": "d, h:mm a – h:mm a v",
+        "h": "d, h:mm–h:mm a v",
+        "m": "d, h:mm–h:mm a v"
+      },
+      "E, hmv": {
+        "a": "ccc, h:mm a – h:mm a v",
+        "h": "ccc, h:mm–h:mm a v",
+        "m": "ccc, h:mm–h:mm a v"
+      },
+      "Ed, hmv": {
+        "a": "E, d., h:mm a – h:mm a v",
+        "h": "E, d., h:mm–h:mm a v",
+        "m": "E, d., h:mm–h:mm a v"
+      },
+      "Gy, hmv": {
+        "a": "y G, h:mm a – h:mm a v",
+        "h": "y G, h:mm–h:mm a v",
+        "m": "y G, h:mm–h:mm a v"
+      },
+      "GyM, hmv": {
+        "a": "MM/y G, h:mm a – h:mm a v",
+        "h": "MM/y G, h:mm–h:mm a v",
+        "m": "MM/y G, h:mm–h:mm a v"
+      },
+      "GyMd, hmv": {
+        "a": "dd.MM.y G, h:mm a – h:mm a v",
+        "h": "dd.MM.y G, h:mm–h:mm a v",
+        "m": "dd.MM.y G, h:mm–h:mm a v"
+      },
+      "GyMEd, hmv": {
+        "a": "E, dd.MM.y G, h:mm a – h:mm a v",
+        "h": "E, dd.MM.y G, h:mm–h:mm a v",
+        "m": "E, dd.MM.y G, h:mm–h:mm a v"
+      },
+      "GyMMM, hmv": {
+        "a": "MMM y G, h:mm a – h:mm a v",
+        "h": "MMM y G, h:mm–h:mm a v",
+        "m": "MMM y G, h:mm–h:mm a v"
+      },
+      "GyMMMd, hmv": {
+        "a": "d. MMM y G, h:mm a – h:mm a v",
+        "h": "d. MMM y G, h:mm–h:mm a v",
+        "m": "d. MMM y G, h:mm–h:mm a v"
+      },
+      "GyMMMEd, hmv": {
+        "a": "E, d. MMM y G, h:mm a – h:mm a v",
+        "h": "E, d. MMM y G, h:mm–h:mm a v",
+        "m": "E, d. MMM y G, h:mm–h:mm a v"
+      },
+      "M, hmv": {
+        "a": "L, h:mm a – h:mm a v",
+        "h": "L, h:mm–h:mm a v",
+        "m": "L, h:mm–h:mm a v"
+      },
+      "Md, hmv": {
+        "a": "d.M., h:mm a – h:mm a v",
+        "h": "d.M., h:mm–h:mm a v",
+        "m": "d.M., h:mm–h:mm a v"
+      },
+      "MEd, hmv": {
+        "a": "E, d.M., h:mm a – h:mm a v",
+        "h": "E, d.M., h:mm–h:mm a v",
+        "m": "E, d.M., h:mm–h:mm a v"
+      },
+      "MMd, hmv": {
+        "a": "dd.MM., h:mm a – h:mm a v",
+        "h": "dd.MM., h:mm–h:mm a v",
+        "m": "dd.MM., h:mm–h:mm a v"
+      },
+      "MMdd, hmv": {
+        "a": "dd.MM., h:mm a – h:mm a v",
+        "h": "dd.MM., h:mm–h:mm a v",
+        "m": "dd.MM., h:mm–h:mm a v"
+      },
+      "MMM, hmv": {
+        "a": "LLL, h:mm a – h:mm a v",
+        "h": "LLL, h:mm–h:mm a v",
+        "m": "LLL, h:mm–h:mm a v"
+      },
+      "MMMd, hmv": {
+        "a": "d. MMM, h:mm a – h:mm a v",
+        "h": "d. MMM, h:mm–h:mm a v",
+        "m": "d. MMM, h:mm–h:mm a v"
+      },
+      "MMMEd, hmv": {
+        "a": "E, d. MMM, h:mm a – h:mm a v",
+        "h": "E, d. MMM, h:mm–h:mm a v",
+        "m": "E, d. MMM, h:mm–h:mm a v"
+      },
+      "MMMMd, hmv": {
+        "a": "d. MMMM, h:mm a – h:mm a v",
+        "h": "d. MMMM, h:mm–h:mm a v",
+        "m": "d. MMMM, h:mm–h:mm a v"
+      },
+      "MMMMEd, hmv": {
+        "a": "E, d. MMMM, h:mm a – h:mm a v",
+        "h": "E, d. MMMM, h:mm–h:mm a v",
+        "m": "E, d. MMMM, h:mm–h:mm a v"
+      },
+      "y, hmv": {
+        "a": "y, h:mm a – h:mm a v",
+        "h": "y, h:mm–h:mm a v",
+        "m": "y, h:mm–h:mm a v"
+      },
+      "yM, hmv": {
+        "a": "M/y, h:mm a – h:mm a v",
+        "h": "M/y, h:mm–h:mm a v",
+        "m": "M/y, h:mm–h:mm a v"
+      },
+      "yMd, hmv": {
+        "a": "d.M.y, h:mm a – h:mm a v",
+        "h": "d.M.y, h:mm–h:mm a v",
+        "m": "d.M.y, h:mm–h:mm a v"
+      },
+      "yMEd, hmv": {
+        "a": "E, d.M.y, h:mm a – h:mm a v",
+        "h": "E, d.M.y, h:mm–h:mm a v",
+        "m": "E, d.M.y, h:mm–h:mm a v"
+      },
+      "yMM, hmv": {
+        "a": "MM/y, h:mm a – h:mm a v",
+        "h": "MM/y, h:mm–h:mm a v",
+        "m": "MM/y, h:mm–h:mm a v"
+      },
+      "yMMdd, hmv": {
+        "a": "dd.MM.y, h:mm a – h:mm a v",
+        "h": "dd.MM.y, h:mm–h:mm a v",
+        "m": "dd.MM.y, h:mm–h:mm a v"
+      },
+      "yMMM, hmv": {
+        "a": "MMM y, h:mm a – h:mm a v",
+        "h": "MMM y, h:mm–h:mm a v",
+        "m": "MMM y, h:mm–h:mm a v"
+      },
+      "yMMMd, hmv": {
+        "a": "d. MMM y, h:mm a – h:mm a v",
+        "h": "d. MMM y, h:mm–h:mm a v",
+        "m": "d. MMM y, h:mm–h:mm a v"
+      },
+      "yMMMEd, hmv": {
+        "a": "E, d. MMM y, h:mm a – h:mm a v",
+        "h": "E, d. MMM y, h:mm–h:mm a v",
+        "m": "E, d. MMM y, h:mm–h:mm a v"
+      },
+      "yMMMM, hmv": {
+        "a": "MMMM y, h:mm a – h:mm a v",
+        "h": "MMMM y, h:mm–h:mm a v",
+        "m": "MMMM y, h:mm–h:mm a v"
+      },
+      "EEEE, d. MMMM y, Hmv": {
+        "H": "EEEE, d. MMMM y, HH:mm–HH:mm 'Uhr' v",
+        "m": "EEEE, d. MMMM y, HH:mm–HH:mm 'Uhr' v"
+      },
+      "d. MMMM y, Hmv": {
+        "H": "d. MMMM y, HH:mm–HH:mm 'Uhr' v",
+        "m": "d. MMMM y, HH:mm–HH:mm 'Uhr' v"
+      },
+      "dd.MM.y, Hmv": {
+        "H": "dd.MM.y, HH:mm–HH:mm 'Uhr' v",
+        "m": "dd.MM.y, HH:mm–HH:mm 'Uhr' v"
+      },
+      "dd.MM.yy, Hmv": {
+        "H": "dd.MM.yy, HH:mm–HH:mm 'Uhr' v",
+        "m": "dd.MM.yy, HH:mm–HH:mm 'Uhr' v"
+      },
+      "d, Hmv": {
+        "H": "d, HH:mm–HH:mm 'Uhr' v",
+        "m": "d, HH:mm–HH:mm 'Uhr' v"
+      },
+      "E, Hmv": {
+        "H": "ccc, HH:mm–HH:mm 'Uhr' v",
+        "m": "ccc, HH:mm–HH:mm 'Uhr' v"
+      },
+      "Ed, Hmv": {
+        "H": "E, d., HH:mm–HH:mm 'Uhr' v",
+        "m": "E, d., HH:mm–HH:mm 'Uhr' v"
+      },
+      "Gy, Hmv": {
+        "H": "y G, HH:mm–HH:mm 'Uhr' v",
+        "m": "y G, HH:mm–HH:mm 'Uhr' v"
+      },
+      "GyM, Hmv": {
+        "H": "MM/y G, HH:mm–HH:mm 'Uhr' v",
+        "m": "MM/y G, HH:mm–HH:mm 'Uhr' v"
+      },
+      "GyMd, Hmv": {
+        "H": "dd.MM.y G, HH:mm–HH:mm 'Uhr' v",
+        "m": "dd.MM.y G, HH:mm–HH:mm 'Uhr' v"
+      },
+      "GyMEd, Hmv": {
+        "H": "E, dd.MM.y G, HH:mm–HH:mm 'Uhr' v",
+        "m": "E, dd.MM.y G, HH:mm–HH:mm 'Uhr' v"
+      },
+      "GyMMM, Hmv": {
+        "H": "MMM y G, HH:mm–HH:mm 'Uhr' v",
+        "m": "MMM y G, HH:mm–HH:mm 'Uhr' v"
+      },
+      "GyMMMd, Hmv": {
+        "H": "d. MMM y G, HH:mm–HH:mm 'Uhr' v",
+        "m": "d. MMM y G, HH:mm–HH:mm 'Uhr' v"
+      },
+      "GyMMMEd, Hmv": {
+        "H": "E, d. MMM y G, HH:mm–HH:mm 'Uhr' v",
+        "m": "E, d. MMM y G, HH:mm–HH:mm 'Uhr' v"
+      },
+      "M, Hmv": {
+        "H": "L, HH:mm–HH:mm 'Uhr' v",
+        "m": "L, HH:mm–HH:mm 'Uhr' v"
+      },
+      "Md, Hmv": {
+        "H": "d.M., HH:mm–HH:mm 'Uhr' v",
+        "m": "d.M., HH:mm–HH:mm 'Uhr' v"
+      },
+      "MEd, Hmv": {
+        "H": "E, d.M., HH:mm–HH:mm 'Uhr' v",
+        "m": "E, d.M., HH:mm–HH:mm 'Uhr' v"
+      },
+      "MMd, Hmv": {
+        "H": "dd.MM., HH:mm–HH:mm 'Uhr' v",
+        "m": "dd.MM., HH:mm–HH:mm 'Uhr' v"
+      },
+      "MMdd, Hmv": {
+        "H": "dd.MM., HH:mm–HH:mm 'Uhr' v",
+        "m": "dd.MM., HH:mm–HH:mm 'Uhr' v"
+      },
+      "MMM, Hmv": {
+        "H": "LLL, HH:mm–HH:mm 'Uhr' v",
+        "m": "LLL, HH:mm–HH:mm 'Uhr' v"
+      },
+      "MMMd, Hmv": {
+        "H": "d. MMM, HH:mm–HH:mm 'Uhr' v",
+        "m": "d. MMM, HH:mm–HH:mm 'Uhr' v"
+      },
+      "MMMEd, Hmv": {
+        "H": "E, d. MMM, HH:mm–HH:mm 'Uhr' v",
+        "m": "E, d. MMM, HH:mm–HH:mm 'Uhr' v"
+      },
+      "MMMMd, Hmv": {
+        "H": "d. MMMM, HH:mm–HH:mm 'Uhr' v",
+        "m": "d. MMMM, HH:mm–HH:mm 'Uhr' v"
+      },
+      "MMMMEd, Hmv": {
+        "H": "E, d. MMMM, HH:mm–HH:mm 'Uhr' v",
+        "m": "E, d. MMMM, HH:mm–HH:mm 'Uhr' v"
+      },
+      "y, Hmv": {
+        "H": "y, HH:mm–HH:mm 'Uhr' v",
+        "m": "y, HH:mm–HH:mm 'Uhr' v"
+      },
+      "yM, Hmv": {
+        "H": "M/y, HH:mm–HH:mm 'Uhr' v",
+        "m": "M/y, HH:mm–HH:mm 'Uhr' v"
+      },
+      "yMd, Hmv": {
+        "H": "d.M.y, HH:mm–HH:mm 'Uhr' v",
+        "m": "d.M.y, HH:mm–HH:mm 'Uhr' v"
+      },
+      "yMEd, Hmv": {
+        "H": "E, d.M.y, HH:mm–HH:mm 'Uhr' v",
+        "m": "E, d.M.y, HH:mm–HH:mm 'Uhr' v"
+      },
+      "yMM, Hmv": {
+        "H": "MM/y, HH:mm–HH:mm 'Uhr' v",
+        "m": "MM/y, HH:mm–HH:mm 'Uhr' v"
+      },
+      "yMMdd, Hmv": {
+        "H": "dd.MM.y, HH:mm–HH:mm 'Uhr' v",
+        "m": "dd.MM.y, HH:mm–HH:mm 'Uhr' v"
+      },
+      "yMMM, Hmv": {
+        "H": "MMM y, HH:mm–HH:mm 'Uhr' v",
+        "m": "MMM y, HH:mm–HH:mm 'Uhr' v"
+      },
+      "yMMMd, Hmv": {
+        "H": "d. MMM y, HH:mm–HH:mm 'Uhr' v",
+        "m": "d. MMM y, HH:mm–HH:mm 'Uhr' v"
+      },
+      "yMMMEd, Hmv": {
+        "H": "E, d. MMM y, HH:mm–HH:mm 'Uhr' v",
+        "m": "E, d. MMM y, HH:mm–HH:mm 'Uhr' v"
+      },
+      "yMMMM, Hmv": {
+        "H": "MMMM y, HH:mm–HH:mm 'Uhr' v",
+        "m": "MMMM y, HH:mm–HH:mm 'Uhr' v"
+      },
+      "EEEE, d. MMMM y, hv": {
+        "a": "EEEE, d. MMMM y, h a – h a v",
+        "h": "EEEE, d. MMMM y, h–h a v"
+      },
+      "d. MMMM y, hv": {
+        "a": "d. MMMM y, h a – h a v",
+        "h": "d. MMMM y, h–h a v"
+      },
+      "dd.MM.y, hv": {
+        "a": "dd.MM.y, h a – h a v",
+        "h": "dd.MM.y, h–h a v"
+      },
+      "dd.MM.yy, hv": {
+        "a": "dd.MM.yy, h a – h a v",
+        "h": "dd.MM.yy, h–h a v"
+      },
+      "d, hv": {
+        "a": "d, h a – h a v",
+        "h": "d, h–h a v"
+      },
+      "E, hv": {
+        "a": "ccc, h a – h a v",
+        "h": "ccc, h–h a v"
+      },
+      "Ed, hv": {
+        "a": "E, d., h a – h a v",
+        "h": "E, d., h–h a v"
+      },
+      "Gy, hv": {
+        "a": "y G, h a – h a v",
+        "h": "y G, h–h a v"
+      },
+      "GyM, hv": {
+        "a": "MM/y G, h a – h a v",
+        "h": "MM/y G, h–h a v"
+      },
+      "GyMd, hv": {
+        "a": "dd.MM.y G, h a – h a v",
+        "h": "dd.MM.y G, h–h a v"
+      },
+      "GyMEd, hv": {
+        "a": "E, dd.MM.y G, h a – h a v",
+        "h": "E, dd.MM.y G, h–h a v"
+      },
+      "GyMMM, hv": {
+        "a": "MMM y G, h a – h a v",
+        "h": "MMM y G, h–h a v"
+      },
+      "GyMMMd, hv": {
+        "a": "d. MMM y G, h a – h a v",
+        "h": "d. MMM y G, h–h a v"
+      },
+      "GyMMMEd, hv": {
+        "a": "E, d. MMM y G, h a – h a v",
+        "h": "E, d. MMM y G, h–h a v"
+      },
+      "M, hv": {
+        "a": "L, h a – h a v",
+        "h": "L, h–h a v"
+      },
+      "Md, hv": {
+        "a": "d.M., h a – h a v",
+        "h": "d.M., h–h a v"
+      },
+      "MEd, hv": {
+        "a": "E, d.M., h a – h a v",
+        "h": "E, d.M., h–h a v"
+      },
+      "MMd, hv": {
+        "a": "dd.MM., h a – h a v",
+        "h": "dd.MM., h–h a v"
+      },
+      "MMdd, hv": {
+        "a": "dd.MM., h a – h a v",
+        "h": "dd.MM., h–h a v"
+      },
+      "MMM, hv": {
+        "a": "LLL, h a – h a v",
+        "h": "LLL, h–h a v"
+      },
+      "MMMd, hv": {
+        "a": "d. MMM, h a – h a v",
+        "h": "d. MMM, h–h a v"
+      },
+      "MMMEd, hv": {
+        "a": "E, d. MMM, h a – h a v",
+        "h": "E, d. MMM, h–h a v"
+      },
+      "MMMMd, hv": {
+        "a": "d. MMMM, h a – h a v",
+        "h": "d. MMMM, h–h a v"
+      },
+      "MMMMEd, hv": {
+        "a": "E, d. MMMM, h a – h a v",
+        "h": "E, d. MMMM, h–h a v"
+      },
+      "y, hv": {
+        "a": "y, h a – h a v",
+        "h": "y, h–h a v"
+      },
+      "yM, hv": {
+        "a": "M/y, h a – h a v",
+        "h": "M/y, h–h a v"
+      },
+      "yMd, hv": {
+        "a": "d.M.y, h a – h a v",
+        "h": "d.M.y, h–h a v"
+      },
+      "yMEd, hv": {
+        "a": "E, d.M.y, h a – h a v",
+        "h": "E, d.M.y, h–h a v"
+      },
+      "yMM, hv": {
+        "a": "MM/y, h a – h a v",
+        "h": "MM/y, h–h a v"
+      },
+      "yMMdd, hv": {
+        "a": "dd.MM.y, h a – h a v",
+        "h": "dd.MM.y, h–h a v"
+      },
+      "yMMM, hv": {
+        "a": "MMM y, h a – h a v",
+        "h": "MMM y, h–h a v"
+      },
+      "yMMMd, hv": {
+        "a": "d. MMM y, h a – h a v",
+        "h": "d. MMM y, h–h a v"
+      },
+      "yMMMEd, hv": {
+        "a": "E, d. MMM y, h a – h a v",
+        "h": "E, d. MMM y, h–h a v"
+      },
+      "yMMMM, hv": {
+        "a": "MMMM y, h a – h a v",
+        "h": "MMMM y, h–h a v"
+      },
+      "EEEE, d. MMMM y, Hv": {
+        "H": "EEEE, d. MMMM y, HH–HH 'Uhr' v"
+      },
+      "d. MMMM y, Hv": {
+        "H": "d. MMMM y, HH–HH 'Uhr' v"
+      },
+      "dd.MM.y, Hv": {
+        "H": "dd.MM.y, HH–HH 'Uhr' v"
+      },
+      "dd.MM.yy, Hv": {
+        "H": "dd.MM.yy, HH–HH 'Uhr' v"
+      },
+      "d, Hv": {
+        "H": "d, HH–HH 'Uhr' v"
+      },
+      "E, Hv": {
+        "H": "ccc, HH–HH 'Uhr' v"
+      },
+      "Ed, Hv": {
+        "H": "E, d., HH–HH 'Uhr' v"
+      },
+      "Gy, Hv": {
+        "H": "y G, HH–HH 'Uhr' v"
+      },
+      "GyM, Hv": {
+        "H": "MM/y G, HH–HH 'Uhr' v"
+      },
+      "GyMd, Hv": {
+        "H": "dd.MM.y G, HH–HH 'Uhr' v"
+      },
+      "GyMEd, Hv": {
+        "H": "E, dd.MM.y G, HH–HH 'Uhr' v"
+      },
+      "GyMMM, Hv": {
+        "H": "MMM y G, HH–HH 'Uhr' v"
+      },
+      "GyMMMd, Hv": {
+        "H": "d. MMM y G, HH–HH 'Uhr' v"
+      },
+      "GyMMMEd, Hv": {
+        "H": "E, d. MMM y G, HH–HH 'Uhr' v"
+      },
+      "M, Hv": {
+        "H": "L, HH–HH 'Uhr' v"
+      },
+      "Md, Hv": {
+        "H": "d.M., HH–HH 'Uhr' v"
+      },
+      "MEd, Hv": {
+        "H": "E, d.M., HH–HH 'Uhr' v"
+      },
+      "MMd, Hv": {
+        "H": "dd.MM., HH–HH 'Uhr' v"
+      },
+      "MMdd, Hv": {
+        "H": "dd.MM., HH–HH 'Uhr' v"
+      },
+      "MMM, Hv": {
+        "H": "LLL, HH–HH 'Uhr' v"
+      },
+      "MMMd, Hv": {
+        "H": "d. MMM, HH–HH 'Uhr' v"
+      },
+      "MMMEd, Hv": {
+        "H": "E, d. MMM, HH–HH 'Uhr' v"
+      },
+      "MMMMd, Hv": {
+        "H": "d. MMMM, HH–HH 'Uhr' v"
+      },
+      "MMMMEd, Hv": {
+        "H": "E, d. MMMM, HH–HH 'Uhr' v"
+      },
+      "y, Hv": {
+        "H": "y, HH–HH 'Uhr' v"
+      },
+      "yM, Hv": {
+        "H": "M/y, HH–HH 'Uhr' v"
+      },
+      "yMd, Hv": {
+        "H": "d.M.y, HH–HH 'Uhr' v"
+      },
+      "yMEd, Hv": {
+        "H": "E, d.M.y, HH–HH 'Uhr' v"
+      },
+      "yMM, Hv": {
+        "H": "MM/y, HH–HH 'Uhr' v"
+      },
+      "yMMdd, Hv": {
+        "H": "dd.MM.y, HH–HH 'Uhr' v"
+      },
+      "yMMM, Hv": {
+        "H": "MMM y, HH–HH 'Uhr' v"
+      },
+      "yMMMd, Hv": {
+        "H": "d. MMM y, HH–HH 'Uhr' v"
+      },
+      "yMMMEd, Hv": {
+        "H": "E, d. MMM y, HH–HH 'Uhr' v"
+      },
+      "yMMMM, Hv": {
+        "H": "MMMM y, HH–HH 'Uhr' v"
       }
     },
     "hourCycle": "h23",

--- a/packages/intl-datetimeformat/tests/locale-data/en-CA.json
+++ b/packages/intl-datetimeformat/tests/locale-data/en-CA.json
@@ -2987,6 +2987,1277 @@
       "yMMMM": {
         "M": "MMMM–MMMM y",
         "y": "MMMM y–MMMM y"
+      },
+      "EEEE, MMMM d, y, Bh": {
+        "B": "EEEE, MMMM d, y, h B–h B",
+        "h": "EEEE, MMMM d, y, h–h B"
+      },
+      "MMMM d, y, Bh": {
+        "B": "MMMM d, y, h B–h B",
+        "h": "MMMM d, y, h–h B"
+      },
+      "MMM d, y, Bh": {
+        "B": "MMM d, y, h B–h B",
+        "h": "MMM d, y, h–h B"
+      },
+      "y-MM-dd, Bh": {
+        "B": "y-MM-dd, h B–h B",
+        "h": "y-MM-dd, h–h B"
+      },
+      "d/M/yy, Bh": {
+        "B": "d/M/yy, h B–h B",
+        "h": "d/M/yy, h–h B"
+      },
+      "d, Bh": {
+        "B": "d, h B–h B",
+        "h": "d, h–h B"
+      },
+      "E, Bh": {
+        "B": "ccc, h B–h B",
+        "h": "ccc, h–h B"
+      },
+      "Ed, Bh": {
+        "B": "E d, h B–h B",
+        "h": "E d, h–h B"
+      },
+      "Gy, Bh": {
+        "B": "y G, h B–h B",
+        "h": "y G, h–h B"
+      },
+      "GyM, Bh": {
+        "B": "M/y G, h B–h B",
+        "h": "M/y G, h–h B"
+      },
+      "GyMd, Bh": {
+        "B": "M/d/y G, h B–h B",
+        "h": "M/d/y G, h–h B"
+      },
+      "GyMEd, Bh": {
+        "B": "E, M/d/y G, h B–h B",
+        "h": "E, M/d/y G, h–h B"
+      },
+      "GyMMM, Bh": {
+        "B": "MMM y G, h B–h B",
+        "h": "MMM y G, h–h B"
+      },
+      "GyMMMd, Bh": {
+        "B": "MMM d, y G, h B–h B",
+        "h": "MMM d, y G, h–h B"
+      },
+      "GyMMMEd, Bh": {
+        "B": "E, MMM d, y G, h B–h B",
+        "h": "E, MMM d, y G, h–h B"
+      },
+      "M, Bh": {
+        "B": "L, h B–h B",
+        "h": "L, h–h B"
+      },
+      "Md, Bh": {
+        "B": "MM-dd, h B–h B",
+        "h": "MM-dd, h–h B"
+      },
+      "MEd, Bh": {
+        "B": "E, MM-dd, h B–h B",
+        "h": "E, MM-dd, h–h B"
+      },
+      "MMdd, Bh": {
+        "B": "MM-dd, h B–h B",
+        "h": "MM-dd, h–h B"
+      },
+      "MMM, Bh": {
+        "B": "LLL, h B–h B",
+        "h": "LLL, h–h B"
+      },
+      "MMMd, Bh": {
+        "B": "MMM d, h B–h B",
+        "h": "MMM d, h–h B"
+      },
+      "MMMEd, Bh": {
+        "B": "E, MMM d, h B–h B",
+        "h": "E, MMM d, h–h B"
+      },
+      "MMMMd, Bh": {
+        "B": "MMMM d, h B–h B",
+        "h": "MMMM d, h–h B"
+      },
+      "y, Bh": {
+        "B": "y, h B–h B",
+        "h": "y, h–h B"
+      },
+      "yM, Bh": {
+        "B": "y-MM, h B–h B",
+        "h": "y-MM, h–h B"
+      },
+      "yMd, Bh": {
+        "B": "y-MM-dd, h B–h B",
+        "h": "y-MM-dd, h–h B"
+      },
+      "yMEd, Bh": {
+        "B": "E, y-MM-dd, h B–h B",
+        "h": "E, y-MM-dd, h–h B"
+      },
+      "yMMM, Bh": {
+        "B": "MMM y, h B–h B",
+        "h": "MMM y, h–h B"
+      },
+      "yMMMd, Bh": {
+        "B": "MMM d, y, h B–h B",
+        "h": "MMM d, y, h–h B"
+      },
+      "yMMMEd, Bh": {
+        "B": "E, MMM d, y, h B–h B",
+        "h": "E, MMM d, y, h–h B"
+      },
+      "yMMMM, Bh": {
+        "B": "MMMM y, h B–h B",
+        "h": "MMMM y, h–h B"
+      },
+      "EEEE, MMMM d, y, Bhm": {
+        "B": "EEEE, MMMM d, y, h:mm B–h:mm B",
+        "h": "EEEE, MMMM d, y, h:mm–h:mm B",
+        "m": "EEEE, MMMM d, y, h:mm–h:mm B"
+      },
+      "MMMM d, y, Bhm": {
+        "B": "MMMM d, y, h:mm B–h:mm B",
+        "h": "MMMM d, y, h:mm–h:mm B",
+        "m": "MMMM d, y, h:mm–h:mm B"
+      },
+      "MMM d, y, Bhm": {
+        "B": "MMM d, y, h:mm B–h:mm B",
+        "h": "MMM d, y, h:mm–h:mm B",
+        "m": "MMM d, y, h:mm–h:mm B"
+      },
+      "y-MM-dd, Bhm": {
+        "B": "y-MM-dd, h:mm B–h:mm B",
+        "h": "y-MM-dd, h:mm–h:mm B",
+        "m": "y-MM-dd, h:mm–h:mm B"
+      },
+      "d/M/yy, Bhm": {
+        "B": "d/M/yy, h:mm B–h:mm B",
+        "h": "d/M/yy, h:mm–h:mm B",
+        "m": "d/M/yy, h:mm–h:mm B"
+      },
+      "d, Bhm": {
+        "B": "d, h:mm B–h:mm B",
+        "h": "d, h:mm–h:mm B",
+        "m": "d, h:mm–h:mm B"
+      },
+      "E, Bhm": {
+        "B": "ccc, h:mm B–h:mm B",
+        "h": "ccc, h:mm–h:mm B",
+        "m": "ccc, h:mm–h:mm B"
+      },
+      "Ed, Bhm": {
+        "B": "E d, h:mm B–h:mm B",
+        "h": "E d, h:mm–h:mm B",
+        "m": "E d, h:mm–h:mm B"
+      },
+      "Gy, Bhm": {
+        "B": "y G, h:mm B–h:mm B",
+        "h": "y G, h:mm–h:mm B",
+        "m": "y G, h:mm–h:mm B"
+      },
+      "GyM, Bhm": {
+        "B": "M/y G, h:mm B–h:mm B",
+        "h": "M/y G, h:mm–h:mm B",
+        "m": "M/y G, h:mm–h:mm B"
+      },
+      "GyMd, Bhm": {
+        "B": "M/d/y G, h:mm B–h:mm B",
+        "h": "M/d/y G, h:mm–h:mm B",
+        "m": "M/d/y G, h:mm–h:mm B"
+      },
+      "GyMEd, Bhm": {
+        "B": "E, M/d/y G, h:mm B–h:mm B",
+        "h": "E, M/d/y G, h:mm–h:mm B",
+        "m": "E, M/d/y G, h:mm–h:mm B"
+      },
+      "GyMMM, Bhm": {
+        "B": "MMM y G, h:mm B–h:mm B",
+        "h": "MMM y G, h:mm–h:mm B",
+        "m": "MMM y G, h:mm–h:mm B"
+      },
+      "GyMMMd, Bhm": {
+        "B": "MMM d, y G, h:mm B–h:mm B",
+        "h": "MMM d, y G, h:mm–h:mm B",
+        "m": "MMM d, y G, h:mm–h:mm B"
+      },
+      "GyMMMEd, Bhm": {
+        "B": "E, MMM d, y G, h:mm B–h:mm B",
+        "h": "E, MMM d, y G, h:mm–h:mm B",
+        "m": "E, MMM d, y G, h:mm–h:mm B"
+      },
+      "M, Bhm": {
+        "B": "L, h:mm B–h:mm B",
+        "h": "L, h:mm–h:mm B",
+        "m": "L, h:mm–h:mm B"
+      },
+      "Md, Bhm": {
+        "B": "MM-dd, h:mm B–h:mm B",
+        "h": "MM-dd, h:mm–h:mm B",
+        "m": "MM-dd, h:mm–h:mm B"
+      },
+      "MEd, Bhm": {
+        "B": "E, MM-dd, h:mm B–h:mm B",
+        "h": "E, MM-dd, h:mm–h:mm B",
+        "m": "E, MM-dd, h:mm–h:mm B"
+      },
+      "MMdd, Bhm": {
+        "B": "MM-dd, h:mm B–h:mm B",
+        "h": "MM-dd, h:mm–h:mm B",
+        "m": "MM-dd, h:mm–h:mm B"
+      },
+      "MMM, Bhm": {
+        "B": "LLL, h:mm B–h:mm B",
+        "h": "LLL, h:mm–h:mm B",
+        "m": "LLL, h:mm–h:mm B"
+      },
+      "MMMd, Bhm": {
+        "B": "MMM d, h:mm B–h:mm B",
+        "h": "MMM d, h:mm–h:mm B",
+        "m": "MMM d, h:mm–h:mm B"
+      },
+      "MMMEd, Bhm": {
+        "B": "E, MMM d, h:mm B–h:mm B",
+        "h": "E, MMM d, h:mm–h:mm B",
+        "m": "E, MMM d, h:mm–h:mm B"
+      },
+      "MMMMd, Bhm": {
+        "B": "MMMM d, h:mm B–h:mm B",
+        "h": "MMMM d, h:mm–h:mm B",
+        "m": "MMMM d, h:mm–h:mm B"
+      },
+      "y, Bhm": {
+        "B": "y, h:mm B–h:mm B",
+        "h": "y, h:mm–h:mm B",
+        "m": "y, h:mm–h:mm B"
+      },
+      "yM, Bhm": {
+        "B": "y-MM, h:mm B–h:mm B",
+        "h": "y-MM, h:mm–h:mm B",
+        "m": "y-MM, h:mm–h:mm B"
+      },
+      "yMd, Bhm": {
+        "B": "y-MM-dd, h:mm B–h:mm B",
+        "h": "y-MM-dd, h:mm–h:mm B",
+        "m": "y-MM-dd, h:mm–h:mm B"
+      },
+      "yMEd, Bhm": {
+        "B": "E, y-MM-dd, h:mm B–h:mm B",
+        "h": "E, y-MM-dd, h:mm–h:mm B",
+        "m": "E, y-MM-dd, h:mm–h:mm B"
+      },
+      "yMMM, Bhm": {
+        "B": "MMM y, h:mm B–h:mm B",
+        "h": "MMM y, h:mm–h:mm B",
+        "m": "MMM y, h:mm–h:mm B"
+      },
+      "yMMMd, Bhm": {
+        "B": "MMM d, y, h:mm B–h:mm B",
+        "h": "MMM d, y, h:mm–h:mm B",
+        "m": "MMM d, y, h:mm–h:mm B"
+      },
+      "yMMMEd, Bhm": {
+        "B": "E, MMM d, y, h:mm B–h:mm B",
+        "h": "E, MMM d, y, h:mm–h:mm B",
+        "m": "E, MMM d, y, h:mm–h:mm B"
+      },
+      "yMMMM, Bhm": {
+        "B": "MMMM y, h:mm B–h:mm B",
+        "h": "MMMM y, h:mm–h:mm B",
+        "m": "MMMM y, h:mm–h:mm B"
+      },
+      "EEEE, MMMM d, y, h": {
+        "a": "EEEE, MMMM d, y, h a–h a",
+        "h": "EEEE, MMMM d, y, h–h a"
+      },
+      "MMMM d, y, h": {
+        "a": "MMMM d, y, h a–h a",
+        "h": "MMMM d, y, h–h a"
+      },
+      "MMM d, y, h": {
+        "a": "MMM d, y, h a–h a",
+        "h": "MMM d, y, h–h a"
+      },
+      "y-MM-dd, h": {
+        "a": "y-MM-dd, h a–h a",
+        "h": "y-MM-dd, h–h a"
+      },
+      "d/M/yy, h": {
+        "a": "d/M/yy, h a–h a",
+        "h": "d/M/yy, h–h a"
+      },
+      "d, h": {
+        "a": "d, h a–h a",
+        "h": "d, h–h a"
+      },
+      "E, h": {
+        "a": "ccc, h a–h a",
+        "h": "ccc, h–h a"
+      },
+      "Ed, h": {
+        "a": "E d, h a–h a",
+        "h": "E d, h–h a"
+      },
+      "Gy, h": {
+        "a": "y G, h a–h a",
+        "h": "y G, h–h a"
+      },
+      "GyM, h": {
+        "a": "M/y G, h a–h a",
+        "h": "M/y G, h–h a"
+      },
+      "GyMd, h": {
+        "a": "M/d/y G, h a–h a",
+        "h": "M/d/y G, h–h a"
+      },
+      "GyMEd, h": {
+        "a": "E, M/d/y G, h a–h a",
+        "h": "E, M/d/y G, h–h a"
+      },
+      "GyMMM, h": {
+        "a": "MMM y G, h a–h a",
+        "h": "MMM y G, h–h a"
+      },
+      "GyMMMd, h": {
+        "a": "MMM d, y G, h a–h a",
+        "h": "MMM d, y G, h–h a"
+      },
+      "GyMMMEd, h": {
+        "a": "E, MMM d, y G, h a–h a",
+        "h": "E, MMM d, y G, h–h a"
+      },
+      "M, h": {
+        "a": "L, h a–h a",
+        "h": "L, h–h a"
+      },
+      "Md, h": {
+        "a": "MM-dd, h a–h a",
+        "h": "MM-dd, h–h a"
+      },
+      "MEd, h": {
+        "a": "E, MM-dd, h a–h a",
+        "h": "E, MM-dd, h–h a"
+      },
+      "MMdd, h": {
+        "a": "MM-dd, h a–h a",
+        "h": "MM-dd, h–h a"
+      },
+      "MMM, h": {
+        "a": "LLL, h a–h a",
+        "h": "LLL, h–h a"
+      },
+      "MMMd, h": {
+        "a": "MMM d, h a–h a",
+        "h": "MMM d, h–h a"
+      },
+      "MMMEd, h": {
+        "a": "E, MMM d, h a–h a",
+        "h": "E, MMM d, h–h a"
+      },
+      "MMMMd, h": {
+        "a": "MMMM d, h a–h a",
+        "h": "MMMM d, h–h a"
+      },
+      "y, h": {
+        "a": "y, h a–h a",
+        "h": "y, h–h a"
+      },
+      "yM, h": {
+        "a": "y-MM, h a–h a",
+        "h": "y-MM, h–h a"
+      },
+      "yMd, h": {
+        "a": "y-MM-dd, h a–h a",
+        "h": "y-MM-dd, h–h a"
+      },
+      "yMEd, h": {
+        "a": "E, y-MM-dd, h a–h a",
+        "h": "E, y-MM-dd, h–h a"
+      },
+      "yMMM, h": {
+        "a": "MMM y, h a–h a",
+        "h": "MMM y, h–h a"
+      },
+      "yMMMd, h": {
+        "a": "MMM d, y, h a–h a",
+        "h": "MMM d, y, h–h a"
+      },
+      "yMMMEd, h": {
+        "a": "E, MMM d, y, h a–h a",
+        "h": "E, MMM d, y, h–h a"
+      },
+      "yMMMM, h": {
+        "a": "MMMM y, h a–h a",
+        "h": "MMMM y, h–h a"
+      },
+      "EEEE, MMMM d, y, H": {
+        "H": "EEEE, MMMM d, y, HH–HH"
+      },
+      "MMMM d, y, H": {
+        "H": "MMMM d, y, HH–HH"
+      },
+      "MMM d, y, H": {
+        "H": "MMM d, y, HH–HH"
+      },
+      "y-MM-dd, H": {
+        "H": "y-MM-dd, HH–HH"
+      },
+      "d/M/yy, H": {
+        "H": "d/M/yy, HH–HH"
+      },
+      "d, H": {
+        "H": "d, HH–HH"
+      },
+      "E, H": {
+        "H": "ccc, HH–HH"
+      },
+      "Ed, H": {
+        "H": "E d, HH–HH"
+      },
+      "Gy, H": {
+        "H": "y G, HH–HH"
+      },
+      "GyM, H": {
+        "H": "M/y G, HH–HH"
+      },
+      "GyMd, H": {
+        "H": "M/d/y G, HH–HH"
+      },
+      "GyMEd, H": {
+        "H": "E, M/d/y G, HH–HH"
+      },
+      "GyMMM, H": {
+        "H": "MMM y G, HH–HH"
+      },
+      "GyMMMd, H": {
+        "H": "MMM d, y G, HH–HH"
+      },
+      "GyMMMEd, H": {
+        "H": "E, MMM d, y G, HH–HH"
+      },
+      "M, H": {
+        "H": "L, HH–HH"
+      },
+      "Md, H": {
+        "H": "MM-dd, HH–HH"
+      },
+      "MEd, H": {
+        "H": "E, MM-dd, HH–HH"
+      },
+      "MMdd, H": {
+        "H": "MM-dd, HH–HH"
+      },
+      "MMM, H": {
+        "H": "LLL, HH–HH"
+      },
+      "MMMd, H": {
+        "H": "MMM d, HH–HH"
+      },
+      "MMMEd, H": {
+        "H": "E, MMM d, HH–HH"
+      },
+      "MMMMd, H": {
+        "H": "MMMM d, HH–HH"
+      },
+      "y, H": {
+        "H": "y, HH–HH"
+      },
+      "yM, H": {
+        "H": "y-MM, HH–HH"
+      },
+      "yMd, H": {
+        "H": "y-MM-dd, HH–HH"
+      },
+      "yMEd, H": {
+        "H": "E, y-MM-dd, HH–HH"
+      },
+      "yMMM, H": {
+        "H": "MMM y, HH–HH"
+      },
+      "yMMMd, H": {
+        "H": "MMM d, y, HH–HH"
+      },
+      "yMMMEd, H": {
+        "H": "E, MMM d, y, HH–HH"
+      },
+      "yMMMM, H": {
+        "H": "MMMM y, HH–HH"
+      },
+      "EEEE, MMMM d, y, hm": {
+        "a": "EEEE, MMMM d, y, h:mm a–h:mm a",
+        "h": "EEEE, MMMM d, y, h:mm–h:mm a",
+        "m": "EEEE, MMMM d, y, h:mm–h:mm a"
+      },
+      "MMMM d, y, hm": {
+        "a": "MMMM d, y, h:mm a–h:mm a",
+        "h": "MMMM d, y, h:mm–h:mm a",
+        "m": "MMMM d, y, h:mm–h:mm a"
+      },
+      "MMM d, y, hm": {
+        "a": "MMM d, y, h:mm a–h:mm a",
+        "h": "MMM d, y, h:mm–h:mm a",
+        "m": "MMM d, y, h:mm–h:mm a"
+      },
+      "y-MM-dd, hm": {
+        "a": "y-MM-dd, h:mm a–h:mm a",
+        "h": "y-MM-dd, h:mm–h:mm a",
+        "m": "y-MM-dd, h:mm–h:mm a"
+      },
+      "d/M/yy, hm": {
+        "a": "d/M/yy, h:mm a–h:mm a",
+        "h": "d/M/yy, h:mm–h:mm a",
+        "m": "d/M/yy, h:mm–h:mm a"
+      },
+      "d, hm": {
+        "a": "d, h:mm a–h:mm a",
+        "h": "d, h:mm–h:mm a",
+        "m": "d, h:mm–h:mm a"
+      },
+      "E, hm": {
+        "a": "ccc, h:mm a–h:mm a",
+        "h": "ccc, h:mm–h:mm a",
+        "m": "ccc, h:mm–h:mm a"
+      },
+      "Ed, hm": {
+        "a": "E d, h:mm a–h:mm a",
+        "h": "E d, h:mm–h:mm a",
+        "m": "E d, h:mm–h:mm a"
+      },
+      "Gy, hm": {
+        "a": "y G, h:mm a–h:mm a",
+        "h": "y G, h:mm–h:mm a",
+        "m": "y G, h:mm–h:mm a"
+      },
+      "GyM, hm": {
+        "a": "M/y G, h:mm a–h:mm a",
+        "h": "M/y G, h:mm–h:mm a",
+        "m": "M/y G, h:mm–h:mm a"
+      },
+      "GyMd, hm": {
+        "a": "M/d/y G, h:mm a–h:mm a",
+        "h": "M/d/y G, h:mm–h:mm a",
+        "m": "M/d/y G, h:mm–h:mm a"
+      },
+      "GyMEd, hm": {
+        "a": "E, M/d/y G, h:mm a–h:mm a",
+        "h": "E, M/d/y G, h:mm–h:mm a",
+        "m": "E, M/d/y G, h:mm–h:mm a"
+      },
+      "GyMMM, hm": {
+        "a": "MMM y G, h:mm a–h:mm a",
+        "h": "MMM y G, h:mm–h:mm a",
+        "m": "MMM y G, h:mm–h:mm a"
+      },
+      "GyMMMd, hm": {
+        "a": "MMM d, y G, h:mm a–h:mm a",
+        "h": "MMM d, y G, h:mm–h:mm a",
+        "m": "MMM d, y G, h:mm–h:mm a"
+      },
+      "GyMMMEd, hm": {
+        "a": "E, MMM d, y G, h:mm a–h:mm a",
+        "h": "E, MMM d, y G, h:mm–h:mm a",
+        "m": "E, MMM d, y G, h:mm–h:mm a"
+      },
+      "M, hm": {
+        "a": "L, h:mm a–h:mm a",
+        "h": "L, h:mm–h:mm a",
+        "m": "L, h:mm–h:mm a"
+      },
+      "Md, hm": {
+        "a": "MM-dd, h:mm a–h:mm a",
+        "h": "MM-dd, h:mm–h:mm a",
+        "m": "MM-dd, h:mm–h:mm a"
+      },
+      "MEd, hm": {
+        "a": "E, MM-dd, h:mm a–h:mm a",
+        "h": "E, MM-dd, h:mm–h:mm a",
+        "m": "E, MM-dd, h:mm–h:mm a"
+      },
+      "MMdd, hm": {
+        "a": "MM-dd, h:mm a–h:mm a",
+        "h": "MM-dd, h:mm–h:mm a",
+        "m": "MM-dd, h:mm–h:mm a"
+      },
+      "MMM, hm": {
+        "a": "LLL, h:mm a–h:mm a",
+        "h": "LLL, h:mm–h:mm a",
+        "m": "LLL, h:mm–h:mm a"
+      },
+      "MMMd, hm": {
+        "a": "MMM d, h:mm a–h:mm a",
+        "h": "MMM d, h:mm–h:mm a",
+        "m": "MMM d, h:mm–h:mm a"
+      },
+      "MMMEd, hm": {
+        "a": "E, MMM d, h:mm a–h:mm a",
+        "h": "E, MMM d, h:mm–h:mm a",
+        "m": "E, MMM d, h:mm–h:mm a"
+      },
+      "MMMMd, hm": {
+        "a": "MMMM d, h:mm a–h:mm a",
+        "h": "MMMM d, h:mm–h:mm a",
+        "m": "MMMM d, h:mm–h:mm a"
+      },
+      "y, hm": {
+        "a": "y, h:mm a–h:mm a",
+        "h": "y, h:mm–h:mm a",
+        "m": "y, h:mm–h:mm a"
+      },
+      "yM, hm": {
+        "a": "y-MM, h:mm a–h:mm a",
+        "h": "y-MM, h:mm–h:mm a",
+        "m": "y-MM, h:mm–h:mm a"
+      },
+      "yMd, hm": {
+        "a": "y-MM-dd, h:mm a–h:mm a",
+        "h": "y-MM-dd, h:mm–h:mm a",
+        "m": "y-MM-dd, h:mm–h:mm a"
+      },
+      "yMEd, hm": {
+        "a": "E, y-MM-dd, h:mm a–h:mm a",
+        "h": "E, y-MM-dd, h:mm–h:mm a",
+        "m": "E, y-MM-dd, h:mm–h:mm a"
+      },
+      "yMMM, hm": {
+        "a": "MMM y, h:mm a–h:mm a",
+        "h": "MMM y, h:mm–h:mm a",
+        "m": "MMM y, h:mm–h:mm a"
+      },
+      "yMMMd, hm": {
+        "a": "MMM d, y, h:mm a–h:mm a",
+        "h": "MMM d, y, h:mm–h:mm a",
+        "m": "MMM d, y, h:mm–h:mm a"
+      },
+      "yMMMEd, hm": {
+        "a": "E, MMM d, y, h:mm a–h:mm a",
+        "h": "E, MMM d, y, h:mm–h:mm a",
+        "m": "E, MMM d, y, h:mm–h:mm a"
+      },
+      "yMMMM, hm": {
+        "a": "MMMM y, h:mm a–h:mm a",
+        "h": "MMMM y, h:mm–h:mm a",
+        "m": "MMMM y, h:mm–h:mm a"
+      },
+      "EEEE, MMMM d, y, Hm": {
+        "H": "EEEE, MMMM d, y, HH:mm–HH:mm",
+        "m": "EEEE, MMMM d, y, HH:mm–HH:mm"
+      },
+      "MMMM d, y, Hm": {
+        "H": "MMMM d, y, HH:mm–HH:mm",
+        "m": "MMMM d, y, HH:mm–HH:mm"
+      },
+      "MMM d, y, Hm": {
+        "H": "MMM d, y, HH:mm–HH:mm",
+        "m": "MMM d, y, HH:mm–HH:mm"
+      },
+      "y-MM-dd, Hm": {
+        "H": "y-MM-dd, HH:mm–HH:mm",
+        "m": "y-MM-dd, HH:mm–HH:mm"
+      },
+      "d/M/yy, Hm": {
+        "H": "d/M/yy, HH:mm–HH:mm",
+        "m": "d/M/yy, HH:mm–HH:mm"
+      },
+      "d, Hm": {
+        "H": "d, HH:mm–HH:mm",
+        "m": "d, HH:mm–HH:mm"
+      },
+      "E, Hm": {
+        "H": "ccc, HH:mm–HH:mm",
+        "m": "ccc, HH:mm–HH:mm"
+      },
+      "Ed, Hm": {
+        "H": "E d, HH:mm–HH:mm",
+        "m": "E d, HH:mm–HH:mm"
+      },
+      "Gy, Hm": {
+        "H": "y G, HH:mm–HH:mm",
+        "m": "y G, HH:mm–HH:mm"
+      },
+      "GyM, Hm": {
+        "H": "M/y G, HH:mm–HH:mm",
+        "m": "M/y G, HH:mm–HH:mm"
+      },
+      "GyMd, Hm": {
+        "H": "M/d/y G, HH:mm–HH:mm",
+        "m": "M/d/y G, HH:mm–HH:mm"
+      },
+      "GyMEd, Hm": {
+        "H": "E, M/d/y G, HH:mm–HH:mm",
+        "m": "E, M/d/y G, HH:mm–HH:mm"
+      },
+      "GyMMM, Hm": {
+        "H": "MMM y G, HH:mm–HH:mm",
+        "m": "MMM y G, HH:mm–HH:mm"
+      },
+      "GyMMMd, Hm": {
+        "H": "MMM d, y G, HH:mm–HH:mm",
+        "m": "MMM d, y G, HH:mm–HH:mm"
+      },
+      "GyMMMEd, Hm": {
+        "H": "E, MMM d, y G, HH:mm–HH:mm",
+        "m": "E, MMM d, y G, HH:mm–HH:mm"
+      },
+      "M, Hm": {
+        "H": "L, HH:mm–HH:mm",
+        "m": "L, HH:mm–HH:mm"
+      },
+      "Md, Hm": {
+        "H": "MM-dd, HH:mm–HH:mm",
+        "m": "MM-dd, HH:mm–HH:mm"
+      },
+      "MEd, Hm": {
+        "H": "E, MM-dd, HH:mm–HH:mm",
+        "m": "E, MM-dd, HH:mm–HH:mm"
+      },
+      "MMdd, Hm": {
+        "H": "MM-dd, HH:mm–HH:mm",
+        "m": "MM-dd, HH:mm–HH:mm"
+      },
+      "MMM, Hm": {
+        "H": "LLL, HH:mm–HH:mm",
+        "m": "LLL, HH:mm–HH:mm"
+      },
+      "MMMd, Hm": {
+        "H": "MMM d, HH:mm–HH:mm",
+        "m": "MMM d, HH:mm–HH:mm"
+      },
+      "MMMEd, Hm": {
+        "H": "E, MMM d, HH:mm–HH:mm",
+        "m": "E, MMM d, HH:mm–HH:mm"
+      },
+      "MMMMd, Hm": {
+        "H": "MMMM d, HH:mm–HH:mm",
+        "m": "MMMM d, HH:mm–HH:mm"
+      },
+      "y, Hm": {
+        "H": "y, HH:mm–HH:mm",
+        "m": "y, HH:mm–HH:mm"
+      },
+      "yM, Hm": {
+        "H": "y-MM, HH:mm–HH:mm",
+        "m": "y-MM, HH:mm–HH:mm"
+      },
+      "yMd, Hm": {
+        "H": "y-MM-dd, HH:mm–HH:mm",
+        "m": "y-MM-dd, HH:mm–HH:mm"
+      },
+      "yMEd, Hm": {
+        "H": "E, y-MM-dd, HH:mm–HH:mm",
+        "m": "E, y-MM-dd, HH:mm–HH:mm"
+      },
+      "yMMM, Hm": {
+        "H": "MMM y, HH:mm–HH:mm",
+        "m": "MMM y, HH:mm–HH:mm"
+      },
+      "yMMMd, Hm": {
+        "H": "MMM d, y, HH:mm–HH:mm",
+        "m": "MMM d, y, HH:mm–HH:mm"
+      },
+      "yMMMEd, Hm": {
+        "H": "E, MMM d, y, HH:mm–HH:mm",
+        "m": "E, MMM d, y, HH:mm–HH:mm"
+      },
+      "yMMMM, Hm": {
+        "H": "MMMM y, HH:mm–HH:mm",
+        "m": "MMMM y, HH:mm–HH:mm"
+      },
+      "EEEE, MMMM d, y, hmv": {
+        "a": "EEEE, MMMM d, y, h:mm a–h:mm a v",
+        "h": "EEEE, MMMM d, y, h:mm–h:mm a v",
+        "m": "EEEE, MMMM d, y, h:mm–h:mm a v"
+      },
+      "MMMM d, y, hmv": {
+        "a": "MMMM d, y, h:mm a–h:mm a v",
+        "h": "MMMM d, y, h:mm–h:mm a v",
+        "m": "MMMM d, y, h:mm–h:mm a v"
+      },
+      "MMM d, y, hmv": {
+        "a": "MMM d, y, h:mm a–h:mm a v",
+        "h": "MMM d, y, h:mm–h:mm a v",
+        "m": "MMM d, y, h:mm–h:mm a v"
+      },
+      "y-MM-dd, hmv": {
+        "a": "y-MM-dd, h:mm a–h:mm a v",
+        "h": "y-MM-dd, h:mm–h:mm a v",
+        "m": "y-MM-dd, h:mm–h:mm a v"
+      },
+      "d/M/yy, hmv": {
+        "a": "d/M/yy, h:mm a–h:mm a v",
+        "h": "d/M/yy, h:mm–h:mm a v",
+        "m": "d/M/yy, h:mm–h:mm a v"
+      },
+      "d, hmv": {
+        "a": "d, h:mm a–h:mm a v",
+        "h": "d, h:mm–h:mm a v",
+        "m": "d, h:mm–h:mm a v"
+      },
+      "E, hmv": {
+        "a": "ccc, h:mm a–h:mm a v",
+        "h": "ccc, h:mm–h:mm a v",
+        "m": "ccc, h:mm–h:mm a v"
+      },
+      "Ed, hmv": {
+        "a": "E d, h:mm a–h:mm a v",
+        "h": "E d, h:mm–h:mm a v",
+        "m": "E d, h:mm–h:mm a v"
+      },
+      "Gy, hmv": {
+        "a": "y G, h:mm a–h:mm a v",
+        "h": "y G, h:mm–h:mm a v",
+        "m": "y G, h:mm–h:mm a v"
+      },
+      "GyM, hmv": {
+        "a": "M/y G, h:mm a–h:mm a v",
+        "h": "M/y G, h:mm–h:mm a v",
+        "m": "M/y G, h:mm–h:mm a v"
+      },
+      "GyMd, hmv": {
+        "a": "M/d/y G, h:mm a–h:mm a v",
+        "h": "M/d/y G, h:mm–h:mm a v",
+        "m": "M/d/y G, h:mm–h:mm a v"
+      },
+      "GyMEd, hmv": {
+        "a": "E, M/d/y G, h:mm a–h:mm a v",
+        "h": "E, M/d/y G, h:mm–h:mm a v",
+        "m": "E, M/d/y G, h:mm–h:mm a v"
+      },
+      "GyMMM, hmv": {
+        "a": "MMM y G, h:mm a–h:mm a v",
+        "h": "MMM y G, h:mm–h:mm a v",
+        "m": "MMM y G, h:mm–h:mm a v"
+      },
+      "GyMMMd, hmv": {
+        "a": "MMM d, y G, h:mm a–h:mm a v",
+        "h": "MMM d, y G, h:mm–h:mm a v",
+        "m": "MMM d, y G, h:mm–h:mm a v"
+      },
+      "GyMMMEd, hmv": {
+        "a": "E, MMM d, y G, h:mm a–h:mm a v",
+        "h": "E, MMM d, y G, h:mm–h:mm a v",
+        "m": "E, MMM d, y G, h:mm–h:mm a v"
+      },
+      "M, hmv": {
+        "a": "L, h:mm a–h:mm a v",
+        "h": "L, h:mm–h:mm a v",
+        "m": "L, h:mm–h:mm a v"
+      },
+      "Md, hmv": {
+        "a": "MM-dd, h:mm a–h:mm a v",
+        "h": "MM-dd, h:mm–h:mm a v",
+        "m": "MM-dd, h:mm–h:mm a v"
+      },
+      "MEd, hmv": {
+        "a": "E, MM-dd, h:mm a–h:mm a v",
+        "h": "E, MM-dd, h:mm–h:mm a v",
+        "m": "E, MM-dd, h:mm–h:mm a v"
+      },
+      "MMdd, hmv": {
+        "a": "MM-dd, h:mm a–h:mm a v",
+        "h": "MM-dd, h:mm–h:mm a v",
+        "m": "MM-dd, h:mm–h:mm a v"
+      },
+      "MMM, hmv": {
+        "a": "LLL, h:mm a–h:mm a v",
+        "h": "LLL, h:mm–h:mm a v",
+        "m": "LLL, h:mm–h:mm a v"
+      },
+      "MMMd, hmv": {
+        "a": "MMM d, h:mm a–h:mm a v",
+        "h": "MMM d, h:mm–h:mm a v",
+        "m": "MMM d, h:mm–h:mm a v"
+      },
+      "MMMEd, hmv": {
+        "a": "E, MMM d, h:mm a–h:mm a v",
+        "h": "E, MMM d, h:mm–h:mm a v",
+        "m": "E, MMM d, h:mm–h:mm a v"
+      },
+      "MMMMd, hmv": {
+        "a": "MMMM d, h:mm a–h:mm a v",
+        "h": "MMMM d, h:mm–h:mm a v",
+        "m": "MMMM d, h:mm–h:mm a v"
+      },
+      "y, hmv": {
+        "a": "y, h:mm a–h:mm a v",
+        "h": "y, h:mm–h:mm a v",
+        "m": "y, h:mm–h:mm a v"
+      },
+      "yM, hmv": {
+        "a": "y-MM, h:mm a–h:mm a v",
+        "h": "y-MM, h:mm–h:mm a v",
+        "m": "y-MM, h:mm–h:mm a v"
+      },
+      "yMd, hmv": {
+        "a": "y-MM-dd, h:mm a–h:mm a v",
+        "h": "y-MM-dd, h:mm–h:mm a v",
+        "m": "y-MM-dd, h:mm–h:mm a v"
+      },
+      "yMEd, hmv": {
+        "a": "E, y-MM-dd, h:mm a–h:mm a v",
+        "h": "E, y-MM-dd, h:mm–h:mm a v",
+        "m": "E, y-MM-dd, h:mm–h:mm a v"
+      },
+      "yMMM, hmv": {
+        "a": "MMM y, h:mm a–h:mm a v",
+        "h": "MMM y, h:mm–h:mm a v",
+        "m": "MMM y, h:mm–h:mm a v"
+      },
+      "yMMMd, hmv": {
+        "a": "MMM d, y, h:mm a–h:mm a v",
+        "h": "MMM d, y, h:mm–h:mm a v",
+        "m": "MMM d, y, h:mm–h:mm a v"
+      },
+      "yMMMEd, hmv": {
+        "a": "E, MMM d, y, h:mm a–h:mm a v",
+        "h": "E, MMM d, y, h:mm–h:mm a v",
+        "m": "E, MMM d, y, h:mm–h:mm a v"
+      },
+      "yMMMM, hmv": {
+        "a": "MMMM y, h:mm a–h:mm a v",
+        "h": "MMMM y, h:mm–h:mm a v",
+        "m": "MMMM y, h:mm–h:mm a v"
+      },
+      "EEEE, MMMM d, y, Hmv": {
+        "H": "EEEE, MMMM d, y, HH:mm–HH:mm v",
+        "m": "EEEE, MMMM d, y, HH:mm–HH:mm v"
+      },
+      "MMMM d, y, Hmv": {
+        "H": "MMMM d, y, HH:mm–HH:mm v",
+        "m": "MMMM d, y, HH:mm–HH:mm v"
+      },
+      "MMM d, y, Hmv": {
+        "H": "MMM d, y, HH:mm–HH:mm v",
+        "m": "MMM d, y, HH:mm–HH:mm v"
+      },
+      "y-MM-dd, Hmv": {
+        "H": "y-MM-dd, HH:mm–HH:mm v",
+        "m": "y-MM-dd, HH:mm–HH:mm v"
+      },
+      "d/M/yy, Hmv": {
+        "H": "d/M/yy, HH:mm–HH:mm v",
+        "m": "d/M/yy, HH:mm–HH:mm v"
+      },
+      "d, Hmv": {
+        "H": "d, HH:mm–HH:mm v",
+        "m": "d, HH:mm–HH:mm v"
+      },
+      "E, Hmv": {
+        "H": "ccc, HH:mm–HH:mm v",
+        "m": "ccc, HH:mm–HH:mm v"
+      },
+      "Ed, Hmv": {
+        "H": "E d, HH:mm–HH:mm v",
+        "m": "E d, HH:mm–HH:mm v"
+      },
+      "Gy, Hmv": {
+        "H": "y G, HH:mm–HH:mm v",
+        "m": "y G, HH:mm–HH:mm v"
+      },
+      "GyM, Hmv": {
+        "H": "M/y G, HH:mm–HH:mm v",
+        "m": "M/y G, HH:mm–HH:mm v"
+      },
+      "GyMd, Hmv": {
+        "H": "M/d/y G, HH:mm–HH:mm v",
+        "m": "M/d/y G, HH:mm–HH:mm v"
+      },
+      "GyMEd, Hmv": {
+        "H": "E, M/d/y G, HH:mm–HH:mm v",
+        "m": "E, M/d/y G, HH:mm–HH:mm v"
+      },
+      "GyMMM, Hmv": {
+        "H": "MMM y G, HH:mm–HH:mm v",
+        "m": "MMM y G, HH:mm–HH:mm v"
+      },
+      "GyMMMd, Hmv": {
+        "H": "MMM d, y G, HH:mm–HH:mm v",
+        "m": "MMM d, y G, HH:mm–HH:mm v"
+      },
+      "GyMMMEd, Hmv": {
+        "H": "E, MMM d, y G, HH:mm–HH:mm v",
+        "m": "E, MMM d, y G, HH:mm–HH:mm v"
+      },
+      "M, Hmv": {
+        "H": "L, HH:mm–HH:mm v",
+        "m": "L, HH:mm–HH:mm v"
+      },
+      "Md, Hmv": {
+        "H": "MM-dd, HH:mm–HH:mm v",
+        "m": "MM-dd, HH:mm–HH:mm v"
+      },
+      "MEd, Hmv": {
+        "H": "E, MM-dd, HH:mm–HH:mm v",
+        "m": "E, MM-dd, HH:mm–HH:mm v"
+      },
+      "MMdd, Hmv": {
+        "H": "MM-dd, HH:mm–HH:mm v",
+        "m": "MM-dd, HH:mm–HH:mm v"
+      },
+      "MMM, Hmv": {
+        "H": "LLL, HH:mm–HH:mm v",
+        "m": "LLL, HH:mm–HH:mm v"
+      },
+      "MMMd, Hmv": {
+        "H": "MMM d, HH:mm–HH:mm v",
+        "m": "MMM d, HH:mm–HH:mm v"
+      },
+      "MMMEd, Hmv": {
+        "H": "E, MMM d, HH:mm–HH:mm v",
+        "m": "E, MMM d, HH:mm–HH:mm v"
+      },
+      "MMMMd, Hmv": {
+        "H": "MMMM d, HH:mm–HH:mm v",
+        "m": "MMMM d, HH:mm–HH:mm v"
+      },
+      "y, Hmv": {
+        "H": "y, HH:mm–HH:mm v",
+        "m": "y, HH:mm–HH:mm v"
+      },
+      "yM, Hmv": {
+        "H": "y-MM, HH:mm–HH:mm v",
+        "m": "y-MM, HH:mm–HH:mm v"
+      },
+      "yMd, Hmv": {
+        "H": "y-MM-dd, HH:mm–HH:mm v",
+        "m": "y-MM-dd, HH:mm–HH:mm v"
+      },
+      "yMEd, Hmv": {
+        "H": "E, y-MM-dd, HH:mm–HH:mm v",
+        "m": "E, y-MM-dd, HH:mm–HH:mm v"
+      },
+      "yMMM, Hmv": {
+        "H": "MMM y, HH:mm–HH:mm v",
+        "m": "MMM y, HH:mm–HH:mm v"
+      },
+      "yMMMd, Hmv": {
+        "H": "MMM d, y, HH:mm–HH:mm v",
+        "m": "MMM d, y, HH:mm–HH:mm v"
+      },
+      "yMMMEd, Hmv": {
+        "H": "E, MMM d, y, HH:mm–HH:mm v",
+        "m": "E, MMM d, y, HH:mm–HH:mm v"
+      },
+      "yMMMM, Hmv": {
+        "H": "MMMM y, HH:mm–HH:mm v",
+        "m": "MMMM y, HH:mm–HH:mm v"
+      },
+      "EEEE, MMMM d, y, hv": {
+        "a": "EEEE, MMMM d, y, h a–h a v",
+        "h": "EEEE, MMMM d, y, h–h a v"
+      },
+      "MMMM d, y, hv": {
+        "a": "MMMM d, y, h a–h a v",
+        "h": "MMMM d, y, h–h a v"
+      },
+      "MMM d, y, hv": {
+        "a": "MMM d, y, h a–h a v",
+        "h": "MMM d, y, h–h a v"
+      },
+      "y-MM-dd, hv": {
+        "a": "y-MM-dd, h a–h a v",
+        "h": "y-MM-dd, h–h a v"
+      },
+      "d/M/yy, hv": {
+        "a": "d/M/yy, h a–h a v",
+        "h": "d/M/yy, h–h a v"
+      },
+      "d, hv": {
+        "a": "d, h a–h a v",
+        "h": "d, h–h a v"
+      },
+      "E, hv": {
+        "a": "ccc, h a–h a v",
+        "h": "ccc, h–h a v"
+      },
+      "Ed, hv": {
+        "a": "E d, h a–h a v",
+        "h": "E d, h–h a v"
+      },
+      "Gy, hv": {
+        "a": "y G, h a–h a v",
+        "h": "y G, h–h a v"
+      },
+      "GyM, hv": {
+        "a": "M/y G, h a–h a v",
+        "h": "M/y G, h–h a v"
+      },
+      "GyMd, hv": {
+        "a": "M/d/y G, h a–h a v",
+        "h": "M/d/y G, h–h a v"
+      },
+      "GyMEd, hv": {
+        "a": "E, M/d/y G, h a–h a v",
+        "h": "E, M/d/y G, h–h a v"
+      },
+      "GyMMM, hv": {
+        "a": "MMM y G, h a–h a v",
+        "h": "MMM y G, h–h a v"
+      },
+      "GyMMMd, hv": {
+        "a": "MMM d, y G, h a–h a v",
+        "h": "MMM d, y G, h–h a v"
+      },
+      "GyMMMEd, hv": {
+        "a": "E, MMM d, y G, h a–h a v",
+        "h": "E, MMM d, y G, h–h a v"
+      },
+      "M, hv": {
+        "a": "L, h a–h a v",
+        "h": "L, h–h a v"
+      },
+      "Md, hv": {
+        "a": "MM-dd, h a–h a v",
+        "h": "MM-dd, h–h a v"
+      },
+      "MEd, hv": {
+        "a": "E, MM-dd, h a–h a v",
+        "h": "E, MM-dd, h–h a v"
+      },
+      "MMdd, hv": {
+        "a": "MM-dd, h a–h a v",
+        "h": "MM-dd, h–h a v"
+      },
+      "MMM, hv": {
+        "a": "LLL, h a–h a v",
+        "h": "LLL, h–h a v"
+      },
+      "MMMd, hv": {
+        "a": "MMM d, h a–h a v",
+        "h": "MMM d, h–h a v"
+      },
+      "MMMEd, hv": {
+        "a": "E, MMM d, h a–h a v",
+        "h": "E, MMM d, h–h a v"
+      },
+      "MMMMd, hv": {
+        "a": "MMMM d, h a–h a v",
+        "h": "MMMM d, h–h a v"
+      },
+      "y, hv": {
+        "a": "y, h a–h a v",
+        "h": "y, h–h a v"
+      },
+      "yM, hv": {
+        "a": "y-MM, h a–h a v",
+        "h": "y-MM, h–h a v"
+      },
+      "yMd, hv": {
+        "a": "y-MM-dd, h a–h a v",
+        "h": "y-MM-dd, h–h a v"
+      },
+      "yMEd, hv": {
+        "a": "E, y-MM-dd, h a–h a v",
+        "h": "E, y-MM-dd, h–h a v"
+      },
+      "yMMM, hv": {
+        "a": "MMM y, h a–h a v",
+        "h": "MMM y, h–h a v"
+      },
+      "yMMMd, hv": {
+        "a": "MMM d, y, h a–h a v",
+        "h": "MMM d, y, h–h a v"
+      },
+      "yMMMEd, hv": {
+        "a": "E, MMM d, y, h a–h a v",
+        "h": "E, MMM d, y, h–h a v"
+      },
+      "yMMMM, hv": {
+        "a": "MMMM y, h a–h a v",
+        "h": "MMMM y, h–h a v"
+      },
+      "EEEE, MMMM d, y, Hv": {
+        "H": "EEEE, MMMM d, y, HH–HH v"
+      },
+      "MMMM d, y, Hv": {
+        "H": "MMMM d, y, HH–HH v"
+      },
+      "MMM d, y, Hv": {
+        "H": "MMM d, y, HH–HH v"
+      },
+      "y-MM-dd, Hv": {
+        "H": "y-MM-dd, HH–HH v"
+      },
+      "d/M/yy, Hv": {
+        "H": "d/M/yy, HH–HH v"
+      },
+      "d, Hv": {
+        "H": "d, HH–HH v"
+      },
+      "E, Hv": {
+        "H": "ccc, HH–HH v"
+      },
+      "Ed, Hv": {
+        "H": "E d, HH–HH v"
+      },
+      "Gy, Hv": {
+        "H": "y G, HH–HH v"
+      },
+      "GyM, Hv": {
+        "H": "M/y G, HH–HH v"
+      },
+      "GyMd, Hv": {
+        "H": "M/d/y G, HH–HH v"
+      },
+      "GyMEd, Hv": {
+        "H": "E, M/d/y G, HH–HH v"
+      },
+      "GyMMM, Hv": {
+        "H": "MMM y G, HH–HH v"
+      },
+      "GyMMMd, Hv": {
+        "H": "MMM d, y G, HH–HH v"
+      },
+      "GyMMMEd, Hv": {
+        "H": "E, MMM d, y G, HH–HH v"
+      },
+      "M, Hv": {
+        "H": "L, HH–HH v"
+      },
+      "Md, Hv": {
+        "H": "MM-dd, HH–HH v"
+      },
+      "MEd, Hv": {
+        "H": "E, MM-dd, HH–HH v"
+      },
+      "MMdd, Hv": {
+        "H": "MM-dd, HH–HH v"
+      },
+      "MMM, Hv": {
+        "H": "LLL, HH–HH v"
+      },
+      "MMMd, Hv": {
+        "H": "MMM d, HH–HH v"
+      },
+      "MMMEd, Hv": {
+        "H": "E, MMM d, HH–HH v"
+      },
+      "MMMMd, Hv": {
+        "H": "MMMM d, HH–HH v"
+      },
+      "y, Hv": {
+        "H": "y, HH–HH v"
+      },
+      "yM, Hv": {
+        "H": "y-MM, HH–HH v"
+      },
+      "yMd, Hv": {
+        "H": "y-MM-dd, HH–HH v"
+      },
+      "yMEd, Hv": {
+        "H": "E, y-MM-dd, HH–HH v"
+      },
+      "yMMM, Hv": {
+        "H": "MMM y, HH–HH v"
+      },
+      "yMMMd, Hv": {
+        "H": "MMM d, y, HH–HH v"
+      },
+      "yMMMEd, Hv": {
+        "H": "E, MMM d, y, HH–HH v"
+      },
+      "yMMMM, Hv": {
+        "H": "MMMM y, HH–HH v"
       }
     },
     "hourCycle": "h12",

--- a/packages/intl-datetimeformat/tests/locale-data/en-GB.json
+++ b/packages/intl-datetimeformat/tests/locale-data/en-GB.json
@@ -3087,6 +3087,1441 @@
         "d": "EEEE d MMMM – EEEE d MMMM y",
         "M": "EEEE d MMMM – EEEE d MMMM y",
         "y": "EEEE d MMMM y – EEEE d MMMM y"
+      },
+      "EEEE, d MMMM y, Bh": {
+        "B": "EEEE, d MMMM y, h B – h B",
+        "h": "EEEE, d MMMM y, h – h B"
+      },
+      "d MMMM y, Bh": {
+        "B": "d MMMM y, h B – h B",
+        "h": "d MMMM y, h – h B"
+      },
+      "d MMM y, Bh": {
+        "B": "d MMM y, h B – h B",
+        "h": "d MMM y, h – h B"
+      },
+      "dd/MM/y, Bh": {
+        "B": "dd/MM/y, h B – h B",
+        "h": "dd/MM/y, h – h B"
+      },
+      "d, Bh": {
+        "B": "d, h B – h B",
+        "h": "d, h – h B"
+      },
+      "E, Bh": {
+        "B": "ccc, h B – h B",
+        "h": "ccc, h – h B"
+      },
+      "Ed, Bh": {
+        "B": "E d, h B – h B",
+        "h": "E d, h – h B"
+      },
+      "Gy, Bh": {
+        "B": "y G, h B – h B",
+        "h": "y G, h – h B"
+      },
+      "GyM, Bh": {
+        "B": "M/y G, h B – h B",
+        "h": "M/y G, h – h B"
+      },
+      "GyMd, Bh": {
+        "B": "dd/MM/y G, h B – h B",
+        "h": "dd/MM/y G, h – h B"
+      },
+      "GyMEd, Bh": {
+        "B": "E, d/M/y G, h B – h B",
+        "h": "E, d/M/y G, h – h B"
+      },
+      "GyMMM, Bh": {
+        "B": "MMM y G, h B – h B",
+        "h": "MMM y G, h – h B"
+      },
+      "GyMMMd, Bh": {
+        "B": "d MMM y G, h B – h B",
+        "h": "d MMM y G, h – h B"
+      },
+      "GyMMMEd, Bh": {
+        "B": "E, d MMM y G, h B – h B",
+        "h": "E, d MMM y G, h – h B"
+      },
+      "GyMMMEEEEd, Bh": {
+        "B": "EEEE, d MMM y G, h B – h B",
+        "h": "EEEE, d MMM y G, h – h B"
+      },
+      "M, Bh": {
+        "B": "L, h B – h B",
+        "h": "L, h – h B"
+      },
+      "Md, Bh": {
+        "B": "dd/MM, h B – h B",
+        "h": "dd/MM, h – h B"
+      },
+      "MEd, Bh": {
+        "B": "E dd/MM, h B – h B",
+        "h": "E dd/MM, h – h B"
+      },
+      "MMdd, Bh": {
+        "B": "dd/MM, h B – h B",
+        "h": "dd/MM, h – h B"
+      },
+      "MMM, Bh": {
+        "B": "LLL, h B – h B",
+        "h": "LLL, h – h B"
+      },
+      "MMMd, Bh": {
+        "B": "d MMM, h B – h B",
+        "h": "d MMM, h – h B"
+      },
+      "MMMEd, Bh": {
+        "B": "E d MMM, h B – h B",
+        "h": "E d MMM, h – h B"
+      },
+      "MMMEEEEd, Bh": {
+        "B": "EEEE d MMM, h B – h B",
+        "h": "EEEE d MMM, h – h B"
+      },
+      "MMMMd, Bh": {
+        "B": "d MMMM, h B – h B",
+        "h": "d MMMM, h – h B"
+      },
+      "MMMMEEEEd, Bh": {
+        "B": "EEEE d MMMM, h B – h B",
+        "h": "EEEE d MMMM, h – h B"
+      },
+      "y, Bh": {
+        "B": "y, h B – h B",
+        "h": "y, h – h B"
+      },
+      "yM, Bh": {
+        "B": "MM/y, h B – h B",
+        "h": "MM/y, h – h B"
+      },
+      "yMd, Bh": {
+        "B": "dd/MM/y, h B – h B",
+        "h": "dd/MM/y, h – h B"
+      },
+      "yMEd, Bh": {
+        "B": "E, dd/MM/y, h B – h B",
+        "h": "E, dd/MM/y, h – h B"
+      },
+      "yMMM, Bh": {
+        "B": "MMM y, h B – h B",
+        "h": "MMM y, h – h B"
+      },
+      "yMMMd, Bh": {
+        "B": "d MMM y, h B – h B",
+        "h": "d MMM y, h – h B"
+      },
+      "yMMMEd, Bh": {
+        "B": "E, d MMM y, h B – h B",
+        "h": "E, d MMM y, h – h B"
+      },
+      "yMMMEEEEd, Bh": {
+        "B": "EEEE, d MMM y, h B – h B",
+        "h": "EEEE, d MMM y, h – h B"
+      },
+      "yMMMM, Bh": {
+        "B": "MMMM y, h B – h B",
+        "h": "MMMM y, h – h B"
+      },
+      "yMMMMEEEEd, Bh": {
+        "B": "EEEE, d MMMM y, h B – h B",
+        "h": "EEEE, d MMMM y, h – h B"
+      },
+      "EEEE, d MMMM y, Bhm": {
+        "B": "EEEE, d MMMM y, h:mm B – h:mm B",
+        "h": "EEEE, d MMMM y, h:mm – h:mm B",
+        "m": "EEEE, d MMMM y, h:mm – h:mm B"
+      },
+      "d MMMM y, Bhm": {
+        "B": "d MMMM y, h:mm B – h:mm B",
+        "h": "d MMMM y, h:mm – h:mm B",
+        "m": "d MMMM y, h:mm – h:mm B"
+      },
+      "d MMM y, Bhm": {
+        "B": "d MMM y, h:mm B – h:mm B",
+        "h": "d MMM y, h:mm – h:mm B",
+        "m": "d MMM y, h:mm – h:mm B"
+      },
+      "dd/MM/y, Bhm": {
+        "B": "dd/MM/y, h:mm B – h:mm B",
+        "h": "dd/MM/y, h:mm – h:mm B",
+        "m": "dd/MM/y, h:mm – h:mm B"
+      },
+      "d, Bhm": {
+        "B": "d, h:mm B – h:mm B",
+        "h": "d, h:mm – h:mm B",
+        "m": "d, h:mm – h:mm B"
+      },
+      "E, Bhm": {
+        "B": "ccc, h:mm B – h:mm B",
+        "h": "ccc, h:mm – h:mm B",
+        "m": "ccc, h:mm – h:mm B"
+      },
+      "Ed, Bhm": {
+        "B": "E d, h:mm B – h:mm B",
+        "h": "E d, h:mm – h:mm B",
+        "m": "E d, h:mm – h:mm B"
+      },
+      "Gy, Bhm": {
+        "B": "y G, h:mm B – h:mm B",
+        "h": "y G, h:mm – h:mm B",
+        "m": "y G, h:mm – h:mm B"
+      },
+      "GyM, Bhm": {
+        "B": "M/y G, h:mm B – h:mm B",
+        "h": "M/y G, h:mm – h:mm B",
+        "m": "M/y G, h:mm – h:mm B"
+      },
+      "GyMd, Bhm": {
+        "B": "dd/MM/y G, h:mm B – h:mm B",
+        "h": "dd/MM/y G, h:mm – h:mm B",
+        "m": "dd/MM/y G, h:mm – h:mm B"
+      },
+      "GyMEd, Bhm": {
+        "B": "E, d/M/y G, h:mm B – h:mm B",
+        "h": "E, d/M/y G, h:mm – h:mm B",
+        "m": "E, d/M/y G, h:mm – h:mm B"
+      },
+      "GyMMM, Bhm": {
+        "B": "MMM y G, h:mm B – h:mm B",
+        "h": "MMM y G, h:mm – h:mm B",
+        "m": "MMM y G, h:mm – h:mm B"
+      },
+      "GyMMMd, Bhm": {
+        "B": "d MMM y G, h:mm B – h:mm B",
+        "h": "d MMM y G, h:mm – h:mm B",
+        "m": "d MMM y G, h:mm – h:mm B"
+      },
+      "GyMMMEd, Bhm": {
+        "B": "E, d MMM y G, h:mm B – h:mm B",
+        "h": "E, d MMM y G, h:mm – h:mm B",
+        "m": "E, d MMM y G, h:mm – h:mm B"
+      },
+      "GyMMMEEEEd, Bhm": {
+        "B": "EEEE, d MMM y G, h:mm B – h:mm B",
+        "h": "EEEE, d MMM y G, h:mm – h:mm B",
+        "m": "EEEE, d MMM y G, h:mm – h:mm B"
+      },
+      "M, Bhm": {
+        "B": "L, h:mm B – h:mm B",
+        "h": "L, h:mm – h:mm B",
+        "m": "L, h:mm – h:mm B"
+      },
+      "Md, Bhm": {
+        "B": "dd/MM, h:mm B – h:mm B",
+        "h": "dd/MM, h:mm – h:mm B",
+        "m": "dd/MM, h:mm – h:mm B"
+      },
+      "MEd, Bhm": {
+        "B": "E dd/MM, h:mm B – h:mm B",
+        "h": "E dd/MM, h:mm – h:mm B",
+        "m": "E dd/MM, h:mm – h:mm B"
+      },
+      "MMdd, Bhm": {
+        "B": "dd/MM, h:mm B – h:mm B",
+        "h": "dd/MM, h:mm – h:mm B",
+        "m": "dd/MM, h:mm – h:mm B"
+      },
+      "MMM, Bhm": {
+        "B": "LLL, h:mm B – h:mm B",
+        "h": "LLL, h:mm – h:mm B",
+        "m": "LLL, h:mm – h:mm B"
+      },
+      "MMMd, Bhm": {
+        "B": "d MMM, h:mm B – h:mm B",
+        "h": "d MMM, h:mm – h:mm B",
+        "m": "d MMM, h:mm – h:mm B"
+      },
+      "MMMEd, Bhm": {
+        "B": "E d MMM, h:mm B – h:mm B",
+        "h": "E d MMM, h:mm – h:mm B",
+        "m": "E d MMM, h:mm – h:mm B"
+      },
+      "MMMEEEEd, Bhm": {
+        "B": "EEEE d MMM, h:mm B – h:mm B",
+        "h": "EEEE d MMM, h:mm – h:mm B",
+        "m": "EEEE d MMM, h:mm – h:mm B"
+      },
+      "MMMMd, Bhm": {
+        "B": "d MMMM, h:mm B – h:mm B",
+        "h": "d MMMM, h:mm – h:mm B",
+        "m": "d MMMM, h:mm – h:mm B"
+      },
+      "MMMMEEEEd, Bhm": {
+        "B": "EEEE d MMMM, h:mm B – h:mm B",
+        "h": "EEEE d MMMM, h:mm – h:mm B",
+        "m": "EEEE d MMMM, h:mm – h:mm B"
+      },
+      "y, Bhm": {
+        "B": "y, h:mm B – h:mm B",
+        "h": "y, h:mm – h:mm B",
+        "m": "y, h:mm – h:mm B"
+      },
+      "yM, Bhm": {
+        "B": "MM/y, h:mm B – h:mm B",
+        "h": "MM/y, h:mm – h:mm B",
+        "m": "MM/y, h:mm – h:mm B"
+      },
+      "yMd, Bhm": {
+        "B": "dd/MM/y, h:mm B – h:mm B",
+        "h": "dd/MM/y, h:mm – h:mm B",
+        "m": "dd/MM/y, h:mm – h:mm B"
+      },
+      "yMEd, Bhm": {
+        "B": "E, dd/MM/y, h:mm B – h:mm B",
+        "h": "E, dd/MM/y, h:mm – h:mm B",
+        "m": "E, dd/MM/y, h:mm – h:mm B"
+      },
+      "yMMM, Bhm": {
+        "B": "MMM y, h:mm B – h:mm B",
+        "h": "MMM y, h:mm – h:mm B",
+        "m": "MMM y, h:mm – h:mm B"
+      },
+      "yMMMd, Bhm": {
+        "B": "d MMM y, h:mm B – h:mm B",
+        "h": "d MMM y, h:mm – h:mm B",
+        "m": "d MMM y, h:mm – h:mm B"
+      },
+      "yMMMEd, Bhm": {
+        "B": "E, d MMM y, h:mm B – h:mm B",
+        "h": "E, d MMM y, h:mm – h:mm B",
+        "m": "E, d MMM y, h:mm – h:mm B"
+      },
+      "yMMMEEEEd, Bhm": {
+        "B": "EEEE, d MMM y, h:mm B – h:mm B",
+        "h": "EEEE, d MMM y, h:mm – h:mm B",
+        "m": "EEEE, d MMM y, h:mm – h:mm B"
+      },
+      "yMMMM, Bhm": {
+        "B": "MMMM y, h:mm B – h:mm B",
+        "h": "MMMM y, h:mm – h:mm B",
+        "m": "MMMM y, h:mm – h:mm B"
+      },
+      "yMMMMEEEEd, Bhm": {
+        "B": "EEEE, d MMMM y, h:mm B – h:mm B",
+        "h": "EEEE, d MMMM y, h:mm – h:mm B",
+        "m": "EEEE, d MMMM y, h:mm – h:mm B"
+      },
+      "EEEE, d MMMM y, h": {
+        "a": "EEEE, d MMMM y, h a – h a",
+        "h": "EEEE, d MMMM y, h–h a"
+      },
+      "d MMMM y, h": {
+        "a": "d MMMM y, h a – h a",
+        "h": "d MMMM y, h–h a"
+      },
+      "d MMM y, h": {
+        "a": "d MMM y, h a – h a",
+        "h": "d MMM y, h–h a"
+      },
+      "dd/MM/y, h": {
+        "a": "dd/MM/y, h a – h a",
+        "h": "dd/MM/y, h–h a"
+      },
+      "d, h": {
+        "a": "d, h a – h a",
+        "h": "d, h–h a"
+      },
+      "E, h": {
+        "a": "ccc, h a – h a",
+        "h": "ccc, h–h a"
+      },
+      "Ed, h": {
+        "a": "E d, h a – h a",
+        "h": "E d, h–h a"
+      },
+      "Gy, h": {
+        "a": "y G, h a – h a",
+        "h": "y G, h–h a"
+      },
+      "GyM, h": {
+        "a": "M/y G, h a – h a",
+        "h": "M/y G, h–h a"
+      },
+      "GyMd, h": {
+        "a": "dd/MM/y G, h a – h a",
+        "h": "dd/MM/y G, h–h a"
+      },
+      "GyMEd, h": {
+        "a": "E, d/M/y G, h a – h a",
+        "h": "E, d/M/y G, h–h a"
+      },
+      "GyMMM, h": {
+        "a": "MMM y G, h a – h a",
+        "h": "MMM y G, h–h a"
+      },
+      "GyMMMd, h": {
+        "a": "d MMM y G, h a – h a",
+        "h": "d MMM y G, h–h a"
+      },
+      "GyMMMEd, h": {
+        "a": "E, d MMM y G, h a – h a",
+        "h": "E, d MMM y G, h–h a"
+      },
+      "GyMMMEEEEd, h": {
+        "a": "EEEE, d MMM y G, h a – h a",
+        "h": "EEEE, d MMM y G, h–h a"
+      },
+      "M, h": {
+        "a": "L, h a – h a",
+        "h": "L, h–h a"
+      },
+      "Md, h": {
+        "a": "dd/MM, h a – h a",
+        "h": "dd/MM, h–h a"
+      },
+      "MEd, h": {
+        "a": "E dd/MM, h a – h a",
+        "h": "E dd/MM, h–h a"
+      },
+      "MMdd, h": {
+        "a": "dd/MM, h a – h a",
+        "h": "dd/MM, h–h a"
+      },
+      "MMM, h": {
+        "a": "LLL, h a – h a",
+        "h": "LLL, h–h a"
+      },
+      "MMMd, h": {
+        "a": "d MMM, h a – h a",
+        "h": "d MMM, h–h a"
+      },
+      "MMMEd, h": {
+        "a": "E d MMM, h a – h a",
+        "h": "E d MMM, h–h a"
+      },
+      "MMMEEEEd, h": {
+        "a": "EEEE d MMM, h a – h a",
+        "h": "EEEE d MMM, h–h a"
+      },
+      "MMMMd, h": {
+        "a": "d MMMM, h a – h a",
+        "h": "d MMMM, h–h a"
+      },
+      "MMMMEEEEd, h": {
+        "a": "EEEE d MMMM, h a – h a",
+        "h": "EEEE d MMMM, h–h a"
+      },
+      "y, h": {
+        "a": "y, h a – h a",
+        "h": "y, h–h a"
+      },
+      "yM, h": {
+        "a": "MM/y, h a – h a",
+        "h": "MM/y, h–h a"
+      },
+      "yMd, h": {
+        "a": "dd/MM/y, h a – h a",
+        "h": "dd/MM/y, h–h a"
+      },
+      "yMEd, h": {
+        "a": "E, dd/MM/y, h a – h a",
+        "h": "E, dd/MM/y, h–h a"
+      },
+      "yMMM, h": {
+        "a": "MMM y, h a – h a",
+        "h": "MMM y, h–h a"
+      },
+      "yMMMd, h": {
+        "a": "d MMM y, h a – h a",
+        "h": "d MMM y, h–h a"
+      },
+      "yMMMEd, h": {
+        "a": "E, d MMM y, h a – h a",
+        "h": "E, d MMM y, h–h a"
+      },
+      "yMMMEEEEd, h": {
+        "a": "EEEE, d MMM y, h a – h a",
+        "h": "EEEE, d MMM y, h–h a"
+      },
+      "yMMMM, h": {
+        "a": "MMMM y, h a – h a",
+        "h": "MMMM y, h–h a"
+      },
+      "yMMMMEEEEd, h": {
+        "a": "EEEE, d MMMM y, h a – h a",
+        "h": "EEEE, d MMMM y, h–h a"
+      },
+      "EEEE, d MMMM y, H": {
+        "H": "EEEE, d MMMM y, HH–HH"
+      },
+      "d MMMM y, H": {
+        "H": "d MMMM y, HH–HH"
+      },
+      "d MMM y, H": {
+        "H": "d MMM y, HH–HH"
+      },
+      "dd/MM/y, H": {
+        "H": "dd/MM/y, HH–HH"
+      },
+      "d, H": {
+        "H": "d, HH–HH"
+      },
+      "E, H": {
+        "H": "ccc, HH–HH"
+      },
+      "Ed, H": {
+        "H": "E d, HH–HH"
+      },
+      "Gy, H": {
+        "H": "y G, HH–HH"
+      },
+      "GyM, H": {
+        "H": "M/y G, HH–HH"
+      },
+      "GyMd, H": {
+        "H": "dd/MM/y G, HH–HH"
+      },
+      "GyMEd, H": {
+        "H": "E, d/M/y G, HH–HH"
+      },
+      "GyMMM, H": {
+        "H": "MMM y G, HH–HH"
+      },
+      "GyMMMd, H": {
+        "H": "d MMM y G, HH–HH"
+      },
+      "GyMMMEd, H": {
+        "H": "E, d MMM y G, HH–HH"
+      },
+      "GyMMMEEEEd, H": {
+        "H": "EEEE, d MMM y G, HH–HH"
+      },
+      "M, H": {
+        "H": "L, HH–HH"
+      },
+      "Md, H": {
+        "H": "dd/MM, HH–HH"
+      },
+      "MEd, H": {
+        "H": "E dd/MM, HH–HH"
+      },
+      "MMdd, H": {
+        "H": "dd/MM, HH–HH"
+      },
+      "MMM, H": {
+        "H": "LLL, HH–HH"
+      },
+      "MMMd, H": {
+        "H": "d MMM, HH–HH"
+      },
+      "MMMEd, H": {
+        "H": "E d MMM, HH–HH"
+      },
+      "MMMEEEEd, H": {
+        "H": "EEEE d MMM, HH–HH"
+      },
+      "MMMMd, H": {
+        "H": "d MMMM, HH–HH"
+      },
+      "MMMMEEEEd, H": {
+        "H": "EEEE d MMMM, HH–HH"
+      },
+      "y, H": {
+        "H": "y, HH–HH"
+      },
+      "yM, H": {
+        "H": "MM/y, HH–HH"
+      },
+      "yMd, H": {
+        "H": "dd/MM/y, HH–HH"
+      },
+      "yMEd, H": {
+        "H": "E, dd/MM/y, HH–HH"
+      },
+      "yMMM, H": {
+        "H": "MMM y, HH–HH"
+      },
+      "yMMMd, H": {
+        "H": "d MMM y, HH–HH"
+      },
+      "yMMMEd, H": {
+        "H": "E, d MMM y, HH–HH"
+      },
+      "yMMMEEEEd, H": {
+        "H": "EEEE, d MMM y, HH–HH"
+      },
+      "yMMMM, H": {
+        "H": "MMMM y, HH–HH"
+      },
+      "yMMMMEEEEd, H": {
+        "H": "EEEE, d MMMM y, HH–HH"
+      },
+      "EEEE, d MMMM y, hm": {
+        "a": "EEEE, d MMMM y, h:mm a – h:mm a",
+        "h": "EEEE, d MMMM y, h:mm – h:mm a",
+        "m": "EEEE, d MMMM y, h:mm – h:mm a"
+      },
+      "d MMMM y, hm": {
+        "a": "d MMMM y, h:mm a – h:mm a",
+        "h": "d MMMM y, h:mm – h:mm a",
+        "m": "d MMMM y, h:mm – h:mm a"
+      },
+      "d MMM y, hm": {
+        "a": "d MMM y, h:mm a – h:mm a",
+        "h": "d MMM y, h:mm – h:mm a",
+        "m": "d MMM y, h:mm – h:mm a"
+      },
+      "dd/MM/y, hm": {
+        "a": "dd/MM/y, h:mm a – h:mm a",
+        "h": "dd/MM/y, h:mm – h:mm a",
+        "m": "dd/MM/y, h:mm – h:mm a"
+      },
+      "d, hm": {
+        "a": "d, h:mm a – h:mm a",
+        "h": "d, h:mm – h:mm a",
+        "m": "d, h:mm – h:mm a"
+      },
+      "E, hm": {
+        "a": "ccc, h:mm a – h:mm a",
+        "h": "ccc, h:mm – h:mm a",
+        "m": "ccc, h:mm – h:mm a"
+      },
+      "Ed, hm": {
+        "a": "E d, h:mm a – h:mm a",
+        "h": "E d, h:mm – h:mm a",
+        "m": "E d, h:mm – h:mm a"
+      },
+      "Gy, hm": {
+        "a": "y G, h:mm a – h:mm a",
+        "h": "y G, h:mm – h:mm a",
+        "m": "y G, h:mm – h:mm a"
+      },
+      "GyM, hm": {
+        "a": "M/y G, h:mm a – h:mm a",
+        "h": "M/y G, h:mm – h:mm a",
+        "m": "M/y G, h:mm – h:mm a"
+      },
+      "GyMd, hm": {
+        "a": "dd/MM/y G, h:mm a – h:mm a",
+        "h": "dd/MM/y G, h:mm – h:mm a",
+        "m": "dd/MM/y G, h:mm – h:mm a"
+      },
+      "GyMEd, hm": {
+        "a": "E, d/M/y G, h:mm a – h:mm a",
+        "h": "E, d/M/y G, h:mm – h:mm a",
+        "m": "E, d/M/y G, h:mm – h:mm a"
+      },
+      "GyMMM, hm": {
+        "a": "MMM y G, h:mm a – h:mm a",
+        "h": "MMM y G, h:mm – h:mm a",
+        "m": "MMM y G, h:mm – h:mm a"
+      },
+      "GyMMMd, hm": {
+        "a": "d MMM y G, h:mm a – h:mm a",
+        "h": "d MMM y G, h:mm – h:mm a",
+        "m": "d MMM y G, h:mm – h:mm a"
+      },
+      "GyMMMEd, hm": {
+        "a": "E, d MMM y G, h:mm a – h:mm a",
+        "h": "E, d MMM y G, h:mm – h:mm a",
+        "m": "E, d MMM y G, h:mm – h:mm a"
+      },
+      "GyMMMEEEEd, hm": {
+        "a": "EEEE, d MMM y G, h:mm a – h:mm a",
+        "h": "EEEE, d MMM y G, h:mm – h:mm a",
+        "m": "EEEE, d MMM y G, h:mm – h:mm a"
+      },
+      "M, hm": {
+        "a": "L, h:mm a – h:mm a",
+        "h": "L, h:mm – h:mm a",
+        "m": "L, h:mm – h:mm a"
+      },
+      "Md, hm": {
+        "a": "dd/MM, h:mm a – h:mm a",
+        "h": "dd/MM, h:mm – h:mm a",
+        "m": "dd/MM, h:mm – h:mm a"
+      },
+      "MEd, hm": {
+        "a": "E dd/MM, h:mm a – h:mm a",
+        "h": "E dd/MM, h:mm – h:mm a",
+        "m": "E dd/MM, h:mm – h:mm a"
+      },
+      "MMdd, hm": {
+        "a": "dd/MM, h:mm a – h:mm a",
+        "h": "dd/MM, h:mm – h:mm a",
+        "m": "dd/MM, h:mm – h:mm a"
+      },
+      "MMM, hm": {
+        "a": "LLL, h:mm a – h:mm a",
+        "h": "LLL, h:mm – h:mm a",
+        "m": "LLL, h:mm – h:mm a"
+      },
+      "MMMd, hm": {
+        "a": "d MMM, h:mm a – h:mm a",
+        "h": "d MMM, h:mm – h:mm a",
+        "m": "d MMM, h:mm – h:mm a"
+      },
+      "MMMEd, hm": {
+        "a": "E d MMM, h:mm a – h:mm a",
+        "h": "E d MMM, h:mm – h:mm a",
+        "m": "E d MMM, h:mm – h:mm a"
+      },
+      "MMMEEEEd, hm": {
+        "a": "EEEE d MMM, h:mm a – h:mm a",
+        "h": "EEEE d MMM, h:mm – h:mm a",
+        "m": "EEEE d MMM, h:mm – h:mm a"
+      },
+      "MMMMd, hm": {
+        "a": "d MMMM, h:mm a – h:mm a",
+        "h": "d MMMM, h:mm – h:mm a",
+        "m": "d MMMM, h:mm – h:mm a"
+      },
+      "MMMMEEEEd, hm": {
+        "a": "EEEE d MMMM, h:mm a – h:mm a",
+        "h": "EEEE d MMMM, h:mm – h:mm a",
+        "m": "EEEE d MMMM, h:mm – h:mm a"
+      },
+      "y, hm": {
+        "a": "y, h:mm a – h:mm a",
+        "h": "y, h:mm – h:mm a",
+        "m": "y, h:mm – h:mm a"
+      },
+      "yM, hm": {
+        "a": "MM/y, h:mm a – h:mm a",
+        "h": "MM/y, h:mm – h:mm a",
+        "m": "MM/y, h:mm – h:mm a"
+      },
+      "yMd, hm": {
+        "a": "dd/MM/y, h:mm a – h:mm a",
+        "h": "dd/MM/y, h:mm – h:mm a",
+        "m": "dd/MM/y, h:mm – h:mm a"
+      },
+      "yMEd, hm": {
+        "a": "E, dd/MM/y, h:mm a – h:mm a",
+        "h": "E, dd/MM/y, h:mm – h:mm a",
+        "m": "E, dd/MM/y, h:mm – h:mm a"
+      },
+      "yMMM, hm": {
+        "a": "MMM y, h:mm a – h:mm a",
+        "h": "MMM y, h:mm – h:mm a",
+        "m": "MMM y, h:mm – h:mm a"
+      },
+      "yMMMd, hm": {
+        "a": "d MMM y, h:mm a – h:mm a",
+        "h": "d MMM y, h:mm – h:mm a",
+        "m": "d MMM y, h:mm – h:mm a"
+      },
+      "yMMMEd, hm": {
+        "a": "E, d MMM y, h:mm a – h:mm a",
+        "h": "E, d MMM y, h:mm – h:mm a",
+        "m": "E, d MMM y, h:mm – h:mm a"
+      },
+      "yMMMEEEEd, hm": {
+        "a": "EEEE, d MMM y, h:mm a – h:mm a",
+        "h": "EEEE, d MMM y, h:mm – h:mm a",
+        "m": "EEEE, d MMM y, h:mm – h:mm a"
+      },
+      "yMMMM, hm": {
+        "a": "MMMM y, h:mm a – h:mm a",
+        "h": "MMMM y, h:mm – h:mm a",
+        "m": "MMMM y, h:mm – h:mm a"
+      },
+      "yMMMMEEEEd, hm": {
+        "a": "EEEE, d MMMM y, h:mm a – h:mm a",
+        "h": "EEEE, d MMMM y, h:mm – h:mm a",
+        "m": "EEEE, d MMMM y, h:mm – h:mm a"
+      },
+      "EEEE, d MMMM y, Hm": {
+        "H": "EEEE, d MMMM y, HH:mm–HH:mm",
+        "m": "EEEE, d MMMM y, HH:mm–HH:mm"
+      },
+      "d MMMM y, Hm": {
+        "H": "d MMMM y, HH:mm–HH:mm",
+        "m": "d MMMM y, HH:mm–HH:mm"
+      },
+      "d MMM y, Hm": {
+        "H": "d MMM y, HH:mm–HH:mm",
+        "m": "d MMM y, HH:mm–HH:mm"
+      },
+      "dd/MM/y, Hm": {
+        "H": "dd/MM/y, HH:mm–HH:mm",
+        "m": "dd/MM/y, HH:mm–HH:mm"
+      },
+      "d, Hm": {
+        "H": "d, HH:mm–HH:mm",
+        "m": "d, HH:mm–HH:mm"
+      },
+      "E, Hm": {
+        "H": "ccc, HH:mm–HH:mm",
+        "m": "ccc, HH:mm–HH:mm"
+      },
+      "Ed, Hm": {
+        "H": "E d, HH:mm–HH:mm",
+        "m": "E d, HH:mm–HH:mm"
+      },
+      "Gy, Hm": {
+        "H": "y G, HH:mm–HH:mm",
+        "m": "y G, HH:mm–HH:mm"
+      },
+      "GyM, Hm": {
+        "H": "M/y G, HH:mm–HH:mm",
+        "m": "M/y G, HH:mm–HH:mm"
+      },
+      "GyMd, Hm": {
+        "H": "dd/MM/y G, HH:mm–HH:mm",
+        "m": "dd/MM/y G, HH:mm–HH:mm"
+      },
+      "GyMEd, Hm": {
+        "H": "E, d/M/y G, HH:mm–HH:mm",
+        "m": "E, d/M/y G, HH:mm–HH:mm"
+      },
+      "GyMMM, Hm": {
+        "H": "MMM y G, HH:mm–HH:mm",
+        "m": "MMM y G, HH:mm–HH:mm"
+      },
+      "GyMMMd, Hm": {
+        "H": "d MMM y G, HH:mm–HH:mm",
+        "m": "d MMM y G, HH:mm–HH:mm"
+      },
+      "GyMMMEd, Hm": {
+        "H": "E, d MMM y G, HH:mm–HH:mm",
+        "m": "E, d MMM y G, HH:mm–HH:mm"
+      },
+      "GyMMMEEEEd, Hm": {
+        "H": "EEEE, d MMM y G, HH:mm–HH:mm",
+        "m": "EEEE, d MMM y G, HH:mm–HH:mm"
+      },
+      "M, Hm": {
+        "H": "L, HH:mm–HH:mm",
+        "m": "L, HH:mm–HH:mm"
+      },
+      "Md, Hm": {
+        "H": "dd/MM, HH:mm–HH:mm",
+        "m": "dd/MM, HH:mm–HH:mm"
+      },
+      "MEd, Hm": {
+        "H": "E dd/MM, HH:mm–HH:mm",
+        "m": "E dd/MM, HH:mm–HH:mm"
+      },
+      "MMdd, Hm": {
+        "H": "dd/MM, HH:mm–HH:mm",
+        "m": "dd/MM, HH:mm–HH:mm"
+      },
+      "MMM, Hm": {
+        "H": "LLL, HH:mm–HH:mm",
+        "m": "LLL, HH:mm–HH:mm"
+      },
+      "MMMd, Hm": {
+        "H": "d MMM, HH:mm–HH:mm",
+        "m": "d MMM, HH:mm–HH:mm"
+      },
+      "MMMEd, Hm": {
+        "H": "E d MMM, HH:mm–HH:mm",
+        "m": "E d MMM, HH:mm–HH:mm"
+      },
+      "MMMEEEEd, Hm": {
+        "H": "EEEE d MMM, HH:mm–HH:mm",
+        "m": "EEEE d MMM, HH:mm–HH:mm"
+      },
+      "MMMMd, Hm": {
+        "H": "d MMMM, HH:mm–HH:mm",
+        "m": "d MMMM, HH:mm–HH:mm"
+      },
+      "MMMMEEEEd, Hm": {
+        "H": "EEEE d MMMM, HH:mm–HH:mm",
+        "m": "EEEE d MMMM, HH:mm–HH:mm"
+      },
+      "y, Hm": {
+        "H": "y, HH:mm–HH:mm",
+        "m": "y, HH:mm–HH:mm"
+      },
+      "yM, Hm": {
+        "H": "MM/y, HH:mm–HH:mm",
+        "m": "MM/y, HH:mm–HH:mm"
+      },
+      "yMd, Hm": {
+        "H": "dd/MM/y, HH:mm–HH:mm",
+        "m": "dd/MM/y, HH:mm–HH:mm"
+      },
+      "yMEd, Hm": {
+        "H": "E, dd/MM/y, HH:mm–HH:mm",
+        "m": "E, dd/MM/y, HH:mm–HH:mm"
+      },
+      "yMMM, Hm": {
+        "H": "MMM y, HH:mm–HH:mm",
+        "m": "MMM y, HH:mm–HH:mm"
+      },
+      "yMMMd, Hm": {
+        "H": "d MMM y, HH:mm–HH:mm",
+        "m": "d MMM y, HH:mm–HH:mm"
+      },
+      "yMMMEd, Hm": {
+        "H": "E, d MMM y, HH:mm–HH:mm",
+        "m": "E, d MMM y, HH:mm–HH:mm"
+      },
+      "yMMMEEEEd, Hm": {
+        "H": "EEEE, d MMM y, HH:mm–HH:mm",
+        "m": "EEEE, d MMM y, HH:mm–HH:mm"
+      },
+      "yMMMM, Hm": {
+        "H": "MMMM y, HH:mm–HH:mm",
+        "m": "MMMM y, HH:mm–HH:mm"
+      },
+      "yMMMMEEEEd, Hm": {
+        "H": "EEEE, d MMMM y, HH:mm–HH:mm",
+        "m": "EEEE, d MMMM y, HH:mm–HH:mm"
+      },
+      "EEEE, d MMMM y, hmv": {
+        "a": "EEEE, d MMMM y, h:mm a – h:mm a v",
+        "h": "EEEE, d MMMM y, h:mm – h:mm a v",
+        "m": "EEEE, d MMMM y, h:mm – h:mm a v"
+      },
+      "d MMMM y, hmv": {
+        "a": "d MMMM y, h:mm a – h:mm a v",
+        "h": "d MMMM y, h:mm – h:mm a v",
+        "m": "d MMMM y, h:mm – h:mm a v"
+      },
+      "d MMM y, hmv": {
+        "a": "d MMM y, h:mm a – h:mm a v",
+        "h": "d MMM y, h:mm – h:mm a v",
+        "m": "d MMM y, h:mm – h:mm a v"
+      },
+      "dd/MM/y, hmv": {
+        "a": "dd/MM/y, h:mm a – h:mm a v",
+        "h": "dd/MM/y, h:mm – h:mm a v",
+        "m": "dd/MM/y, h:mm – h:mm a v"
+      },
+      "d, hmv": {
+        "a": "d, h:mm a – h:mm a v",
+        "h": "d, h:mm – h:mm a v",
+        "m": "d, h:mm – h:mm a v"
+      },
+      "E, hmv": {
+        "a": "ccc, h:mm a – h:mm a v",
+        "h": "ccc, h:mm – h:mm a v",
+        "m": "ccc, h:mm – h:mm a v"
+      },
+      "Ed, hmv": {
+        "a": "E d, h:mm a – h:mm a v",
+        "h": "E d, h:mm – h:mm a v",
+        "m": "E d, h:mm – h:mm a v"
+      },
+      "Gy, hmv": {
+        "a": "y G, h:mm a – h:mm a v",
+        "h": "y G, h:mm – h:mm a v",
+        "m": "y G, h:mm – h:mm a v"
+      },
+      "GyM, hmv": {
+        "a": "M/y G, h:mm a – h:mm a v",
+        "h": "M/y G, h:mm – h:mm a v",
+        "m": "M/y G, h:mm – h:mm a v"
+      },
+      "GyMd, hmv": {
+        "a": "dd/MM/y G, h:mm a – h:mm a v",
+        "h": "dd/MM/y G, h:mm – h:mm a v",
+        "m": "dd/MM/y G, h:mm – h:mm a v"
+      },
+      "GyMEd, hmv": {
+        "a": "E, d/M/y G, h:mm a – h:mm a v",
+        "h": "E, d/M/y G, h:mm – h:mm a v",
+        "m": "E, d/M/y G, h:mm – h:mm a v"
+      },
+      "GyMMM, hmv": {
+        "a": "MMM y G, h:mm a – h:mm a v",
+        "h": "MMM y G, h:mm – h:mm a v",
+        "m": "MMM y G, h:mm – h:mm a v"
+      },
+      "GyMMMd, hmv": {
+        "a": "d MMM y G, h:mm a – h:mm a v",
+        "h": "d MMM y G, h:mm – h:mm a v",
+        "m": "d MMM y G, h:mm – h:mm a v"
+      },
+      "GyMMMEd, hmv": {
+        "a": "E, d MMM y G, h:mm a – h:mm a v",
+        "h": "E, d MMM y G, h:mm – h:mm a v",
+        "m": "E, d MMM y G, h:mm – h:mm a v"
+      },
+      "GyMMMEEEEd, hmv": {
+        "a": "EEEE, d MMM y G, h:mm a – h:mm a v",
+        "h": "EEEE, d MMM y G, h:mm – h:mm a v",
+        "m": "EEEE, d MMM y G, h:mm – h:mm a v"
+      },
+      "M, hmv": {
+        "a": "L, h:mm a – h:mm a v",
+        "h": "L, h:mm – h:mm a v",
+        "m": "L, h:mm – h:mm a v"
+      },
+      "Md, hmv": {
+        "a": "dd/MM, h:mm a – h:mm a v",
+        "h": "dd/MM, h:mm – h:mm a v",
+        "m": "dd/MM, h:mm – h:mm a v"
+      },
+      "MEd, hmv": {
+        "a": "E dd/MM, h:mm a – h:mm a v",
+        "h": "E dd/MM, h:mm – h:mm a v",
+        "m": "E dd/MM, h:mm – h:mm a v"
+      },
+      "MMdd, hmv": {
+        "a": "dd/MM, h:mm a – h:mm a v",
+        "h": "dd/MM, h:mm – h:mm a v",
+        "m": "dd/MM, h:mm – h:mm a v"
+      },
+      "MMM, hmv": {
+        "a": "LLL, h:mm a – h:mm a v",
+        "h": "LLL, h:mm – h:mm a v",
+        "m": "LLL, h:mm – h:mm a v"
+      },
+      "MMMd, hmv": {
+        "a": "d MMM, h:mm a – h:mm a v",
+        "h": "d MMM, h:mm – h:mm a v",
+        "m": "d MMM, h:mm – h:mm a v"
+      },
+      "MMMEd, hmv": {
+        "a": "E d MMM, h:mm a – h:mm a v",
+        "h": "E d MMM, h:mm – h:mm a v",
+        "m": "E d MMM, h:mm – h:mm a v"
+      },
+      "MMMEEEEd, hmv": {
+        "a": "EEEE d MMM, h:mm a – h:mm a v",
+        "h": "EEEE d MMM, h:mm – h:mm a v",
+        "m": "EEEE d MMM, h:mm – h:mm a v"
+      },
+      "MMMMd, hmv": {
+        "a": "d MMMM, h:mm a – h:mm a v",
+        "h": "d MMMM, h:mm – h:mm a v",
+        "m": "d MMMM, h:mm – h:mm a v"
+      },
+      "MMMMEEEEd, hmv": {
+        "a": "EEEE d MMMM, h:mm a – h:mm a v",
+        "h": "EEEE d MMMM, h:mm – h:mm a v",
+        "m": "EEEE d MMMM, h:mm – h:mm a v"
+      },
+      "y, hmv": {
+        "a": "y, h:mm a – h:mm a v",
+        "h": "y, h:mm – h:mm a v",
+        "m": "y, h:mm – h:mm a v"
+      },
+      "yM, hmv": {
+        "a": "MM/y, h:mm a – h:mm a v",
+        "h": "MM/y, h:mm – h:mm a v",
+        "m": "MM/y, h:mm – h:mm a v"
+      },
+      "yMd, hmv": {
+        "a": "dd/MM/y, h:mm a – h:mm a v",
+        "h": "dd/MM/y, h:mm – h:mm a v",
+        "m": "dd/MM/y, h:mm – h:mm a v"
+      },
+      "yMEd, hmv": {
+        "a": "E, dd/MM/y, h:mm a – h:mm a v",
+        "h": "E, dd/MM/y, h:mm – h:mm a v",
+        "m": "E, dd/MM/y, h:mm – h:mm a v"
+      },
+      "yMMM, hmv": {
+        "a": "MMM y, h:mm a – h:mm a v",
+        "h": "MMM y, h:mm – h:mm a v",
+        "m": "MMM y, h:mm – h:mm a v"
+      },
+      "yMMMd, hmv": {
+        "a": "d MMM y, h:mm a – h:mm a v",
+        "h": "d MMM y, h:mm – h:mm a v",
+        "m": "d MMM y, h:mm – h:mm a v"
+      },
+      "yMMMEd, hmv": {
+        "a": "E, d MMM y, h:mm a – h:mm a v",
+        "h": "E, d MMM y, h:mm – h:mm a v",
+        "m": "E, d MMM y, h:mm – h:mm a v"
+      },
+      "yMMMEEEEd, hmv": {
+        "a": "EEEE, d MMM y, h:mm a – h:mm a v",
+        "h": "EEEE, d MMM y, h:mm – h:mm a v",
+        "m": "EEEE, d MMM y, h:mm – h:mm a v"
+      },
+      "yMMMM, hmv": {
+        "a": "MMMM y, h:mm a – h:mm a v",
+        "h": "MMMM y, h:mm – h:mm a v",
+        "m": "MMMM y, h:mm – h:mm a v"
+      },
+      "yMMMMEEEEd, hmv": {
+        "a": "EEEE, d MMMM y, h:mm a – h:mm a v",
+        "h": "EEEE, d MMMM y, h:mm – h:mm a v",
+        "m": "EEEE, d MMMM y, h:mm – h:mm a v"
+      },
+      "EEEE, d MMMM y, Hmv": {
+        "H": "EEEE, d MMMM y, HH:mm–HH:mm v",
+        "m": "EEEE, d MMMM y, HH:mm–HH:mm v"
+      },
+      "d MMMM y, Hmv": {
+        "H": "d MMMM y, HH:mm–HH:mm v",
+        "m": "d MMMM y, HH:mm–HH:mm v"
+      },
+      "d MMM y, Hmv": {
+        "H": "d MMM y, HH:mm–HH:mm v",
+        "m": "d MMM y, HH:mm–HH:mm v"
+      },
+      "dd/MM/y, Hmv": {
+        "H": "dd/MM/y, HH:mm–HH:mm v",
+        "m": "dd/MM/y, HH:mm–HH:mm v"
+      },
+      "d, Hmv": {
+        "H": "d, HH:mm–HH:mm v",
+        "m": "d, HH:mm–HH:mm v"
+      },
+      "E, Hmv": {
+        "H": "ccc, HH:mm–HH:mm v",
+        "m": "ccc, HH:mm–HH:mm v"
+      },
+      "Ed, Hmv": {
+        "H": "E d, HH:mm–HH:mm v",
+        "m": "E d, HH:mm–HH:mm v"
+      },
+      "Gy, Hmv": {
+        "H": "y G, HH:mm–HH:mm v",
+        "m": "y G, HH:mm–HH:mm v"
+      },
+      "GyM, Hmv": {
+        "H": "M/y G, HH:mm–HH:mm v",
+        "m": "M/y G, HH:mm–HH:mm v"
+      },
+      "GyMd, Hmv": {
+        "H": "dd/MM/y G, HH:mm–HH:mm v",
+        "m": "dd/MM/y G, HH:mm–HH:mm v"
+      },
+      "GyMEd, Hmv": {
+        "H": "E, d/M/y G, HH:mm–HH:mm v",
+        "m": "E, d/M/y G, HH:mm–HH:mm v"
+      },
+      "GyMMM, Hmv": {
+        "H": "MMM y G, HH:mm–HH:mm v",
+        "m": "MMM y G, HH:mm–HH:mm v"
+      },
+      "GyMMMd, Hmv": {
+        "H": "d MMM y G, HH:mm–HH:mm v",
+        "m": "d MMM y G, HH:mm–HH:mm v"
+      },
+      "GyMMMEd, Hmv": {
+        "H": "E, d MMM y G, HH:mm–HH:mm v",
+        "m": "E, d MMM y G, HH:mm–HH:mm v"
+      },
+      "GyMMMEEEEd, Hmv": {
+        "H": "EEEE, d MMM y G, HH:mm–HH:mm v",
+        "m": "EEEE, d MMM y G, HH:mm–HH:mm v"
+      },
+      "M, Hmv": {
+        "H": "L, HH:mm–HH:mm v",
+        "m": "L, HH:mm–HH:mm v"
+      },
+      "Md, Hmv": {
+        "H": "dd/MM, HH:mm–HH:mm v",
+        "m": "dd/MM, HH:mm–HH:mm v"
+      },
+      "MEd, Hmv": {
+        "H": "E dd/MM, HH:mm–HH:mm v",
+        "m": "E dd/MM, HH:mm–HH:mm v"
+      },
+      "MMdd, Hmv": {
+        "H": "dd/MM, HH:mm–HH:mm v",
+        "m": "dd/MM, HH:mm–HH:mm v"
+      },
+      "MMM, Hmv": {
+        "H": "LLL, HH:mm–HH:mm v",
+        "m": "LLL, HH:mm–HH:mm v"
+      },
+      "MMMd, Hmv": {
+        "H": "d MMM, HH:mm–HH:mm v",
+        "m": "d MMM, HH:mm–HH:mm v"
+      },
+      "MMMEd, Hmv": {
+        "H": "E d MMM, HH:mm–HH:mm v",
+        "m": "E d MMM, HH:mm–HH:mm v"
+      },
+      "MMMEEEEd, Hmv": {
+        "H": "EEEE d MMM, HH:mm–HH:mm v",
+        "m": "EEEE d MMM, HH:mm–HH:mm v"
+      },
+      "MMMMd, Hmv": {
+        "H": "d MMMM, HH:mm–HH:mm v",
+        "m": "d MMMM, HH:mm–HH:mm v"
+      },
+      "MMMMEEEEd, Hmv": {
+        "H": "EEEE d MMMM, HH:mm–HH:mm v",
+        "m": "EEEE d MMMM, HH:mm–HH:mm v"
+      },
+      "y, Hmv": {
+        "H": "y, HH:mm–HH:mm v",
+        "m": "y, HH:mm–HH:mm v"
+      },
+      "yM, Hmv": {
+        "H": "MM/y, HH:mm–HH:mm v",
+        "m": "MM/y, HH:mm–HH:mm v"
+      },
+      "yMd, Hmv": {
+        "H": "dd/MM/y, HH:mm–HH:mm v",
+        "m": "dd/MM/y, HH:mm–HH:mm v"
+      },
+      "yMEd, Hmv": {
+        "H": "E, dd/MM/y, HH:mm–HH:mm v",
+        "m": "E, dd/MM/y, HH:mm–HH:mm v"
+      },
+      "yMMM, Hmv": {
+        "H": "MMM y, HH:mm–HH:mm v",
+        "m": "MMM y, HH:mm–HH:mm v"
+      },
+      "yMMMd, Hmv": {
+        "H": "d MMM y, HH:mm–HH:mm v",
+        "m": "d MMM y, HH:mm–HH:mm v"
+      },
+      "yMMMEd, Hmv": {
+        "H": "E, d MMM y, HH:mm–HH:mm v",
+        "m": "E, d MMM y, HH:mm–HH:mm v"
+      },
+      "yMMMEEEEd, Hmv": {
+        "H": "EEEE, d MMM y, HH:mm–HH:mm v",
+        "m": "EEEE, d MMM y, HH:mm–HH:mm v"
+      },
+      "yMMMM, Hmv": {
+        "H": "MMMM y, HH:mm–HH:mm v",
+        "m": "MMMM y, HH:mm–HH:mm v"
+      },
+      "yMMMMEEEEd, Hmv": {
+        "H": "EEEE, d MMMM y, HH:mm–HH:mm v",
+        "m": "EEEE, d MMMM y, HH:mm–HH:mm v"
+      },
+      "EEEE, d MMMM y, hv": {
+        "a": "EEEE, d MMMM y, h a – h a v",
+        "h": "EEEE, d MMMM y, h–h a v"
+      },
+      "d MMMM y, hv": {
+        "a": "d MMMM y, h a – h a v",
+        "h": "d MMMM y, h–h a v"
+      },
+      "d MMM y, hv": {
+        "a": "d MMM y, h a – h a v",
+        "h": "d MMM y, h–h a v"
+      },
+      "dd/MM/y, hv": {
+        "a": "dd/MM/y, h a – h a v",
+        "h": "dd/MM/y, h–h a v"
+      },
+      "d, hv": {
+        "a": "d, h a – h a v",
+        "h": "d, h–h a v"
+      },
+      "E, hv": {
+        "a": "ccc, h a – h a v",
+        "h": "ccc, h–h a v"
+      },
+      "Ed, hv": {
+        "a": "E d, h a – h a v",
+        "h": "E d, h–h a v"
+      },
+      "Gy, hv": {
+        "a": "y G, h a – h a v",
+        "h": "y G, h–h a v"
+      },
+      "GyM, hv": {
+        "a": "M/y G, h a – h a v",
+        "h": "M/y G, h–h a v"
+      },
+      "GyMd, hv": {
+        "a": "dd/MM/y G, h a – h a v",
+        "h": "dd/MM/y G, h–h a v"
+      },
+      "GyMEd, hv": {
+        "a": "E, d/M/y G, h a – h a v",
+        "h": "E, d/M/y G, h–h a v"
+      },
+      "GyMMM, hv": {
+        "a": "MMM y G, h a – h a v",
+        "h": "MMM y G, h–h a v"
+      },
+      "GyMMMd, hv": {
+        "a": "d MMM y G, h a – h a v",
+        "h": "d MMM y G, h–h a v"
+      },
+      "GyMMMEd, hv": {
+        "a": "E, d MMM y G, h a – h a v",
+        "h": "E, d MMM y G, h–h a v"
+      },
+      "GyMMMEEEEd, hv": {
+        "a": "EEEE, d MMM y G, h a – h a v",
+        "h": "EEEE, d MMM y G, h–h a v"
+      },
+      "M, hv": {
+        "a": "L, h a – h a v",
+        "h": "L, h–h a v"
+      },
+      "Md, hv": {
+        "a": "dd/MM, h a – h a v",
+        "h": "dd/MM, h–h a v"
+      },
+      "MEd, hv": {
+        "a": "E dd/MM, h a – h a v",
+        "h": "E dd/MM, h–h a v"
+      },
+      "MMdd, hv": {
+        "a": "dd/MM, h a – h a v",
+        "h": "dd/MM, h–h a v"
+      },
+      "MMM, hv": {
+        "a": "LLL, h a – h a v",
+        "h": "LLL, h–h a v"
+      },
+      "MMMd, hv": {
+        "a": "d MMM, h a – h a v",
+        "h": "d MMM, h–h a v"
+      },
+      "MMMEd, hv": {
+        "a": "E d MMM, h a – h a v",
+        "h": "E d MMM, h–h a v"
+      },
+      "MMMEEEEd, hv": {
+        "a": "EEEE d MMM, h a – h a v",
+        "h": "EEEE d MMM, h–h a v"
+      },
+      "MMMMd, hv": {
+        "a": "d MMMM, h a – h a v",
+        "h": "d MMMM, h–h a v"
+      },
+      "MMMMEEEEd, hv": {
+        "a": "EEEE d MMMM, h a – h a v",
+        "h": "EEEE d MMMM, h–h a v"
+      },
+      "y, hv": {
+        "a": "y, h a – h a v",
+        "h": "y, h–h a v"
+      },
+      "yM, hv": {
+        "a": "MM/y, h a – h a v",
+        "h": "MM/y, h–h a v"
+      },
+      "yMd, hv": {
+        "a": "dd/MM/y, h a – h a v",
+        "h": "dd/MM/y, h–h a v"
+      },
+      "yMEd, hv": {
+        "a": "E, dd/MM/y, h a – h a v",
+        "h": "E, dd/MM/y, h–h a v"
+      },
+      "yMMM, hv": {
+        "a": "MMM y, h a – h a v",
+        "h": "MMM y, h–h a v"
+      },
+      "yMMMd, hv": {
+        "a": "d MMM y, h a – h a v",
+        "h": "d MMM y, h–h a v"
+      },
+      "yMMMEd, hv": {
+        "a": "E, d MMM y, h a – h a v",
+        "h": "E, d MMM y, h–h a v"
+      },
+      "yMMMEEEEd, hv": {
+        "a": "EEEE, d MMM y, h a – h a v",
+        "h": "EEEE, d MMM y, h–h a v"
+      },
+      "yMMMM, hv": {
+        "a": "MMMM y, h a – h a v",
+        "h": "MMMM y, h–h a v"
+      },
+      "yMMMMEEEEd, hv": {
+        "a": "EEEE, d MMMM y, h a – h a v",
+        "h": "EEEE, d MMMM y, h–h a v"
+      },
+      "EEEE, d MMMM y, Hv": {
+        "H": "EEEE, d MMMM y, HH–HH v"
+      },
+      "d MMMM y, Hv": {
+        "H": "d MMMM y, HH–HH v"
+      },
+      "d MMM y, Hv": {
+        "H": "d MMM y, HH–HH v"
+      },
+      "dd/MM/y, Hv": {
+        "H": "dd/MM/y, HH–HH v"
+      },
+      "d, Hv": {
+        "H": "d, HH–HH v"
+      },
+      "E, Hv": {
+        "H": "ccc, HH–HH v"
+      },
+      "Ed, Hv": {
+        "H": "E d, HH–HH v"
+      },
+      "Gy, Hv": {
+        "H": "y G, HH–HH v"
+      },
+      "GyM, Hv": {
+        "H": "M/y G, HH–HH v"
+      },
+      "GyMd, Hv": {
+        "H": "dd/MM/y G, HH–HH v"
+      },
+      "GyMEd, Hv": {
+        "H": "E, d/M/y G, HH–HH v"
+      },
+      "GyMMM, Hv": {
+        "H": "MMM y G, HH–HH v"
+      },
+      "GyMMMd, Hv": {
+        "H": "d MMM y G, HH–HH v"
+      },
+      "GyMMMEd, Hv": {
+        "H": "E, d MMM y G, HH–HH v"
+      },
+      "GyMMMEEEEd, Hv": {
+        "H": "EEEE, d MMM y G, HH–HH v"
+      },
+      "M, Hv": {
+        "H": "L, HH–HH v"
+      },
+      "Md, Hv": {
+        "H": "dd/MM, HH–HH v"
+      },
+      "MEd, Hv": {
+        "H": "E dd/MM, HH–HH v"
+      },
+      "MMdd, Hv": {
+        "H": "dd/MM, HH–HH v"
+      },
+      "MMM, Hv": {
+        "H": "LLL, HH–HH v"
+      },
+      "MMMd, Hv": {
+        "H": "d MMM, HH–HH v"
+      },
+      "MMMEd, Hv": {
+        "H": "E d MMM, HH–HH v"
+      },
+      "MMMEEEEd, Hv": {
+        "H": "EEEE d MMM, HH–HH v"
+      },
+      "MMMMd, Hv": {
+        "H": "d MMMM, HH–HH v"
+      },
+      "MMMMEEEEd, Hv": {
+        "H": "EEEE d MMMM, HH–HH v"
+      },
+      "y, Hv": {
+        "H": "y, HH–HH v"
+      },
+      "yM, Hv": {
+        "H": "MM/y, HH–HH v"
+      },
+      "yMd, Hv": {
+        "H": "dd/MM/y, HH–HH v"
+      },
+      "yMEd, Hv": {
+        "H": "E, dd/MM/y, HH–HH v"
+      },
+      "yMMM, Hv": {
+        "H": "MMM y, HH–HH v"
+      },
+      "yMMMd, Hv": {
+        "H": "d MMM y, HH–HH v"
+      },
+      "yMMMEd, Hv": {
+        "H": "E, d MMM y, HH–HH v"
+      },
+      "yMMMEEEEd, Hv": {
+        "H": "EEEE, d MMM y, HH–HH v"
+      },
+      "yMMMM, Hv": {
+        "H": "MMMM y, HH–HH v"
+      },
+      "yMMMMEEEEd, Hv": {
+        "H": "EEEE, d MMMM y, HH–HH v"
       }
     },
     "hourCycle": "h23",

--- a/packages/intl-datetimeformat/tests/locale-data/en.json
+++ b/packages/intl-datetimeformat/tests/locale-data/en.json
@@ -2929,6 +2929,1195 @@
       "yMMMM": {
         "M": "MMMM – MMMM y",
         "y": "MMMM y – MMMM y"
+      },
+      "EEEE, MMMM d, y, Bh": {
+        "B": "EEEE, MMMM d, y, h B – h B",
+        "h": "EEEE, MMMM d, y, h – h B"
+      },
+      "MMMM d, y, Bh": {
+        "B": "MMMM d, y, h B – h B",
+        "h": "MMMM d, y, h – h B"
+      },
+      "MMM d, y, Bh": {
+        "B": "MMM d, y, h B – h B",
+        "h": "MMM d, y, h – h B"
+      },
+      "M/d/yy, Bh": {
+        "B": "M/d/yy, h B – h B",
+        "h": "M/d/yy, h – h B"
+      },
+      "d, Bh": {
+        "B": "d, h B – h B",
+        "h": "d, h – h B"
+      },
+      "E, Bh": {
+        "B": "ccc, h B – h B",
+        "h": "ccc, h – h B"
+      },
+      "Ed, Bh": {
+        "B": "d E, h B – h B",
+        "h": "d E, h – h B"
+      },
+      "Gy, Bh": {
+        "B": "y G, h B – h B",
+        "h": "y G, h – h B"
+      },
+      "GyM, Bh": {
+        "B": "M/y G, h B – h B",
+        "h": "M/y G, h – h B"
+      },
+      "GyMd, Bh": {
+        "B": "M/d/y G, h B – h B",
+        "h": "M/d/y G, h – h B"
+      },
+      "GyMEd, Bh": {
+        "B": "E, M/d/y G, h B – h B",
+        "h": "E, M/d/y G, h – h B"
+      },
+      "GyMMM, Bh": {
+        "B": "MMM y G, h B – h B",
+        "h": "MMM y G, h – h B"
+      },
+      "GyMMMd, Bh": {
+        "B": "MMM d, y G, h B – h B",
+        "h": "MMM d, y G, h – h B"
+      },
+      "GyMMMEd, Bh": {
+        "B": "E, MMM d, y G, h B – h B",
+        "h": "E, MMM d, y G, h – h B"
+      },
+      "M, Bh": {
+        "B": "L, h B – h B",
+        "h": "L, h – h B"
+      },
+      "Md, Bh": {
+        "B": "M/d, h B – h B",
+        "h": "M/d, h – h B"
+      },
+      "MEd, Bh": {
+        "B": "E, M/d, h B – h B",
+        "h": "E, M/d, h – h B"
+      },
+      "MMM, Bh": {
+        "B": "LLL, h B – h B",
+        "h": "LLL, h – h B"
+      },
+      "MMMd, Bh": {
+        "B": "MMM d, h B – h B",
+        "h": "MMM d, h – h B"
+      },
+      "MMMEd, Bh": {
+        "B": "E, MMM d, h B – h B",
+        "h": "E, MMM d, h – h B"
+      },
+      "MMMMd, Bh": {
+        "B": "MMMM d, h B – h B",
+        "h": "MMMM d, h – h B"
+      },
+      "y, Bh": {
+        "B": "y, h B – h B",
+        "h": "y, h – h B"
+      },
+      "yM, Bh": {
+        "B": "M/y, h B – h B",
+        "h": "M/y, h – h B"
+      },
+      "yMd, Bh": {
+        "B": "M/d/y, h B – h B",
+        "h": "M/d/y, h – h B"
+      },
+      "yMEd, Bh": {
+        "B": "E, M/d/y, h B – h B",
+        "h": "E, M/d/y, h – h B"
+      },
+      "yMMM, Bh": {
+        "B": "MMM y, h B – h B",
+        "h": "MMM y, h – h B"
+      },
+      "yMMMd, Bh": {
+        "B": "MMM d, y, h B – h B",
+        "h": "MMM d, y, h – h B"
+      },
+      "yMMMEd, Bh": {
+        "B": "E, MMM d, y, h B – h B",
+        "h": "E, MMM d, y, h – h B"
+      },
+      "yMMMM, Bh": {
+        "B": "MMMM y, h B – h B",
+        "h": "MMMM y, h – h B"
+      },
+      "EEEE, MMMM d, y, Bhm": {
+        "B": "EEEE, MMMM d, y, h:mm B – h:mm B",
+        "h": "EEEE, MMMM d, y, h:mm – h:mm B",
+        "m": "EEEE, MMMM d, y, h:mm – h:mm B"
+      },
+      "MMMM d, y, Bhm": {
+        "B": "MMMM d, y, h:mm B – h:mm B",
+        "h": "MMMM d, y, h:mm – h:mm B",
+        "m": "MMMM d, y, h:mm – h:mm B"
+      },
+      "MMM d, y, Bhm": {
+        "B": "MMM d, y, h:mm B – h:mm B",
+        "h": "MMM d, y, h:mm – h:mm B",
+        "m": "MMM d, y, h:mm – h:mm B"
+      },
+      "M/d/yy, Bhm": {
+        "B": "M/d/yy, h:mm B – h:mm B",
+        "h": "M/d/yy, h:mm – h:mm B",
+        "m": "M/d/yy, h:mm – h:mm B"
+      },
+      "d, Bhm": {
+        "B": "d, h:mm B – h:mm B",
+        "h": "d, h:mm – h:mm B",
+        "m": "d, h:mm – h:mm B"
+      },
+      "E, Bhm": {
+        "B": "ccc, h:mm B – h:mm B",
+        "h": "ccc, h:mm – h:mm B",
+        "m": "ccc, h:mm – h:mm B"
+      },
+      "Ed, Bhm": {
+        "B": "d E, h:mm B – h:mm B",
+        "h": "d E, h:mm – h:mm B",
+        "m": "d E, h:mm – h:mm B"
+      },
+      "Gy, Bhm": {
+        "B": "y G, h:mm B – h:mm B",
+        "h": "y G, h:mm – h:mm B",
+        "m": "y G, h:mm – h:mm B"
+      },
+      "GyM, Bhm": {
+        "B": "M/y G, h:mm B – h:mm B",
+        "h": "M/y G, h:mm – h:mm B",
+        "m": "M/y G, h:mm – h:mm B"
+      },
+      "GyMd, Bhm": {
+        "B": "M/d/y G, h:mm B – h:mm B",
+        "h": "M/d/y G, h:mm – h:mm B",
+        "m": "M/d/y G, h:mm – h:mm B"
+      },
+      "GyMEd, Bhm": {
+        "B": "E, M/d/y G, h:mm B – h:mm B",
+        "h": "E, M/d/y G, h:mm – h:mm B",
+        "m": "E, M/d/y G, h:mm – h:mm B"
+      },
+      "GyMMM, Bhm": {
+        "B": "MMM y G, h:mm B – h:mm B",
+        "h": "MMM y G, h:mm – h:mm B",
+        "m": "MMM y G, h:mm – h:mm B"
+      },
+      "GyMMMd, Bhm": {
+        "B": "MMM d, y G, h:mm B – h:mm B",
+        "h": "MMM d, y G, h:mm – h:mm B",
+        "m": "MMM d, y G, h:mm – h:mm B"
+      },
+      "GyMMMEd, Bhm": {
+        "B": "E, MMM d, y G, h:mm B – h:mm B",
+        "h": "E, MMM d, y G, h:mm – h:mm B",
+        "m": "E, MMM d, y G, h:mm – h:mm B"
+      },
+      "M, Bhm": {
+        "B": "L, h:mm B – h:mm B",
+        "h": "L, h:mm – h:mm B",
+        "m": "L, h:mm – h:mm B"
+      },
+      "Md, Bhm": {
+        "B": "M/d, h:mm B – h:mm B",
+        "h": "M/d, h:mm – h:mm B",
+        "m": "M/d, h:mm – h:mm B"
+      },
+      "MEd, Bhm": {
+        "B": "E, M/d, h:mm B – h:mm B",
+        "h": "E, M/d, h:mm – h:mm B",
+        "m": "E, M/d, h:mm – h:mm B"
+      },
+      "MMM, Bhm": {
+        "B": "LLL, h:mm B – h:mm B",
+        "h": "LLL, h:mm – h:mm B",
+        "m": "LLL, h:mm – h:mm B"
+      },
+      "MMMd, Bhm": {
+        "B": "MMM d, h:mm B – h:mm B",
+        "h": "MMM d, h:mm – h:mm B",
+        "m": "MMM d, h:mm – h:mm B"
+      },
+      "MMMEd, Bhm": {
+        "B": "E, MMM d, h:mm B – h:mm B",
+        "h": "E, MMM d, h:mm – h:mm B",
+        "m": "E, MMM d, h:mm – h:mm B"
+      },
+      "MMMMd, Bhm": {
+        "B": "MMMM d, h:mm B – h:mm B",
+        "h": "MMMM d, h:mm – h:mm B",
+        "m": "MMMM d, h:mm – h:mm B"
+      },
+      "y, Bhm": {
+        "B": "y, h:mm B – h:mm B",
+        "h": "y, h:mm – h:mm B",
+        "m": "y, h:mm – h:mm B"
+      },
+      "yM, Bhm": {
+        "B": "M/y, h:mm B – h:mm B",
+        "h": "M/y, h:mm – h:mm B",
+        "m": "M/y, h:mm – h:mm B"
+      },
+      "yMd, Bhm": {
+        "B": "M/d/y, h:mm B – h:mm B",
+        "h": "M/d/y, h:mm – h:mm B",
+        "m": "M/d/y, h:mm – h:mm B"
+      },
+      "yMEd, Bhm": {
+        "B": "E, M/d/y, h:mm B – h:mm B",
+        "h": "E, M/d/y, h:mm – h:mm B",
+        "m": "E, M/d/y, h:mm – h:mm B"
+      },
+      "yMMM, Bhm": {
+        "B": "MMM y, h:mm B – h:mm B",
+        "h": "MMM y, h:mm – h:mm B",
+        "m": "MMM y, h:mm – h:mm B"
+      },
+      "yMMMd, Bhm": {
+        "B": "MMM d, y, h:mm B – h:mm B",
+        "h": "MMM d, y, h:mm – h:mm B",
+        "m": "MMM d, y, h:mm – h:mm B"
+      },
+      "yMMMEd, Bhm": {
+        "B": "E, MMM d, y, h:mm B – h:mm B",
+        "h": "E, MMM d, y, h:mm – h:mm B",
+        "m": "E, MMM d, y, h:mm – h:mm B"
+      },
+      "yMMMM, Bhm": {
+        "B": "MMMM y, h:mm B – h:mm B",
+        "h": "MMMM y, h:mm – h:mm B",
+        "m": "MMMM y, h:mm – h:mm B"
+      },
+      "EEEE, MMMM d, y, h": {
+        "a": "EEEE, MMMM d, y, h a – h a",
+        "h": "EEEE, MMMM d, y, h – h a"
+      },
+      "MMMM d, y, h": {
+        "a": "MMMM d, y, h a – h a",
+        "h": "MMMM d, y, h – h a"
+      },
+      "MMM d, y, h": {
+        "a": "MMM d, y, h a – h a",
+        "h": "MMM d, y, h – h a"
+      },
+      "M/d/yy, h": {
+        "a": "M/d/yy, h a – h a",
+        "h": "M/d/yy, h – h a"
+      },
+      "d, h": {
+        "a": "d, h a – h a",
+        "h": "d, h – h a"
+      },
+      "E, h": {
+        "a": "ccc, h a – h a",
+        "h": "ccc, h – h a"
+      },
+      "Ed, h": {
+        "a": "d E, h a – h a",
+        "h": "d E, h – h a"
+      },
+      "Gy, h": {
+        "a": "y G, h a – h a",
+        "h": "y G, h – h a"
+      },
+      "GyM, h": {
+        "a": "M/y G, h a – h a",
+        "h": "M/y G, h – h a"
+      },
+      "GyMd, h": {
+        "a": "M/d/y G, h a – h a",
+        "h": "M/d/y G, h – h a"
+      },
+      "GyMEd, h": {
+        "a": "E, M/d/y G, h a – h a",
+        "h": "E, M/d/y G, h – h a"
+      },
+      "GyMMM, h": {
+        "a": "MMM y G, h a – h a",
+        "h": "MMM y G, h – h a"
+      },
+      "GyMMMd, h": {
+        "a": "MMM d, y G, h a – h a",
+        "h": "MMM d, y G, h – h a"
+      },
+      "GyMMMEd, h": {
+        "a": "E, MMM d, y G, h a – h a",
+        "h": "E, MMM d, y G, h – h a"
+      },
+      "M, h": {
+        "a": "L, h a – h a",
+        "h": "L, h – h a"
+      },
+      "Md, h": {
+        "a": "M/d, h a – h a",
+        "h": "M/d, h – h a"
+      },
+      "MEd, h": {
+        "a": "E, M/d, h a – h a",
+        "h": "E, M/d, h – h a"
+      },
+      "MMM, h": {
+        "a": "LLL, h a – h a",
+        "h": "LLL, h – h a"
+      },
+      "MMMd, h": {
+        "a": "MMM d, h a – h a",
+        "h": "MMM d, h – h a"
+      },
+      "MMMEd, h": {
+        "a": "E, MMM d, h a – h a",
+        "h": "E, MMM d, h – h a"
+      },
+      "MMMMd, h": {
+        "a": "MMMM d, h a – h a",
+        "h": "MMMM d, h – h a"
+      },
+      "y, h": {
+        "a": "y, h a – h a",
+        "h": "y, h – h a"
+      },
+      "yM, h": {
+        "a": "M/y, h a – h a",
+        "h": "M/y, h – h a"
+      },
+      "yMd, h": {
+        "a": "M/d/y, h a – h a",
+        "h": "M/d/y, h – h a"
+      },
+      "yMEd, h": {
+        "a": "E, M/d/y, h a – h a",
+        "h": "E, M/d/y, h – h a"
+      },
+      "yMMM, h": {
+        "a": "MMM y, h a – h a",
+        "h": "MMM y, h – h a"
+      },
+      "yMMMd, h": {
+        "a": "MMM d, y, h a – h a",
+        "h": "MMM d, y, h – h a"
+      },
+      "yMMMEd, h": {
+        "a": "E, MMM d, y, h a – h a",
+        "h": "E, MMM d, y, h – h a"
+      },
+      "yMMMM, h": {
+        "a": "MMMM y, h a – h a",
+        "h": "MMMM y, h – h a"
+      },
+      "EEEE, MMMM d, y, H": {
+        "H": "EEEE, MMMM d, y, HH – HH"
+      },
+      "MMMM d, y, H": {
+        "H": "MMMM d, y, HH – HH"
+      },
+      "MMM d, y, H": {
+        "H": "MMM d, y, HH – HH"
+      },
+      "M/d/yy, H": {
+        "H": "M/d/yy, HH – HH"
+      },
+      "d, H": {
+        "H": "d, HH – HH"
+      },
+      "E, H": {
+        "H": "ccc, HH – HH"
+      },
+      "Ed, H": {
+        "H": "d E, HH – HH"
+      },
+      "Gy, H": {
+        "H": "y G, HH – HH"
+      },
+      "GyM, H": {
+        "H": "M/y G, HH – HH"
+      },
+      "GyMd, H": {
+        "H": "M/d/y G, HH – HH"
+      },
+      "GyMEd, H": {
+        "H": "E, M/d/y G, HH – HH"
+      },
+      "GyMMM, H": {
+        "H": "MMM y G, HH – HH"
+      },
+      "GyMMMd, H": {
+        "H": "MMM d, y G, HH – HH"
+      },
+      "GyMMMEd, H": {
+        "H": "E, MMM d, y G, HH – HH"
+      },
+      "M, H": {
+        "H": "L, HH – HH"
+      },
+      "Md, H": {
+        "H": "M/d, HH – HH"
+      },
+      "MEd, H": {
+        "H": "E, M/d, HH – HH"
+      },
+      "MMM, H": {
+        "H": "LLL, HH – HH"
+      },
+      "MMMd, H": {
+        "H": "MMM d, HH – HH"
+      },
+      "MMMEd, H": {
+        "H": "E, MMM d, HH – HH"
+      },
+      "MMMMd, H": {
+        "H": "MMMM d, HH – HH"
+      },
+      "y, H": {
+        "H": "y, HH – HH"
+      },
+      "yM, H": {
+        "H": "M/y, HH – HH"
+      },
+      "yMd, H": {
+        "H": "M/d/y, HH – HH"
+      },
+      "yMEd, H": {
+        "H": "E, M/d/y, HH – HH"
+      },
+      "yMMM, H": {
+        "H": "MMM y, HH – HH"
+      },
+      "yMMMd, H": {
+        "H": "MMM d, y, HH – HH"
+      },
+      "yMMMEd, H": {
+        "H": "E, MMM d, y, HH – HH"
+      },
+      "yMMMM, H": {
+        "H": "MMMM y, HH – HH"
+      },
+      "EEEE, MMMM d, y, hm": {
+        "a": "EEEE, MMMM d, y, h:mm a – h:mm a",
+        "h": "EEEE, MMMM d, y, h:mm – h:mm a",
+        "m": "EEEE, MMMM d, y, h:mm – h:mm a"
+      },
+      "MMMM d, y, hm": {
+        "a": "MMMM d, y, h:mm a – h:mm a",
+        "h": "MMMM d, y, h:mm – h:mm a",
+        "m": "MMMM d, y, h:mm – h:mm a"
+      },
+      "MMM d, y, hm": {
+        "a": "MMM d, y, h:mm a – h:mm a",
+        "h": "MMM d, y, h:mm – h:mm a",
+        "m": "MMM d, y, h:mm – h:mm a"
+      },
+      "M/d/yy, hm": {
+        "a": "M/d/yy, h:mm a – h:mm a",
+        "h": "M/d/yy, h:mm – h:mm a",
+        "m": "M/d/yy, h:mm – h:mm a"
+      },
+      "d, hm": {
+        "a": "d, h:mm a – h:mm a",
+        "h": "d, h:mm – h:mm a",
+        "m": "d, h:mm – h:mm a"
+      },
+      "E, hm": {
+        "a": "ccc, h:mm a – h:mm a",
+        "h": "ccc, h:mm – h:mm a",
+        "m": "ccc, h:mm – h:mm a"
+      },
+      "Ed, hm": {
+        "a": "d E, h:mm a – h:mm a",
+        "h": "d E, h:mm – h:mm a",
+        "m": "d E, h:mm – h:mm a"
+      },
+      "Gy, hm": {
+        "a": "y G, h:mm a – h:mm a",
+        "h": "y G, h:mm – h:mm a",
+        "m": "y G, h:mm – h:mm a"
+      },
+      "GyM, hm": {
+        "a": "M/y G, h:mm a – h:mm a",
+        "h": "M/y G, h:mm – h:mm a",
+        "m": "M/y G, h:mm – h:mm a"
+      },
+      "GyMd, hm": {
+        "a": "M/d/y G, h:mm a – h:mm a",
+        "h": "M/d/y G, h:mm – h:mm a",
+        "m": "M/d/y G, h:mm – h:mm a"
+      },
+      "GyMEd, hm": {
+        "a": "E, M/d/y G, h:mm a – h:mm a",
+        "h": "E, M/d/y G, h:mm – h:mm a",
+        "m": "E, M/d/y G, h:mm – h:mm a"
+      },
+      "GyMMM, hm": {
+        "a": "MMM y G, h:mm a – h:mm a",
+        "h": "MMM y G, h:mm – h:mm a",
+        "m": "MMM y G, h:mm – h:mm a"
+      },
+      "GyMMMd, hm": {
+        "a": "MMM d, y G, h:mm a – h:mm a",
+        "h": "MMM d, y G, h:mm – h:mm a",
+        "m": "MMM d, y G, h:mm – h:mm a"
+      },
+      "GyMMMEd, hm": {
+        "a": "E, MMM d, y G, h:mm a – h:mm a",
+        "h": "E, MMM d, y G, h:mm – h:mm a",
+        "m": "E, MMM d, y G, h:mm – h:mm a"
+      },
+      "M, hm": {
+        "a": "L, h:mm a – h:mm a",
+        "h": "L, h:mm – h:mm a",
+        "m": "L, h:mm – h:mm a"
+      },
+      "Md, hm": {
+        "a": "M/d, h:mm a – h:mm a",
+        "h": "M/d, h:mm – h:mm a",
+        "m": "M/d, h:mm – h:mm a"
+      },
+      "MEd, hm": {
+        "a": "E, M/d, h:mm a – h:mm a",
+        "h": "E, M/d, h:mm – h:mm a",
+        "m": "E, M/d, h:mm – h:mm a"
+      },
+      "MMM, hm": {
+        "a": "LLL, h:mm a – h:mm a",
+        "h": "LLL, h:mm – h:mm a",
+        "m": "LLL, h:mm – h:mm a"
+      },
+      "MMMd, hm": {
+        "a": "MMM d, h:mm a – h:mm a",
+        "h": "MMM d, h:mm – h:mm a",
+        "m": "MMM d, h:mm – h:mm a"
+      },
+      "MMMEd, hm": {
+        "a": "E, MMM d, h:mm a – h:mm a",
+        "h": "E, MMM d, h:mm – h:mm a",
+        "m": "E, MMM d, h:mm – h:mm a"
+      },
+      "MMMMd, hm": {
+        "a": "MMMM d, h:mm a – h:mm a",
+        "h": "MMMM d, h:mm – h:mm a",
+        "m": "MMMM d, h:mm – h:mm a"
+      },
+      "y, hm": {
+        "a": "y, h:mm a – h:mm a",
+        "h": "y, h:mm – h:mm a",
+        "m": "y, h:mm – h:mm a"
+      },
+      "yM, hm": {
+        "a": "M/y, h:mm a – h:mm a",
+        "h": "M/y, h:mm – h:mm a",
+        "m": "M/y, h:mm – h:mm a"
+      },
+      "yMd, hm": {
+        "a": "M/d/y, h:mm a – h:mm a",
+        "h": "M/d/y, h:mm – h:mm a",
+        "m": "M/d/y, h:mm – h:mm a"
+      },
+      "yMEd, hm": {
+        "a": "E, M/d/y, h:mm a – h:mm a",
+        "h": "E, M/d/y, h:mm – h:mm a",
+        "m": "E, M/d/y, h:mm – h:mm a"
+      },
+      "yMMM, hm": {
+        "a": "MMM y, h:mm a – h:mm a",
+        "h": "MMM y, h:mm – h:mm a",
+        "m": "MMM y, h:mm – h:mm a"
+      },
+      "yMMMd, hm": {
+        "a": "MMM d, y, h:mm a – h:mm a",
+        "h": "MMM d, y, h:mm – h:mm a",
+        "m": "MMM d, y, h:mm – h:mm a"
+      },
+      "yMMMEd, hm": {
+        "a": "E, MMM d, y, h:mm a – h:mm a",
+        "h": "E, MMM d, y, h:mm – h:mm a",
+        "m": "E, MMM d, y, h:mm – h:mm a"
+      },
+      "yMMMM, hm": {
+        "a": "MMMM y, h:mm a – h:mm a",
+        "h": "MMMM y, h:mm – h:mm a",
+        "m": "MMMM y, h:mm – h:mm a"
+      },
+      "EEEE, MMMM d, y, Hm": {
+        "H": "EEEE, MMMM d, y, HH:mm – HH:mm",
+        "m": "EEEE, MMMM d, y, HH:mm – HH:mm"
+      },
+      "MMMM d, y, Hm": {
+        "H": "MMMM d, y, HH:mm – HH:mm",
+        "m": "MMMM d, y, HH:mm – HH:mm"
+      },
+      "MMM d, y, Hm": {
+        "H": "MMM d, y, HH:mm – HH:mm",
+        "m": "MMM d, y, HH:mm – HH:mm"
+      },
+      "M/d/yy, Hm": {
+        "H": "M/d/yy, HH:mm – HH:mm",
+        "m": "M/d/yy, HH:mm – HH:mm"
+      },
+      "d, Hm": {
+        "H": "d, HH:mm – HH:mm",
+        "m": "d, HH:mm – HH:mm"
+      },
+      "E, Hm": {
+        "H": "ccc, HH:mm – HH:mm",
+        "m": "ccc, HH:mm – HH:mm"
+      },
+      "Ed, Hm": {
+        "H": "d E, HH:mm – HH:mm",
+        "m": "d E, HH:mm – HH:mm"
+      },
+      "Gy, Hm": {
+        "H": "y G, HH:mm – HH:mm",
+        "m": "y G, HH:mm – HH:mm"
+      },
+      "GyM, Hm": {
+        "H": "M/y G, HH:mm – HH:mm",
+        "m": "M/y G, HH:mm – HH:mm"
+      },
+      "GyMd, Hm": {
+        "H": "M/d/y G, HH:mm – HH:mm",
+        "m": "M/d/y G, HH:mm – HH:mm"
+      },
+      "GyMEd, Hm": {
+        "H": "E, M/d/y G, HH:mm – HH:mm",
+        "m": "E, M/d/y G, HH:mm – HH:mm"
+      },
+      "GyMMM, Hm": {
+        "H": "MMM y G, HH:mm – HH:mm",
+        "m": "MMM y G, HH:mm – HH:mm"
+      },
+      "GyMMMd, Hm": {
+        "H": "MMM d, y G, HH:mm – HH:mm",
+        "m": "MMM d, y G, HH:mm – HH:mm"
+      },
+      "GyMMMEd, Hm": {
+        "H": "E, MMM d, y G, HH:mm – HH:mm",
+        "m": "E, MMM d, y G, HH:mm – HH:mm"
+      },
+      "M, Hm": {
+        "H": "L, HH:mm – HH:mm",
+        "m": "L, HH:mm – HH:mm"
+      },
+      "Md, Hm": {
+        "H": "M/d, HH:mm – HH:mm",
+        "m": "M/d, HH:mm – HH:mm"
+      },
+      "MEd, Hm": {
+        "H": "E, M/d, HH:mm – HH:mm",
+        "m": "E, M/d, HH:mm – HH:mm"
+      },
+      "MMM, Hm": {
+        "H": "LLL, HH:mm – HH:mm",
+        "m": "LLL, HH:mm – HH:mm"
+      },
+      "MMMd, Hm": {
+        "H": "MMM d, HH:mm – HH:mm",
+        "m": "MMM d, HH:mm – HH:mm"
+      },
+      "MMMEd, Hm": {
+        "H": "E, MMM d, HH:mm – HH:mm",
+        "m": "E, MMM d, HH:mm – HH:mm"
+      },
+      "MMMMd, Hm": {
+        "H": "MMMM d, HH:mm – HH:mm",
+        "m": "MMMM d, HH:mm – HH:mm"
+      },
+      "y, Hm": {
+        "H": "y, HH:mm – HH:mm",
+        "m": "y, HH:mm – HH:mm"
+      },
+      "yM, Hm": {
+        "H": "M/y, HH:mm – HH:mm",
+        "m": "M/y, HH:mm – HH:mm"
+      },
+      "yMd, Hm": {
+        "H": "M/d/y, HH:mm – HH:mm",
+        "m": "M/d/y, HH:mm – HH:mm"
+      },
+      "yMEd, Hm": {
+        "H": "E, M/d/y, HH:mm – HH:mm",
+        "m": "E, M/d/y, HH:mm – HH:mm"
+      },
+      "yMMM, Hm": {
+        "H": "MMM y, HH:mm – HH:mm",
+        "m": "MMM y, HH:mm – HH:mm"
+      },
+      "yMMMd, Hm": {
+        "H": "MMM d, y, HH:mm – HH:mm",
+        "m": "MMM d, y, HH:mm – HH:mm"
+      },
+      "yMMMEd, Hm": {
+        "H": "E, MMM d, y, HH:mm – HH:mm",
+        "m": "E, MMM d, y, HH:mm – HH:mm"
+      },
+      "yMMMM, Hm": {
+        "H": "MMMM y, HH:mm – HH:mm",
+        "m": "MMMM y, HH:mm – HH:mm"
+      },
+      "EEEE, MMMM d, y, hmv": {
+        "a": "EEEE, MMMM d, y, h:mm a – h:mm a v",
+        "h": "EEEE, MMMM d, y, h:mm – h:mm a v",
+        "m": "EEEE, MMMM d, y, h:mm – h:mm a v"
+      },
+      "MMMM d, y, hmv": {
+        "a": "MMMM d, y, h:mm a – h:mm a v",
+        "h": "MMMM d, y, h:mm – h:mm a v",
+        "m": "MMMM d, y, h:mm – h:mm a v"
+      },
+      "MMM d, y, hmv": {
+        "a": "MMM d, y, h:mm a – h:mm a v",
+        "h": "MMM d, y, h:mm – h:mm a v",
+        "m": "MMM d, y, h:mm – h:mm a v"
+      },
+      "M/d/yy, hmv": {
+        "a": "M/d/yy, h:mm a – h:mm a v",
+        "h": "M/d/yy, h:mm – h:mm a v",
+        "m": "M/d/yy, h:mm – h:mm a v"
+      },
+      "d, hmv": {
+        "a": "d, h:mm a – h:mm a v",
+        "h": "d, h:mm – h:mm a v",
+        "m": "d, h:mm – h:mm a v"
+      },
+      "E, hmv": {
+        "a": "ccc, h:mm a – h:mm a v",
+        "h": "ccc, h:mm – h:mm a v",
+        "m": "ccc, h:mm – h:mm a v"
+      },
+      "Ed, hmv": {
+        "a": "d E, h:mm a – h:mm a v",
+        "h": "d E, h:mm – h:mm a v",
+        "m": "d E, h:mm – h:mm a v"
+      },
+      "Gy, hmv": {
+        "a": "y G, h:mm a – h:mm a v",
+        "h": "y G, h:mm – h:mm a v",
+        "m": "y G, h:mm – h:mm a v"
+      },
+      "GyM, hmv": {
+        "a": "M/y G, h:mm a – h:mm a v",
+        "h": "M/y G, h:mm – h:mm a v",
+        "m": "M/y G, h:mm – h:mm a v"
+      },
+      "GyMd, hmv": {
+        "a": "M/d/y G, h:mm a – h:mm a v",
+        "h": "M/d/y G, h:mm – h:mm a v",
+        "m": "M/d/y G, h:mm – h:mm a v"
+      },
+      "GyMEd, hmv": {
+        "a": "E, M/d/y G, h:mm a – h:mm a v",
+        "h": "E, M/d/y G, h:mm – h:mm a v",
+        "m": "E, M/d/y G, h:mm – h:mm a v"
+      },
+      "GyMMM, hmv": {
+        "a": "MMM y G, h:mm a – h:mm a v",
+        "h": "MMM y G, h:mm – h:mm a v",
+        "m": "MMM y G, h:mm – h:mm a v"
+      },
+      "GyMMMd, hmv": {
+        "a": "MMM d, y G, h:mm a – h:mm a v",
+        "h": "MMM d, y G, h:mm – h:mm a v",
+        "m": "MMM d, y G, h:mm – h:mm a v"
+      },
+      "GyMMMEd, hmv": {
+        "a": "E, MMM d, y G, h:mm a – h:mm a v",
+        "h": "E, MMM d, y G, h:mm – h:mm a v",
+        "m": "E, MMM d, y G, h:mm – h:mm a v"
+      },
+      "M, hmv": {
+        "a": "L, h:mm a – h:mm a v",
+        "h": "L, h:mm – h:mm a v",
+        "m": "L, h:mm – h:mm a v"
+      },
+      "Md, hmv": {
+        "a": "M/d, h:mm a – h:mm a v",
+        "h": "M/d, h:mm – h:mm a v",
+        "m": "M/d, h:mm – h:mm a v"
+      },
+      "MEd, hmv": {
+        "a": "E, M/d, h:mm a – h:mm a v",
+        "h": "E, M/d, h:mm – h:mm a v",
+        "m": "E, M/d, h:mm – h:mm a v"
+      },
+      "MMM, hmv": {
+        "a": "LLL, h:mm a – h:mm a v",
+        "h": "LLL, h:mm – h:mm a v",
+        "m": "LLL, h:mm – h:mm a v"
+      },
+      "MMMd, hmv": {
+        "a": "MMM d, h:mm a – h:mm a v",
+        "h": "MMM d, h:mm – h:mm a v",
+        "m": "MMM d, h:mm – h:mm a v"
+      },
+      "MMMEd, hmv": {
+        "a": "E, MMM d, h:mm a – h:mm a v",
+        "h": "E, MMM d, h:mm – h:mm a v",
+        "m": "E, MMM d, h:mm – h:mm a v"
+      },
+      "MMMMd, hmv": {
+        "a": "MMMM d, h:mm a – h:mm a v",
+        "h": "MMMM d, h:mm – h:mm a v",
+        "m": "MMMM d, h:mm – h:mm a v"
+      },
+      "y, hmv": {
+        "a": "y, h:mm a – h:mm a v",
+        "h": "y, h:mm – h:mm a v",
+        "m": "y, h:mm – h:mm a v"
+      },
+      "yM, hmv": {
+        "a": "M/y, h:mm a – h:mm a v",
+        "h": "M/y, h:mm – h:mm a v",
+        "m": "M/y, h:mm – h:mm a v"
+      },
+      "yMd, hmv": {
+        "a": "M/d/y, h:mm a – h:mm a v",
+        "h": "M/d/y, h:mm – h:mm a v",
+        "m": "M/d/y, h:mm – h:mm a v"
+      },
+      "yMEd, hmv": {
+        "a": "E, M/d/y, h:mm a – h:mm a v",
+        "h": "E, M/d/y, h:mm – h:mm a v",
+        "m": "E, M/d/y, h:mm – h:mm a v"
+      },
+      "yMMM, hmv": {
+        "a": "MMM y, h:mm a – h:mm a v",
+        "h": "MMM y, h:mm – h:mm a v",
+        "m": "MMM y, h:mm – h:mm a v"
+      },
+      "yMMMd, hmv": {
+        "a": "MMM d, y, h:mm a – h:mm a v",
+        "h": "MMM d, y, h:mm – h:mm a v",
+        "m": "MMM d, y, h:mm – h:mm a v"
+      },
+      "yMMMEd, hmv": {
+        "a": "E, MMM d, y, h:mm a – h:mm a v",
+        "h": "E, MMM d, y, h:mm – h:mm a v",
+        "m": "E, MMM d, y, h:mm – h:mm a v"
+      },
+      "yMMMM, hmv": {
+        "a": "MMMM y, h:mm a – h:mm a v",
+        "h": "MMMM y, h:mm – h:mm a v",
+        "m": "MMMM y, h:mm – h:mm a v"
+      },
+      "EEEE, MMMM d, y, Hmv": {
+        "H": "EEEE, MMMM d, y, HH:mm – HH:mm v",
+        "m": "EEEE, MMMM d, y, HH:mm – HH:mm v"
+      },
+      "MMMM d, y, Hmv": {
+        "H": "MMMM d, y, HH:mm – HH:mm v",
+        "m": "MMMM d, y, HH:mm – HH:mm v"
+      },
+      "MMM d, y, Hmv": {
+        "H": "MMM d, y, HH:mm – HH:mm v",
+        "m": "MMM d, y, HH:mm – HH:mm v"
+      },
+      "M/d/yy, Hmv": {
+        "H": "M/d/yy, HH:mm – HH:mm v",
+        "m": "M/d/yy, HH:mm – HH:mm v"
+      },
+      "d, Hmv": {
+        "H": "d, HH:mm – HH:mm v",
+        "m": "d, HH:mm – HH:mm v"
+      },
+      "E, Hmv": {
+        "H": "ccc, HH:mm – HH:mm v",
+        "m": "ccc, HH:mm – HH:mm v"
+      },
+      "Ed, Hmv": {
+        "H": "d E, HH:mm – HH:mm v",
+        "m": "d E, HH:mm – HH:mm v"
+      },
+      "Gy, Hmv": {
+        "H": "y G, HH:mm – HH:mm v",
+        "m": "y G, HH:mm – HH:mm v"
+      },
+      "GyM, Hmv": {
+        "H": "M/y G, HH:mm – HH:mm v",
+        "m": "M/y G, HH:mm – HH:mm v"
+      },
+      "GyMd, Hmv": {
+        "H": "M/d/y G, HH:mm – HH:mm v",
+        "m": "M/d/y G, HH:mm – HH:mm v"
+      },
+      "GyMEd, Hmv": {
+        "H": "E, M/d/y G, HH:mm – HH:mm v",
+        "m": "E, M/d/y G, HH:mm – HH:mm v"
+      },
+      "GyMMM, Hmv": {
+        "H": "MMM y G, HH:mm – HH:mm v",
+        "m": "MMM y G, HH:mm – HH:mm v"
+      },
+      "GyMMMd, Hmv": {
+        "H": "MMM d, y G, HH:mm – HH:mm v",
+        "m": "MMM d, y G, HH:mm – HH:mm v"
+      },
+      "GyMMMEd, Hmv": {
+        "H": "E, MMM d, y G, HH:mm – HH:mm v",
+        "m": "E, MMM d, y G, HH:mm – HH:mm v"
+      },
+      "M, Hmv": {
+        "H": "L, HH:mm – HH:mm v",
+        "m": "L, HH:mm – HH:mm v"
+      },
+      "Md, Hmv": {
+        "H": "M/d, HH:mm – HH:mm v",
+        "m": "M/d, HH:mm – HH:mm v"
+      },
+      "MEd, Hmv": {
+        "H": "E, M/d, HH:mm – HH:mm v",
+        "m": "E, M/d, HH:mm – HH:mm v"
+      },
+      "MMM, Hmv": {
+        "H": "LLL, HH:mm – HH:mm v",
+        "m": "LLL, HH:mm – HH:mm v"
+      },
+      "MMMd, Hmv": {
+        "H": "MMM d, HH:mm – HH:mm v",
+        "m": "MMM d, HH:mm – HH:mm v"
+      },
+      "MMMEd, Hmv": {
+        "H": "E, MMM d, HH:mm – HH:mm v",
+        "m": "E, MMM d, HH:mm – HH:mm v"
+      },
+      "MMMMd, Hmv": {
+        "H": "MMMM d, HH:mm – HH:mm v",
+        "m": "MMMM d, HH:mm – HH:mm v"
+      },
+      "y, Hmv": {
+        "H": "y, HH:mm – HH:mm v",
+        "m": "y, HH:mm – HH:mm v"
+      },
+      "yM, Hmv": {
+        "H": "M/y, HH:mm – HH:mm v",
+        "m": "M/y, HH:mm – HH:mm v"
+      },
+      "yMd, Hmv": {
+        "H": "M/d/y, HH:mm – HH:mm v",
+        "m": "M/d/y, HH:mm – HH:mm v"
+      },
+      "yMEd, Hmv": {
+        "H": "E, M/d/y, HH:mm – HH:mm v",
+        "m": "E, M/d/y, HH:mm – HH:mm v"
+      },
+      "yMMM, Hmv": {
+        "H": "MMM y, HH:mm – HH:mm v",
+        "m": "MMM y, HH:mm – HH:mm v"
+      },
+      "yMMMd, Hmv": {
+        "H": "MMM d, y, HH:mm – HH:mm v",
+        "m": "MMM d, y, HH:mm – HH:mm v"
+      },
+      "yMMMEd, Hmv": {
+        "H": "E, MMM d, y, HH:mm – HH:mm v",
+        "m": "E, MMM d, y, HH:mm – HH:mm v"
+      },
+      "yMMMM, Hmv": {
+        "H": "MMMM y, HH:mm – HH:mm v",
+        "m": "MMMM y, HH:mm – HH:mm v"
+      },
+      "EEEE, MMMM d, y, hv": {
+        "a": "EEEE, MMMM d, y, h a – h a v",
+        "h": "EEEE, MMMM d, y, h – h a v"
+      },
+      "MMMM d, y, hv": {
+        "a": "MMMM d, y, h a – h a v",
+        "h": "MMMM d, y, h – h a v"
+      },
+      "MMM d, y, hv": {
+        "a": "MMM d, y, h a – h a v",
+        "h": "MMM d, y, h – h a v"
+      },
+      "M/d/yy, hv": {
+        "a": "M/d/yy, h a – h a v",
+        "h": "M/d/yy, h – h a v"
+      },
+      "d, hv": {
+        "a": "d, h a – h a v",
+        "h": "d, h – h a v"
+      },
+      "E, hv": {
+        "a": "ccc, h a – h a v",
+        "h": "ccc, h – h a v"
+      },
+      "Ed, hv": {
+        "a": "d E, h a – h a v",
+        "h": "d E, h – h a v"
+      },
+      "Gy, hv": {
+        "a": "y G, h a – h a v",
+        "h": "y G, h – h a v"
+      },
+      "GyM, hv": {
+        "a": "M/y G, h a – h a v",
+        "h": "M/y G, h – h a v"
+      },
+      "GyMd, hv": {
+        "a": "M/d/y G, h a – h a v",
+        "h": "M/d/y G, h – h a v"
+      },
+      "GyMEd, hv": {
+        "a": "E, M/d/y G, h a – h a v",
+        "h": "E, M/d/y G, h – h a v"
+      },
+      "GyMMM, hv": {
+        "a": "MMM y G, h a – h a v",
+        "h": "MMM y G, h – h a v"
+      },
+      "GyMMMd, hv": {
+        "a": "MMM d, y G, h a – h a v",
+        "h": "MMM d, y G, h – h a v"
+      },
+      "GyMMMEd, hv": {
+        "a": "E, MMM d, y G, h a – h a v",
+        "h": "E, MMM d, y G, h – h a v"
+      },
+      "M, hv": {
+        "a": "L, h a – h a v",
+        "h": "L, h – h a v"
+      },
+      "Md, hv": {
+        "a": "M/d, h a – h a v",
+        "h": "M/d, h – h a v"
+      },
+      "MEd, hv": {
+        "a": "E, M/d, h a – h a v",
+        "h": "E, M/d, h – h a v"
+      },
+      "MMM, hv": {
+        "a": "LLL, h a – h a v",
+        "h": "LLL, h – h a v"
+      },
+      "MMMd, hv": {
+        "a": "MMM d, h a – h a v",
+        "h": "MMM d, h – h a v"
+      },
+      "MMMEd, hv": {
+        "a": "E, MMM d, h a – h a v",
+        "h": "E, MMM d, h – h a v"
+      },
+      "MMMMd, hv": {
+        "a": "MMMM d, h a – h a v",
+        "h": "MMMM d, h – h a v"
+      },
+      "y, hv": {
+        "a": "y, h a – h a v",
+        "h": "y, h – h a v"
+      },
+      "yM, hv": {
+        "a": "M/y, h a – h a v",
+        "h": "M/y, h – h a v"
+      },
+      "yMd, hv": {
+        "a": "M/d/y, h a – h a v",
+        "h": "M/d/y, h – h a v"
+      },
+      "yMEd, hv": {
+        "a": "E, M/d/y, h a – h a v",
+        "h": "E, M/d/y, h – h a v"
+      },
+      "yMMM, hv": {
+        "a": "MMM y, h a – h a v",
+        "h": "MMM y, h – h a v"
+      },
+      "yMMMd, hv": {
+        "a": "MMM d, y, h a – h a v",
+        "h": "MMM d, y, h – h a v"
+      },
+      "yMMMEd, hv": {
+        "a": "E, MMM d, y, h a – h a v",
+        "h": "E, MMM d, y, h – h a v"
+      },
+      "yMMMM, hv": {
+        "a": "MMMM y, h a – h a v",
+        "h": "MMMM y, h – h a v"
+      },
+      "EEEE, MMMM d, y, Hv": {
+        "H": "EEEE, MMMM d, y, HH – HH v"
+      },
+      "MMMM d, y, Hv": {
+        "H": "MMMM d, y, HH – HH v"
+      },
+      "MMM d, y, Hv": {
+        "H": "MMM d, y, HH – HH v"
+      },
+      "M/d/yy, Hv": {
+        "H": "M/d/yy, HH – HH v"
+      },
+      "d, Hv": {
+        "H": "d, HH – HH v"
+      },
+      "E, Hv": {
+        "H": "ccc, HH – HH v"
+      },
+      "Ed, Hv": {
+        "H": "d E, HH – HH v"
+      },
+      "Gy, Hv": {
+        "H": "y G, HH – HH v"
+      },
+      "GyM, Hv": {
+        "H": "M/y G, HH – HH v"
+      },
+      "GyMd, Hv": {
+        "H": "M/d/y G, HH – HH v"
+      },
+      "GyMEd, Hv": {
+        "H": "E, M/d/y G, HH – HH v"
+      },
+      "GyMMM, Hv": {
+        "H": "MMM y G, HH – HH v"
+      },
+      "GyMMMd, Hv": {
+        "H": "MMM d, y G, HH – HH v"
+      },
+      "GyMMMEd, Hv": {
+        "H": "E, MMM d, y G, HH – HH v"
+      },
+      "M, Hv": {
+        "H": "L, HH – HH v"
+      },
+      "Md, Hv": {
+        "H": "M/d, HH – HH v"
+      },
+      "MEd, Hv": {
+        "H": "E, M/d, HH – HH v"
+      },
+      "MMM, Hv": {
+        "H": "LLL, HH – HH v"
+      },
+      "MMMd, Hv": {
+        "H": "MMM d, HH – HH v"
+      },
+      "MMMEd, Hv": {
+        "H": "E, MMM d, HH – HH v"
+      },
+      "MMMMd, Hv": {
+        "H": "MMMM d, HH – HH v"
+      },
+      "y, Hv": {
+        "H": "y, HH – HH v"
+      },
+      "yM, Hv": {
+        "H": "M/y, HH – HH v"
+      },
+      "yMd, Hv": {
+        "H": "M/d/y, HH – HH v"
+      },
+      "yMEd, Hv": {
+        "H": "E, M/d/y, HH – HH v"
+      },
+      "yMMM, Hv": {
+        "H": "MMM y, HH – HH v"
+      },
+      "yMMMd, Hv": {
+        "H": "MMM d, y, HH – HH v"
+      },
+      "yMMMEd, Hv": {
+        "H": "E, MMM d, y, HH – HH v"
+      },
+      "yMMMM, Hv": {
+        "H": "MMMM y, HH – HH v"
       }
     },
     "hourCycle": "h12",

--- a/packages/intl-datetimeformat/tests/locale-data/fa.json
+++ b/packages/intl-datetimeformat/tests/locale-data/fa.json
@@ -2702,6 +2702,1277 @@
       "yMMMM": {
         "M": "MMMM تا MMMM y",
         "y": "MMMM y تا MMMM y"
+      },
+      "EEEE d MMMM y، ساعت Bh": {
+        "B": "EEEE d MMMM y، ساعت h B تا h B",
+        "h": "EEEE d MMMM y، ساعت h تا h B"
+      },
+      "d MMMM y، ساعت Bh": {
+        "B": "d MMMM y، ساعت h B تا h B",
+        "h": "d MMMM y، ساعت h تا h B"
+      },
+      "d MMM y،‏ Bh": {
+        "B": "d MMM y،‏ h B تا h B",
+        "h": "d MMM y،‏ h تا h B"
+      },
+      "y/M/d،‏ Bh": {
+        "B": "y/M/d،‏ h B تا h B",
+        "h": "y/M/d،‏ h تا h B"
+      },
+      "d،‏ Bh": {
+        "B": "d،‏ h B تا h B",
+        "h": "d،‏ h تا h B"
+      },
+      "E،‏ Bh": {
+        "B": "ccc،‏ h B تا h B",
+        "h": "ccc،‏ h تا h B"
+      },
+      "Ed،‏ Bh": {
+        "B": "E d،‏ h B تا h B",
+        "h": "E d،‏ h تا h B"
+      },
+      "Gy،‏ Bh": {
+        "B": "y G،‏ h B تا h B",
+        "h": "y G،‏ h تا h B"
+      },
+      "GyM،‏ Bh": {
+        "B": "y/M G،‏ h B تا h B",
+        "h": "y/M G،‏ h تا h B"
+      },
+      "GyMd،‏ Bh": {
+        "B": "y/M/d GGGGG،‏ h B تا h B",
+        "h": "y/M/d GGGGG،‏ h تا h B"
+      },
+      "GyMEd،‏ Bh": {
+        "B": "E، y/M/d G،‏ h B تا h B",
+        "h": "E، y/M/d G،‏ h تا h B"
+      },
+      "GyMMM،‏ Bh": {
+        "B": "MMM y G،‏ h B تا h B",
+        "h": "MMM y G،‏ h تا h B"
+      },
+      "GyMMMd،‏ Bh": {
+        "B": "d MMM y G،‏ h B تا h B",
+        "h": "d MMM y G،‏ h تا h B"
+      },
+      "GyMMMEd،‏ Bh": {
+        "B": "E d MMM y G،‏ h B تا h B",
+        "h": "E d MMM y G،‏ h تا h B"
+      },
+      "M،‏ Bh": {
+        "B": "L،‏ h B تا h B",
+        "h": "L،‏ h تا h B"
+      },
+      "Md،‏ Bh": {
+        "B": "M/d،‏ h B تا h B",
+        "h": "M/d،‏ h تا h B"
+      },
+      "MEd،‏ Bh": {
+        "B": "E M/d،‏ h B تا h B",
+        "h": "E M/d،‏ h تا h B"
+      },
+      "MMM،‏ Bh": {
+        "B": "LLL،‏ h B تا h B",
+        "h": "LLL،‏ h تا h B"
+      },
+      "MMMd،‏ Bh": {
+        "B": "d LLL،‏ h B تا h B",
+        "h": "d LLL،‏ h تا h B"
+      },
+      "MMMEd،‏ Bh": {
+        "B": "E d LLL،‏ h B تا h B",
+        "h": "E d LLL،‏ h تا h B"
+      },
+      "MMMMd، ساعت Bh": {
+        "B": "d LLLL، ساعت h B تا h B",
+        "h": "d LLLL، ساعت h تا h B"
+      },
+      "MMMMEd، ساعت Bh": {
+        "B": "E d LLLL، ساعت h B تا h B",
+        "h": "E d LLLL، ساعت h تا h B"
+      },
+      "y،‏ Bh": {
+        "B": "y،‏ h B تا h B",
+        "h": "y،‏ h تا h B"
+      },
+      "yM،‏ Bh": {
+        "B": "y/M،‏ h B تا h B",
+        "h": "y/M،‏ h تا h B"
+      },
+      "yMd،‏ Bh": {
+        "B": "y/M/d،‏ h B تا h B",
+        "h": "y/M/d،‏ h تا h B"
+      },
+      "yMEd،‏ Bh": {
+        "B": "E y/M/d،‏ h B تا h B",
+        "h": "E y/M/d،‏ h تا h B"
+      },
+      "yMMM،‏ Bh": {
+        "B": "MMM y،‏ h B تا h B",
+        "h": "MMM y،‏ h تا h B"
+      },
+      "yMMMd،‏ Bh": {
+        "B": "d MMM y،‏ h B تا h B",
+        "h": "d MMM y،‏ h تا h B"
+      },
+      "yMMMEd،‏ Bh": {
+        "B": "E d MMM y،‏ h B تا h B",
+        "h": "E d MMM y،‏ h تا h B"
+      },
+      "yMMMM، ساعت Bh": {
+        "B": "MMMM y، ساعت h B تا h B",
+        "h": "MMMM y، ساعت h تا h B"
+      },
+      "yMMMMEEEEd، ساعت Bh": {
+        "B": "EEEE d MMMM y، ساعت h B تا h B",
+        "h": "EEEE d MMMM y، ساعت h تا h B"
+      },
+      "EEEE d MMMM y، ساعت Bhm": {
+        "B": "EEEE d MMMM y، ساعت h:mm B تا h:mm B",
+        "h": "EEEE d MMMM y، ساعت h:mm تا h:mm B",
+        "m": "EEEE d MMMM y، ساعت h:mm تا h:mm B"
+      },
+      "d MMMM y، ساعت Bhm": {
+        "B": "d MMMM y، ساعت h:mm B تا h:mm B",
+        "h": "d MMMM y، ساعت h:mm تا h:mm B",
+        "m": "d MMMM y، ساعت h:mm تا h:mm B"
+      },
+      "d MMM y،‏ Bhm": {
+        "B": "d MMM y،‏ h:mm B تا h:mm B",
+        "h": "d MMM y،‏ h:mm تا h:mm B",
+        "m": "d MMM y،‏ h:mm تا h:mm B"
+      },
+      "y/M/d،‏ Bhm": {
+        "B": "y/M/d،‏ h:mm B تا h:mm B",
+        "h": "y/M/d،‏ h:mm تا h:mm B",
+        "m": "y/M/d،‏ h:mm تا h:mm B"
+      },
+      "d،‏ Bhm": {
+        "B": "d،‏ h:mm B تا h:mm B",
+        "h": "d،‏ h:mm تا h:mm B",
+        "m": "d،‏ h:mm تا h:mm B"
+      },
+      "E،‏ Bhm": {
+        "B": "ccc،‏ h:mm B تا h:mm B",
+        "h": "ccc،‏ h:mm تا h:mm B",
+        "m": "ccc،‏ h:mm تا h:mm B"
+      },
+      "Ed،‏ Bhm": {
+        "B": "E d،‏ h:mm B تا h:mm B",
+        "h": "E d،‏ h:mm تا h:mm B",
+        "m": "E d،‏ h:mm تا h:mm B"
+      },
+      "Gy،‏ Bhm": {
+        "B": "y G،‏ h:mm B تا h:mm B",
+        "h": "y G،‏ h:mm تا h:mm B",
+        "m": "y G،‏ h:mm تا h:mm B"
+      },
+      "GyM،‏ Bhm": {
+        "B": "y/M G،‏ h:mm B تا h:mm B",
+        "h": "y/M G،‏ h:mm تا h:mm B",
+        "m": "y/M G،‏ h:mm تا h:mm B"
+      },
+      "GyMd،‏ Bhm": {
+        "B": "y/M/d GGGGG،‏ h:mm B تا h:mm B",
+        "h": "y/M/d GGGGG،‏ h:mm تا h:mm B",
+        "m": "y/M/d GGGGG،‏ h:mm تا h:mm B"
+      },
+      "GyMEd،‏ Bhm": {
+        "B": "E، y/M/d G،‏ h:mm B تا h:mm B",
+        "h": "E، y/M/d G،‏ h:mm تا h:mm B",
+        "m": "E، y/M/d G،‏ h:mm تا h:mm B"
+      },
+      "GyMMM،‏ Bhm": {
+        "B": "MMM y G،‏ h:mm B تا h:mm B",
+        "h": "MMM y G،‏ h:mm تا h:mm B",
+        "m": "MMM y G،‏ h:mm تا h:mm B"
+      },
+      "GyMMMd،‏ Bhm": {
+        "B": "d MMM y G،‏ h:mm B تا h:mm B",
+        "h": "d MMM y G،‏ h:mm تا h:mm B",
+        "m": "d MMM y G،‏ h:mm تا h:mm B"
+      },
+      "GyMMMEd،‏ Bhm": {
+        "B": "E d MMM y G،‏ h:mm B تا h:mm B",
+        "h": "E d MMM y G،‏ h:mm تا h:mm B",
+        "m": "E d MMM y G،‏ h:mm تا h:mm B"
+      },
+      "M،‏ Bhm": {
+        "B": "L،‏ h:mm B تا h:mm B",
+        "h": "L،‏ h:mm تا h:mm B",
+        "m": "L،‏ h:mm تا h:mm B"
+      },
+      "Md،‏ Bhm": {
+        "B": "M/d،‏ h:mm B تا h:mm B",
+        "h": "M/d،‏ h:mm تا h:mm B",
+        "m": "M/d،‏ h:mm تا h:mm B"
+      },
+      "MEd،‏ Bhm": {
+        "B": "E M/d،‏ h:mm B تا h:mm B",
+        "h": "E M/d،‏ h:mm تا h:mm B",
+        "m": "E M/d،‏ h:mm تا h:mm B"
+      },
+      "MMM،‏ Bhm": {
+        "B": "LLL،‏ h:mm B تا h:mm B",
+        "h": "LLL،‏ h:mm تا h:mm B",
+        "m": "LLL،‏ h:mm تا h:mm B"
+      },
+      "MMMd،‏ Bhm": {
+        "B": "d LLL،‏ h:mm B تا h:mm B",
+        "h": "d LLL،‏ h:mm تا h:mm B",
+        "m": "d LLL،‏ h:mm تا h:mm B"
+      },
+      "MMMEd،‏ Bhm": {
+        "B": "E d LLL،‏ h:mm B تا h:mm B",
+        "h": "E d LLL،‏ h:mm تا h:mm B",
+        "m": "E d LLL،‏ h:mm تا h:mm B"
+      },
+      "MMMMd، ساعت Bhm": {
+        "B": "d LLLL، ساعت h:mm B تا h:mm B",
+        "h": "d LLLL، ساعت h:mm تا h:mm B",
+        "m": "d LLLL، ساعت h:mm تا h:mm B"
+      },
+      "MMMMEd، ساعت Bhm": {
+        "B": "E d LLLL، ساعت h:mm B تا h:mm B",
+        "h": "E d LLLL، ساعت h:mm تا h:mm B",
+        "m": "E d LLLL، ساعت h:mm تا h:mm B"
+      },
+      "y،‏ Bhm": {
+        "B": "y،‏ h:mm B تا h:mm B",
+        "h": "y،‏ h:mm تا h:mm B",
+        "m": "y،‏ h:mm تا h:mm B"
+      },
+      "yM،‏ Bhm": {
+        "B": "y/M،‏ h:mm B تا h:mm B",
+        "h": "y/M،‏ h:mm تا h:mm B",
+        "m": "y/M،‏ h:mm تا h:mm B"
+      },
+      "yMd،‏ Bhm": {
+        "B": "y/M/d،‏ h:mm B تا h:mm B",
+        "h": "y/M/d،‏ h:mm تا h:mm B",
+        "m": "y/M/d،‏ h:mm تا h:mm B"
+      },
+      "yMEd،‏ Bhm": {
+        "B": "E y/M/d،‏ h:mm B تا h:mm B",
+        "h": "E y/M/d،‏ h:mm تا h:mm B",
+        "m": "E y/M/d،‏ h:mm تا h:mm B"
+      },
+      "yMMM،‏ Bhm": {
+        "B": "MMM y،‏ h:mm B تا h:mm B",
+        "h": "MMM y،‏ h:mm تا h:mm B",
+        "m": "MMM y،‏ h:mm تا h:mm B"
+      },
+      "yMMMd،‏ Bhm": {
+        "B": "d MMM y،‏ h:mm B تا h:mm B",
+        "h": "d MMM y،‏ h:mm تا h:mm B",
+        "m": "d MMM y،‏ h:mm تا h:mm B"
+      },
+      "yMMMEd،‏ Bhm": {
+        "B": "E d MMM y،‏ h:mm B تا h:mm B",
+        "h": "E d MMM y،‏ h:mm تا h:mm B",
+        "m": "E d MMM y،‏ h:mm تا h:mm B"
+      },
+      "yMMMM، ساعت Bhm": {
+        "B": "MMMM y، ساعت h:mm B تا h:mm B",
+        "h": "MMMM y، ساعت h:mm تا h:mm B",
+        "m": "MMMM y، ساعت h:mm تا h:mm B"
+      },
+      "yMMMMEEEEd، ساعت Bhm": {
+        "B": "EEEE d MMMM y، ساعت h:mm B تا h:mm B",
+        "h": "EEEE d MMMM y، ساعت h:mm تا h:mm B",
+        "m": "EEEE d MMMM y، ساعت h:mm تا h:mm B"
+      },
+      "EEEE d MMMM y، ساعت h": {
+        "a": "EEEE d MMMM y، ساعت h a تا h a",
+        "h": "EEEE d MMMM y، ساعت h تا h a"
+      },
+      "d MMMM y، ساعت h": {
+        "a": "d MMMM y، ساعت h a تا h a",
+        "h": "d MMMM y، ساعت h تا h a"
+      },
+      "d MMM y،‏ h": {
+        "a": "d MMM y،‏ h a تا h a",
+        "h": "d MMM y،‏ h تا h a"
+      },
+      "y/M/d،‏ h": {
+        "a": "y/M/d،‏ h a تا h a",
+        "h": "y/M/d،‏ h تا h a"
+      },
+      "d،‏ h": {
+        "a": "d،‏ h a تا h a",
+        "h": "d،‏ h تا h a"
+      },
+      "E،‏ h": {
+        "a": "ccc،‏ h a تا h a",
+        "h": "ccc،‏ h تا h a"
+      },
+      "Ed،‏ h": {
+        "a": "E d،‏ h a تا h a",
+        "h": "E d،‏ h تا h a"
+      },
+      "Gy،‏ h": {
+        "a": "y G،‏ h a تا h a",
+        "h": "y G،‏ h تا h a"
+      },
+      "GyM،‏ h": {
+        "a": "y/M G،‏ h a تا h a",
+        "h": "y/M G،‏ h تا h a"
+      },
+      "GyMd،‏ h": {
+        "a": "y/M/d GGGGG،‏ h a تا h a",
+        "h": "y/M/d GGGGG،‏ h تا h a"
+      },
+      "GyMEd،‏ h": {
+        "a": "E، y/M/d G،‏ h a تا h a",
+        "h": "E، y/M/d G،‏ h تا h a"
+      },
+      "GyMMM،‏ h": {
+        "a": "MMM y G،‏ h a تا h a",
+        "h": "MMM y G،‏ h تا h a"
+      },
+      "GyMMMd،‏ h": {
+        "a": "d MMM y G،‏ h a تا h a",
+        "h": "d MMM y G،‏ h تا h a"
+      },
+      "GyMMMEd،‏ h": {
+        "a": "E d MMM y G،‏ h a تا h a",
+        "h": "E d MMM y G،‏ h تا h a"
+      },
+      "M،‏ h": {
+        "a": "L،‏ h a تا h a",
+        "h": "L،‏ h تا h a"
+      },
+      "Md،‏ h": {
+        "a": "M/d،‏ h a تا h a",
+        "h": "M/d،‏ h تا h a"
+      },
+      "MEd،‏ h": {
+        "a": "E M/d،‏ h a تا h a",
+        "h": "E M/d،‏ h تا h a"
+      },
+      "MMM،‏ h": {
+        "a": "LLL،‏ h a تا h a",
+        "h": "LLL،‏ h تا h a"
+      },
+      "MMMd،‏ h": {
+        "a": "d LLL،‏ h a تا h a",
+        "h": "d LLL،‏ h تا h a"
+      },
+      "MMMEd،‏ h": {
+        "a": "E d LLL،‏ h a تا h a",
+        "h": "E d LLL،‏ h تا h a"
+      },
+      "MMMMd، ساعت h": {
+        "a": "d LLLL، ساعت h a تا h a",
+        "h": "d LLLL، ساعت h تا h a"
+      },
+      "MMMMEd، ساعت h": {
+        "a": "E d LLLL، ساعت h a تا h a",
+        "h": "E d LLLL، ساعت h تا h a"
+      },
+      "y،‏ h": {
+        "a": "y،‏ h a تا h a",
+        "h": "y،‏ h تا h a"
+      },
+      "yM،‏ h": {
+        "a": "y/M،‏ h a تا h a",
+        "h": "y/M،‏ h تا h a"
+      },
+      "yMd،‏ h": {
+        "a": "y/M/d،‏ h a تا h a",
+        "h": "y/M/d،‏ h تا h a"
+      },
+      "yMEd،‏ h": {
+        "a": "E y/M/d،‏ h a تا h a",
+        "h": "E y/M/d،‏ h تا h a"
+      },
+      "yMMM،‏ h": {
+        "a": "MMM y،‏ h a تا h a",
+        "h": "MMM y،‏ h تا h a"
+      },
+      "yMMMd،‏ h": {
+        "a": "d MMM y،‏ h a تا h a",
+        "h": "d MMM y،‏ h تا h a"
+      },
+      "yMMMEd،‏ h": {
+        "a": "E d MMM y،‏ h a تا h a",
+        "h": "E d MMM y،‏ h تا h a"
+      },
+      "yMMMM، ساعت h": {
+        "a": "MMMM y، ساعت h a تا h a",
+        "h": "MMMM y، ساعت h تا h a"
+      },
+      "yMMMMEEEEd، ساعت h": {
+        "a": "EEEE d MMMM y، ساعت h a تا h a",
+        "h": "EEEE d MMMM y، ساعت h تا h a"
+      },
+      "EEEE d MMMM y، ساعت H": {
+        "H": "EEEE d MMMM y، ساعت H تا H"
+      },
+      "d MMMM y، ساعت H": {
+        "H": "d MMMM y، ساعت H تا H"
+      },
+      "d MMM y،‏ H": {
+        "H": "d MMM y،‏ H تا H"
+      },
+      "y/M/d،‏ H": {
+        "H": "y/M/d،‏ H تا H"
+      },
+      "d،‏ H": {
+        "H": "d،‏ H تا H"
+      },
+      "E،‏ H": {
+        "H": "ccc،‏ H تا H"
+      },
+      "Ed،‏ H": {
+        "H": "E d،‏ H تا H"
+      },
+      "Gy،‏ H": {
+        "H": "y G،‏ H تا H"
+      },
+      "GyM،‏ H": {
+        "H": "y/M G،‏ H تا H"
+      },
+      "GyMd،‏ H": {
+        "H": "y/M/d GGGGG،‏ H تا H"
+      },
+      "GyMEd،‏ H": {
+        "H": "E، y/M/d G،‏ H تا H"
+      },
+      "GyMMM،‏ H": {
+        "H": "MMM y G،‏ H تا H"
+      },
+      "GyMMMd،‏ H": {
+        "H": "d MMM y G،‏ H تا H"
+      },
+      "GyMMMEd،‏ H": {
+        "H": "E d MMM y G،‏ H تا H"
+      },
+      "M،‏ H": {
+        "H": "L،‏ H تا H"
+      },
+      "Md،‏ H": {
+        "H": "M/d،‏ H تا H"
+      },
+      "MEd،‏ H": {
+        "H": "E M/d،‏ H تا H"
+      },
+      "MMM،‏ H": {
+        "H": "LLL،‏ H تا H"
+      },
+      "MMMd،‏ H": {
+        "H": "d LLL،‏ H تا H"
+      },
+      "MMMEd،‏ H": {
+        "H": "E d LLL،‏ H تا H"
+      },
+      "MMMMd، ساعت H": {
+        "H": "d LLLL، ساعت H تا H"
+      },
+      "MMMMEd، ساعت H": {
+        "H": "E d LLLL، ساعت H تا H"
+      },
+      "y،‏ H": {
+        "H": "y،‏ H تا H"
+      },
+      "yM،‏ H": {
+        "H": "y/M،‏ H تا H"
+      },
+      "yMd،‏ H": {
+        "H": "y/M/d،‏ H تا H"
+      },
+      "yMEd،‏ H": {
+        "H": "E y/M/d،‏ H تا H"
+      },
+      "yMMM،‏ H": {
+        "H": "MMM y،‏ H تا H"
+      },
+      "yMMMd،‏ H": {
+        "H": "d MMM y،‏ H تا H"
+      },
+      "yMMMEd،‏ H": {
+        "H": "E d MMM y،‏ H تا H"
+      },
+      "yMMMM، ساعت H": {
+        "H": "MMMM y، ساعت H تا H"
+      },
+      "yMMMMEEEEd، ساعت H": {
+        "H": "EEEE d MMMM y، ساعت H تا H"
+      },
+      "EEEE d MMMM y، ساعت hm": {
+        "a": "EEEE d MMMM y، ساعت h:mm a تا h:mm a",
+        "h": "EEEE d MMMM y، ساعت h:mm تا h:mm a",
+        "m": "EEEE d MMMM y، ساعت h:mm تا h:mm a"
+      },
+      "d MMMM y، ساعت hm": {
+        "a": "d MMMM y، ساعت h:mm a تا h:mm a",
+        "h": "d MMMM y، ساعت h:mm تا h:mm a",
+        "m": "d MMMM y، ساعت h:mm تا h:mm a"
+      },
+      "d MMM y،‏ hm": {
+        "a": "d MMM y،‏ h:mm a تا h:mm a",
+        "h": "d MMM y،‏ h:mm تا h:mm a",
+        "m": "d MMM y،‏ h:mm تا h:mm a"
+      },
+      "y/M/d،‏ hm": {
+        "a": "y/M/d،‏ h:mm a تا h:mm a",
+        "h": "y/M/d،‏ h:mm تا h:mm a",
+        "m": "y/M/d،‏ h:mm تا h:mm a"
+      },
+      "d،‏ hm": {
+        "a": "d،‏ h:mm a تا h:mm a",
+        "h": "d،‏ h:mm تا h:mm a",
+        "m": "d،‏ h:mm تا h:mm a"
+      },
+      "E،‏ hm": {
+        "a": "ccc،‏ h:mm a تا h:mm a",
+        "h": "ccc،‏ h:mm تا h:mm a",
+        "m": "ccc،‏ h:mm تا h:mm a"
+      },
+      "Ed،‏ hm": {
+        "a": "E d،‏ h:mm a تا h:mm a",
+        "h": "E d،‏ h:mm تا h:mm a",
+        "m": "E d،‏ h:mm تا h:mm a"
+      },
+      "Gy،‏ hm": {
+        "a": "y G،‏ h:mm a تا h:mm a",
+        "h": "y G،‏ h:mm تا h:mm a",
+        "m": "y G،‏ h:mm تا h:mm a"
+      },
+      "GyM،‏ hm": {
+        "a": "y/M G،‏ h:mm a تا h:mm a",
+        "h": "y/M G،‏ h:mm تا h:mm a",
+        "m": "y/M G،‏ h:mm تا h:mm a"
+      },
+      "GyMd،‏ hm": {
+        "a": "y/M/d GGGGG،‏ h:mm a تا h:mm a",
+        "h": "y/M/d GGGGG،‏ h:mm تا h:mm a",
+        "m": "y/M/d GGGGG،‏ h:mm تا h:mm a"
+      },
+      "GyMEd،‏ hm": {
+        "a": "E، y/M/d G،‏ h:mm a تا h:mm a",
+        "h": "E، y/M/d G،‏ h:mm تا h:mm a",
+        "m": "E، y/M/d G،‏ h:mm تا h:mm a"
+      },
+      "GyMMM،‏ hm": {
+        "a": "MMM y G،‏ h:mm a تا h:mm a",
+        "h": "MMM y G،‏ h:mm تا h:mm a",
+        "m": "MMM y G،‏ h:mm تا h:mm a"
+      },
+      "GyMMMd،‏ hm": {
+        "a": "d MMM y G،‏ h:mm a تا h:mm a",
+        "h": "d MMM y G،‏ h:mm تا h:mm a",
+        "m": "d MMM y G،‏ h:mm تا h:mm a"
+      },
+      "GyMMMEd،‏ hm": {
+        "a": "E d MMM y G،‏ h:mm a تا h:mm a",
+        "h": "E d MMM y G،‏ h:mm تا h:mm a",
+        "m": "E d MMM y G،‏ h:mm تا h:mm a"
+      },
+      "M،‏ hm": {
+        "a": "L،‏ h:mm a تا h:mm a",
+        "h": "L،‏ h:mm تا h:mm a",
+        "m": "L،‏ h:mm تا h:mm a"
+      },
+      "Md،‏ hm": {
+        "a": "M/d،‏ h:mm a تا h:mm a",
+        "h": "M/d،‏ h:mm تا h:mm a",
+        "m": "M/d،‏ h:mm تا h:mm a"
+      },
+      "MEd،‏ hm": {
+        "a": "E M/d،‏ h:mm a تا h:mm a",
+        "h": "E M/d،‏ h:mm تا h:mm a",
+        "m": "E M/d،‏ h:mm تا h:mm a"
+      },
+      "MMM،‏ hm": {
+        "a": "LLL،‏ h:mm a تا h:mm a",
+        "h": "LLL،‏ h:mm تا h:mm a",
+        "m": "LLL،‏ h:mm تا h:mm a"
+      },
+      "MMMd،‏ hm": {
+        "a": "d LLL،‏ h:mm a تا h:mm a",
+        "h": "d LLL،‏ h:mm تا h:mm a",
+        "m": "d LLL،‏ h:mm تا h:mm a"
+      },
+      "MMMEd،‏ hm": {
+        "a": "E d LLL،‏ h:mm a تا h:mm a",
+        "h": "E d LLL،‏ h:mm تا h:mm a",
+        "m": "E d LLL،‏ h:mm تا h:mm a"
+      },
+      "MMMMd، ساعت hm": {
+        "a": "d LLLL، ساعت h:mm a تا h:mm a",
+        "h": "d LLLL، ساعت h:mm تا h:mm a",
+        "m": "d LLLL، ساعت h:mm تا h:mm a"
+      },
+      "MMMMEd، ساعت hm": {
+        "a": "E d LLLL، ساعت h:mm a تا h:mm a",
+        "h": "E d LLLL، ساعت h:mm تا h:mm a",
+        "m": "E d LLLL، ساعت h:mm تا h:mm a"
+      },
+      "y،‏ hm": {
+        "a": "y،‏ h:mm a تا h:mm a",
+        "h": "y،‏ h:mm تا h:mm a",
+        "m": "y،‏ h:mm تا h:mm a"
+      },
+      "yM،‏ hm": {
+        "a": "y/M،‏ h:mm a تا h:mm a",
+        "h": "y/M،‏ h:mm تا h:mm a",
+        "m": "y/M،‏ h:mm تا h:mm a"
+      },
+      "yMd،‏ hm": {
+        "a": "y/M/d،‏ h:mm a تا h:mm a",
+        "h": "y/M/d،‏ h:mm تا h:mm a",
+        "m": "y/M/d،‏ h:mm تا h:mm a"
+      },
+      "yMEd،‏ hm": {
+        "a": "E y/M/d،‏ h:mm a تا h:mm a",
+        "h": "E y/M/d،‏ h:mm تا h:mm a",
+        "m": "E y/M/d،‏ h:mm تا h:mm a"
+      },
+      "yMMM،‏ hm": {
+        "a": "MMM y،‏ h:mm a تا h:mm a",
+        "h": "MMM y،‏ h:mm تا h:mm a",
+        "m": "MMM y،‏ h:mm تا h:mm a"
+      },
+      "yMMMd،‏ hm": {
+        "a": "d MMM y،‏ h:mm a تا h:mm a",
+        "h": "d MMM y،‏ h:mm تا h:mm a",
+        "m": "d MMM y،‏ h:mm تا h:mm a"
+      },
+      "yMMMEd،‏ hm": {
+        "a": "E d MMM y،‏ h:mm a تا h:mm a",
+        "h": "E d MMM y،‏ h:mm تا h:mm a",
+        "m": "E d MMM y،‏ h:mm تا h:mm a"
+      },
+      "yMMMM، ساعت hm": {
+        "a": "MMMM y، ساعت h:mm a تا h:mm a",
+        "h": "MMMM y، ساعت h:mm تا h:mm a",
+        "m": "MMMM y، ساعت h:mm تا h:mm a"
+      },
+      "yMMMMEEEEd، ساعت hm": {
+        "a": "EEEE d MMMM y، ساعت h:mm a تا h:mm a",
+        "h": "EEEE d MMMM y، ساعت h:mm تا h:mm a",
+        "m": "EEEE d MMMM y، ساعت h:mm تا h:mm a"
+      },
+      "EEEE d MMMM y، ساعت Hm": {
+        "H": "EEEE d MMMM y، ساعت H:mm تا H:mm",
+        "m": "EEEE d MMMM y، ساعت H:mm تا H:mm"
+      },
+      "d MMMM y، ساعت Hm": {
+        "H": "d MMMM y، ساعت H:mm تا H:mm",
+        "m": "d MMMM y، ساعت H:mm تا H:mm"
+      },
+      "d MMM y،‏ Hm": {
+        "H": "d MMM y،‏ H:mm تا H:mm",
+        "m": "d MMM y،‏ H:mm تا H:mm"
+      },
+      "y/M/d،‏ Hm": {
+        "H": "y/M/d،‏ H:mm تا H:mm",
+        "m": "y/M/d،‏ H:mm تا H:mm"
+      },
+      "d،‏ Hm": {
+        "H": "d،‏ H:mm تا H:mm",
+        "m": "d،‏ H:mm تا H:mm"
+      },
+      "E،‏ Hm": {
+        "H": "ccc،‏ H:mm تا H:mm",
+        "m": "ccc،‏ H:mm تا H:mm"
+      },
+      "Ed،‏ Hm": {
+        "H": "E d،‏ H:mm تا H:mm",
+        "m": "E d،‏ H:mm تا H:mm"
+      },
+      "Gy،‏ Hm": {
+        "H": "y G،‏ H:mm تا H:mm",
+        "m": "y G،‏ H:mm تا H:mm"
+      },
+      "GyM،‏ Hm": {
+        "H": "y/M G،‏ H:mm تا H:mm",
+        "m": "y/M G،‏ H:mm تا H:mm"
+      },
+      "GyMd،‏ Hm": {
+        "H": "y/M/d GGGGG،‏ H:mm تا H:mm",
+        "m": "y/M/d GGGGG،‏ H:mm تا H:mm"
+      },
+      "GyMEd،‏ Hm": {
+        "H": "E، y/M/d G،‏ H:mm تا H:mm",
+        "m": "E، y/M/d G،‏ H:mm تا H:mm"
+      },
+      "GyMMM،‏ Hm": {
+        "H": "MMM y G،‏ H:mm تا H:mm",
+        "m": "MMM y G،‏ H:mm تا H:mm"
+      },
+      "GyMMMd،‏ Hm": {
+        "H": "d MMM y G،‏ H:mm تا H:mm",
+        "m": "d MMM y G،‏ H:mm تا H:mm"
+      },
+      "GyMMMEd،‏ Hm": {
+        "H": "E d MMM y G،‏ H:mm تا H:mm",
+        "m": "E d MMM y G،‏ H:mm تا H:mm"
+      },
+      "M،‏ Hm": {
+        "H": "L،‏ H:mm تا H:mm",
+        "m": "L،‏ H:mm تا H:mm"
+      },
+      "Md،‏ Hm": {
+        "H": "M/d،‏ H:mm تا H:mm",
+        "m": "M/d،‏ H:mm تا H:mm"
+      },
+      "MEd،‏ Hm": {
+        "H": "E M/d،‏ H:mm تا H:mm",
+        "m": "E M/d،‏ H:mm تا H:mm"
+      },
+      "MMM،‏ Hm": {
+        "H": "LLL،‏ H:mm تا H:mm",
+        "m": "LLL،‏ H:mm تا H:mm"
+      },
+      "MMMd،‏ Hm": {
+        "H": "d LLL،‏ H:mm تا H:mm",
+        "m": "d LLL،‏ H:mm تا H:mm"
+      },
+      "MMMEd،‏ Hm": {
+        "H": "E d LLL،‏ H:mm تا H:mm",
+        "m": "E d LLL،‏ H:mm تا H:mm"
+      },
+      "MMMMd، ساعت Hm": {
+        "H": "d LLLL، ساعت H:mm تا H:mm",
+        "m": "d LLLL، ساعت H:mm تا H:mm"
+      },
+      "MMMMEd، ساعت Hm": {
+        "H": "E d LLLL، ساعت H:mm تا H:mm",
+        "m": "E d LLLL، ساعت H:mm تا H:mm"
+      },
+      "y،‏ Hm": {
+        "H": "y،‏ H:mm تا H:mm",
+        "m": "y،‏ H:mm تا H:mm"
+      },
+      "yM،‏ Hm": {
+        "H": "y/M،‏ H:mm تا H:mm",
+        "m": "y/M،‏ H:mm تا H:mm"
+      },
+      "yMd،‏ Hm": {
+        "H": "y/M/d،‏ H:mm تا H:mm",
+        "m": "y/M/d،‏ H:mm تا H:mm"
+      },
+      "yMEd،‏ Hm": {
+        "H": "E y/M/d،‏ H:mm تا H:mm",
+        "m": "E y/M/d،‏ H:mm تا H:mm"
+      },
+      "yMMM،‏ Hm": {
+        "H": "MMM y،‏ H:mm تا H:mm",
+        "m": "MMM y،‏ H:mm تا H:mm"
+      },
+      "yMMMd،‏ Hm": {
+        "H": "d MMM y،‏ H:mm تا H:mm",
+        "m": "d MMM y،‏ H:mm تا H:mm"
+      },
+      "yMMMEd،‏ Hm": {
+        "H": "E d MMM y،‏ H:mm تا H:mm",
+        "m": "E d MMM y،‏ H:mm تا H:mm"
+      },
+      "yMMMM، ساعت Hm": {
+        "H": "MMMM y، ساعت H:mm تا H:mm",
+        "m": "MMMM y، ساعت H:mm تا H:mm"
+      },
+      "yMMMMEEEEd، ساعت Hm": {
+        "H": "EEEE d MMMM y، ساعت H:mm تا H:mm",
+        "m": "EEEE d MMMM y، ساعت H:mm تا H:mm"
+      },
+      "EEEE d MMMM y، ساعت hmv": {
+        "a": "EEEE d MMMM y، ساعت h:mm a تا h:mm a v",
+        "h": "EEEE d MMMM y، ساعت h:mm تا h:mm a v",
+        "m": "EEEE d MMMM y، ساعت h:mm تا h:mm a v"
+      },
+      "d MMMM y، ساعت hmv": {
+        "a": "d MMMM y، ساعت h:mm a تا h:mm a v",
+        "h": "d MMMM y، ساعت h:mm تا h:mm a v",
+        "m": "d MMMM y، ساعت h:mm تا h:mm a v"
+      },
+      "d MMM y،‏ hmv": {
+        "a": "d MMM y،‏ h:mm a تا h:mm a v",
+        "h": "d MMM y،‏ h:mm تا h:mm a v",
+        "m": "d MMM y،‏ h:mm تا h:mm a v"
+      },
+      "y/M/d،‏ hmv": {
+        "a": "y/M/d،‏ h:mm a تا h:mm a v",
+        "h": "y/M/d،‏ h:mm تا h:mm a v",
+        "m": "y/M/d،‏ h:mm تا h:mm a v"
+      },
+      "d،‏ hmv": {
+        "a": "d،‏ h:mm a تا h:mm a v",
+        "h": "d،‏ h:mm تا h:mm a v",
+        "m": "d،‏ h:mm تا h:mm a v"
+      },
+      "E،‏ hmv": {
+        "a": "ccc،‏ h:mm a تا h:mm a v",
+        "h": "ccc،‏ h:mm تا h:mm a v",
+        "m": "ccc،‏ h:mm تا h:mm a v"
+      },
+      "Ed،‏ hmv": {
+        "a": "E d،‏ h:mm a تا h:mm a v",
+        "h": "E d،‏ h:mm تا h:mm a v",
+        "m": "E d،‏ h:mm تا h:mm a v"
+      },
+      "Gy،‏ hmv": {
+        "a": "y G،‏ h:mm a تا h:mm a v",
+        "h": "y G،‏ h:mm تا h:mm a v",
+        "m": "y G،‏ h:mm تا h:mm a v"
+      },
+      "GyM،‏ hmv": {
+        "a": "y/M G،‏ h:mm a تا h:mm a v",
+        "h": "y/M G،‏ h:mm تا h:mm a v",
+        "m": "y/M G،‏ h:mm تا h:mm a v"
+      },
+      "GyMd،‏ hmv": {
+        "a": "y/M/d GGGGG،‏ h:mm a تا h:mm a v",
+        "h": "y/M/d GGGGG،‏ h:mm تا h:mm a v",
+        "m": "y/M/d GGGGG،‏ h:mm تا h:mm a v"
+      },
+      "GyMEd،‏ hmv": {
+        "a": "E، y/M/d G،‏ h:mm a تا h:mm a v",
+        "h": "E، y/M/d G،‏ h:mm تا h:mm a v",
+        "m": "E، y/M/d G،‏ h:mm تا h:mm a v"
+      },
+      "GyMMM،‏ hmv": {
+        "a": "MMM y G،‏ h:mm a تا h:mm a v",
+        "h": "MMM y G،‏ h:mm تا h:mm a v",
+        "m": "MMM y G،‏ h:mm تا h:mm a v"
+      },
+      "GyMMMd،‏ hmv": {
+        "a": "d MMM y G،‏ h:mm a تا h:mm a v",
+        "h": "d MMM y G،‏ h:mm تا h:mm a v",
+        "m": "d MMM y G،‏ h:mm تا h:mm a v"
+      },
+      "GyMMMEd،‏ hmv": {
+        "a": "E d MMM y G،‏ h:mm a تا h:mm a v",
+        "h": "E d MMM y G،‏ h:mm تا h:mm a v",
+        "m": "E d MMM y G،‏ h:mm تا h:mm a v"
+      },
+      "M،‏ hmv": {
+        "a": "L،‏ h:mm a تا h:mm a v",
+        "h": "L،‏ h:mm تا h:mm a v",
+        "m": "L،‏ h:mm تا h:mm a v"
+      },
+      "Md،‏ hmv": {
+        "a": "M/d،‏ h:mm a تا h:mm a v",
+        "h": "M/d،‏ h:mm تا h:mm a v",
+        "m": "M/d،‏ h:mm تا h:mm a v"
+      },
+      "MEd،‏ hmv": {
+        "a": "E M/d،‏ h:mm a تا h:mm a v",
+        "h": "E M/d،‏ h:mm تا h:mm a v",
+        "m": "E M/d،‏ h:mm تا h:mm a v"
+      },
+      "MMM،‏ hmv": {
+        "a": "LLL،‏ h:mm a تا h:mm a v",
+        "h": "LLL،‏ h:mm تا h:mm a v",
+        "m": "LLL،‏ h:mm تا h:mm a v"
+      },
+      "MMMd،‏ hmv": {
+        "a": "d LLL،‏ h:mm a تا h:mm a v",
+        "h": "d LLL،‏ h:mm تا h:mm a v",
+        "m": "d LLL،‏ h:mm تا h:mm a v"
+      },
+      "MMMEd،‏ hmv": {
+        "a": "E d LLL،‏ h:mm a تا h:mm a v",
+        "h": "E d LLL،‏ h:mm تا h:mm a v",
+        "m": "E d LLL،‏ h:mm تا h:mm a v"
+      },
+      "MMMMd، ساعت hmv": {
+        "a": "d LLLL، ساعت h:mm a تا h:mm a v",
+        "h": "d LLLL، ساعت h:mm تا h:mm a v",
+        "m": "d LLLL، ساعت h:mm تا h:mm a v"
+      },
+      "MMMMEd، ساعت hmv": {
+        "a": "E d LLLL، ساعت h:mm a تا h:mm a v",
+        "h": "E d LLLL، ساعت h:mm تا h:mm a v",
+        "m": "E d LLLL، ساعت h:mm تا h:mm a v"
+      },
+      "y،‏ hmv": {
+        "a": "y،‏ h:mm a تا h:mm a v",
+        "h": "y،‏ h:mm تا h:mm a v",
+        "m": "y،‏ h:mm تا h:mm a v"
+      },
+      "yM،‏ hmv": {
+        "a": "y/M،‏ h:mm a تا h:mm a v",
+        "h": "y/M،‏ h:mm تا h:mm a v",
+        "m": "y/M،‏ h:mm تا h:mm a v"
+      },
+      "yMd،‏ hmv": {
+        "a": "y/M/d،‏ h:mm a تا h:mm a v",
+        "h": "y/M/d،‏ h:mm تا h:mm a v",
+        "m": "y/M/d،‏ h:mm تا h:mm a v"
+      },
+      "yMEd،‏ hmv": {
+        "a": "E y/M/d،‏ h:mm a تا h:mm a v",
+        "h": "E y/M/d،‏ h:mm تا h:mm a v",
+        "m": "E y/M/d،‏ h:mm تا h:mm a v"
+      },
+      "yMMM،‏ hmv": {
+        "a": "MMM y،‏ h:mm a تا h:mm a v",
+        "h": "MMM y،‏ h:mm تا h:mm a v",
+        "m": "MMM y،‏ h:mm تا h:mm a v"
+      },
+      "yMMMd،‏ hmv": {
+        "a": "d MMM y،‏ h:mm a تا h:mm a v",
+        "h": "d MMM y،‏ h:mm تا h:mm a v",
+        "m": "d MMM y،‏ h:mm تا h:mm a v"
+      },
+      "yMMMEd،‏ hmv": {
+        "a": "E d MMM y،‏ h:mm a تا h:mm a v",
+        "h": "E d MMM y،‏ h:mm تا h:mm a v",
+        "m": "E d MMM y،‏ h:mm تا h:mm a v"
+      },
+      "yMMMM، ساعت hmv": {
+        "a": "MMMM y، ساعت h:mm a تا h:mm a v",
+        "h": "MMMM y، ساعت h:mm تا h:mm a v",
+        "m": "MMMM y، ساعت h:mm تا h:mm a v"
+      },
+      "yMMMMEEEEd، ساعت hmv": {
+        "a": "EEEE d MMMM y، ساعت h:mm a تا h:mm a v",
+        "h": "EEEE d MMMM y، ساعت h:mm تا h:mm a v",
+        "m": "EEEE d MMMM y، ساعت h:mm تا h:mm a v"
+      },
+      "EEEE d MMMM y، ساعت Hmv": {
+        "H": "EEEE d MMMM y، ساعت H:mm تا H:mm v",
+        "m": "EEEE d MMMM y، ساعت H:mm تا H:mm v"
+      },
+      "d MMMM y، ساعت Hmv": {
+        "H": "d MMMM y، ساعت H:mm تا H:mm v",
+        "m": "d MMMM y، ساعت H:mm تا H:mm v"
+      },
+      "d MMM y،‏ Hmv": {
+        "H": "d MMM y،‏ H:mm تا H:mm v",
+        "m": "d MMM y،‏ H:mm تا H:mm v"
+      },
+      "y/M/d،‏ Hmv": {
+        "H": "y/M/d،‏ H:mm تا H:mm v",
+        "m": "y/M/d،‏ H:mm تا H:mm v"
+      },
+      "d،‏ Hmv": {
+        "H": "d،‏ H:mm تا H:mm v",
+        "m": "d،‏ H:mm تا H:mm v"
+      },
+      "E،‏ Hmv": {
+        "H": "ccc،‏ H:mm تا H:mm v",
+        "m": "ccc،‏ H:mm تا H:mm v"
+      },
+      "Ed،‏ Hmv": {
+        "H": "E d،‏ H:mm تا H:mm v",
+        "m": "E d،‏ H:mm تا H:mm v"
+      },
+      "Gy،‏ Hmv": {
+        "H": "y G،‏ H:mm تا H:mm v",
+        "m": "y G،‏ H:mm تا H:mm v"
+      },
+      "GyM،‏ Hmv": {
+        "H": "y/M G،‏ H:mm تا H:mm v",
+        "m": "y/M G،‏ H:mm تا H:mm v"
+      },
+      "GyMd،‏ Hmv": {
+        "H": "y/M/d GGGGG،‏ H:mm تا H:mm v",
+        "m": "y/M/d GGGGG،‏ H:mm تا H:mm v"
+      },
+      "GyMEd،‏ Hmv": {
+        "H": "E، y/M/d G،‏ H:mm تا H:mm v",
+        "m": "E، y/M/d G،‏ H:mm تا H:mm v"
+      },
+      "GyMMM،‏ Hmv": {
+        "H": "MMM y G،‏ H:mm تا H:mm v",
+        "m": "MMM y G،‏ H:mm تا H:mm v"
+      },
+      "GyMMMd،‏ Hmv": {
+        "H": "d MMM y G،‏ H:mm تا H:mm v",
+        "m": "d MMM y G،‏ H:mm تا H:mm v"
+      },
+      "GyMMMEd،‏ Hmv": {
+        "H": "E d MMM y G،‏ H:mm تا H:mm v",
+        "m": "E d MMM y G،‏ H:mm تا H:mm v"
+      },
+      "M،‏ Hmv": {
+        "H": "L،‏ H:mm تا H:mm v",
+        "m": "L،‏ H:mm تا H:mm v"
+      },
+      "Md،‏ Hmv": {
+        "H": "M/d،‏ H:mm تا H:mm v",
+        "m": "M/d،‏ H:mm تا H:mm v"
+      },
+      "MEd،‏ Hmv": {
+        "H": "E M/d،‏ H:mm تا H:mm v",
+        "m": "E M/d،‏ H:mm تا H:mm v"
+      },
+      "MMM،‏ Hmv": {
+        "H": "LLL،‏ H:mm تا H:mm v",
+        "m": "LLL،‏ H:mm تا H:mm v"
+      },
+      "MMMd،‏ Hmv": {
+        "H": "d LLL،‏ H:mm تا H:mm v",
+        "m": "d LLL،‏ H:mm تا H:mm v"
+      },
+      "MMMEd،‏ Hmv": {
+        "H": "E d LLL،‏ H:mm تا H:mm v",
+        "m": "E d LLL،‏ H:mm تا H:mm v"
+      },
+      "MMMMd، ساعت Hmv": {
+        "H": "d LLLL، ساعت H:mm تا H:mm v",
+        "m": "d LLLL، ساعت H:mm تا H:mm v"
+      },
+      "MMMMEd، ساعت Hmv": {
+        "H": "E d LLLL، ساعت H:mm تا H:mm v",
+        "m": "E d LLLL، ساعت H:mm تا H:mm v"
+      },
+      "y،‏ Hmv": {
+        "H": "y،‏ H:mm تا H:mm v",
+        "m": "y،‏ H:mm تا H:mm v"
+      },
+      "yM،‏ Hmv": {
+        "H": "y/M،‏ H:mm تا H:mm v",
+        "m": "y/M،‏ H:mm تا H:mm v"
+      },
+      "yMd،‏ Hmv": {
+        "H": "y/M/d،‏ H:mm تا H:mm v",
+        "m": "y/M/d،‏ H:mm تا H:mm v"
+      },
+      "yMEd،‏ Hmv": {
+        "H": "E y/M/d،‏ H:mm تا H:mm v",
+        "m": "E y/M/d،‏ H:mm تا H:mm v"
+      },
+      "yMMM،‏ Hmv": {
+        "H": "MMM y،‏ H:mm تا H:mm v",
+        "m": "MMM y،‏ H:mm تا H:mm v"
+      },
+      "yMMMd،‏ Hmv": {
+        "H": "d MMM y،‏ H:mm تا H:mm v",
+        "m": "d MMM y،‏ H:mm تا H:mm v"
+      },
+      "yMMMEd،‏ Hmv": {
+        "H": "E d MMM y،‏ H:mm تا H:mm v",
+        "m": "E d MMM y،‏ H:mm تا H:mm v"
+      },
+      "yMMMM، ساعت Hmv": {
+        "H": "MMMM y، ساعت H:mm تا H:mm v",
+        "m": "MMMM y، ساعت H:mm تا H:mm v"
+      },
+      "yMMMMEEEEd، ساعت Hmv": {
+        "H": "EEEE d MMMM y، ساعت H:mm تا H:mm v",
+        "m": "EEEE d MMMM y، ساعت H:mm تا H:mm v"
+      },
+      "EEEE d MMMM y، ساعت hv": {
+        "a": "EEEE d MMMM y، ساعت h a تا h a v",
+        "h": "EEEE d MMMM y، ساعت h تا h a v"
+      },
+      "d MMMM y، ساعت hv": {
+        "a": "d MMMM y، ساعت h a تا h a v",
+        "h": "d MMMM y، ساعت h تا h a v"
+      },
+      "d MMM y،‏ hv": {
+        "a": "d MMM y،‏ h a تا h a v",
+        "h": "d MMM y،‏ h تا h a v"
+      },
+      "y/M/d،‏ hv": {
+        "a": "y/M/d،‏ h a تا h a v",
+        "h": "y/M/d،‏ h تا h a v"
+      },
+      "d،‏ hv": {
+        "a": "d،‏ h a تا h a v",
+        "h": "d،‏ h تا h a v"
+      },
+      "E،‏ hv": {
+        "a": "ccc،‏ h a تا h a v",
+        "h": "ccc،‏ h تا h a v"
+      },
+      "Ed،‏ hv": {
+        "a": "E d،‏ h a تا h a v",
+        "h": "E d،‏ h تا h a v"
+      },
+      "Gy،‏ hv": {
+        "a": "y G،‏ h a تا h a v",
+        "h": "y G،‏ h تا h a v"
+      },
+      "GyM،‏ hv": {
+        "a": "y/M G،‏ h a تا h a v",
+        "h": "y/M G،‏ h تا h a v"
+      },
+      "GyMd،‏ hv": {
+        "a": "y/M/d GGGGG،‏ h a تا h a v",
+        "h": "y/M/d GGGGG،‏ h تا h a v"
+      },
+      "GyMEd،‏ hv": {
+        "a": "E، y/M/d G،‏ h a تا h a v",
+        "h": "E، y/M/d G،‏ h تا h a v"
+      },
+      "GyMMM،‏ hv": {
+        "a": "MMM y G،‏ h a تا h a v",
+        "h": "MMM y G،‏ h تا h a v"
+      },
+      "GyMMMd،‏ hv": {
+        "a": "d MMM y G،‏ h a تا h a v",
+        "h": "d MMM y G،‏ h تا h a v"
+      },
+      "GyMMMEd،‏ hv": {
+        "a": "E d MMM y G،‏ h a تا h a v",
+        "h": "E d MMM y G،‏ h تا h a v"
+      },
+      "M،‏ hv": {
+        "a": "L،‏ h a تا h a v",
+        "h": "L،‏ h تا h a v"
+      },
+      "Md،‏ hv": {
+        "a": "M/d،‏ h a تا h a v",
+        "h": "M/d،‏ h تا h a v"
+      },
+      "MEd،‏ hv": {
+        "a": "E M/d،‏ h a تا h a v",
+        "h": "E M/d،‏ h تا h a v"
+      },
+      "MMM،‏ hv": {
+        "a": "LLL،‏ h a تا h a v",
+        "h": "LLL،‏ h تا h a v"
+      },
+      "MMMd،‏ hv": {
+        "a": "d LLL،‏ h a تا h a v",
+        "h": "d LLL،‏ h تا h a v"
+      },
+      "MMMEd،‏ hv": {
+        "a": "E d LLL،‏ h a تا h a v",
+        "h": "E d LLL،‏ h تا h a v"
+      },
+      "MMMMd، ساعت hv": {
+        "a": "d LLLL، ساعت h a تا h a v",
+        "h": "d LLLL، ساعت h تا h a v"
+      },
+      "MMMMEd، ساعت hv": {
+        "a": "E d LLLL، ساعت h a تا h a v",
+        "h": "E d LLLL، ساعت h تا h a v"
+      },
+      "y،‏ hv": {
+        "a": "y،‏ h a تا h a v",
+        "h": "y،‏ h تا h a v"
+      },
+      "yM،‏ hv": {
+        "a": "y/M،‏ h a تا h a v",
+        "h": "y/M،‏ h تا h a v"
+      },
+      "yMd،‏ hv": {
+        "a": "y/M/d،‏ h a تا h a v",
+        "h": "y/M/d،‏ h تا h a v"
+      },
+      "yMEd،‏ hv": {
+        "a": "E y/M/d،‏ h a تا h a v",
+        "h": "E y/M/d،‏ h تا h a v"
+      },
+      "yMMM،‏ hv": {
+        "a": "MMM y،‏ h a تا h a v",
+        "h": "MMM y،‏ h تا h a v"
+      },
+      "yMMMd،‏ hv": {
+        "a": "d MMM y،‏ h a تا h a v",
+        "h": "d MMM y،‏ h تا h a v"
+      },
+      "yMMMEd،‏ hv": {
+        "a": "E d MMM y،‏ h a تا h a v",
+        "h": "E d MMM y،‏ h تا h a v"
+      },
+      "yMMMM، ساعت hv": {
+        "a": "MMMM y، ساعت h a تا h a v",
+        "h": "MMMM y، ساعت h تا h a v"
+      },
+      "yMMMMEEEEd، ساعت hv": {
+        "a": "EEEE d MMMM y، ساعت h a تا h a v",
+        "h": "EEEE d MMMM y، ساعت h تا h a v"
+      },
+      "EEEE d MMMM y، ساعت Hv": {
+        "H": "EEEE d MMMM y، ساعت H تا H v"
+      },
+      "d MMMM y، ساعت Hv": {
+        "H": "d MMMM y، ساعت H تا H v"
+      },
+      "d MMM y،‏ Hv": {
+        "H": "d MMM y،‏ H تا H v"
+      },
+      "y/M/d،‏ Hv": {
+        "H": "y/M/d،‏ H تا H v"
+      },
+      "d،‏ Hv": {
+        "H": "d،‏ H تا H v"
+      },
+      "E،‏ Hv": {
+        "H": "ccc،‏ H تا H v"
+      },
+      "Ed،‏ Hv": {
+        "H": "E d،‏ H تا H v"
+      },
+      "Gy،‏ Hv": {
+        "H": "y G،‏ H تا H v"
+      },
+      "GyM،‏ Hv": {
+        "H": "y/M G،‏ H تا H v"
+      },
+      "GyMd،‏ Hv": {
+        "H": "y/M/d GGGGG،‏ H تا H v"
+      },
+      "GyMEd،‏ Hv": {
+        "H": "E، y/M/d G،‏ H تا H v"
+      },
+      "GyMMM،‏ Hv": {
+        "H": "MMM y G،‏ H تا H v"
+      },
+      "GyMMMd،‏ Hv": {
+        "H": "d MMM y G،‏ H تا H v"
+      },
+      "GyMMMEd،‏ Hv": {
+        "H": "E d MMM y G،‏ H تا H v"
+      },
+      "M،‏ Hv": {
+        "H": "L،‏ H تا H v"
+      },
+      "Md،‏ Hv": {
+        "H": "M/d،‏ H تا H v"
+      },
+      "MEd،‏ Hv": {
+        "H": "E M/d،‏ H تا H v"
+      },
+      "MMM،‏ Hv": {
+        "H": "LLL،‏ H تا H v"
+      },
+      "MMMd،‏ Hv": {
+        "H": "d LLL،‏ H تا H v"
+      },
+      "MMMEd،‏ Hv": {
+        "H": "E d LLL،‏ H تا H v"
+      },
+      "MMMMd، ساعت Hv": {
+        "H": "d LLLL، ساعت H تا H v"
+      },
+      "MMMMEd، ساعت Hv": {
+        "H": "E d LLLL، ساعت H تا H v"
+      },
+      "y،‏ Hv": {
+        "H": "y،‏ H تا H v"
+      },
+      "yM،‏ Hv": {
+        "H": "y/M،‏ H تا H v"
+      },
+      "yMd،‏ Hv": {
+        "H": "y/M/d،‏ H تا H v"
+      },
+      "yMEd،‏ Hv": {
+        "H": "E y/M/d،‏ H تا H v"
+      },
+      "yMMM،‏ Hv": {
+        "H": "MMM y،‏ H تا H v"
+      },
+      "yMMMd،‏ Hv": {
+        "H": "d MMM y،‏ H تا H v"
+      },
+      "yMMMEd،‏ Hv": {
+        "H": "E d MMM y،‏ H تا H v"
+      },
+      "yMMMM، ساعت Hv": {
+        "H": "MMMM y، ساعت H تا H v"
+      },
+      "yMMMMEEEEd، ساعت Hv": {
+        "H": "EEEE d MMMM y، ساعت H تا H v"
       }
     },
     "hourCycle": "",

--- a/packages/intl-datetimeformat/tests/locale-data/ko.json
+++ b/packages/intl-datetimeformat/tests/locale-data/ko.json
@@ -2769,6 +2769,1482 @@
       "yMMMM": {
         "M": "y년 MMMM~MMMM",
         "y": "y년 MMMM~y년 MMMM"
+      },
+      "y년 MMMM d일 EEEE Bh": {
+        "B": "y년 MMMM d일 EEEE B h시 ~ B h시",
+        "h": "y년 MMMM d일 EEEE B h시~h시"
+      },
+      "y년 MMMM d일 Bh": {
+        "B": "y년 MMMM d일 B h시 ~ B h시",
+        "h": "y년 MMMM d일 B h시~h시"
+      },
+      "y. M. d. Bh": {
+        "B": "y. M. d. B h시 ~ B h시",
+        "h": "y. M. d. B h시~h시"
+      },
+      "yy. M. d. Bh": {
+        "B": "yy. M. d. B h시 ~ B h시",
+        "h": "yy. M. d. B h시~h시"
+      },
+      "d Bh": {
+        "B": "d일 B h시 ~ B h시",
+        "h": "d일 B h시~h시"
+      },
+      "E Bh": {
+        "B": "ccc B h시 ~ B h시",
+        "h": "ccc B h시~h시"
+      },
+      "Ed Bh": {
+        "B": "d일 (E) B h시 ~ B h시",
+        "h": "d일 (E) B h시~h시"
+      },
+      "EEEEd Bh": {
+        "B": "d일 EEEE B h시 ~ B h시",
+        "h": "d일 EEEE B h시~h시"
+      },
+      "Gy Bh": {
+        "B": "G y년 B h시 ~ B h시",
+        "h": "G y년 B h시~h시"
+      },
+      "GyM Bh": {
+        "B": "G y/M B h시 ~ B h시",
+        "h": "G y/M B h시~h시"
+      },
+      "GyMd Bh": {
+        "B": "GGGGG y/M/d B h시 ~ B h시",
+        "h": "GGGGG y/M/d B h시~h시"
+      },
+      "GyMEd Bh": {
+        "B": "G y/M/d (E) B h시 ~ B h시",
+        "h": "G y/M/d (E) B h시~h시"
+      },
+      "GyMMM Bh": {
+        "B": "G y년 MMM B h시 ~ B h시",
+        "h": "G y년 MMM B h시~h시"
+      },
+      "GyMMMd Bh": {
+        "B": "G y년 MMM d일 B h시 ~ B h시",
+        "h": "G y년 MMM d일 B h시~h시"
+      },
+      "GyMMMEd Bh": {
+        "B": "G y년 MMM d일 (E) B h시 ~ B h시",
+        "h": "G y년 MMM d일 (E) B h시~h시"
+      },
+      "GyMMMEEEEd Bh": {
+        "B": "G y년 MMM d일 EEEE B h시 ~ B h시",
+        "h": "G y년 MMM d일 EEEE B h시~h시"
+      },
+      "M Bh": {
+        "B": "M월 B h시 ~ B h시",
+        "h": "M월 B h시~h시"
+      },
+      "Md Bh": {
+        "B": "M. d. B h시 ~ B h시",
+        "h": "M. d. B h시~h시"
+      },
+      "MEd Bh": {
+        "B": "M. d. (E) B h시 ~ B h시",
+        "h": "M. d. (E) B h시~h시"
+      },
+      "MEEEEd Bh": {
+        "B": "M. d. EEEE B h시 ~ B h시",
+        "h": "M. d. EEEE B h시~h시"
+      },
+      "MMM Bh": {
+        "B": "LLL B h시 ~ B h시",
+        "h": "LLL B h시~h시"
+      },
+      "MMMd Bh": {
+        "B": "MMM d일 B h시 ~ B h시",
+        "h": "MMM d일 B h시~h시"
+      },
+      "MMMEd Bh": {
+        "B": "MMM d일 (E) B h시 ~ B h시",
+        "h": "MMM d일 (E) B h시~h시"
+      },
+      "MMMEEEEd Bh": {
+        "B": "MMM d일 EEEE B h시 ~ B h시",
+        "h": "MMM d일 EEEE B h시~h시"
+      },
+      "MMMMd Bh": {
+        "B": "MMMM d일 B h시 ~ B h시",
+        "h": "MMMM d일 B h시~h시"
+      },
+      "y Bh": {
+        "B": "y년 B h시 ~ B h시",
+        "h": "y년 B h시~h시"
+      },
+      "yM Bh": {
+        "B": "y. M. B h시 ~ B h시",
+        "h": "y. M. B h시~h시"
+      },
+      "yMd Bh": {
+        "B": "y. M. d. B h시 ~ B h시",
+        "h": "y. M. d. B h시~h시"
+      },
+      "yMEd Bh": {
+        "B": "y. M. d. (E) B h시 ~ B h시",
+        "h": "y. M. d. (E) B h시~h시"
+      },
+      "yMEEEEd Bh": {
+        "B": "y. M. d. EEEE B h시 ~ B h시",
+        "h": "y. M. d. EEEE B h시~h시"
+      },
+      "yMM Bh": {
+        "B": "y. M. B h시 ~ B h시",
+        "h": "y. M. B h시~h시"
+      },
+      "yMMM Bh": {
+        "B": "y년 MMM B h시 ~ B h시",
+        "h": "y년 MMM B h시~h시"
+      },
+      "yMMMd Bh": {
+        "B": "y년 MMM d일 B h시 ~ B h시",
+        "h": "y년 MMM d일 B h시~h시"
+      },
+      "yMMMEd Bh": {
+        "B": "y년 MMM d일 (E) B h시 ~ B h시",
+        "h": "y년 MMM d일 (E) B h시~h시"
+      },
+      "yMMMEEEEd Bh": {
+        "B": "y년 MMM d일 EEEE B h시 ~ B h시",
+        "h": "y년 MMM d일 EEEE B h시~h시"
+      },
+      "yMMMM Bh": {
+        "B": "y년 MMMM B h시 ~ B h시",
+        "h": "y년 MMMM B h시~h시"
+      },
+      "y년 MMMM d일 EEEE Bhm": {
+        "B": "y년 MMMM d일 EEEE B h:mm~B h:mm",
+        "h": "y년 MMMM d일 EEEE B h:mm ~ h:mm",
+        "m": "y년 MMMM d일 EEEE B h:mm ~ h:mm"
+      },
+      "y년 MMMM d일 Bhm": {
+        "B": "y년 MMMM d일 B h:mm~B h:mm",
+        "h": "y년 MMMM d일 B h:mm ~ h:mm",
+        "m": "y년 MMMM d일 B h:mm ~ h:mm"
+      },
+      "y. M. d. Bhm": {
+        "B": "y. M. d. B h:mm~B h:mm",
+        "h": "y. M. d. B h:mm ~ h:mm",
+        "m": "y. M. d. B h:mm ~ h:mm"
+      },
+      "yy. M. d. Bhm": {
+        "B": "yy. M. d. B h:mm~B h:mm",
+        "h": "yy. M. d. B h:mm ~ h:mm",
+        "m": "yy. M. d. B h:mm ~ h:mm"
+      },
+      "d Bhm": {
+        "B": "d일 B h:mm~B h:mm",
+        "h": "d일 B h:mm ~ h:mm",
+        "m": "d일 B h:mm ~ h:mm"
+      },
+      "E Bhm": {
+        "B": "ccc B h:mm~B h:mm",
+        "h": "ccc B h:mm ~ h:mm",
+        "m": "ccc B h:mm ~ h:mm"
+      },
+      "Ed Bhm": {
+        "B": "d일 (E) B h:mm~B h:mm",
+        "h": "d일 (E) B h:mm ~ h:mm",
+        "m": "d일 (E) B h:mm ~ h:mm"
+      },
+      "EEEEd Bhm": {
+        "B": "d일 EEEE B h:mm~B h:mm",
+        "h": "d일 EEEE B h:mm ~ h:mm",
+        "m": "d일 EEEE B h:mm ~ h:mm"
+      },
+      "Gy Bhm": {
+        "B": "G y년 B h:mm~B h:mm",
+        "h": "G y년 B h:mm ~ h:mm",
+        "m": "G y년 B h:mm ~ h:mm"
+      },
+      "GyM Bhm": {
+        "B": "G y/M B h:mm~B h:mm",
+        "h": "G y/M B h:mm ~ h:mm",
+        "m": "G y/M B h:mm ~ h:mm"
+      },
+      "GyMd Bhm": {
+        "B": "GGGGG y/M/d B h:mm~B h:mm",
+        "h": "GGGGG y/M/d B h:mm ~ h:mm",
+        "m": "GGGGG y/M/d B h:mm ~ h:mm"
+      },
+      "GyMEd Bhm": {
+        "B": "G y/M/d (E) B h:mm~B h:mm",
+        "h": "G y/M/d (E) B h:mm ~ h:mm",
+        "m": "G y/M/d (E) B h:mm ~ h:mm"
+      },
+      "GyMMM Bhm": {
+        "B": "G y년 MMM B h:mm~B h:mm",
+        "h": "G y년 MMM B h:mm ~ h:mm",
+        "m": "G y년 MMM B h:mm ~ h:mm"
+      },
+      "GyMMMd Bhm": {
+        "B": "G y년 MMM d일 B h:mm~B h:mm",
+        "h": "G y년 MMM d일 B h:mm ~ h:mm",
+        "m": "G y년 MMM d일 B h:mm ~ h:mm"
+      },
+      "GyMMMEd Bhm": {
+        "B": "G y년 MMM d일 (E) B h:mm~B h:mm",
+        "h": "G y년 MMM d일 (E) B h:mm ~ h:mm",
+        "m": "G y년 MMM d일 (E) B h:mm ~ h:mm"
+      },
+      "GyMMMEEEEd Bhm": {
+        "B": "G y년 MMM d일 EEEE B h:mm~B h:mm",
+        "h": "G y년 MMM d일 EEEE B h:mm ~ h:mm",
+        "m": "G y년 MMM d일 EEEE B h:mm ~ h:mm"
+      },
+      "M Bhm": {
+        "B": "M월 B h:mm~B h:mm",
+        "h": "M월 B h:mm ~ h:mm",
+        "m": "M월 B h:mm ~ h:mm"
+      },
+      "Md Bhm": {
+        "B": "M. d. B h:mm~B h:mm",
+        "h": "M. d. B h:mm ~ h:mm",
+        "m": "M. d. B h:mm ~ h:mm"
+      },
+      "MEd Bhm": {
+        "B": "M. d. (E) B h:mm~B h:mm",
+        "h": "M. d. (E) B h:mm ~ h:mm",
+        "m": "M. d. (E) B h:mm ~ h:mm"
+      },
+      "MEEEEd Bhm": {
+        "B": "M. d. EEEE B h:mm~B h:mm",
+        "h": "M. d. EEEE B h:mm ~ h:mm",
+        "m": "M. d. EEEE B h:mm ~ h:mm"
+      },
+      "MMM Bhm": {
+        "B": "LLL B h:mm~B h:mm",
+        "h": "LLL B h:mm ~ h:mm",
+        "m": "LLL B h:mm ~ h:mm"
+      },
+      "MMMd Bhm": {
+        "B": "MMM d일 B h:mm~B h:mm",
+        "h": "MMM d일 B h:mm ~ h:mm",
+        "m": "MMM d일 B h:mm ~ h:mm"
+      },
+      "MMMEd Bhm": {
+        "B": "MMM d일 (E) B h:mm~B h:mm",
+        "h": "MMM d일 (E) B h:mm ~ h:mm",
+        "m": "MMM d일 (E) B h:mm ~ h:mm"
+      },
+      "MMMEEEEd Bhm": {
+        "B": "MMM d일 EEEE B h:mm~B h:mm",
+        "h": "MMM d일 EEEE B h:mm ~ h:mm",
+        "m": "MMM d일 EEEE B h:mm ~ h:mm"
+      },
+      "MMMMd Bhm": {
+        "B": "MMMM d일 B h:mm~B h:mm",
+        "h": "MMMM d일 B h:mm ~ h:mm",
+        "m": "MMMM d일 B h:mm ~ h:mm"
+      },
+      "y Bhm": {
+        "B": "y년 B h:mm~B h:mm",
+        "h": "y년 B h:mm ~ h:mm",
+        "m": "y년 B h:mm ~ h:mm"
+      },
+      "yM Bhm": {
+        "B": "y. M. B h:mm~B h:mm",
+        "h": "y. M. B h:mm ~ h:mm",
+        "m": "y. M. B h:mm ~ h:mm"
+      },
+      "yMd Bhm": {
+        "B": "y. M. d. B h:mm~B h:mm",
+        "h": "y. M. d. B h:mm ~ h:mm",
+        "m": "y. M. d. B h:mm ~ h:mm"
+      },
+      "yMEd Bhm": {
+        "B": "y. M. d. (E) B h:mm~B h:mm",
+        "h": "y. M. d. (E) B h:mm ~ h:mm",
+        "m": "y. M. d. (E) B h:mm ~ h:mm"
+      },
+      "yMEEEEd Bhm": {
+        "B": "y. M. d. EEEE B h:mm~B h:mm",
+        "h": "y. M. d. EEEE B h:mm ~ h:mm",
+        "m": "y. M. d. EEEE B h:mm ~ h:mm"
+      },
+      "yMM Bhm": {
+        "B": "y. M. B h:mm~B h:mm",
+        "h": "y. M. B h:mm ~ h:mm",
+        "m": "y. M. B h:mm ~ h:mm"
+      },
+      "yMMM Bhm": {
+        "B": "y년 MMM B h:mm~B h:mm",
+        "h": "y년 MMM B h:mm ~ h:mm",
+        "m": "y년 MMM B h:mm ~ h:mm"
+      },
+      "yMMMd Bhm": {
+        "B": "y년 MMM d일 B h:mm~B h:mm",
+        "h": "y년 MMM d일 B h:mm ~ h:mm",
+        "m": "y년 MMM d일 B h:mm ~ h:mm"
+      },
+      "yMMMEd Bhm": {
+        "B": "y년 MMM d일 (E) B h:mm~B h:mm",
+        "h": "y년 MMM d일 (E) B h:mm ~ h:mm",
+        "m": "y년 MMM d일 (E) B h:mm ~ h:mm"
+      },
+      "yMMMEEEEd Bhm": {
+        "B": "y년 MMM d일 EEEE B h:mm~B h:mm",
+        "h": "y년 MMM d일 EEEE B h:mm ~ h:mm",
+        "m": "y년 MMM d일 EEEE B h:mm ~ h:mm"
+      },
+      "yMMMM Bhm": {
+        "B": "y년 MMMM B h:mm~B h:mm",
+        "h": "y년 MMMM B h:mm ~ h:mm",
+        "m": "y년 MMMM B h:mm ~ h:mm"
+      },
+      "y년 MMMM d일 EEEE h": {
+        "a": "y년 MMMM d일 EEEE a h시 ~ a h시",
+        "h": "y년 MMMM d일 EEEE a h시 ~ h시"
+      },
+      "y년 MMMM d일 h": {
+        "a": "y년 MMMM d일 a h시 ~ a h시",
+        "h": "y년 MMMM d일 a h시 ~ h시"
+      },
+      "y. M. d. h": {
+        "a": "y. M. d. a h시 ~ a h시",
+        "h": "y. M. d. a h시 ~ h시"
+      },
+      "yy. M. d. h": {
+        "a": "yy. M. d. a h시 ~ a h시",
+        "h": "yy. M. d. a h시 ~ h시"
+      },
+      "d h": {
+        "a": "d일 a h시 ~ a h시",
+        "h": "d일 a h시 ~ h시"
+      },
+      "E h": {
+        "a": "ccc a h시 ~ a h시",
+        "h": "ccc a h시 ~ h시"
+      },
+      "Ed h": {
+        "a": "d일 (E) a h시 ~ a h시",
+        "h": "d일 (E) a h시 ~ h시"
+      },
+      "EEEEd h": {
+        "a": "d일 EEEE a h시 ~ a h시",
+        "h": "d일 EEEE a h시 ~ h시"
+      },
+      "Gy h": {
+        "a": "G y년 a h시 ~ a h시",
+        "h": "G y년 a h시 ~ h시"
+      },
+      "GyM h": {
+        "a": "G y/M a h시 ~ a h시",
+        "h": "G y/M a h시 ~ h시"
+      },
+      "GyMd h": {
+        "a": "GGGGG y/M/d a h시 ~ a h시",
+        "h": "GGGGG y/M/d a h시 ~ h시"
+      },
+      "GyMEd h": {
+        "a": "G y/M/d (E) a h시 ~ a h시",
+        "h": "G y/M/d (E) a h시 ~ h시"
+      },
+      "GyMMM h": {
+        "a": "G y년 MMM a h시 ~ a h시",
+        "h": "G y년 MMM a h시 ~ h시"
+      },
+      "GyMMMd h": {
+        "a": "G y년 MMM d일 a h시 ~ a h시",
+        "h": "G y년 MMM d일 a h시 ~ h시"
+      },
+      "GyMMMEd h": {
+        "a": "G y년 MMM d일 (E) a h시 ~ a h시",
+        "h": "G y년 MMM d일 (E) a h시 ~ h시"
+      },
+      "GyMMMEEEEd h": {
+        "a": "G y년 MMM d일 EEEE a h시 ~ a h시",
+        "h": "G y년 MMM d일 EEEE a h시 ~ h시"
+      },
+      "M h": {
+        "a": "M월 a h시 ~ a h시",
+        "h": "M월 a h시 ~ h시"
+      },
+      "Md h": {
+        "a": "M. d. a h시 ~ a h시",
+        "h": "M. d. a h시 ~ h시"
+      },
+      "MEd h": {
+        "a": "M. d. (E) a h시 ~ a h시",
+        "h": "M. d. (E) a h시 ~ h시"
+      },
+      "MEEEEd h": {
+        "a": "M. d. EEEE a h시 ~ a h시",
+        "h": "M. d. EEEE a h시 ~ h시"
+      },
+      "MMM h": {
+        "a": "LLL a h시 ~ a h시",
+        "h": "LLL a h시 ~ h시"
+      },
+      "MMMd h": {
+        "a": "MMM d일 a h시 ~ a h시",
+        "h": "MMM d일 a h시 ~ h시"
+      },
+      "MMMEd h": {
+        "a": "MMM d일 (E) a h시 ~ a h시",
+        "h": "MMM d일 (E) a h시 ~ h시"
+      },
+      "MMMEEEEd h": {
+        "a": "MMM d일 EEEE a h시 ~ a h시",
+        "h": "MMM d일 EEEE a h시 ~ h시"
+      },
+      "MMMMd h": {
+        "a": "MMMM d일 a h시 ~ a h시",
+        "h": "MMMM d일 a h시 ~ h시"
+      },
+      "y h": {
+        "a": "y년 a h시 ~ a h시",
+        "h": "y년 a h시 ~ h시"
+      },
+      "yM h": {
+        "a": "y. M. a h시 ~ a h시",
+        "h": "y. M. a h시 ~ h시"
+      },
+      "yMd h": {
+        "a": "y. M. d. a h시 ~ a h시",
+        "h": "y. M. d. a h시 ~ h시"
+      },
+      "yMEd h": {
+        "a": "y. M. d. (E) a h시 ~ a h시",
+        "h": "y. M. d. (E) a h시 ~ h시"
+      },
+      "yMEEEEd h": {
+        "a": "y. M. d. EEEE a h시 ~ a h시",
+        "h": "y. M. d. EEEE a h시 ~ h시"
+      },
+      "yMM h": {
+        "a": "y. M. a h시 ~ a h시",
+        "h": "y. M. a h시 ~ h시"
+      },
+      "yMMM h": {
+        "a": "y년 MMM a h시 ~ a h시",
+        "h": "y년 MMM a h시 ~ h시"
+      },
+      "yMMMd h": {
+        "a": "y년 MMM d일 a h시 ~ a h시",
+        "h": "y년 MMM d일 a h시 ~ h시"
+      },
+      "yMMMEd h": {
+        "a": "y년 MMM d일 (E) a h시 ~ a h시",
+        "h": "y년 MMM d일 (E) a h시 ~ h시"
+      },
+      "yMMMEEEEd h": {
+        "a": "y년 MMM d일 EEEE a h시 ~ a h시",
+        "h": "y년 MMM d일 EEEE a h시 ~ h시"
+      },
+      "yMMMM h": {
+        "a": "y년 MMMM a h시 ~ a h시",
+        "h": "y년 MMMM a h시 ~ h시"
+      },
+      "y년 MMMM d일 EEEE H": {
+        "H": "y년 MMMM d일 EEEE H ~ H시"
+      },
+      "y년 MMMM d일 H": {
+        "H": "y년 MMMM d일 H ~ H시"
+      },
+      "y. M. d. H": {
+        "H": "y. M. d. H ~ H시"
+      },
+      "yy. M. d. H": {
+        "H": "yy. M. d. H ~ H시"
+      },
+      "d H": {
+        "H": "d일 H ~ H시"
+      },
+      "E H": {
+        "H": "ccc H ~ H시"
+      },
+      "Ed H": {
+        "H": "d일 (E) H ~ H시"
+      },
+      "EEEEd H": {
+        "H": "d일 EEEE H ~ H시"
+      },
+      "Gy H": {
+        "H": "G y년 H ~ H시"
+      },
+      "GyM H": {
+        "H": "G y/M H ~ H시"
+      },
+      "GyMd H": {
+        "H": "GGGGG y/M/d H ~ H시"
+      },
+      "GyMEd H": {
+        "H": "G y/M/d (E) H ~ H시"
+      },
+      "GyMMM H": {
+        "H": "G y년 MMM H ~ H시"
+      },
+      "GyMMMd H": {
+        "H": "G y년 MMM d일 H ~ H시"
+      },
+      "GyMMMEd H": {
+        "H": "G y년 MMM d일 (E) H ~ H시"
+      },
+      "GyMMMEEEEd H": {
+        "H": "G y년 MMM d일 EEEE H ~ H시"
+      },
+      "M H": {
+        "H": "M월 H ~ H시"
+      },
+      "Md H": {
+        "H": "M. d. H ~ H시"
+      },
+      "MEd H": {
+        "H": "M. d. (E) H ~ H시"
+      },
+      "MEEEEd H": {
+        "H": "M. d. EEEE H ~ H시"
+      },
+      "MMM H": {
+        "H": "LLL H ~ H시"
+      },
+      "MMMd H": {
+        "H": "MMM d일 H ~ H시"
+      },
+      "MMMEd H": {
+        "H": "MMM d일 (E) H ~ H시"
+      },
+      "MMMEEEEd H": {
+        "H": "MMM d일 EEEE H ~ H시"
+      },
+      "MMMMd H": {
+        "H": "MMMM d일 H ~ H시"
+      },
+      "y H": {
+        "H": "y년 H ~ H시"
+      },
+      "yM H": {
+        "H": "y. M. H ~ H시"
+      },
+      "yMd H": {
+        "H": "y. M. d. H ~ H시"
+      },
+      "yMEd H": {
+        "H": "y. M. d. (E) H ~ H시"
+      },
+      "yMEEEEd H": {
+        "H": "y. M. d. EEEE H ~ H시"
+      },
+      "yMM H": {
+        "H": "y. M. H ~ H시"
+      },
+      "yMMM H": {
+        "H": "y년 MMM H ~ H시"
+      },
+      "yMMMd H": {
+        "H": "y년 MMM d일 H ~ H시"
+      },
+      "yMMMEd H": {
+        "H": "y년 MMM d일 (E) H ~ H시"
+      },
+      "yMMMEEEEd H": {
+        "H": "y년 MMM d일 EEEE H ~ H시"
+      },
+      "yMMMM H": {
+        "H": "y년 MMMM H ~ H시"
+      },
+      "y년 MMMM d일 EEEE hm": {
+        "a": "y년 MMMM d일 EEEE a h:mm ~ a h:mm",
+        "h": "y년 MMMM d일 EEEE a h:mm~h:mm",
+        "m": "y년 MMMM d일 EEEE a h:mm~h:mm"
+      },
+      "y년 MMMM d일 hm": {
+        "a": "y년 MMMM d일 a h:mm ~ a h:mm",
+        "h": "y년 MMMM d일 a h:mm~h:mm",
+        "m": "y년 MMMM d일 a h:mm~h:mm"
+      },
+      "y. M. d. hm": {
+        "a": "y. M. d. a h:mm ~ a h:mm",
+        "h": "y. M. d. a h:mm~h:mm",
+        "m": "y. M. d. a h:mm~h:mm"
+      },
+      "yy. M. d. hm": {
+        "a": "yy. M. d. a h:mm ~ a h:mm",
+        "h": "yy. M. d. a h:mm~h:mm",
+        "m": "yy. M. d. a h:mm~h:mm"
+      },
+      "d hm": {
+        "a": "d일 a h:mm ~ a h:mm",
+        "h": "d일 a h:mm~h:mm",
+        "m": "d일 a h:mm~h:mm"
+      },
+      "E hm": {
+        "a": "ccc a h:mm ~ a h:mm",
+        "h": "ccc a h:mm~h:mm",
+        "m": "ccc a h:mm~h:mm"
+      },
+      "Ed hm": {
+        "a": "d일 (E) a h:mm ~ a h:mm",
+        "h": "d일 (E) a h:mm~h:mm",
+        "m": "d일 (E) a h:mm~h:mm"
+      },
+      "EEEEd hm": {
+        "a": "d일 EEEE a h:mm ~ a h:mm",
+        "h": "d일 EEEE a h:mm~h:mm",
+        "m": "d일 EEEE a h:mm~h:mm"
+      },
+      "Gy hm": {
+        "a": "G y년 a h:mm ~ a h:mm",
+        "h": "G y년 a h:mm~h:mm",
+        "m": "G y년 a h:mm~h:mm"
+      },
+      "GyM hm": {
+        "a": "G y/M a h:mm ~ a h:mm",
+        "h": "G y/M a h:mm~h:mm",
+        "m": "G y/M a h:mm~h:mm"
+      },
+      "GyMd hm": {
+        "a": "GGGGG y/M/d a h:mm ~ a h:mm",
+        "h": "GGGGG y/M/d a h:mm~h:mm",
+        "m": "GGGGG y/M/d a h:mm~h:mm"
+      },
+      "GyMEd hm": {
+        "a": "G y/M/d (E) a h:mm ~ a h:mm",
+        "h": "G y/M/d (E) a h:mm~h:mm",
+        "m": "G y/M/d (E) a h:mm~h:mm"
+      },
+      "GyMMM hm": {
+        "a": "G y년 MMM a h:mm ~ a h:mm",
+        "h": "G y년 MMM a h:mm~h:mm",
+        "m": "G y년 MMM a h:mm~h:mm"
+      },
+      "GyMMMd hm": {
+        "a": "G y년 MMM d일 a h:mm ~ a h:mm",
+        "h": "G y년 MMM d일 a h:mm~h:mm",
+        "m": "G y년 MMM d일 a h:mm~h:mm"
+      },
+      "GyMMMEd hm": {
+        "a": "G y년 MMM d일 (E) a h:mm ~ a h:mm",
+        "h": "G y년 MMM d일 (E) a h:mm~h:mm",
+        "m": "G y년 MMM d일 (E) a h:mm~h:mm"
+      },
+      "GyMMMEEEEd hm": {
+        "a": "G y년 MMM d일 EEEE a h:mm ~ a h:mm",
+        "h": "G y년 MMM d일 EEEE a h:mm~h:mm",
+        "m": "G y년 MMM d일 EEEE a h:mm~h:mm"
+      },
+      "M hm": {
+        "a": "M월 a h:mm ~ a h:mm",
+        "h": "M월 a h:mm~h:mm",
+        "m": "M월 a h:mm~h:mm"
+      },
+      "Md hm": {
+        "a": "M. d. a h:mm ~ a h:mm",
+        "h": "M. d. a h:mm~h:mm",
+        "m": "M. d. a h:mm~h:mm"
+      },
+      "MEd hm": {
+        "a": "M. d. (E) a h:mm ~ a h:mm",
+        "h": "M. d. (E) a h:mm~h:mm",
+        "m": "M. d. (E) a h:mm~h:mm"
+      },
+      "MEEEEd hm": {
+        "a": "M. d. EEEE a h:mm ~ a h:mm",
+        "h": "M. d. EEEE a h:mm~h:mm",
+        "m": "M. d. EEEE a h:mm~h:mm"
+      },
+      "MMM hm": {
+        "a": "LLL a h:mm ~ a h:mm",
+        "h": "LLL a h:mm~h:mm",
+        "m": "LLL a h:mm~h:mm"
+      },
+      "MMMd hm": {
+        "a": "MMM d일 a h:mm ~ a h:mm",
+        "h": "MMM d일 a h:mm~h:mm",
+        "m": "MMM d일 a h:mm~h:mm"
+      },
+      "MMMEd hm": {
+        "a": "MMM d일 (E) a h:mm ~ a h:mm",
+        "h": "MMM d일 (E) a h:mm~h:mm",
+        "m": "MMM d일 (E) a h:mm~h:mm"
+      },
+      "MMMEEEEd hm": {
+        "a": "MMM d일 EEEE a h:mm ~ a h:mm",
+        "h": "MMM d일 EEEE a h:mm~h:mm",
+        "m": "MMM d일 EEEE a h:mm~h:mm"
+      },
+      "MMMMd hm": {
+        "a": "MMMM d일 a h:mm ~ a h:mm",
+        "h": "MMMM d일 a h:mm~h:mm",
+        "m": "MMMM d일 a h:mm~h:mm"
+      },
+      "y hm": {
+        "a": "y년 a h:mm ~ a h:mm",
+        "h": "y년 a h:mm~h:mm",
+        "m": "y년 a h:mm~h:mm"
+      },
+      "yM hm": {
+        "a": "y. M. a h:mm ~ a h:mm",
+        "h": "y. M. a h:mm~h:mm",
+        "m": "y. M. a h:mm~h:mm"
+      },
+      "yMd hm": {
+        "a": "y. M. d. a h:mm ~ a h:mm",
+        "h": "y. M. d. a h:mm~h:mm",
+        "m": "y. M. d. a h:mm~h:mm"
+      },
+      "yMEd hm": {
+        "a": "y. M. d. (E) a h:mm ~ a h:mm",
+        "h": "y. M. d. (E) a h:mm~h:mm",
+        "m": "y. M. d. (E) a h:mm~h:mm"
+      },
+      "yMEEEEd hm": {
+        "a": "y. M. d. EEEE a h:mm ~ a h:mm",
+        "h": "y. M. d. EEEE a h:mm~h:mm",
+        "m": "y. M. d. EEEE a h:mm~h:mm"
+      },
+      "yMM hm": {
+        "a": "y. M. a h:mm ~ a h:mm",
+        "h": "y. M. a h:mm~h:mm",
+        "m": "y. M. a h:mm~h:mm"
+      },
+      "yMMM hm": {
+        "a": "y년 MMM a h:mm ~ a h:mm",
+        "h": "y년 MMM a h:mm~h:mm",
+        "m": "y년 MMM a h:mm~h:mm"
+      },
+      "yMMMd hm": {
+        "a": "y년 MMM d일 a h:mm ~ a h:mm",
+        "h": "y년 MMM d일 a h:mm~h:mm",
+        "m": "y년 MMM d일 a h:mm~h:mm"
+      },
+      "yMMMEd hm": {
+        "a": "y년 MMM d일 (E) a h:mm ~ a h:mm",
+        "h": "y년 MMM d일 (E) a h:mm~h:mm",
+        "m": "y년 MMM d일 (E) a h:mm~h:mm"
+      },
+      "yMMMEEEEd hm": {
+        "a": "y년 MMM d일 EEEE a h:mm ~ a h:mm",
+        "h": "y년 MMM d일 EEEE a h:mm~h:mm",
+        "m": "y년 MMM d일 EEEE a h:mm~h:mm"
+      },
+      "yMMMM hm": {
+        "a": "y년 MMMM a h:mm ~ a h:mm",
+        "h": "y년 MMMM a h:mm~h:mm",
+        "m": "y년 MMMM a h:mm~h:mm"
+      },
+      "y년 MMMM d일 EEEE Hm": {
+        "H": "y년 MMMM d일 EEEE HH:mm ~ HH:mm",
+        "m": "y년 MMMM d일 EEEE HH:mm ~ HH:mm"
+      },
+      "y년 MMMM d일 Hm": {
+        "H": "y년 MMMM d일 HH:mm ~ HH:mm",
+        "m": "y년 MMMM d일 HH:mm ~ HH:mm"
+      },
+      "y. M. d. Hm": {
+        "H": "y. M. d. HH:mm ~ HH:mm",
+        "m": "y. M. d. HH:mm ~ HH:mm"
+      },
+      "yy. M. d. Hm": {
+        "H": "yy. M. d. HH:mm ~ HH:mm",
+        "m": "yy. M. d. HH:mm ~ HH:mm"
+      },
+      "d Hm": {
+        "H": "d일 HH:mm ~ HH:mm",
+        "m": "d일 HH:mm ~ HH:mm"
+      },
+      "E Hm": {
+        "H": "ccc HH:mm ~ HH:mm",
+        "m": "ccc HH:mm ~ HH:mm"
+      },
+      "Ed Hm": {
+        "H": "d일 (E) HH:mm ~ HH:mm",
+        "m": "d일 (E) HH:mm ~ HH:mm"
+      },
+      "EEEEd Hm": {
+        "H": "d일 EEEE HH:mm ~ HH:mm",
+        "m": "d일 EEEE HH:mm ~ HH:mm"
+      },
+      "Gy Hm": {
+        "H": "G y년 HH:mm ~ HH:mm",
+        "m": "G y년 HH:mm ~ HH:mm"
+      },
+      "GyM Hm": {
+        "H": "G y/M HH:mm ~ HH:mm",
+        "m": "G y/M HH:mm ~ HH:mm"
+      },
+      "GyMd Hm": {
+        "H": "GGGGG y/M/d HH:mm ~ HH:mm",
+        "m": "GGGGG y/M/d HH:mm ~ HH:mm"
+      },
+      "GyMEd Hm": {
+        "H": "G y/M/d (E) HH:mm ~ HH:mm",
+        "m": "G y/M/d (E) HH:mm ~ HH:mm"
+      },
+      "GyMMM Hm": {
+        "H": "G y년 MMM HH:mm ~ HH:mm",
+        "m": "G y년 MMM HH:mm ~ HH:mm"
+      },
+      "GyMMMd Hm": {
+        "H": "G y년 MMM d일 HH:mm ~ HH:mm",
+        "m": "G y년 MMM d일 HH:mm ~ HH:mm"
+      },
+      "GyMMMEd Hm": {
+        "H": "G y년 MMM d일 (E) HH:mm ~ HH:mm",
+        "m": "G y년 MMM d일 (E) HH:mm ~ HH:mm"
+      },
+      "GyMMMEEEEd Hm": {
+        "H": "G y년 MMM d일 EEEE HH:mm ~ HH:mm",
+        "m": "G y년 MMM d일 EEEE HH:mm ~ HH:mm"
+      },
+      "M Hm": {
+        "H": "M월 HH:mm ~ HH:mm",
+        "m": "M월 HH:mm ~ HH:mm"
+      },
+      "Md Hm": {
+        "H": "M. d. HH:mm ~ HH:mm",
+        "m": "M. d. HH:mm ~ HH:mm"
+      },
+      "MEd Hm": {
+        "H": "M. d. (E) HH:mm ~ HH:mm",
+        "m": "M. d. (E) HH:mm ~ HH:mm"
+      },
+      "MEEEEd Hm": {
+        "H": "M. d. EEEE HH:mm ~ HH:mm",
+        "m": "M. d. EEEE HH:mm ~ HH:mm"
+      },
+      "MMM Hm": {
+        "H": "LLL HH:mm ~ HH:mm",
+        "m": "LLL HH:mm ~ HH:mm"
+      },
+      "MMMd Hm": {
+        "H": "MMM d일 HH:mm ~ HH:mm",
+        "m": "MMM d일 HH:mm ~ HH:mm"
+      },
+      "MMMEd Hm": {
+        "H": "MMM d일 (E) HH:mm ~ HH:mm",
+        "m": "MMM d일 (E) HH:mm ~ HH:mm"
+      },
+      "MMMEEEEd Hm": {
+        "H": "MMM d일 EEEE HH:mm ~ HH:mm",
+        "m": "MMM d일 EEEE HH:mm ~ HH:mm"
+      },
+      "MMMMd Hm": {
+        "H": "MMMM d일 HH:mm ~ HH:mm",
+        "m": "MMMM d일 HH:mm ~ HH:mm"
+      },
+      "y Hm": {
+        "H": "y년 HH:mm ~ HH:mm",
+        "m": "y년 HH:mm ~ HH:mm"
+      },
+      "yM Hm": {
+        "H": "y. M. HH:mm ~ HH:mm",
+        "m": "y. M. HH:mm ~ HH:mm"
+      },
+      "yMd Hm": {
+        "H": "y. M. d. HH:mm ~ HH:mm",
+        "m": "y. M. d. HH:mm ~ HH:mm"
+      },
+      "yMEd Hm": {
+        "H": "y. M. d. (E) HH:mm ~ HH:mm",
+        "m": "y. M. d. (E) HH:mm ~ HH:mm"
+      },
+      "yMEEEEd Hm": {
+        "H": "y. M. d. EEEE HH:mm ~ HH:mm",
+        "m": "y. M. d. EEEE HH:mm ~ HH:mm"
+      },
+      "yMM Hm": {
+        "H": "y. M. HH:mm ~ HH:mm",
+        "m": "y. M. HH:mm ~ HH:mm"
+      },
+      "yMMM Hm": {
+        "H": "y년 MMM HH:mm ~ HH:mm",
+        "m": "y년 MMM HH:mm ~ HH:mm"
+      },
+      "yMMMd Hm": {
+        "H": "y년 MMM d일 HH:mm ~ HH:mm",
+        "m": "y년 MMM d일 HH:mm ~ HH:mm"
+      },
+      "yMMMEd Hm": {
+        "H": "y년 MMM d일 (E) HH:mm ~ HH:mm",
+        "m": "y년 MMM d일 (E) HH:mm ~ HH:mm"
+      },
+      "yMMMEEEEd Hm": {
+        "H": "y년 MMM d일 EEEE HH:mm ~ HH:mm",
+        "m": "y년 MMM d일 EEEE HH:mm ~ HH:mm"
+      },
+      "yMMMM Hm": {
+        "H": "y년 MMMM HH:mm ~ HH:mm",
+        "m": "y년 MMMM HH:mm ~ HH:mm"
+      },
+      "y년 MMMM d일 EEEE hmv": {
+        "a": "y년 MMMM d일 EEEE a h:mm ~ a h:mm v",
+        "h": "y년 MMMM d일 EEEE a h:mm~h:mm v",
+        "m": "y년 MMMM d일 EEEE a h:mm~h:mm v"
+      },
+      "y년 MMMM d일 hmv": {
+        "a": "y년 MMMM d일 a h:mm ~ a h:mm v",
+        "h": "y년 MMMM d일 a h:mm~h:mm v",
+        "m": "y년 MMMM d일 a h:mm~h:mm v"
+      },
+      "y. M. d. hmv": {
+        "a": "y. M. d. a h:mm ~ a h:mm v",
+        "h": "y. M. d. a h:mm~h:mm v",
+        "m": "y. M. d. a h:mm~h:mm v"
+      },
+      "yy. M. d. hmv": {
+        "a": "yy. M. d. a h:mm ~ a h:mm v",
+        "h": "yy. M. d. a h:mm~h:mm v",
+        "m": "yy. M. d. a h:mm~h:mm v"
+      },
+      "d hmv": {
+        "a": "d일 a h:mm ~ a h:mm v",
+        "h": "d일 a h:mm~h:mm v",
+        "m": "d일 a h:mm~h:mm v"
+      },
+      "E hmv": {
+        "a": "ccc a h:mm ~ a h:mm v",
+        "h": "ccc a h:mm~h:mm v",
+        "m": "ccc a h:mm~h:mm v"
+      },
+      "Ed hmv": {
+        "a": "d일 (E) a h:mm ~ a h:mm v",
+        "h": "d일 (E) a h:mm~h:mm v",
+        "m": "d일 (E) a h:mm~h:mm v"
+      },
+      "EEEEd hmv": {
+        "a": "d일 EEEE a h:mm ~ a h:mm v",
+        "h": "d일 EEEE a h:mm~h:mm v",
+        "m": "d일 EEEE a h:mm~h:mm v"
+      },
+      "Gy hmv": {
+        "a": "G y년 a h:mm ~ a h:mm v",
+        "h": "G y년 a h:mm~h:mm v",
+        "m": "G y년 a h:mm~h:mm v"
+      },
+      "GyM hmv": {
+        "a": "G y/M a h:mm ~ a h:mm v",
+        "h": "G y/M a h:mm~h:mm v",
+        "m": "G y/M a h:mm~h:mm v"
+      },
+      "GyMd hmv": {
+        "a": "GGGGG y/M/d a h:mm ~ a h:mm v",
+        "h": "GGGGG y/M/d a h:mm~h:mm v",
+        "m": "GGGGG y/M/d a h:mm~h:mm v"
+      },
+      "GyMEd hmv": {
+        "a": "G y/M/d (E) a h:mm ~ a h:mm v",
+        "h": "G y/M/d (E) a h:mm~h:mm v",
+        "m": "G y/M/d (E) a h:mm~h:mm v"
+      },
+      "GyMMM hmv": {
+        "a": "G y년 MMM a h:mm ~ a h:mm v",
+        "h": "G y년 MMM a h:mm~h:mm v",
+        "m": "G y년 MMM a h:mm~h:mm v"
+      },
+      "GyMMMd hmv": {
+        "a": "G y년 MMM d일 a h:mm ~ a h:mm v",
+        "h": "G y년 MMM d일 a h:mm~h:mm v",
+        "m": "G y년 MMM d일 a h:mm~h:mm v"
+      },
+      "GyMMMEd hmv": {
+        "a": "G y년 MMM d일 (E) a h:mm ~ a h:mm v",
+        "h": "G y년 MMM d일 (E) a h:mm~h:mm v",
+        "m": "G y년 MMM d일 (E) a h:mm~h:mm v"
+      },
+      "GyMMMEEEEd hmv": {
+        "a": "G y년 MMM d일 EEEE a h:mm ~ a h:mm v",
+        "h": "G y년 MMM d일 EEEE a h:mm~h:mm v",
+        "m": "G y년 MMM d일 EEEE a h:mm~h:mm v"
+      },
+      "M hmv": {
+        "a": "M월 a h:mm ~ a h:mm v",
+        "h": "M월 a h:mm~h:mm v",
+        "m": "M월 a h:mm~h:mm v"
+      },
+      "Md hmv": {
+        "a": "M. d. a h:mm ~ a h:mm v",
+        "h": "M. d. a h:mm~h:mm v",
+        "m": "M. d. a h:mm~h:mm v"
+      },
+      "MEd hmv": {
+        "a": "M. d. (E) a h:mm ~ a h:mm v",
+        "h": "M. d. (E) a h:mm~h:mm v",
+        "m": "M. d. (E) a h:mm~h:mm v"
+      },
+      "MEEEEd hmv": {
+        "a": "M. d. EEEE a h:mm ~ a h:mm v",
+        "h": "M. d. EEEE a h:mm~h:mm v",
+        "m": "M. d. EEEE a h:mm~h:mm v"
+      },
+      "MMM hmv": {
+        "a": "LLL a h:mm ~ a h:mm v",
+        "h": "LLL a h:mm~h:mm v",
+        "m": "LLL a h:mm~h:mm v"
+      },
+      "MMMd hmv": {
+        "a": "MMM d일 a h:mm ~ a h:mm v",
+        "h": "MMM d일 a h:mm~h:mm v",
+        "m": "MMM d일 a h:mm~h:mm v"
+      },
+      "MMMEd hmv": {
+        "a": "MMM d일 (E) a h:mm ~ a h:mm v",
+        "h": "MMM d일 (E) a h:mm~h:mm v",
+        "m": "MMM d일 (E) a h:mm~h:mm v"
+      },
+      "MMMEEEEd hmv": {
+        "a": "MMM d일 EEEE a h:mm ~ a h:mm v",
+        "h": "MMM d일 EEEE a h:mm~h:mm v",
+        "m": "MMM d일 EEEE a h:mm~h:mm v"
+      },
+      "MMMMd hmv": {
+        "a": "MMMM d일 a h:mm ~ a h:mm v",
+        "h": "MMMM d일 a h:mm~h:mm v",
+        "m": "MMMM d일 a h:mm~h:mm v"
+      },
+      "y hmv": {
+        "a": "y년 a h:mm ~ a h:mm v",
+        "h": "y년 a h:mm~h:mm v",
+        "m": "y년 a h:mm~h:mm v"
+      },
+      "yM hmv": {
+        "a": "y. M. a h:mm ~ a h:mm v",
+        "h": "y. M. a h:mm~h:mm v",
+        "m": "y. M. a h:mm~h:mm v"
+      },
+      "yMd hmv": {
+        "a": "y. M. d. a h:mm ~ a h:mm v",
+        "h": "y. M. d. a h:mm~h:mm v",
+        "m": "y. M. d. a h:mm~h:mm v"
+      },
+      "yMEd hmv": {
+        "a": "y. M. d. (E) a h:mm ~ a h:mm v",
+        "h": "y. M. d. (E) a h:mm~h:mm v",
+        "m": "y. M. d. (E) a h:mm~h:mm v"
+      },
+      "yMEEEEd hmv": {
+        "a": "y. M. d. EEEE a h:mm ~ a h:mm v",
+        "h": "y. M. d. EEEE a h:mm~h:mm v",
+        "m": "y. M. d. EEEE a h:mm~h:mm v"
+      },
+      "yMM hmv": {
+        "a": "y. M. a h:mm ~ a h:mm v",
+        "h": "y. M. a h:mm~h:mm v",
+        "m": "y. M. a h:mm~h:mm v"
+      },
+      "yMMM hmv": {
+        "a": "y년 MMM a h:mm ~ a h:mm v",
+        "h": "y년 MMM a h:mm~h:mm v",
+        "m": "y년 MMM a h:mm~h:mm v"
+      },
+      "yMMMd hmv": {
+        "a": "y년 MMM d일 a h:mm ~ a h:mm v",
+        "h": "y년 MMM d일 a h:mm~h:mm v",
+        "m": "y년 MMM d일 a h:mm~h:mm v"
+      },
+      "yMMMEd hmv": {
+        "a": "y년 MMM d일 (E) a h:mm ~ a h:mm v",
+        "h": "y년 MMM d일 (E) a h:mm~h:mm v",
+        "m": "y년 MMM d일 (E) a h:mm~h:mm v"
+      },
+      "yMMMEEEEd hmv": {
+        "a": "y년 MMM d일 EEEE a h:mm ~ a h:mm v",
+        "h": "y년 MMM d일 EEEE a h:mm~h:mm v",
+        "m": "y년 MMM d일 EEEE a h:mm~h:mm v"
+      },
+      "yMMMM hmv": {
+        "a": "y년 MMMM a h:mm ~ a h:mm v",
+        "h": "y년 MMMM a h:mm~h:mm v",
+        "m": "y년 MMMM a h:mm~h:mm v"
+      },
+      "y년 MMMM d일 EEEE Hmv": {
+        "H": "y년 MMMM d일 EEEE HH:mm ~ HH:mm v",
+        "m": "y년 MMMM d일 EEEE HH:mm ~ HH:mm v"
+      },
+      "y년 MMMM d일 Hmv": {
+        "H": "y년 MMMM d일 HH:mm ~ HH:mm v",
+        "m": "y년 MMMM d일 HH:mm ~ HH:mm v"
+      },
+      "y. M. d. Hmv": {
+        "H": "y. M. d. HH:mm ~ HH:mm v",
+        "m": "y. M. d. HH:mm ~ HH:mm v"
+      },
+      "yy. M. d. Hmv": {
+        "H": "yy. M. d. HH:mm ~ HH:mm v",
+        "m": "yy. M. d. HH:mm ~ HH:mm v"
+      },
+      "d Hmv": {
+        "H": "d일 HH:mm ~ HH:mm v",
+        "m": "d일 HH:mm ~ HH:mm v"
+      },
+      "E Hmv": {
+        "H": "ccc HH:mm ~ HH:mm v",
+        "m": "ccc HH:mm ~ HH:mm v"
+      },
+      "Ed Hmv": {
+        "H": "d일 (E) HH:mm ~ HH:mm v",
+        "m": "d일 (E) HH:mm ~ HH:mm v"
+      },
+      "EEEEd Hmv": {
+        "H": "d일 EEEE HH:mm ~ HH:mm v",
+        "m": "d일 EEEE HH:mm ~ HH:mm v"
+      },
+      "Gy Hmv": {
+        "H": "G y년 HH:mm ~ HH:mm v",
+        "m": "G y년 HH:mm ~ HH:mm v"
+      },
+      "GyM Hmv": {
+        "H": "G y/M HH:mm ~ HH:mm v",
+        "m": "G y/M HH:mm ~ HH:mm v"
+      },
+      "GyMd Hmv": {
+        "H": "GGGGG y/M/d HH:mm ~ HH:mm v",
+        "m": "GGGGG y/M/d HH:mm ~ HH:mm v"
+      },
+      "GyMEd Hmv": {
+        "H": "G y/M/d (E) HH:mm ~ HH:mm v",
+        "m": "G y/M/d (E) HH:mm ~ HH:mm v"
+      },
+      "GyMMM Hmv": {
+        "H": "G y년 MMM HH:mm ~ HH:mm v",
+        "m": "G y년 MMM HH:mm ~ HH:mm v"
+      },
+      "GyMMMd Hmv": {
+        "H": "G y년 MMM d일 HH:mm ~ HH:mm v",
+        "m": "G y년 MMM d일 HH:mm ~ HH:mm v"
+      },
+      "GyMMMEd Hmv": {
+        "H": "G y년 MMM d일 (E) HH:mm ~ HH:mm v",
+        "m": "G y년 MMM d일 (E) HH:mm ~ HH:mm v"
+      },
+      "GyMMMEEEEd Hmv": {
+        "H": "G y년 MMM d일 EEEE HH:mm ~ HH:mm v",
+        "m": "G y년 MMM d일 EEEE HH:mm ~ HH:mm v"
+      },
+      "M Hmv": {
+        "H": "M월 HH:mm ~ HH:mm v",
+        "m": "M월 HH:mm ~ HH:mm v"
+      },
+      "Md Hmv": {
+        "H": "M. d. HH:mm ~ HH:mm v",
+        "m": "M. d. HH:mm ~ HH:mm v"
+      },
+      "MEd Hmv": {
+        "H": "M. d. (E) HH:mm ~ HH:mm v",
+        "m": "M. d. (E) HH:mm ~ HH:mm v"
+      },
+      "MEEEEd Hmv": {
+        "H": "M. d. EEEE HH:mm ~ HH:mm v",
+        "m": "M. d. EEEE HH:mm ~ HH:mm v"
+      },
+      "MMM Hmv": {
+        "H": "LLL HH:mm ~ HH:mm v",
+        "m": "LLL HH:mm ~ HH:mm v"
+      },
+      "MMMd Hmv": {
+        "H": "MMM d일 HH:mm ~ HH:mm v",
+        "m": "MMM d일 HH:mm ~ HH:mm v"
+      },
+      "MMMEd Hmv": {
+        "H": "MMM d일 (E) HH:mm ~ HH:mm v",
+        "m": "MMM d일 (E) HH:mm ~ HH:mm v"
+      },
+      "MMMEEEEd Hmv": {
+        "H": "MMM d일 EEEE HH:mm ~ HH:mm v",
+        "m": "MMM d일 EEEE HH:mm ~ HH:mm v"
+      },
+      "MMMMd Hmv": {
+        "H": "MMMM d일 HH:mm ~ HH:mm v",
+        "m": "MMMM d일 HH:mm ~ HH:mm v"
+      },
+      "y Hmv": {
+        "H": "y년 HH:mm ~ HH:mm v",
+        "m": "y년 HH:mm ~ HH:mm v"
+      },
+      "yM Hmv": {
+        "H": "y. M. HH:mm ~ HH:mm v",
+        "m": "y. M. HH:mm ~ HH:mm v"
+      },
+      "yMd Hmv": {
+        "H": "y. M. d. HH:mm ~ HH:mm v",
+        "m": "y. M. d. HH:mm ~ HH:mm v"
+      },
+      "yMEd Hmv": {
+        "H": "y. M. d. (E) HH:mm ~ HH:mm v",
+        "m": "y. M. d. (E) HH:mm ~ HH:mm v"
+      },
+      "yMEEEEd Hmv": {
+        "H": "y. M. d. EEEE HH:mm ~ HH:mm v",
+        "m": "y. M. d. EEEE HH:mm ~ HH:mm v"
+      },
+      "yMM Hmv": {
+        "H": "y. M. HH:mm ~ HH:mm v",
+        "m": "y. M. HH:mm ~ HH:mm v"
+      },
+      "yMMM Hmv": {
+        "H": "y년 MMM HH:mm ~ HH:mm v",
+        "m": "y년 MMM HH:mm ~ HH:mm v"
+      },
+      "yMMMd Hmv": {
+        "H": "y년 MMM d일 HH:mm ~ HH:mm v",
+        "m": "y년 MMM d일 HH:mm ~ HH:mm v"
+      },
+      "yMMMEd Hmv": {
+        "H": "y년 MMM d일 (E) HH:mm ~ HH:mm v",
+        "m": "y년 MMM d일 (E) HH:mm ~ HH:mm v"
+      },
+      "yMMMEEEEd Hmv": {
+        "H": "y년 MMM d일 EEEE HH:mm ~ HH:mm v",
+        "m": "y년 MMM d일 EEEE HH:mm ~ HH:mm v"
+      },
+      "yMMMM Hmv": {
+        "H": "y년 MMMM HH:mm ~ HH:mm v",
+        "m": "y년 MMMM HH:mm ~ HH:mm v"
+      },
+      "y년 MMMM d일 EEEE hv": {
+        "a": "y년 MMMM d일 EEEE a h시 ~ a h시(v)",
+        "h": "y년 MMMM d일 EEEE a h시 ~ h시(v)"
+      },
+      "y년 MMMM d일 hv": {
+        "a": "y년 MMMM d일 a h시 ~ a h시(v)",
+        "h": "y년 MMMM d일 a h시 ~ h시(v)"
+      },
+      "y. M. d. hv": {
+        "a": "y. M. d. a h시 ~ a h시(v)",
+        "h": "y. M. d. a h시 ~ h시(v)"
+      },
+      "yy. M. d. hv": {
+        "a": "yy. M. d. a h시 ~ a h시(v)",
+        "h": "yy. M. d. a h시 ~ h시(v)"
+      },
+      "d hv": {
+        "a": "d일 a h시 ~ a h시(v)",
+        "h": "d일 a h시 ~ h시(v)"
+      },
+      "E hv": {
+        "a": "ccc a h시 ~ a h시(v)",
+        "h": "ccc a h시 ~ h시(v)"
+      },
+      "Ed hv": {
+        "a": "d일 (E) a h시 ~ a h시(v)",
+        "h": "d일 (E) a h시 ~ h시(v)"
+      },
+      "EEEEd hv": {
+        "a": "d일 EEEE a h시 ~ a h시(v)",
+        "h": "d일 EEEE a h시 ~ h시(v)"
+      },
+      "Gy hv": {
+        "a": "G y년 a h시 ~ a h시(v)",
+        "h": "G y년 a h시 ~ h시(v)"
+      },
+      "GyM hv": {
+        "a": "G y/M a h시 ~ a h시(v)",
+        "h": "G y/M a h시 ~ h시(v)"
+      },
+      "GyMd hv": {
+        "a": "GGGGG y/M/d a h시 ~ a h시(v)",
+        "h": "GGGGG y/M/d a h시 ~ h시(v)"
+      },
+      "GyMEd hv": {
+        "a": "G y/M/d (E) a h시 ~ a h시(v)",
+        "h": "G y/M/d (E) a h시 ~ h시(v)"
+      },
+      "GyMMM hv": {
+        "a": "G y년 MMM a h시 ~ a h시(v)",
+        "h": "G y년 MMM a h시 ~ h시(v)"
+      },
+      "GyMMMd hv": {
+        "a": "G y년 MMM d일 a h시 ~ a h시(v)",
+        "h": "G y년 MMM d일 a h시 ~ h시(v)"
+      },
+      "GyMMMEd hv": {
+        "a": "G y년 MMM d일 (E) a h시 ~ a h시(v)",
+        "h": "G y년 MMM d일 (E) a h시 ~ h시(v)"
+      },
+      "GyMMMEEEEd hv": {
+        "a": "G y년 MMM d일 EEEE a h시 ~ a h시(v)",
+        "h": "G y년 MMM d일 EEEE a h시 ~ h시(v)"
+      },
+      "M hv": {
+        "a": "M월 a h시 ~ a h시(v)",
+        "h": "M월 a h시 ~ h시(v)"
+      },
+      "Md hv": {
+        "a": "M. d. a h시 ~ a h시(v)",
+        "h": "M. d. a h시 ~ h시(v)"
+      },
+      "MEd hv": {
+        "a": "M. d. (E) a h시 ~ a h시(v)",
+        "h": "M. d. (E) a h시 ~ h시(v)"
+      },
+      "MEEEEd hv": {
+        "a": "M. d. EEEE a h시 ~ a h시(v)",
+        "h": "M. d. EEEE a h시 ~ h시(v)"
+      },
+      "MMM hv": {
+        "a": "LLL a h시 ~ a h시(v)",
+        "h": "LLL a h시 ~ h시(v)"
+      },
+      "MMMd hv": {
+        "a": "MMM d일 a h시 ~ a h시(v)",
+        "h": "MMM d일 a h시 ~ h시(v)"
+      },
+      "MMMEd hv": {
+        "a": "MMM d일 (E) a h시 ~ a h시(v)",
+        "h": "MMM d일 (E) a h시 ~ h시(v)"
+      },
+      "MMMEEEEd hv": {
+        "a": "MMM d일 EEEE a h시 ~ a h시(v)",
+        "h": "MMM d일 EEEE a h시 ~ h시(v)"
+      },
+      "MMMMd hv": {
+        "a": "MMMM d일 a h시 ~ a h시(v)",
+        "h": "MMMM d일 a h시 ~ h시(v)"
+      },
+      "y hv": {
+        "a": "y년 a h시 ~ a h시(v)",
+        "h": "y년 a h시 ~ h시(v)"
+      },
+      "yM hv": {
+        "a": "y. M. a h시 ~ a h시(v)",
+        "h": "y. M. a h시 ~ h시(v)"
+      },
+      "yMd hv": {
+        "a": "y. M. d. a h시 ~ a h시(v)",
+        "h": "y. M. d. a h시 ~ h시(v)"
+      },
+      "yMEd hv": {
+        "a": "y. M. d. (E) a h시 ~ a h시(v)",
+        "h": "y. M. d. (E) a h시 ~ h시(v)"
+      },
+      "yMEEEEd hv": {
+        "a": "y. M. d. EEEE a h시 ~ a h시(v)",
+        "h": "y. M. d. EEEE a h시 ~ h시(v)"
+      },
+      "yMM hv": {
+        "a": "y. M. a h시 ~ a h시(v)",
+        "h": "y. M. a h시 ~ h시(v)"
+      },
+      "yMMM hv": {
+        "a": "y년 MMM a h시 ~ a h시(v)",
+        "h": "y년 MMM a h시 ~ h시(v)"
+      },
+      "yMMMd hv": {
+        "a": "y년 MMM d일 a h시 ~ a h시(v)",
+        "h": "y년 MMM d일 a h시 ~ h시(v)"
+      },
+      "yMMMEd hv": {
+        "a": "y년 MMM d일 (E) a h시 ~ a h시(v)",
+        "h": "y년 MMM d일 (E) a h시 ~ h시(v)"
+      },
+      "yMMMEEEEd hv": {
+        "a": "y년 MMM d일 EEEE a h시 ~ a h시(v)",
+        "h": "y년 MMM d일 EEEE a h시 ~ h시(v)"
+      },
+      "yMMMM hv": {
+        "a": "y년 MMMM a h시 ~ a h시(v)",
+        "h": "y년 MMMM a h시 ~ h시(v)"
+      },
+      "y년 MMMM d일 EEEE Hv": {
+        "H": "y년 MMMM d일 EEEE HH ~ HH시 v"
+      },
+      "y년 MMMM d일 Hv": {
+        "H": "y년 MMMM d일 HH ~ HH시 v"
+      },
+      "y. M. d. Hv": {
+        "H": "y. M. d. HH ~ HH시 v"
+      },
+      "yy. M. d. Hv": {
+        "H": "yy. M. d. HH ~ HH시 v"
+      },
+      "d Hv": {
+        "H": "d일 HH ~ HH시 v"
+      },
+      "E Hv": {
+        "H": "ccc HH ~ HH시 v"
+      },
+      "Ed Hv": {
+        "H": "d일 (E) HH ~ HH시 v"
+      },
+      "EEEEd Hv": {
+        "H": "d일 EEEE HH ~ HH시 v"
+      },
+      "Gy Hv": {
+        "H": "G y년 HH ~ HH시 v"
+      },
+      "GyM Hv": {
+        "H": "G y/M HH ~ HH시 v"
+      },
+      "GyMd Hv": {
+        "H": "GGGGG y/M/d HH ~ HH시 v"
+      },
+      "GyMEd Hv": {
+        "H": "G y/M/d (E) HH ~ HH시 v"
+      },
+      "GyMMM Hv": {
+        "H": "G y년 MMM HH ~ HH시 v"
+      },
+      "GyMMMd Hv": {
+        "H": "G y년 MMM d일 HH ~ HH시 v"
+      },
+      "GyMMMEd Hv": {
+        "H": "G y년 MMM d일 (E) HH ~ HH시 v"
+      },
+      "GyMMMEEEEd Hv": {
+        "H": "G y년 MMM d일 EEEE HH ~ HH시 v"
+      },
+      "M Hv": {
+        "H": "M월 HH ~ HH시 v"
+      },
+      "Md Hv": {
+        "H": "M. d. HH ~ HH시 v"
+      },
+      "MEd Hv": {
+        "H": "M. d. (E) HH ~ HH시 v"
+      },
+      "MEEEEd Hv": {
+        "H": "M. d. EEEE HH ~ HH시 v"
+      },
+      "MMM Hv": {
+        "H": "LLL HH ~ HH시 v"
+      },
+      "MMMd Hv": {
+        "H": "MMM d일 HH ~ HH시 v"
+      },
+      "MMMEd Hv": {
+        "H": "MMM d일 (E) HH ~ HH시 v"
+      },
+      "MMMEEEEd Hv": {
+        "H": "MMM d일 EEEE HH ~ HH시 v"
+      },
+      "MMMMd Hv": {
+        "H": "MMMM d일 HH ~ HH시 v"
+      },
+      "y Hv": {
+        "H": "y년 HH ~ HH시 v"
+      },
+      "yM Hv": {
+        "H": "y. M. HH ~ HH시 v"
+      },
+      "yMd Hv": {
+        "H": "y. M. d. HH ~ HH시 v"
+      },
+      "yMEd Hv": {
+        "H": "y. M. d. (E) HH ~ HH시 v"
+      },
+      "yMEEEEd Hv": {
+        "H": "y. M. d. EEEE HH ~ HH시 v"
+      },
+      "yMM Hv": {
+        "H": "y. M. HH ~ HH시 v"
+      },
+      "yMMM Hv": {
+        "H": "y년 MMM HH ~ HH시 v"
+      },
+      "yMMMd Hv": {
+        "H": "y년 MMM d일 HH ~ HH시 v"
+      },
+      "yMMMEd Hv": {
+        "H": "y년 MMM d일 (E) HH ~ HH시 v"
+      },
+      "yMMMEEEEd Hv": {
+        "H": "y년 MMM d일 EEEE HH ~ HH시 v"
+      },
+      "yMMMM Hv": {
+        "H": "y년 MMMM HH ~ HH시 v"
       }
     },
     "hourCycle": "h12",

--- a/packages/intl-datetimeformat/tests/locale-data/nl.json
+++ b/packages/intl-datetimeformat/tests/locale-data/nl.json
@@ -2971,6 +2971,1195 @@
       "yMMMM": {
         "M": "MMMM–MMMM y",
         "y": "MMMM y – MMMM y"
+      },
+      "EEEE d MMMM y, Bh": {
+        "B": "EEEE d MMMM y, h B – h B",
+        "h": "EEEE d MMMM y, h–h B"
+      },
+      "d MMMM y, Bh": {
+        "B": "d MMMM y, h B – h B",
+        "h": "d MMMM y, h–h B"
+      },
+      "d MMM y, Bh": {
+        "B": "d MMM y, h B – h B",
+        "h": "d MMM y, h–h B"
+      },
+      "dd-MM-y, Bh": {
+        "B": "dd-MM-y, h B – h B",
+        "h": "dd-MM-y, h–h B"
+      },
+      "d, Bh": {
+        "B": "d, h B – h B",
+        "h": "d, h–h B"
+      },
+      "E, Bh": {
+        "B": "ccc, h B – h B",
+        "h": "ccc, h–h B"
+      },
+      "Ed, Bh": {
+        "B": "E d, h B – h B",
+        "h": "E d, h–h B"
+      },
+      "Gy, Bh": {
+        "B": "y G, h B – h B",
+        "h": "y G, h–h B"
+      },
+      "GyM, Bh": {
+        "B": "M/y G, h B – h B",
+        "h": "M/y G, h–h B"
+      },
+      "GyMd, Bh": {
+        "B": "d/M/y GGGGG, h B – h B",
+        "h": "d/M/y GGGGG, h–h B"
+      },
+      "GyMEd, Bh": {
+        "B": "E d/M/y G, h B – h B",
+        "h": "E d/M/y G, h–h B"
+      },
+      "GyMMM, Bh": {
+        "B": "MMM y G, h B – h B",
+        "h": "MMM y G, h–h B"
+      },
+      "GyMMMd, Bh": {
+        "B": "d MMM y G, h B – h B",
+        "h": "d MMM y G, h–h B"
+      },
+      "GyMMMEd, Bh": {
+        "B": "E d MMM y G, h B – h B",
+        "h": "E d MMM y G, h–h B"
+      },
+      "M, Bh": {
+        "B": "L, h B – h B",
+        "h": "L, h–h B"
+      },
+      "Md, Bh": {
+        "B": "d-M, h B – h B",
+        "h": "d-M, h–h B"
+      },
+      "MEd, Bh": {
+        "B": "E d-M, h B – h B",
+        "h": "E d-M, h–h B"
+      },
+      "MMM, Bh": {
+        "B": "LLL, h B – h B",
+        "h": "LLL, h–h B"
+      },
+      "MMMd, Bh": {
+        "B": "d MMM, h B – h B",
+        "h": "d MMM, h–h B"
+      },
+      "MMMEd, Bh": {
+        "B": "E d MMM, h B – h B",
+        "h": "E d MMM, h–h B"
+      },
+      "MMMMd, Bh": {
+        "B": "d MMMM, h B – h B",
+        "h": "d MMMM, h–h B"
+      },
+      "y, Bh": {
+        "B": "y, h B – h B",
+        "h": "y, h–h B"
+      },
+      "yM, Bh": {
+        "B": "M-y, h B – h B",
+        "h": "M-y, h–h B"
+      },
+      "yMd, Bh": {
+        "B": "d-M-y, h B – h B",
+        "h": "d-M-y, h–h B"
+      },
+      "yMEd, Bh": {
+        "B": "E d-M-y, h B – h B",
+        "h": "E d-M-y, h–h B"
+      },
+      "yMMM, Bh": {
+        "B": "MMM y, h B – h B",
+        "h": "MMM y, h–h B"
+      },
+      "yMMMd, Bh": {
+        "B": "d MMM y, h B – h B",
+        "h": "d MMM y, h–h B"
+      },
+      "yMMMEd, Bh": {
+        "B": "E d MMM y, h B – h B",
+        "h": "E d MMM y, h–h B"
+      },
+      "yMMMM, Bh": {
+        "B": "MMMM y, h B – h B",
+        "h": "MMMM y, h–h B"
+      },
+      "EEEE d MMMM y, Bhm": {
+        "B": "EEEE d MMMM y, h:mm B – h:mm B",
+        "h": "EEEE d MMMM y, h:mm–h:mm B",
+        "m": "EEEE d MMMM y, h:mm–h:mm B"
+      },
+      "d MMMM y, Bhm": {
+        "B": "d MMMM y, h:mm B – h:mm B",
+        "h": "d MMMM y, h:mm–h:mm B",
+        "m": "d MMMM y, h:mm–h:mm B"
+      },
+      "d MMM y, Bhm": {
+        "B": "d MMM y, h:mm B – h:mm B",
+        "h": "d MMM y, h:mm–h:mm B",
+        "m": "d MMM y, h:mm–h:mm B"
+      },
+      "dd-MM-y, Bhm": {
+        "B": "dd-MM-y, h:mm B – h:mm B",
+        "h": "dd-MM-y, h:mm–h:mm B",
+        "m": "dd-MM-y, h:mm–h:mm B"
+      },
+      "d, Bhm": {
+        "B": "d, h:mm B – h:mm B",
+        "h": "d, h:mm–h:mm B",
+        "m": "d, h:mm–h:mm B"
+      },
+      "E, Bhm": {
+        "B": "ccc, h:mm B – h:mm B",
+        "h": "ccc, h:mm–h:mm B",
+        "m": "ccc, h:mm–h:mm B"
+      },
+      "Ed, Bhm": {
+        "B": "E d, h:mm B – h:mm B",
+        "h": "E d, h:mm–h:mm B",
+        "m": "E d, h:mm–h:mm B"
+      },
+      "Gy, Bhm": {
+        "B": "y G, h:mm B – h:mm B",
+        "h": "y G, h:mm–h:mm B",
+        "m": "y G, h:mm–h:mm B"
+      },
+      "GyM, Bhm": {
+        "B": "M/y G, h:mm B – h:mm B",
+        "h": "M/y G, h:mm–h:mm B",
+        "m": "M/y G, h:mm–h:mm B"
+      },
+      "GyMd, Bhm": {
+        "B": "d/M/y GGGGG, h:mm B – h:mm B",
+        "h": "d/M/y GGGGG, h:mm–h:mm B",
+        "m": "d/M/y GGGGG, h:mm–h:mm B"
+      },
+      "GyMEd, Bhm": {
+        "B": "E d/M/y G, h:mm B – h:mm B",
+        "h": "E d/M/y G, h:mm–h:mm B",
+        "m": "E d/M/y G, h:mm–h:mm B"
+      },
+      "GyMMM, Bhm": {
+        "B": "MMM y G, h:mm B – h:mm B",
+        "h": "MMM y G, h:mm–h:mm B",
+        "m": "MMM y G, h:mm–h:mm B"
+      },
+      "GyMMMd, Bhm": {
+        "B": "d MMM y G, h:mm B – h:mm B",
+        "h": "d MMM y G, h:mm–h:mm B",
+        "m": "d MMM y G, h:mm–h:mm B"
+      },
+      "GyMMMEd, Bhm": {
+        "B": "E d MMM y G, h:mm B – h:mm B",
+        "h": "E d MMM y G, h:mm–h:mm B",
+        "m": "E d MMM y G, h:mm–h:mm B"
+      },
+      "M, Bhm": {
+        "B": "L, h:mm B – h:mm B",
+        "h": "L, h:mm–h:mm B",
+        "m": "L, h:mm–h:mm B"
+      },
+      "Md, Bhm": {
+        "B": "d-M, h:mm B – h:mm B",
+        "h": "d-M, h:mm–h:mm B",
+        "m": "d-M, h:mm–h:mm B"
+      },
+      "MEd, Bhm": {
+        "B": "E d-M, h:mm B – h:mm B",
+        "h": "E d-M, h:mm–h:mm B",
+        "m": "E d-M, h:mm–h:mm B"
+      },
+      "MMM, Bhm": {
+        "B": "LLL, h:mm B – h:mm B",
+        "h": "LLL, h:mm–h:mm B",
+        "m": "LLL, h:mm–h:mm B"
+      },
+      "MMMd, Bhm": {
+        "B": "d MMM, h:mm B – h:mm B",
+        "h": "d MMM, h:mm–h:mm B",
+        "m": "d MMM, h:mm–h:mm B"
+      },
+      "MMMEd, Bhm": {
+        "B": "E d MMM, h:mm B – h:mm B",
+        "h": "E d MMM, h:mm–h:mm B",
+        "m": "E d MMM, h:mm–h:mm B"
+      },
+      "MMMMd, Bhm": {
+        "B": "d MMMM, h:mm B – h:mm B",
+        "h": "d MMMM, h:mm–h:mm B",
+        "m": "d MMMM, h:mm–h:mm B"
+      },
+      "y, Bhm": {
+        "B": "y, h:mm B – h:mm B",
+        "h": "y, h:mm–h:mm B",
+        "m": "y, h:mm–h:mm B"
+      },
+      "yM, Bhm": {
+        "B": "M-y, h:mm B – h:mm B",
+        "h": "M-y, h:mm–h:mm B",
+        "m": "M-y, h:mm–h:mm B"
+      },
+      "yMd, Bhm": {
+        "B": "d-M-y, h:mm B – h:mm B",
+        "h": "d-M-y, h:mm–h:mm B",
+        "m": "d-M-y, h:mm–h:mm B"
+      },
+      "yMEd, Bhm": {
+        "B": "E d-M-y, h:mm B – h:mm B",
+        "h": "E d-M-y, h:mm–h:mm B",
+        "m": "E d-M-y, h:mm–h:mm B"
+      },
+      "yMMM, Bhm": {
+        "B": "MMM y, h:mm B – h:mm B",
+        "h": "MMM y, h:mm–h:mm B",
+        "m": "MMM y, h:mm–h:mm B"
+      },
+      "yMMMd, Bhm": {
+        "B": "d MMM y, h:mm B – h:mm B",
+        "h": "d MMM y, h:mm–h:mm B",
+        "m": "d MMM y, h:mm–h:mm B"
+      },
+      "yMMMEd, Bhm": {
+        "B": "E d MMM y, h:mm B – h:mm B",
+        "h": "E d MMM y, h:mm–h:mm B",
+        "m": "E d MMM y, h:mm–h:mm B"
+      },
+      "yMMMM, Bhm": {
+        "B": "MMMM y, h:mm B – h:mm B",
+        "h": "MMMM y, h:mm–h:mm B",
+        "m": "MMMM y, h:mm–h:mm B"
+      },
+      "EEEE d MMMM y, h": {
+        "a": "EEEE d MMMM y, h a – h a",
+        "h": "EEEE d MMMM y, h–h a"
+      },
+      "d MMMM y, h": {
+        "a": "d MMMM y, h a – h a",
+        "h": "d MMMM y, h–h a"
+      },
+      "d MMM y, h": {
+        "a": "d MMM y, h a – h a",
+        "h": "d MMM y, h–h a"
+      },
+      "dd-MM-y, h": {
+        "a": "dd-MM-y, h a – h a",
+        "h": "dd-MM-y, h–h a"
+      },
+      "d, h": {
+        "a": "d, h a – h a",
+        "h": "d, h–h a"
+      },
+      "E, h": {
+        "a": "ccc, h a – h a",
+        "h": "ccc, h–h a"
+      },
+      "Ed, h": {
+        "a": "E d, h a – h a",
+        "h": "E d, h–h a"
+      },
+      "Gy, h": {
+        "a": "y G, h a – h a",
+        "h": "y G, h–h a"
+      },
+      "GyM, h": {
+        "a": "M/y G, h a – h a",
+        "h": "M/y G, h–h a"
+      },
+      "GyMd, h": {
+        "a": "d/M/y GGGGG, h a – h a",
+        "h": "d/M/y GGGGG, h–h a"
+      },
+      "GyMEd, h": {
+        "a": "E d/M/y G, h a – h a",
+        "h": "E d/M/y G, h–h a"
+      },
+      "GyMMM, h": {
+        "a": "MMM y G, h a – h a",
+        "h": "MMM y G, h–h a"
+      },
+      "GyMMMd, h": {
+        "a": "d MMM y G, h a – h a",
+        "h": "d MMM y G, h–h a"
+      },
+      "GyMMMEd, h": {
+        "a": "E d MMM y G, h a – h a",
+        "h": "E d MMM y G, h–h a"
+      },
+      "M, h": {
+        "a": "L, h a – h a",
+        "h": "L, h–h a"
+      },
+      "Md, h": {
+        "a": "d-M, h a – h a",
+        "h": "d-M, h–h a"
+      },
+      "MEd, h": {
+        "a": "E d-M, h a – h a",
+        "h": "E d-M, h–h a"
+      },
+      "MMM, h": {
+        "a": "LLL, h a – h a",
+        "h": "LLL, h–h a"
+      },
+      "MMMd, h": {
+        "a": "d MMM, h a – h a",
+        "h": "d MMM, h–h a"
+      },
+      "MMMEd, h": {
+        "a": "E d MMM, h a – h a",
+        "h": "E d MMM, h–h a"
+      },
+      "MMMMd, h": {
+        "a": "d MMMM, h a – h a",
+        "h": "d MMMM, h–h a"
+      },
+      "y, h": {
+        "a": "y, h a – h a",
+        "h": "y, h–h a"
+      },
+      "yM, h": {
+        "a": "M-y, h a – h a",
+        "h": "M-y, h–h a"
+      },
+      "yMd, h": {
+        "a": "d-M-y, h a – h a",
+        "h": "d-M-y, h–h a"
+      },
+      "yMEd, h": {
+        "a": "E d-M-y, h a – h a",
+        "h": "E d-M-y, h–h a"
+      },
+      "yMMM, h": {
+        "a": "MMM y, h a – h a",
+        "h": "MMM y, h–h a"
+      },
+      "yMMMd, h": {
+        "a": "d MMM y, h a – h a",
+        "h": "d MMM y, h–h a"
+      },
+      "yMMMEd, h": {
+        "a": "E d MMM y, h a – h a",
+        "h": "E d MMM y, h–h a"
+      },
+      "yMMMM, h": {
+        "a": "MMMM y, h a – h a",
+        "h": "MMMM y, h–h a"
+      },
+      "EEEE d MMMM y, H": {
+        "H": "EEEE d MMMM y, HH–HH"
+      },
+      "d MMMM y, H": {
+        "H": "d MMMM y, HH–HH"
+      },
+      "d MMM y, H": {
+        "H": "d MMM y, HH–HH"
+      },
+      "dd-MM-y, H": {
+        "H": "dd-MM-y, HH–HH"
+      },
+      "d, H": {
+        "H": "d, HH–HH"
+      },
+      "E, H": {
+        "H": "ccc, HH–HH"
+      },
+      "Ed, H": {
+        "H": "E d, HH–HH"
+      },
+      "Gy, H": {
+        "H": "y G, HH–HH"
+      },
+      "GyM, H": {
+        "H": "M/y G, HH–HH"
+      },
+      "GyMd, H": {
+        "H": "d/M/y GGGGG, HH–HH"
+      },
+      "GyMEd, H": {
+        "H": "E d/M/y G, HH–HH"
+      },
+      "GyMMM, H": {
+        "H": "MMM y G, HH–HH"
+      },
+      "GyMMMd, H": {
+        "H": "d MMM y G, HH–HH"
+      },
+      "GyMMMEd, H": {
+        "H": "E d MMM y G, HH–HH"
+      },
+      "M, H": {
+        "H": "L, HH–HH"
+      },
+      "Md, H": {
+        "H": "d-M, HH–HH"
+      },
+      "MEd, H": {
+        "H": "E d-M, HH–HH"
+      },
+      "MMM, H": {
+        "H": "LLL, HH–HH"
+      },
+      "MMMd, H": {
+        "H": "d MMM, HH–HH"
+      },
+      "MMMEd, H": {
+        "H": "E d MMM, HH–HH"
+      },
+      "MMMMd, H": {
+        "H": "d MMMM, HH–HH"
+      },
+      "y, H": {
+        "H": "y, HH–HH"
+      },
+      "yM, H": {
+        "H": "M-y, HH–HH"
+      },
+      "yMd, H": {
+        "H": "d-M-y, HH–HH"
+      },
+      "yMEd, H": {
+        "H": "E d-M-y, HH–HH"
+      },
+      "yMMM, H": {
+        "H": "MMM y, HH–HH"
+      },
+      "yMMMd, H": {
+        "H": "d MMM y, HH–HH"
+      },
+      "yMMMEd, H": {
+        "H": "E d MMM y, HH–HH"
+      },
+      "yMMMM, H": {
+        "H": "MMMM y, HH–HH"
+      },
+      "EEEE d MMMM y, hm": {
+        "a": "EEEE d MMMM y, h:mm a – h:mm a",
+        "h": "EEEE d MMMM y, h:mm–h:mm a",
+        "m": "EEEE d MMMM y, h:mm–h:mm a"
+      },
+      "d MMMM y, hm": {
+        "a": "d MMMM y, h:mm a – h:mm a",
+        "h": "d MMMM y, h:mm–h:mm a",
+        "m": "d MMMM y, h:mm–h:mm a"
+      },
+      "d MMM y, hm": {
+        "a": "d MMM y, h:mm a – h:mm a",
+        "h": "d MMM y, h:mm–h:mm a",
+        "m": "d MMM y, h:mm–h:mm a"
+      },
+      "dd-MM-y, hm": {
+        "a": "dd-MM-y, h:mm a – h:mm a",
+        "h": "dd-MM-y, h:mm–h:mm a",
+        "m": "dd-MM-y, h:mm–h:mm a"
+      },
+      "d, hm": {
+        "a": "d, h:mm a – h:mm a",
+        "h": "d, h:mm–h:mm a",
+        "m": "d, h:mm–h:mm a"
+      },
+      "E, hm": {
+        "a": "ccc, h:mm a – h:mm a",
+        "h": "ccc, h:mm–h:mm a",
+        "m": "ccc, h:mm–h:mm a"
+      },
+      "Ed, hm": {
+        "a": "E d, h:mm a – h:mm a",
+        "h": "E d, h:mm–h:mm a",
+        "m": "E d, h:mm–h:mm a"
+      },
+      "Gy, hm": {
+        "a": "y G, h:mm a – h:mm a",
+        "h": "y G, h:mm–h:mm a",
+        "m": "y G, h:mm–h:mm a"
+      },
+      "GyM, hm": {
+        "a": "M/y G, h:mm a – h:mm a",
+        "h": "M/y G, h:mm–h:mm a",
+        "m": "M/y G, h:mm–h:mm a"
+      },
+      "GyMd, hm": {
+        "a": "d/M/y GGGGG, h:mm a – h:mm a",
+        "h": "d/M/y GGGGG, h:mm–h:mm a",
+        "m": "d/M/y GGGGG, h:mm–h:mm a"
+      },
+      "GyMEd, hm": {
+        "a": "E d/M/y G, h:mm a – h:mm a",
+        "h": "E d/M/y G, h:mm–h:mm a",
+        "m": "E d/M/y G, h:mm–h:mm a"
+      },
+      "GyMMM, hm": {
+        "a": "MMM y G, h:mm a – h:mm a",
+        "h": "MMM y G, h:mm–h:mm a",
+        "m": "MMM y G, h:mm–h:mm a"
+      },
+      "GyMMMd, hm": {
+        "a": "d MMM y G, h:mm a – h:mm a",
+        "h": "d MMM y G, h:mm–h:mm a",
+        "m": "d MMM y G, h:mm–h:mm a"
+      },
+      "GyMMMEd, hm": {
+        "a": "E d MMM y G, h:mm a – h:mm a",
+        "h": "E d MMM y G, h:mm–h:mm a",
+        "m": "E d MMM y G, h:mm–h:mm a"
+      },
+      "M, hm": {
+        "a": "L, h:mm a – h:mm a",
+        "h": "L, h:mm–h:mm a",
+        "m": "L, h:mm–h:mm a"
+      },
+      "Md, hm": {
+        "a": "d-M, h:mm a – h:mm a",
+        "h": "d-M, h:mm–h:mm a",
+        "m": "d-M, h:mm–h:mm a"
+      },
+      "MEd, hm": {
+        "a": "E d-M, h:mm a – h:mm a",
+        "h": "E d-M, h:mm–h:mm a",
+        "m": "E d-M, h:mm–h:mm a"
+      },
+      "MMM, hm": {
+        "a": "LLL, h:mm a – h:mm a",
+        "h": "LLL, h:mm–h:mm a",
+        "m": "LLL, h:mm–h:mm a"
+      },
+      "MMMd, hm": {
+        "a": "d MMM, h:mm a – h:mm a",
+        "h": "d MMM, h:mm–h:mm a",
+        "m": "d MMM, h:mm–h:mm a"
+      },
+      "MMMEd, hm": {
+        "a": "E d MMM, h:mm a – h:mm a",
+        "h": "E d MMM, h:mm–h:mm a",
+        "m": "E d MMM, h:mm–h:mm a"
+      },
+      "MMMMd, hm": {
+        "a": "d MMMM, h:mm a – h:mm a",
+        "h": "d MMMM, h:mm–h:mm a",
+        "m": "d MMMM, h:mm–h:mm a"
+      },
+      "y, hm": {
+        "a": "y, h:mm a – h:mm a",
+        "h": "y, h:mm–h:mm a",
+        "m": "y, h:mm–h:mm a"
+      },
+      "yM, hm": {
+        "a": "M-y, h:mm a – h:mm a",
+        "h": "M-y, h:mm–h:mm a",
+        "m": "M-y, h:mm–h:mm a"
+      },
+      "yMd, hm": {
+        "a": "d-M-y, h:mm a – h:mm a",
+        "h": "d-M-y, h:mm–h:mm a",
+        "m": "d-M-y, h:mm–h:mm a"
+      },
+      "yMEd, hm": {
+        "a": "E d-M-y, h:mm a – h:mm a",
+        "h": "E d-M-y, h:mm–h:mm a",
+        "m": "E d-M-y, h:mm–h:mm a"
+      },
+      "yMMM, hm": {
+        "a": "MMM y, h:mm a – h:mm a",
+        "h": "MMM y, h:mm–h:mm a",
+        "m": "MMM y, h:mm–h:mm a"
+      },
+      "yMMMd, hm": {
+        "a": "d MMM y, h:mm a – h:mm a",
+        "h": "d MMM y, h:mm–h:mm a",
+        "m": "d MMM y, h:mm–h:mm a"
+      },
+      "yMMMEd, hm": {
+        "a": "E d MMM y, h:mm a – h:mm a",
+        "h": "E d MMM y, h:mm–h:mm a",
+        "m": "E d MMM y, h:mm–h:mm a"
+      },
+      "yMMMM, hm": {
+        "a": "MMMM y, h:mm a – h:mm a",
+        "h": "MMMM y, h:mm–h:mm a",
+        "m": "MMMM y, h:mm–h:mm a"
+      },
+      "EEEE d MMMM y, Hm": {
+        "H": "EEEE d MMMM y, HH:mm–HH:mm",
+        "m": "EEEE d MMMM y, HH:mm–HH:mm"
+      },
+      "d MMMM y, Hm": {
+        "H": "d MMMM y, HH:mm–HH:mm",
+        "m": "d MMMM y, HH:mm–HH:mm"
+      },
+      "d MMM y, Hm": {
+        "H": "d MMM y, HH:mm–HH:mm",
+        "m": "d MMM y, HH:mm–HH:mm"
+      },
+      "dd-MM-y, Hm": {
+        "H": "dd-MM-y, HH:mm–HH:mm",
+        "m": "dd-MM-y, HH:mm–HH:mm"
+      },
+      "d, Hm": {
+        "H": "d, HH:mm–HH:mm",
+        "m": "d, HH:mm–HH:mm"
+      },
+      "E, Hm": {
+        "H": "ccc, HH:mm–HH:mm",
+        "m": "ccc, HH:mm–HH:mm"
+      },
+      "Ed, Hm": {
+        "H": "E d, HH:mm–HH:mm",
+        "m": "E d, HH:mm–HH:mm"
+      },
+      "Gy, Hm": {
+        "H": "y G, HH:mm–HH:mm",
+        "m": "y G, HH:mm–HH:mm"
+      },
+      "GyM, Hm": {
+        "H": "M/y G, HH:mm–HH:mm",
+        "m": "M/y G, HH:mm–HH:mm"
+      },
+      "GyMd, Hm": {
+        "H": "d/M/y GGGGG, HH:mm–HH:mm",
+        "m": "d/M/y GGGGG, HH:mm–HH:mm"
+      },
+      "GyMEd, Hm": {
+        "H": "E d/M/y G, HH:mm–HH:mm",
+        "m": "E d/M/y G, HH:mm–HH:mm"
+      },
+      "GyMMM, Hm": {
+        "H": "MMM y G, HH:mm–HH:mm",
+        "m": "MMM y G, HH:mm–HH:mm"
+      },
+      "GyMMMd, Hm": {
+        "H": "d MMM y G, HH:mm–HH:mm",
+        "m": "d MMM y G, HH:mm–HH:mm"
+      },
+      "GyMMMEd, Hm": {
+        "H": "E d MMM y G, HH:mm–HH:mm",
+        "m": "E d MMM y G, HH:mm–HH:mm"
+      },
+      "M, Hm": {
+        "H": "L, HH:mm–HH:mm",
+        "m": "L, HH:mm–HH:mm"
+      },
+      "Md, Hm": {
+        "H": "d-M, HH:mm–HH:mm",
+        "m": "d-M, HH:mm–HH:mm"
+      },
+      "MEd, Hm": {
+        "H": "E d-M, HH:mm–HH:mm",
+        "m": "E d-M, HH:mm–HH:mm"
+      },
+      "MMM, Hm": {
+        "H": "LLL, HH:mm–HH:mm",
+        "m": "LLL, HH:mm–HH:mm"
+      },
+      "MMMd, Hm": {
+        "H": "d MMM, HH:mm–HH:mm",
+        "m": "d MMM, HH:mm–HH:mm"
+      },
+      "MMMEd, Hm": {
+        "H": "E d MMM, HH:mm–HH:mm",
+        "m": "E d MMM, HH:mm–HH:mm"
+      },
+      "MMMMd, Hm": {
+        "H": "d MMMM, HH:mm–HH:mm",
+        "m": "d MMMM, HH:mm–HH:mm"
+      },
+      "y, Hm": {
+        "H": "y, HH:mm–HH:mm",
+        "m": "y, HH:mm–HH:mm"
+      },
+      "yM, Hm": {
+        "H": "M-y, HH:mm–HH:mm",
+        "m": "M-y, HH:mm–HH:mm"
+      },
+      "yMd, Hm": {
+        "H": "d-M-y, HH:mm–HH:mm",
+        "m": "d-M-y, HH:mm–HH:mm"
+      },
+      "yMEd, Hm": {
+        "H": "E d-M-y, HH:mm–HH:mm",
+        "m": "E d-M-y, HH:mm–HH:mm"
+      },
+      "yMMM, Hm": {
+        "H": "MMM y, HH:mm–HH:mm",
+        "m": "MMM y, HH:mm–HH:mm"
+      },
+      "yMMMd, Hm": {
+        "H": "d MMM y, HH:mm–HH:mm",
+        "m": "d MMM y, HH:mm–HH:mm"
+      },
+      "yMMMEd, Hm": {
+        "H": "E d MMM y, HH:mm–HH:mm",
+        "m": "E d MMM y, HH:mm–HH:mm"
+      },
+      "yMMMM, Hm": {
+        "H": "MMMM y, HH:mm–HH:mm",
+        "m": "MMMM y, HH:mm–HH:mm"
+      },
+      "EEEE d MMMM y, hmv": {
+        "a": "EEEE d MMMM y, h:mm a – h:mm a v",
+        "h": "EEEE d MMMM y, h:mm–h:mm a v",
+        "m": "EEEE d MMMM y, h:mm–h:mm a v"
+      },
+      "d MMMM y, hmv": {
+        "a": "d MMMM y, h:mm a – h:mm a v",
+        "h": "d MMMM y, h:mm–h:mm a v",
+        "m": "d MMMM y, h:mm–h:mm a v"
+      },
+      "d MMM y, hmv": {
+        "a": "d MMM y, h:mm a – h:mm a v",
+        "h": "d MMM y, h:mm–h:mm a v",
+        "m": "d MMM y, h:mm–h:mm a v"
+      },
+      "dd-MM-y, hmv": {
+        "a": "dd-MM-y, h:mm a – h:mm a v",
+        "h": "dd-MM-y, h:mm–h:mm a v",
+        "m": "dd-MM-y, h:mm–h:mm a v"
+      },
+      "d, hmv": {
+        "a": "d, h:mm a – h:mm a v",
+        "h": "d, h:mm–h:mm a v",
+        "m": "d, h:mm–h:mm a v"
+      },
+      "E, hmv": {
+        "a": "ccc, h:mm a – h:mm a v",
+        "h": "ccc, h:mm–h:mm a v",
+        "m": "ccc, h:mm–h:mm a v"
+      },
+      "Ed, hmv": {
+        "a": "E d, h:mm a – h:mm a v",
+        "h": "E d, h:mm–h:mm a v",
+        "m": "E d, h:mm–h:mm a v"
+      },
+      "Gy, hmv": {
+        "a": "y G, h:mm a – h:mm a v",
+        "h": "y G, h:mm–h:mm a v",
+        "m": "y G, h:mm–h:mm a v"
+      },
+      "GyM, hmv": {
+        "a": "M/y G, h:mm a – h:mm a v",
+        "h": "M/y G, h:mm–h:mm a v",
+        "m": "M/y G, h:mm–h:mm a v"
+      },
+      "GyMd, hmv": {
+        "a": "d/M/y GGGGG, h:mm a – h:mm a v",
+        "h": "d/M/y GGGGG, h:mm–h:mm a v",
+        "m": "d/M/y GGGGG, h:mm–h:mm a v"
+      },
+      "GyMEd, hmv": {
+        "a": "E d/M/y G, h:mm a – h:mm a v",
+        "h": "E d/M/y G, h:mm–h:mm a v",
+        "m": "E d/M/y G, h:mm–h:mm a v"
+      },
+      "GyMMM, hmv": {
+        "a": "MMM y G, h:mm a – h:mm a v",
+        "h": "MMM y G, h:mm–h:mm a v",
+        "m": "MMM y G, h:mm–h:mm a v"
+      },
+      "GyMMMd, hmv": {
+        "a": "d MMM y G, h:mm a – h:mm a v",
+        "h": "d MMM y G, h:mm–h:mm a v",
+        "m": "d MMM y G, h:mm–h:mm a v"
+      },
+      "GyMMMEd, hmv": {
+        "a": "E d MMM y G, h:mm a – h:mm a v",
+        "h": "E d MMM y G, h:mm–h:mm a v",
+        "m": "E d MMM y G, h:mm–h:mm a v"
+      },
+      "M, hmv": {
+        "a": "L, h:mm a – h:mm a v",
+        "h": "L, h:mm–h:mm a v",
+        "m": "L, h:mm–h:mm a v"
+      },
+      "Md, hmv": {
+        "a": "d-M, h:mm a – h:mm a v",
+        "h": "d-M, h:mm–h:mm a v",
+        "m": "d-M, h:mm–h:mm a v"
+      },
+      "MEd, hmv": {
+        "a": "E d-M, h:mm a – h:mm a v",
+        "h": "E d-M, h:mm–h:mm a v",
+        "m": "E d-M, h:mm–h:mm a v"
+      },
+      "MMM, hmv": {
+        "a": "LLL, h:mm a – h:mm a v",
+        "h": "LLL, h:mm–h:mm a v",
+        "m": "LLL, h:mm–h:mm a v"
+      },
+      "MMMd, hmv": {
+        "a": "d MMM, h:mm a – h:mm a v",
+        "h": "d MMM, h:mm–h:mm a v",
+        "m": "d MMM, h:mm–h:mm a v"
+      },
+      "MMMEd, hmv": {
+        "a": "E d MMM, h:mm a – h:mm a v",
+        "h": "E d MMM, h:mm–h:mm a v",
+        "m": "E d MMM, h:mm–h:mm a v"
+      },
+      "MMMMd, hmv": {
+        "a": "d MMMM, h:mm a – h:mm a v",
+        "h": "d MMMM, h:mm–h:mm a v",
+        "m": "d MMMM, h:mm–h:mm a v"
+      },
+      "y, hmv": {
+        "a": "y, h:mm a – h:mm a v",
+        "h": "y, h:mm–h:mm a v",
+        "m": "y, h:mm–h:mm a v"
+      },
+      "yM, hmv": {
+        "a": "M-y, h:mm a – h:mm a v",
+        "h": "M-y, h:mm–h:mm a v",
+        "m": "M-y, h:mm–h:mm a v"
+      },
+      "yMd, hmv": {
+        "a": "d-M-y, h:mm a – h:mm a v",
+        "h": "d-M-y, h:mm–h:mm a v",
+        "m": "d-M-y, h:mm–h:mm a v"
+      },
+      "yMEd, hmv": {
+        "a": "E d-M-y, h:mm a – h:mm a v",
+        "h": "E d-M-y, h:mm–h:mm a v",
+        "m": "E d-M-y, h:mm–h:mm a v"
+      },
+      "yMMM, hmv": {
+        "a": "MMM y, h:mm a – h:mm a v",
+        "h": "MMM y, h:mm–h:mm a v",
+        "m": "MMM y, h:mm–h:mm a v"
+      },
+      "yMMMd, hmv": {
+        "a": "d MMM y, h:mm a – h:mm a v",
+        "h": "d MMM y, h:mm–h:mm a v",
+        "m": "d MMM y, h:mm–h:mm a v"
+      },
+      "yMMMEd, hmv": {
+        "a": "E d MMM y, h:mm a – h:mm a v",
+        "h": "E d MMM y, h:mm–h:mm a v",
+        "m": "E d MMM y, h:mm–h:mm a v"
+      },
+      "yMMMM, hmv": {
+        "a": "MMMM y, h:mm a – h:mm a v",
+        "h": "MMMM y, h:mm–h:mm a v",
+        "m": "MMMM y, h:mm–h:mm a v"
+      },
+      "EEEE d MMMM y, Hmv": {
+        "H": "EEEE d MMMM y, HH:mm–HH:mm v",
+        "m": "EEEE d MMMM y, HH:mm–HH:mm v"
+      },
+      "d MMMM y, Hmv": {
+        "H": "d MMMM y, HH:mm–HH:mm v",
+        "m": "d MMMM y, HH:mm–HH:mm v"
+      },
+      "d MMM y, Hmv": {
+        "H": "d MMM y, HH:mm–HH:mm v",
+        "m": "d MMM y, HH:mm–HH:mm v"
+      },
+      "dd-MM-y, Hmv": {
+        "H": "dd-MM-y, HH:mm–HH:mm v",
+        "m": "dd-MM-y, HH:mm–HH:mm v"
+      },
+      "d, Hmv": {
+        "H": "d, HH:mm–HH:mm v",
+        "m": "d, HH:mm–HH:mm v"
+      },
+      "E, Hmv": {
+        "H": "ccc, HH:mm–HH:mm v",
+        "m": "ccc, HH:mm–HH:mm v"
+      },
+      "Ed, Hmv": {
+        "H": "E d, HH:mm–HH:mm v",
+        "m": "E d, HH:mm–HH:mm v"
+      },
+      "Gy, Hmv": {
+        "H": "y G, HH:mm–HH:mm v",
+        "m": "y G, HH:mm–HH:mm v"
+      },
+      "GyM, Hmv": {
+        "H": "M/y G, HH:mm–HH:mm v",
+        "m": "M/y G, HH:mm–HH:mm v"
+      },
+      "GyMd, Hmv": {
+        "H": "d/M/y GGGGG, HH:mm–HH:mm v",
+        "m": "d/M/y GGGGG, HH:mm–HH:mm v"
+      },
+      "GyMEd, Hmv": {
+        "H": "E d/M/y G, HH:mm–HH:mm v",
+        "m": "E d/M/y G, HH:mm–HH:mm v"
+      },
+      "GyMMM, Hmv": {
+        "H": "MMM y G, HH:mm–HH:mm v",
+        "m": "MMM y G, HH:mm–HH:mm v"
+      },
+      "GyMMMd, Hmv": {
+        "H": "d MMM y G, HH:mm–HH:mm v",
+        "m": "d MMM y G, HH:mm–HH:mm v"
+      },
+      "GyMMMEd, Hmv": {
+        "H": "E d MMM y G, HH:mm–HH:mm v",
+        "m": "E d MMM y G, HH:mm–HH:mm v"
+      },
+      "M, Hmv": {
+        "H": "L, HH:mm–HH:mm v",
+        "m": "L, HH:mm–HH:mm v"
+      },
+      "Md, Hmv": {
+        "H": "d-M, HH:mm–HH:mm v",
+        "m": "d-M, HH:mm–HH:mm v"
+      },
+      "MEd, Hmv": {
+        "H": "E d-M, HH:mm–HH:mm v",
+        "m": "E d-M, HH:mm–HH:mm v"
+      },
+      "MMM, Hmv": {
+        "H": "LLL, HH:mm–HH:mm v",
+        "m": "LLL, HH:mm–HH:mm v"
+      },
+      "MMMd, Hmv": {
+        "H": "d MMM, HH:mm–HH:mm v",
+        "m": "d MMM, HH:mm–HH:mm v"
+      },
+      "MMMEd, Hmv": {
+        "H": "E d MMM, HH:mm–HH:mm v",
+        "m": "E d MMM, HH:mm–HH:mm v"
+      },
+      "MMMMd, Hmv": {
+        "H": "d MMMM, HH:mm–HH:mm v",
+        "m": "d MMMM, HH:mm–HH:mm v"
+      },
+      "y, Hmv": {
+        "H": "y, HH:mm–HH:mm v",
+        "m": "y, HH:mm–HH:mm v"
+      },
+      "yM, Hmv": {
+        "H": "M-y, HH:mm–HH:mm v",
+        "m": "M-y, HH:mm–HH:mm v"
+      },
+      "yMd, Hmv": {
+        "H": "d-M-y, HH:mm–HH:mm v",
+        "m": "d-M-y, HH:mm–HH:mm v"
+      },
+      "yMEd, Hmv": {
+        "H": "E d-M-y, HH:mm–HH:mm v",
+        "m": "E d-M-y, HH:mm–HH:mm v"
+      },
+      "yMMM, Hmv": {
+        "H": "MMM y, HH:mm–HH:mm v",
+        "m": "MMM y, HH:mm–HH:mm v"
+      },
+      "yMMMd, Hmv": {
+        "H": "d MMM y, HH:mm–HH:mm v",
+        "m": "d MMM y, HH:mm–HH:mm v"
+      },
+      "yMMMEd, Hmv": {
+        "H": "E d MMM y, HH:mm–HH:mm v",
+        "m": "E d MMM y, HH:mm–HH:mm v"
+      },
+      "yMMMM, Hmv": {
+        "H": "MMMM y, HH:mm–HH:mm v",
+        "m": "MMMM y, HH:mm–HH:mm v"
+      },
+      "EEEE d MMMM y, hv": {
+        "a": "EEEE d MMMM y, h a – h a v",
+        "h": "EEEE d MMMM y, h–h a v"
+      },
+      "d MMMM y, hv": {
+        "a": "d MMMM y, h a – h a v",
+        "h": "d MMMM y, h–h a v"
+      },
+      "d MMM y, hv": {
+        "a": "d MMM y, h a – h a v",
+        "h": "d MMM y, h–h a v"
+      },
+      "dd-MM-y, hv": {
+        "a": "dd-MM-y, h a – h a v",
+        "h": "dd-MM-y, h–h a v"
+      },
+      "d, hv": {
+        "a": "d, h a – h a v",
+        "h": "d, h–h a v"
+      },
+      "E, hv": {
+        "a": "ccc, h a – h a v",
+        "h": "ccc, h–h a v"
+      },
+      "Ed, hv": {
+        "a": "E d, h a – h a v",
+        "h": "E d, h–h a v"
+      },
+      "Gy, hv": {
+        "a": "y G, h a – h a v",
+        "h": "y G, h–h a v"
+      },
+      "GyM, hv": {
+        "a": "M/y G, h a – h a v",
+        "h": "M/y G, h–h a v"
+      },
+      "GyMd, hv": {
+        "a": "d/M/y GGGGG, h a – h a v",
+        "h": "d/M/y GGGGG, h–h a v"
+      },
+      "GyMEd, hv": {
+        "a": "E d/M/y G, h a – h a v",
+        "h": "E d/M/y G, h–h a v"
+      },
+      "GyMMM, hv": {
+        "a": "MMM y G, h a – h a v",
+        "h": "MMM y G, h–h a v"
+      },
+      "GyMMMd, hv": {
+        "a": "d MMM y G, h a – h a v",
+        "h": "d MMM y G, h–h a v"
+      },
+      "GyMMMEd, hv": {
+        "a": "E d MMM y G, h a – h a v",
+        "h": "E d MMM y G, h–h a v"
+      },
+      "M, hv": {
+        "a": "L, h a – h a v",
+        "h": "L, h–h a v"
+      },
+      "Md, hv": {
+        "a": "d-M, h a – h a v",
+        "h": "d-M, h–h a v"
+      },
+      "MEd, hv": {
+        "a": "E d-M, h a – h a v",
+        "h": "E d-M, h–h a v"
+      },
+      "MMM, hv": {
+        "a": "LLL, h a – h a v",
+        "h": "LLL, h–h a v"
+      },
+      "MMMd, hv": {
+        "a": "d MMM, h a – h a v",
+        "h": "d MMM, h–h a v"
+      },
+      "MMMEd, hv": {
+        "a": "E d MMM, h a – h a v",
+        "h": "E d MMM, h–h a v"
+      },
+      "MMMMd, hv": {
+        "a": "d MMMM, h a – h a v",
+        "h": "d MMMM, h–h a v"
+      },
+      "y, hv": {
+        "a": "y, h a – h a v",
+        "h": "y, h–h a v"
+      },
+      "yM, hv": {
+        "a": "M-y, h a – h a v",
+        "h": "M-y, h–h a v"
+      },
+      "yMd, hv": {
+        "a": "d-M-y, h a – h a v",
+        "h": "d-M-y, h–h a v"
+      },
+      "yMEd, hv": {
+        "a": "E d-M-y, h a – h a v",
+        "h": "E d-M-y, h–h a v"
+      },
+      "yMMM, hv": {
+        "a": "MMM y, h a – h a v",
+        "h": "MMM y, h–h a v"
+      },
+      "yMMMd, hv": {
+        "a": "d MMM y, h a – h a v",
+        "h": "d MMM y, h–h a v"
+      },
+      "yMMMEd, hv": {
+        "a": "E d MMM y, h a – h a v",
+        "h": "E d MMM y, h–h a v"
+      },
+      "yMMMM, hv": {
+        "a": "MMMM y, h a – h a v",
+        "h": "MMMM y, h–h a v"
+      },
+      "EEEE d MMMM y, Hv": {
+        "H": "EEEE d MMMM y, HH–HH v"
+      },
+      "d MMMM y, Hv": {
+        "H": "d MMMM y, HH–HH v"
+      },
+      "d MMM y, Hv": {
+        "H": "d MMM y, HH–HH v"
+      },
+      "dd-MM-y, Hv": {
+        "H": "dd-MM-y, HH–HH v"
+      },
+      "d, Hv": {
+        "H": "d, HH–HH v"
+      },
+      "E, Hv": {
+        "H": "ccc, HH–HH v"
+      },
+      "Ed, Hv": {
+        "H": "E d, HH–HH v"
+      },
+      "Gy, Hv": {
+        "H": "y G, HH–HH v"
+      },
+      "GyM, Hv": {
+        "H": "M/y G, HH–HH v"
+      },
+      "GyMd, Hv": {
+        "H": "d/M/y GGGGG, HH–HH v"
+      },
+      "GyMEd, Hv": {
+        "H": "E d/M/y G, HH–HH v"
+      },
+      "GyMMM, Hv": {
+        "H": "MMM y G, HH–HH v"
+      },
+      "GyMMMd, Hv": {
+        "H": "d MMM y G, HH–HH v"
+      },
+      "GyMMMEd, Hv": {
+        "H": "E d MMM y G, HH–HH v"
+      },
+      "M, Hv": {
+        "H": "L, HH–HH v"
+      },
+      "Md, Hv": {
+        "H": "d-M, HH–HH v"
+      },
+      "MEd, Hv": {
+        "H": "E d-M, HH–HH v"
+      },
+      "MMM, Hv": {
+        "H": "LLL, HH–HH v"
+      },
+      "MMMd, Hv": {
+        "H": "d MMM, HH–HH v"
+      },
+      "MMMEd, Hv": {
+        "H": "E d MMM, HH–HH v"
+      },
+      "MMMMd, Hv": {
+        "H": "d MMMM, HH–HH v"
+      },
+      "y, Hv": {
+        "H": "y, HH–HH v"
+      },
+      "yM, Hv": {
+        "H": "M-y, HH–HH v"
+      },
+      "yMd, Hv": {
+        "H": "d-M-y, HH–HH v"
+      },
+      "yMEd, Hv": {
+        "H": "E d-M-y, HH–HH v"
+      },
+      "yMMM, Hv": {
+        "H": "MMM y, HH–HH v"
+      },
+      "yMMMd, Hv": {
+        "H": "d MMM y, HH–HH v"
+      },
+      "yMMMEd, Hv": {
+        "H": "E d MMM y, HH–HH v"
+      },
+      "yMMMM, Hv": {
+        "H": "MMMM y, HH–HH v"
       }
     },
     "hourCycle": "h23",

--- a/packages/intl-datetimeformat/tests/locale-data/pl.json
+++ b/packages/intl-datetimeformat/tests/locale-data/pl.json
@@ -2872,6 +2872,1441 @@
         "d": "E, d MMMM – E, d MMMM y",
         "M": "E, d MMMM – E, d MMMM y",
         "y": "E, d MMMM y – E, d MMMM y"
+      },
+      "EEEE, d MMMM y Bh": {
+        "B": "EEEE, d MMMM y h B – h B",
+        "h": "EEEE, d MMMM y h–h B"
+      },
+      "d MMMM y Bh": {
+        "B": "d MMMM y h B – h B",
+        "h": "d MMMM y h–h B"
+      },
+      "d MMM y, Bh": {
+        "B": "d MMM y, h B – h B",
+        "h": "d MMM y, h–h B"
+      },
+      "d.MM.y, Bh": {
+        "B": "d.MM.y, h B – h B",
+        "h": "d.MM.y, h–h B"
+      },
+      "d, Bh": {
+        "B": "d, h B – h B",
+        "h": "d, h–h B"
+      },
+      "E, Bh": {
+        "B": "ccc, h B – h B",
+        "h": "ccc, h–h B"
+      },
+      "Ed, Bh": {
+        "B": "E, d, h B – h B",
+        "h": "E, d, h–h B"
+      },
+      "Gy, Bh": {
+        "B": "y G, h B – h B",
+        "h": "y G, h–h B"
+      },
+      "GyM, Bh": {
+        "B": "MM.y G, h B – h B",
+        "h": "MM.y G, h–h B"
+      },
+      "GyMd, Bh": {
+        "B": "d.MM.y GGGGG, h B – h B",
+        "h": "d.MM.y GGGGG, h–h B"
+      },
+      "GyMEd, Bh": {
+        "B": "E, d.MM.y G, h B – h B",
+        "h": "E, d.MM.y G, h–h B"
+      },
+      "GyMMM, Bh": {
+        "B": "MMM y G, h B – h B",
+        "h": "MMM y G, h–h B"
+      },
+      "GyMMMd, Bh": {
+        "B": "d MMM y G, h B – h B",
+        "h": "d MMM y G, h–h B"
+      },
+      "GyMMMEd, Bh": {
+        "B": "E, d MMM y G, h B – h B",
+        "h": "E, d MMM y G, h–h B"
+      },
+      "GyMMMM Bh": {
+        "B": "LLLL y G h B – h B",
+        "h": "LLLL y G h–h B"
+      },
+      "GyMMMMd Bh": {
+        "B": "d MMMM y G h B – h B",
+        "h": "d MMMM y G h–h B"
+      },
+      "GyMMMMEd Bh": {
+        "B": "E, d MMMM y G h B – h B",
+        "h": "E, d MMMM y G h–h B"
+      },
+      "M, Bh": {
+        "B": "L, h B – h B",
+        "h": "L, h–h B"
+      },
+      "Md, Bh": {
+        "B": "d.MM, h B – h B",
+        "h": "d.MM, h–h B"
+      },
+      "MEd, Bh": {
+        "B": "E, d.MM, h B – h B",
+        "h": "E, d.MM, h–h B"
+      },
+      "MMM, Bh": {
+        "B": "LLL, h B – h B",
+        "h": "LLL, h–h B"
+      },
+      "MMMd, Bh": {
+        "B": "d MMM, h B – h B",
+        "h": "d MMM, h–h B"
+      },
+      "MMMEd, Bh": {
+        "B": "E, d MMM, h B – h B",
+        "h": "E, d MMM, h–h B"
+      },
+      "MMMMd Bh": {
+        "B": "d MMMM h B – h B",
+        "h": "d MMMM h–h B"
+      },
+      "MMMMEd Bh": {
+        "B": "E, d MMMM h B – h B",
+        "h": "E, d MMMM h–h B"
+      },
+      "y, Bh": {
+        "B": "y, h B – h B",
+        "h": "y, h–h B"
+      },
+      "yM, Bh": {
+        "B": "MM.y, h B – h B",
+        "h": "MM.y, h–h B"
+      },
+      "yMd, Bh": {
+        "B": "d.MM.y, h B – h B",
+        "h": "d.MM.y, h–h B"
+      },
+      "yMEd, Bh": {
+        "B": "E, d.MM.y, h B – h B",
+        "h": "E, d.MM.y, h–h B"
+      },
+      "yMMM, Bh": {
+        "B": "LLL y, h B – h B",
+        "h": "LLL y, h–h B"
+      },
+      "yMMMd, Bh": {
+        "B": "d MMM y, h B – h B",
+        "h": "d MMM y, h–h B"
+      },
+      "yMMMEd, Bh": {
+        "B": "E, d MMM y, h B – h B",
+        "h": "E, d MMM y, h–h B"
+      },
+      "yMMMM Bh": {
+        "B": "LLLL y h B – h B",
+        "h": "LLLL y h–h B"
+      },
+      "yMMMMd Bh": {
+        "B": "d MMMM y h B – h B",
+        "h": "d MMMM y h–h B"
+      },
+      "yMMMMEd Bh": {
+        "B": "E, d MMMM y h B – h B",
+        "h": "E, d MMMM y h–h B"
+      },
+      "EEEE, d MMMM y Bhm": {
+        "B": "EEEE, d MMMM y h:mm B – h:mm B",
+        "h": "EEEE, d MMMM y h:mm–h:mm B",
+        "m": "EEEE, d MMMM y h:mm–h:mm B"
+      },
+      "d MMMM y Bhm": {
+        "B": "d MMMM y h:mm B – h:mm B",
+        "h": "d MMMM y h:mm–h:mm B",
+        "m": "d MMMM y h:mm–h:mm B"
+      },
+      "d MMM y, Bhm": {
+        "B": "d MMM y, h:mm B – h:mm B",
+        "h": "d MMM y, h:mm–h:mm B",
+        "m": "d MMM y, h:mm–h:mm B"
+      },
+      "d.MM.y, Bhm": {
+        "B": "d.MM.y, h:mm B – h:mm B",
+        "h": "d.MM.y, h:mm–h:mm B",
+        "m": "d.MM.y, h:mm–h:mm B"
+      },
+      "d, Bhm": {
+        "B": "d, h:mm B – h:mm B",
+        "h": "d, h:mm–h:mm B",
+        "m": "d, h:mm–h:mm B"
+      },
+      "E, Bhm": {
+        "B": "ccc, h:mm B – h:mm B",
+        "h": "ccc, h:mm–h:mm B",
+        "m": "ccc, h:mm–h:mm B"
+      },
+      "Ed, Bhm": {
+        "B": "E, d, h:mm B – h:mm B",
+        "h": "E, d, h:mm–h:mm B",
+        "m": "E, d, h:mm–h:mm B"
+      },
+      "Gy, Bhm": {
+        "B": "y G, h:mm B – h:mm B",
+        "h": "y G, h:mm–h:mm B",
+        "m": "y G, h:mm–h:mm B"
+      },
+      "GyM, Bhm": {
+        "B": "MM.y G, h:mm B – h:mm B",
+        "h": "MM.y G, h:mm–h:mm B",
+        "m": "MM.y G, h:mm–h:mm B"
+      },
+      "GyMd, Bhm": {
+        "B": "d.MM.y GGGGG, h:mm B – h:mm B",
+        "h": "d.MM.y GGGGG, h:mm–h:mm B",
+        "m": "d.MM.y GGGGG, h:mm–h:mm B"
+      },
+      "GyMEd, Bhm": {
+        "B": "E, d.MM.y G, h:mm B – h:mm B",
+        "h": "E, d.MM.y G, h:mm–h:mm B",
+        "m": "E, d.MM.y G, h:mm–h:mm B"
+      },
+      "GyMMM, Bhm": {
+        "B": "MMM y G, h:mm B – h:mm B",
+        "h": "MMM y G, h:mm–h:mm B",
+        "m": "MMM y G, h:mm–h:mm B"
+      },
+      "GyMMMd, Bhm": {
+        "B": "d MMM y G, h:mm B – h:mm B",
+        "h": "d MMM y G, h:mm–h:mm B",
+        "m": "d MMM y G, h:mm–h:mm B"
+      },
+      "GyMMMEd, Bhm": {
+        "B": "E, d MMM y G, h:mm B – h:mm B",
+        "h": "E, d MMM y G, h:mm–h:mm B",
+        "m": "E, d MMM y G, h:mm–h:mm B"
+      },
+      "GyMMMM Bhm": {
+        "B": "LLLL y G h:mm B – h:mm B",
+        "h": "LLLL y G h:mm–h:mm B",
+        "m": "LLLL y G h:mm–h:mm B"
+      },
+      "GyMMMMd Bhm": {
+        "B": "d MMMM y G h:mm B – h:mm B",
+        "h": "d MMMM y G h:mm–h:mm B",
+        "m": "d MMMM y G h:mm–h:mm B"
+      },
+      "GyMMMMEd Bhm": {
+        "B": "E, d MMMM y G h:mm B – h:mm B",
+        "h": "E, d MMMM y G h:mm–h:mm B",
+        "m": "E, d MMMM y G h:mm–h:mm B"
+      },
+      "M, Bhm": {
+        "B": "L, h:mm B – h:mm B",
+        "h": "L, h:mm–h:mm B",
+        "m": "L, h:mm–h:mm B"
+      },
+      "Md, Bhm": {
+        "B": "d.MM, h:mm B – h:mm B",
+        "h": "d.MM, h:mm–h:mm B",
+        "m": "d.MM, h:mm–h:mm B"
+      },
+      "MEd, Bhm": {
+        "B": "E, d.MM, h:mm B – h:mm B",
+        "h": "E, d.MM, h:mm–h:mm B",
+        "m": "E, d.MM, h:mm–h:mm B"
+      },
+      "MMM, Bhm": {
+        "B": "LLL, h:mm B – h:mm B",
+        "h": "LLL, h:mm–h:mm B",
+        "m": "LLL, h:mm–h:mm B"
+      },
+      "MMMd, Bhm": {
+        "B": "d MMM, h:mm B – h:mm B",
+        "h": "d MMM, h:mm–h:mm B",
+        "m": "d MMM, h:mm–h:mm B"
+      },
+      "MMMEd, Bhm": {
+        "B": "E, d MMM, h:mm B – h:mm B",
+        "h": "E, d MMM, h:mm–h:mm B",
+        "m": "E, d MMM, h:mm–h:mm B"
+      },
+      "MMMMd Bhm": {
+        "B": "d MMMM h:mm B – h:mm B",
+        "h": "d MMMM h:mm–h:mm B",
+        "m": "d MMMM h:mm–h:mm B"
+      },
+      "MMMMEd Bhm": {
+        "B": "E, d MMMM h:mm B – h:mm B",
+        "h": "E, d MMMM h:mm–h:mm B",
+        "m": "E, d MMMM h:mm–h:mm B"
+      },
+      "y, Bhm": {
+        "B": "y, h:mm B – h:mm B",
+        "h": "y, h:mm–h:mm B",
+        "m": "y, h:mm–h:mm B"
+      },
+      "yM, Bhm": {
+        "B": "MM.y, h:mm B – h:mm B",
+        "h": "MM.y, h:mm–h:mm B",
+        "m": "MM.y, h:mm–h:mm B"
+      },
+      "yMd, Bhm": {
+        "B": "d.MM.y, h:mm B – h:mm B",
+        "h": "d.MM.y, h:mm–h:mm B",
+        "m": "d.MM.y, h:mm–h:mm B"
+      },
+      "yMEd, Bhm": {
+        "B": "E, d.MM.y, h:mm B – h:mm B",
+        "h": "E, d.MM.y, h:mm–h:mm B",
+        "m": "E, d.MM.y, h:mm–h:mm B"
+      },
+      "yMMM, Bhm": {
+        "B": "LLL y, h:mm B – h:mm B",
+        "h": "LLL y, h:mm–h:mm B",
+        "m": "LLL y, h:mm–h:mm B"
+      },
+      "yMMMd, Bhm": {
+        "B": "d MMM y, h:mm B – h:mm B",
+        "h": "d MMM y, h:mm–h:mm B",
+        "m": "d MMM y, h:mm–h:mm B"
+      },
+      "yMMMEd, Bhm": {
+        "B": "E, d MMM y, h:mm B – h:mm B",
+        "h": "E, d MMM y, h:mm–h:mm B",
+        "m": "E, d MMM y, h:mm–h:mm B"
+      },
+      "yMMMM Bhm": {
+        "B": "LLLL y h:mm B – h:mm B",
+        "h": "LLLL y h:mm–h:mm B",
+        "m": "LLLL y h:mm–h:mm B"
+      },
+      "yMMMMd Bhm": {
+        "B": "d MMMM y h:mm B – h:mm B",
+        "h": "d MMMM y h:mm–h:mm B",
+        "m": "d MMMM y h:mm–h:mm B"
+      },
+      "yMMMMEd Bhm": {
+        "B": "E, d MMMM y h:mm B – h:mm B",
+        "h": "E, d MMMM y h:mm–h:mm B",
+        "m": "E, d MMMM y h:mm–h:mm B"
+      },
+      "EEEE, d MMMM y h": {
+        "a": "EEEE, d MMMM y h a–h a",
+        "h": "EEEE, d MMMM y h–h a"
+      },
+      "d MMMM y h": {
+        "a": "d MMMM y h a–h a",
+        "h": "d MMMM y h–h a"
+      },
+      "d MMM y, h": {
+        "a": "d MMM y, h a–h a",
+        "h": "d MMM y, h–h a"
+      },
+      "d.MM.y, h": {
+        "a": "d.MM.y, h a–h a",
+        "h": "d.MM.y, h–h a"
+      },
+      "d, h": {
+        "a": "d, h a–h a",
+        "h": "d, h–h a"
+      },
+      "E, h": {
+        "a": "ccc, h a–h a",
+        "h": "ccc, h–h a"
+      },
+      "Ed, h": {
+        "a": "E, d, h a–h a",
+        "h": "E, d, h–h a"
+      },
+      "Gy, h": {
+        "a": "y G, h a–h a",
+        "h": "y G, h–h a"
+      },
+      "GyM, h": {
+        "a": "MM.y G, h a–h a",
+        "h": "MM.y G, h–h a"
+      },
+      "GyMd, h": {
+        "a": "d.MM.y GGGGG, h a–h a",
+        "h": "d.MM.y GGGGG, h–h a"
+      },
+      "GyMEd, h": {
+        "a": "E, d.MM.y G, h a–h a",
+        "h": "E, d.MM.y G, h–h a"
+      },
+      "GyMMM, h": {
+        "a": "MMM y G, h a–h a",
+        "h": "MMM y G, h–h a"
+      },
+      "GyMMMd, h": {
+        "a": "d MMM y G, h a–h a",
+        "h": "d MMM y G, h–h a"
+      },
+      "GyMMMEd, h": {
+        "a": "E, d MMM y G, h a–h a",
+        "h": "E, d MMM y G, h–h a"
+      },
+      "GyMMMM h": {
+        "a": "LLLL y G h a–h a",
+        "h": "LLLL y G h–h a"
+      },
+      "GyMMMMd h": {
+        "a": "d MMMM y G h a–h a",
+        "h": "d MMMM y G h–h a"
+      },
+      "GyMMMMEd h": {
+        "a": "E, d MMMM y G h a–h a",
+        "h": "E, d MMMM y G h–h a"
+      },
+      "M, h": {
+        "a": "L, h a–h a",
+        "h": "L, h–h a"
+      },
+      "Md, h": {
+        "a": "d.MM, h a–h a",
+        "h": "d.MM, h–h a"
+      },
+      "MEd, h": {
+        "a": "E, d.MM, h a–h a",
+        "h": "E, d.MM, h–h a"
+      },
+      "MMM, h": {
+        "a": "LLL, h a–h a",
+        "h": "LLL, h–h a"
+      },
+      "MMMd, h": {
+        "a": "d MMM, h a–h a",
+        "h": "d MMM, h–h a"
+      },
+      "MMMEd, h": {
+        "a": "E, d MMM, h a–h a",
+        "h": "E, d MMM, h–h a"
+      },
+      "MMMMd h": {
+        "a": "d MMMM h a–h a",
+        "h": "d MMMM h–h a"
+      },
+      "MMMMEd h": {
+        "a": "E, d MMMM h a–h a",
+        "h": "E, d MMMM h–h a"
+      },
+      "y, h": {
+        "a": "y, h a–h a",
+        "h": "y, h–h a"
+      },
+      "yM, h": {
+        "a": "MM.y, h a–h a",
+        "h": "MM.y, h–h a"
+      },
+      "yMd, h": {
+        "a": "d.MM.y, h a–h a",
+        "h": "d.MM.y, h–h a"
+      },
+      "yMEd, h": {
+        "a": "E, d.MM.y, h a–h a",
+        "h": "E, d.MM.y, h–h a"
+      },
+      "yMMM, h": {
+        "a": "LLL y, h a–h a",
+        "h": "LLL y, h–h a"
+      },
+      "yMMMd, h": {
+        "a": "d MMM y, h a–h a",
+        "h": "d MMM y, h–h a"
+      },
+      "yMMMEd, h": {
+        "a": "E, d MMM y, h a–h a",
+        "h": "E, d MMM y, h–h a"
+      },
+      "yMMMM h": {
+        "a": "LLLL y h a–h a",
+        "h": "LLLL y h–h a"
+      },
+      "yMMMMd h": {
+        "a": "d MMMM y h a–h a",
+        "h": "d MMMM y h–h a"
+      },
+      "yMMMMEd h": {
+        "a": "E, d MMMM y h a–h a",
+        "h": "E, d MMMM y h–h a"
+      },
+      "EEEE, d MMMM y H": {
+        "H": "EEEE, d MMMM y HH–HH"
+      },
+      "d MMMM y H": {
+        "H": "d MMMM y HH–HH"
+      },
+      "d MMM y, H": {
+        "H": "d MMM y, HH–HH"
+      },
+      "d.MM.y, H": {
+        "H": "d.MM.y, HH–HH"
+      },
+      "d, H": {
+        "H": "d, HH–HH"
+      },
+      "E, H": {
+        "H": "ccc, HH–HH"
+      },
+      "Ed, H": {
+        "H": "E, d, HH–HH"
+      },
+      "Gy, H": {
+        "H": "y G, HH–HH"
+      },
+      "GyM, H": {
+        "H": "MM.y G, HH–HH"
+      },
+      "GyMd, H": {
+        "H": "d.MM.y GGGGG, HH–HH"
+      },
+      "GyMEd, H": {
+        "H": "E, d.MM.y G, HH–HH"
+      },
+      "GyMMM, H": {
+        "H": "MMM y G, HH–HH"
+      },
+      "GyMMMd, H": {
+        "H": "d MMM y G, HH–HH"
+      },
+      "GyMMMEd, H": {
+        "H": "E, d MMM y G, HH–HH"
+      },
+      "GyMMMM H": {
+        "H": "LLLL y G HH–HH"
+      },
+      "GyMMMMd H": {
+        "H": "d MMMM y G HH–HH"
+      },
+      "GyMMMMEd H": {
+        "H": "E, d MMMM y G HH–HH"
+      },
+      "M, H": {
+        "H": "L, HH–HH"
+      },
+      "Md, H": {
+        "H": "d.MM, HH–HH"
+      },
+      "MEd, H": {
+        "H": "E, d.MM, HH–HH"
+      },
+      "MMM, H": {
+        "H": "LLL, HH–HH"
+      },
+      "MMMd, H": {
+        "H": "d MMM, HH–HH"
+      },
+      "MMMEd, H": {
+        "H": "E, d MMM, HH–HH"
+      },
+      "MMMMd H": {
+        "H": "d MMMM HH–HH"
+      },
+      "MMMMEd H": {
+        "H": "E, d MMMM HH–HH"
+      },
+      "y, H": {
+        "H": "y, HH–HH"
+      },
+      "yM, H": {
+        "H": "MM.y, HH–HH"
+      },
+      "yMd, H": {
+        "H": "d.MM.y, HH–HH"
+      },
+      "yMEd, H": {
+        "H": "E, d.MM.y, HH–HH"
+      },
+      "yMMM, H": {
+        "H": "LLL y, HH–HH"
+      },
+      "yMMMd, H": {
+        "H": "d MMM y, HH–HH"
+      },
+      "yMMMEd, H": {
+        "H": "E, d MMM y, HH–HH"
+      },
+      "yMMMM H": {
+        "H": "LLLL y HH–HH"
+      },
+      "yMMMMd H": {
+        "H": "d MMMM y HH–HH"
+      },
+      "yMMMMEd H": {
+        "H": "E, d MMMM y HH–HH"
+      },
+      "EEEE, d MMMM y hm": {
+        "a": "EEEE, d MMMM y h:mm a–h:mm a",
+        "h": "EEEE, d MMMM y h:mm–h:mm a",
+        "m": "EEEE, d MMMM y h:mm–h:mm a"
+      },
+      "d MMMM y hm": {
+        "a": "d MMMM y h:mm a–h:mm a",
+        "h": "d MMMM y h:mm–h:mm a",
+        "m": "d MMMM y h:mm–h:mm a"
+      },
+      "d MMM y, hm": {
+        "a": "d MMM y, h:mm a–h:mm a",
+        "h": "d MMM y, h:mm–h:mm a",
+        "m": "d MMM y, h:mm–h:mm a"
+      },
+      "d.MM.y, hm": {
+        "a": "d.MM.y, h:mm a–h:mm a",
+        "h": "d.MM.y, h:mm–h:mm a",
+        "m": "d.MM.y, h:mm–h:mm a"
+      },
+      "d, hm": {
+        "a": "d, h:mm a–h:mm a",
+        "h": "d, h:mm–h:mm a",
+        "m": "d, h:mm–h:mm a"
+      },
+      "E, hm": {
+        "a": "ccc, h:mm a–h:mm a",
+        "h": "ccc, h:mm–h:mm a",
+        "m": "ccc, h:mm–h:mm a"
+      },
+      "Ed, hm": {
+        "a": "E, d, h:mm a–h:mm a",
+        "h": "E, d, h:mm–h:mm a",
+        "m": "E, d, h:mm–h:mm a"
+      },
+      "Gy, hm": {
+        "a": "y G, h:mm a–h:mm a",
+        "h": "y G, h:mm–h:mm a",
+        "m": "y G, h:mm–h:mm a"
+      },
+      "GyM, hm": {
+        "a": "MM.y G, h:mm a–h:mm a",
+        "h": "MM.y G, h:mm–h:mm a",
+        "m": "MM.y G, h:mm–h:mm a"
+      },
+      "GyMd, hm": {
+        "a": "d.MM.y GGGGG, h:mm a–h:mm a",
+        "h": "d.MM.y GGGGG, h:mm–h:mm a",
+        "m": "d.MM.y GGGGG, h:mm–h:mm a"
+      },
+      "GyMEd, hm": {
+        "a": "E, d.MM.y G, h:mm a–h:mm a",
+        "h": "E, d.MM.y G, h:mm–h:mm a",
+        "m": "E, d.MM.y G, h:mm–h:mm a"
+      },
+      "GyMMM, hm": {
+        "a": "MMM y G, h:mm a–h:mm a",
+        "h": "MMM y G, h:mm–h:mm a",
+        "m": "MMM y G, h:mm–h:mm a"
+      },
+      "GyMMMd, hm": {
+        "a": "d MMM y G, h:mm a–h:mm a",
+        "h": "d MMM y G, h:mm–h:mm a",
+        "m": "d MMM y G, h:mm–h:mm a"
+      },
+      "GyMMMEd, hm": {
+        "a": "E, d MMM y G, h:mm a–h:mm a",
+        "h": "E, d MMM y G, h:mm–h:mm a",
+        "m": "E, d MMM y G, h:mm–h:mm a"
+      },
+      "GyMMMM hm": {
+        "a": "LLLL y G h:mm a–h:mm a",
+        "h": "LLLL y G h:mm–h:mm a",
+        "m": "LLLL y G h:mm–h:mm a"
+      },
+      "GyMMMMd hm": {
+        "a": "d MMMM y G h:mm a–h:mm a",
+        "h": "d MMMM y G h:mm–h:mm a",
+        "m": "d MMMM y G h:mm–h:mm a"
+      },
+      "GyMMMMEd hm": {
+        "a": "E, d MMMM y G h:mm a–h:mm a",
+        "h": "E, d MMMM y G h:mm–h:mm a",
+        "m": "E, d MMMM y G h:mm–h:mm a"
+      },
+      "M, hm": {
+        "a": "L, h:mm a–h:mm a",
+        "h": "L, h:mm–h:mm a",
+        "m": "L, h:mm–h:mm a"
+      },
+      "Md, hm": {
+        "a": "d.MM, h:mm a–h:mm a",
+        "h": "d.MM, h:mm–h:mm a",
+        "m": "d.MM, h:mm–h:mm a"
+      },
+      "MEd, hm": {
+        "a": "E, d.MM, h:mm a–h:mm a",
+        "h": "E, d.MM, h:mm–h:mm a",
+        "m": "E, d.MM, h:mm–h:mm a"
+      },
+      "MMM, hm": {
+        "a": "LLL, h:mm a–h:mm a",
+        "h": "LLL, h:mm–h:mm a",
+        "m": "LLL, h:mm–h:mm a"
+      },
+      "MMMd, hm": {
+        "a": "d MMM, h:mm a–h:mm a",
+        "h": "d MMM, h:mm–h:mm a",
+        "m": "d MMM, h:mm–h:mm a"
+      },
+      "MMMEd, hm": {
+        "a": "E, d MMM, h:mm a–h:mm a",
+        "h": "E, d MMM, h:mm–h:mm a",
+        "m": "E, d MMM, h:mm–h:mm a"
+      },
+      "MMMMd hm": {
+        "a": "d MMMM h:mm a–h:mm a",
+        "h": "d MMMM h:mm–h:mm a",
+        "m": "d MMMM h:mm–h:mm a"
+      },
+      "MMMMEd hm": {
+        "a": "E, d MMMM h:mm a–h:mm a",
+        "h": "E, d MMMM h:mm–h:mm a",
+        "m": "E, d MMMM h:mm–h:mm a"
+      },
+      "y, hm": {
+        "a": "y, h:mm a–h:mm a",
+        "h": "y, h:mm–h:mm a",
+        "m": "y, h:mm–h:mm a"
+      },
+      "yM, hm": {
+        "a": "MM.y, h:mm a–h:mm a",
+        "h": "MM.y, h:mm–h:mm a",
+        "m": "MM.y, h:mm–h:mm a"
+      },
+      "yMd, hm": {
+        "a": "d.MM.y, h:mm a–h:mm a",
+        "h": "d.MM.y, h:mm–h:mm a",
+        "m": "d.MM.y, h:mm–h:mm a"
+      },
+      "yMEd, hm": {
+        "a": "E, d.MM.y, h:mm a–h:mm a",
+        "h": "E, d.MM.y, h:mm–h:mm a",
+        "m": "E, d.MM.y, h:mm–h:mm a"
+      },
+      "yMMM, hm": {
+        "a": "LLL y, h:mm a–h:mm a",
+        "h": "LLL y, h:mm–h:mm a",
+        "m": "LLL y, h:mm–h:mm a"
+      },
+      "yMMMd, hm": {
+        "a": "d MMM y, h:mm a–h:mm a",
+        "h": "d MMM y, h:mm–h:mm a",
+        "m": "d MMM y, h:mm–h:mm a"
+      },
+      "yMMMEd, hm": {
+        "a": "E, d MMM y, h:mm a–h:mm a",
+        "h": "E, d MMM y, h:mm–h:mm a",
+        "m": "E, d MMM y, h:mm–h:mm a"
+      },
+      "yMMMM hm": {
+        "a": "LLLL y h:mm a–h:mm a",
+        "h": "LLLL y h:mm–h:mm a",
+        "m": "LLLL y h:mm–h:mm a"
+      },
+      "yMMMMd hm": {
+        "a": "d MMMM y h:mm a–h:mm a",
+        "h": "d MMMM y h:mm–h:mm a",
+        "m": "d MMMM y h:mm–h:mm a"
+      },
+      "yMMMMEd hm": {
+        "a": "E, d MMMM y h:mm a–h:mm a",
+        "h": "E, d MMMM y h:mm–h:mm a",
+        "m": "E, d MMMM y h:mm–h:mm a"
+      },
+      "EEEE, d MMMM y Hm": {
+        "H": "EEEE, d MMMM y HH:mm–HH:mm",
+        "m": "EEEE, d MMMM y HH:mm–HH:mm"
+      },
+      "d MMMM y Hm": {
+        "H": "d MMMM y HH:mm–HH:mm",
+        "m": "d MMMM y HH:mm–HH:mm"
+      },
+      "d MMM y, Hm": {
+        "H": "d MMM y, HH:mm–HH:mm",
+        "m": "d MMM y, HH:mm–HH:mm"
+      },
+      "d.MM.y, Hm": {
+        "H": "d.MM.y, HH:mm–HH:mm",
+        "m": "d.MM.y, HH:mm–HH:mm"
+      },
+      "d, Hm": {
+        "H": "d, HH:mm–HH:mm",
+        "m": "d, HH:mm–HH:mm"
+      },
+      "E, Hm": {
+        "H": "ccc, HH:mm–HH:mm",
+        "m": "ccc, HH:mm–HH:mm"
+      },
+      "Ed, Hm": {
+        "H": "E, d, HH:mm–HH:mm",
+        "m": "E, d, HH:mm–HH:mm"
+      },
+      "Gy, Hm": {
+        "H": "y G, HH:mm–HH:mm",
+        "m": "y G, HH:mm–HH:mm"
+      },
+      "GyM, Hm": {
+        "H": "MM.y G, HH:mm–HH:mm",
+        "m": "MM.y G, HH:mm–HH:mm"
+      },
+      "GyMd, Hm": {
+        "H": "d.MM.y GGGGG, HH:mm–HH:mm",
+        "m": "d.MM.y GGGGG, HH:mm–HH:mm"
+      },
+      "GyMEd, Hm": {
+        "H": "E, d.MM.y G, HH:mm–HH:mm",
+        "m": "E, d.MM.y G, HH:mm–HH:mm"
+      },
+      "GyMMM, Hm": {
+        "H": "MMM y G, HH:mm–HH:mm",
+        "m": "MMM y G, HH:mm–HH:mm"
+      },
+      "GyMMMd, Hm": {
+        "H": "d MMM y G, HH:mm–HH:mm",
+        "m": "d MMM y G, HH:mm–HH:mm"
+      },
+      "GyMMMEd, Hm": {
+        "H": "E, d MMM y G, HH:mm–HH:mm",
+        "m": "E, d MMM y G, HH:mm–HH:mm"
+      },
+      "GyMMMM Hm": {
+        "H": "LLLL y G HH:mm–HH:mm",
+        "m": "LLLL y G HH:mm–HH:mm"
+      },
+      "GyMMMMd Hm": {
+        "H": "d MMMM y G HH:mm–HH:mm",
+        "m": "d MMMM y G HH:mm–HH:mm"
+      },
+      "GyMMMMEd Hm": {
+        "H": "E, d MMMM y G HH:mm–HH:mm",
+        "m": "E, d MMMM y G HH:mm–HH:mm"
+      },
+      "M, Hm": {
+        "H": "L, HH:mm–HH:mm",
+        "m": "L, HH:mm–HH:mm"
+      },
+      "Md, Hm": {
+        "H": "d.MM, HH:mm–HH:mm",
+        "m": "d.MM, HH:mm–HH:mm"
+      },
+      "MEd, Hm": {
+        "H": "E, d.MM, HH:mm–HH:mm",
+        "m": "E, d.MM, HH:mm–HH:mm"
+      },
+      "MMM, Hm": {
+        "H": "LLL, HH:mm–HH:mm",
+        "m": "LLL, HH:mm–HH:mm"
+      },
+      "MMMd, Hm": {
+        "H": "d MMM, HH:mm–HH:mm",
+        "m": "d MMM, HH:mm–HH:mm"
+      },
+      "MMMEd, Hm": {
+        "H": "E, d MMM, HH:mm–HH:mm",
+        "m": "E, d MMM, HH:mm–HH:mm"
+      },
+      "MMMMd Hm": {
+        "H": "d MMMM HH:mm–HH:mm",
+        "m": "d MMMM HH:mm–HH:mm"
+      },
+      "MMMMEd Hm": {
+        "H": "E, d MMMM HH:mm–HH:mm",
+        "m": "E, d MMMM HH:mm–HH:mm"
+      },
+      "y, Hm": {
+        "H": "y, HH:mm–HH:mm",
+        "m": "y, HH:mm–HH:mm"
+      },
+      "yM, Hm": {
+        "H": "MM.y, HH:mm–HH:mm",
+        "m": "MM.y, HH:mm–HH:mm"
+      },
+      "yMd, Hm": {
+        "H": "d.MM.y, HH:mm–HH:mm",
+        "m": "d.MM.y, HH:mm–HH:mm"
+      },
+      "yMEd, Hm": {
+        "H": "E, d.MM.y, HH:mm–HH:mm",
+        "m": "E, d.MM.y, HH:mm–HH:mm"
+      },
+      "yMMM, Hm": {
+        "H": "LLL y, HH:mm–HH:mm",
+        "m": "LLL y, HH:mm–HH:mm"
+      },
+      "yMMMd, Hm": {
+        "H": "d MMM y, HH:mm–HH:mm",
+        "m": "d MMM y, HH:mm–HH:mm"
+      },
+      "yMMMEd, Hm": {
+        "H": "E, d MMM y, HH:mm–HH:mm",
+        "m": "E, d MMM y, HH:mm–HH:mm"
+      },
+      "yMMMM Hm": {
+        "H": "LLLL y HH:mm–HH:mm",
+        "m": "LLLL y HH:mm–HH:mm"
+      },
+      "yMMMMd Hm": {
+        "H": "d MMMM y HH:mm–HH:mm",
+        "m": "d MMMM y HH:mm–HH:mm"
+      },
+      "yMMMMEd Hm": {
+        "H": "E, d MMMM y HH:mm–HH:mm",
+        "m": "E, d MMMM y HH:mm–HH:mm"
+      },
+      "EEEE, d MMMM y hmv": {
+        "a": "EEEE, d MMMM y h:mm a–h:mm a v",
+        "h": "EEEE, d MMMM y h:mm–h:mm a v",
+        "m": "EEEE, d MMMM y h:mm–h:mm a v"
+      },
+      "d MMMM y hmv": {
+        "a": "d MMMM y h:mm a–h:mm a v",
+        "h": "d MMMM y h:mm–h:mm a v",
+        "m": "d MMMM y h:mm–h:mm a v"
+      },
+      "d MMM y, hmv": {
+        "a": "d MMM y, h:mm a–h:mm a v",
+        "h": "d MMM y, h:mm–h:mm a v",
+        "m": "d MMM y, h:mm–h:mm a v"
+      },
+      "d.MM.y, hmv": {
+        "a": "d.MM.y, h:mm a–h:mm a v",
+        "h": "d.MM.y, h:mm–h:mm a v",
+        "m": "d.MM.y, h:mm–h:mm a v"
+      },
+      "d, hmv": {
+        "a": "d, h:mm a–h:mm a v",
+        "h": "d, h:mm–h:mm a v",
+        "m": "d, h:mm–h:mm a v"
+      },
+      "E, hmv": {
+        "a": "ccc, h:mm a–h:mm a v",
+        "h": "ccc, h:mm–h:mm a v",
+        "m": "ccc, h:mm–h:mm a v"
+      },
+      "Ed, hmv": {
+        "a": "E, d, h:mm a–h:mm a v",
+        "h": "E, d, h:mm–h:mm a v",
+        "m": "E, d, h:mm–h:mm a v"
+      },
+      "Gy, hmv": {
+        "a": "y G, h:mm a–h:mm a v",
+        "h": "y G, h:mm–h:mm a v",
+        "m": "y G, h:mm–h:mm a v"
+      },
+      "GyM, hmv": {
+        "a": "MM.y G, h:mm a–h:mm a v",
+        "h": "MM.y G, h:mm–h:mm a v",
+        "m": "MM.y G, h:mm–h:mm a v"
+      },
+      "GyMd, hmv": {
+        "a": "d.MM.y GGGGG, h:mm a–h:mm a v",
+        "h": "d.MM.y GGGGG, h:mm–h:mm a v",
+        "m": "d.MM.y GGGGG, h:mm–h:mm a v"
+      },
+      "GyMEd, hmv": {
+        "a": "E, d.MM.y G, h:mm a–h:mm a v",
+        "h": "E, d.MM.y G, h:mm–h:mm a v",
+        "m": "E, d.MM.y G, h:mm–h:mm a v"
+      },
+      "GyMMM, hmv": {
+        "a": "MMM y G, h:mm a–h:mm a v",
+        "h": "MMM y G, h:mm–h:mm a v",
+        "m": "MMM y G, h:mm–h:mm a v"
+      },
+      "GyMMMd, hmv": {
+        "a": "d MMM y G, h:mm a–h:mm a v",
+        "h": "d MMM y G, h:mm–h:mm a v",
+        "m": "d MMM y G, h:mm–h:mm a v"
+      },
+      "GyMMMEd, hmv": {
+        "a": "E, d MMM y G, h:mm a–h:mm a v",
+        "h": "E, d MMM y G, h:mm–h:mm a v",
+        "m": "E, d MMM y G, h:mm–h:mm a v"
+      },
+      "GyMMMM hmv": {
+        "a": "LLLL y G h:mm a–h:mm a v",
+        "h": "LLLL y G h:mm–h:mm a v",
+        "m": "LLLL y G h:mm–h:mm a v"
+      },
+      "GyMMMMd hmv": {
+        "a": "d MMMM y G h:mm a–h:mm a v",
+        "h": "d MMMM y G h:mm–h:mm a v",
+        "m": "d MMMM y G h:mm–h:mm a v"
+      },
+      "GyMMMMEd hmv": {
+        "a": "E, d MMMM y G h:mm a–h:mm a v",
+        "h": "E, d MMMM y G h:mm–h:mm a v",
+        "m": "E, d MMMM y G h:mm–h:mm a v"
+      },
+      "M, hmv": {
+        "a": "L, h:mm a–h:mm a v",
+        "h": "L, h:mm–h:mm a v",
+        "m": "L, h:mm–h:mm a v"
+      },
+      "Md, hmv": {
+        "a": "d.MM, h:mm a–h:mm a v",
+        "h": "d.MM, h:mm–h:mm a v",
+        "m": "d.MM, h:mm–h:mm a v"
+      },
+      "MEd, hmv": {
+        "a": "E, d.MM, h:mm a–h:mm a v",
+        "h": "E, d.MM, h:mm–h:mm a v",
+        "m": "E, d.MM, h:mm–h:mm a v"
+      },
+      "MMM, hmv": {
+        "a": "LLL, h:mm a–h:mm a v",
+        "h": "LLL, h:mm–h:mm a v",
+        "m": "LLL, h:mm–h:mm a v"
+      },
+      "MMMd, hmv": {
+        "a": "d MMM, h:mm a–h:mm a v",
+        "h": "d MMM, h:mm–h:mm a v",
+        "m": "d MMM, h:mm–h:mm a v"
+      },
+      "MMMEd, hmv": {
+        "a": "E, d MMM, h:mm a–h:mm a v",
+        "h": "E, d MMM, h:mm–h:mm a v",
+        "m": "E, d MMM, h:mm–h:mm a v"
+      },
+      "MMMMd hmv": {
+        "a": "d MMMM h:mm a–h:mm a v",
+        "h": "d MMMM h:mm–h:mm a v",
+        "m": "d MMMM h:mm–h:mm a v"
+      },
+      "MMMMEd hmv": {
+        "a": "E, d MMMM h:mm a–h:mm a v",
+        "h": "E, d MMMM h:mm–h:mm a v",
+        "m": "E, d MMMM h:mm–h:mm a v"
+      },
+      "y, hmv": {
+        "a": "y, h:mm a–h:mm a v",
+        "h": "y, h:mm–h:mm a v",
+        "m": "y, h:mm–h:mm a v"
+      },
+      "yM, hmv": {
+        "a": "MM.y, h:mm a–h:mm a v",
+        "h": "MM.y, h:mm–h:mm a v",
+        "m": "MM.y, h:mm–h:mm a v"
+      },
+      "yMd, hmv": {
+        "a": "d.MM.y, h:mm a–h:mm a v",
+        "h": "d.MM.y, h:mm–h:mm a v",
+        "m": "d.MM.y, h:mm–h:mm a v"
+      },
+      "yMEd, hmv": {
+        "a": "E, d.MM.y, h:mm a–h:mm a v",
+        "h": "E, d.MM.y, h:mm–h:mm a v",
+        "m": "E, d.MM.y, h:mm–h:mm a v"
+      },
+      "yMMM, hmv": {
+        "a": "LLL y, h:mm a–h:mm a v",
+        "h": "LLL y, h:mm–h:mm a v",
+        "m": "LLL y, h:mm–h:mm a v"
+      },
+      "yMMMd, hmv": {
+        "a": "d MMM y, h:mm a–h:mm a v",
+        "h": "d MMM y, h:mm–h:mm a v",
+        "m": "d MMM y, h:mm–h:mm a v"
+      },
+      "yMMMEd, hmv": {
+        "a": "E, d MMM y, h:mm a–h:mm a v",
+        "h": "E, d MMM y, h:mm–h:mm a v",
+        "m": "E, d MMM y, h:mm–h:mm a v"
+      },
+      "yMMMM hmv": {
+        "a": "LLLL y h:mm a–h:mm a v",
+        "h": "LLLL y h:mm–h:mm a v",
+        "m": "LLLL y h:mm–h:mm a v"
+      },
+      "yMMMMd hmv": {
+        "a": "d MMMM y h:mm a–h:mm a v",
+        "h": "d MMMM y h:mm–h:mm a v",
+        "m": "d MMMM y h:mm–h:mm a v"
+      },
+      "yMMMMEd hmv": {
+        "a": "E, d MMMM y h:mm a–h:mm a v",
+        "h": "E, d MMMM y h:mm–h:mm a v",
+        "m": "E, d MMMM y h:mm–h:mm a v"
+      },
+      "EEEE, d MMMM y Hmv": {
+        "H": "EEEE, d MMMM y HH:mm–HH:mm v",
+        "m": "EEEE, d MMMM y HH:mm–HH:mm v"
+      },
+      "d MMMM y Hmv": {
+        "H": "d MMMM y HH:mm–HH:mm v",
+        "m": "d MMMM y HH:mm–HH:mm v"
+      },
+      "d MMM y, Hmv": {
+        "H": "d MMM y, HH:mm–HH:mm v",
+        "m": "d MMM y, HH:mm–HH:mm v"
+      },
+      "d.MM.y, Hmv": {
+        "H": "d.MM.y, HH:mm–HH:mm v",
+        "m": "d.MM.y, HH:mm–HH:mm v"
+      },
+      "d, Hmv": {
+        "H": "d, HH:mm–HH:mm v",
+        "m": "d, HH:mm–HH:mm v"
+      },
+      "E, Hmv": {
+        "H": "ccc, HH:mm–HH:mm v",
+        "m": "ccc, HH:mm–HH:mm v"
+      },
+      "Ed, Hmv": {
+        "H": "E, d, HH:mm–HH:mm v",
+        "m": "E, d, HH:mm–HH:mm v"
+      },
+      "Gy, Hmv": {
+        "H": "y G, HH:mm–HH:mm v",
+        "m": "y G, HH:mm–HH:mm v"
+      },
+      "GyM, Hmv": {
+        "H": "MM.y G, HH:mm–HH:mm v",
+        "m": "MM.y G, HH:mm–HH:mm v"
+      },
+      "GyMd, Hmv": {
+        "H": "d.MM.y GGGGG, HH:mm–HH:mm v",
+        "m": "d.MM.y GGGGG, HH:mm–HH:mm v"
+      },
+      "GyMEd, Hmv": {
+        "H": "E, d.MM.y G, HH:mm–HH:mm v",
+        "m": "E, d.MM.y G, HH:mm–HH:mm v"
+      },
+      "GyMMM, Hmv": {
+        "H": "MMM y G, HH:mm–HH:mm v",
+        "m": "MMM y G, HH:mm–HH:mm v"
+      },
+      "GyMMMd, Hmv": {
+        "H": "d MMM y G, HH:mm–HH:mm v",
+        "m": "d MMM y G, HH:mm–HH:mm v"
+      },
+      "GyMMMEd, Hmv": {
+        "H": "E, d MMM y G, HH:mm–HH:mm v",
+        "m": "E, d MMM y G, HH:mm–HH:mm v"
+      },
+      "GyMMMM Hmv": {
+        "H": "LLLL y G HH:mm–HH:mm v",
+        "m": "LLLL y G HH:mm–HH:mm v"
+      },
+      "GyMMMMd Hmv": {
+        "H": "d MMMM y G HH:mm–HH:mm v",
+        "m": "d MMMM y G HH:mm–HH:mm v"
+      },
+      "GyMMMMEd Hmv": {
+        "H": "E, d MMMM y G HH:mm–HH:mm v",
+        "m": "E, d MMMM y G HH:mm–HH:mm v"
+      },
+      "M, Hmv": {
+        "H": "L, HH:mm–HH:mm v",
+        "m": "L, HH:mm–HH:mm v"
+      },
+      "Md, Hmv": {
+        "H": "d.MM, HH:mm–HH:mm v",
+        "m": "d.MM, HH:mm–HH:mm v"
+      },
+      "MEd, Hmv": {
+        "H": "E, d.MM, HH:mm–HH:mm v",
+        "m": "E, d.MM, HH:mm–HH:mm v"
+      },
+      "MMM, Hmv": {
+        "H": "LLL, HH:mm–HH:mm v",
+        "m": "LLL, HH:mm–HH:mm v"
+      },
+      "MMMd, Hmv": {
+        "H": "d MMM, HH:mm–HH:mm v",
+        "m": "d MMM, HH:mm–HH:mm v"
+      },
+      "MMMEd, Hmv": {
+        "H": "E, d MMM, HH:mm–HH:mm v",
+        "m": "E, d MMM, HH:mm–HH:mm v"
+      },
+      "MMMMd Hmv": {
+        "H": "d MMMM HH:mm–HH:mm v",
+        "m": "d MMMM HH:mm–HH:mm v"
+      },
+      "MMMMEd Hmv": {
+        "H": "E, d MMMM HH:mm–HH:mm v",
+        "m": "E, d MMMM HH:mm–HH:mm v"
+      },
+      "y, Hmv": {
+        "H": "y, HH:mm–HH:mm v",
+        "m": "y, HH:mm–HH:mm v"
+      },
+      "yM, Hmv": {
+        "H": "MM.y, HH:mm–HH:mm v",
+        "m": "MM.y, HH:mm–HH:mm v"
+      },
+      "yMd, Hmv": {
+        "H": "d.MM.y, HH:mm–HH:mm v",
+        "m": "d.MM.y, HH:mm–HH:mm v"
+      },
+      "yMEd, Hmv": {
+        "H": "E, d.MM.y, HH:mm–HH:mm v",
+        "m": "E, d.MM.y, HH:mm–HH:mm v"
+      },
+      "yMMM, Hmv": {
+        "H": "LLL y, HH:mm–HH:mm v",
+        "m": "LLL y, HH:mm–HH:mm v"
+      },
+      "yMMMd, Hmv": {
+        "H": "d MMM y, HH:mm–HH:mm v",
+        "m": "d MMM y, HH:mm–HH:mm v"
+      },
+      "yMMMEd, Hmv": {
+        "H": "E, d MMM y, HH:mm–HH:mm v",
+        "m": "E, d MMM y, HH:mm–HH:mm v"
+      },
+      "yMMMM Hmv": {
+        "H": "LLLL y HH:mm–HH:mm v",
+        "m": "LLLL y HH:mm–HH:mm v"
+      },
+      "yMMMMd Hmv": {
+        "H": "d MMMM y HH:mm–HH:mm v",
+        "m": "d MMMM y HH:mm–HH:mm v"
+      },
+      "yMMMMEd Hmv": {
+        "H": "E, d MMMM y HH:mm–HH:mm v",
+        "m": "E, d MMMM y HH:mm–HH:mm v"
+      },
+      "EEEE, d MMMM y hv": {
+        "a": "EEEE, d MMMM y h a – h a v",
+        "h": "EEEE, d MMMM y h–h a v"
+      },
+      "d MMMM y hv": {
+        "a": "d MMMM y h a – h a v",
+        "h": "d MMMM y h–h a v"
+      },
+      "d MMM y, hv": {
+        "a": "d MMM y, h a – h a v",
+        "h": "d MMM y, h–h a v"
+      },
+      "d.MM.y, hv": {
+        "a": "d.MM.y, h a – h a v",
+        "h": "d.MM.y, h–h a v"
+      },
+      "d, hv": {
+        "a": "d, h a – h a v",
+        "h": "d, h–h a v"
+      },
+      "E, hv": {
+        "a": "ccc, h a – h a v",
+        "h": "ccc, h–h a v"
+      },
+      "Ed, hv": {
+        "a": "E, d, h a – h a v",
+        "h": "E, d, h–h a v"
+      },
+      "Gy, hv": {
+        "a": "y G, h a – h a v",
+        "h": "y G, h–h a v"
+      },
+      "GyM, hv": {
+        "a": "MM.y G, h a – h a v",
+        "h": "MM.y G, h–h a v"
+      },
+      "GyMd, hv": {
+        "a": "d.MM.y GGGGG, h a – h a v",
+        "h": "d.MM.y GGGGG, h–h a v"
+      },
+      "GyMEd, hv": {
+        "a": "E, d.MM.y G, h a – h a v",
+        "h": "E, d.MM.y G, h–h a v"
+      },
+      "GyMMM, hv": {
+        "a": "MMM y G, h a – h a v",
+        "h": "MMM y G, h–h a v"
+      },
+      "GyMMMd, hv": {
+        "a": "d MMM y G, h a – h a v",
+        "h": "d MMM y G, h–h a v"
+      },
+      "GyMMMEd, hv": {
+        "a": "E, d MMM y G, h a – h a v",
+        "h": "E, d MMM y G, h–h a v"
+      },
+      "GyMMMM hv": {
+        "a": "LLLL y G h a – h a v",
+        "h": "LLLL y G h–h a v"
+      },
+      "GyMMMMd hv": {
+        "a": "d MMMM y G h a – h a v",
+        "h": "d MMMM y G h–h a v"
+      },
+      "GyMMMMEd hv": {
+        "a": "E, d MMMM y G h a – h a v",
+        "h": "E, d MMMM y G h–h a v"
+      },
+      "M, hv": {
+        "a": "L, h a – h a v",
+        "h": "L, h–h a v"
+      },
+      "Md, hv": {
+        "a": "d.MM, h a – h a v",
+        "h": "d.MM, h–h a v"
+      },
+      "MEd, hv": {
+        "a": "E, d.MM, h a – h a v",
+        "h": "E, d.MM, h–h a v"
+      },
+      "MMM, hv": {
+        "a": "LLL, h a – h a v",
+        "h": "LLL, h–h a v"
+      },
+      "MMMd, hv": {
+        "a": "d MMM, h a – h a v",
+        "h": "d MMM, h–h a v"
+      },
+      "MMMEd, hv": {
+        "a": "E, d MMM, h a – h a v",
+        "h": "E, d MMM, h–h a v"
+      },
+      "MMMMd hv": {
+        "a": "d MMMM h a – h a v",
+        "h": "d MMMM h–h a v"
+      },
+      "MMMMEd hv": {
+        "a": "E, d MMMM h a – h a v",
+        "h": "E, d MMMM h–h a v"
+      },
+      "y, hv": {
+        "a": "y, h a – h a v",
+        "h": "y, h–h a v"
+      },
+      "yM, hv": {
+        "a": "MM.y, h a – h a v",
+        "h": "MM.y, h–h a v"
+      },
+      "yMd, hv": {
+        "a": "d.MM.y, h a – h a v",
+        "h": "d.MM.y, h–h a v"
+      },
+      "yMEd, hv": {
+        "a": "E, d.MM.y, h a – h a v",
+        "h": "E, d.MM.y, h–h a v"
+      },
+      "yMMM, hv": {
+        "a": "LLL y, h a – h a v",
+        "h": "LLL y, h–h a v"
+      },
+      "yMMMd, hv": {
+        "a": "d MMM y, h a – h a v",
+        "h": "d MMM y, h–h a v"
+      },
+      "yMMMEd, hv": {
+        "a": "E, d MMM y, h a – h a v",
+        "h": "E, d MMM y, h–h a v"
+      },
+      "yMMMM hv": {
+        "a": "LLLL y h a – h a v",
+        "h": "LLLL y h–h a v"
+      },
+      "yMMMMd hv": {
+        "a": "d MMMM y h a – h a v",
+        "h": "d MMMM y h–h a v"
+      },
+      "yMMMMEd hv": {
+        "a": "E, d MMMM y h a – h a v",
+        "h": "E, d MMMM y h–h a v"
+      },
+      "EEEE, d MMMM y Hv": {
+        "H": "EEEE, d MMMM y HH–HH v"
+      },
+      "d MMMM y Hv": {
+        "H": "d MMMM y HH–HH v"
+      },
+      "d MMM y, Hv": {
+        "H": "d MMM y, HH–HH v"
+      },
+      "d.MM.y, Hv": {
+        "H": "d.MM.y, HH–HH v"
+      },
+      "d, Hv": {
+        "H": "d, HH–HH v"
+      },
+      "E, Hv": {
+        "H": "ccc, HH–HH v"
+      },
+      "Ed, Hv": {
+        "H": "E, d, HH–HH v"
+      },
+      "Gy, Hv": {
+        "H": "y G, HH–HH v"
+      },
+      "GyM, Hv": {
+        "H": "MM.y G, HH–HH v"
+      },
+      "GyMd, Hv": {
+        "H": "d.MM.y GGGGG, HH–HH v"
+      },
+      "GyMEd, Hv": {
+        "H": "E, d.MM.y G, HH–HH v"
+      },
+      "GyMMM, Hv": {
+        "H": "MMM y G, HH–HH v"
+      },
+      "GyMMMd, Hv": {
+        "H": "d MMM y G, HH–HH v"
+      },
+      "GyMMMEd, Hv": {
+        "H": "E, d MMM y G, HH–HH v"
+      },
+      "GyMMMM Hv": {
+        "H": "LLLL y G HH–HH v"
+      },
+      "GyMMMMd Hv": {
+        "H": "d MMMM y G HH–HH v"
+      },
+      "GyMMMMEd Hv": {
+        "H": "E, d MMMM y G HH–HH v"
+      },
+      "M, Hv": {
+        "H": "L, HH–HH v"
+      },
+      "Md, Hv": {
+        "H": "d.MM, HH–HH v"
+      },
+      "MEd, Hv": {
+        "H": "E, d.MM, HH–HH v"
+      },
+      "MMM, Hv": {
+        "H": "LLL, HH–HH v"
+      },
+      "MMMd, Hv": {
+        "H": "d MMM, HH–HH v"
+      },
+      "MMMEd, Hv": {
+        "H": "E, d MMM, HH–HH v"
+      },
+      "MMMMd Hv": {
+        "H": "d MMMM HH–HH v"
+      },
+      "MMMMEd Hv": {
+        "H": "E, d MMMM HH–HH v"
+      },
+      "y, Hv": {
+        "H": "y, HH–HH v"
+      },
+      "yM, Hv": {
+        "H": "MM.y, HH–HH v"
+      },
+      "yMd, Hv": {
+        "H": "d.MM.y, HH–HH v"
+      },
+      "yMEd, Hv": {
+        "H": "E, d.MM.y, HH–HH v"
+      },
+      "yMMM, Hv": {
+        "H": "LLL y, HH–HH v"
+      },
+      "yMMMd, Hv": {
+        "H": "d MMM y, HH–HH v"
+      },
+      "yMMMEd, Hv": {
+        "H": "E, d MMM y, HH–HH v"
+      },
+      "yMMMM Hv": {
+        "H": "LLLL y HH–HH v"
+      },
+      "yMMMMd Hv": {
+        "H": "d MMMM y HH–HH v"
+      },
+      "yMMMMEd Hv": {
+        "H": "E, d MMMM y HH–HH v"
       }
     },
     "hourCycle": "h23",

--- a/packages/intl-datetimeformat/tests/locale-data/ru.json
+++ b/packages/intl-datetimeformat/tests/locale-data/ru.json
@@ -2653,6 +2653,1277 @@
       "yMMMM": {
         "M": "LLLL – LLLL y 'г'.",
         "y": "LLLL y 'г'. – LLLL y 'г'."
+      },
+      "EEEE, d MMMM y 'г'., Bh": {
+        "B": "EEEE, d MMMM y 'г'., h B – h B",
+        "h": "EEEE, d MMMM y 'г'., h–h B"
+      },
+      "d MMMM y 'г'., Bh": {
+        "B": "d MMMM y 'г'., h B – h B",
+        "h": "d MMMM y 'г'., h–h B"
+      },
+      "d MMM y 'г'., Bh": {
+        "B": "d MMM y 'г'., h B – h B",
+        "h": "d MMM y 'г'., h–h B"
+      },
+      "dd.MM.y, Bh": {
+        "B": "dd.MM.y, h B – h B",
+        "h": "dd.MM.y, h–h B"
+      },
+      "d, Bh": {
+        "B": "d, h B – h B",
+        "h": "d, h–h B"
+      },
+      "E, Bh": {
+        "B": "ccc, h B – h B",
+        "h": "ccc, h–h B"
+      },
+      "Ed, Bh": {
+        "B": "ccc, d, h B – h B",
+        "h": "ccc, d, h–h B"
+      },
+      "Gy, Bh": {
+        "B": "y 'г'. G, h B – h B",
+        "h": "y 'г'. G, h–h B"
+      },
+      "GyM, Bh": {
+        "B": "MM.y GGGGG, h B – h B",
+        "h": "MM.y GGGGG, h–h B"
+      },
+      "GyMd, Bh": {
+        "B": "dd.MM.y GGGGG, h B – h B",
+        "h": "dd.MM.y GGGGG, h–h B"
+      },
+      "GyMEd, Bh": {
+        "B": "E, dd.MM.y GGGGG, h B – h B",
+        "h": "E, dd.MM.y GGGGG, h–h B"
+      },
+      "GyMMM, Bh": {
+        "B": "LLL y 'г'. G, h B – h B",
+        "h": "LLL y 'г'. G, h–h B"
+      },
+      "GyMMMd, Bh": {
+        "B": "d MMM y 'г'. G, h B – h B",
+        "h": "d MMM y 'г'. G, h–h B"
+      },
+      "GyMMMEd, Bh": {
+        "B": "E, d MMM y 'г'. G, h B – h B",
+        "h": "E, d MMM y 'г'. G, h–h B"
+      },
+      "M, Bh": {
+        "B": "L, h B – h B",
+        "h": "L, h–h B"
+      },
+      "Md, Bh": {
+        "B": "dd.MM, h B – h B",
+        "h": "dd.MM, h–h B"
+      },
+      "MEd, Bh": {
+        "B": "E, dd.MM, h B – h B",
+        "h": "E, dd.MM, h–h B"
+      },
+      "MMdd, Bh": {
+        "B": "dd.MM, h B – h B",
+        "h": "dd.MM, h–h B"
+      },
+      "MMM, Bh": {
+        "B": "LLL, h B – h B",
+        "h": "LLL, h–h B"
+      },
+      "MMMd, Bh": {
+        "B": "d MMM, h B – h B",
+        "h": "d MMM, h–h B"
+      },
+      "MMMEd, Bh": {
+        "B": "ccc, d MMM, h B – h B",
+        "h": "ccc, d MMM, h–h B"
+      },
+      "MMMMd, Bh": {
+        "B": "d MMMM, h B – h B",
+        "h": "d MMMM, h–h B"
+      },
+      "y, Bh": {
+        "B": "y, h B – h B",
+        "h": "y, h–h B"
+      },
+      "yM, Bh": {
+        "B": "MM.y, h B – h B",
+        "h": "MM.y, h–h B"
+      },
+      "yMd, Bh": {
+        "B": "dd.MM.y, h B – h B",
+        "h": "dd.MM.y, h–h B"
+      },
+      "yMEd, Bh": {
+        "B": "ccc, dd.MM.y, h B – h B",
+        "h": "ccc, dd.MM.y, h–h B"
+      },
+      "yMM, Bh": {
+        "B": "MM.y, h B – h B",
+        "h": "MM.y, h–h B"
+      },
+      "yMMM, Bh": {
+        "B": "LLL y 'г'., h B – h B",
+        "h": "LLL y 'г'., h–h B"
+      },
+      "yMMMd, Bh": {
+        "B": "d MMM y 'г'., h B – h B",
+        "h": "d MMM y 'г'., h–h B"
+      },
+      "yMMMEd, Bh": {
+        "B": "E, d MMM y 'г'., h B – h B",
+        "h": "E, d MMM y 'г'., h–h B"
+      },
+      "yMMMM, Bh": {
+        "B": "LLLL y 'г'., h B – h B",
+        "h": "LLLL y 'г'., h–h B"
+      },
+      "EEEE, d MMMM y 'г'., Bhm": {
+        "B": "EEEE, d MMMM y 'г'., h:mm B – h:mm B",
+        "h": "EEEE, d MMMM y 'г'., h:mm–h:mm B",
+        "m": "EEEE, d MMMM y 'г'., h:mm–h:mm B"
+      },
+      "d MMMM y 'г'., Bhm": {
+        "B": "d MMMM y 'г'., h:mm B – h:mm B",
+        "h": "d MMMM y 'г'., h:mm–h:mm B",
+        "m": "d MMMM y 'г'., h:mm–h:mm B"
+      },
+      "d MMM y 'г'., Bhm": {
+        "B": "d MMM y 'г'., h:mm B – h:mm B",
+        "h": "d MMM y 'г'., h:mm–h:mm B",
+        "m": "d MMM y 'г'., h:mm–h:mm B"
+      },
+      "dd.MM.y, Bhm": {
+        "B": "dd.MM.y, h:mm B – h:mm B",
+        "h": "dd.MM.y, h:mm–h:mm B",
+        "m": "dd.MM.y, h:mm–h:mm B"
+      },
+      "d, Bhm": {
+        "B": "d, h:mm B – h:mm B",
+        "h": "d, h:mm–h:mm B",
+        "m": "d, h:mm–h:mm B"
+      },
+      "E, Bhm": {
+        "B": "ccc, h:mm B – h:mm B",
+        "h": "ccc, h:mm–h:mm B",
+        "m": "ccc, h:mm–h:mm B"
+      },
+      "Ed, Bhm": {
+        "B": "ccc, d, h:mm B – h:mm B",
+        "h": "ccc, d, h:mm–h:mm B",
+        "m": "ccc, d, h:mm–h:mm B"
+      },
+      "Gy, Bhm": {
+        "B": "y 'г'. G, h:mm B – h:mm B",
+        "h": "y 'г'. G, h:mm–h:mm B",
+        "m": "y 'г'. G, h:mm–h:mm B"
+      },
+      "GyM, Bhm": {
+        "B": "MM.y GGGGG, h:mm B – h:mm B",
+        "h": "MM.y GGGGG, h:mm–h:mm B",
+        "m": "MM.y GGGGG, h:mm–h:mm B"
+      },
+      "GyMd, Bhm": {
+        "B": "dd.MM.y GGGGG, h:mm B – h:mm B",
+        "h": "dd.MM.y GGGGG, h:mm–h:mm B",
+        "m": "dd.MM.y GGGGG, h:mm–h:mm B"
+      },
+      "GyMEd, Bhm": {
+        "B": "E, dd.MM.y GGGGG, h:mm B – h:mm B",
+        "h": "E, dd.MM.y GGGGG, h:mm–h:mm B",
+        "m": "E, dd.MM.y GGGGG, h:mm–h:mm B"
+      },
+      "GyMMM, Bhm": {
+        "B": "LLL y 'г'. G, h:mm B – h:mm B",
+        "h": "LLL y 'г'. G, h:mm–h:mm B",
+        "m": "LLL y 'г'. G, h:mm–h:mm B"
+      },
+      "GyMMMd, Bhm": {
+        "B": "d MMM y 'г'. G, h:mm B – h:mm B",
+        "h": "d MMM y 'г'. G, h:mm–h:mm B",
+        "m": "d MMM y 'г'. G, h:mm–h:mm B"
+      },
+      "GyMMMEd, Bhm": {
+        "B": "E, d MMM y 'г'. G, h:mm B – h:mm B",
+        "h": "E, d MMM y 'г'. G, h:mm–h:mm B",
+        "m": "E, d MMM y 'г'. G, h:mm–h:mm B"
+      },
+      "M, Bhm": {
+        "B": "L, h:mm B – h:mm B",
+        "h": "L, h:mm–h:mm B",
+        "m": "L, h:mm–h:mm B"
+      },
+      "Md, Bhm": {
+        "B": "dd.MM, h:mm B – h:mm B",
+        "h": "dd.MM, h:mm–h:mm B",
+        "m": "dd.MM, h:mm–h:mm B"
+      },
+      "MEd, Bhm": {
+        "B": "E, dd.MM, h:mm B – h:mm B",
+        "h": "E, dd.MM, h:mm–h:mm B",
+        "m": "E, dd.MM, h:mm–h:mm B"
+      },
+      "MMdd, Bhm": {
+        "B": "dd.MM, h:mm B – h:mm B",
+        "h": "dd.MM, h:mm–h:mm B",
+        "m": "dd.MM, h:mm–h:mm B"
+      },
+      "MMM, Bhm": {
+        "B": "LLL, h:mm B – h:mm B",
+        "h": "LLL, h:mm–h:mm B",
+        "m": "LLL, h:mm–h:mm B"
+      },
+      "MMMd, Bhm": {
+        "B": "d MMM, h:mm B – h:mm B",
+        "h": "d MMM, h:mm–h:mm B",
+        "m": "d MMM, h:mm–h:mm B"
+      },
+      "MMMEd, Bhm": {
+        "B": "ccc, d MMM, h:mm B – h:mm B",
+        "h": "ccc, d MMM, h:mm–h:mm B",
+        "m": "ccc, d MMM, h:mm–h:mm B"
+      },
+      "MMMMd, Bhm": {
+        "B": "d MMMM, h:mm B – h:mm B",
+        "h": "d MMMM, h:mm–h:mm B",
+        "m": "d MMMM, h:mm–h:mm B"
+      },
+      "y, Bhm": {
+        "B": "y, h:mm B – h:mm B",
+        "h": "y, h:mm–h:mm B",
+        "m": "y, h:mm–h:mm B"
+      },
+      "yM, Bhm": {
+        "B": "MM.y, h:mm B – h:mm B",
+        "h": "MM.y, h:mm–h:mm B",
+        "m": "MM.y, h:mm–h:mm B"
+      },
+      "yMd, Bhm": {
+        "B": "dd.MM.y, h:mm B – h:mm B",
+        "h": "dd.MM.y, h:mm–h:mm B",
+        "m": "dd.MM.y, h:mm–h:mm B"
+      },
+      "yMEd, Bhm": {
+        "B": "ccc, dd.MM.y, h:mm B – h:mm B",
+        "h": "ccc, dd.MM.y, h:mm–h:mm B",
+        "m": "ccc, dd.MM.y, h:mm–h:mm B"
+      },
+      "yMM, Bhm": {
+        "B": "MM.y, h:mm B – h:mm B",
+        "h": "MM.y, h:mm–h:mm B",
+        "m": "MM.y, h:mm–h:mm B"
+      },
+      "yMMM, Bhm": {
+        "B": "LLL y 'г'., h:mm B – h:mm B",
+        "h": "LLL y 'г'., h:mm–h:mm B",
+        "m": "LLL y 'г'., h:mm–h:mm B"
+      },
+      "yMMMd, Bhm": {
+        "B": "d MMM y 'г'., h:mm B – h:mm B",
+        "h": "d MMM y 'г'., h:mm–h:mm B",
+        "m": "d MMM y 'г'., h:mm–h:mm B"
+      },
+      "yMMMEd, Bhm": {
+        "B": "E, d MMM y 'г'., h:mm B – h:mm B",
+        "h": "E, d MMM y 'г'., h:mm–h:mm B",
+        "m": "E, d MMM y 'г'., h:mm–h:mm B"
+      },
+      "yMMMM, Bhm": {
+        "B": "LLLL y 'г'., h:mm B – h:mm B",
+        "h": "LLLL y 'г'., h:mm–h:mm B",
+        "m": "LLLL y 'г'., h:mm–h:mm B"
+      },
+      "EEEE, d MMMM y 'г'., h": {
+        "a": "EEEE, d MMMM y 'г'., h a – h a",
+        "h": "EEEE, d MMMM y 'г'., h–h a"
+      },
+      "d MMMM y 'г'., h": {
+        "a": "d MMMM y 'г'., h a – h a",
+        "h": "d MMMM y 'г'., h–h a"
+      },
+      "d MMM y 'г'., h": {
+        "a": "d MMM y 'г'., h a – h a",
+        "h": "d MMM y 'г'., h–h a"
+      },
+      "dd.MM.y, h": {
+        "a": "dd.MM.y, h a – h a",
+        "h": "dd.MM.y, h–h a"
+      },
+      "d, h": {
+        "a": "d, h a – h a",
+        "h": "d, h–h a"
+      },
+      "E, h": {
+        "a": "ccc, h a – h a",
+        "h": "ccc, h–h a"
+      },
+      "Ed, h": {
+        "a": "ccc, d, h a – h a",
+        "h": "ccc, d, h–h a"
+      },
+      "Gy, h": {
+        "a": "y 'г'. G, h a – h a",
+        "h": "y 'г'. G, h–h a"
+      },
+      "GyM, h": {
+        "a": "MM.y GGGGG, h a – h a",
+        "h": "MM.y GGGGG, h–h a"
+      },
+      "GyMd, h": {
+        "a": "dd.MM.y GGGGG, h a – h a",
+        "h": "dd.MM.y GGGGG, h–h a"
+      },
+      "GyMEd, h": {
+        "a": "E, dd.MM.y GGGGG, h a – h a",
+        "h": "E, dd.MM.y GGGGG, h–h a"
+      },
+      "GyMMM, h": {
+        "a": "LLL y 'г'. G, h a – h a",
+        "h": "LLL y 'г'. G, h–h a"
+      },
+      "GyMMMd, h": {
+        "a": "d MMM y 'г'. G, h a – h a",
+        "h": "d MMM y 'г'. G, h–h a"
+      },
+      "GyMMMEd, h": {
+        "a": "E, d MMM y 'г'. G, h a – h a",
+        "h": "E, d MMM y 'г'. G, h–h a"
+      },
+      "M, h": {
+        "a": "L, h a – h a",
+        "h": "L, h–h a"
+      },
+      "Md, h": {
+        "a": "dd.MM, h a – h a",
+        "h": "dd.MM, h–h a"
+      },
+      "MEd, h": {
+        "a": "E, dd.MM, h a – h a",
+        "h": "E, dd.MM, h–h a"
+      },
+      "MMdd, h": {
+        "a": "dd.MM, h a – h a",
+        "h": "dd.MM, h–h a"
+      },
+      "MMM, h": {
+        "a": "LLL, h a – h a",
+        "h": "LLL, h–h a"
+      },
+      "MMMd, h": {
+        "a": "d MMM, h a – h a",
+        "h": "d MMM, h–h a"
+      },
+      "MMMEd, h": {
+        "a": "ccc, d MMM, h a – h a",
+        "h": "ccc, d MMM, h–h a"
+      },
+      "MMMMd, h": {
+        "a": "d MMMM, h a – h a",
+        "h": "d MMMM, h–h a"
+      },
+      "y, h": {
+        "a": "y, h a – h a",
+        "h": "y, h–h a"
+      },
+      "yM, h": {
+        "a": "MM.y, h a – h a",
+        "h": "MM.y, h–h a"
+      },
+      "yMd, h": {
+        "a": "dd.MM.y, h a – h a",
+        "h": "dd.MM.y, h–h a"
+      },
+      "yMEd, h": {
+        "a": "ccc, dd.MM.y, h a – h a",
+        "h": "ccc, dd.MM.y, h–h a"
+      },
+      "yMM, h": {
+        "a": "MM.y, h a – h a",
+        "h": "MM.y, h–h a"
+      },
+      "yMMM, h": {
+        "a": "LLL y 'г'., h a – h a",
+        "h": "LLL y 'г'., h–h a"
+      },
+      "yMMMd, h": {
+        "a": "d MMM y 'г'., h a – h a",
+        "h": "d MMM y 'г'., h–h a"
+      },
+      "yMMMEd, h": {
+        "a": "E, d MMM y 'г'., h a – h a",
+        "h": "E, d MMM y 'г'., h–h a"
+      },
+      "yMMMM, h": {
+        "a": "LLLL y 'г'., h a – h a",
+        "h": "LLLL y 'г'., h–h a"
+      },
+      "EEEE, d MMMM y 'г'., H": {
+        "H": "EEEE, d MMMM y 'г'., HH–HH 'ч'"
+      },
+      "d MMMM y 'г'., H": {
+        "H": "d MMMM y 'г'., HH–HH 'ч'"
+      },
+      "d MMM y 'г'., H": {
+        "H": "d MMM y 'г'., HH–HH 'ч'"
+      },
+      "dd.MM.y, H": {
+        "H": "dd.MM.y, HH–HH 'ч'"
+      },
+      "d, H": {
+        "H": "d, HH–HH 'ч'"
+      },
+      "E, H": {
+        "H": "ccc, HH–HH 'ч'"
+      },
+      "Ed, H": {
+        "H": "ccc, d, HH–HH 'ч'"
+      },
+      "Gy, H": {
+        "H": "y 'г'. G, HH–HH 'ч'"
+      },
+      "GyM, H": {
+        "H": "MM.y GGGGG, HH–HH 'ч'"
+      },
+      "GyMd, H": {
+        "H": "dd.MM.y GGGGG, HH–HH 'ч'"
+      },
+      "GyMEd, H": {
+        "H": "E, dd.MM.y GGGGG, HH–HH 'ч'"
+      },
+      "GyMMM, H": {
+        "H": "LLL y 'г'. G, HH–HH 'ч'"
+      },
+      "GyMMMd, H": {
+        "H": "d MMM y 'г'. G, HH–HH 'ч'"
+      },
+      "GyMMMEd, H": {
+        "H": "E, d MMM y 'г'. G, HH–HH 'ч'"
+      },
+      "M, H": {
+        "H": "L, HH–HH 'ч'"
+      },
+      "Md, H": {
+        "H": "dd.MM, HH–HH 'ч'"
+      },
+      "MEd, H": {
+        "H": "E, dd.MM, HH–HH 'ч'"
+      },
+      "MMdd, H": {
+        "H": "dd.MM, HH–HH 'ч'"
+      },
+      "MMM, H": {
+        "H": "LLL, HH–HH 'ч'"
+      },
+      "MMMd, H": {
+        "H": "d MMM, HH–HH 'ч'"
+      },
+      "MMMEd, H": {
+        "H": "ccc, d MMM, HH–HH 'ч'"
+      },
+      "MMMMd, H": {
+        "H": "d MMMM, HH–HH 'ч'"
+      },
+      "y, H": {
+        "H": "y, HH–HH 'ч'"
+      },
+      "yM, H": {
+        "H": "MM.y, HH–HH 'ч'"
+      },
+      "yMd, H": {
+        "H": "dd.MM.y, HH–HH 'ч'"
+      },
+      "yMEd, H": {
+        "H": "ccc, dd.MM.y, HH–HH 'ч'"
+      },
+      "yMM, H": {
+        "H": "MM.y, HH–HH 'ч'"
+      },
+      "yMMM, H": {
+        "H": "LLL y 'г'., HH–HH 'ч'"
+      },
+      "yMMMd, H": {
+        "H": "d MMM y 'г'., HH–HH 'ч'"
+      },
+      "yMMMEd, H": {
+        "H": "E, d MMM y 'г'., HH–HH 'ч'"
+      },
+      "yMMMM, H": {
+        "H": "LLLL y 'г'., HH–HH 'ч'"
+      },
+      "EEEE, d MMMM y 'г'., hm": {
+        "a": "EEEE, d MMMM y 'г'., h:mm a – h:mm a",
+        "h": "EEEE, d MMMM y 'г'., h:mm–h:mm a",
+        "m": "EEEE, d MMMM y 'г'., h:mm–h:mm a"
+      },
+      "d MMMM y 'г'., hm": {
+        "a": "d MMMM y 'г'., h:mm a – h:mm a",
+        "h": "d MMMM y 'г'., h:mm–h:mm a",
+        "m": "d MMMM y 'г'., h:mm–h:mm a"
+      },
+      "d MMM y 'г'., hm": {
+        "a": "d MMM y 'г'., h:mm a – h:mm a",
+        "h": "d MMM y 'г'., h:mm–h:mm a",
+        "m": "d MMM y 'г'., h:mm–h:mm a"
+      },
+      "dd.MM.y, hm": {
+        "a": "dd.MM.y, h:mm a – h:mm a",
+        "h": "dd.MM.y, h:mm–h:mm a",
+        "m": "dd.MM.y, h:mm–h:mm a"
+      },
+      "d, hm": {
+        "a": "d, h:mm a – h:mm a",
+        "h": "d, h:mm–h:mm a",
+        "m": "d, h:mm–h:mm a"
+      },
+      "E, hm": {
+        "a": "ccc, h:mm a – h:mm a",
+        "h": "ccc, h:mm–h:mm a",
+        "m": "ccc, h:mm–h:mm a"
+      },
+      "Ed, hm": {
+        "a": "ccc, d, h:mm a – h:mm a",
+        "h": "ccc, d, h:mm–h:mm a",
+        "m": "ccc, d, h:mm–h:mm a"
+      },
+      "Gy, hm": {
+        "a": "y 'г'. G, h:mm a – h:mm a",
+        "h": "y 'г'. G, h:mm–h:mm a",
+        "m": "y 'г'. G, h:mm–h:mm a"
+      },
+      "GyM, hm": {
+        "a": "MM.y GGGGG, h:mm a – h:mm a",
+        "h": "MM.y GGGGG, h:mm–h:mm a",
+        "m": "MM.y GGGGG, h:mm–h:mm a"
+      },
+      "GyMd, hm": {
+        "a": "dd.MM.y GGGGG, h:mm a – h:mm a",
+        "h": "dd.MM.y GGGGG, h:mm–h:mm a",
+        "m": "dd.MM.y GGGGG, h:mm–h:mm a"
+      },
+      "GyMEd, hm": {
+        "a": "E, dd.MM.y GGGGG, h:mm a – h:mm a",
+        "h": "E, dd.MM.y GGGGG, h:mm–h:mm a",
+        "m": "E, dd.MM.y GGGGG, h:mm–h:mm a"
+      },
+      "GyMMM, hm": {
+        "a": "LLL y 'г'. G, h:mm a – h:mm a",
+        "h": "LLL y 'г'. G, h:mm–h:mm a",
+        "m": "LLL y 'г'. G, h:mm–h:mm a"
+      },
+      "GyMMMd, hm": {
+        "a": "d MMM y 'г'. G, h:mm a – h:mm a",
+        "h": "d MMM y 'г'. G, h:mm–h:mm a",
+        "m": "d MMM y 'г'. G, h:mm–h:mm a"
+      },
+      "GyMMMEd, hm": {
+        "a": "E, d MMM y 'г'. G, h:mm a – h:mm a",
+        "h": "E, d MMM y 'г'. G, h:mm–h:mm a",
+        "m": "E, d MMM y 'г'. G, h:mm–h:mm a"
+      },
+      "M, hm": {
+        "a": "L, h:mm a – h:mm a",
+        "h": "L, h:mm–h:mm a",
+        "m": "L, h:mm–h:mm a"
+      },
+      "Md, hm": {
+        "a": "dd.MM, h:mm a – h:mm a",
+        "h": "dd.MM, h:mm–h:mm a",
+        "m": "dd.MM, h:mm–h:mm a"
+      },
+      "MEd, hm": {
+        "a": "E, dd.MM, h:mm a – h:mm a",
+        "h": "E, dd.MM, h:mm–h:mm a",
+        "m": "E, dd.MM, h:mm–h:mm a"
+      },
+      "MMdd, hm": {
+        "a": "dd.MM, h:mm a – h:mm a",
+        "h": "dd.MM, h:mm–h:mm a",
+        "m": "dd.MM, h:mm–h:mm a"
+      },
+      "MMM, hm": {
+        "a": "LLL, h:mm a – h:mm a",
+        "h": "LLL, h:mm–h:mm a",
+        "m": "LLL, h:mm–h:mm a"
+      },
+      "MMMd, hm": {
+        "a": "d MMM, h:mm a – h:mm a",
+        "h": "d MMM, h:mm–h:mm a",
+        "m": "d MMM, h:mm–h:mm a"
+      },
+      "MMMEd, hm": {
+        "a": "ccc, d MMM, h:mm a – h:mm a",
+        "h": "ccc, d MMM, h:mm–h:mm a",
+        "m": "ccc, d MMM, h:mm–h:mm a"
+      },
+      "MMMMd, hm": {
+        "a": "d MMMM, h:mm a – h:mm a",
+        "h": "d MMMM, h:mm–h:mm a",
+        "m": "d MMMM, h:mm–h:mm a"
+      },
+      "y, hm": {
+        "a": "y, h:mm a – h:mm a",
+        "h": "y, h:mm–h:mm a",
+        "m": "y, h:mm–h:mm a"
+      },
+      "yM, hm": {
+        "a": "MM.y, h:mm a – h:mm a",
+        "h": "MM.y, h:mm–h:mm a",
+        "m": "MM.y, h:mm–h:mm a"
+      },
+      "yMd, hm": {
+        "a": "dd.MM.y, h:mm a – h:mm a",
+        "h": "dd.MM.y, h:mm–h:mm a",
+        "m": "dd.MM.y, h:mm–h:mm a"
+      },
+      "yMEd, hm": {
+        "a": "ccc, dd.MM.y, h:mm a – h:mm a",
+        "h": "ccc, dd.MM.y, h:mm–h:mm a",
+        "m": "ccc, dd.MM.y, h:mm–h:mm a"
+      },
+      "yMM, hm": {
+        "a": "MM.y, h:mm a – h:mm a",
+        "h": "MM.y, h:mm–h:mm a",
+        "m": "MM.y, h:mm–h:mm a"
+      },
+      "yMMM, hm": {
+        "a": "LLL y 'г'., h:mm a – h:mm a",
+        "h": "LLL y 'г'., h:mm–h:mm a",
+        "m": "LLL y 'г'., h:mm–h:mm a"
+      },
+      "yMMMd, hm": {
+        "a": "d MMM y 'г'., h:mm a – h:mm a",
+        "h": "d MMM y 'г'., h:mm–h:mm a",
+        "m": "d MMM y 'г'., h:mm–h:mm a"
+      },
+      "yMMMEd, hm": {
+        "a": "E, d MMM y 'г'., h:mm a – h:mm a",
+        "h": "E, d MMM y 'г'., h:mm–h:mm a",
+        "m": "E, d MMM y 'г'., h:mm–h:mm a"
+      },
+      "yMMMM, hm": {
+        "a": "LLLL y 'г'., h:mm a – h:mm a",
+        "h": "LLLL y 'г'., h:mm–h:mm a",
+        "m": "LLLL y 'г'., h:mm–h:mm a"
+      },
+      "EEEE, d MMMM y 'г'., Hm": {
+        "H": "EEEE, d MMMM y 'г'., HH:mm–HH:mm",
+        "m": "EEEE, d MMMM y 'г'., HH:mm–HH:mm"
+      },
+      "d MMMM y 'г'., Hm": {
+        "H": "d MMMM y 'г'., HH:mm–HH:mm",
+        "m": "d MMMM y 'г'., HH:mm–HH:mm"
+      },
+      "d MMM y 'г'., Hm": {
+        "H": "d MMM y 'г'., HH:mm–HH:mm",
+        "m": "d MMM y 'г'., HH:mm–HH:mm"
+      },
+      "dd.MM.y, Hm": {
+        "H": "dd.MM.y, HH:mm–HH:mm",
+        "m": "dd.MM.y, HH:mm–HH:mm"
+      },
+      "d, Hm": {
+        "H": "d, HH:mm–HH:mm",
+        "m": "d, HH:mm–HH:mm"
+      },
+      "E, Hm": {
+        "H": "ccc, HH:mm–HH:mm",
+        "m": "ccc, HH:mm–HH:mm"
+      },
+      "Ed, Hm": {
+        "H": "ccc, d, HH:mm–HH:mm",
+        "m": "ccc, d, HH:mm–HH:mm"
+      },
+      "Gy, Hm": {
+        "H": "y 'г'. G, HH:mm–HH:mm",
+        "m": "y 'г'. G, HH:mm–HH:mm"
+      },
+      "GyM, Hm": {
+        "H": "MM.y GGGGG, HH:mm–HH:mm",
+        "m": "MM.y GGGGG, HH:mm–HH:mm"
+      },
+      "GyMd, Hm": {
+        "H": "dd.MM.y GGGGG, HH:mm–HH:mm",
+        "m": "dd.MM.y GGGGG, HH:mm–HH:mm"
+      },
+      "GyMEd, Hm": {
+        "H": "E, dd.MM.y GGGGG, HH:mm–HH:mm",
+        "m": "E, dd.MM.y GGGGG, HH:mm–HH:mm"
+      },
+      "GyMMM, Hm": {
+        "H": "LLL y 'г'. G, HH:mm–HH:mm",
+        "m": "LLL y 'г'. G, HH:mm–HH:mm"
+      },
+      "GyMMMd, Hm": {
+        "H": "d MMM y 'г'. G, HH:mm–HH:mm",
+        "m": "d MMM y 'г'. G, HH:mm–HH:mm"
+      },
+      "GyMMMEd, Hm": {
+        "H": "E, d MMM y 'г'. G, HH:mm–HH:mm",
+        "m": "E, d MMM y 'г'. G, HH:mm–HH:mm"
+      },
+      "M, Hm": {
+        "H": "L, HH:mm–HH:mm",
+        "m": "L, HH:mm–HH:mm"
+      },
+      "Md, Hm": {
+        "H": "dd.MM, HH:mm–HH:mm",
+        "m": "dd.MM, HH:mm–HH:mm"
+      },
+      "MEd, Hm": {
+        "H": "E, dd.MM, HH:mm–HH:mm",
+        "m": "E, dd.MM, HH:mm–HH:mm"
+      },
+      "MMdd, Hm": {
+        "H": "dd.MM, HH:mm–HH:mm",
+        "m": "dd.MM, HH:mm–HH:mm"
+      },
+      "MMM, Hm": {
+        "H": "LLL, HH:mm–HH:mm",
+        "m": "LLL, HH:mm–HH:mm"
+      },
+      "MMMd, Hm": {
+        "H": "d MMM, HH:mm–HH:mm",
+        "m": "d MMM, HH:mm–HH:mm"
+      },
+      "MMMEd, Hm": {
+        "H": "ccc, d MMM, HH:mm–HH:mm",
+        "m": "ccc, d MMM, HH:mm–HH:mm"
+      },
+      "MMMMd, Hm": {
+        "H": "d MMMM, HH:mm–HH:mm",
+        "m": "d MMMM, HH:mm–HH:mm"
+      },
+      "y, Hm": {
+        "H": "y, HH:mm–HH:mm",
+        "m": "y, HH:mm–HH:mm"
+      },
+      "yM, Hm": {
+        "H": "MM.y, HH:mm–HH:mm",
+        "m": "MM.y, HH:mm–HH:mm"
+      },
+      "yMd, Hm": {
+        "H": "dd.MM.y, HH:mm–HH:mm",
+        "m": "dd.MM.y, HH:mm–HH:mm"
+      },
+      "yMEd, Hm": {
+        "H": "ccc, dd.MM.y, HH:mm–HH:mm",
+        "m": "ccc, dd.MM.y, HH:mm–HH:mm"
+      },
+      "yMM, Hm": {
+        "H": "MM.y, HH:mm–HH:mm",
+        "m": "MM.y, HH:mm–HH:mm"
+      },
+      "yMMM, Hm": {
+        "H": "LLL y 'г'., HH:mm–HH:mm",
+        "m": "LLL y 'г'., HH:mm–HH:mm"
+      },
+      "yMMMd, Hm": {
+        "H": "d MMM y 'г'., HH:mm–HH:mm",
+        "m": "d MMM y 'г'., HH:mm–HH:mm"
+      },
+      "yMMMEd, Hm": {
+        "H": "E, d MMM y 'г'., HH:mm–HH:mm",
+        "m": "E, d MMM y 'г'., HH:mm–HH:mm"
+      },
+      "yMMMM, Hm": {
+        "H": "LLLL y 'г'., HH:mm–HH:mm",
+        "m": "LLLL y 'г'., HH:mm–HH:mm"
+      },
+      "EEEE, d MMMM y 'г'., hmv": {
+        "a": "EEEE, d MMMM y 'г'., h:mm a – h:mm a v",
+        "h": "EEEE, d MMMM y 'г'., h:mm–h:mm a v",
+        "m": "EEEE, d MMMM y 'г'., h:mm–h:mm a v"
+      },
+      "d MMMM y 'г'., hmv": {
+        "a": "d MMMM y 'г'., h:mm a – h:mm a v",
+        "h": "d MMMM y 'г'., h:mm–h:mm a v",
+        "m": "d MMMM y 'г'., h:mm–h:mm a v"
+      },
+      "d MMM y 'г'., hmv": {
+        "a": "d MMM y 'г'., h:mm a – h:mm a v",
+        "h": "d MMM y 'г'., h:mm–h:mm a v",
+        "m": "d MMM y 'г'., h:mm–h:mm a v"
+      },
+      "dd.MM.y, hmv": {
+        "a": "dd.MM.y, h:mm a – h:mm a v",
+        "h": "dd.MM.y, h:mm–h:mm a v",
+        "m": "dd.MM.y, h:mm–h:mm a v"
+      },
+      "d, hmv": {
+        "a": "d, h:mm a – h:mm a v",
+        "h": "d, h:mm–h:mm a v",
+        "m": "d, h:mm–h:mm a v"
+      },
+      "E, hmv": {
+        "a": "ccc, h:mm a – h:mm a v",
+        "h": "ccc, h:mm–h:mm a v",
+        "m": "ccc, h:mm–h:mm a v"
+      },
+      "Ed, hmv": {
+        "a": "ccc, d, h:mm a – h:mm a v",
+        "h": "ccc, d, h:mm–h:mm a v",
+        "m": "ccc, d, h:mm–h:mm a v"
+      },
+      "Gy, hmv": {
+        "a": "y 'г'. G, h:mm a – h:mm a v",
+        "h": "y 'г'. G, h:mm–h:mm a v",
+        "m": "y 'г'. G, h:mm–h:mm a v"
+      },
+      "GyM, hmv": {
+        "a": "MM.y GGGGG, h:mm a – h:mm a v",
+        "h": "MM.y GGGGG, h:mm–h:mm a v",
+        "m": "MM.y GGGGG, h:mm–h:mm a v"
+      },
+      "GyMd, hmv": {
+        "a": "dd.MM.y GGGGG, h:mm a – h:mm a v",
+        "h": "dd.MM.y GGGGG, h:mm–h:mm a v",
+        "m": "dd.MM.y GGGGG, h:mm–h:mm a v"
+      },
+      "GyMEd, hmv": {
+        "a": "E, dd.MM.y GGGGG, h:mm a – h:mm a v",
+        "h": "E, dd.MM.y GGGGG, h:mm–h:mm a v",
+        "m": "E, dd.MM.y GGGGG, h:mm–h:mm a v"
+      },
+      "GyMMM, hmv": {
+        "a": "LLL y 'г'. G, h:mm a – h:mm a v",
+        "h": "LLL y 'г'. G, h:mm–h:mm a v",
+        "m": "LLL y 'г'. G, h:mm–h:mm a v"
+      },
+      "GyMMMd, hmv": {
+        "a": "d MMM y 'г'. G, h:mm a – h:mm a v",
+        "h": "d MMM y 'г'. G, h:mm–h:mm a v",
+        "m": "d MMM y 'г'. G, h:mm–h:mm a v"
+      },
+      "GyMMMEd, hmv": {
+        "a": "E, d MMM y 'г'. G, h:mm a – h:mm a v",
+        "h": "E, d MMM y 'г'. G, h:mm–h:mm a v",
+        "m": "E, d MMM y 'г'. G, h:mm–h:mm a v"
+      },
+      "M, hmv": {
+        "a": "L, h:mm a – h:mm a v",
+        "h": "L, h:mm–h:mm a v",
+        "m": "L, h:mm–h:mm a v"
+      },
+      "Md, hmv": {
+        "a": "dd.MM, h:mm a – h:mm a v",
+        "h": "dd.MM, h:mm–h:mm a v",
+        "m": "dd.MM, h:mm–h:mm a v"
+      },
+      "MEd, hmv": {
+        "a": "E, dd.MM, h:mm a – h:mm a v",
+        "h": "E, dd.MM, h:mm–h:mm a v",
+        "m": "E, dd.MM, h:mm–h:mm a v"
+      },
+      "MMdd, hmv": {
+        "a": "dd.MM, h:mm a – h:mm a v",
+        "h": "dd.MM, h:mm–h:mm a v",
+        "m": "dd.MM, h:mm–h:mm a v"
+      },
+      "MMM, hmv": {
+        "a": "LLL, h:mm a – h:mm a v",
+        "h": "LLL, h:mm–h:mm a v",
+        "m": "LLL, h:mm–h:mm a v"
+      },
+      "MMMd, hmv": {
+        "a": "d MMM, h:mm a – h:mm a v",
+        "h": "d MMM, h:mm–h:mm a v",
+        "m": "d MMM, h:mm–h:mm a v"
+      },
+      "MMMEd, hmv": {
+        "a": "ccc, d MMM, h:mm a – h:mm a v",
+        "h": "ccc, d MMM, h:mm–h:mm a v",
+        "m": "ccc, d MMM, h:mm–h:mm a v"
+      },
+      "MMMMd, hmv": {
+        "a": "d MMMM, h:mm a – h:mm a v",
+        "h": "d MMMM, h:mm–h:mm a v",
+        "m": "d MMMM, h:mm–h:mm a v"
+      },
+      "y, hmv": {
+        "a": "y, h:mm a – h:mm a v",
+        "h": "y, h:mm–h:mm a v",
+        "m": "y, h:mm–h:mm a v"
+      },
+      "yM, hmv": {
+        "a": "MM.y, h:mm a – h:mm a v",
+        "h": "MM.y, h:mm–h:mm a v",
+        "m": "MM.y, h:mm–h:mm a v"
+      },
+      "yMd, hmv": {
+        "a": "dd.MM.y, h:mm a – h:mm a v",
+        "h": "dd.MM.y, h:mm–h:mm a v",
+        "m": "dd.MM.y, h:mm–h:mm a v"
+      },
+      "yMEd, hmv": {
+        "a": "ccc, dd.MM.y, h:mm a – h:mm a v",
+        "h": "ccc, dd.MM.y, h:mm–h:mm a v",
+        "m": "ccc, dd.MM.y, h:mm–h:mm a v"
+      },
+      "yMM, hmv": {
+        "a": "MM.y, h:mm a – h:mm a v",
+        "h": "MM.y, h:mm–h:mm a v",
+        "m": "MM.y, h:mm–h:mm a v"
+      },
+      "yMMM, hmv": {
+        "a": "LLL y 'г'., h:mm a – h:mm a v",
+        "h": "LLL y 'г'., h:mm–h:mm a v",
+        "m": "LLL y 'г'., h:mm–h:mm a v"
+      },
+      "yMMMd, hmv": {
+        "a": "d MMM y 'г'., h:mm a – h:mm a v",
+        "h": "d MMM y 'г'., h:mm–h:mm a v",
+        "m": "d MMM y 'г'., h:mm–h:mm a v"
+      },
+      "yMMMEd, hmv": {
+        "a": "E, d MMM y 'г'., h:mm a – h:mm a v",
+        "h": "E, d MMM y 'г'., h:mm–h:mm a v",
+        "m": "E, d MMM y 'г'., h:mm–h:mm a v"
+      },
+      "yMMMM, hmv": {
+        "a": "LLLL y 'г'., h:mm a – h:mm a v",
+        "h": "LLLL y 'г'., h:mm–h:mm a v",
+        "m": "LLLL y 'г'., h:mm–h:mm a v"
+      },
+      "EEEE, d MMMM y 'г'., Hmv": {
+        "H": "EEEE, d MMMM y 'г'., HH:mm–HH:mm v",
+        "m": "EEEE, d MMMM y 'г'., HH:mm–HH:mm v"
+      },
+      "d MMMM y 'г'., Hmv": {
+        "H": "d MMMM y 'г'., HH:mm–HH:mm v",
+        "m": "d MMMM y 'г'., HH:mm–HH:mm v"
+      },
+      "d MMM y 'г'., Hmv": {
+        "H": "d MMM y 'г'., HH:mm–HH:mm v",
+        "m": "d MMM y 'г'., HH:mm–HH:mm v"
+      },
+      "dd.MM.y, Hmv": {
+        "H": "dd.MM.y, HH:mm–HH:mm v",
+        "m": "dd.MM.y, HH:mm–HH:mm v"
+      },
+      "d, Hmv": {
+        "H": "d, HH:mm–HH:mm v",
+        "m": "d, HH:mm–HH:mm v"
+      },
+      "E, Hmv": {
+        "H": "ccc, HH:mm–HH:mm v",
+        "m": "ccc, HH:mm–HH:mm v"
+      },
+      "Ed, Hmv": {
+        "H": "ccc, d, HH:mm–HH:mm v",
+        "m": "ccc, d, HH:mm–HH:mm v"
+      },
+      "Gy, Hmv": {
+        "H": "y 'г'. G, HH:mm–HH:mm v",
+        "m": "y 'г'. G, HH:mm–HH:mm v"
+      },
+      "GyM, Hmv": {
+        "H": "MM.y GGGGG, HH:mm–HH:mm v",
+        "m": "MM.y GGGGG, HH:mm–HH:mm v"
+      },
+      "GyMd, Hmv": {
+        "H": "dd.MM.y GGGGG, HH:mm–HH:mm v",
+        "m": "dd.MM.y GGGGG, HH:mm–HH:mm v"
+      },
+      "GyMEd, Hmv": {
+        "H": "E, dd.MM.y GGGGG, HH:mm–HH:mm v",
+        "m": "E, dd.MM.y GGGGG, HH:mm–HH:mm v"
+      },
+      "GyMMM, Hmv": {
+        "H": "LLL y 'г'. G, HH:mm–HH:mm v",
+        "m": "LLL y 'г'. G, HH:mm–HH:mm v"
+      },
+      "GyMMMd, Hmv": {
+        "H": "d MMM y 'г'. G, HH:mm–HH:mm v",
+        "m": "d MMM y 'г'. G, HH:mm–HH:mm v"
+      },
+      "GyMMMEd, Hmv": {
+        "H": "E, d MMM y 'г'. G, HH:mm–HH:mm v",
+        "m": "E, d MMM y 'г'. G, HH:mm–HH:mm v"
+      },
+      "M, Hmv": {
+        "H": "L, HH:mm–HH:mm v",
+        "m": "L, HH:mm–HH:mm v"
+      },
+      "Md, Hmv": {
+        "H": "dd.MM, HH:mm–HH:mm v",
+        "m": "dd.MM, HH:mm–HH:mm v"
+      },
+      "MEd, Hmv": {
+        "H": "E, dd.MM, HH:mm–HH:mm v",
+        "m": "E, dd.MM, HH:mm–HH:mm v"
+      },
+      "MMdd, Hmv": {
+        "H": "dd.MM, HH:mm–HH:mm v",
+        "m": "dd.MM, HH:mm–HH:mm v"
+      },
+      "MMM, Hmv": {
+        "H": "LLL, HH:mm–HH:mm v",
+        "m": "LLL, HH:mm–HH:mm v"
+      },
+      "MMMd, Hmv": {
+        "H": "d MMM, HH:mm–HH:mm v",
+        "m": "d MMM, HH:mm–HH:mm v"
+      },
+      "MMMEd, Hmv": {
+        "H": "ccc, d MMM, HH:mm–HH:mm v",
+        "m": "ccc, d MMM, HH:mm–HH:mm v"
+      },
+      "MMMMd, Hmv": {
+        "H": "d MMMM, HH:mm–HH:mm v",
+        "m": "d MMMM, HH:mm–HH:mm v"
+      },
+      "y, Hmv": {
+        "H": "y, HH:mm–HH:mm v",
+        "m": "y, HH:mm–HH:mm v"
+      },
+      "yM, Hmv": {
+        "H": "MM.y, HH:mm–HH:mm v",
+        "m": "MM.y, HH:mm–HH:mm v"
+      },
+      "yMd, Hmv": {
+        "H": "dd.MM.y, HH:mm–HH:mm v",
+        "m": "dd.MM.y, HH:mm–HH:mm v"
+      },
+      "yMEd, Hmv": {
+        "H": "ccc, dd.MM.y, HH:mm–HH:mm v",
+        "m": "ccc, dd.MM.y, HH:mm–HH:mm v"
+      },
+      "yMM, Hmv": {
+        "H": "MM.y, HH:mm–HH:mm v",
+        "m": "MM.y, HH:mm–HH:mm v"
+      },
+      "yMMM, Hmv": {
+        "H": "LLL y 'г'., HH:mm–HH:mm v",
+        "m": "LLL y 'г'., HH:mm–HH:mm v"
+      },
+      "yMMMd, Hmv": {
+        "H": "d MMM y 'г'., HH:mm–HH:mm v",
+        "m": "d MMM y 'г'., HH:mm–HH:mm v"
+      },
+      "yMMMEd, Hmv": {
+        "H": "E, d MMM y 'г'., HH:mm–HH:mm v",
+        "m": "E, d MMM y 'г'., HH:mm–HH:mm v"
+      },
+      "yMMMM, Hmv": {
+        "H": "LLLL y 'г'., HH:mm–HH:mm v",
+        "m": "LLLL y 'г'., HH:mm–HH:mm v"
+      },
+      "EEEE, d MMMM y 'г'., hv": {
+        "a": "EEEE, d MMMM y 'г'., h a – h a v",
+        "h": "EEEE, d MMMM y 'г'., h–h a v"
+      },
+      "d MMMM y 'г'., hv": {
+        "a": "d MMMM y 'г'., h a – h a v",
+        "h": "d MMMM y 'г'., h–h a v"
+      },
+      "d MMM y 'г'., hv": {
+        "a": "d MMM y 'г'., h a – h a v",
+        "h": "d MMM y 'г'., h–h a v"
+      },
+      "dd.MM.y, hv": {
+        "a": "dd.MM.y, h a – h a v",
+        "h": "dd.MM.y, h–h a v"
+      },
+      "d, hv": {
+        "a": "d, h a – h a v",
+        "h": "d, h–h a v"
+      },
+      "E, hv": {
+        "a": "ccc, h a – h a v",
+        "h": "ccc, h–h a v"
+      },
+      "Ed, hv": {
+        "a": "ccc, d, h a – h a v",
+        "h": "ccc, d, h–h a v"
+      },
+      "Gy, hv": {
+        "a": "y 'г'. G, h a – h a v",
+        "h": "y 'г'. G, h–h a v"
+      },
+      "GyM, hv": {
+        "a": "MM.y GGGGG, h a – h a v",
+        "h": "MM.y GGGGG, h–h a v"
+      },
+      "GyMd, hv": {
+        "a": "dd.MM.y GGGGG, h a – h a v",
+        "h": "dd.MM.y GGGGG, h–h a v"
+      },
+      "GyMEd, hv": {
+        "a": "E, dd.MM.y GGGGG, h a – h a v",
+        "h": "E, dd.MM.y GGGGG, h–h a v"
+      },
+      "GyMMM, hv": {
+        "a": "LLL y 'г'. G, h a – h a v",
+        "h": "LLL y 'г'. G, h–h a v"
+      },
+      "GyMMMd, hv": {
+        "a": "d MMM y 'г'. G, h a – h a v",
+        "h": "d MMM y 'г'. G, h–h a v"
+      },
+      "GyMMMEd, hv": {
+        "a": "E, d MMM y 'г'. G, h a – h a v",
+        "h": "E, d MMM y 'г'. G, h–h a v"
+      },
+      "M, hv": {
+        "a": "L, h a – h a v",
+        "h": "L, h–h a v"
+      },
+      "Md, hv": {
+        "a": "dd.MM, h a – h a v",
+        "h": "dd.MM, h–h a v"
+      },
+      "MEd, hv": {
+        "a": "E, dd.MM, h a – h a v",
+        "h": "E, dd.MM, h–h a v"
+      },
+      "MMdd, hv": {
+        "a": "dd.MM, h a – h a v",
+        "h": "dd.MM, h–h a v"
+      },
+      "MMM, hv": {
+        "a": "LLL, h a – h a v",
+        "h": "LLL, h–h a v"
+      },
+      "MMMd, hv": {
+        "a": "d MMM, h a – h a v",
+        "h": "d MMM, h–h a v"
+      },
+      "MMMEd, hv": {
+        "a": "ccc, d MMM, h a – h a v",
+        "h": "ccc, d MMM, h–h a v"
+      },
+      "MMMMd, hv": {
+        "a": "d MMMM, h a – h a v",
+        "h": "d MMMM, h–h a v"
+      },
+      "y, hv": {
+        "a": "y, h a – h a v",
+        "h": "y, h–h a v"
+      },
+      "yM, hv": {
+        "a": "MM.y, h a – h a v",
+        "h": "MM.y, h–h a v"
+      },
+      "yMd, hv": {
+        "a": "dd.MM.y, h a – h a v",
+        "h": "dd.MM.y, h–h a v"
+      },
+      "yMEd, hv": {
+        "a": "ccc, dd.MM.y, h a – h a v",
+        "h": "ccc, dd.MM.y, h–h a v"
+      },
+      "yMM, hv": {
+        "a": "MM.y, h a – h a v",
+        "h": "MM.y, h–h a v"
+      },
+      "yMMM, hv": {
+        "a": "LLL y 'г'., h a – h a v",
+        "h": "LLL y 'г'., h–h a v"
+      },
+      "yMMMd, hv": {
+        "a": "d MMM y 'г'., h a – h a v",
+        "h": "d MMM y 'г'., h–h a v"
+      },
+      "yMMMEd, hv": {
+        "a": "E, d MMM y 'г'., h a – h a v",
+        "h": "E, d MMM y 'г'., h–h a v"
+      },
+      "yMMMM, hv": {
+        "a": "LLLL y 'г'., h a – h a v",
+        "h": "LLLL y 'г'., h–h a v"
+      },
+      "EEEE, d MMMM y 'г'., Hv": {
+        "H": "EEEE, d MMMM y 'г'., HH–HH 'ч'. v"
+      },
+      "d MMMM y 'г'., Hv": {
+        "H": "d MMMM y 'г'., HH–HH 'ч'. v"
+      },
+      "d MMM y 'г'., Hv": {
+        "H": "d MMM y 'г'., HH–HH 'ч'. v"
+      },
+      "dd.MM.y, Hv": {
+        "H": "dd.MM.y, HH–HH 'ч'. v"
+      },
+      "d, Hv": {
+        "H": "d, HH–HH 'ч'. v"
+      },
+      "E, Hv": {
+        "H": "ccc, HH–HH 'ч'. v"
+      },
+      "Ed, Hv": {
+        "H": "ccc, d, HH–HH 'ч'. v"
+      },
+      "Gy, Hv": {
+        "H": "y 'г'. G, HH–HH 'ч'. v"
+      },
+      "GyM, Hv": {
+        "H": "MM.y GGGGG, HH–HH 'ч'. v"
+      },
+      "GyMd, Hv": {
+        "H": "dd.MM.y GGGGG, HH–HH 'ч'. v"
+      },
+      "GyMEd, Hv": {
+        "H": "E, dd.MM.y GGGGG, HH–HH 'ч'. v"
+      },
+      "GyMMM, Hv": {
+        "H": "LLL y 'г'. G, HH–HH 'ч'. v"
+      },
+      "GyMMMd, Hv": {
+        "H": "d MMM y 'г'. G, HH–HH 'ч'. v"
+      },
+      "GyMMMEd, Hv": {
+        "H": "E, d MMM y 'г'. G, HH–HH 'ч'. v"
+      },
+      "M, Hv": {
+        "H": "L, HH–HH 'ч'. v"
+      },
+      "Md, Hv": {
+        "H": "dd.MM, HH–HH 'ч'. v"
+      },
+      "MEd, Hv": {
+        "H": "E, dd.MM, HH–HH 'ч'. v"
+      },
+      "MMdd, Hv": {
+        "H": "dd.MM, HH–HH 'ч'. v"
+      },
+      "MMM, Hv": {
+        "H": "LLL, HH–HH 'ч'. v"
+      },
+      "MMMd, Hv": {
+        "H": "d MMM, HH–HH 'ч'. v"
+      },
+      "MMMEd, Hv": {
+        "H": "ccc, d MMM, HH–HH 'ч'. v"
+      },
+      "MMMMd, Hv": {
+        "H": "d MMMM, HH–HH 'ч'. v"
+      },
+      "y, Hv": {
+        "H": "y, HH–HH 'ч'. v"
+      },
+      "yM, Hv": {
+        "H": "MM.y, HH–HH 'ч'. v"
+      },
+      "yMd, Hv": {
+        "H": "dd.MM.y, HH–HH 'ч'. v"
+      },
+      "yMEd, Hv": {
+        "H": "ccc, dd.MM.y, HH–HH 'ч'. v"
+      },
+      "yMM, Hv": {
+        "H": "MM.y, HH–HH 'ч'. v"
+      },
+      "yMMM, Hv": {
+        "H": "LLL y 'г'., HH–HH 'ч'. v"
+      },
+      "yMMMd, Hv": {
+        "H": "d MMM y 'г'., HH–HH 'ч'. v"
+      },
+      "yMMMEd, Hv": {
+        "H": "E, d MMM y 'г'., HH–HH 'ч'. v"
+      },
+      "yMMMM, Hv": {
+        "H": "LLLL y 'г'., HH–HH 'ч'. v"
       }
     },
     "hourCycle": "h23",

--- a/packages/intl-datetimeformat/tests/locale-data/zh-Hans.json
+++ b/packages/intl-datetimeformat/tests/locale-data/zh-Hans.json
@@ -2606,6 +2606,1277 @@
       "yMMMM": {
         "M": "y年M月 – M月",
         "y": "y年M月 – y年M月"
+      },
+      "y年M月d日EEEE Bh": {
+        "B": "y年M月d日EEEE Bh时至Bh时",
+        "h": "y年M月d日EEEE Bh时至h时"
+      },
+      "y年M月d日 Bh": {
+        "B": "y年M月d日 Bh时至Bh时",
+        "h": "y年M月d日 Bh时至h时"
+      },
+      "y/M/d Bh": {
+        "B": "y/M/d Bh时至Bh时",
+        "h": "y/M/d Bh时至h时"
+      },
+      "d Bh": {
+        "B": "d日 Bh时至Bh时",
+        "h": "d日 Bh时至h时"
+      },
+      "E Bh": {
+        "B": "ccc Bh时至Bh时",
+        "h": "ccc Bh时至h时"
+      },
+      "Ed Bh": {
+        "B": "d日E Bh时至Bh时",
+        "h": "d日E Bh时至h时"
+      },
+      "Gy Bh": {
+        "B": "Gy年 Bh时至Bh时",
+        "h": "Gy年 Bh时至h时"
+      },
+      "GyM Bh": {
+        "B": "Gy年M月 Bh时至Bh时",
+        "h": "Gy年M月 Bh时至h时"
+      },
+      "GyMd Bh": {
+        "B": "Gy-MM-dd Bh时至Bh时",
+        "h": "Gy-MM-dd Bh时至h时"
+      },
+      "GyMEd Bh": {
+        "B": "Gy-MM-ddE Bh时至Bh时",
+        "h": "Gy-MM-ddE Bh时至h时"
+      },
+      "GyMMM Bh": {
+        "B": "Gy年M月 Bh时至Bh时",
+        "h": "Gy年M月 Bh时至h时"
+      },
+      "GyMMMd Bh": {
+        "B": "Gy年M月d日 Bh时至Bh时",
+        "h": "Gy年M月d日 Bh时至h时"
+      },
+      "GyMMMEd Bh": {
+        "B": "Gy年M月d日E Bh时至Bh时",
+        "h": "Gy年M月d日E Bh时至h时"
+      },
+      "M Bh": {
+        "B": "M月 Bh时至Bh时",
+        "h": "M月 Bh时至h时"
+      },
+      "Md Bh": {
+        "B": "M/d Bh时至Bh时",
+        "h": "M/d Bh时至h时"
+      },
+      "MEd Bh": {
+        "B": "M/dE Bh时至Bh时",
+        "h": "M/dE Bh时至h时"
+      },
+      "MMdd Bh": {
+        "B": "MM/dd Bh时至Bh时",
+        "h": "MM/dd Bh时至h时"
+      },
+      "MMM Bh": {
+        "B": "LLL Bh时至Bh时",
+        "h": "LLL Bh时至h时"
+      },
+      "MMMd Bh": {
+        "B": "M月d日 Bh时至Bh时",
+        "h": "M月d日 Bh时至h时"
+      },
+      "MMMEd Bh": {
+        "B": "M月d日E Bh时至Bh时",
+        "h": "M月d日E Bh时至h时"
+      },
+      "MMMMd Bh": {
+        "B": "M月d日 Bh时至Bh时",
+        "h": "M月d日 Bh时至h时"
+      },
+      "y Bh": {
+        "B": "y年 Bh时至Bh时",
+        "h": "y年 Bh时至h时"
+      },
+      "yM Bh": {
+        "B": "y/M Bh时至Bh时",
+        "h": "y/M Bh时至h时"
+      },
+      "yMd Bh": {
+        "B": "y/M/d Bh时至Bh时",
+        "h": "y/M/d Bh时至h时"
+      },
+      "yMEd Bh": {
+        "B": "y/M/dE Bh时至Bh时",
+        "h": "y/M/dE Bh时至h时"
+      },
+      "yMEEEEd Bh": {
+        "B": "y年M月d日EEEE Bh时至Bh时",
+        "h": "y年M月d日EEEE Bh时至h时"
+      },
+      "yMM Bh": {
+        "B": "y年M月 Bh时至Bh时",
+        "h": "y年M月 Bh时至h时"
+      },
+      "yMMM Bh": {
+        "B": "y年M月 Bh时至Bh时",
+        "h": "y年M月 Bh时至h时"
+      },
+      "yMMMd Bh": {
+        "B": "y年M月d日 Bh时至Bh时",
+        "h": "y年M月d日 Bh时至h时"
+      },
+      "yMMMEd Bh": {
+        "B": "y年M月d日E Bh时至Bh时",
+        "h": "y年M月d日E Bh时至h时"
+      },
+      "yMMMM Bh": {
+        "B": "y年M月 Bh时至Bh时",
+        "h": "y年M月 Bh时至h时"
+      },
+      "y年M月d日EEEE Bhm": {
+        "B": "y年M月d日EEEE Bh:mm至Bh:mm",
+        "h": "y年M月d日EEEE Bh:mm至h:mm",
+        "m": "y年M月d日EEEE Bh:mm至h:mm"
+      },
+      "y年M月d日 Bhm": {
+        "B": "y年M月d日 Bh:mm至Bh:mm",
+        "h": "y年M月d日 Bh:mm至h:mm",
+        "m": "y年M月d日 Bh:mm至h:mm"
+      },
+      "y/M/d Bhm": {
+        "B": "y/M/d Bh:mm至Bh:mm",
+        "h": "y/M/d Bh:mm至h:mm",
+        "m": "y/M/d Bh:mm至h:mm"
+      },
+      "d Bhm": {
+        "B": "d日 Bh:mm至Bh:mm",
+        "h": "d日 Bh:mm至h:mm",
+        "m": "d日 Bh:mm至h:mm"
+      },
+      "E Bhm": {
+        "B": "ccc Bh:mm至Bh:mm",
+        "h": "ccc Bh:mm至h:mm",
+        "m": "ccc Bh:mm至h:mm"
+      },
+      "Ed Bhm": {
+        "B": "d日E Bh:mm至Bh:mm",
+        "h": "d日E Bh:mm至h:mm",
+        "m": "d日E Bh:mm至h:mm"
+      },
+      "Gy Bhm": {
+        "B": "Gy年 Bh:mm至Bh:mm",
+        "h": "Gy年 Bh:mm至h:mm",
+        "m": "Gy年 Bh:mm至h:mm"
+      },
+      "GyM Bhm": {
+        "B": "Gy年M月 Bh:mm至Bh:mm",
+        "h": "Gy年M月 Bh:mm至h:mm",
+        "m": "Gy年M月 Bh:mm至h:mm"
+      },
+      "GyMd Bhm": {
+        "B": "Gy-MM-dd Bh:mm至Bh:mm",
+        "h": "Gy-MM-dd Bh:mm至h:mm",
+        "m": "Gy-MM-dd Bh:mm至h:mm"
+      },
+      "GyMEd Bhm": {
+        "B": "Gy-MM-ddE Bh:mm至Bh:mm",
+        "h": "Gy-MM-ddE Bh:mm至h:mm",
+        "m": "Gy-MM-ddE Bh:mm至h:mm"
+      },
+      "GyMMM Bhm": {
+        "B": "Gy年M月 Bh:mm至Bh:mm",
+        "h": "Gy年M月 Bh:mm至h:mm",
+        "m": "Gy年M月 Bh:mm至h:mm"
+      },
+      "GyMMMd Bhm": {
+        "B": "Gy年M月d日 Bh:mm至Bh:mm",
+        "h": "Gy年M月d日 Bh:mm至h:mm",
+        "m": "Gy年M月d日 Bh:mm至h:mm"
+      },
+      "GyMMMEd Bhm": {
+        "B": "Gy年M月d日E Bh:mm至Bh:mm",
+        "h": "Gy年M月d日E Bh:mm至h:mm",
+        "m": "Gy年M月d日E Bh:mm至h:mm"
+      },
+      "M Bhm": {
+        "B": "M月 Bh:mm至Bh:mm",
+        "h": "M月 Bh:mm至h:mm",
+        "m": "M月 Bh:mm至h:mm"
+      },
+      "Md Bhm": {
+        "B": "M/d Bh:mm至Bh:mm",
+        "h": "M/d Bh:mm至h:mm",
+        "m": "M/d Bh:mm至h:mm"
+      },
+      "MEd Bhm": {
+        "B": "M/dE Bh:mm至Bh:mm",
+        "h": "M/dE Bh:mm至h:mm",
+        "m": "M/dE Bh:mm至h:mm"
+      },
+      "MMdd Bhm": {
+        "B": "MM/dd Bh:mm至Bh:mm",
+        "h": "MM/dd Bh:mm至h:mm",
+        "m": "MM/dd Bh:mm至h:mm"
+      },
+      "MMM Bhm": {
+        "B": "LLL Bh:mm至Bh:mm",
+        "h": "LLL Bh:mm至h:mm",
+        "m": "LLL Bh:mm至h:mm"
+      },
+      "MMMd Bhm": {
+        "B": "M月d日 Bh:mm至Bh:mm",
+        "h": "M月d日 Bh:mm至h:mm",
+        "m": "M月d日 Bh:mm至h:mm"
+      },
+      "MMMEd Bhm": {
+        "B": "M月d日E Bh:mm至Bh:mm",
+        "h": "M月d日E Bh:mm至h:mm",
+        "m": "M月d日E Bh:mm至h:mm"
+      },
+      "MMMMd Bhm": {
+        "B": "M月d日 Bh:mm至Bh:mm",
+        "h": "M月d日 Bh:mm至h:mm",
+        "m": "M月d日 Bh:mm至h:mm"
+      },
+      "y Bhm": {
+        "B": "y年 Bh:mm至Bh:mm",
+        "h": "y年 Bh:mm至h:mm",
+        "m": "y年 Bh:mm至h:mm"
+      },
+      "yM Bhm": {
+        "B": "y/M Bh:mm至Bh:mm",
+        "h": "y/M Bh:mm至h:mm",
+        "m": "y/M Bh:mm至h:mm"
+      },
+      "yMd Bhm": {
+        "B": "y/M/d Bh:mm至Bh:mm",
+        "h": "y/M/d Bh:mm至h:mm",
+        "m": "y/M/d Bh:mm至h:mm"
+      },
+      "yMEd Bhm": {
+        "B": "y/M/dE Bh:mm至Bh:mm",
+        "h": "y/M/dE Bh:mm至h:mm",
+        "m": "y/M/dE Bh:mm至h:mm"
+      },
+      "yMEEEEd Bhm": {
+        "B": "y年M月d日EEEE Bh:mm至Bh:mm",
+        "h": "y年M月d日EEEE Bh:mm至h:mm",
+        "m": "y年M月d日EEEE Bh:mm至h:mm"
+      },
+      "yMM Bhm": {
+        "B": "y年M月 Bh:mm至Bh:mm",
+        "h": "y年M月 Bh:mm至h:mm",
+        "m": "y年M月 Bh:mm至h:mm"
+      },
+      "yMMM Bhm": {
+        "B": "y年M月 Bh:mm至Bh:mm",
+        "h": "y年M月 Bh:mm至h:mm",
+        "m": "y年M月 Bh:mm至h:mm"
+      },
+      "yMMMd Bhm": {
+        "B": "y年M月d日 Bh:mm至Bh:mm",
+        "h": "y年M月d日 Bh:mm至h:mm",
+        "m": "y年M月d日 Bh:mm至h:mm"
+      },
+      "yMMMEd Bhm": {
+        "B": "y年M月d日E Bh:mm至Bh:mm",
+        "h": "y年M月d日E Bh:mm至h:mm",
+        "m": "y年M月d日E Bh:mm至h:mm"
+      },
+      "yMMMM Bhm": {
+        "B": "y年M月 Bh:mm至Bh:mm",
+        "h": "y年M月 Bh:mm至h:mm",
+        "m": "y年M月 Bh:mm至h:mm"
+      },
+      "y年M月d日EEEE h": {
+        "a": "y年M月d日EEEE ah时至ah时",
+        "h": "y年M月d日EEEE ah时至h时"
+      },
+      "y年M月d日 h": {
+        "a": "y年M月d日 ah时至ah时",
+        "h": "y年M月d日 ah时至h时"
+      },
+      "y/M/d h": {
+        "a": "y/M/d ah时至ah时",
+        "h": "y/M/d ah时至h时"
+      },
+      "d h": {
+        "a": "d日 ah时至ah时",
+        "h": "d日 ah时至h时"
+      },
+      "E h": {
+        "a": "ccc ah时至ah时",
+        "h": "ccc ah时至h时"
+      },
+      "Ed h": {
+        "a": "d日E ah时至ah时",
+        "h": "d日E ah时至h时"
+      },
+      "Gy h": {
+        "a": "Gy年 ah时至ah时",
+        "h": "Gy年 ah时至h时"
+      },
+      "GyM h": {
+        "a": "Gy年M月 ah时至ah时",
+        "h": "Gy年M月 ah时至h时"
+      },
+      "GyMd h": {
+        "a": "Gy-MM-dd ah时至ah时",
+        "h": "Gy-MM-dd ah时至h时"
+      },
+      "GyMEd h": {
+        "a": "Gy-MM-ddE ah时至ah时",
+        "h": "Gy-MM-ddE ah时至h时"
+      },
+      "GyMMM h": {
+        "a": "Gy年M月 ah时至ah时",
+        "h": "Gy年M月 ah时至h时"
+      },
+      "GyMMMd h": {
+        "a": "Gy年M月d日 ah时至ah时",
+        "h": "Gy年M月d日 ah时至h时"
+      },
+      "GyMMMEd h": {
+        "a": "Gy年M月d日E ah时至ah时",
+        "h": "Gy年M月d日E ah时至h时"
+      },
+      "M h": {
+        "a": "M月 ah时至ah时",
+        "h": "M月 ah时至h时"
+      },
+      "Md h": {
+        "a": "M/d ah时至ah时",
+        "h": "M/d ah时至h时"
+      },
+      "MEd h": {
+        "a": "M/dE ah时至ah时",
+        "h": "M/dE ah时至h时"
+      },
+      "MMdd h": {
+        "a": "MM/dd ah时至ah时",
+        "h": "MM/dd ah时至h时"
+      },
+      "MMM h": {
+        "a": "LLL ah时至ah时",
+        "h": "LLL ah时至h时"
+      },
+      "MMMd h": {
+        "a": "M月d日 ah时至ah时",
+        "h": "M月d日 ah时至h时"
+      },
+      "MMMEd h": {
+        "a": "M月d日E ah时至ah时",
+        "h": "M月d日E ah时至h时"
+      },
+      "MMMMd h": {
+        "a": "M月d日 ah时至ah时",
+        "h": "M月d日 ah时至h时"
+      },
+      "y h": {
+        "a": "y年 ah时至ah时",
+        "h": "y年 ah时至h时"
+      },
+      "yM h": {
+        "a": "y/M ah时至ah时",
+        "h": "y/M ah时至h时"
+      },
+      "yMd h": {
+        "a": "y/M/d ah时至ah时",
+        "h": "y/M/d ah时至h时"
+      },
+      "yMEd h": {
+        "a": "y/M/dE ah时至ah时",
+        "h": "y/M/dE ah时至h时"
+      },
+      "yMEEEEd h": {
+        "a": "y年M月d日EEEE ah时至ah时",
+        "h": "y年M月d日EEEE ah时至h时"
+      },
+      "yMM h": {
+        "a": "y年M月 ah时至ah时",
+        "h": "y年M月 ah时至h时"
+      },
+      "yMMM h": {
+        "a": "y年M月 ah时至ah时",
+        "h": "y年M月 ah时至h时"
+      },
+      "yMMMd h": {
+        "a": "y年M月d日 ah时至ah时",
+        "h": "y年M月d日 ah时至h时"
+      },
+      "yMMMEd h": {
+        "a": "y年M月d日E ah时至ah时",
+        "h": "y年M月d日E ah时至h时"
+      },
+      "yMMMM h": {
+        "a": "y年M月 ah时至ah时",
+        "h": "y年M月 ah时至h时"
+      },
+      "y年M月d日EEEE H": {
+        "H": "y年M月d日EEEE HH–HH"
+      },
+      "y年M月d日 H": {
+        "H": "y年M月d日 HH–HH"
+      },
+      "y/M/d H": {
+        "H": "y/M/d HH–HH"
+      },
+      "d H": {
+        "H": "d日 HH–HH"
+      },
+      "E H": {
+        "H": "ccc HH–HH"
+      },
+      "Ed H": {
+        "H": "d日E HH–HH"
+      },
+      "Gy H": {
+        "H": "Gy年 HH–HH"
+      },
+      "GyM H": {
+        "H": "Gy年M月 HH–HH"
+      },
+      "GyMd H": {
+        "H": "Gy-MM-dd HH–HH"
+      },
+      "GyMEd H": {
+        "H": "Gy-MM-ddE HH–HH"
+      },
+      "GyMMM H": {
+        "H": "Gy年M月 HH–HH"
+      },
+      "GyMMMd H": {
+        "H": "Gy年M月d日 HH–HH"
+      },
+      "GyMMMEd H": {
+        "H": "Gy年M月d日E HH–HH"
+      },
+      "M H": {
+        "H": "M月 HH–HH"
+      },
+      "Md H": {
+        "H": "M/d HH–HH"
+      },
+      "MEd H": {
+        "H": "M/dE HH–HH"
+      },
+      "MMdd H": {
+        "H": "MM/dd HH–HH"
+      },
+      "MMM H": {
+        "H": "LLL HH–HH"
+      },
+      "MMMd H": {
+        "H": "M月d日 HH–HH"
+      },
+      "MMMEd H": {
+        "H": "M月d日E HH–HH"
+      },
+      "MMMMd H": {
+        "H": "M月d日 HH–HH"
+      },
+      "y H": {
+        "H": "y年 HH–HH"
+      },
+      "yM H": {
+        "H": "y/M HH–HH"
+      },
+      "yMd H": {
+        "H": "y/M/d HH–HH"
+      },
+      "yMEd H": {
+        "H": "y/M/dE HH–HH"
+      },
+      "yMEEEEd H": {
+        "H": "y年M月d日EEEE HH–HH"
+      },
+      "yMM H": {
+        "H": "y年M月 HH–HH"
+      },
+      "yMMM H": {
+        "H": "y年M月 HH–HH"
+      },
+      "yMMMd H": {
+        "H": "y年M月d日 HH–HH"
+      },
+      "yMMMEd H": {
+        "H": "y年M月d日E HH–HH"
+      },
+      "yMMMM H": {
+        "H": "y年M月 HH–HH"
+      },
+      "y年M月d日EEEE hm": {
+        "a": "y年M月d日EEEE ah:mm至ah:mm",
+        "h": "y年M月d日EEEE ah:mm至h:mm",
+        "m": "y年M月d日EEEE ah:mm至h:mm"
+      },
+      "y年M月d日 hm": {
+        "a": "y年M月d日 ah:mm至ah:mm",
+        "h": "y年M月d日 ah:mm至h:mm",
+        "m": "y年M月d日 ah:mm至h:mm"
+      },
+      "y/M/d hm": {
+        "a": "y/M/d ah:mm至ah:mm",
+        "h": "y/M/d ah:mm至h:mm",
+        "m": "y/M/d ah:mm至h:mm"
+      },
+      "d hm": {
+        "a": "d日 ah:mm至ah:mm",
+        "h": "d日 ah:mm至h:mm",
+        "m": "d日 ah:mm至h:mm"
+      },
+      "E hm": {
+        "a": "ccc ah:mm至ah:mm",
+        "h": "ccc ah:mm至h:mm",
+        "m": "ccc ah:mm至h:mm"
+      },
+      "Ed hm": {
+        "a": "d日E ah:mm至ah:mm",
+        "h": "d日E ah:mm至h:mm",
+        "m": "d日E ah:mm至h:mm"
+      },
+      "Gy hm": {
+        "a": "Gy年 ah:mm至ah:mm",
+        "h": "Gy年 ah:mm至h:mm",
+        "m": "Gy年 ah:mm至h:mm"
+      },
+      "GyM hm": {
+        "a": "Gy年M月 ah:mm至ah:mm",
+        "h": "Gy年M月 ah:mm至h:mm",
+        "m": "Gy年M月 ah:mm至h:mm"
+      },
+      "GyMd hm": {
+        "a": "Gy-MM-dd ah:mm至ah:mm",
+        "h": "Gy-MM-dd ah:mm至h:mm",
+        "m": "Gy-MM-dd ah:mm至h:mm"
+      },
+      "GyMEd hm": {
+        "a": "Gy-MM-ddE ah:mm至ah:mm",
+        "h": "Gy-MM-ddE ah:mm至h:mm",
+        "m": "Gy-MM-ddE ah:mm至h:mm"
+      },
+      "GyMMM hm": {
+        "a": "Gy年M月 ah:mm至ah:mm",
+        "h": "Gy年M月 ah:mm至h:mm",
+        "m": "Gy年M月 ah:mm至h:mm"
+      },
+      "GyMMMd hm": {
+        "a": "Gy年M月d日 ah:mm至ah:mm",
+        "h": "Gy年M月d日 ah:mm至h:mm",
+        "m": "Gy年M月d日 ah:mm至h:mm"
+      },
+      "GyMMMEd hm": {
+        "a": "Gy年M月d日E ah:mm至ah:mm",
+        "h": "Gy年M月d日E ah:mm至h:mm",
+        "m": "Gy年M月d日E ah:mm至h:mm"
+      },
+      "M hm": {
+        "a": "M月 ah:mm至ah:mm",
+        "h": "M月 ah:mm至h:mm",
+        "m": "M月 ah:mm至h:mm"
+      },
+      "Md hm": {
+        "a": "M/d ah:mm至ah:mm",
+        "h": "M/d ah:mm至h:mm",
+        "m": "M/d ah:mm至h:mm"
+      },
+      "MEd hm": {
+        "a": "M/dE ah:mm至ah:mm",
+        "h": "M/dE ah:mm至h:mm",
+        "m": "M/dE ah:mm至h:mm"
+      },
+      "MMdd hm": {
+        "a": "MM/dd ah:mm至ah:mm",
+        "h": "MM/dd ah:mm至h:mm",
+        "m": "MM/dd ah:mm至h:mm"
+      },
+      "MMM hm": {
+        "a": "LLL ah:mm至ah:mm",
+        "h": "LLL ah:mm至h:mm",
+        "m": "LLL ah:mm至h:mm"
+      },
+      "MMMd hm": {
+        "a": "M月d日 ah:mm至ah:mm",
+        "h": "M月d日 ah:mm至h:mm",
+        "m": "M月d日 ah:mm至h:mm"
+      },
+      "MMMEd hm": {
+        "a": "M月d日E ah:mm至ah:mm",
+        "h": "M月d日E ah:mm至h:mm",
+        "m": "M月d日E ah:mm至h:mm"
+      },
+      "MMMMd hm": {
+        "a": "M月d日 ah:mm至ah:mm",
+        "h": "M月d日 ah:mm至h:mm",
+        "m": "M月d日 ah:mm至h:mm"
+      },
+      "y hm": {
+        "a": "y年 ah:mm至ah:mm",
+        "h": "y年 ah:mm至h:mm",
+        "m": "y年 ah:mm至h:mm"
+      },
+      "yM hm": {
+        "a": "y/M ah:mm至ah:mm",
+        "h": "y/M ah:mm至h:mm",
+        "m": "y/M ah:mm至h:mm"
+      },
+      "yMd hm": {
+        "a": "y/M/d ah:mm至ah:mm",
+        "h": "y/M/d ah:mm至h:mm",
+        "m": "y/M/d ah:mm至h:mm"
+      },
+      "yMEd hm": {
+        "a": "y/M/dE ah:mm至ah:mm",
+        "h": "y/M/dE ah:mm至h:mm",
+        "m": "y/M/dE ah:mm至h:mm"
+      },
+      "yMEEEEd hm": {
+        "a": "y年M月d日EEEE ah:mm至ah:mm",
+        "h": "y年M月d日EEEE ah:mm至h:mm",
+        "m": "y年M月d日EEEE ah:mm至h:mm"
+      },
+      "yMM hm": {
+        "a": "y年M月 ah:mm至ah:mm",
+        "h": "y年M月 ah:mm至h:mm",
+        "m": "y年M月 ah:mm至h:mm"
+      },
+      "yMMM hm": {
+        "a": "y年M月 ah:mm至ah:mm",
+        "h": "y年M月 ah:mm至h:mm",
+        "m": "y年M月 ah:mm至h:mm"
+      },
+      "yMMMd hm": {
+        "a": "y年M月d日 ah:mm至ah:mm",
+        "h": "y年M月d日 ah:mm至h:mm",
+        "m": "y年M月d日 ah:mm至h:mm"
+      },
+      "yMMMEd hm": {
+        "a": "y年M月d日E ah:mm至ah:mm",
+        "h": "y年M月d日E ah:mm至h:mm",
+        "m": "y年M月d日E ah:mm至h:mm"
+      },
+      "yMMMM hm": {
+        "a": "y年M月 ah:mm至ah:mm",
+        "h": "y年M月 ah:mm至h:mm",
+        "m": "y年M月 ah:mm至h:mm"
+      },
+      "y年M月d日EEEE Hm": {
+        "H": "y年M月d日EEEE HH:mm–HH:mm",
+        "m": "y年M月d日EEEE HH:mm–HH:mm"
+      },
+      "y年M月d日 Hm": {
+        "H": "y年M月d日 HH:mm–HH:mm",
+        "m": "y年M月d日 HH:mm–HH:mm"
+      },
+      "y/M/d Hm": {
+        "H": "y/M/d HH:mm–HH:mm",
+        "m": "y/M/d HH:mm–HH:mm"
+      },
+      "d Hm": {
+        "H": "d日 HH:mm–HH:mm",
+        "m": "d日 HH:mm–HH:mm"
+      },
+      "E Hm": {
+        "H": "ccc HH:mm–HH:mm",
+        "m": "ccc HH:mm–HH:mm"
+      },
+      "Ed Hm": {
+        "H": "d日E HH:mm–HH:mm",
+        "m": "d日E HH:mm–HH:mm"
+      },
+      "Gy Hm": {
+        "H": "Gy年 HH:mm–HH:mm",
+        "m": "Gy年 HH:mm–HH:mm"
+      },
+      "GyM Hm": {
+        "H": "Gy年M月 HH:mm–HH:mm",
+        "m": "Gy年M月 HH:mm–HH:mm"
+      },
+      "GyMd Hm": {
+        "H": "Gy-MM-dd HH:mm–HH:mm",
+        "m": "Gy-MM-dd HH:mm–HH:mm"
+      },
+      "GyMEd Hm": {
+        "H": "Gy-MM-ddE HH:mm–HH:mm",
+        "m": "Gy-MM-ddE HH:mm–HH:mm"
+      },
+      "GyMMM Hm": {
+        "H": "Gy年M月 HH:mm–HH:mm",
+        "m": "Gy年M月 HH:mm–HH:mm"
+      },
+      "GyMMMd Hm": {
+        "H": "Gy年M月d日 HH:mm–HH:mm",
+        "m": "Gy年M月d日 HH:mm–HH:mm"
+      },
+      "GyMMMEd Hm": {
+        "H": "Gy年M月d日E HH:mm–HH:mm",
+        "m": "Gy年M月d日E HH:mm–HH:mm"
+      },
+      "M Hm": {
+        "H": "M月 HH:mm–HH:mm",
+        "m": "M月 HH:mm–HH:mm"
+      },
+      "Md Hm": {
+        "H": "M/d HH:mm–HH:mm",
+        "m": "M/d HH:mm–HH:mm"
+      },
+      "MEd Hm": {
+        "H": "M/dE HH:mm–HH:mm",
+        "m": "M/dE HH:mm–HH:mm"
+      },
+      "MMdd Hm": {
+        "H": "MM/dd HH:mm–HH:mm",
+        "m": "MM/dd HH:mm–HH:mm"
+      },
+      "MMM Hm": {
+        "H": "LLL HH:mm–HH:mm",
+        "m": "LLL HH:mm–HH:mm"
+      },
+      "MMMd Hm": {
+        "H": "M月d日 HH:mm–HH:mm",
+        "m": "M月d日 HH:mm–HH:mm"
+      },
+      "MMMEd Hm": {
+        "H": "M月d日E HH:mm–HH:mm",
+        "m": "M月d日E HH:mm–HH:mm"
+      },
+      "MMMMd Hm": {
+        "H": "M月d日 HH:mm–HH:mm",
+        "m": "M月d日 HH:mm–HH:mm"
+      },
+      "y Hm": {
+        "H": "y年 HH:mm–HH:mm",
+        "m": "y年 HH:mm–HH:mm"
+      },
+      "yM Hm": {
+        "H": "y/M HH:mm–HH:mm",
+        "m": "y/M HH:mm–HH:mm"
+      },
+      "yMd Hm": {
+        "H": "y/M/d HH:mm–HH:mm",
+        "m": "y/M/d HH:mm–HH:mm"
+      },
+      "yMEd Hm": {
+        "H": "y/M/dE HH:mm–HH:mm",
+        "m": "y/M/dE HH:mm–HH:mm"
+      },
+      "yMEEEEd Hm": {
+        "H": "y年M月d日EEEE HH:mm–HH:mm",
+        "m": "y年M月d日EEEE HH:mm–HH:mm"
+      },
+      "yMM Hm": {
+        "H": "y年M月 HH:mm–HH:mm",
+        "m": "y年M月 HH:mm–HH:mm"
+      },
+      "yMMM Hm": {
+        "H": "y年M月 HH:mm–HH:mm",
+        "m": "y年M月 HH:mm–HH:mm"
+      },
+      "yMMMd Hm": {
+        "H": "y年M月d日 HH:mm–HH:mm",
+        "m": "y年M月d日 HH:mm–HH:mm"
+      },
+      "yMMMEd Hm": {
+        "H": "y年M月d日E HH:mm–HH:mm",
+        "m": "y年M月d日E HH:mm–HH:mm"
+      },
+      "yMMMM Hm": {
+        "H": "y年M月 HH:mm–HH:mm",
+        "m": "y年M月 HH:mm–HH:mm"
+      },
+      "y年M月d日EEEE hmv": {
+        "a": "y年M月d日EEEE vah:mm至ah:mm",
+        "h": "y年M月d日EEEE vah:mm至h:mm",
+        "m": "y年M月d日EEEE vah:mm至h:mm"
+      },
+      "y年M月d日 hmv": {
+        "a": "y年M月d日 vah:mm至ah:mm",
+        "h": "y年M月d日 vah:mm至h:mm",
+        "m": "y年M月d日 vah:mm至h:mm"
+      },
+      "y/M/d hmv": {
+        "a": "y/M/d vah:mm至ah:mm",
+        "h": "y/M/d vah:mm至h:mm",
+        "m": "y/M/d vah:mm至h:mm"
+      },
+      "d hmv": {
+        "a": "d日 vah:mm至ah:mm",
+        "h": "d日 vah:mm至h:mm",
+        "m": "d日 vah:mm至h:mm"
+      },
+      "E hmv": {
+        "a": "ccc vah:mm至ah:mm",
+        "h": "ccc vah:mm至h:mm",
+        "m": "ccc vah:mm至h:mm"
+      },
+      "Ed hmv": {
+        "a": "d日E vah:mm至ah:mm",
+        "h": "d日E vah:mm至h:mm",
+        "m": "d日E vah:mm至h:mm"
+      },
+      "Gy hmv": {
+        "a": "Gy年 vah:mm至ah:mm",
+        "h": "Gy年 vah:mm至h:mm",
+        "m": "Gy年 vah:mm至h:mm"
+      },
+      "GyM hmv": {
+        "a": "Gy年M月 vah:mm至ah:mm",
+        "h": "Gy年M月 vah:mm至h:mm",
+        "m": "Gy年M月 vah:mm至h:mm"
+      },
+      "GyMd hmv": {
+        "a": "Gy-MM-dd vah:mm至ah:mm",
+        "h": "Gy-MM-dd vah:mm至h:mm",
+        "m": "Gy-MM-dd vah:mm至h:mm"
+      },
+      "GyMEd hmv": {
+        "a": "Gy-MM-ddE vah:mm至ah:mm",
+        "h": "Gy-MM-ddE vah:mm至h:mm",
+        "m": "Gy-MM-ddE vah:mm至h:mm"
+      },
+      "GyMMM hmv": {
+        "a": "Gy年M月 vah:mm至ah:mm",
+        "h": "Gy年M月 vah:mm至h:mm",
+        "m": "Gy年M月 vah:mm至h:mm"
+      },
+      "GyMMMd hmv": {
+        "a": "Gy年M月d日 vah:mm至ah:mm",
+        "h": "Gy年M月d日 vah:mm至h:mm",
+        "m": "Gy年M月d日 vah:mm至h:mm"
+      },
+      "GyMMMEd hmv": {
+        "a": "Gy年M月d日E vah:mm至ah:mm",
+        "h": "Gy年M月d日E vah:mm至h:mm",
+        "m": "Gy年M月d日E vah:mm至h:mm"
+      },
+      "M hmv": {
+        "a": "M月 vah:mm至ah:mm",
+        "h": "M月 vah:mm至h:mm",
+        "m": "M月 vah:mm至h:mm"
+      },
+      "Md hmv": {
+        "a": "M/d vah:mm至ah:mm",
+        "h": "M/d vah:mm至h:mm",
+        "m": "M/d vah:mm至h:mm"
+      },
+      "MEd hmv": {
+        "a": "M/dE vah:mm至ah:mm",
+        "h": "M/dE vah:mm至h:mm",
+        "m": "M/dE vah:mm至h:mm"
+      },
+      "MMdd hmv": {
+        "a": "MM/dd vah:mm至ah:mm",
+        "h": "MM/dd vah:mm至h:mm",
+        "m": "MM/dd vah:mm至h:mm"
+      },
+      "MMM hmv": {
+        "a": "LLL vah:mm至ah:mm",
+        "h": "LLL vah:mm至h:mm",
+        "m": "LLL vah:mm至h:mm"
+      },
+      "MMMd hmv": {
+        "a": "M月d日 vah:mm至ah:mm",
+        "h": "M月d日 vah:mm至h:mm",
+        "m": "M月d日 vah:mm至h:mm"
+      },
+      "MMMEd hmv": {
+        "a": "M月d日E vah:mm至ah:mm",
+        "h": "M月d日E vah:mm至h:mm",
+        "m": "M月d日E vah:mm至h:mm"
+      },
+      "MMMMd hmv": {
+        "a": "M月d日 vah:mm至ah:mm",
+        "h": "M月d日 vah:mm至h:mm",
+        "m": "M月d日 vah:mm至h:mm"
+      },
+      "y hmv": {
+        "a": "y年 vah:mm至ah:mm",
+        "h": "y年 vah:mm至h:mm",
+        "m": "y年 vah:mm至h:mm"
+      },
+      "yM hmv": {
+        "a": "y/M vah:mm至ah:mm",
+        "h": "y/M vah:mm至h:mm",
+        "m": "y/M vah:mm至h:mm"
+      },
+      "yMd hmv": {
+        "a": "y/M/d vah:mm至ah:mm",
+        "h": "y/M/d vah:mm至h:mm",
+        "m": "y/M/d vah:mm至h:mm"
+      },
+      "yMEd hmv": {
+        "a": "y/M/dE vah:mm至ah:mm",
+        "h": "y/M/dE vah:mm至h:mm",
+        "m": "y/M/dE vah:mm至h:mm"
+      },
+      "yMEEEEd hmv": {
+        "a": "y年M月d日EEEE vah:mm至ah:mm",
+        "h": "y年M月d日EEEE vah:mm至h:mm",
+        "m": "y年M月d日EEEE vah:mm至h:mm"
+      },
+      "yMM hmv": {
+        "a": "y年M月 vah:mm至ah:mm",
+        "h": "y年M月 vah:mm至h:mm",
+        "m": "y年M月 vah:mm至h:mm"
+      },
+      "yMMM hmv": {
+        "a": "y年M月 vah:mm至ah:mm",
+        "h": "y年M月 vah:mm至h:mm",
+        "m": "y年M月 vah:mm至h:mm"
+      },
+      "yMMMd hmv": {
+        "a": "y年M月d日 vah:mm至ah:mm",
+        "h": "y年M月d日 vah:mm至h:mm",
+        "m": "y年M月d日 vah:mm至h:mm"
+      },
+      "yMMMEd hmv": {
+        "a": "y年M月d日E vah:mm至ah:mm",
+        "h": "y年M月d日E vah:mm至h:mm",
+        "m": "y年M月d日E vah:mm至h:mm"
+      },
+      "yMMMM hmv": {
+        "a": "y年M月 vah:mm至ah:mm",
+        "h": "y年M月 vah:mm至h:mm",
+        "m": "y年M月 vah:mm至h:mm"
+      },
+      "y年M月d日EEEE Hmv": {
+        "H": "y年M月d日EEEE v HH:mm–HH:mm",
+        "m": "y年M月d日EEEE v HH:mm–HH:mm"
+      },
+      "y年M月d日 Hmv": {
+        "H": "y年M月d日 v HH:mm–HH:mm",
+        "m": "y年M月d日 v HH:mm–HH:mm"
+      },
+      "y/M/d Hmv": {
+        "H": "y/M/d v HH:mm–HH:mm",
+        "m": "y/M/d v HH:mm–HH:mm"
+      },
+      "d Hmv": {
+        "H": "d日 v HH:mm–HH:mm",
+        "m": "d日 v HH:mm–HH:mm"
+      },
+      "E Hmv": {
+        "H": "ccc v HH:mm–HH:mm",
+        "m": "ccc v HH:mm–HH:mm"
+      },
+      "Ed Hmv": {
+        "H": "d日E v HH:mm–HH:mm",
+        "m": "d日E v HH:mm–HH:mm"
+      },
+      "Gy Hmv": {
+        "H": "Gy年 v HH:mm–HH:mm",
+        "m": "Gy年 v HH:mm–HH:mm"
+      },
+      "GyM Hmv": {
+        "H": "Gy年M月 v HH:mm–HH:mm",
+        "m": "Gy年M月 v HH:mm–HH:mm"
+      },
+      "GyMd Hmv": {
+        "H": "Gy-MM-dd v HH:mm–HH:mm",
+        "m": "Gy-MM-dd v HH:mm–HH:mm"
+      },
+      "GyMEd Hmv": {
+        "H": "Gy-MM-ddE v HH:mm–HH:mm",
+        "m": "Gy-MM-ddE v HH:mm–HH:mm"
+      },
+      "GyMMM Hmv": {
+        "H": "Gy年M月 v HH:mm–HH:mm",
+        "m": "Gy年M月 v HH:mm–HH:mm"
+      },
+      "GyMMMd Hmv": {
+        "H": "Gy年M月d日 v HH:mm–HH:mm",
+        "m": "Gy年M月d日 v HH:mm–HH:mm"
+      },
+      "GyMMMEd Hmv": {
+        "H": "Gy年M月d日E v HH:mm–HH:mm",
+        "m": "Gy年M月d日E v HH:mm–HH:mm"
+      },
+      "M Hmv": {
+        "H": "M月 v HH:mm–HH:mm",
+        "m": "M月 v HH:mm–HH:mm"
+      },
+      "Md Hmv": {
+        "H": "M/d v HH:mm–HH:mm",
+        "m": "M/d v HH:mm–HH:mm"
+      },
+      "MEd Hmv": {
+        "H": "M/dE v HH:mm–HH:mm",
+        "m": "M/dE v HH:mm–HH:mm"
+      },
+      "MMdd Hmv": {
+        "H": "MM/dd v HH:mm–HH:mm",
+        "m": "MM/dd v HH:mm–HH:mm"
+      },
+      "MMM Hmv": {
+        "H": "LLL v HH:mm–HH:mm",
+        "m": "LLL v HH:mm–HH:mm"
+      },
+      "MMMd Hmv": {
+        "H": "M月d日 v HH:mm–HH:mm",
+        "m": "M月d日 v HH:mm–HH:mm"
+      },
+      "MMMEd Hmv": {
+        "H": "M月d日E v HH:mm–HH:mm",
+        "m": "M月d日E v HH:mm–HH:mm"
+      },
+      "MMMMd Hmv": {
+        "H": "M月d日 v HH:mm–HH:mm",
+        "m": "M月d日 v HH:mm–HH:mm"
+      },
+      "y Hmv": {
+        "H": "y年 v HH:mm–HH:mm",
+        "m": "y年 v HH:mm–HH:mm"
+      },
+      "yM Hmv": {
+        "H": "y/M v HH:mm–HH:mm",
+        "m": "y/M v HH:mm–HH:mm"
+      },
+      "yMd Hmv": {
+        "H": "y/M/d v HH:mm–HH:mm",
+        "m": "y/M/d v HH:mm–HH:mm"
+      },
+      "yMEd Hmv": {
+        "H": "y/M/dE v HH:mm–HH:mm",
+        "m": "y/M/dE v HH:mm–HH:mm"
+      },
+      "yMEEEEd Hmv": {
+        "H": "y年M月d日EEEE v HH:mm–HH:mm",
+        "m": "y年M月d日EEEE v HH:mm–HH:mm"
+      },
+      "yMM Hmv": {
+        "H": "y年M月 v HH:mm–HH:mm",
+        "m": "y年M月 v HH:mm–HH:mm"
+      },
+      "yMMM Hmv": {
+        "H": "y年M月 v HH:mm–HH:mm",
+        "m": "y年M月 v HH:mm–HH:mm"
+      },
+      "yMMMd Hmv": {
+        "H": "y年M月d日 v HH:mm–HH:mm",
+        "m": "y年M月d日 v HH:mm–HH:mm"
+      },
+      "yMMMEd Hmv": {
+        "H": "y年M月d日E v HH:mm–HH:mm",
+        "m": "y年M月d日E v HH:mm–HH:mm"
+      },
+      "yMMMM Hmv": {
+        "H": "y年M月 v HH:mm–HH:mm",
+        "m": "y年M月 v HH:mm–HH:mm"
+      },
+      "y年M月d日EEEE hv": {
+        "a": "y年M月d日EEEE vah时至ah时",
+        "h": "y年M月d日EEEE vah时至h时"
+      },
+      "y年M月d日 hv": {
+        "a": "y年M月d日 vah时至ah时",
+        "h": "y年M月d日 vah时至h时"
+      },
+      "y/M/d hv": {
+        "a": "y/M/d vah时至ah时",
+        "h": "y/M/d vah时至h时"
+      },
+      "d hv": {
+        "a": "d日 vah时至ah时",
+        "h": "d日 vah时至h时"
+      },
+      "E hv": {
+        "a": "ccc vah时至ah时",
+        "h": "ccc vah时至h时"
+      },
+      "Ed hv": {
+        "a": "d日E vah时至ah时",
+        "h": "d日E vah时至h时"
+      },
+      "Gy hv": {
+        "a": "Gy年 vah时至ah时",
+        "h": "Gy年 vah时至h时"
+      },
+      "GyM hv": {
+        "a": "Gy年M月 vah时至ah时",
+        "h": "Gy年M月 vah时至h时"
+      },
+      "GyMd hv": {
+        "a": "Gy-MM-dd vah时至ah时",
+        "h": "Gy-MM-dd vah时至h时"
+      },
+      "GyMEd hv": {
+        "a": "Gy-MM-ddE vah时至ah时",
+        "h": "Gy-MM-ddE vah时至h时"
+      },
+      "GyMMM hv": {
+        "a": "Gy年M月 vah时至ah时",
+        "h": "Gy年M月 vah时至h时"
+      },
+      "GyMMMd hv": {
+        "a": "Gy年M月d日 vah时至ah时",
+        "h": "Gy年M月d日 vah时至h时"
+      },
+      "GyMMMEd hv": {
+        "a": "Gy年M月d日E vah时至ah时",
+        "h": "Gy年M月d日E vah时至h时"
+      },
+      "M hv": {
+        "a": "M月 vah时至ah时",
+        "h": "M月 vah时至h时"
+      },
+      "Md hv": {
+        "a": "M/d vah时至ah时",
+        "h": "M/d vah时至h时"
+      },
+      "MEd hv": {
+        "a": "M/dE vah时至ah时",
+        "h": "M/dE vah时至h时"
+      },
+      "MMdd hv": {
+        "a": "MM/dd vah时至ah时",
+        "h": "MM/dd vah时至h时"
+      },
+      "MMM hv": {
+        "a": "LLL vah时至ah时",
+        "h": "LLL vah时至h时"
+      },
+      "MMMd hv": {
+        "a": "M月d日 vah时至ah时",
+        "h": "M月d日 vah时至h时"
+      },
+      "MMMEd hv": {
+        "a": "M月d日E vah时至ah时",
+        "h": "M月d日E vah时至h时"
+      },
+      "MMMMd hv": {
+        "a": "M月d日 vah时至ah时",
+        "h": "M月d日 vah时至h时"
+      },
+      "y hv": {
+        "a": "y年 vah时至ah时",
+        "h": "y年 vah时至h时"
+      },
+      "yM hv": {
+        "a": "y/M vah时至ah时",
+        "h": "y/M vah时至h时"
+      },
+      "yMd hv": {
+        "a": "y/M/d vah时至ah时",
+        "h": "y/M/d vah时至h时"
+      },
+      "yMEd hv": {
+        "a": "y/M/dE vah时至ah时",
+        "h": "y/M/dE vah时至h时"
+      },
+      "yMEEEEd hv": {
+        "a": "y年M月d日EEEE vah时至ah时",
+        "h": "y年M月d日EEEE vah时至h时"
+      },
+      "yMM hv": {
+        "a": "y年M月 vah时至ah时",
+        "h": "y年M月 vah时至h时"
+      },
+      "yMMM hv": {
+        "a": "y年M月 vah时至ah时",
+        "h": "y年M月 vah时至h时"
+      },
+      "yMMMd hv": {
+        "a": "y年M月d日 vah时至ah时",
+        "h": "y年M月d日 vah时至h时"
+      },
+      "yMMMEd hv": {
+        "a": "y年M月d日E vah时至ah时",
+        "h": "y年M月d日E vah时至h时"
+      },
+      "yMMMM hv": {
+        "a": "y年M月 vah时至ah时",
+        "h": "y年M月 vah时至h时"
+      },
+      "y年M月d日EEEE Hv": {
+        "H": "y年M月d日EEEE v HH–HH"
+      },
+      "y年M月d日 Hv": {
+        "H": "y年M月d日 v HH–HH"
+      },
+      "y/M/d Hv": {
+        "H": "y/M/d v HH–HH"
+      },
+      "d Hv": {
+        "H": "d日 v HH–HH"
+      },
+      "E Hv": {
+        "H": "ccc v HH–HH"
+      },
+      "Ed Hv": {
+        "H": "d日E v HH–HH"
+      },
+      "Gy Hv": {
+        "H": "Gy年 v HH–HH"
+      },
+      "GyM Hv": {
+        "H": "Gy年M月 v HH–HH"
+      },
+      "GyMd Hv": {
+        "H": "Gy-MM-dd v HH–HH"
+      },
+      "GyMEd Hv": {
+        "H": "Gy-MM-ddE v HH–HH"
+      },
+      "GyMMM Hv": {
+        "H": "Gy年M月 v HH–HH"
+      },
+      "GyMMMd Hv": {
+        "H": "Gy年M月d日 v HH–HH"
+      },
+      "GyMMMEd Hv": {
+        "H": "Gy年M月d日E v HH–HH"
+      },
+      "M Hv": {
+        "H": "M月 v HH–HH"
+      },
+      "Md Hv": {
+        "H": "M/d v HH–HH"
+      },
+      "MEd Hv": {
+        "H": "M/dE v HH–HH"
+      },
+      "MMdd Hv": {
+        "H": "MM/dd v HH–HH"
+      },
+      "MMM Hv": {
+        "H": "LLL v HH–HH"
+      },
+      "MMMd Hv": {
+        "H": "M月d日 v HH–HH"
+      },
+      "MMMEd Hv": {
+        "H": "M月d日E v HH–HH"
+      },
+      "MMMMd Hv": {
+        "H": "M月d日 v HH–HH"
+      },
+      "y Hv": {
+        "H": "y年 v HH–HH"
+      },
+      "yM Hv": {
+        "H": "y/M v HH–HH"
+      },
+      "yMd Hv": {
+        "H": "y/M/d v HH–HH"
+      },
+      "yMEd Hv": {
+        "H": "y/M/dE v HH–HH"
+      },
+      "yMEEEEd Hv": {
+        "H": "y年M月d日EEEE v HH–HH"
+      },
+      "yMM Hv": {
+        "H": "y年M月 v HH–HH"
+      },
+      "yMMM Hv": {
+        "H": "y年M月 v HH–HH"
+      },
+      "yMMMd Hv": {
+        "H": "y年M月d日 v HH–HH"
+      },
+      "yMMMEd Hv": {
+        "H": "y年M月d日E v HH–HH"
+      },
+      "yMMMM Hv": {
+        "H": "y年M月 v HH–HH"
       }
     },
     "hourCycle": "h23",


### PR DESCRIPTION
### TL;DR

Fixed date range formatting to avoid duplicating dates when formatting time ranges on the same day.

### What changed?

- Enhanced the date extraction script to properly handle interval formats according to the TR35 specification
- Added support for synthesizing interval formats for combined date+time skeletons
- Implemented logic to use time interval patterns with date patterns when formatting ranges on the same day
- Added test case for issue #4535 to verify the fix works correctly

### How to test?

Run the new test case that verifies a date range on the same day with different times:

```javascript
const dtf = new DateTimeFormat('en-GB', {
  weekday: 'short',
  year: 'numeric',
  month: 'short',
  day: 'numeric',
  hour: 'numeric',
  minute: 'numeric',
});

// Same day (Sept 22, 2024), different times (14:00 to 16:00)
const result = dtf.formatRange(
  new Date('2024-09-22T14:00:00'),
  new Date('2024-09-22T16:00:00')
);

// Should output: "Sun, 22 Sept 2024, 14:00–16:00" (date appears only once)
```

### Why make this change?

Fixes issue #4535 where date ranges on the same day would incorrectly duplicate the date information. This improves readability by following the CLDR standard for interval formatting, which specifies that when formatting a time range on the same day, the date should only appear once. The implementation now correctly follows the TR35 specification for interval formats.