### PR TITLE
docs: fix meta tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ build/
 release/
 !release/BUILD.bazel
 target
+
+# Generated files
+docs/src/search-index.generated.json

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -22,7 +22,9 @@ ts_project(
             "src/**/*.test.ts",
             "src/**/*.test.tsx",
         ],
-    ),
+    ) + [
+        "src/docs-metadata.generated.json",
+    ],
     declaration = True,
     no_emit = True,
     resolve_json_module = True,
@@ -89,6 +91,26 @@ ts_run_binary(
     tool = ":build_search_index_tool",
 )
 
+# Extract metadata tool
+ts_binary(
+    name = "extract_metadata_tool",
+    data = [
+        "//:node_modules/@types/minimist",
+        "//:node_modules/@types/node",
+        "//:node_modules/fast-glob",
+        "//:node_modules/minimist",
+    ],
+    entry_point = "scripts/extract-metadata.ts",
+)
+
+# Extract metadata from MDX docs
+generate_src_file(
+    name = "docs_metadata",
+    src = "src/docs-metadata.generated.json",
+    data = glob(["src/docs/**/*.mdx"]),
+    tool = ":extract_metadata_tool",
+)
+
 # Copy HTML entry point to bin
 copy_to_bin(
     name = "index_html",
@@ -110,6 +132,7 @@ vite_bin.vite(
     name = "dist",
     srcs = [
         ":config_files",
+        ":docs_metadata",
         ":index_html",
         ":node_modules/intl-messageformat",
         ":node_modules/react-intl",
@@ -170,6 +193,7 @@ vite_bin.vite_binary(
     chdir = package_name(),
     data = [
         ":config_files",
+        ":docs_metadata",
         ":index_html",
         ":node_modules/intl-messageformat",
         ":node_modules/react-intl",

--- a/docs/scripts/extract-metadata.ts
+++ b/docs/scripts/extract-metadata.ts
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+import {readFileSync, writeFileSync, mkdirSync} from 'fs'
+import {join, dirname} from 'path'
+import glob from 'fast-glob'
+import minimist from 'minimist'
+
+const argv = minimist(process.argv.slice(2))
+const outputPath = argv.out
+
+if (!outputPath) {
+  console.error('--out parameter is required')
+  process.exit(1)
+}
+
+// Get docs directory relative to current working directory
+// When run from Bazel, cwd is the workspace root
+const docsDir = join(process.cwd(), 'docs', 'src', 'docs')
+
+interface DocMetadata {
+  title: string
+  description: string
+}
+
+type MetadataCollection = Record<string, DocMetadata>
+
+// Extract description from MDX content
+function extractDescription(content: string): string {
+  const lines = content.split('\n')
+  let description = ''
+
+  for (const line of lines) {
+    const trimmed = line.trim()
+
+    // Skip empty lines
+    if (!trimmed) continue
+
+    // Skip badges and images
+    if (trimmed.startsWith('[![') || trimmed.startsWith('![')) continue
+
+    // Skip reference links like [numberformat]: https://...
+    if (/^\[.+\]:\s*https?:\/\//.test(trimmed)) continue
+
+    // Skip headings
+    if (trimmed.startsWith('#')) continue
+
+    // Skip import statements
+    if (trimmed.startsWith('import ')) continue
+
+    // Skip JSX component tags (opening tags only)
+    if (trimmed.startsWith('<') && !trimmed.startsWith('</')) continue
+
+    // This is likely our description
+    // Remove markdown formatting
+    let cleaned = trimmed
+      .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1') // Remove inline markdown links [text](url)
+      .replace(/\[([^\]]+)\]\[[^\]]+\]/g, '$1') // Remove reference-style links [text][ref]
+      .replace(/`([^`]+)`/g, '$1') // Remove inline code
+      .replace(/\*\*([^*]+)\*\*/g, '$1') // Remove bold
+      .replace(/_([^_]+)_/g, '$1') // Remove italic
+
+    description = cleaned
+    break
+  }
+
+  // Fallback if no description found
+  if (!description) {
+    description =
+      'FormatJS documentation. Industry-standard internationalization libraries for JavaScript.'
+  }
+
+  // Limit description length to ~155 characters for SEO
+  if (description.length > 155) {
+    description = description.substring(0, 152) + '...'
+  }
+
+  return description
+}
+
+// Extract title from path
+function extractTitle(path: string): string {
+  const pathParts = path.split('/')
+  const lastPart = pathParts[pathParts.length - 1] || 'docs'
+  return lastPart
+    .split('-')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+}
+
+async function main(): Promise<void> {
+  // Find all MDX files
+  const mdxFiles = await glob('**/*.mdx', {
+    cwd: docsDir,
+    absolute: false,
+  })
+
+  mdxFiles.sort()
+
+  const metadata: MetadataCollection = {}
+
+  for (const file of mdxFiles) {
+    const path = file.replace(/\.mdx$/, '')
+    const fullPath = join(docsDir, file)
+
+    try {
+      const content = readFileSync(fullPath, 'utf-8')
+      const description = extractDescription(content)
+      const title = extractTitle(path)
+
+      metadata[path] = {
+        title,
+        description,
+      }
+
+      console.log(`✓ Extracted metadata for: ${path}`)
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error)
+      console.error(`✗ Error processing ${file}:`, errorMessage)
+    }
+  }
+
+  // Ensure output directory exists
+  const outputDir = dirname(outputPath)
+  mkdirSync(outputDir, {recursive: true})
+
+  // Write metadata to JSON file
+  writeFileSync(outputPath, JSON.stringify(metadata, null, 2))
+
+  console.log(
+    `\n✓ Generated metadata for ${Object.keys(metadata).length} documents`
+  )
+  console.log(`  Output: ${outputPath}`)
+}
+
+main().catch(console.error)

--- a/docs/src/docs-metadata.generated.json
+++ b/docs/src/docs-metadata.generated.json
@@ -1,0 +1,170 @@
+{
+  "core-concepts/basic-internationalization-principles": {
+    "title": "Basic Internationalization Principles",
+    "description": "Internationalized software supports the languages and cultural customs of people throughout the world. The Web reaches all parts of the world. Internati..."
+  },
+  "core-concepts/icu-syntax": {
+    "title": "Icu Syntax",
+    "description": "If you are translating text you'll need a way for your translators to express the subtleties of spelling, grammar, and conjugation inherent in each lang..."
+  },
+  "getting-started/application-workflow": {
+    "title": "Application Workflow",
+    "description": "While our Installation guide can help you get started, this guide gives you an overview how your daily translation workflow might look like."
+  },
+  "getting-started/installation": {
+    "title": "Installation",
+    "description": "formatjs is a set of libraries that help you setup internationalization in any project whether it's React or not."
+  },
+  "getting-started/message-declaration": {
+    "title": "Message Declaration",
+    "description": "While you can declare your messages using only ids, we highly recommend declaring defaultMessages inline along with their usages because of the followin..."
+  },
+  "getting-started/message-distribution": {
+    "title": "Message Distribution",
+    "description": "Now that you've declared your messages, extracted them, sent them to your translation vendor and they have given you back the translated JSON of the sam..."
+  },
+  "getting-started/message-extraction": {
+    "title": "Message Extraction",
+    "description": "Now that you've declared some messages, it's time to extract them."
+  },
+  "guides/advanced-usage": {
+    "title": "Advanced Usage",
+    "description": "react-intl is optimized for both runtime & compile time rendering. Below are a few guidelines you can follow if you have a strict performance budget."
+  },
+  "guides/bundler-plugins": {
+    "title": "Bundler Plugins",
+    "description": "Now that you've had a working pipeline. It's time to dive deeper on how to optimize the build with formatjs. From Message Extraction guide, we explicitl..."
+  },
+  "guides/develop": {
+    "title": "Develop",
+    "description": "Aside from a strong focus on facilitating i18n production pipeline, formatjs also aims to improve i18n DevEx with our eslint-plugin-formatjs."
+  },
+  "guides/distribute-libraries": {
+    "title": "Distribute Libraries",
+    "description": "In larger scale applications/monorepos, not all components/libraries live within the same repo/project and they might get distributed differently. While..."
+  },
+  "guides/runtime-requirements": {
+    "title": "Runtime Requirements",
+    "description": "We support IE11 & 2 most recent versions of Edge, Chrome, Firefox & Safari. If you need older browser support, take a look at polyfill-library that also..."
+  },
+  "guides/testing-with-react-intl": {
+    "title": "Testing With React Intl",
+    "description": "React Intl uses the built-in Intl APIs in JavaScript. Make sure your environment satisfy the requirements listed in Intl APIs requirements"
+  },
+  "icu-messageformat-parser": {
+    "title": "Icu Messageformat Parser",
+    "description": "Parses ICU Message strings into an AST via JavaScript."
+  },
+  "intl-messageformat": {
+    "title": "Intl Messageformat",
+    "description": "Formats ICU Message strings with number, date, plural, and select placeholders to create localized messages."
+  },
+  "intl": {
+    "title": "Intl",
+    "description": "This library contains core intl API that is used by react-intl."
+  },
+  "polyfills": {
+    "title": "Polyfills",
+    "description": "One of our goals is to provide developers with access to newest ECMA-402 Intl APIs. Therefore, FormatJS suite also provide multiple high quality polyfil..."
+  },
+  "polyfills/intl-datetimeformat": {
+    "title": "Intl Datetimeformat",
+    "description": "A spec-compliant polyfill for Intl.DateTimeFormat fully tested by the official ECMAScript Conformance test suite"
+  },
+  "polyfills/intl-displaynames": {
+    "title": "Intl Displaynames",
+    "description": "A polyfill for Intl.DisplayNames."
+  },
+  "polyfills/intl-durationformat": {
+    "title": "Intl Durationformat",
+    "description": "A spec-compliant polyfill for Intl.DurationFormat"
+  },
+  "polyfills/intl-getcanonicallocales": {
+    "title": "Intl Getcanonicallocales",
+    "description": "A spec-compliant polyfill/ponyfill for Intl.getCanonicalLocales tested by the official ECMAScript Conformance test suite"
+  },
+  "polyfills/intl-listformat": {
+    "title": "Intl Listformat",
+    "description": "A spec-compliant polyfill for Intl.ListFormat fully tested by the official ECMAScript Conformance test suite"
+  },
+  "polyfills/intl-locale": {
+    "title": "Intl Locale",
+    "description": "A spec-compliant polyfill/ponyfill for Intl.Locale tested by the official ECMAScript Conformance test suite"
+  },
+  "polyfills/intl-localematcher": {
+    "title": "Intl Localematcher",
+    "description": "A spec-compliant ponyfill for Intl.LocaleMatcher. Since this is only stage-1 this package is a ponyfill instead of polyfill."
+  },
+  "polyfills/intl-numberformat": {
+    "title": "Intl Numberformat",
+    "description": "A polyfill for ESNext Intl.NumberFormat and Number.prototype.toLocaleString."
+  },
+  "polyfills/intl-pluralrules": {
+    "title": "Intl Pluralrules",
+    "description": "A spec-compliant polyfill for Intl.PluralRules fully tested by the official ECMAScript Conformance test suite"
+  },
+  "polyfills/intl-relativetimeformat": {
+    "title": "Intl Relativetimeformat",
+    "description": "A spec-compliant polyfill for Intl.RelativeTimeFormat fully tested by the official ECMAScript Conformance test suite"
+  },
+  "polyfills/intl-segmenter": {
+    "title": "Intl Segmenter",
+    "description": "A polyfill for Intl.Segmenter."
+  },
+  "polyfills/intl-supportedvaluesof": {
+    "title": "Intl Supportedvaluesof",
+    "description": "A spec-compliant polyfill/ponyfill for Intl.supportedValuesOf."
+  },
+  "react-intl": {
+    "title": "React Intl",
+    "description": "Welcome to React Intl's docs! This is the place to find React Intl's docs. Feel free to open a pull request and contribute to the docs to make them better."
+  },
+  "react-intl/api": {
+    "title": "Api",
+    "description": "There are a few API layers that React Intl provides and is built on. When using React Intl you'll be interacting with its API (documented here) and its ..."
+  },
+  "react-intl/components": {
+    "title": "Components",
+    "description": "React Intl has a set of React components that provide a declarative way to setup an i18n context and format dates, numbers, and strings for display in a..."
+  },
+  "react-intl/upgrade-guide-2.x": {
+    "title": "Upgrade Guide 2.x",
+    "description": "React Intl v2 has a peer dependency on react@^0.14.0 || ^15.0.0-0 and now takes advantage of features and changes in React 0.14 and also works with Reac..."
+  },
+  "react-intl/upgrade-guide-3.x": {
+    "title": "Upgrade Guide 3.x",
+    "description": "- addLocaleData has been removed. See Migrate to using native Intl APIs for more details."
+  },
+  "react-intl/upgrade-guide-4.x": {
+    "title": "Upgrade Guide 4.x",
+    "description": "- All tags specified must have corresponding values and will throw error if it's missing, e.g:"
+  },
+  "react-intl/upgrade-guide-5.x": {
+    "title": "Upgrade Guide 5.x",
+    "description": "- Rich text formatting callback function is no longer variadic."
+  },
+  "tooling/babel-plugin": {
+    "title": "Babel Plugin",
+    "description": "Process string messages for translation from modules that use react-intl, specifically:"
+  },
+  "tooling/cli": {
+    "title": "Cli",
+    "description": "groupId=\"npm\""
+  },
+  "tooling/linter": {
+    "title": "Linter",
+    "description": "This eslint plugin allows you to enforce certain rules in your ICU message."
+  },
+  "tooling/swc-plugin": {
+    "title": "Swc Plugin",
+    "description": "This has been migrated over to the swc repo itself. You can find the plugin here."
+  },
+  "tooling/ts-transformer": {
+    "title": "Ts Transformer",
+    "description": "Process string messages for translation from modules that use react-intl, specifically:"
+  },
+  "vue-intl": {
+    "title": "Vue Intl",
+    "description": "This library contains our plugin for Vue."
+  }
+}

--- a/docs/src/pages/+Head.tsx
+++ b/docs/src/pages/+Head.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react'
+
+// Default head tags for all pages
+export function Head(): React.ReactNode {
+  return (
+    <>
+      <meta charSet="UTF-8" />
+      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+      <link rel="icon" href="/img/logo-icon.svg" type="image/svg+xml" />
+      <meta name="theme-color" content="#6f3c97" />
+    </>
+  )
+}

--- a/docs/src/pages/docs/@path/+Head.tsx
+++ b/docs/src/pages/docs/@path/+Head.tsx
@@ -1,0 +1,41 @@
+import {usePageContext} from 'vike-react/usePageContext'
+import * as React from 'react'
+import * as docsMetadata from '../../../docs-metadata.generated.json'
+
+type Metadata = {
+  title: string
+  description: string
+}
+
+const metadata = (docsMetadata as any).default as Record<string, Metadata>
+
+export function Head(): React.ReactNode {
+  const pageContext = usePageContext()
+  const path = (pageContext.routeParams as {path?: string})?.path || ''
+
+  // Use pre-extracted metadata from build-time processing
+  const docMeta = metadata[path] || {
+    title: 'Documentation',
+    description:
+      'FormatJS documentation. Industry-standard internationalization libraries for JavaScript.',
+  }
+
+  const fullTitle = `${docMeta.title} | FormatJS`
+  const description = docMeta.description
+  const url = `https://formatjs.io/docs/${path}`
+
+  return (
+    <>
+      <title>{fullTitle}</title>
+      <meta name="description" content={description} />
+      <meta property="og:title" content={fullTitle} />
+      <meta property="og:description" content={description} />
+      <meta property="og:type" content="article" />
+      <meta property="og:url" content={url} />
+      <meta name="twitter:card" content="summary" />
+      <meta name="twitter:title" content={fullTitle} />
+      <meta name="twitter:description" content={description} />
+      <link rel="canonical" href={url} />
+    </>
+  )
+}

--- a/docs/src/pages/docs/@path/+description.ts
+++ b/docs/src/pages/docs/@path/+description.ts
@@ -1,0 +1,19 @@
+import type {PageContext} from 'vike/types'
+import * as docsMetadata from '../../../docs-metadata.generated.json'
+
+type Metadata = {
+  title: string
+  description: string
+}
+
+const metadata = (docsMetadata as any).default as Record<string, Metadata>
+
+export function description(pageContext: PageContext): string {
+  const path = (pageContext.routeParams as {path?: string})?.path || ''
+  const docMeta = metadata[path] || {
+    title: 'Documentation',
+    description:
+      'FormatJS documentation. Industry-standard internationalization libraries for JavaScript.',
+  }
+  return docMeta.description
+}

--- a/docs/src/pages/docs/@path/+title.ts
+++ b/docs/src/pages/docs/@path/+title.ts
@@ -1,0 +1,19 @@
+import type {PageContext} from 'vike/types'
+import * as docsMetadata from '../../../docs-metadata.generated.json'
+
+type Metadata = {
+  title: string
+  description: string
+}
+
+const metadata = (docsMetadata as any).default as Record<string, Metadata>
+
+export function title(pageContext: PageContext): string {
+  const path = (pageContext.routeParams as {path?: string})?.path || ''
+  const docMeta = metadata[path] || {
+    title: 'Documentation',
+    description:
+      'FormatJS documentation. Industry-standard internationalization libraries for JavaScript.',
+  }
+  return `${docMeta.title} | FormatJS`
+}

--- a/docs/src/pages/index/+Head.tsx
+++ b/docs/src/pages/index/+Head.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react'
+
+export function Head(): React.ReactNode {
+  return (
+    <>
+      <title>
+        FormatJS - Internationalize your web apps on the client & server
+      </title>
+      <meta
+        name="description"
+        content="Industry-standard i18n libraries for JavaScript. FormatJS provides modular libraries for formatting numbers, dates, and strings for React, Vue, and vanilla JS. Built on ICU Message syntax and ECMA-402."
+      />
+      <meta
+        property="og:title"
+        content="FormatJS - Internationalize your web apps"
+      />
+      <meta
+        property="og:description"
+        content="Industry-standard i18n libraries for JavaScript. Built on ICU Message syntax."
+      />
+      <meta property="og:type" content="website" />
+      <meta property="og:url" content="https://formatjs.io/" />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta
+        name="twitter:title"
+        content="FormatJS - Internationalize your web apps"
+      />
+      <meta
+        name="twitter:description"
+        content="Industry-standard i18n libraries for JavaScript. Built on ICU Message syntax."
+      />
+      <link rel="canonical" href="https://formatjs.io/" />
+    </>
+  )
+}


### PR DESCRIPTION
### TL;DR

Added SEO metadata to the FormatJS documentation site with dynamic page titles and descriptions.

### What changed?

- Created a script (`extract-metadata.ts`) to automatically extract titles and descriptions from MDX documentation files
- Added Bazel build rules to generate metadata during the build process
- Added page-specific `+Head.tsx` components for the homepage and documentation pages
- Implemented dynamic title and description generation for documentation pages
- Added canonical URLs and Open Graph metadata for better social sharing
- Added the generated metadata file to `.gitignore`

### How to test?

1. Build the documentation site with `bazel build //docs:dist`
2. Verify that each documentation page has a proper title and description in the HTML head
3. Check that Open Graph and Twitter card metadata is correctly populated
4. Validate that canonical URLs are properly set

### Why make this change?

This change improves the SEO of the FormatJS documentation site by providing search engines with accurate page titles, descriptions, and structured metadata. It also enhances social sharing with proper Open Graph tags. The metadata is automatically extracted from the documentation content, ensuring consistency and reducing manual maintenance.