### PR TITLE
fix(eslint-plugin-formatjs): make err node reporting more accurate

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "plugins": ["import", "typescript", "react", "jsx-a11y"],
+  "categories": {
+    "correctness": "off"
+  },
+  "env": {
+    "builtin": true,
+    "es2026": true,
+    "browser": true
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -58,5 +58,8 @@
   },
   "[rust]": {
     "editor.defaultFormatter": "rust-lang.rust-analyzer"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "vscode.json-language-features"
   }
 }

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -639,7 +639,7 @@
         "bzlTransitiveDigest": "u2i6cw9UufcXbPuESBB66WdqYKm1KTFsDORyv0HawHo=",
         "usagesDigest": "tsxRjH5DN8xUnGoUELCp/xuIp04EwwlFAtYpnGb6Y+4=",
         "recordedFileInputs": {
-          "@@//package.json": "255208c293a86c4d044a65d790fec4325365feb4c0e68d4f72a9fbbbf4aabc5d"
+          "@@//package.json": "da3d59e45c52be8e8225be63c4ca63a47fac454a90c67c73587ba3d861bd3850"
         },
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "karma:local": "bazel test :karma",
     "prepare": "husky && syncpack fix-mismatches && syncpack format",
     "prerelease": "HUSKY=0 lerna version --yes --no-private",
