### PR TITLE
build: tweak builds

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,11 +1,13 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
+load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_js//npm:defs.bzl", "npm_link_package")
 load("@aspect_rules_lint//format:defs.bzl", "format_multirun")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:karma/package_json.bzl", karma_bin = "bin")
 load("@npm//:oxfmt/package_json.bzl", oxfmt = "bin")
 load("@rules_multirun//:defs.bzl", "multirun")
+load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
 
 npm_link_all_packages()
 
@@ -200,6 +202,33 @@ copy_to_bin(
     name = "tsconfig",
     srcs = ["tsconfig.json"],
     visibility = ["//visibility:public"],
+)
+
+# Generate tsconfig.json from BASE_TSCONFIG in tools/tsconfig.bzl
+genrule(
+    name = "tsconfig_generated",
+    outs = ["tsconfig.generated.json"],
+    cmd = "echo '%s' > $@" % json.encode_indent(
+        BASE_TSCONFIG,
+        indent = "  ",
+    ),
+)
+
+# Format the generated tsconfig.json with oxfmt
+genrule(
+    name = "tsconfig_formatted",
+    srcs = [":tsconfig_generated"],
+    outs = ["tsconfig.formatted.json"],
+    cmd = "cat $< | $(location :oxfmt) --stdin-filepath=$(location :tsconfig_generated) > $@",
+    tools = [":oxfmt"],
+)
+
+# Ensure tsconfig.json stays in sync with BASE_TSCONFIG
+write_source_files(
+    name = "tsconfig_sync",
+    files = {
+        "tsconfig.json": ":tsconfig_formatted",
+    },
 )
 
 # Symlink some workspaces to the root workspace, so scripts like benchmarks

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -15,7 +15,7 @@ pre-commit:
       stage_fixed: true
     lint-staged:
       glob: "**/*.{js,mjs,cjs,jsx,ts,mts,cts,tsx,vue,astro,svelte}"
-      run: oxlint --config .oxlintrc.json {staged_files}
+      run: pnpm oxlint --config .oxlintrc.json {staged_files}
       stage_fixed: true
 
 commit-msg:

--- a/packages/react-intl/BUILD.bazel
+++ b/packages/react-intl/BUILD.bazel
@@ -85,6 +85,7 @@ vitest(
     name = "unit_test",
     srcs = SRCS +
            TESTS,
+    config = "vitest.config.mjs",
     dom = True,
     deps = TEST_DEPS,
 )

--- a/packages/react-intl/examples/index.tsx
+++ b/packages/react-intl/examples/index.tsx
@@ -1,5 +1,4 @@
 import '@formatjs/intl-pluralrules/polyfill.js'
-import * as React from 'react'
 import * as ReactDOM from 'react-dom/client'
 import {bootstrapApplication} from './advanced/Advanced'
 import {App as Bug2727} from './Bug2727'

--- a/packages/react-intl/tests/unit/components/date.test.tsx
+++ b/packages/react-intl/tests/unit/components/date.test.tsx
@@ -1,5 +1,4 @@
 import {cleanup, render} from '@testing-library/react'
-import * as React from 'react'
 import {FormattedDate, FormattedDateParts, IntlShape} from '../../..'
 import {createIntl} from '../../../src/components/createIntl'
 import {mountFormattedComponentWithProvider} from '../testUtils'

--- a/packages/react-intl/tests/unit/components/dateTimeRange.test.tsx
+++ b/packages/react-intl/tests/unit/components/dateTimeRange.test.tsx
@@ -1,5 +1,4 @@
 import {cleanup, render} from '@testing-library/react'
-import * as React from 'react'
 import {FormattedDateTimeRange, IntlShape} from '../../..'
 import {createIntl} from '../../../src/components/createIntl'
 import {mountFormattedComponentWithProvider} from '../testUtils'

--- a/packages/react-intl/tests/unit/components/displayName.test.tsx
+++ b/packages/react-intl/tests/unit/components/displayName.test.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react'
 import {describe, expect, it, vi, beforeEach} from 'vitest'
 import {cleanup, render} from '@testing-library/react'
 import {FormattedDisplayName} from '../../..'

--- a/packages/react-intl/tests/unit/components/relative.test.tsx
+++ b/packages/react-intl/tests/unit/components/relative.test.tsx
@@ -1,5 +1,4 @@
 import {act, cleanup, render} from '@testing-library/react'
-import * as React from 'react'
 import {createIntl} from '../../../src/components/createIntl'
 import FormattedRelativeTime from '../../../src/components/relative'
 import type {IntlConfig} from '../../../src/types'

--- a/packages/react-intl/tests/unit/components/useIntl.test.tsx
+++ b/packages/react-intl/tests/unit/components/useIntl.test.tsx
@@ -1,5 +1,4 @@
 import {cleanup, render} from '@testing-library/react'
-import * as React from 'react'
 import {IntlProvider} from '../../..'
 import useIntl from '../../../src/components/useIntl'
 import {describe, expect, it, vi, beforeEach} from 'vitest'

