### PR TITLE
fix(@formatjs/ts-transformer): fix optional chaining extraction, fix #4471

### DIFF
--- a/packages/babel-plugin-formatjs/index.ts
+++ b/packages/babel-plugin-formatjs/index.ts
@@ -93,6 +93,8 @@ const plugin: (
         },
         JSXOpeningElement,
         CallExpression,
+        // GH #4471: Handle optional chaining calls (e.g., intl.formatMessage?.())
+        OptionalCallExpression: CallExpression,
       },
     }
   })

--- a/packages/babel-plugin-formatjs/tests/fixtures/optionalChaining.js
+++ b/packages/babel-plugin-formatjs/tests/fixtures/optionalChaining.js
@@ -1,0 +1,22 @@
+// GH #4471: Test optional chaining with formatMessage
+const intl = {}
+
+export function testOptionalChaining() {
+  // Case 1: Normal call (baseline - should work)
+  intl.formatMessage({
+    defaultMessage: 'Normal call',
+    description: 'Test normal formatMessage call',
+  })
+
+  // Case 2: With optional chaining (should work)
+  intl.formatMessage?.({
+    defaultMessage: 'With optional chaining',
+    description: 'Test formatMessage with optional chaining',
+  })
+
+  // Case 3: Nested optional chaining
+  something?.intl?.formatMessage?.({
+    defaultMessage: 'Nested optional chaining',
+    description: 'Test nested optional chaining',
+  })
+}

--- a/packages/babel-plugin-formatjs/tests/index.test.ts
+++ b/packages/babel-plugin-formatjs/tests/index.test.ts
@@ -209,6 +209,28 @@ test('jsxNestedInCallExpr', () => {
   transformAndCheck('jsxNestedInCallExpr')
 })
 
+// GH #4471: Test optional chaining with formatMessage
+test('optionalChaining', () => {
+  const result = transformAndCheck('optionalChaining')
+  expect(result.data.messages).toEqual([
+    {
+      defaultMessage: 'Normal call',
+      description: 'Test normal formatMessage call',
+      id: 'YWtvBT',
+    },
+    {
+      defaultMessage: 'With optional chaining',
+      description: 'Test formatMessage with optional chaining',
+      id: 'vB3haT',
+    },
+    {
+      defaultMessage: 'Nested optional chaining',
+      description: 'Test nested optional chaining',
+      id: 'vfvOrL',
+    },
+  ])
+})
+
 let cacheBust = 1
 
 function transform(

--- a/packages/babel-plugin-formatjs/visitors/call-expression.ts
+++ b/packages/babel-plugin-formatjs/visitors/call-expression.ts
@@ -32,7 +32,9 @@ function isFormatMessageCall(
     return true
   }
 
-  if (callee.isMemberExpression()) {
+  // GH #4471: Handle both MemberExpression and OptionalMemberExpression
+  // (e.g., intl.formatMessage() and intl.formatMessage?.())
+  if (callee.isMemberExpression() || callee.isOptionalMemberExpression()) {
     const property = callee.get('property') as NodePath<t.MemberExpression>
     return !!functionNames.find(name => property.isIdentifier({name}))
   }

--- a/packages/cli/integration-tests/extract/integration.test.ts
+++ b/packages/cli/integration-tests/extract/integration.test.ts
@@ -319,3 +319,19 @@ test('GH #5069: Tagged template expressions with substitutions in non-message pr
     await readJSON(join(ARTIFACT_PATH, 'taggedTemplates/actual.json'))
   ).toMatchSnapshot()
 })
+
+// https://github.com/formatjs/formatjs/issues/4471
+test('GH #4471: Optional chaining with generics in formatMessage', async () => {
+  await expect(
+    exec(
+      `${BIN_PATH} extract --throws '${join(
+        __dirname,
+        'optionalChaining/actual.tsx'
+      )}' --out-file ${ARTIFACT_PATH}/optionalChaining/actual.json`
+    )
+  ).resolves.toMatchSnapshot()
+
+  expect(
+    await readJSON(join(ARTIFACT_PATH, 'optionalChaining/actual.json'))
+  ).toMatchSnapshot()
+})

--- a/packages/cli/integration-tests/extract/optionalChaining/actual.tsx
+++ b/packages/cli/integration-tests/extract/optionalChaining/actual.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import {useIntl} from 'react-intl'
+
+// GH #4471: Test optional chaining with formatMessage
+export function OptionalChainingComponent() {
+  const intl = useIntl()
+
+  return (
+    <div>
+      {/* Normal call - baseline */}
+      <p>{intl.formatMessage({defaultMessage: 'Normal call'})}</p>
+
+      {/* With generics */}
+      <p>
+        {intl.formatMessage<HTMLElement>({
+          defaultMessage: 'With generics',
+          description: 'formatMessage with generic type parameter',
+        })}
+      </p>
+
+      {/* With optional chaining */}
+      <p>
+        {intl.formatMessage?.({
+          defaultMessage: 'With optional chaining',
+          description: 'formatMessage with optional chaining operator',
+        })}
+      </p>
+
+      {/* With both generics and optional chaining - the problematic case */}
+      <p>
+        {intl.formatMessage<HTMLElement>?.({
+          defaultMessage: 'With both generics and optional chaining',
+          description:
+            'formatMessage with both generic type parameter and optional chaining',
+        })}
+      </p>
+
+      {/* Nested optional chaining */}
+      <p>
+        {intl?.formatMessage?.({
+          defaultMessage: 'Nested optional chaining',
+          description: 'formatMessage with nested optional chaining',
+        })}
+      </p>
+    </div>
+  )
+}

