### PR TITLE
build: remove hardcoded tsconfig golden

### DIFF
--- a/packages/babel-plugin-formatjs/BUILD.bazel
+++ b/packages/babel-plugin-formatjs/BUILD.bazel
@@ -1,8 +1,7 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
-load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "package_json_test", "ts_compile_node")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "package_json_test", "ts_compile_node")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -65,10 +64,8 @@ package_json_test(
     deps = SRC_DEPS,
 )
 
-write_source_files(
-    name = "tsconfig_json",
-    files = {"tsconfig.json": "//tools:tsconfig.golden.json"},
-)
+# Generate tsconfig.json with correct extends path
+generate_ide_tsconfig_json()
 
 copy_to_bin(
     name = "srcs",

--- a/packages/cli-lib/BUILD.bazel
+++ b/packages/cli-lib/BUILD.bazel
@@ -1,9 +1,8 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
-load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "package_json_test", "ts_compile_node")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "package_json_test", "ts_compile_node")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -83,10 +82,8 @@ vitest(
     deps = SRC_DEPS,
 )
 
-write_source_files(
-    name = "tsconfig_json",
-    files = {"tsconfig.json": "//tools:tsconfig.golden.json"},
-)
+# Generate tsconfig.json with correct extends path
+generate_ide_tsconfig_json()
 
 genrule(
     name = "bin",

--- a/packages/ecma376/BUILD.bazel
+++ b/packages/ecma376/BUILD.bazel
@@ -1,7 +1,6 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
-load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
-load("//tools:index.bzl", "package_json_test", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "package_json_test", "ts_compile")
 load("//tools:vitest.bzl", "vitest")
 
 exports_files([
@@ -38,10 +37,8 @@ ts_compile(
     deps = SRC_DEPS,
 )
 
-write_source_files(
-    name = "tsconfig_json",
-    files = {"tsconfig.json": "//tools:tsconfig.golden.json"},
-)
+# Generate tsconfig.json with correct extends path
+generate_ide_tsconfig_json()
 
 vitest(
     name = "unit_test",

--- a/packages/ecma402-abstract/BUILD.bazel
+++ b/packages/ecma402-abstract/BUILD.bazel
@@ -1,8 +1,7 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
-load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_src_file", "package_json_test", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_compile")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -53,10 +52,8 @@ vitest(
     deps = SRC_DEPS,
 )
 
-write_source_files(
-    name = "tsconfig_json",
-    files = {"tsconfig.json": "//tools:tsconfig.golden.json"},
-)
+# Generate tsconfig.json with correct extends path
+generate_ide_tsconfig_json()
 
 # digit-mapping
 generate_src_file(

--- a/packages/eslint-plugin-formatjs/BUILD.bazel
+++ b/packages/eslint-plugin-formatjs/BUILD.bazel
@@ -1,8 +1,7 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
-load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "package_json_test", "ts_compile_node")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "package_json_test", "ts_compile_node")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -71,10 +70,8 @@ vitest(
     ],
 )
 
-write_source_files(
-    name = "tsconfig_json",
-    files = {"tsconfig.json": "//tools:tsconfig.golden.json"},
-)
+# Generate tsconfig.json with correct extends path
+generate_ide_tsconfig_json()
 
 package_json_test(
     name = "package_json_test",

--- a/packages/fast-memoize/BUILD.bazel
+++ b/packages/fast-memoize/BUILD.bazel
@@ -1,8 +1,7 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
-load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "package_json_test", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "package_json_test", "ts_compile")
 
 npm_link_all_packages()
 
@@ -38,10 +37,8 @@ ts_compile(
     deps = SRC_DEPS,
 )
 
-write_source_files(
-    name = "tsconfig_json",
-    files = {"tsconfig.json": "//tools:tsconfig.golden.json"},
-)
+# Generate tsconfig.json with correct extends path
+generate_ide_tsconfig_json()
 
 package_json_test(
     name = "package_json_test",

--- a/packages/icu-messageformat-parser/BUILD.bazel
+++ b/packages/icu-messageformat-parser/BUILD.bazel
@@ -1,8 +1,7 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
-load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_src_file", "package_json_test", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_compile")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -51,10 +50,8 @@ vitest(
     ],
 )
 