--- a/packages/react-intl/vitest.config.mjs
+++ b/packages/react-intl/vitest.config.mjs
@@ -1,0 +1,8 @@
+import {defineConfig} from 'vitest/config'
+
+export default defineConfig({
+  esbuild: {
+    jsx: 'automatic',
+    jsxDev: true,
+  },
+})

--- a/tools/tsconfig.bzl
+++ b/tools/tsconfig.bzl
@@ -1,10 +1,11 @@
 """TypeScript configuration maps for different build targets."""
 
 # Base tsconfig configuration (tsconfig.json)
+# This is the source of truth - tsconfig.json is generated from this
 BASE_TSCONFIG = {
     "compilerOptions": {
-        "module": "ESNext",
-        "moduleResolution": "Bundler",
+        "module": "esnext",
+        "moduleResolution": "bundler",
         "target": "es5",
         "lib": [
             "dom",
@@ -19,7 +20,6 @@ BASE_TSCONFIG = {
             "ES2022.Intl",
             "ESNext.Intl",
         ],
-        "baseUrl": ".",
         "declaration": True,
         "strict": True,
         "resolveJsonModule": True,
@@ -31,7 +31,7 @@ BASE_TSCONFIG = {
         "noFallthroughCasesInSwitch": True,
         "importHelpers": True,
         "isolatedDeclarations": True,
-        "jsx": "react",
+        "jsx": "react-jsx",
     },
     "exclude": [
         "packages/react-intl/example-sandboxes",

--- a/tools/vitest.bzl
+++ b/tools/vitest.bzl
@@ -17,6 +17,7 @@ def vitest(
         dom = False,
         snapshots = [],
         test_timeout = None,
+        config = None,
         **kwargs):
     """
     A rule to define a vitest target.
@@ -68,14 +69,14 @@ def vitest(
 
     vitest_bin.vitest_test(
         name = name,
-        data = srcs + deps + snapshots + fixtures,
+        data = srcs + deps + snapshots + fixtures + ([config] if config else []),
         size = size,
         flaky = flaky,
         tags = tags,
         no_copy_to_bin = no_copy_to_bin,
         args = [
             "run",
-        ] + (["--dom"] if dom else []) + (["--testTimeout ", test_timeout] if test_timeout else []),
+        ] + (["--config", "$(rootpath %s)" % config] if config else []) + (["--dom"] if dom else []) + (["--testTimeout ", test_timeout] if test_timeout else []),
         **kwargs
     )
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,11 @@
 {
   "compilerOptions": {
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "target": "es5",
+    "allowSyntheticDefaultImports": false,
+    "declaration": true,
+    "esModuleInterop": false,
+    "importHelpers": true,
+    "isolatedDeclarations": true,
+    "jsx": "react-jsx",
     "lib": [
       "dom",
       "ES2015",
@@ -16,23 +19,15 @@
       "ES2022.Intl",
       "ESNext.Intl"
     ],
-    "declaration": true,
-    "strict": true,
-    "resolveJsonModule": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "noFallthroughCasesInSwitch": true,
     "noUnusedLocals": true,
-    "esModuleInterop": false,
     "noUnusedParameters": true,
     "preserveConstEnums": true,
-    "allowSyntheticDefaultImports": false,
-    "noFallthroughCasesInSwitch": true,
-    "importHelpers": true,
-    "isolatedDeclarations": true,
-    "jsx": "react"
+    "resolveJsonModule": true,
+    "strict": true,
+    "target": "es5"
   },
-  "exclude": [
-    "packages/react-intl/example-sandboxes",
-    // Exclude any tsd tests because they can mess with normal
-    // type checking in editors.
-    "**/*.test-d.ts"
-  ]
+  "exclude": ["packages/react-intl/example-sandboxes", "**/*.test-d.ts"]
 }


### PR DESCRIPTION
### TL;DR

Updated React JSX handling to use the new JSX transform and improved TypeScript configuration management.

### What changed?

- Updated `tsconfig.json` to use `jsx: "react-jsx"` instead of `react`, enabling the new JSX transform
- Created a Vitest config for react-intl to support the automatic JSX transform
- Added a mechanism to generate `tsconfig.json` from `BASE_TSCONFIG` in `tools/tsconfig.bzl`
- Enhanced the Vitest Bazel rule to support custom config files
- Removed unnecessary React imports from test files
- Fixed oxlint command in lefthook.yml to use pnpm

### How to test?

1. Run the react-intl tests to verify they pass with the new JSX transform:
   ```
   bazel test //packages/react-intl:unit_test
   ```
2. Verify the tsconfig sync works:
   ```
   bazel run //:tsconfig_sync
   ```
3. Check that the examples still render correctly

### Why make this change?

The new JSX transform (introduced in React 17) eliminates the need to import React in every file that uses JSX. This reduces boilerplate and makes the codebase cleaner. Additionally, centralizing the TypeScript configuration in `tools/tsconfig.bzl` and generating the root `tsconfig.json` from it ensures consistency across the project.