### PR TITLE
feat(eslint-plugin-formatjs): add allowWithDescription option to no-useless-message rule

### DIFF
--- a/docs/src/docs/tooling/linter.mdx
+++ b/docs/src/docs/tooling/linter.mdx
@@ -822,6 +822,40 @@ This bans messages that do not require translation.
 
 Messages like `{test}` is not actionable by translators. The code should just directly reference `test`.
 
+#### Options
+
+```js
+
+export default [
+  {
+    plugins: {
+      formatjs,
+    },
+    rules: {
+      'formatjs/no-useless-message': [
+        'error',
+        {
+          allowWithDescription: true,
+        },
+      ],
+    },
+  },
+]
+```
+
+Setting `allowWithDescription: true` allows useless messages when a `description` is provided. This provides an escape hatch for cases where the original language fits the replacement word exactly but the message ID still needs to exist so other locales can provide their own translations.
+
+```tsx
+// PASSES with allowWithDescription: true
+<FormattedMessage
+  defaultMessage="{count}"
+  description="Simple format in English, but other locales need full sentences"
+/>
+
+// FAILS even with allowWithDescription: true (no description)
+<FormattedMessage defaultMessage="{count}" />
+```
+
 ### `prefer-formatted-message`
 
 Use `<FormattedMessage>` instead of the imperative `intl.formatMessage(...)` if applicable.

--- a/packages/eslint-plugin-formatjs/tests/no-useless-message.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/no-useless-message.test.ts
@@ -9,7 +9,51 @@ import {
 } from './fixtures'
 
 ruleTester.run(name, rule, {
-  valid: [defineMessage, dynamicMessage, noMatch, spreadJsx, emptyFnCall],
+  valid: [
+    defineMessage,
+    dynamicMessage,
+    noMatch,
+    spreadJsx,
+    emptyFnCall,
+    {
+      code: `
+      import {FormattedMessage} from 'react-intl';
+      <FormattedMessage defaultMessage="{test}" description="Reason for simple message" />
+      `,
+      options: [{allowWithDescription: true}],
+    },
+    {
+      code: `
+      import {FormattedMessage} from 'react-intl';
+      <FormattedMessage defaultMessage="{test, number}" description="Needed for other locales" />
+      `,
+      options: [{allowWithDescription: true}],
+    },
+    {
+      code: `
+      import {FormattedMessage} from 'react-intl';
+      <FormattedMessage defaultMessage="{test, date}" description="Date formatting context" />
+      `,
+      options: [{allowWithDescription: true}],
+    },
+    {
+      code: `
+      import {FormattedMessage} from 'react-intl';
+      <FormattedMessage defaultMessage="{test, time}" description="Time display reason" />
+      `,
+      options: [{allowWithDescription: true}],
+    },
+    {
+      code: `
+      import {defineMessage} from 'react-intl';
+      defineMessage({
+        defaultMessage: '{count}',
+        description: 'Simple count for EN, but needs translation structure'
+      })
+      `,
+      options: [{allowWithDescription: true}],
+    },
+  ],
   invalid: [
     {
       code: `
@@ -42,6 +86,45 @@ ruleTester.run(name, rule, {
       <FormattedMessage defaultMessage="{test, time}" />
       `,
       errors: [{messageId: 'unnecessaryFormatTime'}],
+    },
+    {
+      code: `
+      import {FormattedMessage} from 'react-intl';
+      <FormattedMessage defaultMessage="{test}" />
+      `,
+      options: [{allowWithDescription: true}],
+      errors: [{messageId: 'unnecessaryFormat'}],
+    },
+    {
+      code: `
+      import {FormattedMessage} from 'react-intl';
+      <FormattedMessage defaultMessage="{test, number}" />
+      `,
+      options: [{allowWithDescription: true}],
+      errors: [{messageId: 'unnecessaryFormatNumber'}],
+    },
+    {
+      code: `
+      import {FormattedMessage} from 'react-intl';
+      <FormattedMessage defaultMessage="{test}" description="Has description" />
+      `,
+      options: [{allowWithDescription: false}],
+      errors: [{messageId: 'unnecessaryFormat'}],
+    },
+    {
+      code: `
+      import {FormattedMessage} from 'react-intl';
+      <FormattedMessage defaultMessage="{test}" description="Has description" />
+      `,
+      options: [],
+      errors: [{messageId: 'unnecessaryFormat'}],
+    },
+    {
+      code: `
+      import {FormattedMessage} from 'react-intl';
+      <FormattedMessage defaultMessage="{test, number}" description="Has description" />
+      `,
+      errors: [{messageId: 'unnecessaryFormatNumber'}],
     },
   ],
 })


### PR DESCRIPTION
I opened this because it seemed pretty trivial to support and modify with backwards compatibility, and it seemed like other people could use.

Add a new allowWithDescription option to the no-useless-message lint rule that allows 'useless' messages when a description is provided. This provides an escape hatch for cases where the original language fits the replacement word exactly but the message ID still needs to exist so other locales can provide their own translations.

The default behavior is preserved when the option is not set or is false.