### PR TITLE
fix(@formatjs/cli): don't try to parse non core fields

### DIFF
--- a/packages/cli/integration-tests/extract/integration.test.ts
+++ b/packages/cli/integration-tests/extract/integration.test.ts
@@ -303,3 +303,19 @@ test('import meta', async () => {
     await readJSON(join(ARTIFACT_PATH, 'typescript/importMeta.json'))
   ).toMatchSnapshot()
 })
+
+// https://github.com/formatjs/formatjs/issues/5069
+test('GH #5069: Tagged template expressions with substitutions in non-message props', async () => {
+  await expect(
+    exec(
+      `${BIN_PATH} extract --throws '${join(
+        __dirname,
+        'taggedTemplates/actual.tsx'
+      )}' --out-file ${ARTIFACT_PATH}/taggedTemplates/actual.json`
+    )
+  ).resolves.toMatchSnapshot()
+
+  expect(
+    await readJSON(join(ARTIFACT_PATH, 'taggedTemplates/actual.json'))
+  ).toMatchSnapshot()
+})

--- a/packages/cli/integration-tests/extract/taggedTemplates/actual.tsx
+++ b/packages/cli/integration-tests/extract/taggedTemplates/actual.tsx
@@ -1,0 +1,54 @@
+/**
+ * GH #5069: Tagged template expressions with substitutions should be allowed
+ * in non-message props like tagName, values, etc.
+ */
+import React from 'react'
+import {FormattedMessage} from 'react-intl'
+import styled from '@emotion/styled'
+import {css} from '@emotion/react'
+
+// Mock variables for styled-components/emotion
+const blackColor = '#000'
+const fontSize = 16
+const fontWeight = 'bold'
+
+export function StyledMessageComponent() {
+  // Should extract messages successfully even with styled-components in tagName
+  return (
+    <div>
+      <FormattedMessage
+        id="message.with.styled.tagname"
+        defaultMessage="This message uses styled-components as tagName"
+        tagName={styled('div')`
+          color: ${blackColor};
+          font-size: ${fontSize}px;
+        `}
+      />
+
+      <FormattedMessage
+        id="message.with.css.tagname"
+        defaultMessage="This message uses emotion css"
+        tagName={css`
+          font-weight: ${fontWeight};
+        `}
+      />
+
+      <FormattedMessage
+        id="message.with.styled.in.values"
+        defaultMessage="Hello {component}"
+        values={{
+          component: styled('span')`
+            color: ${blackColor};
+          `,
+        }}
+      />
+
+      {/* dedent without substitutions should still work */}
+      <FormattedMessage
+        id="message.with.dedent"
+        defaultMessage="Message with dedent"
+        description="Description with dedent"
+      />
+    </div>
+  )
+}

