### PR TITLE
docs: add `pnpm` to examples

### DIFF
--- a/docs/src/docs/getting-started/installation.mdx
+++ b/docs/src/docs/getting-started/installation.mdx
@@ -8,6 +8,7 @@ defaultValue="npm"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'},
 ]}>
 <TabItem value="npm">
 
@@ -20,6 +21,13 @@ npm i -S react react-intl
 
 ```sh
 yarn add react react-intl
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```sh
+pnpm add react react-intl
 ```
 
 </TabItem>
@@ -176,6 +184,7 @@ defaultValue="npm"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'},
 ]}>
 <TabItem value="npm">
 
@@ -188,6 +197,13 @@ npm i -D babel-plugin-formatjs
 
 ```sh
 yarn add -D babel-plugin-formatjs
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```sh
+pnpm add -D babel-plugin-formatjs
 ```
 
 </TabItem>
@@ -217,6 +233,7 @@ defaultValue="npm"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'},
 ]}>
 <TabItem value="npm">
 
@@ -229,6 +246,13 @@ npm i -D @formatjs/ts-transformer
 
 ```sh
 yarn add -D @formatjs/ts-transformer
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```sh
+pnpm add -D @formatjs/ts-transformer
 ```
 
 </TabItem>
@@ -272,6 +296,7 @@ defaultValue="npm"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'},
 ]}>
 <TabItem value="npm">
 
@@ -284,6 +309,13 @@ npm i -D @formatjs/ts-transformer
 
 ```sh
 yarn add -D @formatjs/ts-transformer
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```sh
+pnpm add -D @formatjs/ts-transformer
 ```
 
 </TabItem>
@@ -299,6 +331,7 @@ defaultValue="npm"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'},
 ]}>
 <TabItem value="npm">
 
@@ -311,6 +344,13 @@ npm i -D @formatjs/ts-transformer
 
 ```sh
 yarn add -D @formatjs/ts-transformer
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```sh
+pnpm add -D @formatjs/ts-transformer
 ```
 
 </TabItem>
@@ -340,6 +380,7 @@ defaultValue="npm"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'},
 ]}>
 <TabItem value="npm">
 
@@ -352,6 +393,13 @@ npm i -D @formatjs/ts-transformer
 
 ```sh
 yarn add -D @formatjs/ts-transformer
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```sh
+pnpm add -D @formatjs/ts-transformer
 ```
 
 </TabItem>

--- a/docs/src/docs/getting-started/message-extraction.mdx
+++ b/docs/src/docs/getting-started/message-extraction.mdx
@@ -8,6 +8,7 @@ defaultValue="npm"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'},
 ]}>
 <TabItem value="npm">
 
@@ -20,6 +21,13 @@ npm i -D @formatjs/cli
 
 ```sh
 yarn add -D @formatjs/cli
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```sh
+pnpm add -D @formatjs/cli
 ```
 
 </TabItem>
@@ -45,6 +53,7 @@ defaultValue="npm"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'},
 ]}>
 <TabItem value="npm">
 
@@ -252,6 +261,7 @@ defaultValue="npm"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'},
 ]}>
 <TabItem value="npm">
 

--- a/docs/src/docs/guides/bundler-plugins.mdx
+++ b/docs/src/docs/guides/bundler-plugins.mdx
@@ -8,6 +8,7 @@ defaultValue="npm"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'},
 ]}>
 <TabItem value="npm">
 
@@ -20,6 +21,13 @@ npm i -D babel-plugin-formatjs
 
 ```sh
 yarn add -D babel-plugin-formatjs
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```sh
+pnpm add -D babel-plugin-formatjs
 ```
 
 </TabItem>
@@ -81,6 +89,7 @@ Our plugin also removes `description` because it's only for translator, not end-
   values={[
   {label: 'npm', value: 'npm'},
   {label: 'yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'},
 ]}>
 <TabItem value="npm">
 