-    "test": "syncpack lint && oxlint && bazel test //...",
+    "test": "syncpack lint && oxlint --config .oxlintrc.json && bazel test //...",
     "website": "NO_UPDATE_NOTIFIER=1 bazel run //website:serve"
   },
   "devDependencies": {
@@ -133,7 +133,7 @@
     }
   },
   "lint-staged": {
-    "**/*.{js,mjs,cjs,jsx,ts,mts,cts,tsx,vue,astro,svelte}": "oxlint"
+    "**/*.{js,mjs,cjs,jsx,ts,mts,cts,tsx,vue,astro,svelte}": "oxlint --config .oxlintrc.json"
   },
   "packageManager": "pnpm@10.26.2",
   "pnpm": {

--- a/packages/eslint-plugin-formatjs/BUILD.bazel
+++ b/packages/eslint-plugin-formatjs/BUILD.bazel
@@ -24,6 +24,7 @@ npm_package(
 SRCS = glob(["rules/*.ts"]) + [
     "index.ts",
     "util.ts",
+    "messages.ts",
     "context-compat.ts",
     "package.json",
 ]

--- a/packages/eslint-plugin-formatjs/integration-tests/.oxlintrc.json
+++ b/packages/eslint-plugin-formatjs/integration-tests/.oxlintrc.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "jsPlugins": ["eslint-plugin-formatjs"],
+  "rules": {
+    "formatjs/enforce-id": [
+      "error",
+      {
+        "idInterpolationPattern": "[sha512:contenthash:base64:10]"
+      }
+    ],
+    "formatjs/no-offset": "error",
+    "formatjs/enforce-default-message": ["error", "literal"],
+    "formatjs/enforce-description": ["error", "literal"],
+    "formatjs/enforce-placeholders": "error",
+    "formatjs/no-emoji": "error",
+    "formatjs/no-multiple-whitespaces": "error",
+    "formatjs/no-multiple-plurals": "error",
+    "formatjs/no-complex-selectors": [
+      "error",
+      {
+        "limit": 20
+      }
+    ],
+    "formatjs/no-useless-message": "error",
+    "formatjs/prefer-pound-in-plural": "error",
+    "formatjs/no-missing-icu-plural-one-placeholders": "error",
+    "formatjs/enforce-plural-rules": [
+      "error",
+      {
+        "one": true,
+        "other": true
+      }
+    ],
+    "formatjs/no-literal-string-in-jsx": [
+      "warn",
+      {
+        "props": {
+          "include": [["*", "{label,placeholder,title}"]]
+        }
+      }
+    ],
+    "formatjs/blocklist-elements": ["error", ["selectordinal"]]
+  }
+}

--- a/packages/eslint-plugin-formatjs/integration-tests/BUILD.bazel
+++ b/packages/eslint-plugin-formatjs/integration-tests/BUILD.bazel
@@ -1,10 +1,11 @@
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:eslint/package_json.bzl", eslint_bin = "bin")
+load("@npm//:oxlint/package_json.bzl", oxlint_bin = "bin")
 
 npm_link_all_packages()
 
 eslint_bin.eslint_test(
-    name = "lint_test",
+    name = "eslint_test",
     args = [
         "--config",
         "eslint.config.mjs",
@@ -14,6 +15,44 @@ eslint_bin.eslint_test(
     data = [
         "eslint.config.mjs",
         "fixture.js",
+        ":node_modules/eslint-plugin-formatjs",
+    ],
+    expected_exit_code = 1,
+    node_options = [
+        "--experimental-vm-modules",
+    ],
+)
+
+oxlint_bin.oxlint_test(
+    name = "oxlint_test",
+    args = [
+        "--config",
+        ".oxlintrc.json",
+        "fixture.js",
+    ],
+    chdir = package_name(),
+    data = [
+        ".oxlintrc.json",
+        "fixture.js",
+        ":node_modules/eslint-plugin-formatjs",
+    ],
+    expected_exit_code = 1,
+    node_options = [
+        "--experimental-vm-modules",
+    ],
+)
+
+oxlint_bin.oxlint_test(
+    name = "oxlint_test2",
+    args = [
+        "--config",
+        ".oxlintrc.json",
+        "fixture2.js",
+    ],
+    chdir = package_name(),
+    data = [
+        ".oxlintrc.json",
+        "fixture2.js",
         ":node_modules/eslint-plugin-formatjs",
     ],
     expected_exit_code = 1,

--- a/packages/eslint-plugin-formatjs/integration-tests/fixture2.js
+++ b/packages/eslint-plugin-formatjs/integration-tests/fixture2.js
@@ -1,0 +1,11 @@
+import {defineMessages} from 'react-intl'
+
+export const messages = defineMessages({
+  simple: {
+    defaultMessage: 'Hello, World!',
+  },
+  simple2: {
+    id: 'hello.world.2',
+    defaultMessage: 'Hello, World 2! {a',
+  },
+})

--- a/packages/eslint-plugin-formatjs/messages.ts
+++ b/packages/eslint-plugin-formatjs/messages.ts
@@ -1,0 +1,5 @@
+export type CoreMessageIds = 'parseError'
+
+export const CORE_MESSAGES: Record<CoreMessageIds, string> = {
+  parseError: `Failed to parse message string {{error}}`,
+}

--- a/packages/eslint-plugin-formatjs/rules/enforce-default-message.ts
+++ b/packages/eslint-plugin-formatjs/rules/enforce-default-message.ts
@@ -25,6 +25,7 @@ function checkNode(
     {
       message: {defaultMessage},
       messageNode,
+      messageDescriptorNode,
     },
   ] of msgs) {
     if (!defaultMessage) {
@@ -35,7 +36,7 @@ function checkNode(
         })
       } else if (!messageNode) {
         context.report({
-          node: node,
+          node: messageDescriptorNode,
           messageId: 'defaultMessage',
         })
       }

--- a/packages/eslint-plugin-formatjs/rules/enforce-description.ts
+++ b/packages/eslint-plugin-formatjs/rules/enforce-description.ts
@@ -23,6 +23,7 @@ function checkNode(
     {
       message: {description},
       descriptionNode,
+      messageDescriptorNode,
     },
   ] of msgs) {
     if (!description) {
@@ -33,7 +34,7 @@ function checkNode(
         })
       } else if (!descriptionNode) {
         context.report({
-          node: node,
+          node: messageDescriptorNode,
           messageId: 'enforceDescription',
         })
       }

--- a/packages/eslint-plugin-formatjs/rules/enforce-id.ts
+++ b/packages/eslint-plugin-formatjs/rules/enforce-id.ts
@@ -46,22 +46,26 @@ function checkNode(
       idPropNode,
       descriptionNode,
       messagePropNode,
+      messageDescriptorNode,
     },
   ] of msgs) {
     if (!idInterpolationPattern && !idPropNode) {
       context.report({
-        node,
+        node: messageDescriptorNode ?? node,
         messageId: 'enforceId',
       })
-    } else if (idInterpolationPattern) {
+      return
+    }
+
+    if (idInterpolationPattern) {
       if (!defaultMessage) {
         context.report({
-          node,
+          node: messageDescriptorNode ?? node,
           messageId: 'enforceIdDefaultMessage',
         })
       } else if (!description && descriptionNode) {
         context.report({
-          node,
+          node: messageDescriptorNode ?? node,
           messageId: 'enforceIdDescription',
         })
       } else {
@@ -76,7 +80,7 @@ function checkNode(
 
         const correctId = interpolateName(
           {
-            resourcePath: context.getFilename(),
+            resourcePath: context.filename,
           },
           idInterpolationPattern,
           {
@@ -104,7 +108,7 @@ function checkNode(
 
           const quote = quoteStyle === 'double' ? '"' : "'"
           context.report({
-            node,
+            node: idPropNode ?? messageDescriptorNode ?? node,
             messageId,
             data: messageData,
             fix(fixer) {

--- a/packages/eslint-plugin-formatjs/rules/enforce-placeholders.ts
+++ b/packages/eslint-plugin-formatjs/rules/enforce-placeholders.ts
@@ -7,8 +7,9 @@ import {TSESTree} from '@typescript-eslint/utils'
 import {RuleContext, RuleModule} from '@typescript-eslint/utils/ts-eslint'
 import {getParserServices} from '../context-compat.js'
 import {extractMessages, getSettings} from '../util.js'
+import {CORE_MESSAGES, CoreMessageIds} from '../messages.js'
 
-type MessageIds = 'parserError' | 'missingValue' | 'unusedValue'
+type MessageIds = 'missingValue' | 'unusedValue' | CoreMessageIds
 type Options = [{ignoreList: string[]}?]
 
 function collectPlaceholderNames(ast: MessageFormatElement[]): Set<string> {
@@ -99,8 +100,8 @@ function checkNode(
     } catch (e) {
       context.report({
         node: messageNode,
-        messageId: 'parserError',
-        data: {message: e instanceof Error ? e.message : String(e)},
+        messageId: 'parseError',
+        data: {error: e instanceof Error ? e.message : String(e)},
       })
       continue
     }
@@ -160,7 +161,7 @@ export const rule: RuleModule<MessageIds, Options> = {
       },
     ],
     messages: {
-      parserError: '{{message}}',
+      ...CORE_MESSAGES,
       missingValue:
         'Missing value(s) for the following placeholder(s): {{list}}.',
       unusedValue: 'Value not used by the message.',

--- a/packages/eslint-plugin-formatjs/rules/no-complex-selectors.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-complex-selectors.ts
@@ -7,12 +7,13 @@ import {TSESTree} from '@typescript-eslint/utils'
 import {RuleContext, RuleModule} from '@typescript-eslint/utils/ts-eslint'
 import {getParserServices} from '../context-compat.js'
 import {extractMessages, getSettings} from '../util.js'
+import {CORE_MESSAGES, CoreMessageIds} from '../messages.js'
 
 interface Config {
   limit: number
 }
 
-type MessageIds = 'tooComplex' | 'parserError'
+type MessageIds = 'tooComplex' | CoreMessageIds
 type Options = [Config?]
 
 function calculateComplexity(ast: MessageFormatElement[]): number {
@@ -94,8 +95,8 @@ function checkNode(
     } catch (e) {
       context.report({
         node: messageNode,
-        messageId: 'parserError',
-        data: {message: e instanceof Error ? e.message : String(e)},
+        messageId: 'parseError',
+        data: {error: e instanceof Error ? e.message : String(e)},
       })
       return
     }
@@ -145,8 +146,8 @@ Default complexity limit is 20
     ],
     fixable: 'code',
     messages: {
+      ...CORE_MESSAGES,
       tooComplex: `Message complexity is too high ({{complexity}} vs limit at {{limit}})`,
-      parserError: '{{message}}',
     },
   },
   defaultOptions: [{limit: 20}],

--- a/packages/eslint-plugin-formatjs/rules/no-id.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-id.ts
@@ -28,7 +28,7 @@ function checkNode(
         node: idPropNode,
         messageId: 'noId',
         fix(fixer) {
-          const src = context.getSourceCode()
+          const src = context.sourceCode
           const token = src.getTokenAfter(idPropNode)
           const fixes = [fixer.remove(idPropNode)]
           if (token && !isComment(token) && token?.value === ',') {

--- a/packages/eslint-plugin-formatjs/rules/no-invalid-icu.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-invalid-icu.ts
@@ -3,13 +3,12 @@ import {TSESTree} from '@typescript-eslint/utils'
 import {RuleContext, RuleModule} from '@typescript-eslint/utils/ts-eslint'
 import {getParserServices} from '../context-compat.js'
 import {extractMessages, getSettings} from '../util.js'
-
-type MessageIds = 'icuError'
+import {CoreMessageIds, CORE_MESSAGES} from '../messages.js'
 
 export const name = 'no-invalid-icu'
 
 function checkNode(
-  context: RuleContext<MessageIds, unknown[]>,
+  context: RuleContext<CoreMessageIds, unknown[]>,
   node: TSESTree.Node
 ) {
   const settings = getSettings(context)
@@ -34,17 +33,18 @@ function checkNode(
         ignoreTag: settings.ignoreTag,
       })
     } catch (e) {
-      const msg = e instanceof Error ? e.message : e
       context.report({
         node: messageNode,
-        messageId: 'icuError',
-        data: {message: `Error parsing ICU string: ${msg}`},
+        messageId: 'parseError',
+        data: {
+          error: (e as Error).message,
+        },
       })
     }
   }
 }
 
-export const rule: RuleModule<MessageIds> = {
+export const rule: RuleModule<CoreMessageIds> = {
   meta: {
     type: 'problem',
     docs: {
@@ -52,9 +52,7 @@ export const rule: RuleModule<MessageIds> = {
     },
     fixable: 'code',
     schema: [],
-    messages: {
-      icuError: 'Invalid ICU Message format: {{message}}',
-    },
+    messages: CORE_MESSAGES,
   },
   defaultOptions: [],
   create(context) {

--- a/packages/eslint-plugin-formatjs/rules/no-literal-string-in-jsx.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-literal-string-in-jsx.ts
@@ -177,7 +177,7 @@ export const rule: RuleModule<MessageIds, Options> = {
           (node.quasis.length > 1 || node.quasis[0].value.raw.length > 0))
       ) {
         context.report({
-          node: node,
+          node,
           messageId: 'noLiteralStringInJsx',
         })
       } else if (node.type === 'BinaryExpression' && node.operator === '+') {

--- a/packages/eslint-plugin-formatjs/rules/no-literal-string-in-object.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-literal-string-in-object.ts
@@ -97,7 +97,7 @@ function checkPropertyValue(
       (node.quasis.length > 1 || node.quasis[0].value.raw.length > 0))
   ) {
     context.report({
-      node: node,
+      node,
       messageId: 'untranslatedProperty',
       data: {
         propertyKey: propertyKey,

--- a/packages/eslint-plugin-formatjs/rules/no-multiple-whitespaces.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-multiple-whitespaces.ts
@@ -8,8 +8,9 @@ import {TSESTree} from '@typescript-eslint/utils'
 import {RuleContext, RuleModule} from '@typescript-eslint/utils/ts-eslint'
 import {getParserServices} from '../context-compat.js'
 import {extractMessages, getSettings, patchMessage} from '../util.js'
+import {CORE_MESSAGES, CoreMessageIds} from '../messages.js'
 
-type MessageIds = 'noMultipleWhitespaces' | 'parserError'
+type MessageIds = 'noMultipleWhitespaces' | CoreMessageIds
 
 function isAstValid(ast: MessageFormatElement[]): boolean {
   for (const element of ast) {
@@ -119,8 +120,8 @@ function checkNode(
     } catch (e) {
       context.report({
         node: messageNode,
-        messageId: 'parserError',
-        data: {message: e instanceof Error ? e.message : String(e)},
+        messageId: 'parseError',
+        data: {error: e instanceof Error ? e.message : String(e)},
       })
       return
     }
@@ -150,8 +151,8 @@ export const rule: RuleModule<MessageIds> = {
       url: 'https://formatjs.github.io/docs/tooling/linter#no-multiple-whitespaces',
     },
     messages: {
+      ...CORE_MESSAGES,
       noMultipleWhitespaces: 'Multiple consecutive whitespaces are not allowed',
-      parserError: '{{message}}',
     },
     fixable: 'code',
     schema: [],

--- a/packages/eslint-plugin-formatjs/rules/prefer-pound-in-plural.ts
+++ b/packages/eslint-plugin-formatjs/rules/prefer-pound-in-plural.ts
@@ -9,8 +9,9 @@ import {RuleContext, RuleModule} from '@typescript-eslint/utils/ts-eslint'
 import MagicString from 'magic-string'
 import {getParserServices} from '../context-compat.js'
 import {extractMessages, getSettings, patchMessage} from '../util.js'
+import {CORE_MESSAGES, CoreMessageIds} from '../messages.js'
 
-type MessageIds = 'preferPoundInPlurals' | 'parseError'
+type MessageIds = 'preferPoundInPlurals' | CoreMessageIds
 
 function verifyAst(
   context: RuleContext<MessageIds, unknown[]>,
@@ -208,7 +209,7 @@ function checkNode(
       context.report({
         node: messageNode,
         messageId: 'parseError',
-        data: {message: e instanceof Error ? e.message : String(e)},
+        data: {error: e instanceof Error ? e.message : String(e)},
       })
       return
     }
@@ -228,9 +229,9 @@ export const rule: RuleModule<MessageIds> = {
       url: 'https://formatjs.github.io/docs/tooling/linter#prefer-pound-in-plurals',
     },
     messages: {
+      ...CORE_MESSAGES,
       preferPoundInPlurals:
         'Prefer using # to reference the count in the plural argument instead of repeating the argument.',
-      parseError: '{{message}}',
     },
     fixable: 'code',
     schema: [],

--- a/packages/eslint-plugin-formatjs/tests/enforce-placeholders.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/enforce-placeholders.test.ts
@@ -210,9 +210,9 @@ ruleTester.run(name, rule, {
       `,
       errors: [
         {
-          messageId: 'parserError',
+          messageId: 'parseError',
           data: {
-            message: 'EXPECT_ARGUMENT_CLOSING_BRACE',
+            error: 'EXPECT_ARGUMENT_CLOSING_BRACE',
           },
         },
       ],

--- a/packages/eslint-plugin-formatjs/tests/no-complex-selectors.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/no-complex-selectors.test.ts
@@ -39,8 +39,8 @@ ruleTester.run(name, rule, {
       options: [{limit: 1}],
       errors: [
         {
-          messageId: 'parserError',
-          data: {message: 'EXPECT_ARGUMENT_CLOSING_BRACE'},
+          messageId: 'parseError',
+          data: {error: 'EXPECT_ARGUMENT_CLOSING_BRACE'},
         },
       ],
     },

--- a/packages/eslint-plugin-formatjs/tests/no-invalid-icu.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/no-invalid-icu.test.ts
@@ -111,10 +111,9 @@ ruleTester.run(name, rule, {
         })`,
       errors: [
         {
-          messageId: 'icuError',
+          messageId: 'parseError',
           data: {
-            message:
-              'Error parsing ICU string: EXPECT_PLURAL_ARGUMENT_SELECTOR',
+            error: 'EXPECT_PLURAL_ARGUMENT_SELECTOR',
           },
         },
       ],
@@ -128,8 +127,8 @@ ruleTester.run(name, rule, {
         )`,
       errors: [
         {
-          messageId: 'icuError',
-          data: {message: 'Error parsing ICU string: INVALID_ARGUMENT_TYPE'},
+          messageId: 'parseError',
+          data: {error: 'INVALID_ARGUMENT_TYPE'},
         },
       ],
     },
@@ -142,8 +141,8 @@ ruleTester.run(name, rule, {
         )`,
       errors: [
         {
-          messageId: 'icuError',
-          data: {message: 'Error parsing ICU string: INVALID_ARGUMENT_TYPE'},
+          messageId: 'parseError',
+          data: {error: 'INVALID_ARGUMENT_TYPE'},
         },
       ],
     },
@@ -156,8 +155,8 @@ ruleTester.run(name, rule, {
         )`,
       errors: [
         {
-          messageId: 'icuError',
-          data: {message: 'Error parsing ICU string: INVALID_ARGUMENT_TYPE'},
+          messageId: 'parseError',
+          data: {error: 'INVALID_ARGUMENT_TYPE'},
         },
       ],
     },

--- a/packages/eslint-plugin-formatjs/util.ts
+++ b/packages/eslint-plugin-formatjs/util.ts
@@ -1,4 +1,4 @@
-import {MessageFormatElement} from '@formatjs/icu-messageformat-parser'
+import type {MessageFormatElement} from '@formatjs/icu-messageformat-parser'
 import {TSESTree} from '@typescript-eslint/utils'
 import {RuleContext} from '@typescript-eslint/utils/ts-eslint'
 
@@ -20,6 +20,7 @@ export interface Settings {
 }
 export interface MessageDescriptorNodeInfo {
   message: MessageDescriptor
+  messageDescriptorNode: TSESTree.ObjectExpression | TSESTree.JSXOpeningElement
   messageNode?: TSESTree.Property['value'] | TSESTree.JSXAttribute['value']
   messagePropNode?: TSESTree.Property | TSESTree.JSXAttribute
   descriptionNode?: TSESTree.Property['value'] | TSESTree.JSXAttribute['value']
@@ -107,6 +108,7 @@ export function extractMessageDescriptor(
     return
   }
   const result: MessageDescriptorNodeInfo = {
+    messageDescriptorNode: node,
     message: {},
     messageNode: undefined,
     messagePropNode: undefined,
@@ -172,6 +174,7 @@ function extractMessageDescriptorFromJSXElement(
   }
   let values: TSESTree.ObjectExpression | undefined
   const result: MessageDescriptorNodeInfo = {
+    messageDescriptorNode: node,
     message: {},
     messageNode: undefined,
     messagePropNode: undefined,


### PR DESCRIPTION
### TL;DR

Add oxlint support for eslint-plugin-formatjs

### What changed?

- Added `.oxlintrc.json` configuration file at the root level
- Created a specific oxlint configuration for eslint-plugin-formatjs integration tests
- Added oxlint tests to verify the plugin works correctly with oxlint
- Refactored error handling in eslint-plugin-formatjs rules to use consistent error messages
- Added a new `messages.ts` file to centralize error message definitions
- Updated the package.json scripts to use the new oxlint configuration
- Fixed various rule implementations to better handle error cases and node references
- Added JSON formatter configuration to VSCode settings

### How to test?

1. Run `pnpm test` to verify that oxlint works with the new configuration
2. Run the integration tests for eslint-plugin-formatjs with oxlint:
   ```
   cd packages/eslint-plugin-formatjs/integration-tests
   pnpm oxlint --config .oxlintrc.json fixture.js
   ```
3. Verify that the oxlint tests pass with the expected error codes

### Why make this change?

This change adds support for oxlint, a faster JavaScript/TypeScript linter, to work with eslint-plugin-formatjs. By centralizing error messages and improving error handling, the plugin now provides more consistent feedback across different rules. This enhances the developer experience when using formatjs with oxlint instead of eslint, offering better performance while maintaining the same linting capabilities.