### PR TITLE
docs: clarify ICU select, fix #4281

### DIFF
--- a/docs/src/docs/core-concepts/icu-syntax.mdx
+++ b/docs/src/docs/core-concepts/icu-syntax.mdx
@@ -140,13 +140,13 @@ Similar to `number` type, we also support ICU DateTime skeleton. ICU provides a 
 
 ### `{select}` Format
 
-The `{key, select, matches}` is used to choose output by matching a value to one of many choices. (It is similar to the `switch` statement available in some programming languages.) The key is looked up in the input data. The corresponding value is matched to one of matches and the corresponding output is returned. The `key` argument must follow [Unicode Pattern_Syntax](https://www.unicode.org/reports/tr31/#Pattern_Syntax). The `matches` is a space-separated list of `matches`.
+The `{key, select, matches}` is used to choose output by matching a value to one of many choices. (It is similar to the `switch` statement available in some programming languages.) The `key` is looked up in the input data. The corresponding value is matched to one of the `matches` and the corresponding `output` is returned. The `key` argument must follow [Unicode Pattern_Syntax](https://www.unicode.org/reports/tr31/#Pattern_Syntax).
 
-The format of a match is match `{output}`. (A match is similar to the case statement of the switch found in some programming languages.) The `match` is a literal value. If it is the same as the value for `key` then the corresponding `output` will be used.
+The `matches` is a space-separated list of individual match cases, where each match case has the format `match {output}`. (A match case is similar to the `case` statement of the switch found in some programming languages.) The `match` is a literal value. If it is the same as the value for `key` then the corresponding `output` will be used.
 
-output is itself a message, so it can be a literal string or also have more arguments nested inside of it.
+The `output` is itself a message, so it can be a literal string or also have more arguments nested inside of it.
 
-The `other` match is special and is used if nothing else matches. (This is similar to the default case of the switch found in some programming languages.)
+The `other` match case is special and is used if nothing else matches. (This is similar to the `default` case of the switch found in some programming languages.) Note that `other` is treated as a reserved keyword in the match pattern, not as a variable lookup, so it will always act as the fallback case even if your input data contains a field named `other`.
 
 <Admonition type="danger">
 `other` is required as per `icu4j` implementation. We will throw an error if `select` is used without `other`.


### PR DESCRIPTION
### TL;DR

Improved the documentation for the ICU `select` format to be more precise and clear.

### What changed?

- Clarified the explanation of the `select` format by adding backticks around key terms for better readability
- Added more precise descriptions of how match cases work in the `select` format
- Added an important note explaining that `other` is treated as a reserved keyword, not as a variable lookup
- Improved the comparison to programming language constructs by adding backticks around terms like `case` and `default`

### How to test?

Review the updated documentation in the ICU syntax page to ensure it accurately describes the `select` format behavior, particularly the explanation of how the `other` keyword functions as a reserved fallback case.

### Why make this change?

The previous documentation was slightly ambiguous about how the `select` format works, particularly regarding the `other` keyword. This change provides more precise terminology and a clearer explanation of the matching process, which will help developers better understand how to use the `select` format correctly in their internationalization implementations.