### PR TITLE
fix(intl-messageformat): fix value having special key like constructor, fix ##4490

### DIFF
--- a/packages/intl-messageformat/src/formatters.ts
+++ b/packages/intl-messageformat/src/formatters.ts
@@ -276,7 +276,12 @@ export function formatToParts<T>(
       )
     }
     if (isSelectElement(el)) {
-      const opt = el.options[value as string] || el.options.other
+      // GH #4490: Use hasOwnProperty to avoid prototype chain issues with keys like "constructor"
+      const key = value as string
+      const opt =
+        (Object.prototype.hasOwnProperty.call(el.options, key)
+          ? el.options[key]
+          : undefined) || el.options.other
       if (!opt) {
         throw new InvalidValueError(
           el.value,
@@ -291,7 +296,11 @@ export function formatToParts<T>(
       continue
     }
     if (isPluralElement(el)) {
-      let opt = el.options[`=${value}`]
+      // GH #4490: Use hasOwnProperty to avoid prototype chain issues
+      const exactKey = `=${value}`
+      let opt = Object.prototype.hasOwnProperty.call(el.options, exactKey)
+        ? el.options[exactKey]
+        : undefined
       if (!opt) {
         if (!Intl.PluralRules) {
           throw new FormatError(
@@ -308,7 +317,10 @@ Try polyfilling it using "@formatjs/intl-pluralrules"
         const rule = formatters
           .getPluralRules(locales, {type: el.pluralType})
           .select(numericValue - (el.offset || 0))
-        opt = el.options[rule] || el.options.other
+        opt =
+          (Object.prototype.hasOwnProperty.call(el.options, rule)
+            ? el.options[rule]
+            : undefined) || el.options.other
       }
       if (!opt) {
         throw new InvalidValueError(

--- a/packages/intl-messageformat/tests/index.test.ts
+++ b/packages/intl-messageformat/tests/index.test.ts
@@ -1096,4 +1096,64 @@ describe('IntlMessageFormat', function () {
       expect(result).toBe('10')
     })
   })
+
+  describe('GH #4490 - "constructor" and other prototype properties in select/plural', function () {
+    it('should handle "constructor" in select statement', function () {
+      const msg = new IntlMessageFormat(
+        '{gender, select, constructor {Constructor case} male {Male} female {Female} other {Other}}',
+        'en-US'
+      )
+      expect(msg.format({gender: 'constructor'})).toBe('Constructor case')
+      expect(msg.format({gender: 'male'})).toBe('Male')
+      expect(msg.format({gender: 'unknown'})).toBe('Other')
+    })
+
+    it('should handle "__proto__" in select statement', function () {
+      const msg = new IntlMessageFormat(
+        '{type, select, __proto__ {Proto case} other {Other}}',
+        'en-US'
+      )
+      expect(msg.format({type: '__proto__'})).toBe('Proto case')
+      expect(msg.format({type: 'unknown'})).toBe('Other')
+    })
+
+    it('should handle "toString" in select statement', function () {
+      const msg = new IntlMessageFormat(
+        '{method, select, toString {ToString case} other {Other}}',
+        'en-US'
+      )
+      expect(msg.format({method: 'toString'})).toBe('ToString case')
+      expect(msg.format({method: 'unknown'})).toBe('Other')
+    })
+
+    it('should handle "hasOwnProperty" in select statement', function () {
+      const msg = new IntlMessageFormat(
+        '{method, select, hasOwnProperty {HasOwnProperty case} other {Other}}',
+        'en-US'
+      )
+      expect(msg.format({method: 'hasOwnProperty'})).toBe('HasOwnProperty case')
+      expect(msg.format({method: 'unknown'})).toBe('Other')
+    })
+
+    it('should handle plural rules that could match prototype properties', function () {
+      // Test that plural rules work correctly even with rules that could conflict with prototype properties
+      const msg = new IntlMessageFormat(
+        '{count, plural, one {# item} other {# items}}',
+        'en-US'
+      )
+      // Verify normal operation still works after our prototype-safe changes
+      expect(msg.format({count: 1})).toBe('1 item')
+      expect(msg.format({count: 5})).toBe('5 items')
+    })
+
+    it('should not crash when select value is "constructor"', function () {
+      const msg = new IntlMessageFormat(
+        '{value, select, constructor {Found} other {Not found}}',
+        'en-US'
+      )
+      // This should not throw an error
+      expect(() => msg.format({value: 'constructor'})).not.toThrow()
+      expect(msg.format({value: 'constructor'})).toBe('Found')
+    })
+  })
 })


### PR DESCRIPTION
### TL;DR

Fixed a security vulnerability where prototype properties like "constructor" in select/plural statements could cause unexpected behavior.

### What changed?

Modified the `formatToParts` function to use `Object.prototype.hasOwnProperty.call()` when accessing options in select and plural elements. This prevents potential issues when keys like "constructor", "__proto__", or other JavaScript object prototype properties are used as values in message formats.

### How to test?

Added comprehensive test cases that verify:
- Select statements with "constructor" as a value
- Select statements with "__proto__" as a value
- Select statements with "toString" as a value
- Select statements with "hasOwnProperty" as a value
- Plural rules that could potentially match prototype properties
- Ensuring no crashes when select value is "constructor"

### Why make this change?

This fixes GitHub issue #4490 where using certain property names that exist on the JavaScript object prototype (like "constructor") in select/plural statements could lead to unexpected behavior or potential security vulnerabilities. By using `hasOwnProperty`, we ensure that only the object's own properties are accessed, not those inherited from the prototype chain.