--- a/packages/ts-transformer/src/transform.ts
+++ b/packages/ts-transformer/src/transform.ts
@@ -525,6 +525,18 @@ function isMemberMethodFormatMessageCall(
     return fnNames.has(method.name.text)
   }
 
+  // GH #4471: Handle foo.formatMessage<T>?.() - when both generics and optional chaining are used
+  // TypeScript represents this as ExpressionWithTypeArguments containing a PropertyAccessExpression
+  if (
+    ts.isExpressionWithTypeArguments &&
+    ts.isExpressionWithTypeArguments(method)
+  ) {
+    const expr = method.expression
+    if (ts.isPropertyAccessExpression(expr)) {
+      return fnNames.has(expr.name.text)
+    }
+  }
+
   // Handle formatMessage()
   return ts.isIdentifier(method) && fnNames.has(method.text)
 }

--- a/packages/ts-transformer/tests/fixtures/optionalChaining.tsx
+++ b/packages/ts-transformer/tests/fixtures/optionalChaining.tsx
@@ -1,0 +1,36 @@
+// @ts-ignore
+const intl = {} as any
+
+// GH #4471: Test optional chaining with generics
+export function testOptionalChainingWithGenerics() {
+  // Case 1: Normal call (baseline - should work)
+  intl.formatMessage({
+    defaultMessage: 'Normal call',
+    description: 'Test normal formatMessage call',
+  })
+
+  // Case 2: With generics only (baseline - should work)
+  intl.formatMessage<HTMLElement>({
+    defaultMessage: 'With generics',
+    description: 'Test formatMessage with generic type',
+  })
+
+  // Case 3: With optional chaining only (should work)
+  intl.formatMessage?.({
+    defaultMessage: 'With optional chaining',
+    description: 'Test formatMessage with optional chaining',
+  })
+
+  // Case 4: With both generics and optional chaining (the problematic case - should now work)
+  intl.formatMessage<HTMLElement>?.({
+    defaultMessage: 'With both generics and optional chaining',
+    description:
+      'Test formatMessage with both generic type and optional chaining',
+  })
+
+  // Case 5: Nested optional chaining
+  something?.intl?.formatMessage?.({
+    defaultMessage: 'Nested optional chaining',
+    description: 'Test nested optional chaining',
+  })
+}

--- a/packages/ts-transformer/tests/index.test.ts
+++ b/packages/ts-transformer/tests/index.test.ts
@@ -674,6 +674,40 @@ describe('emit asserts for', function () {
       },
     ])
   })
+
+  it('GH #4471 - formatMessage with optional chaining and generics', async function () {
+    const output = await compile(join(FIXTURES_DIR, 'optionalChaining.tsx'), {
+      pragma: 'react-intl',
+    })
+    expect(output.msgs).toEqual([
+      {
+        defaultMessage: 'Normal call',
+        description: 'Test normal formatMessage call',
+        id: '26SK+TP317',
+      },
+      {
+        defaultMessage: 'With generics',
+        description: 'Test formatMessage with generic type',
+        id: '9jq8ZKiO6S',
+      },
+      {
+        defaultMessage: 'With optional chaining',
+        description: 'Test formatMessage with optional chaining',
+        id: 'LmkGiv2APV',
+      },
+      {
+        defaultMessage: 'With both generics and optional chaining',
+        description:
+          'Test formatMessage with both generic type and optional chaining',
+        id: 'ZhR+Lzge+R',
+      },
+      {
+        defaultMessage: 'Nested optional chaining',
+        description: 'Test nested optional chaining',
+        id: 'DZ/55FDtO6',
+      },
+    ])
+  })
 })
 
 async function compile(filePath: string, options?: Partial<Opts>) {


### PR DESCRIPTION
### TL;DR

Added support for optional chaining in formatjs message extraction.

### What changed?

- Added support for optional chaining syntax in `babel-plugin-formatjs` by handling `OptionalCallExpression` nodes
- Updated the `isFormatMessageCall` function to recognize `OptionalMemberExpression` nodes
- Enhanced the TypeScript transformer to handle optional chaining with generics (e.g., `intl.formatMessage<HTMLElement>?.()`)
- Added test cases for both the Babel plugin and TypeScript transformer to verify functionality

### How to test?

1. Use optional chaining with formatMessage:
   ```javascript
   intl.formatMessage?.({
     defaultMessage: 'With optional chaining',
     description: 'Test with optional chaining',
   })
   ```

2. Test with nested optional chaining:
   ```javascript
   something?.intl?.formatMessage?.({
     defaultMessage: 'Nested optional chaining',
     description: 'Test nested optional chaining',
   })
   ```

3. For TypeScript, test with both generics and optional chaining:
   ```typescript
   intl.formatMessage<HTMLElement>?.({
     defaultMessage: 'With both generics and optional chaining',
     description: 'Test with both features',
   })
   ```

### Why make this change?

Fixes GitHub issue #4471 where message extraction was failing when optional chaining syntax was used with formatMessage calls. This change ensures that messages are properly extracted regardless of whether optional chaining is used, improving developer experience by supporting modern JavaScript syntax patterns.