@@ -93,6 +102,13 @@ npm i -D @formatjs/ts-transformer
 
 ```sh
 yarn add -D @formatjs/ts-transformer
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```sh
+pnpm add -D @formatjs/ts-transformer
 ```
 
 </TabItem>

--- a/docs/src/docs/guides/develop.mdx
+++ b/docs/src/docs/guides/develop.mdx
@@ -8,6 +8,7 @@ defaultValue="npm"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'},
 ]}>
 <TabItem value="npm">
 
@@ -20,6 +21,13 @@ npm i -D eslint-plugin-formatjs eslint
 
 ```sh
 yarn add -D eslint-plugin-formatjs eslint
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```sh
+pnpm add -D eslint-plugin-formatjs eslint
 ```
 
 </TabItem>

--- a/docs/src/docs/intl.mdx
+++ b/docs/src/docs/intl.mdx
@@ -8,6 +8,7 @@ defaultValue="npm"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'},
 ]}>
 <TabItem value="npm">
 
@@ -20,6 +21,13 @@ npm i -S @formatjs/intl
 
 ```sh
 yarn add @formatjs/intl
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```sh
+pnpm add @formatjs/intl
 ```
 
 </TabItem>

--- a/docs/src/docs/polyfills/intl-datetimeformat.mdx
+++ b/docs/src/docs/polyfills/intl-datetimeformat.mdx
@@ -24,6 +24,7 @@ defaultValue="npm"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'},
 ]}>
 <TabItem value="npm">
 
@@ -36,6 +37,13 @@ npm i @formatjs/intl-datetimeformat
 
 ```sh
 yarn add @formatjs/intl-datetimeformat
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```sh
+pnpm add @formatjs/intl-datetimeformat
 ```
 
 </TabItem>

--- a/docs/src/docs/polyfills/intl-displaynames.mdx
+++ b/docs/src/docs/polyfills/intl-displaynames.mdx
@@ -11,6 +11,7 @@ defaultValue="npm"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'},
 ]}>
 <TabItem value="npm">
 
@@ -23,6 +24,13 @@ npm i @formatjs/intl-displaynames
 
 ```sh
 yarn add @formatjs/intl-displaynames
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```sh
+pnpm add @formatjs/intl-displaynames
 ```
 
 </TabItem>

--- a/docs/src/docs/polyfills/intl-durationformat.mdx
+++ b/docs/src/docs/polyfills/intl-durationformat.mdx
@@ -11,6 +11,7 @@ defaultValue="npm"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'},
 ]}>
 <TabItem value="npm">
 
@@ -23,6 +24,13 @@ npm i @formatjs/intl-durationformat
 
 ```sh
 yarn add @formatjs/intl-durationformat
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```sh
+pnpm add @formatjs/intl-durationformat
 ```
 
 </TabItem>

--- a/docs/src/docs/polyfills/intl-getcanonicallocales.mdx
+++ b/docs/src/docs/polyfills/intl-getcanonicallocales.mdx
@@ -11,6 +11,7 @@ defaultValue="npm"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'},
 ]}>
 <TabItem value="npm">
 
@@ -23,6 +24,13 @@ npm i @formatjs/intl-getcanonicallocales
 
 ```sh
 yarn add @formatjs/intl-getcanonicallocales
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```sh
+pnpm add @formatjs/intl-getcanonicallocales
 ```
 
 </TabItem>

--- a/docs/src/docs/polyfills/intl-listformat.mdx
+++ b/docs/src/docs/polyfills/intl-listformat.mdx
@@ -11,6 +11,7 @@ defaultValue="npm"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'},
 ]}>
 <TabItem value="npm">
 
@@ -23,6 +24,13 @@ npm i @formatjs/intl-listformat
 
 ```sh
 yarn add @formatjs/intl-listformat
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```sh
+pnpm add @formatjs/intl-listformat
 ```
 
 </TabItem>

--- a/docs/src/docs/polyfills/intl-locale.mdx
+++ b/docs/src/docs/polyfills/intl-locale.mdx
@@ -11,6 +11,7 @@ defaultValue="npm"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'},
 ]}>
 <TabItem value="npm">
 
