### PR TITLE
fix(intl-messageformat): handle bigint, fix #5081

### DIFF
--- a/tools/tsconfig.bzl
+++ b/tools/tsconfig.bzl
@@ -15,6 +15,7 @@ BASE_TSCONFIG = {
             "ES2018.Intl",
             "ES2019.Intl",
             "ES2020.Intl",
+            "ES2020.BigInt",
             "ES2021.intl",
             "ES2021.String",
             "ES2022.Intl",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
       "ES2018.Intl",
       "ES2019.Intl",
       "ES2020.Intl",
+      "ES2020.BigInt",
       "ES2021.intl",
       "ES2021.String",
       "ES2022.Intl",


### PR DESCRIPTION
### TL;DR

Added support for BigInt values in IntlMessageFormat.

### What changed?

- Updated `PrimitiveType` to include `bigint` as a supported type
- Modified formatters to properly handle BigInt values in various contexts:
  - Simple argument formatting
  - Number formatting with styles and options
  - Plural rules and selectordinal formatting
  - Scale operations (with integer validation for BigInt)
- Added type conversions where necessary to ensure BigInt values work with existing APIs
- Added comprehensive test suite for BigInt support

### How to test?

Run the test suite which includes various BigInt formatting scenarios:
- Basic BigInt formatting: `{value}` where value is a BigInt
- Number formatting: `{value, number}`
- Currency formatting: `{value, number, ::currency/USD}`
- Plural rules: `{count, plural, one {One item} other {# items}}`
- Very large BigInt values beyond Number.MAX_SAFE_INTEGER
- Mixed number and BigInt types in the same message

### Why make this change?

Fixes GitHub issue #5081 where BigInt values weren't properly supported in message formatting. This enhancement allows for working with arbitrarily large integers without precision loss, which is important for financial applications, IDs, and other use cases requiring exact integer representation beyond JavaScript's Number limits.