### PR TITLE
fix(@formatjs/intl-locale): add FF lack of feature detection, fix #5112

### DIFF
--- a/packages/intl-locale/should-polyfill.ts
+++ b/packages/intl-locale/should-polyfill.ts
@@ -9,6 +9,42 @@ function hasIntlGetCanonicalLocalesBug(): boolean {
   }
 }
 
+/**
+ * Check if Intl.Locale is missing critical methods from the Intl Locale Info proposal.
+ * Firefox has an incomplete implementation that lacks getWeekInfo() and other methods.
+ * https://github.com/formatjs/formatjs/issues/5112
+ * https://bugzilla.mozilla.org/show_bug.cgi?id=1693576
+ */
+function hasIncompleteLocaleInfo(): boolean {
+  try {
+    const locale = new (Intl as any).Locale('en-US')
+    // Check for getWeekInfo - critical for week calculations (e.g., Luxon's localWeekNumber)
+    // This is the most important check as it affects date/time libraries
+    if (typeof locale.getWeekInfo !== 'function') {
+      return true
+    }
+    // Also check for other Intl Locale Info methods
+    // These are part of the same proposal and often missing together
+    if (
+      typeof locale.getCalendars !== 'function' ||
+      typeof locale.getCollations !== 'function' ||
+      typeof locale.getHourCycles !== 'function' ||
+      typeof locale.getNumberingSystems !== 'function' ||
+      typeof locale.getTimeZones !== 'function' ||
+      typeof locale.getTextInfo !== 'function'
+    ) {
+      return true
+    }
+    return false
+  } catch {
+    return true
+  }
+}
+
 export function shouldPolyfill(): boolean {
-  return !('Locale' in Intl) || hasIntlGetCanonicalLocalesBug()
+  return (
+    !('Locale' in Intl) ||
+    hasIntlGetCanonicalLocalesBug() ||
+    hasIncompleteLocaleInfo()
+  )
 }

--- a/packages/intl-locale/tests/index.test.ts
+++ b/packages/intl-locale/tests/index.test.ts
@@ -124,3 +124,54 @@ test('GH #4575', function () {
     direction: 'rtl',
   })
 })
+
+test('GH #5112 - getWeekInfo should be available for week calculations', function () {
+  // Issue #5112: Firefox has incomplete Intl.Locale implementation
+  // missing getWeekInfo() which breaks Luxon's localWeekNumber calculation
+  // This test ensures the polyfill provides getWeekInfo() for all locales
+
+  const locale = new Locale('en-US')
+
+  // getWeekInfo() must exist and return proper structure
+  expect(typeof locale.getWeekInfo).toBe('function')
+
+  const weekInfo = locale.getWeekInfo()
+  expect(weekInfo).toHaveProperty('firstDay')
+  expect(weekInfo).toHaveProperty('weekend')
+  expect(weekInfo).toHaveProperty('minimalDays')
+
+  // en-US uses Sunday (7) as first day of week
+  expect(weekInfo.firstDay).toBe(7)
+  expect(weekInfo.minimalDays).toBe(1)
+
+  // Test other locales that might have different week info
+  const localeDe = new Locale('de-DE')
+  const weekInfoDe = localeDe.getWeekInfo()
+  // Germany uses Monday (1) as first day of week
+  expect(weekInfoDe.firstDay).toBe(1)
+  expect(weekInfoDe.minimalDays).toBe(4)
+})
+
+test('GH #5112 - All Intl Locale Info methods should be available', function () {
+  // Issue #5112: Incomplete implementations may be missing multiple methods
+  // from the Intl Locale Info proposal. Ensure all are present.
+
+  const locale = new Locale('en-US')
+
+  // All these methods must exist (part of Intl Locale Info proposal)
+  expect(typeof locale.getWeekInfo).toBe('function')
+  expect(typeof locale.getCalendars).toBe('function')
+  expect(typeof locale.getCollations).toBe('function')
+  expect(typeof locale.getHourCycles).toBe('function')
+  expect(typeof locale.getNumberingSystems).toBe('function')
+  expect(typeof locale.getTimeZones).toBe('function')
+  expect(typeof locale.getTextInfo).toBe('function')
+
+  // Verify they return proper data
+  expect(Array.isArray(locale.getCalendars())).toBe(true)
+  expect(Array.isArray(locale.getCollations())).toBe(true)
+  expect(Array.isArray(locale.getHourCycles())).toBe(true)
+  expect(Array.isArray(locale.getNumberingSystems())).toBe(true)
+  expect(typeof locale.getTextInfo()).toBe('object')
+  expect(typeof locale.getWeekInfo()).toBe('object')
+})


### PR DESCRIPTION
# Fix Firefox's incomplete Intl.Locale implementation

### TL;DR

Enhance the `shouldPolyfill()` function to detect and polyfill incomplete Intl.Locale implementations that lack critical methods from the Intl Locale Info proposal.

### What changed?

- Added a new `hasIncompleteLocaleInfo()` function that checks for missing Intl Locale Info methods
- Updated `shouldPolyfill()` to also check for incomplete implementations
- Added comprehensive tests to verify the availability of all Locale Info methods
- Added specific tests for `getWeekInfo()` which is critical for week calculations

### How to test?

1. Run the test suite with `npm test`
2. Verify the new tests pass, especially those related to issue #5112
3. Test in Firefox to confirm the polyfill correctly provides missing methods like `getWeekInfo()`

### Why make this change?

Fixes #5112 where Firefox's incomplete implementation of Intl.Locale was missing `getWeekInfo()` and other methods from the Intl Locale Info proposal. This was breaking functionality in date/time libraries like Luxon that rely on these methods for week calculations. The enhanced polyfill detection ensures consistent behavior across browsers.