-write_source_files(
-    name = "tsconfig_json",
-    files = {"tsconfig.json": "//tools:tsconfig.golden.json"},
-)
+# Generate tsconfig.json with correct extends path
+generate_ide_tsconfig_json()
 
 generate_src_file(
     name = "regex",

--- a/packages/icu-skeleton-parser/BUILD.bazel
+++ b/packages/icu-skeleton-parser/BUILD.bazel
@@ -2,7 +2,7 @@ load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_src_file", "package_json_test", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_compile")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -40,10 +40,8 @@ vitest(
     deps = SRC_DEPS,
 )
 
-write_source_files(
-    name = "tsconfig_json",
-    files = {"tsconfig.json": "//tools:tsconfig.golden.json"},
-)
+# Generate tsconfig.json with correct extends path
+generate_ide_tsconfig_json()
 
 generate_src_file(
     name = "regex",

--- a/packages/intl-datetimeformat/BUILD.bazel
+++ b/packages/intl-datetimeformat/BUILD.bazel
@@ -7,7 +7,7 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@rules_multirun//:defs.bzl", "multirun")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("//:index.bzl", "ZONES")
-load("//tools:index.bzl", "generate_src_file", "package_json_test", "ts_compile", "ts_run_binary")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_compile", "ts_run_binary")
 load("//tools:vitest.bzl", "vitest")
 load(":index.bzl", "generate_dockerfile")
 
@@ -865,11 +865,13 @@ genrule(
     cmd = "echo 'export {}' > $@",
 )
 
+# Generate tsconfig.json with correct extends path
+generate_ide_tsconfig_json()
+
 write_source_files(
     name = "generated-files",
     files = {
         "supported-locales.generated.ts": ":supported-locales-gen",
-        "tsconfig.json": "//tools:tsconfig.golden.json",
     },
     visibility = ["//:__pkg__"],
 )

--- a/packages/intl-displaynames/BUILD.bazel
+++ b/packages/intl-displaynames/BUILD.bazel
@@ -4,7 +4,7 @@ load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
-load("//tools:index.bzl", "generate_src_file", "package_json_test", "ts_compile", "ts_run_binary")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_compile", "ts_run_binary")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -762,11 +762,13 @@ test262_harness_bin.test262_harness_test(
     tags = ["manual"],
 )
 
+# Generate tsconfig.json with correct extends path
+generate_ide_tsconfig_json()
+
 write_source_files(
     name = "generated-files",
     files = {
         "supported-locales.generated.ts": ":supported-locales-gen",
-        "tsconfig.json": "//tools:tsconfig.golden.json",
     },
     visibility = ["//:__pkg__"],
 )

--- a/packages/intl-durationformat/BUILD.bazel
+++ b/packages/intl-durationformat/BUILD.bazel
@@ -2,7 +2,7 @@ load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_src_file", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -46,11 +46,8 @@ vitest(
     deps = SRC_DEPS,
 )
 
