### PR TITLE
docs: more fixes

### DIFF
--- a/docs/src/components/LiveCodeBlock.tsx
+++ b/docs/src/components/LiveCodeBlock.tsx
@@ -128,18 +128,21 @@ export function LiveCodeBlock({
 }: LiveCodeBlockProps): React.ReactNode {
   const trimmedCode = code.trim()
 
-  // Check if code is already JSX (starts with <)
-  const isJSX = trimmedCode.startsWith('<')
+  const transformCode = React.useCallback((code: string) => {
+    // Check if code is already JSX (starts with <)
+    const isJSX = code.startsWith('<')
 
-  // Wrap non-JSX code in a fragment to render the result
-  const transformedCode = isJSX ? trimmedCode : `<>{${trimmedCode}}</>`
+    // Wrap non-JSX code in a fragment to render the result
+    return isJSX ? code : `<>{${code}}</>`
+  }, [])
 
   return (
     <LiveProvider
-      code={transformedCode}
+      code={trimmedCode}
       scope={scope}
       language={language}
       theme={darkTheme}
+      transformCode={transformCode}
     >
       <div className="my-6 rounded-lg border border-purple-500/20 overflow-hidden bg-gradient-to-br from-gray-900 to-gray-950 shadow-xl">
         <Accordion type="multiple" defaultValue={['editor', 'result']}>

--- a/docs/src/docs/core-concepts/icu-syntax.mdx
+++ b/docs/src/docs/core-concepts/icu-syntax.mdx
@@ -1,6 +1,6 @@
 If you are translating text you'll need a way for your translators to express the subtleties of spelling, grammar, and conjugation inherent in each language. We use the [ICU Message syntax](https://unicode-org.github.io/icu/userguide/format_parse/messages) which is also used in Java and PHP.
 
-The [`intl-messageformat`](intl-messageformat.md) library takes the message and input data and creates an appropriately formatted string. This feature is included with all of the integrations we provide.
+The [`intl-messageformat`](intl-messageformat) library takes the message and input data and creates an appropriately formatted string. This feature is included with all of the integrations we provide.
 
 The following sections describe the ICU Message syntax and show how to use this features provided the FormatJS libraries:
 

--- a/docs/src/docs/getting-started/application-workflow.mdx
+++ b/docs/src/docs/getting-started/application-workflow.mdx
@@ -1,4 +1,4 @@
-While our [Installation](./installation.md) guide can help you get started, this guide gives you an overview how your daily translation workflow might look like.
+While our [Installation](./installation) guide can help you get started, this guide gives you an overview how your daily translation workflow might look like.
 
 There are 2 types of translations tools and services:
 

--- a/docs/src/docs/getting-started/message-declaration.mdx
+++ b/docs/src/docs/getting-started/message-declaration.mdx
@@ -25,7 +25,7 @@ intl.formatMessage(
 ## Using React API `<FormattedMessage/>`
 
 ```tsx
-;<FormattedMessage
+<FormattedMessage
   description="A message" // Description should be a string literal
   defaultMessage="My name is {name}" // Message should be a string literal
   values={
@@ -63,9 +63,9 @@ intl.formatMessage(message, {name: 'John'}) // My name is John
 ```
 
 <Admonition type="caution">
-We rely on AST to extract messages from the codebase, so make sure you call `intl.formatMessage()`, use our builtin React components, use our Vue methods or configure `--additionalFunctionNames`/`--additionalComponentNames` in our [CLI](../tooling/cli.md) properly.
+We rely on AST to extract messages from the codebase, so make sure you call `intl.formatMessage()`, use our builtin React components, use our Vue methods or configure `--additionalFunctionNames`/`--additionalComponentNames` in our [CLI](../tooling/cli) properly.
 </Admonition>
 
 <Admonition type="caution">
-You can declare a message without immediately formatting it with `defineMessage` and our extractor would still be able to extract it. However, our [enforce-placeholders](../tooling/linter.md#enforce-placeholders) linter rule won't be able to analyze it.
+You can declare a message without immediately formatting it with `defineMessage` and our extractor would still be able to extract it. However, our [enforce-placeholders](../tooling/linter#enforce-placeholders) linter rule won't be able to analyze it.
 </Admonition>

--- a/docs/src/docs/getting-started/message-distribution.mdx
+++ b/docs/src/docs/getting-started/message-distribution.mdx
@@ -2,7 +2,7 @@ Now that you've declared your messages, extracted them, sent them to your transl
 
 ## Compiling Messages
 
-Let's take the example from [Message Extraction](./message-extraction.md), assuming we are working with the French version and the file is called `lang/fr.json`:
+Let's take the example from [Message Extraction](./message-extraction), assuming we are working with the French version and the file is called `lang/fr.json`:
 
 ```json
 {
@@ -25,7 +25,7 @@ Let's take the example from [Message Extraction](./message-extraction.md), assum
 }
 ```
 
-We can use [@formatjs/cli](../tooling/cli.md) to compile this into a react-intl consumable JSON file:
+We can use [@formatjs/cli](../tooling/cli) to compile this into a react-intl consumable JSON file:
 
 Add the following command to your `package.json` `scripts`:
 

--- a/docs/src/docs/getting-started/message-extraction.mdx
+++ b/docs/src/docs/getting-started/message-extraction.mdx
@@ -294,7 +294,7 @@ export function format(msgs) {
 }
 ```
 
-We also provide several [builtin formatters](../tooling/cli.md#builtin-formatters) to integrate with 3rd party TMSes so feel free to create PRs to add more.
+We also provide several [builtin formatters](../tooling/cli#builtin-formatters) to integrate with 3rd party TMSes so feel free to create PRs to add more.
 
 | TMS                                                                                                           | `--format`  |
 | ------------------------------------------------------------------------------------------------------------- | ----------- |

--- a/docs/src/docs/guides/advanced-usage.mdx
+++ b/docs/src/docs/guides/advanced-usage.mdx
@@ -2,7 +2,7 @@
 
 ## Pre-compiling messages
 
-You can also pre-compile all messages into `AST` using [`@formatjs/cli`](../tooling/cli.md) `compile` command and pass that into `IntlProvider`. This is especially faster since it saves us time parsing `string` into `AST`. The use cases for this support are:
+You can also pre-compile all messages into `AST` using [`@formatjs/cli`](../tooling/cli) `compile` command and pass that into `IntlProvider`. This is especially faster since it saves us time parsing `string` into `AST`. The use cases for this support are:
 
 1. Server-side rendering or pre-compiling where you can cache the AST and don't have to pay compilation costs multiple time.
 2. Desktop apps using Electron or CEF where you can preload/precompile things in advanced before runtime.

--- a/docs/src/docs/guides/bundler-plugins.mdx
+++ b/docs/src/docs/guides/bundler-plugins.mdx
@@ -1,4 +1,4 @@
-Now that you've had a working pipeline. It's time to dive deeper on how to optimize the build with `formatjs`. From [Message Extraction](../getting-started/message-extraction.md) guide, we explicitly recommend against explicit ID due to potential collision in large application. While our extractor can insert IDs in the extracted JSON file, you'd need to also insert those IDs into the compiled JS output. This guide will cover how to do that.
+Now that you've had a working pipeline. It's time to dive deeper on how to optimize the build with `formatjs`. From [Message Extraction](../getting-started/message-extraction) guide, we explicitly recommend against explicit ID due to potential collision in large application. While our extractor can insert IDs in the extracted JSON file, you'd need to also insert those IDs into the compiled JS output. This guide will cover how to do that.
 
 ## Using babel-plugin-formatjs
 
@@ -46,7 +46,7 @@ Let's take this simple example:
 />
 ```
 
-During runtime this will throw an `Error` saying `ID is required`. In order to inject an ID in the transpiled JS, you can use our [babel-plugin-formatjs](../tooling/babel-plugin.md) similarly as below:
+During runtime this will throw an `Error` saying `ID is required`. In order to inject an ID in the transpiled JS, you can use our [babel-plugin-formatjs](../tooling/babel-plugin) similarly as below:
 
 **babel.config.json**
 

--- a/docs/src/docs/guides/develop.mdx
+++ b/docs/src/docs/guides/develop.mdx
@@ -1,4 +1,4 @@
-Aside from a strong focus on facilitating i18n production pipeline, `formatjs` also aims to improve i18n DevEx with our [eslint-plugin-formatjs](../tooling/linter.md).
+Aside from a strong focus on facilitating i18n production pipeline, `formatjs` also aims to improve i18n DevEx with our [eslint-plugin-formatjs](../tooling/linter).
 
 ## Linter Installation
 
@@ -44,7 +44,7 @@ Then in your eslint config:
 }
 ```
 
-Head over to [eslint-plugin-formatjs](../tooling/linter.md) for more details on our rules.
+Head over to [eslint-plugin-formatjs](../tooling/linter) for more details on our rules.
 
 ## Error Codes
 

--- a/docs/src/docs/guides/distribute-libraries.mdx
+++ b/docs/src/docs/guides/distribute-libraries.mdx
@@ -11,8 +11,8 @@ Translated strings are basically assets, just like CSS, static configuration or 
 
 Each feature/library would be in charge of:
 
-- [Declaring its messages](../getting-started/message-declaration.md).
-- Integrating with the [translation pipeline](../getting-started/application-workflow.md).
+- [Declaring its messages](../getting-started/message-declaration).
+- Integrating with the [translation pipeline](../getting-started/application-workflow).
 - Declaring its translated & aggregated strings using either a [manifest like package.json](https://docs.npmjs.com/files/package.json) or a convention (always output to a specific location) or both.
 
 ## Declaring in package.json

--- a/docs/src/docs/guides/runtime-requirements.mdx
+++ b/docs/src/docs/guides/runtime-requirements.mdx
@@ -8,29 +8,17 @@ React Intl relies on these `Intl` APIs:
 
 - [Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat): Available on IE11+
 - [Intl.DateTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat): Available on IE11+
-- [Intl.PluralRules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/PluralRules): This can be polyfilled using [this package](polyfills/intl-pluralrules.md).
-- (Optional) [Intl.RelativeTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat): Required if you use [`formatRelativeTime`](react-intl/api.md#formatrelativetime)
-  or [`FormattedRelativeTime`](react-intl/components.md#formattedrelativetime). This can be polyfilled using [this package](polyfills/intl-relativetimeformat.md).
-- (Optional) [Intl.DisplayNames](https://tc39.es/proposal-intl-displaynames/): Required if you use [`formatDisplayName`](react-intl/api.md#formatdisplayname)
-  or [`FormattedDisplayName`](react-intl/components.md#formatteddisplayname). This can be polyfilled using [this package](polyfills/intl-displaynames.md).
+- [Intl.PluralRules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/PluralRules): This can be polyfilled using [this package](polyfills/intl-pluralrules).
+- (Optional) [Intl.RelativeTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat): Required if you use [`formatRelativeTime`](react-intl/api#formatrelativetime)
+  or [`FormattedRelativeTime`](react-intl/components#formattedrelativetime). This can be polyfilled using [this package](polyfills/intl-relativetimeformat).
+- (Optional) [Intl.DisplayNames](https://tc39.es/proposal-intl-displaynames/): Required if you use [`formatDisplayName`](react-intl/api#formatdisplayname)
+  or [`FormattedDisplayName`](react-intl/components#formatteddisplayname). This can be polyfilled using [this package](polyfills/intl-displaynames).
 
 We officially support IE11 along with 2 most recent versions of Edge, Chrome & Firefox.
 
 ## Node.js
 
-### full-icu
-
-Starting with Node.js 13.0.0 full-icu is supported by default.
-
-If using React Intl in an earlier version of Node.js, your `node` binary has to either:
-
-- Get compiled with `full-icu` using these [instructions](https://nodejs.org/api/intl.html)
-
-**OR**
-
-- Uses [`full-icu` npm package](https://www.npmjs.com/package/full-icu)
-
-If your `node` version is missing any of the `Intl` APIs above, you'd have to polyfill them accordingly.
+React Intl requires **Node.js 16 or later**, which includes full internationalization support by default. If your Node.js version is missing any of the `Intl` APIs above, you'd have to polyfill them accordingly.
 
 ## React Native
 
@@ -41,10 +29,10 @@ If you're using `react-intl` in React Native, make sure your runtime has built-i
 
 ### React Native on iOS
 
-If you cannot use the Intl variant of JSC (e.g on iOS), follow the instructions in [polyfills](../polyfills.md) to polyfill the following APIs (in this order):
+If you cannot use the Intl variant of JSC (e.g on iOS), follow the instructions in [polyfills](../polyfills) to polyfill the following APIs (in this order):
 
-1. [Intl.getCanonicalLocales](../polyfills/intl-getcanonicallocales.md)
-1. [Intl.Locale](../polyfills/intl-locale.md)
-1. [Intl.PluralRules](../polyfills/intl-pluralrules.md)
-1. [Intl.NumberFormat](../polyfills/intl-numberformat.md)
-1. [Intl.DateTimeFormat](../polyfills/intl-datetimeformat.md)
+1. [Intl.getCanonicalLocales](../polyfills/intl-getcanonicallocales)
+1. [Intl.Locale](../polyfills/intl-locale)
+1. [Intl.PluralRules](../polyfills/intl-pluralrules)
+1. [Intl.NumberFormat](../polyfills/intl-numberformat)
+1. [Intl.DateTimeFormat](../polyfills/intl-datetimeformat)

--- a/docs/src/docs/guides/testing-with-react-intl.mdx
+++ b/docs/src/docs/guides/testing-with-react-intl.mdx
@@ -1,6 +1,6 @@
 ## `Intl` APIs requirements
 
-React Intl uses the built-in [`Intl` APIs](https://mdn.io/intl) in JavaScript. Make sure your environment satisfy the requirements listed in [`Intl` APIs requirements](../guides/runtime-requirements.md)
+React Intl uses the built-in [`Intl` APIs](https://mdn.io/intl) in JavaScript. Make sure your environment satisfy the requirements listed in [`Intl` APIs requirements](../guides/runtime-requirements)
 
 ### Mocha
 

--- a/docs/src/docs/icu-messageformat-parser.mdx
+++ b/docs/src/docs/icu-messageformat-parser.mdx
@@ -5,7 +5,7 @@ Parses [ICU Message strings](https://unicode-org.github.io/icu/userguide/format_
 
 ## Overview
 
-This package implements a parser in JavaScript that parses the industry standard [ICU Message strings](https://unicode-org.github.io/icu/userguide/format_parse/messages) — used for internationalization — into an AST. The produced AST can then be used by a compiler, like [`intl-messageformat`](./intl-messageformat.md), to produce localized formatted strings for display to users.
+This package implements a parser in JavaScript that parses the industry standard [ICU Message strings](https://unicode-org.github.io/icu/userguide/format_parse/messages) — used for internationalization — into an AST. The produced AST can then be used by a compiler, like [`intl-messageformat`](./intl-messageformat), to produce localized formatted strings for display to users.
 
 ## Usage
 

--- a/docs/src/docs/intl-messageformat.mdx
+++ b/docs/src/docs/intl-messageformat.mdx
@@ -17,7 +17,7 @@ This `IntlMessageFormat` API may change to stay in sync with ECMA-402, but this 
 
 ### How It Works
 
-Messages are provided into the constructor as a `String` message, or a [pre-parsed AST](./icu-messageformat-parser.md) object.
+Messages are provided into the constructor as a `String` message, or a [pre-parsed AST](./icu-messageformat-parser) object.
 
 ```tsx
 const msg = new IntlMessageFormat(message, locales, [formats], [opts])
@@ -79,9 +79,9 @@ The message syntax that this package uses is not proprietary, in fact it's a com
 
 This package assumes that the [`Intl`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl) global object exists in the runtime. `Intl` is present in all modern browsers (IE11+) and Node (with full ICU). The `Intl` methods we rely on are:
 
-1. `Intl.NumberFormat` for number formatting (can be polyfilled using [@formatjs/intl-numberformat](./polyfills/intl-numberformat.md))
-2. `Intl.DateTimeFormat` for date time formatting (can be polyfilled using [@formatjs/intl-datetimeformat](./polyfills/intl-datetimeformat.md))
-3. `Intl.PluralRules` for plural/ordinal formatting (can be polyfilled using [@formatjs/intl-pluralrules](./polyfills/intl-pluralrules.md))
+1. `Intl.NumberFormat` for number formatting (can be polyfilled using [@formatjs/intl-numberformat](./polyfills/intl-numberformat))
+2. `Intl.DateTimeFormat` for date time formatting (can be polyfilled using [@formatjs/intl-datetimeformat](./polyfills/intl-datetimeformat))
+3. `Intl.PluralRules` for plural/ordinal formatting (can be polyfilled using [@formatjs/intl-pluralrules](./polyfills/intl-pluralrules))
 
 ### Loading Intl MessageFormat in a browser
 

--- a/docs/src/docs/intl.mdx
+++ b/docs/src/docs/intl.mdx
@@ -209,7 +209,7 @@ intl.formatTime(Date.now()) // "4:03 PM"
 ## formatRelativeTime
 
 <Admonition type="caution" title="browser support">
-This requires [Intl.RelativeTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat) which has limited browser support. Please use our [polyfill](./polyfills/intl-relativetimeformat.md) if you plan to support them.
+This requires [Intl.RelativeTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat) which has limited browser support. Please use our [polyfill](./polyfills/intl-relativetimeformat) if you plan to support them.
 </Admonition>
 
 ```tsx
@@ -267,8 +267,8 @@ intl.formatNumber(1000, {style: 'currency', currency: 'USD'})
 **Formatting Number using `unit`**
 
 Currently this is part of ES2020 [NumberFormat](https://tc39.es/ecma402/#numberformat-objects).
-We've provided a polyfill [here](./polyfills/intl-numberformat.md) and `@formatjs/intl` types allow users to pass
-in a [sanctioned unit](./polyfills/intl-numberformat.md#SupportedUnits):
+We've provided a polyfill [here](./polyfills/intl-numberformat) and `@formatjs/intl` types allow users to pass
+in a [sanctioned unit](./polyfills/intl-numberformat#SupportedUnits):
 
 ```tsx live
 intl.formatNumber(1000, {
@@ -322,7 +322,7 @@ This function should only be used in apps that only need to support one language
 ## formatList
 
 <Admonition type="caution" title="browser support">
-This requires [Intl.ListFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat) which has limited browser support. Please use our [polyfill](./polyfills/intl-listformat.md) if you plan to support them.
+This requires [Intl.ListFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat) which has limited browser support. Please use our [polyfill](./polyfills/intl-listformat) if you plan to support them.
 </Admonition>
 
 ```ts
@@ -350,7 +350,7 @@ intl.formatList(['5 hours', '3 minutes'], {type: 'unit'})
 ## formatDisplayName
 
 <Admonition type="caution" title="browser support">
-This requires [Intl.DisplayNames](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames) which has limited browser support. Please use our [polyfill](./polyfills/intl-displaynames.md) if you plan to support them.
+This requires [Intl.DisplayNames](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames) which has limited browser support. Please use our [polyfill](./polyfills/intl-displaynames) if you plan to support them.
 </Admonition>
 
 ```ts
@@ -428,7 +428,7 @@ type MessageDescriptor = {
 ```
 
 <Admonition type="info" title="Extracting Message Descriptor">
-You can extract inline-declared messages from source files using [our CLI](./getting-started/message-extraction.md).
+You can extract inline-declared messages from source files using [our CLI](./getting-started/message-extraction).
 </Admonition>
 
 ### Message Formatting Fallbacks

--- a/docs/src/docs/polyfills.mdx
+++ b/docs/src/docs/polyfills.mdx
@@ -2,18 +2,18 @@ One of our goals is to provide developers with access to newest ECMA-402 Intl AP
 
 Our current list of polyfills includes:
 
-- [Intl.PluralRules](polyfills/intl-pluralrules.md)
-- [Intl.RelativeTimeFormat](polyfills/intl-relativetimeformat.md)
-- [Intl.ListFormat](polyfills/intl-listformat.md)
-- [Intl.DisplayNames](polyfills/intl-displaynames.md)
-- [Intl.NumberFormat](polyfills/intl-numberformat.md) (ES2020)
-- [Intl.Locale](polyfills/intl-locale.md)
-- [Intl.LocaleMatcher](polyfills/intl-localematcher.md)
-- [Intl.getCanonicalLocales](polyfills/intl-getcanonicallocales.md)
-- [Intl.DateTimeFormat](polyfills/intl-datetimeformat.md) (ES2020)
-- [Intl.Segmenter](polyfills/intl-segmenter.md)
-- [Intl.DurationFormat](polyfills/intl-durationformat.md)
-- [Intl.supportedValuesOf](polyfills/intl-supportedvaluesof.md)
+- [Intl.PluralRules](polyfills/intl-pluralrules)
+- [Intl.RelativeTimeFormat](polyfills/intl-relativetimeformat)
+- [Intl.ListFormat](polyfills/intl-listformat)
+- [Intl.DisplayNames](polyfills/intl-displaynames)
+- [Intl.NumberFormat](polyfills/intl-numberformat) (ES2020)
+- [Intl.Locale](polyfills/intl-locale)
+- [Intl.LocaleMatcher](polyfills/intl-localematcher)
+- [Intl.getCanonicalLocales](polyfills/intl-getcanonicallocales)
+- [Intl.DateTimeFormat](polyfills/intl-datetimeformat) (ES2020)
+- [Intl.Segmenter](polyfills/intl-segmenter)
+- [Intl.DurationFormat](polyfills/intl-durationformat)
+- [Intl.supportedValuesOf](polyfills/intl-supportedvaluesof)
 
 ![Polyfill Hierarchy](/img/polyfills.svg)
 

--- a/docs/src/docs/polyfills/intl-datetimeformat.mdx
+++ b/docs/src/docs/polyfills/intl-datetimeformat.mdx
@@ -53,9 +53,9 @@ pnpm add @formatjs/intl-datetimeformat
 
 This package requires the following capabilities:
 
-- [`Intl.getCanonicalLocales`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/getCanonicalLocales) or [polyfill](intl-getcanonicallocales.md)
-- [`Intl.Locale`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale) or [polyfill](intl-locale.md).
-- [`Intl.NumberFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat) or [polyfill](intl-numberformat.md).
+- [`Intl.getCanonicalLocales`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/getCanonicalLocales) or [polyfill](intl-getcanonicallocales)
+- [`Intl.Locale`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale) or [polyfill](intl-locale).
+- [`Intl.NumberFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat) or [polyfill](intl-numberformat).
 
 ## Usage
 

--- a/docs/src/docs/polyfills/intl-displaynames.mdx
+++ b/docs/src/docs/polyfills/intl-displaynames.mdx
@@ -38,8 +38,8 @@ pnpm add @formatjs/intl-displaynames
 
 ## Requirements
 
-- [`Intl.getCanonicalLocales`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/getCanonicalLocales) or [polyfill](intl-getcanonicallocales.md)
-- [`Intl.Locale`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale) or [polyfill](intl-locale.md).
+- [`Intl.getCanonicalLocales`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/getCanonicalLocales) or [polyfill](intl-getcanonicallocales)
+- [`Intl.Locale`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale) or [polyfill](intl-locale).
 
 ## Features
 

--- a/docs/src/docs/polyfills/intl-durationformat.mdx
+++ b/docs/src/docs/polyfills/intl-durationformat.mdx
@@ -38,8 +38,8 @@ pnpm add @formatjs/intl-durationformat
 
 ## Requirements
 
-- [`Intl.ListFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat) or [polyfill](intl-listformat.md)
-- [`Intl.NumberFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat) or [polyfill](intl-numberformat.md).
+- [`Intl.ListFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat) or [polyfill](intl-listformat)
+- [`Intl.NumberFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat) or [polyfill](intl-numberformat).
 
 ## Usage
 

--- a/docs/src/docs/polyfills/intl-listformat.mdx
+++ b/docs/src/docs/polyfills/intl-listformat.mdx
@@ -38,8 +38,8 @@ pnpm add @formatjs/intl-listformat
 
 ## Requirements
 
-- [`Intl.getCanonicalLocales`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/getCanonicalLocales) or [polyfill](intl-getcanonicallocales.md)
-- [`Intl.Locale`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale) or [polyfill](intl-locale.md).
+- [`Intl.getCanonicalLocales`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/getCanonicalLocales) or [polyfill](intl-getcanonicallocales)
+- [`Intl.Locale`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale) or [polyfill](intl-locale).
 
 ## Usage
 

--- a/docs/src/docs/polyfills/intl-locale.mdx
+++ b/docs/src/docs/polyfills/intl-locale.mdx
@@ -38,7 +38,7 @@ pnpm add @formatjs/intl-locale
 
 ## Requirements
 
-- [`Intl.getCanonicalLocales`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/getCanonicalLocales) or [polyfill](intl-getcanonicallocales.md)
+- [`Intl.getCanonicalLocales`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/getCanonicalLocales) or [polyfill](intl-getcanonicallocales)
 
 ## Usage
 

--- a/docs/src/docs/polyfills/intl-localematcher.mdx
+++ b/docs/src/docs/polyfills/intl-localematcher.mdx
@@ -38,8 +38,8 @@ pnpm add @formatjs/intl-localematcher
 
 ## Requirements
 
-- [`Intl.getCanonicalLocales`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/getCanonicalLocales) or [polyfill](intl-getcanonicallocales.md)
-- [`Intl.Locale`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale) or [polyfill](intl-locale.md)
+- [`Intl.getCanonicalLocales`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/getCanonicalLocales) or [polyfill](intl-getcanonicallocales)
+- [`Intl.Locale`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale) or [polyfill](intl-locale)
 
 ## Usage
 

--- a/docs/src/docs/polyfills/intl-numberformat.mdx
+++ b/docs/src/docs/polyfills/intl-numberformat.mdx
@@ -43,9 +43,9 @@ pnpm add @formatjs/intl-numberformat
 
 This package requires the following capabilities:
 
-- [`Intl.getCanonicalLocales`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/getCanonicalLocales) or [polyfill](intl-getcanonicallocales.md)
-- [`Intl.Locale`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale) or [polyfill](intl-locale.md).
-- [`Intl.PluralRules`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/PluralRules) or [polyfill](intl-pluralrules.md).
+- [`Intl.getCanonicalLocales`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/getCanonicalLocales) or [polyfill](intl-getcanonicallocales)
+- [`Intl.Locale`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale) or [polyfill](intl-locale).
+- [`Intl.PluralRules`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/PluralRules) or [polyfill](intl-pluralrules).
 
 ## Features
 

--- a/docs/src/docs/polyfills/intl-pluralrules.mdx
+++ b/docs/src/docs/polyfills/intl-pluralrules.mdx
@@ -38,8 +38,8 @@ pnpm add @formatjs/intl-pluralrules
 
 ## Requirements
 
-- [`Intl.getCanonicalLocales`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/getCanonicalLocales) or [polyfill](intl-getcanonicallocales.md)
-- [`Intl.Locale`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale) or [polyfill](intl-locale.md).
+- [`Intl.getCanonicalLocales`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/getCanonicalLocales) or [polyfill](intl-getcanonicallocales)
+- [`Intl.Locale`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale) or [polyfill](intl-locale).
 
 ## Usage
 

--- a/docs/src/docs/polyfills/intl-relativetimeformat.mdx
+++ b/docs/src/docs/polyfills/intl-relativetimeformat.mdx
@@ -40,10 +40,10 @@ pnpm add @formatjs/intl-relativetimeformat
 
 This package requires the following capabilities:
 
-- [`Intl.getCanonicalLocales`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/getCanonicalLocales) or [polyfill](intl-getcanonicallocales.md)
-- [`Intl.Locale`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale) or [polyfill](intl-locale.md).
-- [`Intl.PluralRules`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/PluralRules) or [polyfill](intl-pluralrules.md).
-- If you need `formatToParts` and have to support IE11- or Node 10-, you'd need to polyfill using [`@formatjs/intl-numberformat.js`](intl-numberformat.md).
+- [`Intl.getCanonicalLocales`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/getCanonicalLocales) or [polyfill](intl-getcanonicallocales)
+- [`Intl.Locale`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale) or [polyfill](intl-locale).
+- [`Intl.PluralRules`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/PluralRules) or [polyfill](intl-pluralrules).
+- If you need `formatToParts` and have to support IE11- or Node 10-, you'd need to polyfill using [`@formatjs/intl-numberformat.js`](intl-numberformat).
 
 ## Usage
 

--- a/docs/src/docs/polyfills/intl-supportedvaluesof.mdx
+++ b/docs/src/docs/polyfills/intl-supportedvaluesof.mdx
@@ -39,8 +39,8 @@ pnpm add @formatjs/intl-enumerator
 ## Requirements
 
 - [`Intl.Collator`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator)
-- [`Intl.DateTimeFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat) or [polyfill](intl-datetimeformat.md)
-- [`Intl.NumberFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat) or [polyfill](intl-numberformat.md).
+- [`Intl.DateTimeFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat) or [polyfill](intl-datetimeformat)
+- [`Intl.NumberFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat) or [polyfill](intl-numberformat).
 
 ## Usage
 

--- a/docs/src/docs/react-intl.mdx
+++ b/docs/src/docs/react-intl.mdx
@@ -10,37 +10,25 @@ React Intl relies on these `Intl` APIs:
 
 - [Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat): Available on IE11+
 - [Intl.DateTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat): Available on IE11+
-- [Intl.PluralRules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/PluralRules): This can be polyfilled using [this package](polyfills/intl-pluralrules.md).
-- [Intl.RelativeTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat): This can be polyfilled using [this package](polyfills/intl-relativetimeformat.md).
-- (Optional) [Intl.DisplayNames](https://tc39.es/proposal-intl-displaynames/): Required if you use [`formatDisplayName`](react-intl/api.md#formatdisplayname)
-  or [`FormattedDisplayName`](react-intl/components.md#formatteddisplayname). This can be polyfilled using [this package](polyfills/intl-displaynames.md).
+- [Intl.PluralRules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/PluralRules): This can be polyfilled using [this package](polyfills/intl-pluralrules).
+- [Intl.RelativeTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat): This can be polyfilled using [this package](polyfills/intl-relativetimeformat).
+- (Optional) [Intl.DisplayNames](https://tc39.es/proposal-intl-displaynames/): Required if you use [`formatDisplayName`](react-intl/api#formatdisplayname)
+  or [`FormattedDisplayName`](react-intl/components#formatteddisplayname). This can be polyfilled using [this package](polyfills/intl-displaynames).
 
 If you need to support older browsers, we recommend you do the following:
 
-1. If you're supporting browsers that do not have `Intl`, include this [polyfill](polyfills/intl-getcanonicallocales.md) in your build.
-2. Polyfill `Intl.NumberFormat` with [`@formatjs/intl-numberformat`](polyfills/intl-numberformat.md).
-3. Polyfill `Intl.DateTimeFormat` with [`@formatjs/intl-datetimeformat`](polyfills/intl-datetimeformat.md)
-4. If you're supporting browsers that do not have [`Intl.PluralRules`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/PluralRules) (e.g IE11 & Safari 12-), include this [polyfill](polyfills/intl-pluralrules.md) in your build.
+1. If you're supporting browsers that do not have `Intl`, include this [polyfill](polyfills/intl-getcanonicallocales) in your build.
+2. Polyfill `Intl.NumberFormat` with [`@formatjs/intl-numberformat`](polyfills/intl-numberformat).
+3. Polyfill `Intl.DateTimeFormat` with [`@formatjs/intl-datetimeformat`](polyfills/intl-datetimeformat)
+4. If you're supporting browsers that do not have [`Intl.PluralRules`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/PluralRules) (e.g IE11 & Safari 12-), include this [polyfill](polyfills/intl-pluralrules) in your build.
 
-5. If you're supporting browsers that do not have [Intl.RelativeTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat) (e.g IE11, Edge, Safari 12-), include this [polyfill](polyfills/intl-relativetimeformat.md) in your build along with individual CLDR data for each locale you support.
+5. If you're supporting browsers that do not have [Intl.RelativeTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat) (e.g IE11, Edge, Safari 12-), include this [polyfill](polyfills/intl-relativetimeformat) in your build along with individual CLDR data for each locale you support.
 
-6. If you need `Intl.DisplayNames`, include this [polyfill](polyfills/intl-displaynames.md) in your build along with individual CLDR data for each locale you support.
+6. If you need `Intl.DisplayNames`, include this [polyfill](polyfills/intl-displaynames) in your build along with individual CLDR data for each locale you support.
 
 ### Node.js
 
-#### full-icu
-
-Starting with Node.js 13.0.0 full-icu is supported by default.
-
-If using React Intl in an earlier version of Node.js, your `node` binary has to either:
-
-- Get compiled with `full-icu` using these [instructions](https://nodejs.org/api/intl.html)
-
-**OR**
-
-- Uses [`full-icu` npm package](https://www.npmjs.com/package/full-icu)
-
-If your `node` version is missing any of the `Intl` APIs above, you'd have to polyfill them accordingly.
+React Intl requires **Node.js 16 or later**, which includes full internationalization support by default. If your Node.js version is missing any of the `Intl` APIs above, you'd have to polyfill them accordingly.
 
 ### React Native
 
@@ -109,15 +97,15 @@ We've made React Intl work well with module bundlers like: Browserify, Webpack, 
 
 Whether you use the ES6, CommonJS, or UMD version of React Intl, they all provide the same named exports:
 
-- [`injectIntl`](react-intl/api.md#injectintl)
-- [`defineMessages`](react-intl/api.md#definemessages)
-- [`IntlProvider`](react-intl/components.md#intlprovider)
-- [`FormattedDate`](react-intl/components.md#formatteddate)
-- [`FormattedTime`](react-intl/components.md#formattedtime)
-- [`FormattedRelativeTime`](react-intl/components.md#formattedrelativetime)
-- [`FormattedNumber`](react-intl/components.md#formattednumber)
-- [`FormattedPlural`](react-intl/components.md#formattedplural)
-- [`FormattedMessage`](react-intl/components.md#formattedmessage)
+- [`injectIntl`](react-intl/api#injectintl)
+- [`defineMessages`](react-intl/api#definemessages)
+- [`IntlProvider`](react-intl/components#intlprovider)
+- [`FormattedDate`](react-intl/components#formatteddate)
+- [`FormattedTime`](react-intl/components#formattedtime)
+- [`FormattedRelativeTime`](react-intl/components#formattedrelativetime)
+- [`FormattedNumber`](react-intl/components#formattednumber)
+- [`FormattedPlural`](react-intl/components#formattedplural)
+- [`FormattedMessage`](react-intl/components#formattedmessage)
 
 <Admonition type="danger" title="react">
 When using the UMD version of React Intl _without_ a module system, it will expect `react` to exist on the global variable: **`React`**, and put the above named exports on the global variable: **`ReactIntl`**.
@@ -129,7 +117,7 @@ Now with React Intl and its locale data loaded an i18n context can be created fo
 
 React Intl uses the provider pattern to scope an i18n context to a tree of components. This allows configuration like the current locale and set of translated strings/messages to be provided at the root of a component tree and made available to the `<Formatted*>` components. This is the same concept as what Flux frameworks like [Redux](http://redux.js.org/) use to provide access to a store within a component tree.
 
-**All apps using React Intl must use the [`<IntlProvider>` component](react-intl/components.md#intlprovider).**
+**All apps using React Intl must use the [`<IntlProvider>` component](react-intl/components#intlprovider).**
 
 The most common usage is to wrap your root React component with `<IntlProvider>` and configure it with the user's current locale and the corresponding translated strings/messages:
 
@@ -142,13 +130,13 @@ ReactDOM.render(
 )
 ```
 
-**See:** The [**`<IntlProvider>` docs**](react-intl/components.md#intlprovider) for more details.
+**See:** The [**`<IntlProvider>` docs**](react-intl/components#intlprovider) for more details.
 
 ## Formatting Data
 
-React Intl has two ways to format data, through [React components](react-intl/components.md) and its [API](react-intl/api.md). The components provide an idiomatic-React way of integrating internationalization into a React app, and the `<Formatted*>` components have [benefits](react-intl/components.md#why-components) over always using the imperative API directly. The API should be used when your React component needs to format data to a string value where a React element is not suitable; e.g., a `title` or `aria` attribute, or for side-effect in `componentDidMount`.
+React Intl has two ways to format data, through [React components](react-intl/components) and its [API](react-intl/api). The components provide an idiomatic-React way of integrating internationalization into a React app, and the `<Formatted*>` components have [benefits](react-intl/components#why-components) over always using the imperative API directly. The API should be used when your React component needs to format data to a string value where a React element is not suitable; e.g., a `title` or `aria` attribute, or for side-effect in `componentDidMount`.
 
-React Intl's imperative API is accessed via [**`injectIntl`**](react-intl/api.md#injectintl), a High-Order Component (HOC) factory. It will wrap the passed-in React component with another React component which provides the imperative formatting API into the wrapped component via its `props`. (This is similar to the connect-to-stores pattern found in many Flux implementations.)
+React Intl's imperative API is accessed via [**`injectIntl`**](react-intl/api#injectintl), a High-Order Component (HOC) factory. It will wrap the passed-in React component with another React component which provides the imperative formatting API into the wrapped component via its `props`. (This is similar to the connect-to-stores pattern found in many Flux implementations.)
 
 Here's an example using `<IntlProvider>`, `<Formatted*>` components, and the imperative API to setup an i18n context and format data:
 
@@ -199,7 +187,7 @@ Assuming `navigator.language` is `"en-us"`:
 </div>
 ```
 
-**See:** The [**API docs**](react-intl/api.md) and [**Component docs**](react-intl/components.md) for more details.
+**See:** The [**API docs**](react-intl/api) and [**Component docs**](react-intl/components) for more details.
 
 # ESM Build
 
@@ -260,8 +248,8 @@ There are several [**runnable example apps**](https://github.com/formatjs/format
 There are a few API layers that React Intl provides and is built on. When using React Intl you'll be interacting with `Intl` built-ins, React Intl's API, and its React components:
 
 - [ECMAScript Internationalization API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl)
-- [React Intl API](react-intl/api.md)
-- [React Intl Components](react-intl/components.md)
+- [React Intl API](react-intl/api)
+- [React Intl Components](react-intl/components)
 
 # TypeScript Usage
 
@@ -342,13 +330,13 @@ const customFormats = {
 
 # Advanced Usage
 
-Our [Advanced Usage](guides/advanced-usage.md) has further guides for production setup in environments where performance is important.
+Our [Advanced Usage](guides/advanced-usage) has further guides for production setup in environments where performance is important.
 
 # Supported Tooling
 
 ## Message extraction
 
-We've built [@formatjs/cli](tooling/cli.md) that helps you extract messages from a list of files. It uses [babel-plugin-formatjs](tooling/babel-plugin.md) under the hood and should be able to extract messages if you're declaring using 1 of the mechanisms below:
+We've built [@formatjs/cli](tooling/cli) that helps you extract messages from a list of files. It uses [babel-plugin-formatjs](tooling/babel-plugin) under the hood and should be able to extract messages if you're declaring using 1 of the mechanisms below:
 
 ```tsx
 
@@ -362,7 +350,7 @@ defineMessages({
 ```
 
 ```tsx
-;<FormattedMessage id="foo" defaultMessage="foo" description="bar" />
+<FormattedMessage id="foo" defaultMessage="foo" description="bar" />
 ```
 
 ```tsx
@@ -379,4 +367,4 @@ function Comp(props) {
 
 ## ESLint Plugin
 
-We've also built [eslint-plugin-formatjs](tooling/linter.md) that helps enforcing specific rules on your messages if your translation vendor has restrictions.
+We've also built [eslint-plugin-formatjs](tooling/linter) that helps enforcing specific rules on your messages if your translation vendor has restrictions.

--- a/docs/src/docs/react-intl/api.mdx
+++ b/docs/src/docs/react-intl/api.mdx
@@ -1,8 +1,8 @@
-There are a few API layers that React Intl provides and is built on. When using React Intl you'll be interacting with its API (documented here) and its React [components](./components.md).
+There are a few API layers that React Intl provides and is built on. When using React Intl you'll be interacting with its API (documented here) and its React [components](./components).
 
 ## Why Imperative API?
 
-While our [components](./components.md) provide a seamless integration with React, the imperative API are recommended (sometimes required) in several use cases:
+While our [components](./components) provide a seamless integration with React, the imperative API are recommended (sometimes required) in several use cases:
 
 - Setting text attributes such as `title`, `aria-label` and the like where a React component cannot be used (e.g `<img title/>`)
 - Formatting text/datetime... in non-React environment such as Node, Server API, Redux store, testing...
@@ -198,7 +198,7 @@ Default locale & formats for when a message is not translated (missing from `mes
 
 ### textComponent
 
-Provides a way to configure the default wrapper for React Intl's `<Formatted*>` components. If not specified, [`<React.Fragment>`](https://reactjs.org/docs/fragments.html) is used. Before V3, `span` was used instead; check the [migration guide](upgrade-guide-3.x.md) for more info.
+Provides a way to configure the default wrapper for React Intl's `<Formatted*>` components. If not specified, [`<React.Fragment>`](https://reactjs.org/docs/fragments.html) is used. Before V3, `span` was used instead; check the [migration guide](upgrade-guide-3.x) for more info.
 
 ### onError
 
@@ -223,11 +223,11 @@ function formatDate(
 
 This function will return a formatted date string. It expects a `value` which can be parsed as a date (i.e., `isFinite(new Date(value))`), and accepts `options` that conform to `DateTimeFormatOptions`.
 
-<LiveCodeBlock code={`() => <div>{intl.formatDate(Date.now(), {
+<LiveCodeBlock code={`intl.formatDate(Date.now(), {
   year: 'numeric',
   month: 'numeric',
   day: 'numeric',
-})}</div>
+})
 `} />
 
 ## formatTime
@@ -250,13 +250,13 @@ This function will return a formatted date string, but it differs from [`formatD
 
 It expects a `value` which can be parsed as a date (i.e., `isFinite(new Date(value))`), and accepts `options` that conform to `DateTimeFormatOptions`.
 
-<LiveCodeBlock code={`() => <div>{intl.formatTime(Date.now())}</div>
+<LiveCodeBlock code={`intl.formatTime(Date.now())
 `} />
 
 ## formatDateTimeRange
 
 <Admonition type="caution" title="browser support">
-This requires [Intl.DateTimeFormat.prototype.formatRange](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/formatRange) which has limited browser support. Please use our [polyfill](../polyfills/intl-datetimeformat.md) if you plan to support them.
+This requires [Intl.DateTimeFormat.prototype.formatRange](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/formatRange) which has limited browser support. Please use our [polyfill](../polyfills/intl-datetimeformat) if you plan to support them.
 </Admonition>
 
 ```tsx
@@ -271,13 +271,13 @@ This function will return a formatted date/time range string. Both `from` & `to`
 
 It expects 2 values (a `from` Date & a `to` Date) and accepts `options` that conform to `DateTimeFormatOptions`.
 
-<LiveCodeBlock code={`() => <div>{intl.formatDateTimeRange(new Date('2020-1-1'), new Date('2020-1-15'))}</div>
+<LiveCodeBlock code={`intl.formatDateTimeRange(new Date('2020-1-1'), new Date('2020-1-15'))
 `} />
 
 ## formatRelativeTime
 
 <Admonition type="caution" title="browser support">
-This requires [Intl.RelativeTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat) which has limited browser support. Please use our [polyfill](../polyfills/intl-relativetimeformat.md) if you plan to support them.
+This requires [Intl.RelativeTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat) which has limited browser support. Please use our [polyfill](../polyfills/intl-relativetimeformat) if you plan to support them.
 </Admonition>
 
 ```tsx
@@ -307,10 +307,10 @@ function formatRelativeTime(
 
 This function will return a formatted relative time string (e.g., "1 hour ago"). It expects a `value` which is a number, a `unit` and `options` that conform to `Intl.RelativeTimeFormatOptions`.
 
-<LiveCodeBlock code={`() => <div>{intl.formatRelativeTime(0)}</div>
+<LiveCodeBlock code={`intl.formatRelativeTime(0)
 `} />
 
-<LiveCodeBlock code={`() => <div>{intl.formatRelativeTime(-24, 'hour', {style: 'narrow'})}</div>
+<LiveCodeBlock code={`intl.formatRelativeTime(-24, 'hour', {style: 'narrow'})
 `} />
 
 ## formatNumber
@@ -326,27 +326,27 @@ function formatNumber(
 
 This function will return a formatted number string. It expects a `value` which can be parsed as a number, and accepts `options` that conform to `NumberFormatOptions`.
 
-<LiveCodeBlock code={`() => <div>{intl.formatNumber(1000, {style: 'currency', currency: 'USD'})}</div>
+<LiveCodeBlock code={`intl.formatNumber(1000, {style: 'currency', currency: 'USD'})
 `} />
 
 **Formatting Number using `unit`**
 
 Currently this is part of ES2020 [NumberFormat](https://tc39.es/ecma402/#numberformat-objects).
-We've provided a polyfill [here](../polyfills/intl-numberformat.md) and `react-intl` types allow users to pass
-in a [sanctioned unit](../polyfills/intl-numberformat.md#SupportedUnits):
+We've provided a polyfill [here](../polyfills/intl-numberformat) and `react-intl` types allow users to pass
+in a [sanctioned unit](../polyfills/intl-numberformat#SupportedUnits):
 
-<LiveCodeBlock code={`() => <div>{intl.formatNumber(1000, {
+<LiveCodeBlock code={`intl.formatNumber(1000, {
   style: 'unit',
   unit: 'kilobyte',
   unitDisplay: 'narrow',
-})}</div>
+})
 `} />
 
-<LiveCodeBlock code={`() => <div>{intl.formatNumber(1000, {
+<LiveCodeBlock code={`intl.formatNumber(1000, {
   unit: 'fahrenheit',
   unitDisplay: 'long',
   style: 'unit',
-})}</div>
+})
 `} />
 
 ## formatPlural
@@ -366,13 +366,13 @@ This function will return a plural category string: `"zero"`, `"one"`, `"two"`, 
 
 This is a low-level utility whose output could be provided to a `switch` statement to select a particular string to display.
 
-<LiveCodeBlock code={`() => <div>{intl.formatPlural(1)}</div>
+<LiveCodeBlock code={`intl.formatPlural(1)
 `} />
 
-<LiveCodeBlock code={`() => <div>{intl.formatPlural(3, {style: 'ordinal'})}</div>
+<LiveCodeBlock code={`intl.formatPlural(3, {style: 'ordinal'})
 `} />
 
-<LiveCodeBlock code={`() => <div>{intl.formatPlural(4, {style: 'ordinal'})}</div>
+<LiveCodeBlock code={`intl.formatPlural(4, {style: 'ordinal'})
 `} />
 
 <Admonition type="danger" title="multiple language support">
@@ -382,7 +382,7 @@ This function should only be used in apps that only need to support one language
 ## formatList
 
 <Admonition type="caution" title="browser support">
-This requires [Intl.ListFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat) which has limited browser support. Please use our [polyfill](../polyfills/intl-listformat.md) if you plan to support them.
+This requires [Intl.ListFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat) which has limited browser support. Please use our [polyfill](../polyfills/intl-listformat) if you plan to support them.
 </Admonition>
 
 ```ts
@@ -399,16 +399,16 @@ function formatList(
 
 This function allows you to join list of things together in an i18n-safe way. For example, when the locale is `en`:
 
-<LiveCodeBlock code={`() => <div>{intl.formatList(['Me', 'myself', 'I'], {type: 'conjunction'})}</div>
+<LiveCodeBlock code={`intl.formatList(['Me', 'myself', 'I'], {type: 'conjunction'})
 `} />
 
-<LiveCodeBlock code={`() => <div>{intl.formatList(['5 hours', '3 minutes'], {type: 'unit'})}</div>
+<LiveCodeBlock code={`intl.formatList(['5 hours', '3 minutes'], {type: 'unit'})
 `} />
 
 ## formatDisplayName
 
 <Admonition type="caution" title="browser support">
-This requires [Intl.DisplayNames](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames) which has limited browser support. Please use our [polyfill](../polyfills/intl-displaynames.md) if you plan to support them.
+This requires [Intl.DisplayNames](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames) which has limited browser support. Please use our [polyfill](../polyfills/intl-displaynames) if you plan to support them.
 </Admonition>
 
 ```ts
@@ -426,16 +426,16 @@ function formatDisplayName(
 
 Usage examples:
 
-<LiveCodeBlock code={`() => <div>{intl.formatDisplayName('zh-Hans-SG', {type: 'language'})}</div>
+<LiveCodeBlock code={`intl.formatDisplayName('zh-Hans-SG', {type: 'language'})
 `} />
 
-<LiveCodeBlock code={`() => <div>{intl.formatDisplayName('Deva', {type: 'script'})}</div>
+<LiveCodeBlock code={`intl.formatDisplayName('Deva', {type: 'script'})
 `} />
 
-<LiveCodeBlock code={`() => <div>{intl.formatDisplayName('CNY', {type: 'currency'})}</div>
+<LiveCodeBlock code={`intl.formatDisplayName('CNY', {type: 'currency'})
 `} />
 
-<LiveCodeBlock code={`() => <div>{intl.formatDisplayName('UN', {type: 'region'})}</div>
+<LiveCodeBlock code={`intl.formatDisplayName('UN', {type: 'region'})
 `} />
 
 ## formatMessage
@@ -479,7 +479,7 @@ type MessageDescriptor = {
 ```
 
 <Admonition type="info" title="Extracting Message Descriptor">
-You can extract inline-declared messages from source files using [our CLI](../getting-started/message-extraction.md).
+You can extract inline-declared messages from source files using [our CLI](../getting-started/message-extraction).
 </Admonition>
 
 ### Message Formatting Fallbacks

--- a/docs/src/docs/react-intl/components.mdx
+++ b/docs/src/docs/react-intl/components.mdx
@@ -1,4 +1,4 @@
-React Intl has a set of React components that provide a declarative way to setup an i18n context and format dates, numbers, and strings for display in a web UI. The components render React elements by building on React Intl's imperative [API](api.md).
+React Intl has a set of React components that provide a declarative way to setup an i18n context and format dates, numbers, and strings for display in a web UI. The components render React elements by building on React Intl's imperative [API](api).
 
 ## Why Components?
 
@@ -44,7 +44,7 @@ Default locale & formats for when a message is not translated (missing from `mes
 
 ### textComponent
 
-Provides a way to configure the default wrapper for React Intl's `<Formatted*>` components. If not specified, [`<React.Fragment>`](https://reactjs.org/docs/fragments.html) is used. Before V3, `span` was used instead; check the [migration guide](upgrade-guide-3.x.md) for more info.
+Provides a way to configure the default wrapper for React Intl's `<Formatted*>` components. If not specified, [`<React.Fragment>`](https://reactjs.org/docs/fragments.html) is used. Before V3, `span` was used instead; check the [migration guide](upgrade-guide-3.x) for more info.
 
 ### onError
 
@@ -125,7 +125,7 @@ const intl = createIntl({
 
 ## FormattedDate
 
-This component uses the [`formatDate`](api.md#formatdate) and [`Intl.DateTimeFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat) APIs and has `props` that correspond to the `DateTimeFormatOptions` specified above.
+This component uses the [`formatDate`](api#formatdate) and [`Intl.DateTimeFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat) APIs and has `props` that correspond to the `DateTimeFormatOptions` specified above.
 
 **Props:**
 
@@ -160,7 +160,7 @@ By default `<FormattedDate>` will render the formatted date into a `<React.Fragm
 ## FormattedDateParts
 
 <Admonition type="caution" title="browser support">
-This requires [Intl.DateTimeFormat.prototype.formatToParts](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/formatToParts) which is not available in IE11. Please use our [polyfill](../polyfills/intl-datetimeformat.md) if you plan to support IE11.
+This requires [Intl.DateTimeFormat.prototype.formatToParts](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/formatToParts) which is not available in IE11. Please use our [polyfill](../polyfills/intl-datetimeformat) if you plan to support IE11.
 </Admonition>
 
 This component provides more customization to `FormattedDate` by allowing children function to have access to underlying parts of the formatted date. The available parts are listed [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/formatToParts)
@@ -195,7 +195,7 @@ props: Intl.DateTimeFormatOptions &
 
 ## FormattedTime
 
-This component uses the [`formatTime`](api.md#formattime) and [`Intl.DateTimeFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat) APIs and has `props` that correspond to the `DateTimeFormatOptions` specified above, with the following defaults:
+This component uses the [`formatTime`](api#formattime) and [`Intl.DateTimeFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat) APIs and has `props` that correspond to the `DateTimeFormatOptions` specified above, with the following defaults:
 
 ```tsx
 {
@@ -226,7 +226,7 @@ By default `<FormattedTime>` will render the formatted time into a `React.Fragme
 ## FormattedTimeParts
 
 <Admonition type="caution" title="browser support">
-This requires [Intl.DateTimeFormat.prototype.formatToParts](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/formatToParts) which is not available in IE11. Please use our [polyfill](../polyfills/intl-datetimeformat.md) if you plan to support IE11.
+This requires [Intl.DateTimeFormat.prototype.formatToParts](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/formatToParts) which is not available in IE11. Please use our [polyfill](../polyfills/intl-datetimeformat) if you plan to support IE11.
 </Admonition>
 
 This component provides more customization to `FormattedTime` by allowing children function to have access to underlying parts of the formatted date. The available parts are listed [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/formatToParts)
@@ -257,10 +257,10 @@ props: Intl.DateTimeFormatOptions &
 ## FormattedDateTimeRange
 
 <Admonition type="caution" title="browser support">
-This requires stage-3 API [Intl.RelativeTimeFormat.prototype.formatRange](https://github.com/tc39/proposal-intl-DateTimeFormat-formatRange) which has limited browser support. Please use our [polyfill](../polyfills/intl-datetimeformat.md) if you plan to support them.
+This requires stage-3 API [Intl.RelativeTimeFormat.prototype.formatRange](https://github.com/tc39/proposal-intl-DateTimeFormat-formatRange) which has limited browser support. Please use our [polyfill](../polyfills/intl-datetimeformat) if you plan to support them.
 </Admonition>
 
-This component uses the [`formatDateTimeRange`](api.md#formatdatetimerange) and [`Intl.DateTimeFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat) APIs and has `props` that correspond to the `DateTimeFormatOptions` specified above
+This component uses the [`formatDateTimeRange`](api#formatdatetimerange) and [`Intl.DateTimeFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat) APIs and has `props` that correspond to the `DateTimeFormatOptions` specified above
 
 **Props:**
 
@@ -287,10 +287,10 @@ By default `<FormattedDateTimeRange>` will render the formatted time into a `Rea
 ## FormattedRelativeTime
 
 <Admonition type="caution" title="browser support">
-This requires [Intl.RelativeTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat) which has limited browser support. Please use our [polyfill](../polyfills/intl-relativetimeformat.md) if you plan to support them.
+This requires [Intl.RelativeTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat) which has limited browser support. Please use our [polyfill](../polyfills/intl-relativetimeformat) if you plan to support them.
 </Admonition>
 
-This component uses the [`formatRelativeTime`](api.md#formatrelativetime) API and has `props` that correspond to the following relative formatting options:
+This component uses the [`formatRelativeTime`](api#formatrelativetime) API and has `props` that correspond to the following relative formatting options:
 
 ```ts
 type RelativeTimeFormatOptions = {
@@ -338,7 +338,7 @@ This will initially renders `59 seconds ago`, after 1 second, will render `1 min
 
 ## FormattedNumber
 
-This component uses the [`formatNumber`](api.md#formatnumber) and [`Intl.NumberFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat) APIs and has `props` that correspond to `Intl.NumberFormatOptions`.
+This component uses the [`formatNumber`](api#formatnumber) and [`Intl.NumberFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat) APIs and has `props` that correspond to `Intl.NumberFormatOptions`.
 
 **Props:**
 
@@ -368,8 +368,8 @@ By default `<FormattedNumber>` will render the formatted number into a `React.Fr
 **Formatting Number using `unit`**
 
 Currently this is part of ES2020 [NumberFormat](https://tc39.es/ecma402/#numberformat-objects).
-We've provided a polyfill [here](../polyfills/intl-numberformat.md) and `react-intl` types allow users to pass
-in a [sanctioned unit](../polyfills/intl-numberformat.md#SupportedUnits). For example:
+We've provided a polyfill [here](../polyfills/intl-numberformat) and `react-intl` types allow users to pass
+in a [sanctioned unit](../polyfills/intl-numberformat#SupportedUnits). For example:
 
 ```tsx live
 <FormattedNumber
@@ -392,7 +392,7 @@ in a [sanctioned unit](../polyfills/intl-numberformat.md#SupportedUnits). For ex
 ## FormattedNumberParts
 
 <Admonition type="caution" title="browser support">
-This requires [Intl.NumberFormat.prototype.formatToParts](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/formatToParts) which is not available in IE11. Please use our [polyfill](../polyfills/intl-numberformat.md) if you plan to support IE11.
+This requires [Intl.NumberFormat.prototype.formatToParts](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/formatToParts) which is not available in IE11. Please use our [polyfill](../polyfills/intl-numberformat) if you plan to support IE11.
 </Admonition>
 
 This component provides more customization to `FormattedNumber` by allowing children function to have access to underlying parts of the formatted number. The available parts are listed [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat/formatToParts).
@@ -424,7 +424,7 @@ props: NumberFormatOptions &
 
 ## FormattedPlural
 
-This component uses the [`formatPlural`](api.md#formatplural) API and [`Intl.PluralRules`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/PluralRules) has `props` that correspond to `Intl.PluralRulesOptions`.
+This component uses the [`formatPlural`](api#formatplural) API and [`Intl.PluralRules`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/PluralRules) has `props` that correspond to `Intl.PluralRulesOptions`.
 
 **Props:**
 
@@ -455,10 +455,10 @@ By default `<FormattedPlural>` will select a [plural category](http://www.unicod
 ## FormattedList
 
 <Admonition type="caution" title="browser support">
-This requires [Intl.ListFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat) which has limited browser support. Please use our [polyfill](../polyfills/intl-listformat.md) if you plan to support them.
+This requires [Intl.ListFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat) which has limited browser support. Please use our [polyfill](../polyfills/intl-listformat) if you plan to support them.
 </Admonition>
 
-This component uses [`formatList`](api.md#formatlist) API and [Intl.ListFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ListFormat). Its props corresponds to `Intl.ListFormatOptions`.
+This component uses [`formatList`](api#formatlist) API and [Intl.ListFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ListFormat). Its props corresponds to `Intl.ListFormatOptions`.
 
 **Props:**
 
@@ -484,10 +484,10 @@ When the locale is `en`:
 ## FormattedListParts
 
 <Admonition type="caution" title="browser support">
-This requires [Intl.ListFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat) which has limited browser support. Please use our [polyfill](../polyfills/intl-listformat.md) if you plan to support them.
+This requires [Intl.ListFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat) which has limited browser support. Please use our [polyfill](../polyfills/intl-listformat) if you plan to support them.
 </Admonition>
 
-This component uses [`formatListToParts`](api.md#formatlisttoparts) API and [Intl.ListFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ListFormat). Its props corresponds to `Intl.ListFormatOptions`.
+This component uses [`formatListToParts`](api#formatlisttoparts) API and [Intl.ListFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ListFormat). Its props corresponds to `Intl.ListFormatOptions`.
 
 **Props:**
 
@@ -519,11 +519,11 @@ When the locale is `en`:
 ## FormattedDisplayName
 
 <Admonition type="caution" title="browser support">
-This requires [Intl.DisplayNames](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames) which has limited browser support. Please use our [polyfill](../polyfills/intl-displaynames.md) if you plan to support them.
+This requires [Intl.DisplayNames](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames) which has limited browser support. Please use our [polyfill](../polyfills/intl-displaynames) if you plan to support them.
 </Admonition>
 
-This component uses [`formatDisplayName`](api.md#formatdisplayname) and [`Intl.DisplayNames`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames)
-has `props` that correspond to `DisplayNameOptions`. You might need a [polyfill](../polyfills/intl-displaynames.md).
+This component uses [`formatDisplayName`](api#formatdisplayname) and [`Intl.DisplayNames`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames)
+has `props` that correspond to `DisplayNameOptions`. You might need a [polyfill](../polyfills/intl-displaynames).
 
 **Props:**
 
@@ -548,7 +548,7 @@ When the locale is `en`:
 
 ## FormattedMessage
 
-This component uses the [`formatMessage`](api.md#formatmessage) API and has `props` that correspond to a [Message Descriptor](#message-descriptor).
+This component uses the [`formatMessage`](api#formatmessage) API and has `props` that correspond to a [Message Descriptor](#message-descriptor).
 
 **Props:**
 
@@ -600,7 +600,7 @@ type MessageDescriptor = {
 ```
 
 <Admonition type="info" title="compile message descriptors">
-The [babel-plugin-formatjs](../tooling/babel-plugin.md) and [@formatjs/ts-transformer](../tooling/ts-transformer.md) packages can be used to compile Message Descriptors defined in JavaScript source files into AST for performance.
+The [babel-plugin-formatjs](../tooling/babel-plugin) and [@formatjs/ts-transformer](../tooling/ts-transformer) packages can be used to compile Message Descriptors defined in JavaScript source files into AST for performance.
 </Admonition>
 
 ### Message Formatting Fallbacks

--- a/docs/src/docs/react-intl/upgrade-guide-2.x.mdx
+++ b/docs/src/docs/react-intl/upgrade-guide-2.x.mdx
@@ -8,7 +8,7 @@ The locale data modules in React Intl v2 have been refactored to _provide_ data,
 
 ### Add Call to `addLocaleData()` in Browser
 
-There is now an [`addLocaleData()`](api.md#addlocaledata) function that needs to be called with the locale data that has been loaded. You can do the following in your main client JavaScript entry point:
+There is now an [`addLocaleData()`](api#addlocaledata) function that needs to be called with the locale data that has been loaded. You can do the following in your main client JavaScript entry point:
 
 This assumes a locale data `<script>` is added based on the request; e.g., for French speaking users:
 
@@ -43,11 +43,11 @@ This decoupling of the library from the locale data, allows for the files to be 
 
 ## Remove Intl Mixin
 
-**The `IntlMixin` has been removed from React Intl v2.** The mixin did two things: it automatically propagated `locales`, `formats`, and `messages` throughout an app's hierarchy, and it provided an imperative API via `format*()` functions. These jobs are now handled by [`<IntlProvider>`](components.md#intlprovider) and [`injectIntl()`](api.md#injection-api), respectively:
+**The `IntlMixin` has been removed from React Intl v2.** The mixin did two things: it automatically propagated `locales`, `formats`, and `messages` throughout an app's hierarchy, and it provided an imperative API via `format*()` functions. These jobs are now handled by [`<IntlProvider>`](components#intlprovider) and [`injectIntl()`](api#injection-api), respectively:
 
 ### Update to `IntlProvider`
 
-In React Intl v1, you would add the `IntlMixin` to your root component; e.g., `<App>`. Remove the `IntlMixin` and instead wrap your root component with [`<IntlProvider>`](components.md#intlprovider):
+In React Intl v1, you would add the `IntlMixin` to your root component; e.g., `<App>`. Remove the `IntlMixin` and instead wrap your root component with [`<IntlProvider>`](components#intlprovider):
 
 ```tsx
 
@@ -65,9 +65,9 @@ The `locale` prop is **singular**, required, and only accepts a string value. Th
 
 ### Update to `injectIntl()`
 
-The `IntlMixin` also provided the imperative API for custom components to use the `format*()` methods; e.g., `formatDate()` to get formatted strings for using in places like `title` and `aria` attribute. Remove the `IntlMixin` and instead use the [`injectIntl()`](api.md#injectintl) Hight Order Component (HOC) factory function to inject the imperative API via `props`.
+The `IntlMixin` also provided the imperative API for custom components to use the `format*()` methods; e.g., `formatDate()` to get formatted strings for using in places like `title` and `aria` attribute. Remove the `IntlMixin` and instead use the [`injectIntl()`](api#injectintl) Hight Order Component (HOC) factory function to inject the imperative API via `props`.
 
-Here's an example of a custom `<RelativeTime>` stateless component which uses `injectIntl()` and the imperative [`formatDate()`](api.md#formatdate) API:
+Here's an example of a custom `<RelativeTime>` stateless component which uses `injectIntl()` and the imperative [`formatDate()`](api#formatdate) API:
 
 ```tsx
 
@@ -105,7 +105,7 @@ export default injectIntl(RelativeTime)
 
 **The way string messages are formatted in React Intl v2 has changed significantly!** This is the most disruptive set of change when upgrading from v1 to v2; but it enables many great new features.
 
-React Intl v2 introduces a new [**Message Descriptor**](api.md#message-descriptor) concept which can be used to define an app's default string messages. A Message Descriptor is an object with the following properties, `id` is the only required prop:
+React Intl v2 introduces a new [**Message Descriptor**](api#message-descriptor) concept which can be used to define an app's default string messages. A Message Descriptor is an object with the following properties, `id` is the only required prop:
 
 - **`id`**: A unique, stable identifier for the message
 - **`description`**: Context for the translator about how it's used in the UI
@@ -117,7 +117,7 @@ This upgrade guide will focus on using Message Descriptors that only contain an 
 
 ### Flatten `messages` Object
 
-React Intl v2 no longer supports nested `messages` objects, instead the collection of translated string messages passed to [`<IntlProvider>`](components.md#intlprovider) must be flat. This is an explicit design choice which simplifies while increasing flexibility. React Intl v2 does not apply any special semantics to strings with dots; e.g., `"namespaced.string_id"`.
+React Intl v2 no longer supports nested `messages` objects, instead the collection of translated string messages passed to [`<IntlProvider>`](components#intlprovider) must be flat. This is an explicit design choice which simplifies while increasing flexibility. React Intl v2 does not apply any special semantics to strings with dots; e.g., `"namespaced.string_id"`.
 
 Apps using a nested `messages` object structure could use the following function to flatten their object according to React Intl v1's semantics:
 
@@ -181,12 +181,12 @@ let message = this.props.intl.formatMessage({id: 'some.message.id'}, values)
 ```
 
 <Admonition type="info">
-In React Intl v2, the [`formatMessage()`](api.md#formatmessage) function is injected via [`injectIntl()`](api.md#injectintl).
+In React Intl v2, the [`formatMessage()`](api#formatmessage) function is injected via [`injectIntl()`](api#injectintl).
 </Admonition>
 
 ### Update `FormattedMessage` and `FormattedHTMLMessage` Instances
 
-The props for these two components have completely changed in React Intl v2. Instead of taking a `message` prop and treating all other props as values to fill in placeholders in a message, [`<FormattedMessage>`](components.md#formattedmessage) and [`<FormattedHTMLMessage>`](components.md#formattedhtmlmessage) now the same props as a Message Descriptor plus a new `values` prop.
+The props for these two components have completely changed in React Intl v2. Instead of taking a `message` prop and treating all other props as values to fill in placeholders in a message, [`<FormattedMessage>`](components#formattedmessage) and [`<FormattedHTMLMessage>`](components#formattedhtmlmessage) now the same props as a Message Descriptor plus a new `values` prop.
 
 The new `values` prop groups all of the message's placeholder values together into an object.
 
@@ -210,7 +210,7 @@ Minor changes have been made to how the "now" reference time is specified when f
 
 ### Rename `FormattedRelative`'s `now` Prop to `initialNow`
 
-A new feature has been added to [`<FormattedRelative>`](components.md#formattedrelative) instances in React Intl v2, they now "tick" and stay up to date. Since time moves forward, it was confusing to have a prop named `now`, so it has been renamed to `initialNow`. Any `<FormattedRelative>` instances that use `now` should update to prop name to `initialNow`:
+A new feature has been added to [`<FormattedRelative>`](components#formattedrelative) instances in React Intl v2, they now "tick" and stay up to date. Since time moves forward, it was confusing to have a prop named `now`, so it has been renamed to `initialNow`. Any `<FormattedRelative>` instances that use `now` should update to prop name to `initialNow`:
 
 **1.0:**
 
@@ -225,7 +225,7 @@ A new feature has been added to [`<FormattedRelative>`](components.md#formattedr
 ```
 
 <Admonition type="info">
-The [`<IntlProvider>`](components.md#intlprovider) component also has a `initialNow` prop which can be assigned a value to stabilize the "now" reference time for _all_ [`<FormattedRelative>`](components.md#formattedrelative) instances. This is useful for universal/isomorphic apps to proper React checksums between the server and client initial render.
+The [`<IntlProvider>`](components#intlprovider) component also has a `initialNow` prop which can be assigned a value to stabilize the "now" reference time for _all_ [`<FormattedRelative>`](components#formattedrelative) instances. This is useful for universal/isomorphic apps to proper React checksums between the server and client initial render.
 </Admonition>
 
 ### Merge `formatRelative()`'s Second and Third Arguments
@@ -248,5 +248,5 @@ let relative = this.props.intl.formatRelative(date, {
 ```
 
 <Admonition type="info">
-In React Intl v2, the [`formatRelative()`](api.md#formatrelative) function is injected via [`injectIntl()`](api.md#injectintl).
+In React Intl v2, the [`formatRelative()`](api#formatrelative) function is injected via [`injectIntl()`](api#injectintl).
 </Admonition>

--- a/docs/src/docs/react-intl/upgrade-guide-3.x.mdx
+++ b/docs/src/docs/react-intl/upgrade-guide-3.x.mdx
@@ -129,13 +129,7 @@ require('@formatjs/intl-relativetimeformat/polyfill')
 require('@formatjs/intl-relativetimeformat/locale-data/de') // Add locale data for de
 ```
 
-When using React Intl in Node.js, your `node` binary has to either:
-
-- Get compiled with `full-icu` using these [instructions](https://nodejs.org/api/intl.html)
-
-**OR**
-
-- Uses [`full-icu` npm package](https://www.npmjs.com/package/full-icu)
+When using React Intl in Node.js, you need **Node.js 16 or later**, which includes full internationalization support by default.
 
 ## TypeScript Support
 
@@ -217,7 +211,7 @@ You can use `@formatjs/intl-utils` to get close to the previous behavior like th
 ```tsx
 const {value, unit} = selectUnit(Date.now() - 48 * 3600 * 1000)
 // render
-;<FormattedRelativeTime value={value} unit={unit} />
+<FormattedRelativeTime value={value} unit={unit} />
 ```
 
 ## Enhanced `FormattedMessage` & `formatMessage` rich text formatting
@@ -363,4 +357,4 @@ Placeholder argument can no longer have `-` (e.g: `this is a {placeholder-var}` 
 
 ## Testing
 
-We've removed `IntlProvider.getChildContext` for testing and now you can use `createIntl` to create a standalone `intl` object outside of React and use that for testing purposes. See [Testing with React Intl](../guides/testing-with-react-intl.md) for more details.
+We've removed `IntlProvider.getChildContext` for testing and now you can use `createIntl` to create a standalone `intl` object outside of React and use that for testing purposes. See [Testing with React Intl](../guides/testing-with-react-intl) for more details.

--- a/docs/src/docs/tooling/babel-plugin.mdx
+++ b/docs/src/docs/tooling/babel-plugin.mdx
@@ -100,7 +100,7 @@ parse specific additional custom pragma. This allows you to tag certain file wit
 
 ```tsx
 // @intl-meta project:my-custom-project
-;<FormattedMessage defaultMessage="foo" id="bar" />
+<FormattedMessage defaultMessage="foo" id="bar" />
 ```
 
 and with option `{pragma: "@intl-meta"}`, we'll parse out `// @intl-meta project:my-custom-project` into `{project: 'my-custom-project'}` in the result file.

--- a/docs/src/docs/tooling/cli.mdx
+++ b/docs/src/docs/tooling/cli.mdx
@@ -42,7 +42,7 @@ Add the following command to your `package.json` `scripts`:
 }
 ```
 
-We've built this [CLI](https://www.npmjs.com/package/@formatjs/cli) that helps you extract messages from a list of files. It uses [`@formatjs/ts-transformer`](ts-transformer.md) under the hood and should be able to extract messages if you're declaring using 1 of the mechanisms below:
+We've built this [CLI](https://www.npmjs.com/package/@formatjs/cli) that helps you extract messages from a list of files. It uses [`@formatjs/ts-transformer`](ts-transformer) under the hood and should be able to extract messages if you're declaring using 1 of the mechanisms below:
 
 ```tsx
 
@@ -62,7 +62,7 @@ defineMessage({
 ```
 
 ```tsx
-;<FormattedMessage id="foo" defaultMessage="foo" description="bar" />
+<FormattedMessage id="foo" defaultMessage="foo" description="bar" />
 ```
 
 ```tsx
@@ -180,7 +180,7 @@ Parse specific additional custom pragma. This allows you to tag certain file wit
 
 ```tsx
 // @intl-meta project:my-custom-project
-;<FormattedMessage defaultMessage="foo" id="bar" />
+<FormattedMessage defaultMessage="foo" id="bar" />
 ```
 
 and with option `{pragma: "intl-meta"}`, we'll parse out `// @intl-meta project:my-custom-project` into `{project: 'my-custom-project'}` in the result file.
@@ -252,8 +252,8 @@ Whether to check for keys that exist in the target locale but not in the source 
 
 ## Compilation
 
-Compile extracted files from `formatjs extract` to a [react-intl](../react-intl.md) consumable
-JSON file. This also does ICU message verification. See [Message Distribution](../getting-started/message-distribution.md) for more details.
+Compile extracted files from `formatjs extract` to a [react-intl](../react-intl) consumable
+JSON file. This also does ICU message verification. See [Message Distribution](../getting-started/message-distribution) for more details.
 
 <Tabs
 groupId="npm"
@@ -299,7 +299,7 @@ The target file that contains compiled messages.
 
 ### `--ast`
 
-Whether to compile message into AST instead of just string. See [Advanced Usage](../guides/advanced-usage.md)
+Whether to compile message into AST instead of just string. See [Advanced Usage](../guides/advanced-usage)
 
 ### `--pseudo-locale <pseudoLocale>`
 
@@ -406,7 +406,7 @@ values={[
 
 ## Folder Compilation
 
-Batch compile a folder with extracted files from `formatjs extract` to a folder containing react-intl consumable JSON files. This also does ICU message verification. See [Message Distribution](../getting-started/message-distribution.md) for more details.
+Batch compile a folder with extracted files from `formatjs extract` to a folder containing react-intl consumable JSON files. This also does ICU message verification. See [Message Distribution](../getting-started/message-distribution) for more details.
 
 <Tabs
 groupId="npm"
@@ -448,7 +448,7 @@ This is especially useful to convert from a TMS-specific format back to react-in
 
 ### `--ast`
 
-Whether to compile message into AST instead of just string. See [Advanced Usage](../guides/advanced-usage.md)
+Whether to compile message into AST instead of just string. See [Advanced Usage](../guides/advanced-usage)
 
 ### `--skip-errors`
 

--- a/docs/src/docs/tooling/linter.mdx
+++ b/docs/src/docs/tooling/linter.mdx
@@ -69,7 +69,7 @@ defineMessage({
 ```
 
 ```tsx
-;<FormattedMessage defaultMessage="foo" description="bar" />
+<FormattedMessage defaultMessage="foo" description="bar" />
 ```
 
 ```tsx
@@ -102,11 +102,11 @@ These settings are applied globally to all formatjs rules once specified. See [S
 
 ### `formatjs.additionalFunctionNames`
 
-Similar to [babel-plugin-formatjs](./babel-plugin.md#additionalfunctionnames) & [@formatjs/ts-transformer](./ts-transformer.md#additionalfunctionnames), this allows you to specify additional function names to check besides `formatMessage` & `$formatMessage`.
+Similar to [babel-plugin-formatjs](./babel-plugin#additionalfunctionnames) & [@formatjs/ts-transformer](./ts-transformer#additionalfunctionnames), this allows you to specify additional function names to check besides `formatMessage` & `$formatMessage`.
 
 ### `formatjs.additionalComponentNames`
 
-Similar to [babel-plugin-formatjs](./babel-plugin.md#additionalcomponentnames) & [@formatjs/ts-transformer](./ts-transformer.md#additionalcomponentnames), this allows you to specify additional component names to check besides `FormattedMessage`.
+Similar to [babel-plugin-formatjs](./babel-plugin#additionalcomponentnames) & [@formatjs/ts-transformer](./ts-transformer#additionalcomponentnames), this allows you to specify additional component names to check besides `FormattedMessage`.
 
 ## Shareable Configs
 
@@ -846,38 +846,64 @@ Consistent coding style in JSX and less syntax clutter.
 
 Use `#` in the plural argument to reference the count instead of repeating the argument.
 
-```
-// Bad
+**Bad:**
+
+```icu-message-format
 I have {count} {
   count, plural,
     one {apple}
     other {apples}
   }
 }
-// Good
+```
+
+**Bad:**
+
+```icu-message-format
+I have {count} {
+  count, plural,
+    one {apple}
+    other {apples}
+  }
+}
+```
+
+**Good:**
+
+```icu-message-format
 I have {
   count, plural,
     one {# apple}
     other {# apples}
   }
 }
+```
 
-// Bad
+**Bad:**
+
+```icu-message-format
 I have {
   count, plural,
     one {{count} apple}
     other {{count} apples}
   }
 }
-// Good
+```
+
+**Good:**
+
+```icu-message-format
 I have {
   count, plural,
     one {# apple}
     other {# apples}
   }
 }
+```
 
-// Bad
+**Bad:**
+
+```icu-message-format
 I won the {ranking}{
   count, selectordinal,
     one {st}
@@ -885,7 +911,11 @@ I won the {ranking}{
     few {rd}
     other {th}
 } place.
-// Good
+```
+
+**Good:**
+
+```icu-message-format
 I won the {ranking}{
   count, selectordinal,
     one {#st}

--- a/docs/src/docs/tooling/ts-transformer.mdx
+++ b/docs/src/docs/tooling/ts-transformer.mdx
@@ -179,7 +179,7 @@ parse specific additional custom pragma. This allows you to tag certain file wit
 
 ```tsx
 // @intl-meta project:my-custom-project
-;<FormattedMessage defaultMessage="foo" id="bar" />
+<FormattedMessage defaultMessage="foo" id="bar" />
 ```
 
 and with option `{pragma: "@intl-meta"}`, we'll parse out `// @intl-meta project:my-custom-project` into `{project: 'my-custom-project'}` in the result file.

--- a/docs/src/docs/vue-intl.mdx
+++ b/docs/src/docs/vue-intl.mdx
@@ -35,7 +35,7 @@ pnpm add vue-intl
 
 ## Usage
 
-Initialize `VueIntl` plugin with the same `IntlConfig` documented in [@formatjs/intl](./intl.md#IntlShape).
+Initialize `VueIntl` plugin with the same `IntlConfig` documented in [@formatjs/intl](./intl#IntlShape).
 
 ```tsx
 
@@ -55,7 +55,7 @@ From there you can use our APIs in 2 ways:
 
 ### inject
 
-By specifying `inject: {intl: intlKey}`, you can use the full `IntlFormatters` API documented in [@formatjs/intl](./intl.md#IntlShape).
+By specifying `inject: {intl: intlKey}`, you can use the full `IntlFormatters` API documented in [@formatjs/intl](./intl#IntlShape).
 
 Note: `intlKey` needs to be imported from `vue-intl`.
 
@@ -118,16 +118,16 @@ We currently support:
 - `$formatDisplayName`
 - `$formatList`
 
-See [@formatjs/intl](./intl.md) for the full list of API signatures.
+See [@formatjs/intl](./intl) for the full list of API signatures.
 
 ## Tooling
 
 `formatjs` toolchain fully supports `vue`:
 
-- [eslint-plugin-formatjs](./tooling/linter.md): This fully supports `.vue` and JS/TS.
-- [@formatjs/cli](./tooling/cli.md): We now support extracting messages from `.vue` SFC files.
-- [babel-plugin-formatjs](./tooling/babel-plugin.md): Compile messages during bundling for `babel`.
-- [@formatjs/ts-transformer](./tooling/ts-transformer.md): Compile messages during bundling for `TypeScript`.
+- [eslint-plugin-formatjs](./tooling/linter): This fully supports `.vue` and JS/TS.
+- [@formatjs/cli](./tooling/cli): We now support extracting messages from `.vue` SFC files.
+- [babel-plugin-formatjs](./tooling/babel-plugin): Compile messages during bundling for `babel`.
+- [@formatjs/ts-transformer](./tooling/ts-transformer): Compile messages during bundling for `TypeScript`.
 
 ## Caveats
 


### PR DESCRIPTION
### TL;DR

Fixed broken documentation links and improved the LiveCodeBlock component to properly handle code transformations.

### What changed?

- Updated the `LiveCodeBlock` component to use React's `useCallback` for code transformation, moving the transformation logic into a dedicated function that's passed to the `LiveProvider`
- Fixed numerous broken internal documentation links by removing the `.md` extension from all internal links throughout the documentation
- Updated Node.js requirements in documentation to specify Node.js 16+ is required
- Removed outdated information about `full-icu` requirements for Node.js
- Fixed JSX syntax in code examples by removing stray semicolons
- Improved code examples in the documentation for better readability

### How to test?

1. Navigate through the documentation site and verify that internal links work correctly
2. Test the `LiveCodeBlock` component with different code examples to ensure proper rendering
3. Verify that code examples in the documentation render correctly

### Why make this change?

The documentation contained numerous broken internal links due to the `.md` extension being included in links. This change ensures a better user experience by fixing navigation throughout the docs. Additionally, the LiveCodeBlock component transformation was improved to handle code more reliably, ensuring that code examples render correctly regardless of whether they start with JSX or JavaScript expressions.