### PR TITLE
fix(@formatjs/intl-datetimeformat): add support for offset tz, fix #4804

### DIFF
--- a/docs/src/docs/polyfills/intl-datetimeformat.mdx
+++ b/docs/src/docs/polyfills/intl-datetimeformat.mdx
@@ -115,6 +115,55 @@ import '@formatjs/intl-datetimeformat/polyfill.js'
 import '@formatjs/intl-datetimeformat/add-golden-tz.js'
 ```
 
+### UTC Offset Timezones
+
+This polyfill supports UTC offset timezone identifiers as specified in [ECMA-402](https://tc39.es/ecma402/) (ES2026). You can use offset-based timezone strings in addition to IANA timezone names.
+
+#### Supported Formats
+
+The following UTC offset formats are supported:
+
+- `±HH:MM` - e.g., `"+01:00"`, `"-05:00"` (recommended format)
+- `±HHMM` - e.g., `"+0100"`, `"-0500"`
+- `±HH` - e.g., `"+01"`, `"-05"`
+- `±HH:MM:SS` - e.g., `"+01:30:45"` (with seconds)
+- `±HH:MM:SS.sss` - e.g., `"+01:30:45.123"` (with fractional seconds)
+
+All offset formats are automatically canonicalized to `±HH:MM` format (with seconds/fractional seconds preserved if non-zero).
+
+#### Usage Example
+
+```tsx
+import '@formatjs/intl-datetimeformat/polyfill.js'
+import '@formatjs/intl-datetimeformat/locale-data/en.js'
+
+// Using UTC offset timezone
+const formatter = new Intl.DateTimeFormat('en-GB', {
+  timeZone: '+01:00',
+  year: 'numeric',
+  month: 'numeric',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: 'numeric',
+})
+
+console.log(formatter.format(new Date('2024-01-01T00:00:00Z')))
+// Output: "01/01/2024, 01:00"
+
+// Works with @date-fns/tz and other libraries
+const dtf = new Intl.DateTimeFormat('en-GB', {
+  timeZone: '+01:00',
+  hour: 'numeric',
+  timeZoneName: 'longOffset',
+})
+```
+
+#### Compatibility
+
+- UTC offset timezones work without loading any timezone data (`add-all-tz.js` or `add-golden-tz.js`)
+- Compatible with libraries like `@date-fns/tz` in React Native/Hermes environments
+- Follows the same behavior as Chrome and Node.js 22+ native implementations
+
 ### Default Timezone
 
 Since JS Engines do not expose default timezone, there's currently no way for us to detect local timezone that a browser is in. Therefore, the default timezone in this polyfill is `UTC`.

--- a/packages/ecma402-abstract/CanonicalizeTimeZoneName.ts
+++ b/packages/ecma402-abstract/CanonicalizeTimeZoneName.ts
@@ -1,6 +1,79 @@
+// Cached regex patterns for performance
+const OFFSET_TIMEZONE_PREFIX_REGEX = /^[+-]/
+const OFFSET_TIMEZONE_FORMAT_REGEX =
+  /^([+-])(\d{2})(?::?(\d{2}))?(?::?(\d{2}))?(?:\.(\d{1,9}))?$/
+const TRAILING_ZEROS_REGEX = /0+$/
+
 /**
+ * IsTimeZoneOffsetString ( offsetString )
+ * https://tc39.es/ecma262/#sec-istimezoneoffsetstring
+ *
+ * Simplified check to determine if a string is a UTC offset identifier.
+ *
+ * @param offsetString - The string to check
+ * @returns true if offsetString starts with '+' or '-'
+ */
+function IsTimeZoneOffsetString(offsetString: string): boolean {
+  // 1. If offsetString does not start with '+' or '-', return false
+  return OFFSET_TIMEZONE_PREFIX_REGEX.test(offsetString)
+}
+
+/**
+ * ParseTimeZoneOffsetString ( offsetString )
+ * https://tc39.es/ecma262/#sec-parsetimezoneoffsetstring
+ *
+ * Parses a UTC offset string and returns its canonical representation.
+ * Normalizes various formats (±HH, ±HHMM, ±HH:MM, etc.) to ±HH:MM format.
+ *
+ * @param offsetString - The UTC offset string to parse
+ * @returns The canonical offset string in ±HH:MM format (with :SS.sss if non-zero)
+ */
+function ParseTimeZoneOffsetString(offsetString: string): string {
+  // 1. Let parseResult be ParseText(offsetString, UTCOffset)
+  const match = OFFSET_TIMEZONE_FORMAT_REGEX.exec(offsetString)
+
+  // 2. Assert: parseResult is not a List of errors (validated by IsValidTimeZoneName)
+  if (!match) {
+    return offsetString
+  }
+
+  // 3. Extract components from parseResult
+  const sign = match[1]
+  const hours = match[2]
+  const minutes = match[3] ? match[3] : '00'
+  const seconds = match[4]
+  const fractional = match[5]
+
+  // 4. Build canonical format: ±HH:MM
+  let canonical = `${sign}${hours}:${minutes}`
+
+  // 5. If seconds are present and non-zero (or fractional present), include them
+  if (seconds && (parseInt(seconds, 10) !== 0 || fractional)) {
+    canonical += `:${seconds}`
+
+    // 6. If fractional seconds present, include them (trim trailing zeros)
+    if (fractional) {
+      const trimmedFractional = fractional.replace(TRAILING_ZEROS_REGEX, '')
+      if (trimmedFractional) {
+        canonical += `.${trimmedFractional}`
+      }
+    }
+  }
+
+  // 7. Return canonical representation
+  return canonical
+}
+
+/**
+ * CanonicalizeTimeZoneName ( timeZone )
  * https://tc39.es/ecma402/#sec-canonicalizetimezonename
- * @param tz
+ *
+ * Extended to support UTC offset time zones per ECMA-402 PR #788 (ES2026).
+ * Returns the canonical and case-regularized form of a timezone identifier.
+ *
+ * @param tz - The timezone identifier to canonicalize
+ * @param implDetails - Implementation details containing timezone data
+ * @returns The canonical timezone identifier
  */
 export function CanonicalizeTimeZoneName(
   tz: string,
@@ -12,6 +85,16 @@ export function CanonicalizeTimeZoneName(
     uppercaseLinks: Record<string, string>
   }
 ): string {
+  // 1. If IsTimeZoneOffsetString(timeZone) is true, then
+  //    a. Return ParseTimeZoneOffsetString(timeZone)
+  // Per ECMA-402 PR #788, UTC offset identifiers are canonicalized
+  if (IsTimeZoneOffsetString(tz)) {
+    return ParseTimeZoneOffsetString(tz)
+  }
+
+  // 2. Let ianaTimeZone be the String value of the Zone or Link name
+  //    in the IANA Time Zone Database that is an ASCII-case-insensitive
+  //    match of timeZone
   const uppercasedTz = tz.toUpperCase()
   const uppercasedZones = zoneNames.reduce((all: Record<string, string>, z) => {
     all[z.toUpperCase()] = z
@@ -19,8 +102,12 @@ export function CanonicalizeTimeZoneName(
   }, {})
   const ianaTimeZone =
     uppercaseLinks[uppercasedTz] || uppercasedZones[uppercasedTz]
+
+  // 3. If ianaTimeZone is "Etc/UTC" or "Etc/GMT", return "UTC"
   if (ianaTimeZone === 'Etc/UTC' || ianaTimeZone === 'Etc/GMT') {
     return 'UTC'
   }
+
+  // 4. Return ianaTimeZone
   return ianaTimeZone
 }

--- a/packages/ecma402-abstract/IsValidTimeZoneName.ts
+++ b/packages/ecma402-abstract/IsValidTimeZoneName.ts
@@ -1,7 +1,58 @@
+// Cached regex patterns for performance
+const OFFSET_TIMEZONE_PREFIX_REGEX = /^[+-]/
+const OFFSET_TIMEZONE_FORMAT_REGEX =
+  /^([+-])(\d{2})(?::?(\d{2}))?(?::?(\d{2}))?(?:\.(\d{1,9}))?$/
+
 /**
+ * IsTimeZoneOffsetString ( offsetString )
+ * https://tc39.es/ecma262/#sec-istimezoneoffsetstring
+ *
+ * Validates whether a string represents a valid UTC offset timezone.
+ * Supports formats: ±HH, ±HHMM, ±HH:MM, ±HH:MM:SS, ±HH:MM:SS.sss
+ *
+ * @param offsetString - The string to validate as a timezone offset
+ * @returns true if offsetString is a valid UTC offset format
+ */
+function IsTimeZoneOffsetString(offsetString: string): boolean {
+  // 1. If offsetString does not start with '+' or '-', return false
+  if (!OFFSET_TIMEZONE_PREFIX_REGEX.test(offsetString)) {
+    return false
+  }
+
+  // 2. Let parseResult be ParseText(offsetString, UTCOffset)
+  const match = OFFSET_TIMEZONE_FORMAT_REGEX.exec(offsetString)
+
+  // 3. If parseResult is a List of errors, return false
+  if (!match) {
+    return false
+  }
+
+  // 4. Validate component ranges per ECMA-262 grammar
+  // Hour must be 0-23, Minute must be 0-59, Second must be 0-59
+  const hours = parseInt(match[2], 10)
+  const minutes = match[3] ? parseInt(match[3], 10) : 0
+  const seconds = match[4] ? parseInt(match[4], 10) : 0
+
+  if (hours > 23 || minutes > 59 || seconds > 59) {
+    return false
+  }
+
+  // 5. Return true
+  return true
+}
+
+/**
+ * IsValidTimeZoneName ( timeZone )
  * https://tc39.es/ecma402/#sec-isvalidtimezonename
- * @param tz
- * @param implDetails implementation details
+ *
+ * Extended to support UTC offset time zones per ECMA-402 PR #788 (ES2026).
+ * The abstract operation validates both:
+ * 1. UTC offset identifiers (e.g., "+01:00", "-05:30")
+ * 2. Available named time zone identifiers from IANA Time Zone Database
+ *
+ * @param tz - The timezone identifier to validate
+ * @param implDetails - Implementation details containing timezone data
+ * @returns true if timeZone is a valid identifier
  */
 export function IsValidTimeZoneName(
   tz: string,
@@ -13,13 +64,29 @@ export function IsValidTimeZoneName(
     uppercaseLinks: Record<string, string>
   }
 ): boolean {
+  // 1. If IsTimeZoneOffsetString(timeZone) is true, return true
+  // Per ECMA-402 PR #788, UTC offset identifiers are valid
+  if (IsTimeZoneOffsetString(tz)) {
+    return true
+  }
+
+  // 2. Let timeZones be AvailableNamedTimeZoneIdentifiers()
+  // 3. If timeZones contains an element equal to timeZone, return true
+  // NOTE: Implementation uses case-insensitive comparison per spec note
   const uppercasedTz = tz.toUpperCase()
   const zoneNames = new Set()
   const linkNames = new Set()
+
   zoneNamesFromData.map(z => z.toUpperCase()).forEach(z => zoneNames.add(z))
   Object.keys(uppercaseLinks).forEach(linkName => {
     linkNames.add(linkName.toUpperCase())
     zoneNames.add(uppercaseLinks[linkName].toUpperCase())
   })
-  return zoneNames.has(uppercasedTz) || linkNames.has(uppercasedTz)
+
+  if (zoneNames.has(uppercasedTz) || linkNames.has(uppercasedTz)) {
+    return true
+  }
+
+  // 4. Return false
+  return false
 }

--- a/packages/ecma402-abstract/tests/CanonicalizeTimeZoneName.test.ts
+++ b/packages/ecma402-abstract/tests/CanonicalizeTimeZoneName.test.ts
@@ -1,0 +1,101 @@
+import {CanonicalizeTimeZoneName} from '../CanonicalizeTimeZoneName.js'
+import {expect, test, describe} from 'vitest'
+
+describe('CanonicalizeTimeZoneName', () => {
+  test('IANA timezone names', () => {
+    expect(
+      CanonicalizeTimeZoneName('America/Los_Angeles', {
+        zoneNames: ['America/Los_Angeles'],
+        uppercaseLinks: {},
+      })
+    ).toBe('America/Los_Angeles')
+
+    expect(
+      CanonicalizeTimeZoneName('America/Indiana/Indianapolis', {
+        zoneNames: ['America/Indiana/Indianapolis'],
+        uppercaseLinks: {
+          'America/Fort_Wayne': 'America/Indiana/Indianapolis',
+          'America/Indianapolis': 'America/Indiana/Indianapolis',
+        },
+      })
+    ).toBe('America/Indiana/Indianapolis')
+
+    // Test UTC/GMT special cases
+    expect(
+      CanonicalizeTimeZoneName('Etc/UTC', {
+        zoneNames: ['Etc/UTC'],
+        uppercaseLinks: {},
+      })
+    ).toBe('UTC')
+
+    expect(
+      CanonicalizeTimeZoneName('Etc/GMT', {
+        zoneNames: ['Etc/GMT'],
+        uppercaseLinks: {},
+      })
+    ).toBe('UTC')
+  })
+
+  test('UTC offset timezones - canonicalization', () => {
+    const testData = {
+      zoneNames: ['America/New_York'],
+      uppercaseLinks: {},
+    }
+
+    // ±HH:MM format (already canonical)
+    expect(CanonicalizeTimeZoneName('+01:00', testData)).toBe('+01:00')
+    expect(CanonicalizeTimeZoneName('-05:00', testData)).toBe('-05:00')
+    expect(CanonicalizeTimeZoneName('+05:30', testData)).toBe('+05:30')
+    expect(CanonicalizeTimeZoneName('+00:00', testData)).toBe('+00:00')
+
+    // ±HHMM format → ±HH:MM
+    expect(CanonicalizeTimeZoneName('+0100', testData)).toBe('+01:00')
+    expect(CanonicalizeTimeZoneName('-0500', testData)).toBe('-05:00')
+    expect(CanonicalizeTimeZoneName('+0530', testData)).toBe('+05:30')
+    expect(CanonicalizeTimeZoneName('+0000', testData)).toBe('+00:00')
+
+    // ±HH format → ±HH:00
+    expect(CanonicalizeTimeZoneName('+01', testData)).toBe('+01:00')
+    expect(CanonicalizeTimeZoneName('-05', testData)).toBe('-05:00')
+    expect(CanonicalizeTimeZoneName('+00', testData)).toBe('+00:00')
+
+    // With seconds (non-zero) - preserve seconds
+    expect(CanonicalizeTimeZoneName('+01:30:45', testData)).toBe('+01:30:45')
+    expect(CanonicalizeTimeZoneName('-05:00:30', testData)).toBe('-05:00:30')
+
+    // With seconds (zero) - omit seconds
+    expect(CanonicalizeTimeZoneName('+01:30:00', testData)).toBe('+01:30')
+    expect(CanonicalizeTimeZoneName('-05:00:00', testData)).toBe('-05:00')
+
+    // With fractional seconds - preserve non-zero fractional
+    expect(CanonicalizeTimeZoneName('+01:30:45.123', testData)).toBe(
+      '+01:30:45.123'
+    )
+    expect(CanonicalizeTimeZoneName('-05:00:30.5', testData)).toBe(
+      '-05:00:30.5'
+    )
+
+    // With trailing zeros in fractional - remove trailing zeros
+    expect(CanonicalizeTimeZoneName('+01:30:45.1000', testData)).toBe(
+      '+01:30:45.1'
+    )
+    expect(CanonicalizeTimeZoneName('+01:30:45.000', testData)).toBe(
+      '+01:30:45'
+    )
+  })
+
+  test('Edge cases', () => {
+    const testData = {
+      zoneNames: ['America/New_York'],
+      uppercaseLinks: {},
+    }
+
+    // Maximum valid offsets
+    expect(CanonicalizeTimeZoneName('+23:59', testData)).toBe('+23:59')
+    expect(CanonicalizeTimeZoneName('-23:59', testData)).toBe('-23:59')
+
+    // Minimum offset
+    expect(CanonicalizeTimeZoneName('+00:00', testData)).toBe('+00:00')
+    expect(CanonicalizeTimeZoneName('-00:00', testData)).toBe('-00:00')
+  })
+})

--- a/packages/ecma402-abstract/tests/IsValidTimeZoneName.test.ts
+++ b/packages/ecma402-abstract/tests/IsValidTimeZoneName.test.ts
@@ -1,36 +1,104 @@
 import {IsValidTimeZoneName} from '../IsValidTimeZoneName.js'
-import {expect, test} from 'vitest'
-test('IsValidTimeZoneName', () => {
-  expect(
-    IsValidTimeZoneName('America/Los_Angeles', {
-      zoneNamesFromData: ['America/Los_Angeles'],
-      uppercaseLinks: {},
-    })
-  ).toBe(true)
+import {expect, test, describe} from 'vitest'
 
-  expect(
-    IsValidTimeZoneName('America/Indiana/Indianapolis', {
-      zoneNamesFromData: [
-        'America/Indianapolis',
-        'America/Fort_Wayne',
-        'US/East-Indiana',
-      ],
-      uppercaseLinks: {
-        'America/Fort_Wayne': 'America/Indiana/Indianapolis',
-        'America/Indianapolis': 'America/Indiana/Indianapolis',
-        'US/East-Indiana': 'America/Indiana/Indianapolis',
-      },
-    })
-  ).toBe(true)
+describe('IsValidTimeZoneName', () => {
+  test('IANA timezone names', () => {
+    expect(
+      IsValidTimeZoneName('America/Los_Angeles', {
+        zoneNamesFromData: ['America/Los_Angeles'],
+        uppercaseLinks: {},
+      })
+    ).toBe(true)
 
-  expect(
-    IsValidTimeZoneName('America/Indiana/Indianapolis', {
+    expect(
+      IsValidTimeZoneName('America/Indiana/Indianapolis', {
+        zoneNamesFromData: [
+          'America/Indianapolis',
+          'America/Fort_Wayne',
+          'US/East-Indiana',
+        ],
+        uppercaseLinks: {
+          'America/Fort_Wayne': 'America/Indiana/Indianapolis',
+          'America/Indianapolis': 'America/Indiana/Indianapolis',
+          'US/East-Indiana': 'America/Indiana/Indianapolis',
+        },
+      })
+    ).toBe(true)
+
+    expect(
+      IsValidTimeZoneName('America/Indiana/Indianapolis', {
+        zoneNamesFromData: ['America/New_York'],
+        uppercaseLinks: {
+          'America/Fort_Wayne': 'America/Indiana/Indianapolis',
+          'America/Indianapolis': 'America/Indiana/Indianapolis',
+          'US/East-Indiana': 'America/Indiana/Indianapolis',
+        },
+      })
+    ).toBe(true)
+  })
+
+  test('UTC offset timezones - valid formats', () => {
+    const testData = {
       zoneNamesFromData: ['America/New_York'],
-      uppercaseLinks: {
-        'America/Fort_Wayne': 'America/Indiana/Indianapolis',
-        'America/Indianapolis': 'America/Indiana/Indianapolis',
-        'US/East-Indiana': 'America/Indiana/Indianapolis',
-      },
-    })
-  ).toBe(true)
+      uppercaseLinks: {},
+    }
+
+    // ±HH:MM format
+    expect(IsValidTimeZoneName('+00:00', testData)).toBe(true)
+    expect(IsValidTimeZoneName('+01:00', testData)).toBe(true)
+    expect(IsValidTimeZoneName('-05:00', testData)).toBe(true)
+    expect(IsValidTimeZoneName('+05:30', testData)).toBe(true)
+    expect(IsValidTimeZoneName('-12:00', testData)).toBe(true)
+    expect(IsValidTimeZoneName('+23:59', testData)).toBe(true)
+
+    // ±HHMM format (without colon)
+    expect(IsValidTimeZoneName('+0100', testData)).toBe(true)
+    expect(IsValidTimeZoneName('-0500', testData)).toBe(true)
+    expect(IsValidTimeZoneName('+0530', testData)).toBe(true)
+
+    // ±HH format (hours only)
+    expect(IsValidTimeZoneName('+01', testData)).toBe(true)
+    expect(IsValidTimeZoneName('-05', testData)).toBe(true)
+    expect(IsValidTimeZoneName('+00', testData)).toBe(true)
+
+    // With seconds ±HH:MM:SS
+    expect(IsValidTimeZoneName('+01:30:45', testData)).toBe(true)
+    expect(IsValidTimeZoneName('-05:00:00', testData)).toBe(true)
+
+    // With fractional seconds ±HH:MM:SS.sss
+    expect(IsValidTimeZoneName('+01:30:45.123', testData)).toBe(true)
+    expect(IsValidTimeZoneName('-05:00:00.999999999', testData)).toBe(true)
+  })
+
+  test('UTC offset timezones - invalid formats', () => {
+    const testData = {
+      zoneNamesFromData: ['America/New_York'],
+      uppercaseLinks: {},
+    }
+
+    // Out of range hours
+    expect(IsValidTimeZoneName('+24:00', testData)).toBe(false)
+    expect(IsValidTimeZoneName('+25:00', testData)).toBe(false)
+    expect(IsValidTimeZoneName('-24:00', testData)).toBe(false)
+
+    // Out of range minutes
+    expect(IsValidTimeZoneName('+01:60', testData)).toBe(false)
+    expect(IsValidTimeZoneName('+01:99', testData)).toBe(false)
+
+    // Out of range seconds
+    expect(IsValidTimeZoneName('+01:30:60', testData)).toBe(false)
+
+    // Wrong format - single digit components
+    expect(IsValidTimeZoneName('+1:00', testData)).toBe(false)
+    expect(IsValidTimeZoneName('+01:0', testData)).toBe(false)
+    expect(IsValidTimeZoneName('+1:0', testData)).toBe(false)
+
+    // Missing sign
+    expect(IsValidTimeZoneName('01:00', testData)).toBe(false)
+    expect(IsValidTimeZoneName('0100', testData)).toBe(false)
+
+    // Invalid characters
+    expect(IsValidTimeZoneName('+01:00:00:00', testData)).toBe(false)
+    expect(IsValidTimeZoneName('+01:00abc', testData)).toBe(false)
+  })
 })

--- a/packages/intl-datetimeformat/src/abstract/ToLocalTime.ts
+++ b/packages/intl-datetimeformat/src/abstract/ToLocalTime.ts
@@ -12,16 +12,102 @@ import {
 } from '@formatjs/ecma402-abstract'
 import Decimal from 'decimal.js'
 
+// Cached regex patterns for performance
+const OFFSET_TIMEZONE_PREFIX_REGEX = /^[+-]/
+const OFFSET_TIMEZONE_FORMAT_REGEX =
+  /^([+-])(\d{2})(?::?(\d{2}))?(?::?(\d{2}))?(?:\.(\d{1,9}))?$/
+
+/**
+ * IsTimeZoneOffsetString ( offsetString )
+ * https://tc39.es/ecma262/#sec-istimezoneoffsetstring
+ *
+ * Determines if a string is a UTC offset identifier.
+ *
+ * @param offsetString - The string to check
+ * @returns true if offsetString is a UTC offset format
+ */
+function IsTimeZoneOffsetString(offsetString: string): boolean {
+  return OFFSET_TIMEZONE_PREFIX_REGEX.test(offsetString)
+}
+
+/**
+ * ParseTimeZoneOffsetString ( offsetString )
+ * https://tc39.es/ecma262/#sec-parsetimezoneoffsetstring
+ *
+ * Parses a UTC offset string and returns the offset in milliseconds.
+ * This is used to calculate the timezone offset for ToLocalTime.
+ *
+ * Supports formats: ±HH, ±HHMM, ±HH:MM, ±HH:MM:SS, ±HH:MM:SS.sss
+ *
+ * @param offsetString - The UTC offset string to parse (e.g., "+01:00")
+ * @returns The offset in milliseconds
+ */
+function ParseTimeZoneOffsetString(offsetString: string): number {
+  // 1. Let parseResult be ParseText(offsetString, UTCOffset)
+  const match = OFFSET_TIMEZONE_FORMAT_REGEX.exec(offsetString)
+
+  // 2. Assert: parseResult is not a List of errors
+  if (!match) {
+    return 0
+  }
+
+  // 3. Extract components from parseResult
+  const sign = match[1] === '+' ? 1 : -1
+  const hours = parseInt(match[2], 10)
+  const minutes = match[3] ? parseInt(match[3], 10) : 0
+  const seconds = match[4] ? parseInt(match[4], 10) : 0
+  const fractionalStr = match[5] || '0'
+
+  // 4. Convert fractional seconds (nanoseconds) to milliseconds
+  // Pad to 9 digits and divide by 1000000
+  // Use manual padding for compatibility (padEnd is ES2017)
+  const paddedFractional = (fractionalStr + '000000000').slice(0, 9)
+  const fractional = parseInt(paddedFractional, 10) / 1000000
+
+  // 5. Calculate total offset in milliseconds
+  // offset = sign × (hours × 3600000 + minutes × 60000 + seconds × 1000 + fractional)
+  const offsetMs =
+    sign * (hours * 3600000 + minutes * 60000 + seconds * 1000 + fractional)
+
+  // 6. Return offset in milliseconds
+  return offsetMs
+}
+
+/**
+ * GetNamedTimeZoneOffsetNanoseconds ( timeZone, t )
+ * Similar to abstract operation in ECMA-262, adapted for IANA timezone data.
+ * Extended to support UTC offset time zones per ECMA-402 PR #788.
+ *
+ * Returns the timezone offset in milliseconds (not nanoseconds for this impl)
+ * and DST flag for the given timezone at time t.
+ *
+ * @param t - Time value in milliseconds since epoch
+ * @param timeZone - The timezone identifier
+ * @param tzData - IANA timezone database
+ * @returns Tuple of [offset in milliseconds, inDST boolean]
+ */
 function getApplicableZoneData(
   t: number,
   timeZone: string,
   tzData: Record<string, UnpackedZoneData[]>
 ): [number, boolean] {
+  // 1. If IsTimeZoneOffsetString(timeZone) is true, then
+  //    a. Let offsetNs be ParseTimeZoneOffsetString(timeZone)
+  //    b. Return offsetNs (no DST for offset timezones)
+  if (IsTimeZoneOffsetString(timeZone)) {
+    const offsetMs = ParseTimeZoneOffsetString(timeZone)
+    return [offsetMs, false] // UTC offset timezones never observe DST
+  }
+
+  // 2. Let timeZoneData be the IANA Time Zone Database entry for timeZone
   const zoneData = tzData[timeZone]
-  // We don't have data for this so just say it's UTC
+
+  // 3. If no data available, treat as UTC (0 offset, no DST)
   if (!zoneData) {
     return [0, false]
   }
+
+  // 4. Find the applicable transition for time t
   let i = 0
   let offset = 0
   let dst = false
@@ -31,6 +117,8 @@ function getApplicableZoneData(
       break
     }
   }
+
+  // 5. Return offset in milliseconds and DST flag
   return [offset * 1e3, dst]
 }
 

--- a/packages/intl-datetimeformat/tests/offset-timezone.test.ts
+++ b/packages/intl-datetimeformat/tests/offset-timezone.test.ts
@@ -1,0 +1,173 @@
+import '@formatjs/intl-getcanonicallocales/polyfill.js'
+import '@formatjs/intl-locale/polyfill.js'
+import {DateTimeFormat} from '../src/core'
+import allData from '../src/data/all-tz'
+import * as enGB from './locale-data/en-GB.json' with {type: 'json'}
+import * as en from './locale-data/en.json' with {type: 'json'}
+import {describe, expect, it, afterEach} from 'vitest'
+
+// @ts-ignore
+DateTimeFormat.__addLocaleData(en, enGB)
+DateTimeFormat.__addTZData(allData)
+
+const DEFAULT_TIMEZONE = DateTimeFormat.getDefaultTimeZone()
+
+describe('Intl.DateTimeFormat with UTC offset timezones', function () {
+  afterEach(() => {
+    DateTimeFormat.__setDefaultTimeZone(DEFAULT_TIMEZONE)
+  })
+
+  it('should accept +01:00 offset timezone', function () {
+    expect(
+      () =>
+        new DateTimeFormat('en-GB', {
+          timeZone: '+01:00',
+          hour: 'numeric',
+          minute: 'numeric',
+        })
+    ).not.toThrow()
+  })
+
+  it('should accept -05:00 offset timezone', function () {
+    expect(
+      () =>
+        new DateTimeFormat('en-GB', {
+          timeZone: '-05:00',
+          hour: 'numeric',
+        })
+    ).not.toThrow()
+  })
+
+  it('should accept +00:00 (UTC offset)', function () {
+    expect(
+      () =>
+        new DateTimeFormat('en-GB', {
+          timeZone: '+00:00',
+          hour: 'numeric',
+        })
+    ).not.toThrow()
+  })
+
+  it('should accept various offset formats', function () {
+    const formats = ['+01', '+0100', '+01:00', '+01:30', '+05:30:45']
+    formats.forEach(timeZone => {
+      expect(() => new DateTimeFormat('en-GB', {timeZone})).not.toThrow()
+    })
+  })
+
+  it('should reject invalid offset timezones', function () {
+    const invalidFormats = [
+      '+24:00', // Out of range
+      '+01:60', // Invalid minutes
+      '+1:00', // Wrong format
+      '01:00', // Missing sign
+    ]
+    invalidFormats.forEach(timeZone => {
+      expect(() => new DateTimeFormat('en-GB', {timeZone})).toThrow(RangeError)
+    })
+  })
+
+  it('should format with +01:00 offset timezone', function () {
+    const dtf = new DateTimeFormat('en-GB', {
+      timeZone: '+01:00',
+      year: 'numeric',
+      month: 'numeric',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+      hour12: false,
+    })
+    // Unix epoch (Jan 1, 1970 00:00:00 UTC) should be 01:00:00 at +01:00
+    const result = dtf.format(new Date(0))
+    expect(result).toContain('01:00')
+    expect(result).toContain('1970')
+  })
+
+  it('should format with -05:00 offset timezone', function () {
+    const dtf = new DateTimeFormat('en-GB', {
+      timeZone: '-05:00',
+      year: 'numeric',
+      month: 'numeric',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+      hour12: false,
+    })
+    // Unix epoch (Jan 1, 1970 00:00:00 UTC) should be Dec 31, 1969 19:00:00 at -05:00
+    const result = dtf.format(new Date(0))
+    expect(result).toContain('19:00')
+    expect(result).toContain('1969')
+  })
+
+  it('should resolve canonical format in resolvedOptions', function () {
+    // Test that offset timezones are canonicalized
+    const tests = [
+      {input: '+01', expected: '+01:00'},
+      {input: '+0100', expected: '+01:00'},
+      {input: '+01:00', expected: '+01:00'},
+      {input: '-05', expected: '-05:00'},
+      {input: '-0530', expected: '-05:30'},
+    ]
+
+    tests.forEach(({input, expected}) => {
+      const dtf = new DateTimeFormat('en-GB', {timeZone: input})
+      expect(dtf.resolvedOptions().timeZone).toBe(expected)
+    })
+  })
+
+  it('should work with @date-fns/tz pattern from issue #4804', function () {
+    // This is the exact use case from the GitHub issue
+    expect(
+      () =>
+        new DateTimeFormat('en-GB', {
+          timeZone: '+01:00',
+          hour: 'numeric',
+          timeZoneName: 'longOffset',
+        })
+    ).not.toThrow()
+
+    const dtf = new DateTimeFormat('en-GB', {
+      timeZone: '+01:00',
+      hour: 'numeric',
+      timeZoneName: 'longOffset',
+    })
+    const result = dtf.format(new Date('2024-01-01T00:00:00Z'))
+    expect(result).toBeTruthy()
+  })
+
+  it('should handle half-hour offsets like +05:30', function () {
+    const dtf = new DateTimeFormat('en-GB', {
+      timeZone: '+05:30',
+      hour: 'numeric',
+      minute: 'numeric',
+      hour12: false,
+    })
+    // Unix epoch should be 05:30:00 at +05:30
+    const result = dtf.format(new Date(0))
+    expect(result).toContain('05:30')
+  })
+
+  it('should handle quarter-hour offsets like +05:45', function () {
+    const dtf = new DateTimeFormat('en-GB', {
+      timeZone: '+05:45',
+      hour: 'numeric',
+      minute: 'numeric',
+      hour12: false,
+    })
+    // Unix epoch should be 05:45:00 at +05:45
+    const result = dtf.format(new Date(0))
+    expect(result).toContain('05:45')
+  })
+
+  it('should handle negative half-hour offset like -03:30', function () {
+    const dtf = new DateTimeFormat('en-GB', {
+      timeZone: '-03:30',
+      hour: 'numeric',
+      minute: 'numeric',
+      hour12: false,
+    })
+    // Unix epoch (Jan 1, 1970 00:00:00 UTC) should be Dec 31, 1969 20:30:00 at -03:30
+    const result = dtf.format(new Date(0))
+    expect(result).toContain('20:30')
+  })
+})


### PR DESCRIPTION
### TL;DR

Added support for UTC offset timezones in `@formatjs/intl-datetimeformat` polyfill.

### What changed?

- Implemented support for UTC offset timezone identifiers (e.g., `+01:00`, `-05:00`) in the DateTimeFormat polyfill
- Added validation and canonicalization for various offset formats: `±HH:MM`, `±HHMM`, `±HH`, `±HH:MM:SS`, and `±HH:MM:SS.sss`
- Extended the `CanonicalizeTimeZoneName` and `IsValidTimeZoneName` abstract operations to handle offset timezones
- Modified `ToLocalTime` to properly calculate time with UTC offset timezones
- Added comprehensive test coverage for offset timezone functionality
- Updated documentation with examples and usage information

### How to test?

```js
import '@formatjs/intl-datetimeformat/polyfill.js'
import '@formatjs/intl-datetimeformat/locale-data/en.js'

// Using UTC offset timezone
const formatter = new Intl.DateTimeFormat('en-GB', {
  timeZone: '+01:00',
  year: 'numeric',
  month: 'numeric',
  day: 'numeric',
  hour: 'numeric',
  minute: 'numeric',
})

console.log(formatter.format(new Date('2024-01-01T00:00:00Z')))
// Output: "01/01/2024, 01:00"
```

### Why make this change?

This change addresses issue #4804 where the polyfill didn't support UTC offset timezones, causing compatibility issues with libraries like `@date-fns/tz` in React Native/Hermes environments. The implementation follows the ECMA-402 specification (ES2026) and matches the behavior of Chrome and Node.js 22+ native implementations, allowing developers to use offset-based timezone strings in addition to IANA timezone names.