-# Test262
-write_source_files(
-    name = "tsconfig_json",
-    files = {"tsconfig.json": "//tools:tsconfig.golden.json"},
-)
+# Generate tsconfig.json with correct extends path
+generate_ide_tsconfig_json()
 
 # numbering-systems
 write_source_files(

--- a/packages/intl-enumerator/BUILD.bazel
+++ b/packages/intl-enumerator/BUILD.bazel
@@ -4,7 +4,7 @@ load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//:index.bzl", "ZONES")
-load("//tools:index.bzl", "generate_src_file", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -52,10 +52,8 @@ vitest(
 )
 
 # Test262
-write_source_files(
-    name = "tsconfig_json",
-    files = {"tsconfig.json": "//tools:tsconfig.golden.json"},
-)
+# Generate tsconfig.json with correct extends path
+generate_ide_tsconfig_json()
 
 # calendars
 generate_src_file(

--- a/packages/intl-getcanonicallocales/BUILD.bazel
+++ b/packages/intl-getcanonicallocales/BUILD.bazel
@@ -1,9 +1,8 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
-load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_src_file", "package_json_test", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_compile")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -83,10 +82,8 @@ generate_src_file(
     visibility = ["//:__pkg__"],
 )
 
-write_source_files(
-    name = "tsconfig_json",
-    files = {"tsconfig.json": "//tools:tsconfig.golden.json"},
-)
+# Generate tsconfig.json with correct extends path
+generate_ide_tsconfig_json()
 
 esbuild(
     name = "polyfill.iife",

--- a/packages/intl-listformat/BUILD.bazel
+++ b/packages/intl-listformat/BUILD.bazel
@@ -4,7 +4,7 @@ load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
-load("//tools:index.bzl", "generate_src_file", "package_json_test", "ts_compile", "ts_run_binary")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_compile", "ts_run_binary")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -757,7 +757,6 @@ write_source_files(
     name = "generated-files",
     files = {
         "supported-locales.generated.ts": ":supported-locales-gen",
-        "tsconfig.json": "//tools:tsconfig.golden.json",
     },
     visibility = ["//:__pkg__"],
 )

--- a/packages/intl-locale/BUILD.bazel
+++ b/packages/intl-locale/BUILD.bazel
@@ -4,7 +4,7 @@ load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
-load("//tools:index.bzl", "generate_src_file", "package_json_test", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_compile")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -82,10 +82,8 @@ test262_harness_bin.test262_harness_test(
     tags = ["manual"],
 )
 
-write_source_files(
-    name = "tsconfig_json",
-    files = {"tsconfig.json": "//tools:tsconfig.golden.json"},
-)
+# Generate tsconfig.json with correct extends path
+generate_ide_tsconfig_json()
 
 esbuild(
     name = "polyfill.iife",

--- a/packages/intl-localematcher/BUILD.bazel
+++ b/packages/intl-localematcher/BUILD.bazel
@@ -2,7 +2,7 @@ load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_src_file", "package_json_test", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_compile")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -44,11 +44,8 @@ vitest(
     deps = SRC_DEPS,
 )
 
-# Test262
-write_source_files(
-    name = "tsconfig_json",
-    files = {"tsconfig.json": "//tools:tsconfig.golden.json"},
-)
+# Generate tsconfig.json with correct extends path
+generate_ide_tsconfig_json()
 
 package_json_test(
     name = "package_json_test",

--- a/packages/intl-messageformat/BUILD.bazel
+++ b/packages/intl-messageformat/BUILD.bazel
@@ -1,10 +1,9 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
-load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//js:defs.bzl", "js_binary")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "package_json_test", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "package_json_test", "ts_compile")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -82,10 +81,8 @@ esbuild(
     deps = SRC_DEPS,
 )
 
-write_source_files(
-    name = "tsconfig_json",
-    files = {"tsconfig.json": "//tools:tsconfig.golden.json"},
-)
+# Generate tsconfig.json with correct extends path
+generate_ide_tsconfig_json()
 
 # Use with `bazel run`.
 js_binary(

--- a/packages/intl-numberformat/BUILD.bazel
+++ b/packages/intl-numberformat/BUILD.bazel
@@ -5,7 +5,7 @@ load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
-load("//tools:index.bzl", "generate_src_file", "package_json_test", "ts_compile", "ts_run_binary")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_compile", "ts_run_binary")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -957,7 +957,6 @@ write_source_files(
     name = "generated-files",
     files = {
         "supported-locales.generated.ts": ":supported-locales-gen",
-        "tsconfig.json": "//tools:tsconfig.golden.json",
     },
     visibility = ["//:__pkg__"],
 )

--- a/packages/intl-pluralrules/BUILD.bazel
+++ b/packages/intl-pluralrules/BUILD.bazel
@@ -4,7 +4,7 @@ load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
-load("//tools:index.bzl", "generate_src_file", "package_json_test", "ts_compile", "ts_run_binary")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_compile", "ts_run_binary")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -416,7 +416,6 @@ write_source_files(
     name = "generated-files",
     files = {
         "supported-locales.generated.ts": ":supported-locales-gen",
-        "tsconfig.json": "//tools:tsconfig.golden.json",
     },
     visibility = ["//:__pkg__"],
 )

--- a/packages/intl-relativetimeformat/BUILD.bazel
+++ b/packages/intl-relativetimeformat/BUILD.bazel
@@ -4,7 +4,7 @@ load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
-load("//tools:index.bzl", "generate_src_file", "package_json_test", "ts_compile", "ts_run_binary")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_compile", "ts_run_binary")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -754,7 +754,6 @@ write_source_files(
     name = "generated-files",
     files = {
         "supported-locales.generated.ts": ":supported-locales-gen",
-        "tsconfig.json": "//tools:tsconfig.golden.json",
     },
     visibility = ["//:__pkg__"],
 )