@@ -23,6 +24,13 @@ npm i @formatjs/intl-locale
 
 ```sh
 yarn add @formatjs/intl-locale
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```sh
+pnpm add @formatjs/intl-locale
 ```
 
 </TabItem>

--- a/docs/src/docs/polyfills/intl-localematcher.mdx
+++ b/docs/src/docs/polyfills/intl-localematcher.mdx
@@ -11,6 +11,7 @@ defaultValue="npm"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'},
 ]}>
 <TabItem value="npm">
 
@@ -23,6 +24,13 @@ npm i @formatjs/intl-localematcher
 
 ```sh
 yarn add @formatjs/intl-localematcher
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```sh
+pnpm add @formatjs/intl-localematcher
 ```
 
 </TabItem>

--- a/docs/src/docs/polyfills/intl-numberformat.mdx
+++ b/docs/src/docs/polyfills/intl-numberformat.mdx
@@ -14,6 +14,7 @@ defaultValue="npm"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'},
 ]}>
 <TabItem value="npm">
 
@@ -26,6 +27,13 @@ npm i @formatjs/intl-numberformat
 
 ```sh
 yarn add @formatjs/intl-numberformat
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```sh
+pnpm add @formatjs/intl-numberformat
 ```
 
 </TabItem>

--- a/docs/src/docs/polyfills/intl-pluralrules.mdx
+++ b/docs/src/docs/polyfills/intl-pluralrules.mdx
@@ -11,6 +11,7 @@ defaultValue="npm"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'},
 ]}>
 <TabItem value="npm">
 
@@ -23,6 +24,13 @@ npm i @formatjs/intl-pluralrules
 
 ```sh
 yarn add @formatjs/intl-pluralrules
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```sh
+pnpm add @formatjs/intl-pluralrules
 ```
 
 </TabItem>

--- a/docs/src/docs/polyfills/intl-relativetimeformat.mdx
+++ b/docs/src/docs/polyfills/intl-relativetimeformat.mdx
@@ -11,6 +11,7 @@ defaultValue="npm"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'},
 ]}>
 <TabItem value="npm">
 
@@ -23,6 +24,13 @@ npm i @formatjs/intl-relativetimeformat
 
 ```sh
 yarn add @formatjs/intl-relativetimeformat
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```sh
+pnpm add @formatjs/intl-relativetimeformat
 ```
 
 </TabItem>

--- a/docs/src/docs/polyfills/intl-segmenter.mdx
+++ b/docs/src/docs/polyfills/intl-segmenter.mdx
@@ -11,6 +11,7 @@ defaultValue="npm"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'},
 ]}>
 <TabItem value="npm">
 
@@ -23,6 +24,13 @@ npm i @formatjs/intl-segmenter
 
 ```sh
 yarn add @formatjs/intl-segmenter
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```sh
+pnpm add @formatjs/intl-segmenter
 ```
 
 </TabItem>

--- a/docs/src/docs/polyfills/intl-supportedvaluesof.mdx
+++ b/docs/src/docs/polyfills/intl-supportedvaluesof.mdx
@@ -11,6 +11,7 @@ defaultValue="npm"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'},
 ]}>
 <TabItem value="npm">
 
@@ -23,6 +24,13 @@ npm i @formatjs/intl-enumerator
 
 ```sh
 yarn add @formatjs/intl-enumerator
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```sh
+pnpm add @formatjs/intl-enumerator
 ```
 
 </TabItem>

--- a/docs/src/docs/react-intl.mdx
+++ b/docs/src/docs/react-intl.mdx
@@ -63,6 +63,7 @@ defaultValue="npm"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'},
 ]}>
 <TabItem value="npm">
 
@@ -75,6 +76,13 @@ npm i -S react-intl
 
 ```sh
 yarn add react-intl
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```sh
+pnpm add react-intl
 ```
 
 </TabItem>

