### PR TITLE
docs: documentation for vite, port #5720 over

### DIFF
--- a/docs/src/docs/guides/bundler-plugins.mdx
+++ b/docs/src/docs/guides/bundler-plugins.mdx
@@ -161,3 +161,7 @@ React.createElement(FormattedMessage, {
 <Admonition type="info" title="description">
 Our transformer also removes `description` because it's only for translator, not end-user.
 </Admonition>
+
+## Vite
+
+If you use [vite](https://vitejs.dev), you will need to use babel instead of esbuild. You can learn why in [#3225](https://github.com/formatjs/formatjs/issues/3225), with an example `vite.config.ts` to get started.


### PR DESCRIPTION
### TL;DR

Added Vite integration guidance to the bundler plugins documentation.

### What changed?

Added a new section to the bundler plugins documentation that explains Vite users need to use Babel instead of esbuild when working with FormatJS. The section includes a reference to issue #3225 which provides more details and an example configuration.

### How to test?

1. Navigate to the bundler plugins documentation page
2. Scroll to the bottom to find the new Vite section
3. Verify the link to issue #3225 works correctly
4. Check that the information about using Babel instead of esbuild is clear

### Why make this change?

Vite users have been encountering issues when trying to use FormatJS with the default esbuild configuration. This documentation update provides a clear solution by directing them to use Babel instead and pointing to a specific issue with example configuration to help them get started quickly.