--- a/packages/intl-segmenter/BUILD.bazel
+++ b/packages/intl-segmenter/BUILD.bazel
@@ -5,7 +5,7 @@ load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
-load("//tools:index.bzl", "generate_src_file", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile")
 load("//tools:vitest.bzl", "vitest")
 load(":index.bzl", "unicode_file_name")
 
@@ -121,7 +121,6 @@ test262_harness_bin.test262_harness_test(
 
 write_source_files(
     name = "generated-files",
-    files = {"tsconfig.json": "//tools:tsconfig.golden.json"},
     visibility = ["//:__pkg__"],
 )
 

--- a/packages/intl/BUILD.bazel
+++ b/packages/intl/BUILD.bazel
@@ -4,7 +4,7 @@ load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:tsd/package_json.bzl", tsd_bin = "bin")
-load("//tools:index.bzl", "package_json_test", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "package_json_test", "ts_compile")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -57,10 +57,8 @@ vitest(
     ],
 )
 
-write_source_files(
-    name = "tsconfig_json",
-    files = {"tsconfig.json": "//tools:tsconfig.golden.json"},
-)
+# Generate tsconfig.json with correct extends path
+generate_ide_tsconfig_json()
 
 package_json_test(
     name = "package_json_test",

--- a/packages/react-intl/BUILD.bazel
+++ b/packages/react-intl/BUILD.bazel
@@ -1,11 +1,10 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
-load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:tsd/package_json.bzl", tsd_bin = "bin")
-load("//tools:index.bzl", "package_json_test", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "package_json_test", "ts_compile")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -90,10 +89,8 @@ vitest(
     deps = TEST_DEPS,
 )
 
-write_source_files(
-    name = "tsconfig_json",
-    files = {"tsconfig.json": "//tools:tsconfig.golden.json"},
-)
+# Generate tsconfig.json with correct extends path
+generate_ide_tsconfig_json()
 
 package_json_test(
     name = "package_json_test",

--- a/packages/ts-transformer/BUILD.bazel
+++ b/packages/ts-transformer/BUILD.bazel
@@ -2,7 +2,7 @@ load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "package_json_test", "ts_compile_node")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "package_json_test", "ts_compile_node")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -58,10 +58,8 @@ vitest(
     deps = SRC_DEPS,
 )
 
-write_source_files(
-    name = "tsconfig_json",
-    files = {"tsconfig.json": "//tools:tsconfig.golden.json"},
-)
+# Generate tsconfig.json with correct extends path
+generate_ide_tsconfig_json()
 
 package_json_test(
     name = "package_json_test",

--- a/packages/utils/BUILD.bazel
+++ b/packages/utils/BUILD.bazel
@@ -3,7 +3,7 @@ load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_src_file", "package_json_test", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_compile")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -42,10 +42,8 @@ ts_compile(
     deps = SRC_DEPS,
 )
 
-write_source_files(
-    name = "tsconfig_json",
-    files = {"tsconfig.json": "//tools:tsconfig.golden.json"},
-)
+# Generate tsconfig.json with correct extends path
+generate_ide_tsconfig_json()
 
 package_json_test(
     name = "package_json_test",

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,7 +1,6 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 
 exports_files([
-    "tsconfig.golden.json",
     "supported-locales-gen.ts",
 ])
 

--- a/tools/tsconfig.golden.json
+++ b/tools/tsconfig.golden.json
@@ -1,5 +1,0 @@
-// @generated
-{
-  // This is purely for IDE, not for compilation
-  "extends": "../../tsconfig.json"
-}


### PR DESCRIPTION
### TL;DR

Replace hardcoded tsconfig.json files with a dynamic generator that creates the correct relative path based on package location.

### What changed?

- Removed the hardcoded `tools/tsconfig.golden.json` file
- Added a new `generate_ide_tsconfig_json()` Bazel macro that:
  - Calculates the correct relative path to the root tsconfig.json based on package depth
  - Generates a tsconfig.json file with the appropriate `extends` path
- Updated all package BUILD files to use this new macro instead of copying the golden file

### How to test?

1. Verify that the tsconfig.json files in each package correctly point to the root tsconfig.json
2. Check that IDE integration works properly with the new dynamically generated tsconfig files
3. Run Bazel builds to ensure the build process still works correctly

### Why make this change?

The previous approach used a hardcoded path (`"../../tsconfig.json"`) which assumes all packages are exactly two levels deep. The new approach calculates the correct relative path based on the actual package location, making it more flexible and maintainable. This ensures proper IDE integration regardless of where packages are located in the repository structure.