### PR TITLE
fix(eslint-plugin-formatjs): relax eslint dep req

### DIFF
--- a/.syncpackrc.json
+++ b/.syncpackrc.json
@@ -62,6 +62,12 @@
       "pinVersion": "^5.6.0"
     },
     {
+      "label": "ESLint",
+      "dependencies": ["eslint", "@types/eslint"],
+      "packages": ["eslint-plugin-formatjs"],
+      "pinVersion": "9"
+    },
+    {
       "label": "Typescript root",
       "dependencies": ["typescript"],
       "packages": ["formatjs-repo"],

--- a/packages/eslint-plugin-formatjs/package.json
+++ b/packages/eslint-plugin-formatjs/package.json
@@ -9,7 +9,6 @@
   "dependencies": {
     "@formatjs/icu-messageformat-parser": "workspace:*",
     "@formatjs/ts-transformer": "workspace:*",
-    "@types/eslint": "^9.6.1",
     "@types/picomatch": "^4.0.0",
     "@typescript-eslint/utils": "^8.27.0",
     "magic-string": "^0.30.0",
@@ -18,7 +17,8 @@
     "unicode-emoji-utils": "^1.2.0"
   },
   "peerDependencies": {
-    "eslint": "^9.23.0"
+    "@types/eslint": "9",
+    "eslint": "9"
   },
   "bugs": "https://github.com/formatjs/formatjs/issues",
   "homepage": "https://github.com/formatjs/formatjs#readme",


### PR DESCRIPTION
### TL;DR

Move ESLint from dependencies to peerDependencies in eslint-plugin-formatjs and add version constraints.

### What changed?

- Added a new ESLint section to `.syncpackrc.json` to pin ESLint version to 9 for the eslint-plugin-formatjs package
- Moved `@types/eslint` from dependencies to peerDependencies in eslint-plugin-formatjs
- Updated peerDependencies to specify exact major version "9" for both ESLint and its types
- Removed the caret (^) from version constraints to ensure compatibility with ESLint 9

### How to test?

1. Install the eslint-plugin-formatjs package
2. Verify that it correctly requires ESLint 9 as a peer dependency
3. Ensure the plugin works correctly with ESLint 9

### Why make this change?

This change properly defines ESLint as a peer dependency rather than a direct dependency, which is the recommended pattern for ESLint plugins. It also ensures version consistency by pinning to major version 9, which helps prevent compatibility issues between the plugin and different ESLint versions.