### PR TITLE
fix(eslint-plugin-formatjs): handle formatMessage when it's being destructured, fix #4890

### DIFF
--- a/packages/eslint-plugin-formatjs/tests/prefer-formatted-message.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/prefer-formatted-message.test.ts
@@ -25,6 +25,18 @@ ruleTester.run(name, rule, {
     {
       code: `<img src="/example.png" alt={intl.formatMessage({defaultMessage: 'test'})} />`,
     },
+    // GH #4890: formatMessage in attributes (not JSX children) should still be valid
+    {
+      code: `<img src="/example.png" alt={formatMessage({defaultMessage: 'test'})} />`,
+    },
+    // GH #4890: formatMessage with non-object argument should not be flagged
+    {
+      code: `
+      <div>
+        {formatMessage(someVariable)}
+      </div>
+      `,
+    },
   ],
   invalid: [
     {
@@ -57,6 +69,57 @@ ruleTester.run(name, rule, {
         {
           messageId: 'jsxChildren',
         },
+        {
+          messageId: 'jsxChildren',
+        },
+      ],
+    },
+    // GH #4890: Destructured formatMessage should also be detected
+    {
+      code: `
+      <div>
+        {formatMessage({
+          defaultMessage: 'test',
+        })}
+      </div>
+      `,
+      errors: [
+        {
+          messageId: 'jsxChildren',
+        },
+      ],
+    },
+    {
+      code: `
+      <div>
+        {formatMessage({
+          defaultMessage: 'hello',
+        })}
+        {' '}
+        {formatMessage({
+          defaultMessage: 'world',
+        })}
+      </div>
+      `,
+      errors: [
+        {
+          messageId: 'jsxChildren',
+        },
+        {
+          messageId: 'jsxChildren',
+        },
+      ],
+    },
+    // GH #4890: $t alias should also work
+    {
+      code: `
+      <div>
+        {$t({
+          defaultMessage: 'test',
+        })}
+      </div>
+      `,
+      errors: [
         {
           messageId: 'jsxChildren',
         },


### PR DESCRIPTION
### TL;DR

Fix `prefer-formatted-message` rule to properly handle destructured `formatMessage` calls and non-object arguments.

### What changed?

- Enhanced `isIntlFormatMessageCall` utility to detect both `intl.formatMessage()` and destructured `formatMessage()` patterns
- Added support for detecting `$t` alias when used directly (not just as a member expression)
- Added logic to skip validation when `formatMessage` is called with non-object arguments
- Added test cases to verify these scenarios work correctly

### How to test?

Run the test suite to verify the following scenarios:
- Destructured `formatMessage` calls in JSX children are properly flagged
- `formatMessage` calls with non-object arguments are not flagged
- `formatMessage` calls in attributes (not JSX children) are valid
- Multiple `formatMessage` calls in the same JSX element are properly detected
- The `$t` alias works correctly when used directly

### Why make this change?

Fixes issue #4890 where the `prefer-formatted-message` rule was not properly detecting destructured `formatMessage` calls, leading to false negatives. This change ensures the rule works correctly with different usage patterns of `formatMessage`, improving the linting experience for users who destructure the function from `useIntl()`.