--- a/packages/eslint-plugin-formatjs/rules/no-invalid-icu.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-invalid-icu.ts
@@ -12,7 +12,20 @@ function checkNode(
   node: TSESTree.Node
 ) {
   const settings = getSettings(context)
-  const msgs = extractMessages(node, settings)
+  let msgs
+  try {
+    msgs = extractMessages(node, settings)
+  } catch (e) {
+    // GH #5069: Handle errors from extractMessages (e.g., tagged templates with substitutions)
+    context.report({
+      node,
+      messageId: 'parseError',
+      data: {
+        error: (e as Error).message,
+      },
+    })
+    return
+  }
 
   if (!msgs.length) {
     return

--- a/packages/eslint-plugin-formatjs/tests/tagged-template-substitutions.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/tagged-template-substitutions.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Test for GH #5069: Tagged template expressions with substitutions
+ * should be allowed in non-message props like tagName, values, etc.
+ */
+import {name, rule} from '../rules/no-invalid-icu.js'
+import {ruleTester} from './util'
+
+ruleTester.run(name + ' (GH #5069 - tagged templates)', rule, {
+  valid: [
+    {
+      code: `
+        <FormattedMessage
+          id="someid"
+          defaultMessage="Some Default Message"
+          tagName={styled("div")\`
+            color: \${blackColor};
+          \`}
+        />
+      `,
+    },
+    {
+      code: `
+        <FormattedMessage
+          id="someid"
+          defaultMessage="Some Default Message"
+          tagName={css\`font-size: \${fontSize}px;\`}
+        />
+      `,
+    },
+    {
+      code: `
+        intl.formatMessage({
+          id: 'someid',
+          defaultMessage: 'Some Message',
+          tagName: styled("div")\`color: \${color};\`
+        })
+      `,
+    },
+    {
+      code: `
+        <FormattedMessage
+          id="someid"
+          defaultMessage="Some Default Message"
+          values={{
+            component: styled("span")\`font-weight: \${weight};\`
+          }}
+        />
+      `,
+    },
+    // dedent without substitutions should still work
+    {
+      code: `
+        <FormattedMessage
+          id={dedent\`someid\`}
+          defaultMessage={dedent\`Some Default Message\`}
+          description={dedent\`Some description\`}
+        />
+      `,
+    },
+  ],
+  invalid: [
+    // Tagged templates with substitutions in message props should still fail
+    {
+      code: `
+        <FormattedMessage
+          id={dedent\`some\${id}\`}
+          defaultMessage="message"
+        />
+      `,
+      errors: [
+        {
+          messageId: 'parseError',
+          data: {
+            error: 'Tagged template expression must be no substitution',
+          },
+        },
+      ],
+    },
+    {
+      code: `
+        <FormattedMessage
+          id="someid"
+          defaultMessage={dedent\`message \${value}\`}
+        />
+      `,
+      errors: [
+        {
+          messageId: 'parseError',
+          data: {
+            error: 'Tagged template expression must be no substitution',
+          },
+        },
+      ],
+    },
+    {
+      code: `
+        <FormattedMessage
+          id="someid"
+          defaultMessage="message"
+          description={dedent\`description \${value}\`}
+        />
+      `,
+      errors: [
+        {
+          messageId: 'parseError',
+          data: {
+            error: 'Tagged template expression must be no substitution',
+          },
+        },
+      ],
+    },
+    {
+      code: `
+        intl.formatMessage({
+          id: dedent\`id\${value}\`,
+          defaultMessage: 'message'
+        })
+      `,
+      errors: [
+        {
+          messageId: 'parseError',
+          data: {
+            error: 'Tagged template expression must be no substitution',
+          },
+        },
+      ],
+    },
+  ],
+})

--- a/packages/eslint-plugin-formatjs/util.ts
+++ b/packages/eslint-plugin-formatjs/util.ts
@@ -119,6 +119,18 @@ export function extractMessageDescriptor(
     if (prop.type !== 'Property' || prop.key.type !== 'Identifier') {
       continue
     }
+
+    // Only extract values for message-related props
+    // GH #5069: Don't process other props like tagName, values, etc.
+    const propName = prop.key.name
+    if (
+      propName !== 'id' &&
+      propName !== 'defaultMessage' &&
+      propName !== 'description'
+    ) {
+      continue
+    }
+
     const valueNode = prop.value
     let value: string | undefined = undefined
     if (isStringLiteral(valueNode)) {
@@ -144,7 +156,7 @@ export function extractMessageDescriptor(
       }
     }
 
-    switch (prop.key.name) {
+    switch (propName) {
       case 'defaultMessage':
         result.messagePropNode = prop
         result.messageNode = valueNode
@@ -192,9 +204,19 @@ function extractMessageDescriptorFromJSXElement(
       continue
     }
     const key = prop.name
+    const keyName = key.name
+
+    // Only extract values for message-related props
+    // GH #5069: Don't process other props like tagName, values, etc.
+    // Allow them to have tagged templates with substitutions
+    const isMessageProp =
+      keyName === 'id' ||
+      keyName === 'defaultMessage' ||
+      keyName === 'description'
+
     let valueNode = prop.value
     let value: string | undefined = undefined
-    if (valueNode) {
+    if (valueNode && isMessageProp) {
       if (isStringLiteral(valueNode)) {
         value = valueNode.value
       } else if (valueNode?.type === 'JSXExpressionContainer') {
@@ -222,7 +244,7 @@ function extractMessageDescriptorFromJSXElement(
       }
     }
 
-    switch (key.name) {
+    switch (keyName) {
       case 'defaultMessage':
         result.messagePropNode = prop
         result.messageNode = valueNode

--- a/packages/ts-transformer/src/transform.ts
+++ b/packages/ts-transformer/src/transform.ts
@@ -311,7 +311,17 @@ function extractMessageDescriptor(
         }
       }
       // {id: dedent`id`}
+      // GH #5069: Only check for substitutions on message-related props
       else if (ts.isTaggedTemplateExpression(initializer)) {
+        const isMessageProp =
+          name.text === 'id' ||
+          name.text === 'defaultMessage' ||
+          name.text === 'description'
+        if (!isMessageProp) {
+          // Skip non-message props (like tagName, values, etc.)
+          return
+        }
+
         const {template} = initializer
         if (!ts.isNoSubstitutionTemplateLiteral(template)) {
           throw new Error('Tagged template expression must be no substitution')
@@ -369,7 +379,17 @@ function extractMessageDescriptor(
           }
         }
         // <FormattedMessage foo={dedent`dedent Hello World!`} />
+        // GH #5069: Only check for substitutions on message-related props
         else if (ts.isTaggedTemplateExpression(initializer.expression)) {
+          const isMessageProp =
+            name.text === 'id' ||
+            name.text === 'defaultMessage' ||
+            name.text === 'description'
+          if (!isMessageProp) {
+            // Skip non-message props (like tagName, values, etc.)
+            return
+          }
+
           const {
             expression: {template},
           } = initializer


### PR DESCRIPTION
# Fix Tagged Template Expressions with Substitutions in Non-Message Props

### TL;DR

Fixes issue #5069 by allowing tagged template expressions with substitutions in non-message props like `tagName` and `values`.

### What changed?

- Modified the message extraction logic in `eslint-plugin-formatjs` and `ts-transformer` to only validate tagged template expressions in message-related props (`id`, `defaultMessage`, `description`)
- Added error handling in `no-invalid-icu` rule to properly report parsing errors
- Added integration tests to verify that styled-components and emotion CSS templates work correctly with FormattedMessage
- Added unit tests to verify the behavior of tagged templates with substitutions

### How to test?

1. Run the new integration tests:
   ```
   npm test -- -t "GH #5069: Tagged template expressions with substitutions in non-message props"
   ```

2. Run the new unit tests:
   ```
   npm test -- -t "GH #5069 - tagged templates"
   ```

3. Try using styled-components or emotion with FormattedMessage:
   ```jsx
   <FormattedMessage
     id="message.with.styled.tagname"
     defaultMessage="This message uses styled-components as tagName"
     tagName={styled('div')`
       color: ${blackColor};
       font-size: ${fontSize}px;
     `}
   />
   ```

### Why make this change?

Fixes issue #5069 where the formatjs tooling was incorrectly rejecting valid usage of tagged template expressions with substitutions in non-message props. This change allows developers to use styled-components, emotion, and other template literal-based libraries with FormattedMessage components without errors during extraction or linting.