--- a/docs/src/docs/tooling/babel-plugin.mdx
+++ b/docs/src/docs/tooling/babel-plugin.mdx
@@ -13,6 +13,7 @@ defaultValue="npm"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'},
 ]}>
 <TabItem value="npm">
 
@@ -25,6 +26,13 @@ npm i babel-plugin-formatjs
 
 ```sh
 yarn add babel-plugin-formatjs
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```sh
+pnpm add babel-plugin-formatjs
 ```
 
 </TabItem>

--- a/docs/src/docs/tooling/cli.mdx
+++ b/docs/src/docs/tooling/cli.mdx
@@ -6,6 +6,7 @@ defaultValue="npm"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'},
 ]}>
 <TabItem value="npm">
 
@@ -18,6 +19,13 @@ npm i -D @formatjs/cli
 
 ```sh
 yarn add -D @formatjs/cli
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```sh
+pnpm add -D @formatjs/cli
 ```
 
 </TabItem>
@@ -77,6 +85,7 @@ defaultValue="npm"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'},
 ]}>
 <TabItem value="npm">
 
@@ -207,6 +216,7 @@ defaultValue="npm"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'},
 ]}>
 <TabItem value="npm">
 
@@ -251,6 +261,7 @@ defaultValue="npm"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'},
 ]}>
 <TabItem value="npm">
 
@@ -403,6 +414,7 @@ defaultValue="npm"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'},
 ]}>
 <TabItem value="npm">
 
@@ -493,6 +505,7 @@ defaultValue="npm"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'},
 ]}>
 <TabItem value="npm">
 
@@ -505,6 +518,13 @@ npm i -D @formatjs/cli-lib
 
 ```sh
 yarn add -D @formatjs/cli-lib
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```sh
+pnpm add -D @formatjs/cli-lib
 ```
 
 </TabItem>

--- a/docs/src/docs/tooling/linter.mdx
+++ b/docs/src/docs/tooling/linter.mdx
@@ -8,6 +8,7 @@ defaultValue="npm"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'},
 ]}>
 <TabItem value="npm">
 
@@ -20,6 +21,13 @@ npm i -D eslint-plugin-formatjs
 
 ```sh
 yarn add -D eslint-plugin-formatjs
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```sh
+pnpm add -D eslint-plugin-formatjs
 ```
 
 </TabItem>

--- a/docs/src/docs/tooling/ts-transformer.mdx
+++ b/docs/src/docs/tooling/ts-transformer.mdx
@@ -15,6 +15,7 @@ defaultValue="npm"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'},
 ]}>
 <TabItem value="npm">
 
@@ -27,6 +28,13 @@ npm i @formatjs/ts-transformer
 
 ```sh
 yarn add @formatjs/ts-transformer
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```sh
+pnpm add @formatjs/ts-transformer
 ```
 
 </TabItem>

--- a/docs/src/docs/vue-intl.mdx
+++ b/docs/src/docs/vue-intl.mdx
@@ -8,6 +8,7 @@ defaultValue="npm"
 values={[
 {label: 'npm', value: 'npm'},
 {label: 'yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'},
 ]}>
 <TabItem value="npm">
 
@@ -20,6 +21,13 @@ npm i -S vue-intl
 
 ```sh
 yarn add vue-intl
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```sh
+pnpm add vue-intl
 ```
 
 </TabItem>


### PR DESCRIPTION
### TL;DR

Added pnpm installation instructions to all package installation tabs in the documentation.

### What changed?

- Added pnpm as a third option in all installation tab groups throughout the documentation
- Added corresponding pnpm installation commands for all packages
- Maintained consistent formatting with existing npm and yarn instructions

### How to test?

1. Review the documentation pages to ensure pnpm tabs appear correctly
2. Verify that pnpm installation commands are correct for each package
3. Test tab switching functionality to ensure it works properly with the new pnpm option

### Why make this change?

pnpm has become a popular package manager in the JavaScript ecosystem due to its disk space efficiency and performance benefits. Adding pnpm installation instructions makes the documentation more inclusive for developers who prefer this package manager, providing a better developer experience for the growing number of pnpm users.