### PR TITLE
feat(rules_formatjs): add bazel rule for formatjs

### DIFF
--- a/.commitlintrc.mjs
+++ b/.commitlintrc.mjs
@@ -2,9 +2,10 @@ import fastGlobPkg from 'fast-glob'
 import {readJSONSync} from 'fs-extra/esm'
 const {sync: globSync} = fastGlobPkg
 
-const packages = globSync('./packages/*/package.json').map(
-  fn => readJSONSync(fn).name
-)
+const packages = [
+  ...globSync('./packages/*/package.json').map(fn => readJSONSync(fn).name),
+  'rules_formatjs',
+]
 
 export default {
   extends: ['@commitlint/config-angular'],

--- a/.github/workflows/test-rules-formatjs.yml
+++ b/.github/workflows/test-rules-formatjs.yml
@@ -1,0 +1,56 @@
+name: Test rules_formatjs
+
+on:
+  pull_request:
+    paths:
+      - 'rules_formatjs/**'
+      - '.github/workflows/test-rules-formatjs.yml'
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Setup Bazel
+        uses: bazel-contrib/setup-bazel@0.16.0
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}
+          repository-cache: true
+
+      - name: Build rules_formatjs
+        working-directory: rules_formatjs
+        run: |
+          if [ -n "${{ secrets.BUILDBUDDY_ORG_API_KEY }}" ]; then
+            echo "Running with BuildBuddy CI config"
+            bazel build --config=ci --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //...
+          else
+            echo "Running without BuildBuddy (no API key)"
+            bazel build //...
+          fi
+
+      - name: Test Simple Example
+        working-directory: rules_formatjs/examples/simple
+        run: |
+          if [ -n "${{ secrets.BUILDBUDDY_ORG_API_KEY }}" ]; then
+            echo "Running with BuildBuddy CI config"
+            bazel test --config=ci --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //...
+          else
+            echo "Running without BuildBuddy (no API key)"
+            bazel test //...
+          fi
+
+      - name: Test Aggregate Example
+        working-directory: rules_formatjs/examples/aggregate
+        run: |
+          if [ -n "${{ secrets.BUILDBUDDY_ORG_API_KEY }}" ]; then
+            echo "Running with BuildBuddy CI config"
+            bazel test --config=ci --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //...
+          else
+            echo "Running without BuildBuddy (no API key)"
+            bazel test //...
+          fi

--- a/REPO.bazel
+++ b/REPO.bazel
@@ -16,4 +16,5 @@ ignore_directories([
     "target",
     # All node_modules directories recursively using glob pattern
     "**/node_modules",
+    "rules_formatjs",
 ])

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -14,3 +14,48 @@ actions:
       disk: 16GB
     bazel_commands:
       - 'test //...'
+
+  - name: 'Build rules_formatjs'
+    container_image: 'ubuntu-20.04'
+    triggers:
+      push:
+        branches:
+          - 'main'
+      pull_request:
+        branches:
+          - '*'
+        paths:
+          - 'rules_formatjs/**'
+    bazel_workspace_dir: 'rules_formatjs'
+    bazel_commands:
+      - 'build //...'
+
+  - name: 'Test rules_formatjs simple example'
+    container_image: 'ubuntu-20.04'
+    triggers:
+      push:
+        branches:
+          - 'main'
+      pull_request:
+        branches:
+          - '*'
+        paths:
+          - 'rules_formatjs/**'
+    bazel_workspace_dir: 'rules_formatjs/examples/simple'
+    bazel_commands:
+      - 'test //...'
+
+  - name: 'Test rules_formatjs aggregate example'
+    container_image: 'ubuntu-20.04'
+    triggers:
+      push:
+        branches:
+          - 'main'
+      pull_request:
+        branches:
+          - '*'
+        paths:
+          - 'rules_formatjs/**'
+    bazel_workspace_dir: 'rules_formatjs/examples/aggregate'
+    bazel_commands:
+      - 'test //...'

--- a/rules_formatjs/.bazelrc
+++ b/rules_formatjs/.bazelrc
@@ -1,0 +1,36 @@
+# Common Bazel configuration for rules_formatjs
+
+# Use Bzlmod for dependency management
+common --enable_bzlmod
+common --color=yes
+
+# Output and debugging
+build --show_timestamps
+build --verbose_failures
+
+# Performance
+build --jobs=auto
+build --worker_sandboxing
+build --remote_cache_compression
+build --legacy_important_outputs
+build --remote_build_event_upload=minimal
+build --noslim_profile
+build --experimental_profile_include_target_label
+build --experimental_profile_include_primary_output
+common --bes_upload_mode=fully_async
+
+# BuildBuddy CI configuration
+# https://www.buildbuddy.io/docs/rbe-github-actions
+build:ci --build_metadata=ROLE=CI
+build:ci --build_metadata=VISIBILITY=PUBLIC
+build:ci --config=remote
+
+build:remote --bes_backend=grpcs://formatjs.buildbuddy.io
+build:remote --bes_results_url=https://formatjs.buildbuddy.io/invocation/
+build:remote --define=EXECUTOR=remote
+build:remote --jobs=50
+build:remote --remote_cache=grpcs://formatjs.buildbuddy.io
+build:remote --remote_timeout=10m
+
+# Try to import a user-specific .bazelrc
+try-import %workspace%/.bazelrc.user

--- a/rules_formatjs/.gitignore
+++ b/rules_formatjs/.gitignore
@@ -1,0 +1,18 @@
+# Bazel
+bazel-*
+
+# Node
+node_modules/
+package-lock.json
+yarn.lock
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db

--- a/rules_formatjs/BUILD.bazel
+++ b/rules_formatjs/BUILD.bazel
@@ -1,0 +1,6 @@
+"""Root BUILD file for rules_formatjs"""
+
+exports_files([
+    "formatjs.bzl",
+    "MODULE.bazel",
+])

--- a/rules_formatjs/CONTRIBUTING.md
+++ b/rules_formatjs/CONTRIBUTING.md
@@ -1,0 +1,86 @@
+# Contributing to rules_formatjs
+
+## Development
+
+### Prerequisites
+
+- [Bazel](https://bazel.build/) 7.0+
+- [pnpm](https://pnpm.io/) 8.x
+
+### Building
+
+Build all targets:
+
+```bash
+cd rules_formatjs
+bazel build //...
+```
+
+### Testing
+
+Run all tests:
+
+```bash
+bazel test //...
+```
+
+### Running Examples
+
+Test the simple example:
+
+```bash
+cd examples/simple
+bazel build //...
+```
+
+## Project Structure
+
+```
+rules_formatjs/
+├── MODULE.bazel              # Bazel module definition
+├── BUILD.bazel               # Root build file
+├── formatjs.bzl              # Public API entry point
+├── metadata.json             # BCR metadata
+├── README.md                 # User documentation
+├── formatjs/                 # Rule implementations
+│   ├── BUILD.bazel
+│   ├── defs.bzl             # Main API
+│   ├── extract.bzl          # Message extraction rule
+│   └── compile.bzl          # Message compilation rule
+└── examples/                 # Example projects
+    └── simple/              # Simple extraction/compilation example
+        ├── MODULE.bazel
+        ├── BUILD.bazel
+        ├── package.json
+        └── src/
+            └── App.tsx
+```
+
+## Adding New Rules
+
+1. Create a new `.bzl` file in `formatjs/`
+2. Implement your rule following Bazel conventions
+3. Export it from `formatjs/defs.bzl`
+4. Add documentation to README.md
+5. Create an example in `examples/`
+
+## Testing Changes
+
+Before submitting changes:
+
+1. Ensure all builds pass: `bazel build //...`
+2. Run all tests: `bazel test //...`
+3. Test the examples: `cd examples/simple && bazel build //...`
+4. Update documentation if needed
+
+## Submitting to BCR
+
+To submit `rules_formatjs` to the Bazel Central Registry:
+
+1. Update version in `MODULE.bazel`
+2. Create a release tag
+3. Follow [BCR submission process](https://github.com/bazelbuild/bazel-central-registry/blob/main/docs/README.md)
+
+## License
+
+BSD 3-Clause License - Same as FormatJS

--- a/rules_formatjs/MODULE.bazel
+++ b/rules_formatjs/MODULE.bazel
@@ -1,0 +1,14 @@
+"""rules_formatjs - Bazel rules for FormatJS internationalization"""
+
+module(
+    name = "rules_formatjs",
+    version = "0.0.0",
+    compatibility_level = 1,
+)
+
+# jq for JSON manipulation in aggregation aspect
+bazel_dep(name = "jq.bzl", version = "0.4.0")
+
+# Required dependencies (consumers must provide @npm repository with @formatjs/cli)
+bazel_dep(name = "aspect_rules_js", version = "2.8.3")
+bazel_dep(name = "rules_nodejs", version = "6.3.0")

--- a/rules_formatjs/MODULE.bazel.lock
+++ b/rules_formatjs/MODULE.bazel.lock
@@ -1,0 +1,578 @@
+{
+  "lockFileVersion": 24,
+  "registryFileHashes": {
+    "https://bcr.bazel.build/bazel_registry.json": "8a28e4aff06ee60aed2a8c281907fb8bcbf3b753c91fb5a5c57da3215d5b3497",
+    "https://bcr.bazel.build/modules/abseil-cpp/20210324.2/MODULE.bazel": "7cd0312e064fde87c8d1cd79ba06c876bd23630c83466e9500321be55c96ace2",
+    "https://bcr.bazel.build/modules/abseil-cpp/20211102.0/MODULE.bazel": "70390338f7a5106231d20620712f7cccb659cd0e9d073d1991c038eb9fc57589",
+    "https://bcr.bazel.build/modules/abseil-cpp/20230125.1/MODULE.bazel": "89047429cb0207707b2dface14ba7f8df85273d484c2572755be4bab7ce9c3a0",
+    "https://bcr.bazel.build/modules/abseil-cpp/20230802.0.bcr.1/MODULE.bazel": "1c8cec495288dccd14fdae6e3f95f772c1c91857047a098fad772034264cc8cb",
+    "https://bcr.bazel.build/modules/abseil-cpp/20230802.0/MODULE.bazel": "d253ae36a8bd9ee3c5955384096ccb6baf16a1b1e93e858370da0a3b94f77c16",
+    "https://bcr.bazel.build/modules/abseil-cpp/20230802.1/MODULE.bazel": "fa92e2eb41a04df73cdabeec37107316f7e5272650f81d6cc096418fe647b915",
+    "https://bcr.bazel.build/modules/abseil-cpp/20240116.1/MODULE.bazel": "37bcdb4440fbb61df6a1c296ae01b327f19e9bb521f9b8e26ec854b6f97309ed",
+    "https://bcr.bazel.build/modules/abseil-cpp/20240116.1/source.json": "9be551b8d4e3ef76875c0d744b5d6a504a27e3ae67bc6b28f46415fd2d2957da",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.14.0/MODULE.bazel": "2b31ffcc9bdc8295b2167e07a757dbbc9ac8906e7028e5170a3708cecaac119f",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.17.1/MODULE.bazel": "9b027af55f619c7c444cead71061578fab6587e5e1303fa4ed61d49d2b1a7262",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.17.1/source.json": "18435c8f4914c046d6483fae4300d4b2eda06aed6b3cb99e682509dc2bc7e9a1",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.8.1/MODULE.bazel": "812d2dd42f65dca362152101fbec418029cc8fd34cbad1a2fde905383d705838",
+    "https://bcr.bazel.build/modules/aspect_rules_js/2.8.3/MODULE.bazel": "807ce5f624124a8bc586c743394d174e85f0f9c6c4e0e2410b4088aebe790ac8",
+    "https://bcr.bazel.build/modules/aspect_rules_js/2.8.3/source.json": "c35cb4e04f61a09c17f8c569894b80de884b1e3dee2d33829704786e3f778037",
+    "https://bcr.bazel.build/modules/aspect_tools_telemetry/0.3.3/MODULE.bazel": "37c764292861c2f70314efa9846bb6dbb44fc0308903b3285da6528305450183",
+    "https://bcr.bazel.build/modules/aspect_tools_telemetry/0.3.3/source.json": "605086bbc197743a0d360f7ddc550a1d4dfa0441bc807236e17170f636153348",
+    "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
+    "https://bcr.bazel.build/modules/bazel_features/1.11.0/MODULE.bazel": "f9382337dd5a474c3b7d334c2f83e50b6eaedc284253334cf823044a26de03e8",
+    "https://bcr.bazel.build/modules/bazel_features/1.15.0/MODULE.bazel": "d38ff6e517149dc509406aca0db3ad1efdd890a85e049585b7234d04238e2a4d",
+    "https://bcr.bazel.build/modules/bazel_features/1.17.0/MODULE.bazel": "039de32d21b816b47bd42c778e0454217e9c9caac4a3cf8e15c7231ee3ddee4d",
+    "https://bcr.bazel.build/modules/bazel_features/1.18.0/MODULE.bazel": "1be0ae2557ab3a72a57aeb31b29be347bcdc5d2b1eb1e70f39e3851a7e97041a",
+    "https://bcr.bazel.build/modules/bazel_features/1.19.0/MODULE.bazel": "59adcdf28230d220f0067b1f435b8537dd033bfff8db21335ef9217919c7fb58",
+    "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
+    "https://bcr.bazel.build/modules/bazel_features/1.30.0/source.json": "b07e17f067fe4f69f90b03b36ef1e08fe0d1f3cac254c1241a1818773e3423bc",
+    "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
+    "https://bcr.bazel.build/modules/bazel_features/1.9.0/MODULE.bazel": "885151d58d90d8d9c811eb75e3288c11f850e1d6b481a8c9f766adee4712358b",
+    "https://bcr.bazel.build/modules/bazel_features/1.9.1/MODULE.bazel": "8f679097876a9b609ad1f60249c49d68bfab783dd9be012faf9d82547b14815a",
+    "https://bcr.bazel.build/modules/bazel_lib/3.0.0-rc.0/MODULE.bazel": "d6e00979a98ac14ada5e31c8794708b41434d461e7e7ca39b59b765e6d233b18",
+    "https://bcr.bazel.build/modules/bazel_lib/3.0.0/MODULE.bazel": "22b70b80ac89ad3f3772526cd9feee2fa412c2b01933fea7ed13238a448d370d",
+    "https://bcr.bazel.build/modules/bazel_lib/3.0.0/source.json": "895f21909c6fba01d7c17914bb6c8e135982275a1b18cdaa4e62272217ef1751",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.0.3/MODULE.bazel": "bcb0fd896384802d1ad283b4e4eb4d718eebd8cb820b0a2c3a347fb971afd9d8",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.1.1/MODULE.bazel": "1add3e7d93ff2e6998f9e118022c84d163917d912f5afafb3058e3d2f1545b5e",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.2.0/MODULE.bazel": "44fe84260e454ed94ad326352a698422dbe372b21a1ac9f3eab76eb531223686",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.2.1/MODULE.bazel": "f35baf9da0efe45fa3da1696ae906eea3d615ad41e2e3def4aeb4e8bc0ef9a7a",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.3.0/MODULE.bazel": "20228b92868bf5cfc41bda7afc8a8ba2a543201851de39d990ec957b513579c5",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.4.1/MODULE.bazel": "a0dcb779424be33100dcae821e9e27e4f2901d9dfd5333efe5ac6a8d7ab75e1d",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.4.2/MODULE.bazel": "3bd40978e7a1fac911d5989e6b09d8f64921865a45822d8b09e815eaa726a651",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.5.0/MODULE.bazel": "32880f5e2945ce6a03d1fbd588e9198c0a959bb42297b2cfaf1685b7bc32e138",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.6.1/MODULE.bazel": "8fdee2dbaace6c252131c00e1de4b165dc65af02ea278476187765e1a617b917",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.7.0/MODULE.bazel": "0db596f4563de7938de764cc8deeabec291f55e8ec15299718b93c4423e9796d",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.7.1/MODULE.bazel": "3120d80c5861aa616222ec015332e5f8d3171e062e3e804a2a0253e1be26e59b",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.8.1/MODULE.bazel": "88ade7293becda963e0e3ea33e7d54d3425127e0a326e0d17da085a5f1f03ff6",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.8.1/source.json": "7ebaefba0b03efe59cac88ed5bbc67bcf59a3eff33af937345ede2a38b2d368a",
+    "https://bcr.bazel.build/modules/buildozer/7.1.2/MODULE.bazel": "2e8dd40ede9c454042645fd8d8d0cd1527966aa5c919de86661e62953cd73d84",
+    "https://bcr.bazel.build/modules/buildozer/7.1.2/source.json": "c9028a501d2db85793a6996205c8de120944f50a0d570438fcae0457a5f9d1f8",
+    "https://bcr.bazel.build/modules/google_benchmark/1.8.2/MODULE.bazel": "a70cf1bba851000ba93b58ae2f6d76490a9feb74192e57ab8e8ff13c34ec50cb",
+    "https://bcr.bazel.build/modules/googletest/1.11.0/MODULE.bazel": "3a83f095183f66345ca86aa13c58b59f9f94a2f81999c093d4eeaa2d262d12f4",
+    "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/MODULE.bazel": "22c31a561553727960057361aa33bf20fb2e98584bc4fec007906e27053f80c6",
+    "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/source.json": "41e9e129f80d8c8bf103a7acc337b76e54fad1214ac0a7084bf24f4cd924b8b4",
+    "https://bcr.bazel.build/modules/googletest/1.14.0/MODULE.bazel": "cfbcbf3e6eac06ef9d85900f64424708cc08687d1b527f0ef65aa7517af8118f",
+    "https://bcr.bazel.build/modules/jq.bzl/0.1.0/MODULE.bazel": "2ce69b1af49952cd4121a9c3055faa679e748ce774c7f1fda9657f936cae902f",
+    "https://bcr.bazel.build/modules/jq.bzl/0.4.0/MODULE.bazel": "a7b39b37589f2b0dad53fd6c1ccaabbdb290330caa920d7ef3e6aad068cd4ab2",
+    "https://bcr.bazel.build/modules/jq.bzl/0.4.0/source.json": "52ec7530c4618e03f634b30ff719814a68d7d39c235938b7aa2abbfe1eb1c52c",
+    "https://bcr.bazel.build/modules/jsoncpp/1.9.5/MODULE.bazel": "31271aedc59e815656f5736f282bb7509a97c7ecb43e927ac1a37966e0578075",
+    "https://bcr.bazel.build/modules/jsoncpp/1.9.5/source.json": "4108ee5085dd2885a341c7fab149429db457b3169b86eb081fa245eadf69169d",
+    "https://bcr.bazel.build/modules/libpfm/4.11.0/MODULE.bazel": "45061ff025b301940f1e30d2c16bea596c25b176c8b6b3087e92615adbd52902",
+    "https://bcr.bazel.build/modules/package_metadata/0.0.2/MODULE.bazel": "fb8d25550742674d63d7b250063d4580ca530499f045d70748b1b142081ebb92",
+    "https://bcr.bazel.build/modules/package_metadata/0.0.2/source.json": "e53a759a72488d2c0576f57491ef2da0cf4aab05ac0997314012495935531b73",
+    "https://bcr.bazel.build/modules/platforms/0.0.10/MODULE.bazel": "8cb8efaf200bdeb2150d93e162c40f388529a25852b332cec879373771e48ed5",
+    "https://bcr.bazel.build/modules/platforms/0.0.11/MODULE.bazel": "0daefc49732e227caa8bfa834d65dc52e8cc18a2faf80df25e8caea151a9413f",
+    "https://bcr.bazel.build/modules/platforms/0.0.11/source.json": "f7e188b79ebedebfe75e9e1d098b8845226c7992b307e28e1496f23112e8fc29",
+    "https://bcr.bazel.build/modules/platforms/0.0.4/MODULE.bazel": "9b328e31ee156f53f3c416a64f8491f7eb731742655a47c9eec4703a71644aee",
+    "https://bcr.bazel.build/modules/platforms/0.0.5/MODULE.bazel": "5733b54ea419d5eaf7997054bb55f6a1d0b5ff8aedf0176fef9eea44f3acda37",
+    "https://bcr.bazel.build/modules/platforms/0.0.6/MODULE.bazel": "ad6eeef431dc52aefd2d77ed20a4b353f8ebf0f4ecdd26a807d2da5aa8cd0615",
+    "https://bcr.bazel.build/modules/platforms/0.0.7/MODULE.bazel": "72fd4a0ede9ee5c021f6a8dd92b503e089f46c227ba2813ff183b71616034814",
+    "https://bcr.bazel.build/modules/platforms/0.0.8/MODULE.bazel": "9f142c03e348f6d263719f5074b21ef3adf0b139ee4c5133e2aa35664da9eb2d",
+    "https://bcr.bazel.build/modules/protobuf/21.7/MODULE.bazel": "a5a29bb89544f9b97edce05642fac225a808b5b7be74038ea3640fae2f8e66a7",
+    "https://bcr.bazel.build/modules/protobuf/27.0/MODULE.bazel": "7873b60be88844a0a1d8f80b9d5d20cfbd8495a689b8763e76c6372998d3f64c",
+    "https://bcr.bazel.build/modules/protobuf/27.1/MODULE.bazel": "703a7b614728bb06647f965264967a8ef1c39e09e8f167b3ca0bb1fd80449c0d",
+    "https://bcr.bazel.build/modules/protobuf/29.0-rc2/MODULE.bazel": "6241d35983510143049943fc0d57937937122baf1b287862f9dc8590fc4c37df",
+    "https://bcr.bazel.build/modules/protobuf/29.0/MODULE.bazel": "319dc8bf4c679ff87e71b1ccfb5a6e90a6dbc4693501d471f48662ac46d04e4e",
+    "https://bcr.bazel.build/modules/protobuf/29.0/source.json": "b857f93c796750eef95f0d61ee378f3420d00ee1dd38627b27193aa482f4f981",
+    "https://bcr.bazel.build/modules/protobuf/3.19.0/MODULE.bazel": "6b5fbb433f760a99a22b18b6850ed5784ef0e9928a72668b66e4d7ccd47db9b0",
+    "https://bcr.bazel.build/modules/pybind11_bazel/2.11.1/MODULE.bazel": "88af1c246226d87e65be78ed49ecd1e6f5e98648558c14ce99176da041dc378e",
+    "https://bcr.bazel.build/modules/pybind11_bazel/2.11.1/source.json": "be4789e951dd5301282729fe3d4938995dc4c1a81c2ff150afc9f1b0504c6022",
+    "https://bcr.bazel.build/modules/re2/2023-09-01/MODULE.bazel": "cb3d511531b16cfc78a225a9e2136007a48cf8a677e4264baeab57fe78a80206",
+    "https://bcr.bazel.build/modules/re2/2023-09-01/source.json": "e044ce89c2883cd957a2969a43e79f7752f9656f6b20050b62f90ede21ec6eb4",
+    "https://bcr.bazel.build/modules/rules_android/0.1.1/MODULE.bazel": "48809ab0091b07ad0182defb787c4c5328bd3a278938415c00a7b69b50c4d3a8",
+    "https://bcr.bazel.build/modules/rules_android/0.1.1/source.json": "e6986b41626ee10bdc864937ffb6d6bf275bb5b9c65120e6137d56e6331f089e",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.1/MODULE.bazel": "cb2aa0747f84c6c3a78dad4e2049c154f08ab9d166b1273835a8174940365647",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.10/MODULE.bazel": "ec1705118f7eaedd6e118508d3d26deba2a4e76476ada7e0e3965211be012002",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.13/MODULE.bazel": "0e8529ed7b323dad0775ff924d2ae5af7640b23553dfcd4d34344c7e7a867191",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.14/MODULE.bazel": "5e343a3aac88b8d7af3b1b6d2093b55c347b8eefc2e7d1442f7a02dc8fea48ac",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.15/MODULE.bazel": "6704c35f7b4a72502ee81f61bf88706b54f06b3cbe5558ac17e2e14666cd5dcc",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.16/MODULE.bazel": "7661303b8fc1b4d7f532e54e9d6565771fea666fbdf839e0a86affcd02defe87",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.2/MODULE.bazel": "6915987c90970493ab97393024c156ea8fb9f3bea953b2f3ec05c34f19b5695c",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.6/MODULE.bazel": "abf360251023dfe3efcef65ab9d56beefa8394d4176dd29529750e1c57eaa33f",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.8/MODULE.bazel": "964c85c82cfeb6f3855e6a07054fdb159aced38e99a5eecf7bce9d53990afa3e",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.9/MODULE.bazel": "836e76439f354b89afe6a911a7adf59a6b2518fafb174483ad78a2a2fde7b1c5",
+    "https://bcr.bazel.build/modules/rules_cc/0.1.1/MODULE.bazel": "2f0222a6f229f0bf44cd711dc13c858dad98c62d52bd51d8fc3a764a83125513",
+    "https://bcr.bazel.build/modules/rules_cc/0.1.1/source.json": "d61627377bd7dd1da4652063e368d9366fc9a73920bfa396798ad92172cf645c",
+    "https://bcr.bazel.build/modules/rules_foreign_cc/0.9.0/MODULE.bazel": "c9e8c682bf75b0e7c704166d79b599f93b72cfca5ad7477df596947891feeef6",
+    "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/MODULE.bazel": "40c97d1144356f52905566c55811f13b299453a14ac7769dfba2ac38192337a8",
+    "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/source.json": "c8b1e2c717646f1702290959a3302a178fb639d987ab61d548105019f11e527e",
+    "https://bcr.bazel.build/modules/rules_java/4.0.0/MODULE.bazel": "5a78a7ae82cd1a33cef56dc578c7d2a46ed0dca12643ee45edbb8417899e6f74",
+    "https://bcr.bazel.build/modules/rules_java/5.3.5/MODULE.bazel": "a4ec4f2db570171e3e5eb753276ee4b389bae16b96207e9d3230895c99644b86",
+    "https://bcr.bazel.build/modules/rules_java/6.0.0/MODULE.bazel": "8a43b7df601a7ec1af61d79345c17b31ea1fedc6711fd4abfd013ea612978e39",
+    "https://bcr.bazel.build/modules/rules_java/6.3.0/MODULE.bazel": "a97c7678c19f236a956ad260d59c86e10a463badb7eb2eda787490f4c969b963",
+    "https://bcr.bazel.build/modules/rules_java/6.4.0/MODULE.bazel": "e986a9fe25aeaa84ac17ca093ef13a4637f6107375f64667a15999f77db6c8f6",
+    "https://bcr.bazel.build/modules/rules_java/6.5.2/MODULE.bazel": "1d440d262d0e08453fa0c4d8f699ba81609ed0e9a9a0f02cd10b3e7942e61e31",
+    "https://bcr.bazel.build/modules/rules_java/7.10.0/MODULE.bazel": "530c3beb3067e870561739f1144329a21c851ff771cd752a49e06e3dc9c2e71a",
+    "https://bcr.bazel.build/modules/rules_java/7.12.2/MODULE.bazel": "579c505165ee757a4280ef83cda0150eea193eed3bef50b1004ba88b99da6de6",
+    "https://bcr.bazel.build/modules/rules_java/7.2.0/MODULE.bazel": "06c0334c9be61e6cef2c8c84a7800cef502063269a5af25ceb100b192453d4ab",
+    "https://bcr.bazel.build/modules/rules_java/7.3.2/MODULE.bazel": "50dece891cfdf1741ea230d001aa9c14398062f2b7c066470accace78e412bc2",
+    "https://bcr.bazel.build/modules/rules_java/7.6.1/MODULE.bazel": "2f14b7e8a1aa2f67ae92bc69d1ec0fa8d9f827c4e17ff5e5f02e91caa3b2d0fe",
+    "https://bcr.bazel.build/modules/rules_java/8.14.0/MODULE.bazel": "717717ed40cc69994596a45aec6ea78135ea434b8402fb91b009b9151dd65615",
+    "https://bcr.bazel.build/modules/rules_java/8.14.0/source.json": "8a88c4ca9e8759da53cddc88123880565c520503321e2566b4e33d0287a3d4bc",
+    "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
+    "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
+    "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
+    "https://bcr.bazel.build/modules/rules_jvm_external/5.3/MODULE.bazel": "bf93870767689637164657731849fb887ad086739bd5d360d90007a581d5527d",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.1/MODULE.bazel": "75b5fec090dbd46cf9b7d8ea08cf84a0472d92ba3585b476f44c326eda8059c4",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.3/MODULE.bazel": "c998e060b85f71e00de5ec552019347c8bca255062c990ac02d051bb80a38df0",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.3/source.json": "6f5f5a5a4419ae4e37c35a5bb0a6ae657ed40b7abc5a5189111b47fcebe43197",
+    "https://bcr.bazel.build/modules/rules_kotlin/1.9.0/MODULE.bazel": "ef85697305025e5a61f395d4eaede272a5393cee479ace6686dba707de804d59",
+    "https://bcr.bazel.build/modules/rules_kotlin/1.9.6/MODULE.bazel": "d269a01a18ee74d0335450b10f62c9ed81f2321d7958a2934e44272fe82dcef3",
+    "https://bcr.bazel.build/modules/rules_kotlin/1.9.6/source.json": "2faa4794364282db7c06600b7e5e34867a564ae91bda7cae7c29c64e9466b7d5",
+    "https://bcr.bazel.build/modules/rules_license/0.0.3/MODULE.bazel": "627e9ab0247f7d1e05736b59dbb1b6871373de5ad31c3011880b4133cafd4bd0",
+    "https://bcr.bazel.build/modules/rules_license/0.0.7/MODULE.bazel": "088fbeb0b6a419005b89cf93fe62d9517c0a2b8bb56af3244af65ecfe37e7d5d",
+    "https://bcr.bazel.build/modules/rules_license/1.0.0/MODULE.bazel": "a7fda60eefdf3d8c827262ba499957e4df06f659330bbe6cdbdb975b768bb65c",
+    "https://bcr.bazel.build/modules/rules_license/1.0.0/source.json": "a52c89e54cc311196e478f8382df91c15f7a2bfdf4c6cd0e2675cc2ff0b56efb",
+    "https://bcr.bazel.build/modules/rules_nodejs/6.3.0/MODULE.bazel": "45345e4aba35dd6e4701c1eebf5a4e67af4ed708def9ebcdc6027585b34ee52d",
+    "https://bcr.bazel.build/modules/rules_nodejs/6.3.0/source.json": "1254ffd8d0d908a19c67add7fb5e2a1f604df133bc5d206425264293e2e537fc",
+    "https://bcr.bazel.build/modules/rules_pkg/0.7.0/MODULE.bazel": "df99f03fc7934a4737122518bb87e667e62d780b610910f0447665a7e2be62dc",
+    "https://bcr.bazel.build/modules/rules_pkg/1.0.1/MODULE.bazel": "5b1df97dbc29623bccdf2b0dcd0f5cb08e2f2c9050aab1092fd39a41e82686ff",
+    "https://bcr.bazel.build/modules/rules_pkg/1.0.1/source.json": "bd82e5d7b9ce2d31e380dd9f50c111d678c3bdaca190cb76b0e1c71b05e1ba8a",
+    "https://bcr.bazel.build/modules/rules_proto/4.0.0/MODULE.bazel": "a7a7b6ce9bee418c1a760b3d84f83a299ad6952f9903c67f19e4edd964894e06",
+    "https://bcr.bazel.build/modules/rules_proto/5.3.0-21.7/MODULE.bazel": "e8dff86b0971688790ae75528fe1813f71809b5afd57facb44dad9e8eca631b7",
+    "https://bcr.bazel.build/modules/rules_proto/6.0.2/MODULE.bazel": "ce916b775a62b90b61888052a416ccdda405212b6aaeb39522f7dc53431a5e73",
+    "https://bcr.bazel.build/modules/rules_proto/7.0.2/MODULE.bazel": "bf81793bd6d2ad89a37a40693e56c61b0ee30f7a7fdbaf3eabbf5f39de47dea2",
+    "https://bcr.bazel.build/modules/rules_proto/7.0.2/source.json": "1e5e7260ae32ef4f2b52fd1d0de8d03b606a44c91b694d2f1afb1d3b28a48ce1",
+    "https://bcr.bazel.build/modules/rules_python/0.10.2/MODULE.bazel": "cc82bc96f2997baa545ab3ce73f196d040ffb8756fd2d66125a530031cd90e5f",
+    "https://bcr.bazel.build/modules/rules_python/0.23.1/MODULE.bazel": "49ffccf0511cb8414de28321f5fcf2a31312b47c40cc21577144b7447f2bf300",
+    "https://bcr.bazel.build/modules/rules_python/0.25.0/MODULE.bazel": "72f1506841c920a1afec76975b35312410eea3aa7b63267436bfb1dd91d2d382",
+    "https://bcr.bazel.build/modules/rules_python/0.28.0/MODULE.bazel": "cba2573d870babc976664a912539b320cbaa7114cd3e8f053c720171cde331ed",
+    "https://bcr.bazel.build/modules/rules_python/0.31.0/MODULE.bazel": "93a43dc47ee570e6ec9f5779b2e64c1476a6ce921c48cc9a1678a91dd5f8fd58",
+    "https://bcr.bazel.build/modules/rules_python/0.4.0/MODULE.bazel": "9208ee05fd48bf09ac60ed269791cf17fb343db56c8226a720fbb1cdf467166c",
+    "https://bcr.bazel.build/modules/rules_python/0.40.0/MODULE.bazel": "9d1a3cd88ed7d8e39583d9ffe56ae8a244f67783ae89b60caafc9f5cf318ada7",
+    "https://bcr.bazel.build/modules/rules_python/0.40.0/source.json": "939d4bd2e3110f27bfb360292986bb79fd8dcefb874358ccd6cdaa7bda029320",
+    "https://bcr.bazel.build/modules/rules_shell/0.2.0/MODULE.bazel": "fda8a652ab3c7d8fee214de05e7a9916d8b28082234e8d2c0094505c5268ed3c",
+    "https://bcr.bazel.build/modules/rules_shell/0.4.1/MODULE.bazel": "00e501db01bbf4e3e1dd1595959092c2fadf2087b2852d3f553b5370f5633592",
+    "https://bcr.bazel.build/modules/rules_shell/0.4.1/source.json": "4757bd277fe1567763991c4425b483477bb82e35e777a56fd846eb5cceda324a",
+    "https://bcr.bazel.build/modules/stardoc/0.5.1/MODULE.bazel": "1a05d92974d0c122f5ccf09291442580317cdd859f07a8655f1db9a60374f9f8",
+    "https://bcr.bazel.build/modules/stardoc/0.5.3/MODULE.bazel": "c7f6948dae6999bf0db32c1858ae345f112cacf98f174c7a8bb707e41b974f1c",
+    "https://bcr.bazel.build/modules/stardoc/0.5.6/MODULE.bazel": "c43dabc564990eeab55e25ed61c07a1aadafe9ece96a4efabb3f8bf9063b71ef",
+    "https://bcr.bazel.build/modules/stardoc/0.6.2/MODULE.bazel": "7060193196395f5dd668eda046ccbeacebfd98efc77fed418dbe2b82ffaa39fd",
+    "https://bcr.bazel.build/modules/stardoc/0.7.0/MODULE.bazel": "05e3d6d30c099b6770e97da986c53bd31844d7f13d41412480ea265ac9e8079c",
+    "https://bcr.bazel.build/modules/stardoc/0.7.1/MODULE.bazel": "3548faea4ee5dda5580f9af150e79d0f6aea934fc60c1cc50f4efdd9420759e7",
+    "https://bcr.bazel.build/modules/stardoc/0.7.1/source.json": "b6500ffcd7b48cd72c29bb67bcac781e12701cc0d6d55d266a652583cfcdab01",
+    "https://bcr.bazel.build/modules/tar.bzl/0.2.1/MODULE.bazel": "52d1c00a80a8cc67acbd01649e83d8dd6a9dc426a6c0b754a04fe8c219c76468",
+    "https://bcr.bazel.build/modules/tar.bzl/0.2.1/source.json": "600ac6ff61744667a439e7b814ae59c1f29632c3984fccf8000c64c9db8d7bb6",
+    "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
+    "https://bcr.bazel.build/modules/yq.bzl/0.1.1/MODULE.bazel": "9039681f9bcb8958ee2c87ffc74bdafba9f4369096a2b5634b88abc0eaefa072",
+    "https://bcr.bazel.build/modules/yq.bzl/0.3.2/MODULE.bazel": "0384efa70e8033d842ea73aa4b7199fa099709e236a7264345c03937166670b6",
+    "https://bcr.bazel.build/modules/yq.bzl/0.3.2/source.json": "c4ec3e192477e154f08769e29d69e8fd36e8a4f0f623997f3e1f6f7d328f7d7d",
+    "https://bcr.bazel.build/modules/zlib/1.2.11/MODULE.bazel": "07b389abc85fdbca459b69e2ec656ae5622873af3f845e1c9d80fe179f3effa0",
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/MODULE.bazel": "eec517b5bbe5492629466e11dae908d043364302283de25581e3eb944326c4ca",
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/source.json": "22bc55c47af97246cfc093d0acf683a7869377de362b5d1c552c2c2e16b7a806",
+    "https://bcr.bazel.build/modules/zlib/1.3.1/MODULE.bazel": "751c9940dcfe869f5f7274e1295422a34623555916eb98c174c1e945594bf198"
+  },
+  "selectedYankedVersions": {},
+  "moduleExtensions": {
+    "@@aspect_bazel_lib+//lib:extensions.bzl%toolchains": {
+      "general": {
+        "bzlTransitiveDigest": "VrB12udcP5ajwTmhewr93XVbVtgL6paojIz4B7LEnF4=",
+        "usagesDigest": "5Pmz0TsMJdXAkjVYkzPIXZa6qy2pSwZ9vRUijc6CMTc=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "copy_directory_darwin_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_directory_toolchain.bzl%copy_directory_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64"
+            }
+          },
+          "copy_directory_darwin_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_directory_toolchain.bzl%copy_directory_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64"
+            }
+          },
+          "copy_directory_freebsd_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_directory_toolchain.bzl%copy_directory_platform_repo",
+            "attributes": {
+              "platform": "freebsd_amd64"
+            }
+          },
+          "copy_directory_linux_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_directory_toolchain.bzl%copy_directory_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64"
+            }
+          },
+          "copy_directory_linux_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_directory_toolchain.bzl%copy_directory_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64"
+            }
+          },
+          "copy_directory_windows_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_directory_toolchain.bzl%copy_directory_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64"
+            }
+          },
+          "copy_directory_toolchains": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_directory_toolchain.bzl%copy_directory_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "copy_directory"
+            }
+          },
+          "copy_to_directory_darwin_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_to_directory_toolchain.bzl%copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64"
+            }
+          },
+          "copy_to_directory_darwin_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_to_directory_toolchain.bzl%copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64"
+            }
+          },
+          "copy_to_directory_freebsd_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_to_directory_toolchain.bzl%copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "freebsd_amd64"
+            }
+          },
+          "copy_to_directory_linux_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_to_directory_toolchain.bzl%copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64"
+            }
+          },
+          "copy_to_directory_linux_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_to_directory_toolchain.bzl%copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64"
+            }
+          },
+          "copy_to_directory_windows_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_to_directory_toolchain.bzl%copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64"
+            }
+          },
+          "copy_to_directory_toolchains": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_to_directory_toolchain.bzl%copy_to_directory_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "copy_to_directory"
+            }
+          },
+          "jq_darwin_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:jq_toolchain.bzl%jq_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64",
+              "version": "1.7"
+            }
+          },
+          "jq_darwin_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:jq_toolchain.bzl%jq_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64",
+              "version": "1.7"
+            }
+          },
+          "jq_linux_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:jq_toolchain.bzl%jq_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64",
+              "version": "1.7"
+            }
+          },
+          "jq_linux_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:jq_toolchain.bzl%jq_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64",
+              "version": "1.7"
+            }
+          },
+          "jq_windows_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:jq_toolchain.bzl%jq_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64",
+              "version": "1.7"
+            }
+          },
+          "jq": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:jq_toolchain.bzl%jq_host_alias_repo",
+            "attributes": {}
+          },
+          "jq_toolchains": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:jq_toolchain.bzl%jq_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "jq"
+            }
+          },
+          "yq_darwin_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:yq_toolchain.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64",
+              "version": "4.25.2"
+            }
+          },
+          "yq_darwin_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:yq_toolchain.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64",
+              "version": "4.25.2"
+            }
+          },
+          "yq_linux_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:yq_toolchain.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64",
+              "version": "4.25.2"
+            }
+          },
+          "yq_linux_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:yq_toolchain.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64",
+              "version": "4.25.2"
+            }
+          },
+          "yq_linux_s390x": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:yq_toolchain.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "linux_s390x",
+              "version": "4.25.2"
+            }
+          },
+          "yq_linux_ppc64le": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:yq_toolchain.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "linux_ppc64le",
+              "version": "4.25.2"
+            }
+          },
+          "yq_windows_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:yq_toolchain.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64",
+              "version": "4.25.2"
+            }
+          },
+          "yq": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:yq_toolchain.bzl%yq_host_alias_repo",
+            "attributes": {}
+          },
+          "yq_toolchains": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:yq_toolchain.bzl%yq_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "yq"
+            }
+          },
+          "coreutils_darwin_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:coreutils_toolchain.bzl%coreutils_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64",
+              "version": "0.0.26"
+            }
+          },
+          "coreutils_darwin_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:coreutils_toolchain.bzl%coreutils_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64",
+              "version": "0.0.26"
+            }
+          },
+          "coreutils_linux_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:coreutils_toolchain.bzl%coreutils_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64",
+              "version": "0.0.26"
+            }
+          },
+          "coreutils_linux_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:coreutils_toolchain.bzl%coreutils_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64",
+              "version": "0.0.26"
+            }
+          },
+          "coreutils_windows_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:coreutils_toolchain.bzl%coreutils_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64",
+              "version": "0.0.26"
+            }
+          },
+          "coreutils_toolchains": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:coreutils_toolchain.bzl%coreutils_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "coreutils"
+            }
+          },
+          "bsd_tar_darwin_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:tar_toolchain.bzl%bsdtar_binary_repo",
+            "attributes": {
+              "platform": "darwin_amd64"
+            }
+          },
+          "bsd_tar_darwin_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:tar_toolchain.bzl%bsdtar_binary_repo",
+            "attributes": {
+              "platform": "darwin_arm64"
+            }
+          },
+          "bsd_tar_linux_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:tar_toolchain.bzl%bsdtar_binary_repo",
+            "attributes": {
+              "platform": "linux_amd64"
+            }
+          },
+          "bsd_tar_linux_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:tar_toolchain.bzl%bsdtar_binary_repo",
+            "attributes": {
+              "platform": "linux_arm64"
+            }
+          },
+          "bsd_tar_windows_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:tar_toolchain.bzl%bsdtar_binary_repo",
+            "attributes": {
+              "platform": "windows_amd64"
+            }
+          },
+          "bsd_tar_toolchains": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:tar_toolchain.bzl%tar_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "bsd_tar"
+            }
+          },
+          "zstd_darwin_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:zstd_toolchain.bzl%zstd_binary_repo",
+            "attributes": {
+              "platform": "darwin_amd64"
+            }
+          },
+          "zstd_darwin_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:zstd_toolchain.bzl%zstd_binary_repo",
+            "attributes": {
+              "platform": "darwin_arm64"
+            }
+          },
+          "zstd_linux_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:zstd_toolchain.bzl%zstd_binary_repo",
+            "attributes": {
+              "platform": "linux_amd64"
+            }
+          },
+          "zstd_linux_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:zstd_toolchain.bzl%zstd_binary_repo",
+            "attributes": {
+              "platform": "linux_arm64"
+            }
+          },
+          "zstd_toolchains": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:zstd_toolchain.bzl%zstd_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "zstd"
+            }
+          },
+          "expand_template_darwin_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:expand_template_toolchain.bzl%expand_template_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64"
+            }
+          },
+          "expand_template_darwin_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:expand_template_toolchain.bzl%expand_template_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64"
+            }
+          },
+          "expand_template_freebsd_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:expand_template_toolchain.bzl%expand_template_platform_repo",
+            "attributes": {
+              "platform": "freebsd_amd64"
+            }
+          },
+          "expand_template_linux_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:expand_template_toolchain.bzl%expand_template_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64"
+            }
+          },
+          "expand_template_linux_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:expand_template_toolchain.bzl%expand_template_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64"
+            }
+          },
+          "expand_template_windows_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:expand_template_toolchain.bzl%expand_template_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64"
+            }
+          },
+          "expand_template_toolchains": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:expand_template_toolchain.bzl%expand_template_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "expand_template"
+            }
+          },
+          "bats_support": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7815237aafeb42ddcc1b8c698fc5808026d33317d8701d5ec2396e9634e2918f",
+              "urls": [
+                "https://github.com/bats-core/bats-support/archive/v0.3.0.tar.gz"
+              ],
+              "strip_prefix": "bats-support-0.3.0",
+              "build_file_content": "load(\"@aspect_bazel_lib//lib:copy_to_directory.bzl\", \"copy_to_directory\")\n\ncopy_to_directory(\n    name = \"support\",\n    hardlink = \"on\",\n    srcs = glob([\n        \"src/**\",\n        \"load.bash\",\n    ]),\n    out = \"bats-support\",\n    visibility = [\"//visibility:public\"]\n)\n"
+            }
+          },
+          "bats_assert": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "98ca3b685f8b8993e48ec057565e6e2abcc541034ed5b0e81f191505682037fd",
+              "urls": [
+                "https://github.com/bats-core/bats-assert/archive/v2.1.0.tar.gz"
+              ],
+              "strip_prefix": "bats-assert-2.1.0",
+              "build_file_content": "load(\"@aspect_bazel_lib//lib:copy_to_directory.bzl\", \"copy_to_directory\")\n\ncopy_to_directory(\n    name = \"assert\",\n    hardlink = \"on\",\n    srcs = glob([\n        \"src/**\",\n        \"load.bash\",\n    ]),\n    out = \"bats-assert\",\n    visibility = [\"//visibility:public\"]\n)\n"
+            }
+          },
+          "bats_file": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9b69043241f3af1c2d251f89b4fcafa5df3f05e97b89db18d7c9bdf5731bb27a",
+              "urls": [
+                "https://github.com/bats-core/bats-file/archive/v0.4.0.tar.gz"
+              ],
+              "strip_prefix": "bats-file-0.4.0",
+              "build_file_content": "load(\"@aspect_bazel_lib//lib:copy_to_directory.bzl\", \"copy_to_directory\")\n\ncopy_to_directory(\n    name = \"file\",\n    hardlink = \"on\",\n    srcs = glob([\n        \"src/**\",\n        \"load.bash\",\n    ]),\n    out = \"bats-file\",\n    visibility = [\"//visibility:public\"]\n)\n"
+            }
+          },
+          "bats_toolchains": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a1a9f7875aa4b6a9480ca384d5865f1ccf1b0b1faead6b47aa47d79709a5c5fd",
+              "urls": [
+                "https://github.com/bats-core/bats-core/archive/v1.10.0.tar.gz"
+              ],
+              "strip_prefix": "bats-core-1.10.0",
+              "build_file_content": "load(\"@local_config_platform//:constraints.bzl\", \"HOST_CONSTRAINTS\")\nload(\"@aspect_bazel_lib//lib/private:bats_toolchain.bzl\", \"bats_toolchain\")\nload(\"@aspect_bazel_lib//lib:copy_to_directory.bzl\", \"copy_to_directory\")\n\ncopy_to_directory(\n    name = \"core\",\n    hardlink = \"on\",\n    srcs = glob([\n        \"lib/**\",\n        \"libexec/**\"\n    ]) + [\"bin/bats\"],\n    out = \"bats-core\",\n)\n\nbats_toolchain(\n    name = \"toolchain\",\n    core = \":core\",\n    libraries = [\"@bats_support//:support\", \"@bats_assert//:assert\", \"@bats_file//:file\"]\n)\n\ntoolchain(\n    name = \"bats_toolchain\",\n    exec_compatible_with = HOST_CONSTRAINTS,\n    toolchain = \":toolchain\",\n    toolchain_type = \"@aspect_bazel_lib//lib:bats_toolchain_type\",\n)\n"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "aspect_bazel_lib+",
+            "aspect_bazel_lib",
+            "aspect_bazel_lib+"
+          ],
+          [
+            "aspect_bazel_lib+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "aspect_bazel_lib+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    }
+  },
+  "facts": {}
+}

--- a/rules_formatjs/README.md
+++ b/rules_formatjs/README.md
@@ -1,0 +1,270 @@
+# rules_formatjs
+
+Bazel rules for [FormatJS](https://formatjs.io/) - Internationalize your web apps on the client & server.
+
+## Features
+
+- Extract messages from source files (TypeScript, JavaScript, JSX, TSX)
+- Compile messages for optimized runtime performance
+- Integrate with FormatJS CLI tools
+- Type-safe message extraction and compilation
+
+## Installation
+
+Add `rules_formatjs` to your `MODULE.bazel`:
+
+```starlark
+bazel_dep(name = "rules_formatjs", version = "0.0.0")
+```
+
+## Usage
+
+### Extract Messages
+
+Extract internationalized messages from your source code:
+
+```starlark
+load("@rules_formatjs//formatjs:defs.bzl", "formatjs_extract")
+
+formatjs_extract(
+    name = "messages_extracted",
+    srcs = glob(["src/**/*.tsx", "src/**/*.ts"]),
+    out = "en.json",
+    id_interpolation_pattern = "[sha512:contenthash:base64:6]",
+)
+```
+
+### Compile Messages
+
+Compile extracted messages for optimized runtime:
+
+```starlark
+load("@rules_formatjs//formatjs:defs.bzl", "formatjs_compile")
+
+formatjs_compile(
+    name = "messages_compiled",
+    src = ":messages_extracted",
+    out = "en-compiled.json",
+    ast = True,  # Compile to AST for better performance
+)
+```
+
+### Complete Example
+
+```starlark
+load("@rules_formatjs//formatjs:defs.bzl", "formatjs_extract", "formatjs_compile")
+
+# Extract messages from source files
+formatjs_extract(
+    name = "extract_en",
+    srcs = glob([
+        "src/**/*.ts",
+        "src/**/*.tsx",
+    ]),
+    out = "lang/en.json",
+    id_interpolation_pattern = "[sha512:contenthash:base64:6]",
+    extract_from_format_message_call = True,
+)
+
+# Compile for production
+formatjs_compile(
+    name = "compile_en",
+    src = ":extract_en",
+    out = "lang/en-compiled.json",
+    ast = True,
+)
+
+# Compile translations
+formatjs_compile(
+    name = "compile_es",
+    src = "translations/es.json",
+    out = "lang/es-compiled.json",
+    ast = True,
+)
+```
+
+## API Reference
+
+### formatjs_extract
+
+Extract messages from source files. This is a **custom Bazel rule** (not a macro), which means you can attach aspects to it for advanced build graph analysis.
+
+**Attributes:**
+
+- `name` (required): Target name
+- `srcs` (required): List of source files to extract from
+- `out` (optional): Output JSON file (defaults to `name + ".json"`)
+- `id_interpolation_pattern` (optional): Pattern for message ID generation
+  - Example: `"[sha512:contenthash:base64:6]"` for content-based IDs
+- `extract_from_format_message_call` (optional): Extract from `formatMessage()` calls
+- `additional_component_names` (optional): Additional component names to extract from
+- `additional_function_names` (optional): Additional function names to extract from
+- `ignore` (optional): List of glob patterns to ignore
+
+**Providers:**
+
+- `DefaultInfo`: Contains the extracted messages JSON file
+- `FormatjsExtractInfo`: Custom provider with:
+  - `messages`: File containing extracted messages
+  - `srcs`: Depset of source files
+  - `id_interpolation_pattern`: Pattern used for ID generation
+
+### formatjs_compile
+
+Compile extracted messages for optimized runtime.
+
+**Attributes:**
+
+- `name` (required): Target name
+- `src` (required): Source JSON file with extracted messages
+- `out` (optional): Output compiled JSON file (defaults to `name + ".json"`)
+- `ast` (optional): Compile to AST format for better runtime performance
+- `format` (optional): Input format (`simple`, `crowdin`, `smartling`, `transifex`)
+
+## Integration with React
+
+Use compiled messages with `react-intl`:
+
+```typescript
+import { createIntl, createIntlCache, RawIntlProvider } from 'react-intl';
+import messages from './lang/en-compiled.json';
+
+const cache = createIntlCache();
+const intl = createIntl(
+  {
+    locale: 'en',
+    messages,
+  },
+  cache
+);
+
+function App() {
+  return (
+    <RawIntlProvider value={intl}>
+      {/* Your app */}
+    </RawIntlProvider>
+  );
+}
+```
+
+## Advanced: Using Aspects
+
+Since `formatjs_extract` is a custom rule, you can attach Bazel aspects to it for advanced analysis and transformations. This is useful for:
+
+- Collecting statistics about extracted messages
+- Validating message format and completeness
+- Aggregating messages across multiple targets
+- Custom reporting and analysis
+
+### Message Aggregation Aspect
+
+The `formatjs_aggregate_aspect` collects and merges extracted messages from a target and all its dependencies into a single JSON file using `jq`.
+
+#### Usage
+
+```bash
+bazel build //path/to:target \
+  --aspects=@rules_formatjs//formatjs:aggregate.bzl%formatjs_aggregate_aspect \
+  --output_groups=aggregated_messages
+```
+
+#### Example
+
+```starlark
+load("@rules_formatjs//formatjs:defs.bzl", "formatjs_extract", "formatjs_aggregate")
+
+# Extract from multiple modules
+formatjs_extract(name = "module1_msgs", srcs = ["module1/**/*.tsx"])
+formatjs_extract(name = "module2_msgs", srcs = ["module2/**/*.tsx"])
+formatjs_extract(name = "module3_msgs", srcs = ["module3/**/*.tsx"])
+
+# Create aggregation target
+formatjs_aggregate(
+    name = "all_messages",
+    deps = [":module1_msgs", ":module2_msgs", ":module3_msgs"],
+)
+```
+
+Then build with the aspect:
+
+```bash
+bazel build //:all_messages \
+  --aspects=@rules_formatjs//formatjs:aggregate.bzl%formatjs_aggregate_aspect \
+  --output_groups=aggregated_messages
+```
+
+Output: `bazel-bin/all_messages_aggregated_messages.json` containing all merged messages.
+
+**Merge Strategy**: Uses `jq` to merge JSON objects. Later files overwrite earlier ones for duplicate keys.
+
+### Example Aspects
+
+The library also includes demonstration aspects in `formatjs/aspects.bzl`:
+
+#### Message Statistics
+
+```bash
+bazel build //path/to:target \
+  --aspects=@rules_formatjs//formatjs:aspects.bzl%message_stats_aspect \
+  --output_groups=message_stats
+```
+
+#### Message Validation
+
+```bash
+bazel build //path/to:target \
+  --aspects=@rules_formatjs//formatjs:aspects.bzl%message_validator_aspect \
+  --output_groups=message_validation
+```
+
+#### Message Collection (across dependencies)
+
+```bash
+bazel build //path/to:target \
+  --aspects=@rules_formatjs//formatjs:aspects.bzl%message_collector_aspect \
+  --output_groups=all_messages
+```
+
+### Creating Custom Aspects
+
+```starlark
+load("@rules_formatjs//formatjs:defs.bzl", "FormatjsExtractInfo")
+
+def _my_aspect_impl(target, ctx):
+    if FormatjsExtractInfo not in target:
+        return []
+
+    info = target[FormatjsExtractInfo]
+
+    # Access extracted message file
+    messages_file = info.messages
+
+    # Access source files
+    src_files = info.srcs.to_list()
+
+    # Perform custom analysis...
+
+    return [OutputGroupInfo(...)]
+
+my_aspect = aspect(
+    implementation = _my_aspect_impl,
+    doc = "My custom aspect for formatjs_extract",
+)
+```
+
+## Examples
+
+See the [examples](examples/) directory for complete working examples:
+
+- [examples/simple](examples/simple) - Basic message extraction and compilation
+
+## Resources
+
+- [FormatJS Documentation](https://formatjs.io/)
+- [FormatJS CLI](https://formatjs.io/docs/tooling/cli)
+- [React Intl](https://formatjs.io/docs/react-intl)
+- [Bazel](https://bazel.build/)
+
+## License
+
+Same as FormatJS - BSD 3-Clause License

--- a/rules_formatjs/REPO.bazel
+++ b/rules_formatjs/REPO.bazel
@@ -1,0 +1,8 @@
+# Repository-level ignore patterns
+# This file replaces .bazelignore (deprecated in Bazel 8.0+)
+#
+# Ignore example workspaces - they are independent Bazel workspaces with their own MODULE.bazel
+
+ignore_directories([
+    "examples",
+])

--- a/rules_formatjs/examples/aggregate/.bazelrc
+++ b/rules_formatjs/examples/aggregate/.bazelrc
@@ -1,0 +1,33 @@
+# Bazel configuration for rules_formatjs aggregate example
+
+common --enable_bzlmod
+common --color=yes
+
+# Output and debugging
+build --show_timestamps
+build --verbose_failures
+
+# Performance
+build --remote_cache_compression
+build --legacy_important_outputs
+build --remote_build_event_upload=minimal
+build --noslim_profile
+build --experimental_profile_include_target_label
+build --experimental_profile_include_primary_output
+common --bes_upload_mode=fully_async
+
+# BuildBuddy CI configuration
+# https://www.buildbuddy.io/docs/rbe-github-actions
+build:ci --build_metadata=ROLE=CI
+build:ci --build_metadata=VISIBILITY=PUBLIC
+build:ci --config=remote
+
+build:remote --bes_backend=grpcs://formatjs.buildbuddy.io
+build:remote --bes_results_url=https://formatjs.buildbuddy.io/invocation/
+build:remote --define=EXECUTOR=remote
+build:remote --jobs=50
+build:remote --remote_cache=grpcs://formatjs.buildbuddy.io
+build:remote --remote_timeout=10m
+
+# Try to import a user-specific .bazelrc
+try-import %workspace%/.bazelrc.user

--- a/rules_formatjs/examples/aggregate/BUILD.bazel
+++ b/rules_formatjs/examples/aggregate/BUILD.bazel
@@ -1,0 +1,10 @@
+load("@npm//:@formatjs/cli/package_json.bzl", formatjs_bin = "bin")
+load("@npm//:defs.bzl", "npm_link_all_packages")
+
+npm_link_all_packages(name = "node_modules")
+
+# Create formatjs CLI binary target for use across all modules
+formatjs_bin.formatjs_binary(
+    name = "formatjs_cli",
+    visibility = ["//visibility:public"],
+)

--- a/rules_formatjs/examples/aggregate/MODULE.bazel
+++ b/rules_formatjs/examples/aggregate/MODULE.bazel
@@ -1,0 +1,30 @@
+"""
+Message Aggregation Example Workspace
+
+This is a standalone Bazel workspace demonstrating the formatjs_aggregate_aspect.
+"""
+
+module(
+    name = "aggregate_example",
+    version = "0.0.0",
+)
+
+bazel_dep(name = "rules_formatjs", version = "0.0.0")
+local_path_override(
+    module_name = "rules_formatjs",
+    path = "../..",
+)
+
+bazel_dep(name = "aspect_bazel_lib", version = "2.22.2")
+bazel_dep(name = "aspect_rules_js", version = "2.8.3")
+bazel_dep(name = "rules_nodejs", version = "6.3.0")
+
+node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
+node.toolchain(node_version = "20.11.1")
+
+npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm")
+npm.npm_translate_lock(
+    name = "npm",
+    pnpm_lock = "//:pnpm-lock.yaml",
+)
+use_repo(npm, "npm")

--- a/rules_formatjs/examples/aggregate/MODULE.bazel.lock
+++ b/rules_formatjs/examples/aggregate/MODULE.bazel.lock
@@ -1,0 +1,630 @@
+{
+  "lockFileVersion": 24,
+  "registryFileHashes": {
+    "https://bcr.bazel.build/bazel_registry.json": "8a28e4aff06ee60aed2a8c281907fb8bcbf3b753c91fb5a5c57da3215d5b3497",
+    "https://bcr.bazel.build/modules/abseil-cpp/20210324.2/MODULE.bazel": "7cd0312e064fde87c8d1cd79ba06c876bd23630c83466e9500321be55c96ace2",
+    "https://bcr.bazel.build/modules/abseil-cpp/20211102.0/MODULE.bazel": "70390338f7a5106231d20620712f7cccb659cd0e9d073d1991c038eb9fc57589",
+    "https://bcr.bazel.build/modules/abseil-cpp/20230125.1/MODULE.bazel": "89047429cb0207707b2dface14ba7f8df85273d484c2572755be4bab7ce9c3a0",
+    "https://bcr.bazel.build/modules/abseil-cpp/20230802.0.bcr.1/MODULE.bazel": "1c8cec495288dccd14fdae6e3f95f772c1c91857047a098fad772034264cc8cb",
+    "https://bcr.bazel.build/modules/abseil-cpp/20230802.0/MODULE.bazel": "d253ae36a8bd9ee3c5955384096ccb6baf16a1b1e93e858370da0a3b94f77c16",
+    "https://bcr.bazel.build/modules/abseil-cpp/20230802.1/MODULE.bazel": "fa92e2eb41a04df73cdabeec37107316f7e5272650f81d6cc096418fe647b915",
+    "https://bcr.bazel.build/modules/abseil-cpp/20240116.1/MODULE.bazel": "37bcdb4440fbb61df6a1c296ae01b327f19e9bb521f9b8e26ec854b6f97309ed",
+    "https://bcr.bazel.build/modules/abseil-cpp/20240116.2/MODULE.bazel": "73939767a4686cd9a520d16af5ab440071ed75cec1a876bf2fcfaf1f71987a16",
+    "https://bcr.bazel.build/modules/abseil-cpp/20250127.1/MODULE.bazel": "c4a89e7ceb9bf1e25cf84a9f830ff6b817b72874088bf5141b314726e46a57c1",
+    "https://bcr.bazel.build/modules/abseil-cpp/20250512.1/MODULE.bazel": "d209fdb6f36ffaf61c509fcc81b19e81b411a999a934a032e10cd009a0226215",
+    "https://bcr.bazel.build/modules/abseil-cpp/20250814.0/MODULE.bazel": "c43c16ca2c432566cdb78913964497259903ebe8fb7d9b57b38e9f1425b427b8",
+    "https://bcr.bazel.build/modules/abseil-cpp/20250814.0/source.json": "b88bff599ceaf0f56c264c749b1606f8485cec3b8c38ba30f88a4df9af142861",
+    "https://bcr.bazel.build/modules/apple_support/1.11.1/MODULE.bazel": "1843d7cd8a58369a444fc6000e7304425fba600ff641592161d9f15b179fb896",
+    "https://bcr.bazel.build/modules/apple_support/1.15.1/MODULE.bazel": "a0556fefca0b1bb2de8567b8827518f94db6a6e7e7d632b4c48dc5f865bc7c85",
+    "https://bcr.bazel.build/modules/apple_support/1.23.1/MODULE.bazel": "53763fed456a968cf919b3240427cf3a9d5481ec5466abc9d5dc51bc70087442",
+    "https://bcr.bazel.build/modules/apple_support/1.23.1/source.json": "d888b44312eb0ad2c21a91d026753f330caa48a25c9b2102fae75eb2b0dcfdd2",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.14.0/MODULE.bazel": "2b31ffcc9bdc8295b2167e07a757dbbc9ac8906e7028e5170a3708cecaac119f",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.17.1/MODULE.bazel": "9b027af55f619c7c444cead71061578fab6587e5e1303fa4ed61d49d2b1a7262",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.19.3/MODULE.bazel": "253d739ba126f62a5767d832765b12b59e9f8d2bc88cc1572f4a73e46eb298ca",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.22.2/MODULE.bazel": "6b735f3fdd64978e217c9725f4ff0d84bf606554c8e77d20e90977841d7ff2ed",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.22.2/source.json": "58fffa2d722cff47cb8d921c8bbed7701c53f233009d9ca82beb4a0fb8fb9418",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.8.1/MODULE.bazel": "812d2dd42f65dca362152101fbec418029cc8fd34cbad1a2fde905383d705838",
+    "https://bcr.bazel.build/modules/aspect_rules_js/2.8.3/MODULE.bazel": "807ce5f624124a8bc586c743394d174e85f0f9c6c4e0e2410b4088aebe790ac8",
+    "https://bcr.bazel.build/modules/aspect_rules_js/2.8.3/source.json": "c35cb4e04f61a09c17f8c569894b80de884b1e3dee2d33829704786e3f778037",
+    "https://bcr.bazel.build/modules/aspect_tools_telemetry/0.3.3/MODULE.bazel": "37c764292861c2f70314efa9846bb6dbb44fc0308903b3285da6528305450183",
+    "https://bcr.bazel.build/modules/aspect_tools_telemetry/0.3.3/source.json": "605086bbc197743a0d360f7ddc550a1d4dfa0441bc807236e17170f636153348",
+    "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
+    "https://bcr.bazel.build/modules/bazel_features/1.11.0/MODULE.bazel": "f9382337dd5a474c3b7d334c2f83e50b6eaedc284253334cf823044a26de03e8",
+    "https://bcr.bazel.build/modules/bazel_features/1.15.0/MODULE.bazel": "d38ff6e517149dc509406aca0db3ad1efdd890a85e049585b7234d04238e2a4d",
+    "https://bcr.bazel.build/modules/bazel_features/1.17.0/MODULE.bazel": "039de32d21b816b47bd42c778e0454217e9c9caac4a3cf8e15c7231ee3ddee4d",
+    "https://bcr.bazel.build/modules/bazel_features/1.18.0/MODULE.bazel": "1be0ae2557ab3a72a57aeb31b29be347bcdc5d2b1eb1e70f39e3851a7e97041a",
+    "https://bcr.bazel.build/modules/bazel_features/1.19.0/MODULE.bazel": "59adcdf28230d220f0067b1f435b8537dd033bfff8db21335ef9217919c7fb58",
+    "https://bcr.bazel.build/modules/bazel_features/1.21.0/MODULE.bazel": "675642261665d8eea09989aa3b8afb5c37627f1be178382c320d1b46afba5e3b",
+    "https://bcr.bazel.build/modules/bazel_features/1.23.0/MODULE.bazel": "fd1ac84bc4e97a5a0816b7fd7d4d4f6d837b0047cf4cbd81652d616af3a6591a",
+    "https://bcr.bazel.build/modules/bazel_features/1.27.0/MODULE.bazel": "621eeee06c4458a9121d1f104efb80f39d34deff4984e778359c60eaf1a8cb65",
+    "https://bcr.bazel.build/modules/bazel_features/1.28.0/MODULE.bazel": "4b4200e6cbf8fa335b2c3f43e1d6ef3e240319c33d43d60cc0fbd4b87ece299d",
+    "https://bcr.bazel.build/modules/bazel_features/1.3.0/MODULE.bazel": "cdcafe83ec318cda34e02948e81d790aab8df7a929cec6f6969f13a489ccecd9",
+    "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
+    "https://bcr.bazel.build/modules/bazel_features/1.30.0/source.json": "b07e17f067fe4f69f90b03b36ef1e08fe0d1f3cac254c1241a1818773e3423bc",
+    "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
+    "https://bcr.bazel.build/modules/bazel_features/1.9.0/MODULE.bazel": "885151d58d90d8d9c811eb75e3288c11f850e1d6b481a8c9f766adee4712358b",
+    "https://bcr.bazel.build/modules/bazel_features/1.9.1/MODULE.bazel": "8f679097876a9b609ad1f60249c49d68bfab783dd9be012faf9d82547b14815a",
+    "https://bcr.bazel.build/modules/bazel_lib/3.0.0-rc.0/MODULE.bazel": "d6e00979a98ac14ada5e31c8794708b41434d461e7e7ca39b59b765e6d233b18",
+    "https://bcr.bazel.build/modules/bazel_lib/3.0.0/MODULE.bazel": "22b70b80ac89ad3f3772526cd9feee2fa412c2b01933fea7ed13238a448d370d",
+    "https://bcr.bazel.build/modules/bazel_lib/3.0.0/source.json": "895f21909c6fba01d7c17914bb6c8e135982275a1b18cdaa4e62272217ef1751",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.0.3/MODULE.bazel": "bcb0fd896384802d1ad283b4e4eb4d718eebd8cb820b0a2c3a347fb971afd9d8",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.1.1/MODULE.bazel": "1add3e7d93ff2e6998f9e118022c84d163917d912f5afafb3058e3d2f1545b5e",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.2.0/MODULE.bazel": "44fe84260e454ed94ad326352a698422dbe372b21a1ac9f3eab76eb531223686",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.2.1/MODULE.bazel": "f35baf9da0efe45fa3da1696ae906eea3d615ad41e2e3def4aeb4e8bc0ef9a7a",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.3.0/MODULE.bazel": "20228b92868bf5cfc41bda7afc8a8ba2a543201851de39d990ec957b513579c5",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.4.1/MODULE.bazel": "a0dcb779424be33100dcae821e9e27e4f2901d9dfd5333efe5ac6a8d7ab75e1d",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.4.2/MODULE.bazel": "3bd40978e7a1fac911d5989e6b09d8f64921865a45822d8b09e815eaa726a651",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.5.0/MODULE.bazel": "32880f5e2945ce6a03d1fbd588e9198c0a959bb42297b2cfaf1685b7bc32e138",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.6.1/MODULE.bazel": "8fdee2dbaace6c252131c00e1de4b165dc65af02ea278476187765e1a617b917",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.7.0/MODULE.bazel": "0db596f4563de7938de764cc8deeabec291f55e8ec15299718b93c4423e9796d",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.7.1/MODULE.bazel": "3120d80c5861aa616222ec015332e5f8d3171e062e3e804a2a0253e1be26e59b",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.8.1/MODULE.bazel": "88ade7293becda963e0e3ea33e7d54d3425127e0a326e0d17da085a5f1f03ff6",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.8.1/source.json": "7ebaefba0b03efe59cac88ed5bbc67bcf59a3eff33af937345ede2a38b2d368a",
+    "https://bcr.bazel.build/modules/buildozer/7.1.2/MODULE.bazel": "2e8dd40ede9c454042645fd8d8d0cd1527966aa5c919de86661e62953cd73d84",
+    "https://bcr.bazel.build/modules/buildozer/7.1.2/source.json": "c9028a501d2db85793a6996205c8de120944f50a0d570438fcae0457a5f9d1f8",
+    "https://bcr.bazel.build/modules/gawk/5.3.2.bcr.1/MODULE.bazel": "cdf8cbe5ee750db04b78878c9633cc76e80dcf4416cbe982ac3a9222f80713c8",
+    "https://bcr.bazel.build/modules/gawk/5.3.2.bcr.1/source.json": "fa7b512dfcb5eafd90ce3959cf42a2a6fe96144ebbb4b3b3928054895f2afac2",
+    "https://bcr.bazel.build/modules/google_benchmark/1.8.2/MODULE.bazel": "a70cf1bba851000ba93b58ae2f6d76490a9feb74192e57ab8e8ff13c34ec50cb",
+    "https://bcr.bazel.build/modules/googletest/1.11.0/MODULE.bazel": "3a83f095183f66345ca86aa13c58b59f9f94a2f81999c093d4eeaa2d262d12f4",
+    "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/MODULE.bazel": "22c31a561553727960057361aa33bf20fb2e98584bc4fec007906e27053f80c6",
+    "https://bcr.bazel.build/modules/googletest/1.14.0/MODULE.bazel": "cfbcbf3e6eac06ef9d85900f64424708cc08687d1b527f0ef65aa7517af8118f",
+    "https://bcr.bazel.build/modules/googletest/1.15.2/MODULE.bazel": "6de1edc1d26cafb0ea1a6ab3f4d4192d91a312fd2d360b63adaa213cd00b2108",
+    "https://bcr.bazel.build/modules/googletest/1.17.0/MODULE.bazel": "dbec758171594a705933a29fcf69293d2468c49ec1f2ebca65c36f504d72df46",
+    "https://bcr.bazel.build/modules/googletest/1.17.0/source.json": "38e4454b25fc30f15439c0378e57909ab1fd0a443158aa35aec685da727cd713",
+    "https://bcr.bazel.build/modules/jq.bzl/0.1.0/MODULE.bazel": "2ce69b1af49952cd4121a9c3055faa679e748ce774c7f1fda9657f936cae902f",
+    "https://bcr.bazel.build/modules/jq.bzl/0.4.0/MODULE.bazel": "a7b39b37589f2b0dad53fd6c1ccaabbdb290330caa920d7ef3e6aad068cd4ab2",
+    "https://bcr.bazel.build/modules/jq.bzl/0.4.0/source.json": "52ec7530c4618e03f634b30ff719814a68d7d39c235938b7aa2abbfe1eb1c52c",
+    "https://bcr.bazel.build/modules/jsoncpp/1.9.5/MODULE.bazel": "31271aedc59e815656f5736f282bb7509a97c7ecb43e927ac1a37966e0578075",
+    "https://bcr.bazel.build/modules/jsoncpp/1.9.6/MODULE.bazel": "2f8d20d3b7d54143213c4dfc3d98225c42de7d666011528dc8fe91591e2e17b0",
+    "https://bcr.bazel.build/modules/jsoncpp/1.9.6/source.json": "a04756d367a2126c3541682864ecec52f92cdee80a35735a3cb249ce015ca000",
+    "https://bcr.bazel.build/modules/libpfm/4.11.0/MODULE.bazel": "45061ff025b301940f1e30d2c16bea596c25b176c8b6b3087e92615adbd52902",
+    "https://bcr.bazel.build/modules/nlohmann_json/3.6.1/MODULE.bazel": "6f7b417dcc794d9add9e556673ad25cb3ba835224290f4f848f8e2db1e1fca74",
+    "https://bcr.bazel.build/modules/nlohmann_json/3.6.1/source.json": "f448c6e8963fdfa7eb831457df83ad63d3d6355018f6574fb017e8169deb43a9",
+    "https://bcr.bazel.build/modules/package_metadata/0.0.2/MODULE.bazel": "fb8d25550742674d63d7b250063d4580ca530499f045d70748b1b142081ebb92",
+    "https://bcr.bazel.build/modules/package_metadata/0.0.2/source.json": "e53a759a72488d2c0576f57491ef2da0cf4aab05ac0997314012495935531b73",
+    "https://bcr.bazel.build/modules/platforms/0.0.10/MODULE.bazel": "8cb8efaf200bdeb2150d93e162c40f388529a25852b332cec879373771e48ed5",
+    "https://bcr.bazel.build/modules/platforms/0.0.11/MODULE.bazel": "0daefc49732e227caa8bfa834d65dc52e8cc18a2faf80df25e8caea151a9413f",
+    "https://bcr.bazel.build/modules/platforms/0.0.4/MODULE.bazel": "9b328e31ee156f53f3c416a64f8491f7eb731742655a47c9eec4703a71644aee",
+    "https://bcr.bazel.build/modules/platforms/0.0.5/MODULE.bazel": "5733b54ea419d5eaf7997054bb55f6a1d0b5ff8aedf0176fef9eea44f3acda37",
+    "https://bcr.bazel.build/modules/platforms/0.0.6/MODULE.bazel": "ad6eeef431dc52aefd2d77ed20a4b353f8ebf0f4ecdd26a807d2da5aa8cd0615",
+    "https://bcr.bazel.build/modules/platforms/0.0.7/MODULE.bazel": "72fd4a0ede9ee5c021f6a8dd92b503e089f46c227ba2813ff183b71616034814",
+    "https://bcr.bazel.build/modules/platforms/0.0.8/MODULE.bazel": "9f142c03e348f6d263719f5074b21ef3adf0b139ee4c5133e2aa35664da9eb2d",
+    "https://bcr.bazel.build/modules/platforms/0.0.9/MODULE.bazel": "4a87a60c927b56ddd67db50c89acaa62f4ce2a1d2149ccb63ffd871d5ce29ebc",
+    "https://bcr.bazel.build/modules/platforms/1.0.0/MODULE.bazel": "f05feb42b48f1b3c225e4ccf351f367be0371411a803198ec34a389fb22aa580",
+    "https://bcr.bazel.build/modules/platforms/1.0.0/source.json": "f4ff1fd412e0246fd38c82328eb209130ead81d62dcd5a9e40910f867f733d96",
+    "https://bcr.bazel.build/modules/protobuf/21.7/MODULE.bazel": "a5a29bb89544f9b97edce05642fac225a808b5b7be74038ea3640fae2f8e66a7",
+    "https://bcr.bazel.build/modules/protobuf/27.0/MODULE.bazel": "7873b60be88844a0a1d8f80b9d5d20cfbd8495a689b8763e76c6372998d3f64c",
+    "https://bcr.bazel.build/modules/protobuf/27.1/MODULE.bazel": "703a7b614728bb06647f965264967a8ef1c39e09e8f167b3ca0bb1fd80449c0d",
+    "https://bcr.bazel.build/modules/protobuf/29.0-rc2/MODULE.bazel": "6241d35983510143049943fc0d57937937122baf1b287862f9dc8590fc4c37df",
+    "https://bcr.bazel.build/modules/protobuf/29.0-rc3/MODULE.bazel": "33c2dfa286578573afc55a7acaea3cada4122b9631007c594bf0729f41c8de92",
+    "https://bcr.bazel.build/modules/protobuf/29.0/MODULE.bazel": "319dc8bf4c679ff87e71b1ccfb5a6e90a6dbc4693501d471f48662ac46d04e4e",
+    "https://bcr.bazel.build/modules/protobuf/29.1/MODULE.bazel": "557c3457560ff49e122ed76c0bc3397a64af9574691cb8201b4e46d4ab2ecb95",
+    "https://bcr.bazel.build/modules/protobuf/3.19.0/MODULE.bazel": "6b5fbb433f760a99a22b18b6850ed5784ef0e9928a72668b66e4d7ccd47db9b0",
+    "https://bcr.bazel.build/modules/protobuf/32.1/MODULE.bazel": "89cd2866a9cb07fee9ff74c41ceace11554f32e0d849de4e23ac55515cfada4d",
+    "https://bcr.bazel.build/modules/protobuf/32.1/source.json": "bd2664e90875c0cd755d1d9b7a103a4b027893ac8eafa3bba087557ffc244ad4",
+    "https://bcr.bazel.build/modules/pybind11_bazel/2.11.1/MODULE.bazel": "88af1c246226d87e65be78ed49ecd1e6f5e98648558c14ce99176da041dc378e",
+    "https://bcr.bazel.build/modules/pybind11_bazel/2.12.0/MODULE.bazel": "e6f4c20442eaa7c90d7190d8dc539d0ab422f95c65a57cc59562170c58ae3d34",
+    "https://bcr.bazel.build/modules/pybind11_bazel/2.12.0/source.json": "6900fdc8a9e95866b8c0d4ad4aba4d4236317b5c1cd04c502df3f0d33afed680",
+    "https://bcr.bazel.build/modules/re2/2023-09-01/MODULE.bazel": "cb3d511531b16cfc78a225a9e2136007a48cf8a677e4264baeab57fe78a80206",
+    "https://bcr.bazel.build/modules/re2/2024-07-02.bcr.1/MODULE.bazel": "b4963dda9b31080be1905ef085ecd7dd6cd47c05c79b9cdf83ade83ab2ab271a",
+    "https://bcr.bazel.build/modules/re2/2024-07-02.bcr.1/source.json": "2ff292be6ef3340325ce8a045ecc326e92cbfab47c7cbab4bd85d28971b97ac4",
+    "https://bcr.bazel.build/modules/re2/2024-07-02/MODULE.bazel": "0eadc4395959969297cbcf31a249ff457f2f1d456228c67719480205aa306daa",
+    "https://bcr.bazel.build/modules/rules_android/0.1.1/MODULE.bazel": "48809ab0091b07ad0182defb787c4c5328bd3a278938415c00a7b69b50c4d3a8",
+    "https://bcr.bazel.build/modules/rules_android/0.1.1/source.json": "e6986b41626ee10bdc864937ffb6d6bf275bb5b9c65120e6137d56e6331f089e",
+    "https://bcr.bazel.build/modules/rules_apple/3.16.0/MODULE.bazel": "0d1caf0b8375942ce98ea944be754a18874041e4e0459401d925577624d3a54a",
+    "https://bcr.bazel.build/modules/rules_apple/3.16.0/source.json": "d8b5fe461272018cc07cfafce11fe369c7525330804c37eec5a82f84cd475366",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.1/MODULE.bazel": "cb2aa0747f84c6c3a78dad4e2049c154f08ab9d166b1273835a8174940365647",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.10/MODULE.bazel": "ec1705118f7eaedd6e118508d3d26deba2a4e76476ada7e0e3965211be012002",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.13/MODULE.bazel": "0e8529ed7b323dad0775ff924d2ae5af7640b23553dfcd4d34344c7e7a867191",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.14/MODULE.bazel": "5e343a3aac88b8d7af3b1b6d2093b55c347b8eefc2e7d1442f7a02dc8fea48ac",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.15/MODULE.bazel": "6704c35f7b4a72502ee81f61bf88706b54f06b3cbe5558ac17e2e14666cd5dcc",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.16/MODULE.bazel": "7661303b8fc1b4d7f532e54e9d6565771fea666fbdf839e0a86affcd02defe87",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.17/MODULE.bazel": "2ae1d8f4238ec67d7185d8861cb0a2cdf4bc608697c331b95bf990e69b62e64a",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.2/MODULE.bazel": "6915987c90970493ab97393024c156ea8fb9f3bea953b2f3ec05c34f19b5695c",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.6/MODULE.bazel": "abf360251023dfe3efcef65ab9d56beefa8394d4176dd29529750e1c57eaa33f",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.8/MODULE.bazel": "964c85c82cfeb6f3855e6a07054fdb159aced38e99a5eecf7bce9d53990afa3e",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.9/MODULE.bazel": "836e76439f354b89afe6a911a7adf59a6b2518fafb174483ad78a2a2fde7b1c5",
+    "https://bcr.bazel.build/modules/rules_cc/0.1.1/MODULE.bazel": "2f0222a6f229f0bf44cd711dc13c858dad98c62d52bd51d8fc3a764a83125513",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.0/MODULE.bazel": "b5c17f90458caae90d2ccd114c81970062946f49f355610ed89bebf954f5783c",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.8/MODULE.bazel": "f1df20f0bf22c28192a794f29b501ee2018fa37a3862a1a2132ae2940a23a642",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.8/source.json": "85087982aca15f31307bd52698316b28faa31bd2c3095a41f456afec0131344c",
+    "https://bcr.bazel.build/modules/rules_foreign_cc/0.9.0/MODULE.bazel": "c9e8c682bf75b0e7c704166d79b599f93b72cfca5ad7477df596947891feeef6",
+    "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/MODULE.bazel": "40c97d1144356f52905566c55811f13b299453a14ac7769dfba2ac38192337a8",
+    "https://bcr.bazel.build/modules/rules_java/4.0.0/MODULE.bazel": "5a78a7ae82cd1a33cef56dc578c7d2a46ed0dca12643ee45edbb8417899e6f74",
+    "https://bcr.bazel.build/modules/rules_java/5.3.5/MODULE.bazel": "a4ec4f2db570171e3e5eb753276ee4b389bae16b96207e9d3230895c99644b86",
+    "https://bcr.bazel.build/modules/rules_java/6.0.0/MODULE.bazel": "8a43b7df601a7ec1af61d79345c17b31ea1fedc6711fd4abfd013ea612978e39",
+    "https://bcr.bazel.build/modules/rules_java/6.3.0/MODULE.bazel": "a97c7678c19f236a956ad260d59c86e10a463badb7eb2eda787490f4c969b963",
+    "https://bcr.bazel.build/modules/rules_java/6.4.0/MODULE.bazel": "e986a9fe25aeaa84ac17ca093ef13a4637f6107375f64667a15999f77db6c8f6",
+    "https://bcr.bazel.build/modules/rules_java/6.5.2/MODULE.bazel": "1d440d262d0e08453fa0c4d8f699ba81609ed0e9a9a0f02cd10b3e7942e61e31",
+    "https://bcr.bazel.build/modules/rules_java/7.10.0/MODULE.bazel": "530c3beb3067e870561739f1144329a21c851ff771cd752a49e06e3dc9c2e71a",
+    "https://bcr.bazel.build/modules/rules_java/7.12.2/MODULE.bazel": "579c505165ee757a4280ef83cda0150eea193eed3bef50b1004ba88b99da6de6",
+    "https://bcr.bazel.build/modules/rules_java/7.2.0/MODULE.bazel": "06c0334c9be61e6cef2c8c84a7800cef502063269a5af25ceb100b192453d4ab",
+    "https://bcr.bazel.build/modules/rules_java/7.3.2/MODULE.bazel": "50dece891cfdf1741ea230d001aa9c14398062f2b7c066470accace78e412bc2",
+    "https://bcr.bazel.build/modules/rules_java/7.6.1/MODULE.bazel": "2f14b7e8a1aa2f67ae92bc69d1ec0fa8d9f827c4e17ff5e5f02e91caa3b2d0fe",
+    "https://bcr.bazel.build/modules/rules_java/8.14.0/MODULE.bazel": "717717ed40cc69994596a45aec6ea78135ea434b8402fb91b009b9151dd65615",
+    "https://bcr.bazel.build/modules/rules_java/8.16.1/MODULE.bazel": "0f20b1cecaa8e52f60a8f071e59a20b4e3b9a67f6c56c802ea256f6face692d3",
+    "https://bcr.bazel.build/modules/rules_java/8.16.1/source.json": "072f8d11264edc499621be2dc9ea01d6395db5aa6f8799c034ae01a3e857f2e4",
+    "https://bcr.bazel.build/modules/rules_java/8.3.2/MODULE.bazel": "7336d5511ad5af0b8615fdc7477535a2e4e723a357b6713af439fe8cf0195017",
+    "https://bcr.bazel.build/modules/rules_java/8.5.1/MODULE.bazel": "d8a9e38cc5228881f7055a6079f6f7821a073df3744d441978e7a43e20226939",
+    "https://bcr.bazel.build/modules/rules_java/8.6.1/MODULE.bazel": "f4808e2ab5b0197f094cabce9f4b006a27766beb6a9975931da07099560ca9c2",
+    "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
+    "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
+    "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
+    "https://bcr.bazel.build/modules/rules_jvm_external/5.3/MODULE.bazel": "bf93870767689637164657731849fb887ad086739bd5d360d90007a581d5527d",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.1/MODULE.bazel": "75b5fec090dbd46cf9b7d8ea08cf84a0472d92ba3585b476f44c326eda8059c4",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.3/MODULE.bazel": "c998e060b85f71e00de5ec552019347c8bca255062c990ac02d051bb80a38df0",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.7/MODULE.bazel": "e717beabc4d091ecb2c803c2d341b88590e9116b8bf7947915eeb33aab4f96dd",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.7/source.json": "5426f412d0a7fc6b611643376c7e4a82dec991491b9ce5cb1cfdd25fe2e92be4",
+    "https://bcr.bazel.build/modules/rules_kotlin/1.9.0/MODULE.bazel": "ef85697305025e5a61f395d4eaede272a5393cee479ace6686dba707de804d59",
+    "https://bcr.bazel.build/modules/rules_kotlin/1.9.6/MODULE.bazel": "d269a01a18ee74d0335450b10f62c9ed81f2321d7958a2934e44272fe82dcef3",
+    "https://bcr.bazel.build/modules/rules_kotlin/1.9.6/source.json": "2faa4794364282db7c06600b7e5e34867a564ae91bda7cae7c29c64e9466b7d5",
+    "https://bcr.bazel.build/modules/rules_license/0.0.3/MODULE.bazel": "627e9ab0247f7d1e05736b59dbb1b6871373de5ad31c3011880b4133cafd4bd0",
+    "https://bcr.bazel.build/modules/rules_license/0.0.7/MODULE.bazel": "088fbeb0b6a419005b89cf93fe62d9517c0a2b8bb56af3244af65ecfe37e7d5d",
+    "https://bcr.bazel.build/modules/rules_license/1.0.0/MODULE.bazel": "a7fda60eefdf3d8c827262ba499957e4df06f659330bbe6cdbdb975b768bb65c",
+    "https://bcr.bazel.build/modules/rules_license/1.0.0/source.json": "a52c89e54cc311196e478f8382df91c15f7a2bfdf4c6cd0e2675cc2ff0b56efb",
+    "https://bcr.bazel.build/modules/rules_nodejs/6.3.0/MODULE.bazel": "45345e4aba35dd6e4701c1eebf5a4e67af4ed708def9ebcdc6027585b34ee52d",
+    "https://bcr.bazel.build/modules/rules_nodejs/6.3.0/source.json": "1254ffd8d0d908a19c67add7fb5e2a1f604df133bc5d206425264293e2e537fc",
+    "https://bcr.bazel.build/modules/rules_pkg/0.7.0/MODULE.bazel": "df99f03fc7934a4737122518bb87e667e62d780b610910f0447665a7e2be62dc",
+    "https://bcr.bazel.build/modules/rules_pkg/1.0.1/MODULE.bazel": "5b1df97dbc29623bccdf2b0dcd0f5cb08e2f2c9050aab1092fd39a41e82686ff",
+    "https://bcr.bazel.build/modules/rules_pkg/1.0.1/source.json": "bd82e5d7b9ce2d31e380dd9f50c111d678c3bdaca190cb76b0e1c71b05e1ba8a",
+    "https://bcr.bazel.build/modules/rules_proto/4.0.0/MODULE.bazel": "a7a7b6ce9bee418c1a760b3d84f83a299ad6952f9903c67f19e4edd964894e06",
+    "https://bcr.bazel.build/modules/rules_proto/5.3.0-21.7/MODULE.bazel": "e8dff86b0971688790ae75528fe1813f71809b5afd57facb44dad9e8eca631b7",
+    "https://bcr.bazel.build/modules/rules_proto/6.0.0-rc1/MODULE.bazel": "1e5b502e2e1a9e825eef74476a5a1ee524a92297085015a052510b09a1a09483",
+    "https://bcr.bazel.build/modules/rules_proto/6.0.2/MODULE.bazel": "ce916b775a62b90b61888052a416ccdda405212b6aaeb39522f7dc53431a5e73",
+    "https://bcr.bazel.build/modules/rules_proto/7.0.2/MODULE.bazel": "bf81793bd6d2ad89a37a40693e56c61b0ee30f7a7fdbaf3eabbf5f39de47dea2",
+    "https://bcr.bazel.build/modules/rules_proto/7.1.0/MODULE.bazel": "002d62d9108f75bb807cd56245d45648f38275cb3a99dcd45dfb864c5d74cb96",
+    "https://bcr.bazel.build/modules/rules_proto/7.1.0/source.json": "39f89066c12c24097854e8f57ab8558929f9c8d474d34b2c00ac04630ad8940e",
+    "https://bcr.bazel.build/modules/rules_python/0.10.2/MODULE.bazel": "cc82bc96f2997baa545ab3ce73f196d040ffb8756fd2d66125a530031cd90e5f",
+    "https://bcr.bazel.build/modules/rules_python/0.23.1/MODULE.bazel": "49ffccf0511cb8414de28321f5fcf2a31312b47c40cc21577144b7447f2bf300",
+    "https://bcr.bazel.build/modules/rules_python/0.25.0/MODULE.bazel": "72f1506841c920a1afec76975b35312410eea3aa7b63267436bfb1dd91d2d382",
+    "https://bcr.bazel.build/modules/rules_python/0.28.0/MODULE.bazel": "cba2573d870babc976664a912539b320cbaa7114cd3e8f053c720171cde331ed",
+    "https://bcr.bazel.build/modules/rules_python/0.31.0/MODULE.bazel": "93a43dc47ee570e6ec9f5779b2e64c1476a6ce921c48cc9a1678a91dd5f8fd58",
+    "https://bcr.bazel.build/modules/rules_python/0.33.2/MODULE.bazel": "3e036c4ad8d804a4dad897d333d8dce200d943df4827cb849840055be8d2e937",
+    "https://bcr.bazel.build/modules/rules_python/0.4.0/MODULE.bazel": "9208ee05fd48bf09ac60ed269791cf17fb343db56c8226a720fbb1cdf467166c",
+    "https://bcr.bazel.build/modules/rules_python/0.40.0/MODULE.bazel": "9d1a3cd88ed7d8e39583d9ffe56ae8a244f67783ae89b60caafc9f5cf318ada7",
+    "https://bcr.bazel.build/modules/rules_python/1.4.1/MODULE.bazel": "8991ad45bdc25018301d6b7e1d3626afc3c8af8aaf4bc04f23d0b99c938b73a6",
+    "https://bcr.bazel.build/modules/rules_python/1.4.1/source.json": "8ec8c90c70ccacc4de8ca1b97f599e756fb59173e898ee08b733006650057c07",
+    "https://bcr.bazel.build/modules/rules_shell/0.2.0/MODULE.bazel": "fda8a652ab3c7d8fee214de05e7a9916d8b28082234e8d2c0094505c5268ed3c",
+    "https://bcr.bazel.build/modules/rules_shell/0.3.0/MODULE.bazel": "de4402cd12f4cc8fda2354fce179fdb068c0b9ca1ec2d2b17b3e21b24c1a937b",
+    "https://bcr.bazel.build/modules/rules_shell/0.4.1/MODULE.bazel": "00e501db01bbf4e3e1dd1595959092c2fadf2087b2852d3f553b5370f5633592",
+    "https://bcr.bazel.build/modules/rules_shell/0.4.1/source.json": "4757bd277fe1567763991c4425b483477bb82e35e777a56fd846eb5cceda324a",
+    "https://bcr.bazel.build/modules/rules_swift/1.16.0/MODULE.bazel": "4a09f199545a60d09895e8281362b1ff3bb08bbde69c6fc87aff5b92fcc916ca",
+    "https://bcr.bazel.build/modules/rules_swift/2.1.1/MODULE.bazel": "494900a80f944fc7aa61500c2073d9729dff0b764f0e89b824eb746959bc1046",
+    "https://bcr.bazel.build/modules/rules_swift/2.1.1/source.json": "40fc69dfaac64deddbb75bd99cdac55f4427d9ca0afbe408576a65428427a186",
+    "https://bcr.bazel.build/modules/stardoc/0.5.1/MODULE.bazel": "1a05d92974d0c122f5ccf09291442580317cdd859f07a8655f1db9a60374f9f8",
+    "https://bcr.bazel.build/modules/stardoc/0.5.3/MODULE.bazel": "c7f6948dae6999bf0db32c1858ae345f112cacf98f174c7a8bb707e41b974f1c",
+    "https://bcr.bazel.build/modules/stardoc/0.5.6/MODULE.bazel": "c43dabc564990eeab55e25ed61c07a1aadafe9ece96a4efabb3f8bf9063b71ef",
+    "https://bcr.bazel.build/modules/stardoc/0.6.2/MODULE.bazel": "7060193196395f5dd668eda046ccbeacebfd98efc77fed418dbe2b82ffaa39fd",
+    "https://bcr.bazel.build/modules/stardoc/0.7.0/MODULE.bazel": "05e3d6d30c099b6770e97da986c53bd31844d7f13d41412480ea265ac9e8079c",
+    "https://bcr.bazel.build/modules/stardoc/0.7.1/MODULE.bazel": "3548faea4ee5dda5580f9af150e79d0f6aea934fc60c1cc50f4efdd9420759e7",
+    "https://bcr.bazel.build/modules/stardoc/0.7.2/MODULE.bazel": "fc152419aa2ea0f51c29583fab1e8c99ddefd5b3778421845606ee628629e0e5",
+    "https://bcr.bazel.build/modules/stardoc/0.7.2/source.json": "58b029e5e901d6802967754adf0a9056747e8176f017cfe3607c0851f4d42216",
+    "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.1/MODULE.bazel": "5e463fbfba7b1701d957555ed45097d7f984211330106ccd1352c6e0af0dcf91",
+    "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.1/source.json": "32bd87e5f4d7acc57c5b2ff7c325ae3061d5e242c0c4c214ae87e0f1c13e54cb",
+    "https://bcr.bazel.build/modules/tar.bzl/0.2.1/MODULE.bazel": "52d1c00a80a8cc67acbd01649e83d8dd6a9dc426a6c0b754a04fe8c219c76468",
+    "https://bcr.bazel.build/modules/tar.bzl/0.5.1/MODULE.bazel": "7c2eb3dcfc53b0f3d6f9acdfd911ca803eaf92aadf54f8ca6e4c1f3aee288351",
+    "https://bcr.bazel.build/modules/tar.bzl/0.5.1/source.json": "deed3094f7cc779ed1d37a68403847b0e38d9dd9d931e03cb90825f3368b515f",
+    "https://bcr.bazel.build/modules/toolchains_buildbuddy/0.0.4/MODULE.bazel": "735f0ed45a0334971a61157432127380ae9ce285aea6d489565cb81c7a4cf487",
+    "https://bcr.bazel.build/modules/toolchains_buildbuddy/0.0.4/source.json": "a5b69ff999ea39cf89df03cb5c174ae6fd621d7a1a7e4bd6be302ff9f2910695",
+    "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
+    "https://bcr.bazel.build/modules/yq.bzl/0.1.1/MODULE.bazel": "9039681f9bcb8958ee2c87ffc74bdafba9f4369096a2b5634b88abc0eaefa072",
+    "https://bcr.bazel.build/modules/yq.bzl/0.3.2/MODULE.bazel": "0384efa70e8033d842ea73aa4b7199fa099709e236a7264345c03937166670b6",
+    "https://bcr.bazel.build/modules/yq.bzl/0.3.2/source.json": "c4ec3e192477e154f08769e29d69e8fd36e8a4f0f623997f3e1f6f7d328f7d7d",
+    "https://bcr.bazel.build/modules/zlib/1.2.11/MODULE.bazel": "07b389abc85fdbca459b69e2ec656ae5622873af3f845e1c9d80fe179f3effa0",
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/MODULE.bazel": "eec517b5bbe5492629466e11dae908d043364302283de25581e3eb944326c4ca",
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/source.json": "22bc55c47af97246cfc093d0acf683a7869377de362b5d1c552c2c2e16b7a806",
+    "https://bcr.bazel.build/modules/zlib/1.3.1/MODULE.bazel": "751c9940dcfe869f5f7274e1295422a34623555916eb98c174c1e945594bf198"
+  },
+  "selectedYankedVersions": {},
+  "moduleExtensions": {
+    "@@aspect_tools_telemetry+//:extension.bzl%telemetry": {
+      "general": {
+        "bzlTransitiveDigest": "cl5A2O84vDL6Tt+Qga8FCj1DUDGqn+e7ly5rZ+4xvcc=",
+        "usagesDigest": "pLnkJrXl1WS1efPHDXQRX2qSyrjmhYJgshYQaUcOXkg=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "aspect_tools_telemetry_report": {
+            "repoRuleId": "@@aspect_tools_telemetry+//:extension.bzl%tel_repository",
+            "attributes": {
+              "deps": {
+                "aspect_rules_js": "2.8.3",
+                "aspect_tools_telemetry": "0.3.3"
+              }
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "aspect_tools_telemetry+",
+            "bazel_lib",
+            "bazel_lib+"
+          ],
+          [
+            "aspect_tools_telemetry+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ]
+        ]
+      }
+    },
+    "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
+      "general": {
+        "bzlTransitiveDigest": "rL/34P1aFDq2GqVC2zCFgQ8nTuOC6ziogocpvG50Qz8=",
+        "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "com_github_jetbrains_kotlin_git": {
+            "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:compiler.bzl%kotlin_compiler_git_repository",
+            "attributes": {
+              "urls": [
+                "https://github.com/JetBrains/kotlin/releases/download/v1.9.23/kotlin-compiler-1.9.23.zip"
+              ],
+              "sha256": "93137d3aab9afa9b27cb06a824c2324195c6b6f6179d8a8653f440f5bd58be88"
+            }
+          },
+          "com_github_jetbrains_kotlin": {
+            "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:compiler.bzl%kotlin_capabilities_repository",
+            "attributes": {
+              "git_repository_name": "com_github_jetbrains_kotlin_git",
+              "compiler_version": "1.9.23"
+            }
+          },
+          "com_github_google_ksp": {
+            "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:ksp.bzl%ksp_compiler_plugin_repository",
+            "attributes": {
+              "urls": [
+                "https://github.com/google/ksp/releases/download/1.9.23-1.0.20/artifacts.zip"
+              ],
+              "sha256": "ee0618755913ef7fd6511288a232e8fad24838b9af6ea73972a76e81053c8c2d",
+              "strip_version": "1.9.23-1.0.20"
+            }
+          },
+          "com_github_pinterest_ktlint": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "sha256": "01b2e0ef893383a50dbeb13970fe7fa3be36ca3e83259e01649945b09d736985",
+              "urls": [
+                "https://github.com/pinterest/ktlint/releases/download/1.3.0/ktlint"
+              ],
+              "executable": true
+            }
+          },
+          "rules_android": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806",
+              "strip_prefix": "rules_android-0.1.1",
+              "urls": [
+                "https://github.com/bazelbuild/rules_android/archive/v0.1.1.zip"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_kotlin+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_nodejs+//nodejs:extensions.bzl%node": {
+      "general": {
+        "bzlTransitiveDigest": "SqbzUarOVzAfK28Ca5+NIU3LUwnW/b3h0xXBUS97oyI=",
+        "usagesDigest": "Gi4EhJN4YOVPI6KfOCiR3lJmXvBXqfKrz3x6Nnb8aao=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "nodejs_linux_amd64": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
+            "attributes": {
+              "node_download_auth": {},
+              "node_repositories": {},
+              "node_urls": [
+                "https://nodejs.org/dist/v{version}/{filename}"
+              ],
+              "node_version": "20.11.1",
+              "include_headers": false,
+              "platform": "linux_amd64"
+            }
+          },
+          "nodejs_linux_arm64": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
+            "attributes": {
+              "node_download_auth": {},
+              "node_repositories": {},
+              "node_urls": [
+                "https://nodejs.org/dist/v{version}/{filename}"
+              ],
+              "node_version": "20.11.1",
+              "include_headers": false,
+              "platform": "linux_arm64"
+            }
+          },
+          "nodejs_linux_s390x": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
+            "attributes": {
+              "node_download_auth": {},
+              "node_repositories": {},
+              "node_urls": [
+                "https://nodejs.org/dist/v{version}/{filename}"
+              ],
+              "node_version": "20.11.1",
+              "include_headers": false,
+              "platform": "linux_s390x"
+            }
+          },
+          "nodejs_linux_ppc64le": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
+            "attributes": {
+              "node_download_auth": {},
+              "node_repositories": {},
+              "node_urls": [
+                "https://nodejs.org/dist/v{version}/{filename}"
+              ],
+              "node_version": "20.11.1",
+              "include_headers": false,
+              "platform": "linux_ppc64le"
+            }
+          },
+          "nodejs_darwin_amd64": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
+            "attributes": {
+              "node_download_auth": {},
+              "node_repositories": {},
+              "node_urls": [
+                "https://nodejs.org/dist/v{version}/{filename}"
+              ],
+              "node_version": "20.11.1",
+              "include_headers": false,
+              "platform": "darwin_amd64"
+            }
+          },
+          "nodejs_darwin_arm64": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
+            "attributes": {
+              "node_download_auth": {},
+              "node_repositories": {},
+              "node_urls": [
+                "https://nodejs.org/dist/v{version}/{filename}"
+              ],
+              "node_version": "20.11.1",
+              "include_headers": false,
+              "platform": "darwin_arm64"
+            }
+          },
+          "nodejs_windows_amd64": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
+            "attributes": {
+              "node_download_auth": {},
+              "node_repositories": {},
+              "node_urls": [
+                "https://nodejs.org/dist/v{version}/{filename}"
+              ],
+              "node_version": "20.11.1",
+              "include_headers": false,
+              "platform": "windows_amd64"
+            }
+          },
+          "nodejs": {
+            "repoRuleId": "@@rules_nodejs+//nodejs/private:nodejs_repo_host_os_alias.bzl%nodejs_repo_host_os_alias",
+            "attributes": {
+              "user_node_repository_name": "nodejs"
+            }
+          },
+          "nodejs_host": {
+            "repoRuleId": "@@rules_nodejs+//nodejs/private:nodejs_repo_host_os_alias.bzl%nodejs_repo_host_os_alias",
+            "attributes": {
+              "user_node_repository_name": "nodejs"
+            }
+          },
+          "nodejs_toolchains": {
+            "repoRuleId": "@@rules_nodejs+//nodejs/private:nodejs_toolchains_repo.bzl%nodejs_toolchains_repo",
+            "attributes": {
+              "user_node_repository_name": "nodejs"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": []
+      }
+    },
+    "@@rules_python+//python/uv:uv.bzl%uv": {
+      "general": {
+        "bzlTransitiveDigest": "Xpqjnjzy6zZ90Es9Wa888ZLHhn7IsNGbph/e6qoxzw8=",
+        "usagesDigest": "4JapxcpS0mL3524k0TZJffAtVyuRjDHZvN9kBRxxF1U=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "uv": {
+            "repoRuleId": "@@rules_python+//python/uv/private:uv_toolchains_repo.bzl%uv_toolchains_repo",
+            "attributes": {
+              "toolchain_type": "'@@rules_python+//python/uv:uv_toolchain_type'",
+              "toolchain_names": [
+                "none"
+              ],
+              "toolchain_implementations": {
+                "none": "'@@rules_python+//python:none'"
+              },
+              "toolchain_compatible_with": {
+                "none": [
+                  "@platforms//:incompatible"
+                ]
+              },
+              "toolchain_target_settings": {}
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_python+",
+            "platforms",
+            "platforms"
+          ]
+        ]
+      }
+    },
+    "@@tar.bzl+//tar:extensions.bzl%toolchains": {
+      "general": {
+        "bzlTransitiveDigest": "/2afh6fPjq/rcyE/jztQDK3ierehmFFngfvmqyRv72M=",
+        "usagesDigest": "maF8qsAIqeH1ey8pxP0gNZbvJt34kLZvTFeQ0ntrJVA=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "bsd_tar_toolchains": {
+            "repoRuleId": "@@tar.bzl+//tar/toolchain:toolchain.bzl%tar_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "bsd_tar_toolchains"
+            }
+          },
+          "bsd_tar_toolchains_darwin_amd64": {
+            "repoRuleId": "@@tar.bzl+//tar/toolchain:platforms.bzl%bsdtar_binary_repo",
+            "attributes": {
+              "platform": "darwin_amd64"
+            }
+          },
+          "bsd_tar_toolchains_darwin_arm64": {
+            "repoRuleId": "@@tar.bzl+//tar/toolchain:platforms.bzl%bsdtar_binary_repo",
+            "attributes": {
+              "platform": "darwin_arm64"
+            }
+          },
+          "bsd_tar_toolchains_linux_amd64": {
+            "repoRuleId": "@@tar.bzl+//tar/toolchain:platforms.bzl%bsdtar_binary_repo",
+            "attributes": {
+              "platform": "linux_amd64"
+            }
+          },
+          "bsd_tar_toolchains_linux_arm64": {
+            "repoRuleId": "@@tar.bzl+//tar/toolchain:platforms.bzl%bsdtar_binary_repo",
+            "attributes": {
+              "platform": "linux_arm64"
+            }
+          },
+          "bsd_tar_toolchains_windows_amd64": {
+            "repoRuleId": "@@tar.bzl+//tar/toolchain:platforms.bzl%bsdtar_binary_repo",
+            "attributes": {
+              "platform": "windows_amd64"
+            }
+          },
+          "bsd_tar_toolchains_windows_arm64": {
+            "repoRuleId": "@@tar.bzl+//tar/toolchain:platforms.bzl%bsdtar_binary_repo",
+            "attributes": {
+              "platform": "windows_arm64"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": []
+      }
+    },
+    "@@toolchains_buildbuddy+//:extensions.bzl%buildbuddy": {
+      "general": {
+        "bzlTransitiveDigest": "YThiSErJv+jiCHJzZIEyk0yegQRS/x+T/ce309eGTvA=",
+        "usagesDigest": "DPJsxTVmxbvQevUwqgBk0vfNPszfeUaM+dPhDQL5XMM=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "buildbuddy_toolchain": {
+            "repoRuleId": "@@toolchains_buildbuddy+//:rules.bzl%_buildbuddy_toolchain",
+            "attributes": {
+              "container_image": "",
+              "llvm": false,
+              "java_version": "",
+              "gcc_version": "",
+              "msvc_edition": "Community",
+              "msvc_release": "2022",
+              "msvc_version": "14.39.33519",
+              "windows_kits_release": "10",
+              "windows_kits_version": "10.0.22621.0",
+              "extra_cxx_builtin_include_directories": []
+            }
+          }
+        },
+        "recordedRepoMappingEntries": []
+      }
+    },
+    "@@yq.bzl+//yq:extensions.bzl%yq": {
+      "general": {
+        "bzlTransitiveDigest": "61Uz+o5PnlY0jJfPZEUNqsKxnM/UCLeWsn5VVCc8u5Y=",
+        "usagesDigest": "L+otO9xvwIFywi8vrhskBwjeWSSCE7f5iIykUFebyao=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "yq_darwin_amd64": {
+            "repoRuleId": "@@yq.bzl+//yq/toolchain:platforms.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64",
+              "version": "4.45.1"
+            }
+          },
+          "yq_darwin_arm64": {
+            "repoRuleId": "@@yq.bzl+//yq/toolchain:platforms.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64",
+              "version": "4.45.1"
+            }
+          },
+          "yq_linux_amd64": {
+            "repoRuleId": "@@yq.bzl+//yq/toolchain:platforms.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64",
+              "version": "4.45.1"
+            }
+          },
+          "yq_linux_arm64": {
+            "repoRuleId": "@@yq.bzl+//yq/toolchain:platforms.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64",
+              "version": "4.45.1"
+            }
+          },
+          "yq_linux_s390x": {
+            "repoRuleId": "@@yq.bzl+//yq/toolchain:platforms.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "linux_s390x",
+              "version": "4.45.1"
+            }
+          },
+          "yq_linux_riscv64": {
+            "repoRuleId": "@@yq.bzl+//yq/toolchain:platforms.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "linux_riscv64",
+              "version": "4.45.1"
+            }
+          },
+          "yq_linux_ppc64le": {
+            "repoRuleId": "@@yq.bzl+//yq/toolchain:platforms.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "linux_ppc64le",
+              "version": "4.45.1"
+            }
+          },
+          "yq_windows_amd64": {
+            "repoRuleId": "@@yq.bzl+//yq/toolchain:platforms.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64",
+              "version": "4.45.1"
+            }
+          },
+          "yq_toolchains": {
+            "repoRuleId": "@@yq.bzl+//yq/toolchain:toolchain.bzl%yq_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "yq"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": []
+      }
+    }
+  },
+  "facts": {}
+}

--- a/rules_formatjs/examples/aggregate/README.md
+++ b/rules_formatjs/examples/aggregate/README.md
@@ -1,0 +1,154 @@
+# Message Aggregation Example
+
+This example demonstrates how to use the `formatjs_aggregate_aspect` to collect and merge extracted messages from multiple modules into a single JSON file.
+
+## Project Structure
+
+This is a standalone Bazel workspace with the following structure:
+
+```
+aggregate/
+├── MODULE.bazel             # Bazel workspace configuration
+├── BUILD.bazel              # Root build file
+├── module1/
+│   ├── BUILD.bazel         # Module 1 build configuration
+│   └── Messages.tsx        # Module 1 messages
+├── module2/
+│   ├── BUILD.bazel         # Module 2 build configuration
+│   └── Messages.tsx        # Module 2 messages
+├── module3/
+│   ├── BUILD.bazel         # Module 3 build configuration (depends on module1)
+│   └── Messages.tsx        # Module 3 messages (includes some common messages)
+└── app/
+    ├── BUILD.bazel         # Application build configuration
+    ├── App.tsx             # Application that uses all modules
+    └── expected.json       # Expected aggregated messages for testing
+```
+
+## Key Features
+
+- **Transitive Dependency Collection**: Module 3 depends on Module 1, and the app only depends on Module 2 and Module 3. The aspect automatically traverses the dependency graph to collect messages from Module 1 transitively, demonstrating proper dependency graph traversal.
+- **Application-Level Aggregation**: The `formatjs_aggregate` target is at the app level, collecting messages from direct and transitive dependencies
+- **Automated Testing**: Includes a snapshot test that verifies the aggregated output contains all expected messages, including those from Module 1 (which is only a transitive dependency)
+
+## Usage
+
+### Extract Messages from Individual Modules
+
+Extract messages from each module separately:
+
+```bash
+cd examples/aggregate
+bazel build //module1:messages
+bazel build //module2:messages
+bazel build //module3:messages
+```
+
+### Aggregate Messages from All Modules
+
+The `formatjs_aggregate` rule automatically applies the aspect to collect and merge all messages:
+
+```bash
+bazel build //app:all_messages
+```
+
+This will create a single JSON file containing all messages from all three modules. The rule automatically:
+
+- Applies the `formatjs_aggregate_aspect` to traverse dependencies
+- Collects messages from `module2` and `module3` (direct deps)
+- Transitively collects messages from `module1` (via module3's dependency)
+- Merges all messages into a single JSON file using jq
+
+### Run the Test
+
+Verify that the aggregation works correctly:
+
+```bash
+bazel test //app:aggregation_test
+```
+
+This test uses snapshot testing with `write_source_files` to verify the aggregated output matches the expected fixture.
+
+### Update the Snapshot
+
+If you intentionally change the messages, update the snapshot:
+
+```bash
+bazel run //app:update_all_messages_fixture
+```
+
+## Output
+
+The aggregated file will be located at:
+
+```
+bazel-bin/app/all_messages.json
+```
+
+It will contain all messages from all three modules merged into a single JSON object:
+
+```json
+{
+  "module1.title": {
+    "defaultMessage": "Module 1 Title",
+    "description": "Title for module 1"
+  },
+  "module1.description": {
+    "defaultMessage": "This is the first module",
+    "description": "Description for module 1"
+  },
+  "module2.title": {
+    "defaultMessage": "Module 2 Title",
+    "description": "Title for module 2"
+  },
+  "module2.description": {
+    "defaultMessage": "This is the second module",
+    "description": "Description for module 2"
+  },
+  "module3.title": {
+    "defaultMessage": "Module 3 Title",
+    "description": "Title for module 3"
+  },
+  "module3.description": {
+    "defaultMessage": "This is the third module",
+    "description": "Description for module 3"
+  },
+  "common.save": {
+    "defaultMessage": "Save",
+    "description": "Common save button"
+  },
+  "common.cancel": {
+    "defaultMessage": "Cancel",
+    "description": "Common cancel button"
+  }
+}
+```
+
+## How It Works
+
+1. **Extraction**: Each `formatjs_extract` rule extracts messages from its source files
+2. **Dependency Graph**: Module3 depends on Module1, and the app depends on Module2 and Module3
+3. **Aspect Application**: The `formatjs_aggregate` rule applies `formatjs_aggregate_aspect` to its deps
+4. **Transitive Collection**: The aspect traverses the dependency graph, collecting messages from:
+   - Module2 (direct dependency)
+   - Module3 (direct dependency)
+   - Module1 (transitive dependency via Module3)
+5. **Aggregation**: All message files are collected using `FormatjsExtractInfo` and `FormatjsAggregateInfo` providers
+6. **Merging**: `jq` merges all JSON files into a single file using object multiplication
+
+The merge strategy uses `jq`'s `reduce .[] as $item ({}; . * $item)` which:
+
+- Starts with an empty object `{}`
+- Iterates through all message files
+- Merges each file into the result using `*` (object multiplication)
+- Later files overwrite earlier ones for duplicate keys
+
+## Use Cases
+
+This aggregation is useful for:
+
+- **Monorepo Translation**: Collect all messages from multiple packages/modules
+- **Build-time Validation**: Ensure no duplicate message IDs across modules
+- **Translation Workflows**: Generate a single file for translators
+- **CI/CD**: Check for message changes across the entire codebase
+- **Bundle Optimization**: Create optimized message bundles per locale

--- a/rules_formatjs/examples/aggregate/app/App.tsx
+++ b/rules_formatjs/examples/aggregate/app/App.tsx
@@ -1,0 +1,13 @@
+import {Module1Messages} from '../module1/Messages'
+import {Module2Messages} from '../module2/Messages'
+import {Module3Messages} from '../module3/Messages'
+
+export function App() {
+  return (
+    <>
+      <Module1Messages />
+      <Module2Messages />
+      <Module3Messages />
+    </>
+  )
+}

--- a/rules_formatjs/examples/aggregate/app/BUILD.bazel
+++ b/rules_formatjs/examples/aggregate/app/BUILD.bazel
@@ -1,0 +1,32 @@
+"""Application that aggregates messages from all modules"""
+
+load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
+load("@rules_formatjs//formatjs:defs.bzl", "formatjs_aggregate")
+
+# Aggregate messages from module2 and module3
+# Module3 depends on module1, so module1's messages should be included transitively
+# This demonstrates that the aspect properly traverses the dependency graph
+formatjs_aggregate(
+    name = "all_messages",
+    deps = [
+        "//module2:messages",
+        "//module3:messages",
+    ],
+)
+
+# Snapshot test - verifies that aggregated messages match the expected fixture
+# Run `bazel run //app:update_all_messages_fixture` to update the snapshot
+write_source_files(
+    name = "update_all_messages_fixture",
+    files = {
+        "all_messages.fixture.json": ":all_messages",
+    },
+)
+
+# Test target - verifies the snapshot hasn't changed
+write_source_files(
+    name = "aggregation_test",
+    files = {
+        "all_messages.fixture.json": ":all_messages",
+    },
+)

--- a/rules_formatjs/examples/aggregate/app/all_messages.fixture.json
+++ b/rules_formatjs/examples/aggregate/app/all_messages.fixture.json
@@ -1,0 +1,10 @@
+{
+  "module2.description": "This is the second module",
+  "module2.title": "Module 2 Title",
+  "common.cancel": "Cancel",
+  "common.save": "Save",
+  "module3.description": "This is the third module",
+  "module3.title": "Module 3 Title",
+  "module1.description": "This is the first module",
+  "module1.title": "Module 1 Title"
+}

--- a/rules_formatjs/examples/aggregate/app/test.sh
+++ b/rules_formatjs/examples/aggregate/app/test.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Test script for message aggregation
+# This script verifies that the aggregated messages contain all expected messages from all modules
+
+set -euo pipefail
+
+# Get the aggregated messages file
+AGGREGATED_FILE="$1"
+
+if [ ! -f "$AGGREGATED_FILE" ]; then
+  echo "ERROR: Aggregated messages file not found: $AGGREGATED_FILE"
+  exit 1
+fi
+
+echo "Testing aggregated messages file: $AGGREGATED_FILE"
+
+# Check that the file is valid JSON
+if ! jq empty "$AGGREGATED_FILE" 2>/dev/null; then
+  echo "ERROR: File is not valid JSON"
+  exit 1
+fi
+
+# Expected message IDs from all modules
+EXPECTED_IDS=(
+  "module1.title"
+  "module1.description"
+  "module2.title"
+  "module2.description"
+  "module3.title"
+  "module3.description"
+  "common.save"
+  "common.cancel"
+)
+
+# Check that all expected message IDs exist
+for id in "${EXPECTED_IDS[@]}"; do
+  if ! jq -e ".[\"$id\"]" "$AGGREGATED_FILE" >/dev/null 2>&1; then
+    echo "ERROR: Expected message ID not found: $id"
+    exit 1
+  fi
+  echo "✓ Found message: $id"
+done
+
+# Count total messages
+TOTAL_COUNT=$(jq 'length' "$AGGREGATED_FILE")
+EXPECTED_COUNT=${#EXPECTED_IDS[@]}
+
+echo ""
+echo "Summary:"
+echo "  Expected messages: $EXPECTED_COUNT"
+echo "  Found messages: $TOTAL_COUNT"
+
+if [ "$TOTAL_COUNT" -ne "$EXPECTED_COUNT" ]; then
+  echo "ERROR: Message count mismatch!"
+  exit 1
+fi
+
+echo ""
+echo "✓ All tests passed!"

--- a/rules_formatjs/examples/aggregate/module1/BUILD.bazel
+++ b/rules_formatjs/examples/aggregate/module1/BUILD.bazel
@@ -1,0 +1,11 @@
+"""Module 1 - Basic messages"""
+
+load("@rules_formatjs//formatjs:defs.bzl", "formatjs_extract")
+
+formatjs_extract(
+    name = "messages",
+    srcs = ["Messages.tsx"],
+    formatjs_cli = "//:formatjs_cli",
+    id_interpolation_pattern = "[sha512:contenthash:base64:6]",
+    visibility = ["//visibility:public"],
+)

--- a/rules_formatjs/examples/aggregate/module1/Messages.tsx
+++ b/rules_formatjs/examples/aggregate/module1/Messages.tsx
@@ -1,0 +1,18 @@
+import {FormattedMessage} from 'react-intl'
+
+export function Module1Messages() {
+  return (
+    <>
+      <FormattedMessage
+        id="module1.title"
+        defaultMessage="Module 1 Title"
+        description="Title for module 1"
+      />
+      <FormattedMessage
+        id="module1.description"
+        defaultMessage="This is the first module"
+        description="Description for module 1"
+      />
+    </>
+  )
+}

--- a/rules_formatjs/examples/aggregate/module2/BUILD.bazel
+++ b/rules_formatjs/examples/aggregate/module2/BUILD.bazel
@@ -1,0 +1,11 @@
+"""Module 2 - Basic messages"""
+
+load("@rules_formatjs//formatjs:defs.bzl", "formatjs_extract")
+
+formatjs_extract(
+    name = "messages",
+    srcs = ["Messages.tsx"],
+    formatjs_cli = "//:formatjs_cli",
+    id_interpolation_pattern = "[sha512:contenthash:base64:6]",
+    visibility = ["//visibility:public"],
+)

--- a/rules_formatjs/examples/aggregate/module2/Messages.tsx
+++ b/rules_formatjs/examples/aggregate/module2/Messages.tsx
@@ -1,0 +1,18 @@
+import {FormattedMessage} from 'react-intl'
+
+export function Module2Messages() {
+  return (
+    <>
+      <FormattedMessage
+        id="module2.title"
+        defaultMessage="Module 2 Title"
+        description="Title for module 2"
+      />
+      <FormattedMessage
+        id="module2.description"
+        defaultMessage="This is the second module"
+        description="Description for module 2"
+      />
+    </>
+  )
+}

--- a/rules_formatjs/examples/aggregate/module3/BUILD.bazel
+++ b/rules_formatjs/examples/aggregate/module3/BUILD.bazel
@@ -1,0 +1,12 @@
+"""Module 3 - Messages with common strings, depends on Module 1"""
+
+load("@rules_formatjs//formatjs:defs.bzl", "formatjs_extract")
+
+formatjs_extract(
+    name = "messages",
+    srcs = ["Messages.tsx"],
+    formatjs_cli = "//:formatjs_cli",
+    id_interpolation_pattern = "[sha512:contenthash:base64:6]",
+    visibility = ["//visibility:public"],
+    deps = ["//module1:messages"],
+)

--- a/rules_formatjs/examples/aggregate/module3/Messages.tsx
+++ b/rules_formatjs/examples/aggregate/module3/Messages.tsx
@@ -1,0 +1,28 @@
+import {FormattedMessage} from 'react-intl'
+
+export function Module3Messages() {
+  return (
+    <>
+      <FormattedMessage
+        id="module3.title"
+        defaultMessage="Module 3 Title"
+        description="Title for module 3"
+      />
+      <FormattedMessage
+        id="module3.description"
+        defaultMessage="This is the third module"
+        description="Description for module 3"
+      />
+      <FormattedMessage
+        id="common.save"
+        defaultMessage="Save"
+        description="Common save button"
+      />
+      <FormattedMessage
+        id="common.cancel"
+        defaultMessage="Cancel"
+        description="Common cancel button"
+      />
+    </>
+  )
+}

--- a/rules_formatjs/examples/aggregate/package.json
+++ b/rules_formatjs/examples/aggregate/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "formatjs-example-aggregate",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@formatjs/cli": "^6.8.8"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": []
+  }
+}

--- a/rules_formatjs/examples/aggregate/pnpm-lock.yaml
+++ b/rules_formatjs/examples/aggregate/pnpm-lock.yaml
@@ -1,0 +1,50 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@formatjs/cli':
+        specifier: ^6.8.8
+        version: 6.8.8
+
+packages:
+
+  '@formatjs/cli@6.8.8':
+    resolution: {integrity: sha512-YTN8BO0z8dZAMJyXxjpYRxAKuxbfVH0oBKger593/8Ql6+q691YI23yt8DP0L+6b9JzlYOoIa1ghTzd8vaukPw==}
+    engines: {node: '>= 16'}
+    hasBin: true
+    peerDependencies:
+      '@glimmer/env': '*'
+      '@glimmer/reference': '*'
+      '@glimmer/syntax': ^0.95.0
+      '@glimmer/validator': '*'
+      '@vue/compiler-core': ^3.5.12
+      content-tag: '4'
+      ember-template-recast: ^6.1.5
+      vue: ^3.5.12
+    peerDependenciesMeta:
+      '@glimmer/env':
+        optional: true
+      '@glimmer/reference':
+        optional: true
+      '@glimmer/syntax':
+        optional: true
+      '@glimmer/validator':
+        optional: true
+      '@vue/compiler-core':
+        optional: true
+      content-tag:
+        optional: true
+      ember-template-recast:
+        optional: true
+      vue:
+        optional: true
+
+snapshots:
+
+  '@formatjs/cli@6.8.8': {}

--- a/rules_formatjs/examples/simple/.bazelrc
+++ b/rules_formatjs/examples/simple/.bazelrc
@@ -1,0 +1,33 @@
+# Bazel configuration for rules_formatjs simple example
+
+common --enable_bzlmod
+common --color=yes
+
+# Output and debugging
+build --show_timestamps
+build --verbose_failures
+
+# Performance
+build --remote_cache_compression
+build --legacy_important_outputs
+build --remote_build_event_upload=minimal
+build --noslim_profile
+build --experimental_profile_include_target_label
+build --experimental_profile_include_primary_output
+common --bes_upload_mode=fully_async
+
+# BuildBuddy CI configuration
+# https://www.buildbuddy.io/docs/rbe-github-actions
+build:ci --build_metadata=ROLE=CI
+build:ci --build_metadata=VISIBILITY=PUBLIC
+build:ci --config=remote
+
+build:remote --bes_backend=grpcs://formatjs.buildbuddy.io
+build:remote --bes_results_url=https://formatjs.buildbuddy.io/invocation/
+build:remote --define=EXECUTOR=remote
+build:remote --jobs=50
+build:remote --remote_cache=grpcs://formatjs.buildbuddy.io
+build:remote --remote_timeout=10m
+
+# Try to import a user-specific .bazelrc
+try-import %workspace%/.bazelrc.user

--- a/rules_formatjs/examples/simple/.npmrc
+++ b/rules_formatjs/examples/simple/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/rules_formatjs/examples/simple/BUILD.bazel
+++ b/rules_formatjs/examples/simple/BUILD.bazel
@@ -1,0 +1,73 @@
+load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
+load("@npm//:@formatjs/cli/package_json.bzl", formatjs_bin = "bin")
+load("@npm//:defs.bzl", "npm_link_all_packages")
+load("@rules_formatjs//formatjs:defs.bzl", "formatjs_compile", "formatjs_extract", "formatjs_verify_test")
+
+npm_link_all_packages(name = "node_modules")
+
+# Create formatjs CLI binary target
+formatjs_bin.formatjs_binary(
+    name = "formatjs_cli",
+    visibility = ["//visibility:public"],
+)
+
+# Extract messages from source files
+formatjs_extract(
+    name = "extract_messages",
+    srcs = ["src/App.tsx"],
+    out = "messages/en.json",
+    formatjs_cli = ":formatjs_cli",
+    id_interpolation_pattern = "[sha512:contenthash:base64:6]",
+)
+
+# Compile messages for production
+formatjs_compile(
+    name = "compile_messages",
+    src = ":extract_messages",
+    out = "messages/en-compiled.json",
+    ast = True,
+    formatjs_cli = ":formatjs_cli",
+)
+
+# Snapshot test for extraction
+write_source_files(
+    name = "test_extract",
+    files = {
+        "extract_messages.fixture.json": ":extract_messages",
+    },
+)
+
+# Update extraction snapshot
+write_source_files(
+    name = "update_extract_fixture",
+    files = {
+        "extract_messages.fixture.json": ":extract_messages",
+    },
+)
+
+# Snapshot test for compilation
+write_source_files(
+    name = "test_compile",
+    files = {
+        "compile_messages.fixture.json": ":compile_messages",
+    },
+)
+
+# Update compilation snapshot
+write_source_files(
+    name = "update_compile_fixture",
+    files = {
+        "compile_messages.fixture.json": ":compile_messages",
+    },
+)
+
+# Verify French translation is valid and complete
+formatjs_verify_test(
+    name = "verify_french_translation",
+    formatjs_cli = ":formatjs_cli",
+    source_locale = "en",
+    translations = [
+        ":extract_messages",  # en.json (source)
+        "messages/fr.json",  # fr.json (translation)
+    ],
+)

--- a/rules_formatjs/examples/simple/MODULE.bazel
+++ b/rules_formatjs/examples/simple/MODULE.bazel
@@ -1,0 +1,26 @@
+"""Simple example using rules_formatjs"""
+
+module(
+    name = "formatjs_example_simple",
+    version = "0.0.0",
+)
+
+bazel_dep(name = "rules_formatjs", version = "0.0.0")
+local_path_override(
+    module_name = "rules_formatjs",
+    path = "../..",
+)
+
+bazel_dep(name = "aspect_bazel_lib", version = "2.22.2")
+bazel_dep(name = "aspect_rules_js", version = "2.8.3")
+bazel_dep(name = "rules_nodejs", version = "6.3.0")
+
+node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
+node.toolchain(node_version = "20.11.1")
+
+npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm")
+npm.npm_translate_lock(
+    name = "npm",
+    pnpm_lock = "//:pnpm-lock.yaml",
+)
+use_repo(npm, "npm")

--- a/rules_formatjs/examples/simple/MODULE.bazel.lock
+++ b/rules_formatjs/examples/simple/MODULE.bazel.lock
@@ -1,0 +1,630 @@
+{
+  "lockFileVersion": 24,
+  "registryFileHashes": {
+    "https://bcr.bazel.build/bazel_registry.json": "8a28e4aff06ee60aed2a8c281907fb8bcbf3b753c91fb5a5c57da3215d5b3497",
+    "https://bcr.bazel.build/modules/abseil-cpp/20210324.2/MODULE.bazel": "7cd0312e064fde87c8d1cd79ba06c876bd23630c83466e9500321be55c96ace2",
+    "https://bcr.bazel.build/modules/abseil-cpp/20211102.0/MODULE.bazel": "70390338f7a5106231d20620712f7cccb659cd0e9d073d1991c038eb9fc57589",
+    "https://bcr.bazel.build/modules/abseil-cpp/20230125.1/MODULE.bazel": "89047429cb0207707b2dface14ba7f8df85273d484c2572755be4bab7ce9c3a0",
+    "https://bcr.bazel.build/modules/abseil-cpp/20230802.0.bcr.1/MODULE.bazel": "1c8cec495288dccd14fdae6e3f95f772c1c91857047a098fad772034264cc8cb",
+    "https://bcr.bazel.build/modules/abseil-cpp/20230802.0/MODULE.bazel": "d253ae36a8bd9ee3c5955384096ccb6baf16a1b1e93e858370da0a3b94f77c16",
+    "https://bcr.bazel.build/modules/abseil-cpp/20230802.1/MODULE.bazel": "fa92e2eb41a04df73cdabeec37107316f7e5272650f81d6cc096418fe647b915",
+    "https://bcr.bazel.build/modules/abseil-cpp/20240116.1/MODULE.bazel": "37bcdb4440fbb61df6a1c296ae01b327f19e9bb521f9b8e26ec854b6f97309ed",
+    "https://bcr.bazel.build/modules/abseil-cpp/20240116.2/MODULE.bazel": "73939767a4686cd9a520d16af5ab440071ed75cec1a876bf2fcfaf1f71987a16",
+    "https://bcr.bazel.build/modules/abseil-cpp/20250127.1/MODULE.bazel": "c4a89e7ceb9bf1e25cf84a9f830ff6b817b72874088bf5141b314726e46a57c1",
+    "https://bcr.bazel.build/modules/abseil-cpp/20250512.1/MODULE.bazel": "d209fdb6f36ffaf61c509fcc81b19e81b411a999a934a032e10cd009a0226215",
+    "https://bcr.bazel.build/modules/abseil-cpp/20250814.0/MODULE.bazel": "c43c16ca2c432566cdb78913964497259903ebe8fb7d9b57b38e9f1425b427b8",
+    "https://bcr.bazel.build/modules/abseil-cpp/20250814.0/source.json": "b88bff599ceaf0f56c264c749b1606f8485cec3b8c38ba30f88a4df9af142861",
+    "https://bcr.bazel.build/modules/apple_support/1.11.1/MODULE.bazel": "1843d7cd8a58369a444fc6000e7304425fba600ff641592161d9f15b179fb896",
+    "https://bcr.bazel.build/modules/apple_support/1.15.1/MODULE.bazel": "a0556fefca0b1bb2de8567b8827518f94db6a6e7e7d632b4c48dc5f865bc7c85",
+    "https://bcr.bazel.build/modules/apple_support/1.23.1/MODULE.bazel": "53763fed456a968cf919b3240427cf3a9d5481ec5466abc9d5dc51bc70087442",
+    "https://bcr.bazel.build/modules/apple_support/1.23.1/source.json": "d888b44312eb0ad2c21a91d026753f330caa48a25c9b2102fae75eb2b0dcfdd2",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.14.0/MODULE.bazel": "2b31ffcc9bdc8295b2167e07a757dbbc9ac8906e7028e5170a3708cecaac119f",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.17.1/MODULE.bazel": "9b027af55f619c7c444cead71061578fab6587e5e1303fa4ed61d49d2b1a7262",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.19.3/MODULE.bazel": "253d739ba126f62a5767d832765b12b59e9f8d2bc88cc1572f4a73e46eb298ca",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.22.2/MODULE.bazel": "6b735f3fdd64978e217c9725f4ff0d84bf606554c8e77d20e90977841d7ff2ed",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.22.2/source.json": "58fffa2d722cff47cb8d921c8bbed7701c53f233009d9ca82beb4a0fb8fb9418",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.8.1/MODULE.bazel": "812d2dd42f65dca362152101fbec418029cc8fd34cbad1a2fde905383d705838",
+    "https://bcr.bazel.build/modules/aspect_rules_js/2.8.3/MODULE.bazel": "807ce5f624124a8bc586c743394d174e85f0f9c6c4e0e2410b4088aebe790ac8",
+    "https://bcr.bazel.build/modules/aspect_rules_js/2.8.3/source.json": "c35cb4e04f61a09c17f8c569894b80de884b1e3dee2d33829704786e3f778037",
+    "https://bcr.bazel.build/modules/aspect_tools_telemetry/0.3.3/MODULE.bazel": "37c764292861c2f70314efa9846bb6dbb44fc0308903b3285da6528305450183",
+    "https://bcr.bazel.build/modules/aspect_tools_telemetry/0.3.3/source.json": "605086bbc197743a0d360f7ddc550a1d4dfa0441bc807236e17170f636153348",
+    "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
+    "https://bcr.bazel.build/modules/bazel_features/1.11.0/MODULE.bazel": "f9382337dd5a474c3b7d334c2f83e50b6eaedc284253334cf823044a26de03e8",
+    "https://bcr.bazel.build/modules/bazel_features/1.15.0/MODULE.bazel": "d38ff6e517149dc509406aca0db3ad1efdd890a85e049585b7234d04238e2a4d",
+    "https://bcr.bazel.build/modules/bazel_features/1.17.0/MODULE.bazel": "039de32d21b816b47bd42c778e0454217e9c9caac4a3cf8e15c7231ee3ddee4d",
+    "https://bcr.bazel.build/modules/bazel_features/1.18.0/MODULE.bazel": "1be0ae2557ab3a72a57aeb31b29be347bcdc5d2b1eb1e70f39e3851a7e97041a",
+    "https://bcr.bazel.build/modules/bazel_features/1.19.0/MODULE.bazel": "59adcdf28230d220f0067b1f435b8537dd033bfff8db21335ef9217919c7fb58",
+    "https://bcr.bazel.build/modules/bazel_features/1.21.0/MODULE.bazel": "675642261665d8eea09989aa3b8afb5c37627f1be178382c320d1b46afba5e3b",
+    "https://bcr.bazel.build/modules/bazel_features/1.23.0/MODULE.bazel": "fd1ac84bc4e97a5a0816b7fd7d4d4f6d837b0047cf4cbd81652d616af3a6591a",
+    "https://bcr.bazel.build/modules/bazel_features/1.27.0/MODULE.bazel": "621eeee06c4458a9121d1f104efb80f39d34deff4984e778359c60eaf1a8cb65",
+    "https://bcr.bazel.build/modules/bazel_features/1.28.0/MODULE.bazel": "4b4200e6cbf8fa335b2c3f43e1d6ef3e240319c33d43d60cc0fbd4b87ece299d",
+    "https://bcr.bazel.build/modules/bazel_features/1.3.0/MODULE.bazel": "cdcafe83ec318cda34e02948e81d790aab8df7a929cec6f6969f13a489ccecd9",
+    "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
+    "https://bcr.bazel.build/modules/bazel_features/1.30.0/source.json": "b07e17f067fe4f69f90b03b36ef1e08fe0d1f3cac254c1241a1818773e3423bc",
+    "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
+    "https://bcr.bazel.build/modules/bazel_features/1.9.0/MODULE.bazel": "885151d58d90d8d9c811eb75e3288c11f850e1d6b481a8c9f766adee4712358b",
+    "https://bcr.bazel.build/modules/bazel_features/1.9.1/MODULE.bazel": "8f679097876a9b609ad1f60249c49d68bfab783dd9be012faf9d82547b14815a",
+    "https://bcr.bazel.build/modules/bazel_lib/3.0.0-rc.0/MODULE.bazel": "d6e00979a98ac14ada5e31c8794708b41434d461e7e7ca39b59b765e6d233b18",
+    "https://bcr.bazel.build/modules/bazel_lib/3.0.0/MODULE.bazel": "22b70b80ac89ad3f3772526cd9feee2fa412c2b01933fea7ed13238a448d370d",
+    "https://bcr.bazel.build/modules/bazel_lib/3.0.0/source.json": "895f21909c6fba01d7c17914bb6c8e135982275a1b18cdaa4e62272217ef1751",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.0.3/MODULE.bazel": "bcb0fd896384802d1ad283b4e4eb4d718eebd8cb820b0a2c3a347fb971afd9d8",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.1.1/MODULE.bazel": "1add3e7d93ff2e6998f9e118022c84d163917d912f5afafb3058e3d2f1545b5e",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.2.0/MODULE.bazel": "44fe84260e454ed94ad326352a698422dbe372b21a1ac9f3eab76eb531223686",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.2.1/MODULE.bazel": "f35baf9da0efe45fa3da1696ae906eea3d615ad41e2e3def4aeb4e8bc0ef9a7a",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.3.0/MODULE.bazel": "20228b92868bf5cfc41bda7afc8a8ba2a543201851de39d990ec957b513579c5",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.4.1/MODULE.bazel": "a0dcb779424be33100dcae821e9e27e4f2901d9dfd5333efe5ac6a8d7ab75e1d",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.4.2/MODULE.bazel": "3bd40978e7a1fac911d5989e6b09d8f64921865a45822d8b09e815eaa726a651",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.5.0/MODULE.bazel": "32880f5e2945ce6a03d1fbd588e9198c0a959bb42297b2cfaf1685b7bc32e138",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.6.1/MODULE.bazel": "8fdee2dbaace6c252131c00e1de4b165dc65af02ea278476187765e1a617b917",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.7.0/MODULE.bazel": "0db596f4563de7938de764cc8deeabec291f55e8ec15299718b93c4423e9796d",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.7.1/MODULE.bazel": "3120d80c5861aa616222ec015332e5f8d3171e062e3e804a2a0253e1be26e59b",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.8.1/MODULE.bazel": "88ade7293becda963e0e3ea33e7d54d3425127e0a326e0d17da085a5f1f03ff6",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.8.1/source.json": "7ebaefba0b03efe59cac88ed5bbc67bcf59a3eff33af937345ede2a38b2d368a",
+    "https://bcr.bazel.build/modules/buildozer/7.1.2/MODULE.bazel": "2e8dd40ede9c454042645fd8d8d0cd1527966aa5c919de86661e62953cd73d84",
+    "https://bcr.bazel.build/modules/buildozer/7.1.2/source.json": "c9028a501d2db85793a6996205c8de120944f50a0d570438fcae0457a5f9d1f8",
+    "https://bcr.bazel.build/modules/gawk/5.3.2.bcr.1/MODULE.bazel": "cdf8cbe5ee750db04b78878c9633cc76e80dcf4416cbe982ac3a9222f80713c8",
+    "https://bcr.bazel.build/modules/gawk/5.3.2.bcr.1/source.json": "fa7b512dfcb5eafd90ce3959cf42a2a6fe96144ebbb4b3b3928054895f2afac2",
+    "https://bcr.bazel.build/modules/google_benchmark/1.8.2/MODULE.bazel": "a70cf1bba851000ba93b58ae2f6d76490a9feb74192e57ab8e8ff13c34ec50cb",
+    "https://bcr.bazel.build/modules/googletest/1.11.0/MODULE.bazel": "3a83f095183f66345ca86aa13c58b59f9f94a2f81999c093d4eeaa2d262d12f4",
+    "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/MODULE.bazel": "22c31a561553727960057361aa33bf20fb2e98584bc4fec007906e27053f80c6",
+    "https://bcr.bazel.build/modules/googletest/1.14.0/MODULE.bazel": "cfbcbf3e6eac06ef9d85900f64424708cc08687d1b527f0ef65aa7517af8118f",
+    "https://bcr.bazel.build/modules/googletest/1.15.2/MODULE.bazel": "6de1edc1d26cafb0ea1a6ab3f4d4192d91a312fd2d360b63adaa213cd00b2108",
+    "https://bcr.bazel.build/modules/googletest/1.17.0/MODULE.bazel": "dbec758171594a705933a29fcf69293d2468c49ec1f2ebca65c36f504d72df46",
+    "https://bcr.bazel.build/modules/googletest/1.17.0/source.json": "38e4454b25fc30f15439c0378e57909ab1fd0a443158aa35aec685da727cd713",
+    "https://bcr.bazel.build/modules/jq.bzl/0.1.0/MODULE.bazel": "2ce69b1af49952cd4121a9c3055faa679e748ce774c7f1fda9657f936cae902f",
+    "https://bcr.bazel.build/modules/jq.bzl/0.4.0/MODULE.bazel": "a7b39b37589f2b0dad53fd6c1ccaabbdb290330caa920d7ef3e6aad068cd4ab2",
+    "https://bcr.bazel.build/modules/jq.bzl/0.4.0/source.json": "52ec7530c4618e03f634b30ff719814a68d7d39c235938b7aa2abbfe1eb1c52c",
+    "https://bcr.bazel.build/modules/jsoncpp/1.9.5/MODULE.bazel": "31271aedc59e815656f5736f282bb7509a97c7ecb43e927ac1a37966e0578075",
+    "https://bcr.bazel.build/modules/jsoncpp/1.9.6/MODULE.bazel": "2f8d20d3b7d54143213c4dfc3d98225c42de7d666011528dc8fe91591e2e17b0",
+    "https://bcr.bazel.build/modules/jsoncpp/1.9.6/source.json": "a04756d367a2126c3541682864ecec52f92cdee80a35735a3cb249ce015ca000",
+    "https://bcr.bazel.build/modules/libpfm/4.11.0/MODULE.bazel": "45061ff025b301940f1e30d2c16bea596c25b176c8b6b3087e92615adbd52902",
+    "https://bcr.bazel.build/modules/nlohmann_json/3.6.1/MODULE.bazel": "6f7b417dcc794d9add9e556673ad25cb3ba835224290f4f848f8e2db1e1fca74",
+    "https://bcr.bazel.build/modules/nlohmann_json/3.6.1/source.json": "f448c6e8963fdfa7eb831457df83ad63d3d6355018f6574fb017e8169deb43a9",
+    "https://bcr.bazel.build/modules/package_metadata/0.0.2/MODULE.bazel": "fb8d25550742674d63d7b250063d4580ca530499f045d70748b1b142081ebb92",
+    "https://bcr.bazel.build/modules/package_metadata/0.0.2/source.json": "e53a759a72488d2c0576f57491ef2da0cf4aab05ac0997314012495935531b73",
+    "https://bcr.bazel.build/modules/platforms/0.0.10/MODULE.bazel": "8cb8efaf200bdeb2150d93e162c40f388529a25852b332cec879373771e48ed5",
+    "https://bcr.bazel.build/modules/platforms/0.0.11/MODULE.bazel": "0daefc49732e227caa8bfa834d65dc52e8cc18a2faf80df25e8caea151a9413f",
+    "https://bcr.bazel.build/modules/platforms/0.0.4/MODULE.bazel": "9b328e31ee156f53f3c416a64f8491f7eb731742655a47c9eec4703a71644aee",
+    "https://bcr.bazel.build/modules/platforms/0.0.5/MODULE.bazel": "5733b54ea419d5eaf7997054bb55f6a1d0b5ff8aedf0176fef9eea44f3acda37",
+    "https://bcr.bazel.build/modules/platforms/0.0.6/MODULE.bazel": "ad6eeef431dc52aefd2d77ed20a4b353f8ebf0f4ecdd26a807d2da5aa8cd0615",
+    "https://bcr.bazel.build/modules/platforms/0.0.7/MODULE.bazel": "72fd4a0ede9ee5c021f6a8dd92b503e089f46c227ba2813ff183b71616034814",
+    "https://bcr.bazel.build/modules/platforms/0.0.8/MODULE.bazel": "9f142c03e348f6d263719f5074b21ef3adf0b139ee4c5133e2aa35664da9eb2d",
+    "https://bcr.bazel.build/modules/platforms/0.0.9/MODULE.bazel": "4a87a60c927b56ddd67db50c89acaa62f4ce2a1d2149ccb63ffd871d5ce29ebc",
+    "https://bcr.bazel.build/modules/platforms/1.0.0/MODULE.bazel": "f05feb42b48f1b3c225e4ccf351f367be0371411a803198ec34a389fb22aa580",
+    "https://bcr.bazel.build/modules/platforms/1.0.0/source.json": "f4ff1fd412e0246fd38c82328eb209130ead81d62dcd5a9e40910f867f733d96",
+    "https://bcr.bazel.build/modules/protobuf/21.7/MODULE.bazel": "a5a29bb89544f9b97edce05642fac225a808b5b7be74038ea3640fae2f8e66a7",
+    "https://bcr.bazel.build/modules/protobuf/27.0/MODULE.bazel": "7873b60be88844a0a1d8f80b9d5d20cfbd8495a689b8763e76c6372998d3f64c",
+    "https://bcr.bazel.build/modules/protobuf/27.1/MODULE.bazel": "703a7b614728bb06647f965264967a8ef1c39e09e8f167b3ca0bb1fd80449c0d",
+    "https://bcr.bazel.build/modules/protobuf/29.0-rc2/MODULE.bazel": "6241d35983510143049943fc0d57937937122baf1b287862f9dc8590fc4c37df",
+    "https://bcr.bazel.build/modules/protobuf/29.0-rc3/MODULE.bazel": "33c2dfa286578573afc55a7acaea3cada4122b9631007c594bf0729f41c8de92",
+    "https://bcr.bazel.build/modules/protobuf/29.0/MODULE.bazel": "319dc8bf4c679ff87e71b1ccfb5a6e90a6dbc4693501d471f48662ac46d04e4e",
+    "https://bcr.bazel.build/modules/protobuf/29.1/MODULE.bazel": "557c3457560ff49e122ed76c0bc3397a64af9574691cb8201b4e46d4ab2ecb95",
+    "https://bcr.bazel.build/modules/protobuf/3.19.0/MODULE.bazel": "6b5fbb433f760a99a22b18b6850ed5784ef0e9928a72668b66e4d7ccd47db9b0",
+    "https://bcr.bazel.build/modules/protobuf/32.1/MODULE.bazel": "89cd2866a9cb07fee9ff74c41ceace11554f32e0d849de4e23ac55515cfada4d",
+    "https://bcr.bazel.build/modules/protobuf/32.1/source.json": "bd2664e90875c0cd755d1d9b7a103a4b027893ac8eafa3bba087557ffc244ad4",
+    "https://bcr.bazel.build/modules/pybind11_bazel/2.11.1/MODULE.bazel": "88af1c246226d87e65be78ed49ecd1e6f5e98648558c14ce99176da041dc378e",
+    "https://bcr.bazel.build/modules/pybind11_bazel/2.12.0/MODULE.bazel": "e6f4c20442eaa7c90d7190d8dc539d0ab422f95c65a57cc59562170c58ae3d34",
+    "https://bcr.bazel.build/modules/pybind11_bazel/2.12.0/source.json": "6900fdc8a9e95866b8c0d4ad4aba4d4236317b5c1cd04c502df3f0d33afed680",
+    "https://bcr.bazel.build/modules/re2/2023-09-01/MODULE.bazel": "cb3d511531b16cfc78a225a9e2136007a48cf8a677e4264baeab57fe78a80206",
+    "https://bcr.bazel.build/modules/re2/2024-07-02.bcr.1/MODULE.bazel": "b4963dda9b31080be1905ef085ecd7dd6cd47c05c79b9cdf83ade83ab2ab271a",
+    "https://bcr.bazel.build/modules/re2/2024-07-02.bcr.1/source.json": "2ff292be6ef3340325ce8a045ecc326e92cbfab47c7cbab4bd85d28971b97ac4",
+    "https://bcr.bazel.build/modules/re2/2024-07-02/MODULE.bazel": "0eadc4395959969297cbcf31a249ff457f2f1d456228c67719480205aa306daa",
+    "https://bcr.bazel.build/modules/rules_android/0.1.1/MODULE.bazel": "48809ab0091b07ad0182defb787c4c5328bd3a278938415c00a7b69b50c4d3a8",
+    "https://bcr.bazel.build/modules/rules_android/0.1.1/source.json": "e6986b41626ee10bdc864937ffb6d6bf275bb5b9c65120e6137d56e6331f089e",
+    "https://bcr.bazel.build/modules/rules_apple/3.16.0/MODULE.bazel": "0d1caf0b8375942ce98ea944be754a18874041e4e0459401d925577624d3a54a",
+    "https://bcr.bazel.build/modules/rules_apple/3.16.0/source.json": "d8b5fe461272018cc07cfafce11fe369c7525330804c37eec5a82f84cd475366",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.1/MODULE.bazel": "cb2aa0747f84c6c3a78dad4e2049c154f08ab9d166b1273835a8174940365647",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.10/MODULE.bazel": "ec1705118f7eaedd6e118508d3d26deba2a4e76476ada7e0e3965211be012002",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.13/MODULE.bazel": "0e8529ed7b323dad0775ff924d2ae5af7640b23553dfcd4d34344c7e7a867191",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.14/MODULE.bazel": "5e343a3aac88b8d7af3b1b6d2093b55c347b8eefc2e7d1442f7a02dc8fea48ac",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.15/MODULE.bazel": "6704c35f7b4a72502ee81f61bf88706b54f06b3cbe5558ac17e2e14666cd5dcc",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.16/MODULE.bazel": "7661303b8fc1b4d7f532e54e9d6565771fea666fbdf839e0a86affcd02defe87",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.17/MODULE.bazel": "2ae1d8f4238ec67d7185d8861cb0a2cdf4bc608697c331b95bf990e69b62e64a",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.2/MODULE.bazel": "6915987c90970493ab97393024c156ea8fb9f3bea953b2f3ec05c34f19b5695c",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.6/MODULE.bazel": "abf360251023dfe3efcef65ab9d56beefa8394d4176dd29529750e1c57eaa33f",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.8/MODULE.bazel": "964c85c82cfeb6f3855e6a07054fdb159aced38e99a5eecf7bce9d53990afa3e",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.9/MODULE.bazel": "836e76439f354b89afe6a911a7adf59a6b2518fafb174483ad78a2a2fde7b1c5",
+    "https://bcr.bazel.build/modules/rules_cc/0.1.1/MODULE.bazel": "2f0222a6f229f0bf44cd711dc13c858dad98c62d52bd51d8fc3a764a83125513",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.0/MODULE.bazel": "b5c17f90458caae90d2ccd114c81970062946f49f355610ed89bebf954f5783c",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.8/MODULE.bazel": "f1df20f0bf22c28192a794f29b501ee2018fa37a3862a1a2132ae2940a23a642",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.8/source.json": "85087982aca15f31307bd52698316b28faa31bd2c3095a41f456afec0131344c",
+    "https://bcr.bazel.build/modules/rules_foreign_cc/0.9.0/MODULE.bazel": "c9e8c682bf75b0e7c704166d79b599f93b72cfca5ad7477df596947891feeef6",
+    "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/MODULE.bazel": "40c97d1144356f52905566c55811f13b299453a14ac7769dfba2ac38192337a8",
+    "https://bcr.bazel.build/modules/rules_java/4.0.0/MODULE.bazel": "5a78a7ae82cd1a33cef56dc578c7d2a46ed0dca12643ee45edbb8417899e6f74",
+    "https://bcr.bazel.build/modules/rules_java/5.3.5/MODULE.bazel": "a4ec4f2db570171e3e5eb753276ee4b389bae16b96207e9d3230895c99644b86",
+    "https://bcr.bazel.build/modules/rules_java/6.0.0/MODULE.bazel": "8a43b7df601a7ec1af61d79345c17b31ea1fedc6711fd4abfd013ea612978e39",
+    "https://bcr.bazel.build/modules/rules_java/6.3.0/MODULE.bazel": "a97c7678c19f236a956ad260d59c86e10a463badb7eb2eda787490f4c969b963",
+    "https://bcr.bazel.build/modules/rules_java/6.4.0/MODULE.bazel": "e986a9fe25aeaa84ac17ca093ef13a4637f6107375f64667a15999f77db6c8f6",
+    "https://bcr.bazel.build/modules/rules_java/6.5.2/MODULE.bazel": "1d440d262d0e08453fa0c4d8f699ba81609ed0e9a9a0f02cd10b3e7942e61e31",
+    "https://bcr.bazel.build/modules/rules_java/7.10.0/MODULE.bazel": "530c3beb3067e870561739f1144329a21c851ff771cd752a49e06e3dc9c2e71a",
+    "https://bcr.bazel.build/modules/rules_java/7.12.2/MODULE.bazel": "579c505165ee757a4280ef83cda0150eea193eed3bef50b1004ba88b99da6de6",
+    "https://bcr.bazel.build/modules/rules_java/7.2.0/MODULE.bazel": "06c0334c9be61e6cef2c8c84a7800cef502063269a5af25ceb100b192453d4ab",
+    "https://bcr.bazel.build/modules/rules_java/7.3.2/MODULE.bazel": "50dece891cfdf1741ea230d001aa9c14398062f2b7c066470accace78e412bc2",
+    "https://bcr.bazel.build/modules/rules_java/7.6.1/MODULE.bazel": "2f14b7e8a1aa2f67ae92bc69d1ec0fa8d9f827c4e17ff5e5f02e91caa3b2d0fe",
+    "https://bcr.bazel.build/modules/rules_java/8.14.0/MODULE.bazel": "717717ed40cc69994596a45aec6ea78135ea434b8402fb91b009b9151dd65615",
+    "https://bcr.bazel.build/modules/rules_java/8.16.1/MODULE.bazel": "0f20b1cecaa8e52f60a8f071e59a20b4e3b9a67f6c56c802ea256f6face692d3",
+    "https://bcr.bazel.build/modules/rules_java/8.16.1/source.json": "072f8d11264edc499621be2dc9ea01d6395db5aa6f8799c034ae01a3e857f2e4",
+    "https://bcr.bazel.build/modules/rules_java/8.3.2/MODULE.bazel": "7336d5511ad5af0b8615fdc7477535a2e4e723a357b6713af439fe8cf0195017",
+    "https://bcr.bazel.build/modules/rules_java/8.5.1/MODULE.bazel": "d8a9e38cc5228881f7055a6079f6f7821a073df3744d441978e7a43e20226939",
+    "https://bcr.bazel.build/modules/rules_java/8.6.1/MODULE.bazel": "f4808e2ab5b0197f094cabce9f4b006a27766beb6a9975931da07099560ca9c2",
+    "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
+    "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
+    "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
+    "https://bcr.bazel.build/modules/rules_jvm_external/5.3/MODULE.bazel": "bf93870767689637164657731849fb887ad086739bd5d360d90007a581d5527d",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.1/MODULE.bazel": "75b5fec090dbd46cf9b7d8ea08cf84a0472d92ba3585b476f44c326eda8059c4",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.3/MODULE.bazel": "c998e060b85f71e00de5ec552019347c8bca255062c990ac02d051bb80a38df0",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.7/MODULE.bazel": "e717beabc4d091ecb2c803c2d341b88590e9116b8bf7947915eeb33aab4f96dd",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.7/source.json": "5426f412d0a7fc6b611643376c7e4a82dec991491b9ce5cb1cfdd25fe2e92be4",
+    "https://bcr.bazel.build/modules/rules_kotlin/1.9.0/MODULE.bazel": "ef85697305025e5a61f395d4eaede272a5393cee479ace6686dba707de804d59",
+    "https://bcr.bazel.build/modules/rules_kotlin/1.9.6/MODULE.bazel": "d269a01a18ee74d0335450b10f62c9ed81f2321d7958a2934e44272fe82dcef3",
+    "https://bcr.bazel.build/modules/rules_kotlin/1.9.6/source.json": "2faa4794364282db7c06600b7e5e34867a564ae91bda7cae7c29c64e9466b7d5",
+    "https://bcr.bazel.build/modules/rules_license/0.0.3/MODULE.bazel": "627e9ab0247f7d1e05736b59dbb1b6871373de5ad31c3011880b4133cafd4bd0",
+    "https://bcr.bazel.build/modules/rules_license/0.0.7/MODULE.bazel": "088fbeb0b6a419005b89cf93fe62d9517c0a2b8bb56af3244af65ecfe37e7d5d",
+    "https://bcr.bazel.build/modules/rules_license/1.0.0/MODULE.bazel": "a7fda60eefdf3d8c827262ba499957e4df06f659330bbe6cdbdb975b768bb65c",
+    "https://bcr.bazel.build/modules/rules_license/1.0.0/source.json": "a52c89e54cc311196e478f8382df91c15f7a2bfdf4c6cd0e2675cc2ff0b56efb",
+    "https://bcr.bazel.build/modules/rules_nodejs/6.3.0/MODULE.bazel": "45345e4aba35dd6e4701c1eebf5a4e67af4ed708def9ebcdc6027585b34ee52d",
+    "https://bcr.bazel.build/modules/rules_nodejs/6.3.0/source.json": "1254ffd8d0d908a19c67add7fb5e2a1f604df133bc5d206425264293e2e537fc",
+    "https://bcr.bazel.build/modules/rules_pkg/0.7.0/MODULE.bazel": "df99f03fc7934a4737122518bb87e667e62d780b610910f0447665a7e2be62dc",
+    "https://bcr.bazel.build/modules/rules_pkg/1.0.1/MODULE.bazel": "5b1df97dbc29623bccdf2b0dcd0f5cb08e2f2c9050aab1092fd39a41e82686ff",
+    "https://bcr.bazel.build/modules/rules_pkg/1.0.1/source.json": "bd82e5d7b9ce2d31e380dd9f50c111d678c3bdaca190cb76b0e1c71b05e1ba8a",
+    "https://bcr.bazel.build/modules/rules_proto/4.0.0/MODULE.bazel": "a7a7b6ce9bee418c1a760b3d84f83a299ad6952f9903c67f19e4edd964894e06",
+    "https://bcr.bazel.build/modules/rules_proto/5.3.0-21.7/MODULE.bazel": "e8dff86b0971688790ae75528fe1813f71809b5afd57facb44dad9e8eca631b7",
+    "https://bcr.bazel.build/modules/rules_proto/6.0.0-rc1/MODULE.bazel": "1e5b502e2e1a9e825eef74476a5a1ee524a92297085015a052510b09a1a09483",
+    "https://bcr.bazel.build/modules/rules_proto/6.0.2/MODULE.bazel": "ce916b775a62b90b61888052a416ccdda405212b6aaeb39522f7dc53431a5e73",
+    "https://bcr.bazel.build/modules/rules_proto/7.0.2/MODULE.bazel": "bf81793bd6d2ad89a37a40693e56c61b0ee30f7a7fdbaf3eabbf5f39de47dea2",
+    "https://bcr.bazel.build/modules/rules_proto/7.1.0/MODULE.bazel": "002d62d9108f75bb807cd56245d45648f38275cb3a99dcd45dfb864c5d74cb96",
+    "https://bcr.bazel.build/modules/rules_proto/7.1.0/source.json": "39f89066c12c24097854e8f57ab8558929f9c8d474d34b2c00ac04630ad8940e",
+    "https://bcr.bazel.build/modules/rules_python/0.10.2/MODULE.bazel": "cc82bc96f2997baa545ab3ce73f196d040ffb8756fd2d66125a530031cd90e5f",
+    "https://bcr.bazel.build/modules/rules_python/0.23.1/MODULE.bazel": "49ffccf0511cb8414de28321f5fcf2a31312b47c40cc21577144b7447f2bf300",
+    "https://bcr.bazel.build/modules/rules_python/0.25.0/MODULE.bazel": "72f1506841c920a1afec76975b35312410eea3aa7b63267436bfb1dd91d2d382",
+    "https://bcr.bazel.build/modules/rules_python/0.28.0/MODULE.bazel": "cba2573d870babc976664a912539b320cbaa7114cd3e8f053c720171cde331ed",
+    "https://bcr.bazel.build/modules/rules_python/0.31.0/MODULE.bazel": "93a43dc47ee570e6ec9f5779b2e64c1476a6ce921c48cc9a1678a91dd5f8fd58",
+    "https://bcr.bazel.build/modules/rules_python/0.33.2/MODULE.bazel": "3e036c4ad8d804a4dad897d333d8dce200d943df4827cb849840055be8d2e937",
+    "https://bcr.bazel.build/modules/rules_python/0.4.0/MODULE.bazel": "9208ee05fd48bf09ac60ed269791cf17fb343db56c8226a720fbb1cdf467166c",
+    "https://bcr.bazel.build/modules/rules_python/0.40.0/MODULE.bazel": "9d1a3cd88ed7d8e39583d9ffe56ae8a244f67783ae89b60caafc9f5cf318ada7",
+    "https://bcr.bazel.build/modules/rules_python/1.4.1/MODULE.bazel": "8991ad45bdc25018301d6b7e1d3626afc3c8af8aaf4bc04f23d0b99c938b73a6",
+    "https://bcr.bazel.build/modules/rules_python/1.4.1/source.json": "8ec8c90c70ccacc4de8ca1b97f599e756fb59173e898ee08b733006650057c07",
+    "https://bcr.bazel.build/modules/rules_shell/0.2.0/MODULE.bazel": "fda8a652ab3c7d8fee214de05e7a9916d8b28082234e8d2c0094505c5268ed3c",
+    "https://bcr.bazel.build/modules/rules_shell/0.3.0/MODULE.bazel": "de4402cd12f4cc8fda2354fce179fdb068c0b9ca1ec2d2b17b3e21b24c1a937b",
+    "https://bcr.bazel.build/modules/rules_shell/0.4.1/MODULE.bazel": "00e501db01bbf4e3e1dd1595959092c2fadf2087b2852d3f553b5370f5633592",
+    "https://bcr.bazel.build/modules/rules_shell/0.4.1/source.json": "4757bd277fe1567763991c4425b483477bb82e35e777a56fd846eb5cceda324a",
+    "https://bcr.bazel.build/modules/rules_swift/1.16.0/MODULE.bazel": "4a09f199545a60d09895e8281362b1ff3bb08bbde69c6fc87aff5b92fcc916ca",
+    "https://bcr.bazel.build/modules/rules_swift/2.1.1/MODULE.bazel": "494900a80f944fc7aa61500c2073d9729dff0b764f0e89b824eb746959bc1046",
+    "https://bcr.bazel.build/modules/rules_swift/2.1.1/source.json": "40fc69dfaac64deddbb75bd99cdac55f4427d9ca0afbe408576a65428427a186",
+    "https://bcr.bazel.build/modules/stardoc/0.5.1/MODULE.bazel": "1a05d92974d0c122f5ccf09291442580317cdd859f07a8655f1db9a60374f9f8",
+    "https://bcr.bazel.build/modules/stardoc/0.5.3/MODULE.bazel": "c7f6948dae6999bf0db32c1858ae345f112cacf98f174c7a8bb707e41b974f1c",
+    "https://bcr.bazel.build/modules/stardoc/0.5.6/MODULE.bazel": "c43dabc564990eeab55e25ed61c07a1aadafe9ece96a4efabb3f8bf9063b71ef",
+    "https://bcr.bazel.build/modules/stardoc/0.6.2/MODULE.bazel": "7060193196395f5dd668eda046ccbeacebfd98efc77fed418dbe2b82ffaa39fd",
+    "https://bcr.bazel.build/modules/stardoc/0.7.0/MODULE.bazel": "05e3d6d30c099b6770e97da986c53bd31844d7f13d41412480ea265ac9e8079c",
+    "https://bcr.bazel.build/modules/stardoc/0.7.1/MODULE.bazel": "3548faea4ee5dda5580f9af150e79d0f6aea934fc60c1cc50f4efdd9420759e7",
+    "https://bcr.bazel.build/modules/stardoc/0.7.2/MODULE.bazel": "fc152419aa2ea0f51c29583fab1e8c99ddefd5b3778421845606ee628629e0e5",
+    "https://bcr.bazel.build/modules/stardoc/0.7.2/source.json": "58b029e5e901d6802967754adf0a9056747e8176f017cfe3607c0851f4d42216",
+    "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.1/MODULE.bazel": "5e463fbfba7b1701d957555ed45097d7f984211330106ccd1352c6e0af0dcf91",
+    "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.1/source.json": "32bd87e5f4d7acc57c5b2ff7c325ae3061d5e242c0c4c214ae87e0f1c13e54cb",
+    "https://bcr.bazel.build/modules/tar.bzl/0.2.1/MODULE.bazel": "52d1c00a80a8cc67acbd01649e83d8dd6a9dc426a6c0b754a04fe8c219c76468",
+    "https://bcr.bazel.build/modules/tar.bzl/0.5.1/MODULE.bazel": "7c2eb3dcfc53b0f3d6f9acdfd911ca803eaf92aadf54f8ca6e4c1f3aee288351",
+    "https://bcr.bazel.build/modules/tar.bzl/0.5.1/source.json": "deed3094f7cc779ed1d37a68403847b0e38d9dd9d931e03cb90825f3368b515f",
+    "https://bcr.bazel.build/modules/toolchains_buildbuddy/0.0.4/MODULE.bazel": "735f0ed45a0334971a61157432127380ae9ce285aea6d489565cb81c7a4cf487",
+    "https://bcr.bazel.build/modules/toolchains_buildbuddy/0.0.4/source.json": "a5b69ff999ea39cf89df03cb5c174ae6fd621d7a1a7e4bd6be302ff9f2910695",
+    "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
+    "https://bcr.bazel.build/modules/yq.bzl/0.1.1/MODULE.bazel": "9039681f9bcb8958ee2c87ffc74bdafba9f4369096a2b5634b88abc0eaefa072",
+    "https://bcr.bazel.build/modules/yq.bzl/0.3.2/MODULE.bazel": "0384efa70e8033d842ea73aa4b7199fa099709e236a7264345c03937166670b6",
+    "https://bcr.bazel.build/modules/yq.bzl/0.3.2/source.json": "c4ec3e192477e154f08769e29d69e8fd36e8a4f0f623997f3e1f6f7d328f7d7d",
+    "https://bcr.bazel.build/modules/zlib/1.2.11/MODULE.bazel": "07b389abc85fdbca459b69e2ec656ae5622873af3f845e1c9d80fe179f3effa0",
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/MODULE.bazel": "eec517b5bbe5492629466e11dae908d043364302283de25581e3eb944326c4ca",
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/source.json": "22bc55c47af97246cfc093d0acf683a7869377de362b5d1c552c2c2e16b7a806",
+    "https://bcr.bazel.build/modules/zlib/1.3.1/MODULE.bazel": "751c9940dcfe869f5f7274e1295422a34623555916eb98c174c1e945594bf198"
+  },
+  "selectedYankedVersions": {},
+  "moduleExtensions": {
+    "@@aspect_tools_telemetry+//:extension.bzl%telemetry": {
+      "general": {
+        "bzlTransitiveDigest": "cl5A2O84vDL6Tt+Qga8FCj1DUDGqn+e7ly5rZ+4xvcc=",
+        "usagesDigest": "pLnkJrXl1WS1efPHDXQRX2qSyrjmhYJgshYQaUcOXkg=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "aspect_tools_telemetry_report": {
+            "repoRuleId": "@@aspect_tools_telemetry+//:extension.bzl%tel_repository",
+            "attributes": {
+              "deps": {
+                "aspect_rules_js": "2.8.3",
+                "aspect_tools_telemetry": "0.3.3"
+              }
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "aspect_tools_telemetry+",
+            "bazel_lib",
+            "bazel_lib+"
+          ],
+          [
+            "aspect_tools_telemetry+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ]
+        ]
+      }
+    },
+    "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
+      "general": {
+        "bzlTransitiveDigest": "rL/34P1aFDq2GqVC2zCFgQ8nTuOC6ziogocpvG50Qz8=",
+        "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "com_github_jetbrains_kotlin_git": {
+            "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:compiler.bzl%kotlin_compiler_git_repository",
+            "attributes": {
+              "urls": [
+                "https://github.com/JetBrains/kotlin/releases/download/v1.9.23/kotlin-compiler-1.9.23.zip"
+              ],
+              "sha256": "93137d3aab9afa9b27cb06a824c2324195c6b6f6179d8a8653f440f5bd58be88"
+            }
+          },
+          "com_github_jetbrains_kotlin": {
+            "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:compiler.bzl%kotlin_capabilities_repository",
+            "attributes": {
+              "git_repository_name": "com_github_jetbrains_kotlin_git",
+              "compiler_version": "1.9.23"
+            }
+          },
+          "com_github_google_ksp": {
+            "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:ksp.bzl%ksp_compiler_plugin_repository",
+            "attributes": {
+              "urls": [
+                "https://github.com/google/ksp/releases/download/1.9.23-1.0.20/artifacts.zip"
+              ],
+              "sha256": "ee0618755913ef7fd6511288a232e8fad24838b9af6ea73972a76e81053c8c2d",
+              "strip_version": "1.9.23-1.0.20"
+            }
+          },
+          "com_github_pinterest_ktlint": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "sha256": "01b2e0ef893383a50dbeb13970fe7fa3be36ca3e83259e01649945b09d736985",
+              "urls": [
+                "https://github.com/pinterest/ktlint/releases/download/1.3.0/ktlint"
+              ],
+              "executable": true
+            }
+          },
+          "rules_android": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806",
+              "strip_prefix": "rules_android-0.1.1",
+              "urls": [
+                "https://github.com/bazelbuild/rules_android/archive/v0.1.1.zip"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_kotlin+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_nodejs+//nodejs:extensions.bzl%node": {
+      "general": {
+        "bzlTransitiveDigest": "SqbzUarOVzAfK28Ca5+NIU3LUwnW/b3h0xXBUS97oyI=",
+        "usagesDigest": "wBknCNbJZy6tWHRyDzIZ/G86uu0wp2cw1DPCOmwmKvs=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "nodejs_linux_amd64": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
+            "attributes": {
+              "node_download_auth": {},
+              "node_repositories": {},
+              "node_urls": [
+                "https://nodejs.org/dist/v{version}/{filename}"
+              ],
+              "node_version": "20.11.1",
+              "include_headers": false,
+              "platform": "linux_amd64"
+            }
+          },
+          "nodejs_linux_arm64": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
+            "attributes": {
+              "node_download_auth": {},
+              "node_repositories": {},
+              "node_urls": [
+                "https://nodejs.org/dist/v{version}/{filename}"
+              ],
+              "node_version": "20.11.1",
+              "include_headers": false,
+              "platform": "linux_arm64"
+            }
+          },
+          "nodejs_linux_s390x": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
+            "attributes": {
+              "node_download_auth": {},
+              "node_repositories": {},
+              "node_urls": [
+                "https://nodejs.org/dist/v{version}/{filename}"
+              ],
+              "node_version": "20.11.1",
+              "include_headers": false,
+              "platform": "linux_s390x"
+            }
+          },
+          "nodejs_linux_ppc64le": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
+            "attributes": {
+              "node_download_auth": {},
+              "node_repositories": {},
+              "node_urls": [
+                "https://nodejs.org/dist/v{version}/{filename}"
+              ],
+              "node_version": "20.11.1",
+              "include_headers": false,
+              "platform": "linux_ppc64le"
+            }
+          },
+          "nodejs_darwin_amd64": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
+            "attributes": {
+              "node_download_auth": {},
+              "node_repositories": {},
+              "node_urls": [
+                "https://nodejs.org/dist/v{version}/{filename}"
+              ],
+              "node_version": "20.11.1",
+              "include_headers": false,
+              "platform": "darwin_amd64"
+            }
+          },
+          "nodejs_darwin_arm64": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
+            "attributes": {
+              "node_download_auth": {},
+              "node_repositories": {},
+              "node_urls": [
+                "https://nodejs.org/dist/v{version}/{filename}"
+              ],
+              "node_version": "20.11.1",
+              "include_headers": false,
+              "platform": "darwin_arm64"
+            }
+          },
+          "nodejs_windows_amd64": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
+            "attributes": {
+              "node_download_auth": {},
+              "node_repositories": {},
+              "node_urls": [
+                "https://nodejs.org/dist/v{version}/{filename}"
+              ],
+              "node_version": "20.11.1",
+              "include_headers": false,
+              "platform": "windows_amd64"
+            }
+          },
+          "nodejs": {
+            "repoRuleId": "@@rules_nodejs+//nodejs/private:nodejs_repo_host_os_alias.bzl%nodejs_repo_host_os_alias",
+            "attributes": {
+              "user_node_repository_name": "nodejs"
+            }
+          },
+          "nodejs_host": {
+            "repoRuleId": "@@rules_nodejs+//nodejs/private:nodejs_repo_host_os_alias.bzl%nodejs_repo_host_os_alias",
+            "attributes": {
+              "user_node_repository_name": "nodejs"
+            }
+          },
+          "nodejs_toolchains": {
+            "repoRuleId": "@@rules_nodejs+//nodejs/private:nodejs_toolchains_repo.bzl%nodejs_toolchains_repo",
+            "attributes": {
+              "user_node_repository_name": "nodejs"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": []
+      }
+    },
+    "@@rules_python+//python/uv:uv.bzl%uv": {
+      "general": {
+        "bzlTransitiveDigest": "Xpqjnjzy6zZ90Es9Wa888ZLHhn7IsNGbph/e6qoxzw8=",
+        "usagesDigest": "4JapxcpS0mL3524k0TZJffAtVyuRjDHZvN9kBRxxF1U=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "uv": {
+            "repoRuleId": "@@rules_python+//python/uv/private:uv_toolchains_repo.bzl%uv_toolchains_repo",
+            "attributes": {
+              "toolchain_type": "'@@rules_python+//python/uv:uv_toolchain_type'",
+              "toolchain_names": [
+                "none"
+              ],
+              "toolchain_implementations": {
+                "none": "'@@rules_python+//python:none'"
+              },
+              "toolchain_compatible_with": {
+                "none": [
+                  "@platforms//:incompatible"
+                ]
+              },
+              "toolchain_target_settings": {}
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_python+",
+            "platforms",
+            "platforms"
+          ]
+        ]
+      }
+    },
+    "@@tar.bzl+//tar:extensions.bzl%toolchains": {
+      "general": {
+        "bzlTransitiveDigest": "/2afh6fPjq/rcyE/jztQDK3ierehmFFngfvmqyRv72M=",
+        "usagesDigest": "maF8qsAIqeH1ey8pxP0gNZbvJt34kLZvTFeQ0ntrJVA=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "bsd_tar_toolchains": {
+            "repoRuleId": "@@tar.bzl+//tar/toolchain:toolchain.bzl%tar_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "bsd_tar_toolchains"
+            }
+          },
+          "bsd_tar_toolchains_darwin_amd64": {
+            "repoRuleId": "@@tar.bzl+//tar/toolchain:platforms.bzl%bsdtar_binary_repo",
+            "attributes": {
+              "platform": "darwin_amd64"
+            }
+          },
+          "bsd_tar_toolchains_darwin_arm64": {
+            "repoRuleId": "@@tar.bzl+//tar/toolchain:platforms.bzl%bsdtar_binary_repo",
+            "attributes": {
+              "platform": "darwin_arm64"
+            }
+          },
+          "bsd_tar_toolchains_linux_amd64": {
+            "repoRuleId": "@@tar.bzl+//tar/toolchain:platforms.bzl%bsdtar_binary_repo",
+            "attributes": {
+              "platform": "linux_amd64"
+            }
+          },
+          "bsd_tar_toolchains_linux_arm64": {
+            "repoRuleId": "@@tar.bzl+//tar/toolchain:platforms.bzl%bsdtar_binary_repo",
+            "attributes": {
+              "platform": "linux_arm64"
+            }
+          },
+          "bsd_tar_toolchains_windows_amd64": {
+            "repoRuleId": "@@tar.bzl+//tar/toolchain:platforms.bzl%bsdtar_binary_repo",
+            "attributes": {
+              "platform": "windows_amd64"
+            }
+          },
+          "bsd_tar_toolchains_windows_arm64": {
+            "repoRuleId": "@@tar.bzl+//tar/toolchain:platforms.bzl%bsdtar_binary_repo",
+            "attributes": {
+              "platform": "windows_arm64"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": []
+      }
+    },
+    "@@toolchains_buildbuddy+//:extensions.bzl%buildbuddy": {
+      "general": {
+        "bzlTransitiveDigest": "YThiSErJv+jiCHJzZIEyk0yegQRS/x+T/ce309eGTvA=",
+        "usagesDigest": "ChnwfQ8erQcmwQ7tR9Kl7O9v/X76NCoK0ry2KRbfCEc=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "buildbuddy_toolchain": {
+            "repoRuleId": "@@toolchains_buildbuddy+//:rules.bzl%_buildbuddy_toolchain",
+            "attributes": {
+              "container_image": "",
+              "llvm": false,
+              "java_version": "",
+              "gcc_version": "",
+              "msvc_edition": "Community",
+              "msvc_release": "2022",
+              "msvc_version": "14.39.33519",
+              "windows_kits_release": "10",
+              "windows_kits_version": "10.0.22621.0",
+              "extra_cxx_builtin_include_directories": []
+            }
+          }
+        },
+        "recordedRepoMappingEntries": []
+      }
+    },
+    "@@yq.bzl+//yq:extensions.bzl%yq": {
+      "general": {
+        "bzlTransitiveDigest": "61Uz+o5PnlY0jJfPZEUNqsKxnM/UCLeWsn5VVCc8u5Y=",
+        "usagesDigest": "L+otO9xvwIFywi8vrhskBwjeWSSCE7f5iIykUFebyao=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "yq_darwin_amd64": {
+            "repoRuleId": "@@yq.bzl+//yq/toolchain:platforms.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64",
+              "version": "4.45.1"
+            }
+          },
+          "yq_darwin_arm64": {
+            "repoRuleId": "@@yq.bzl+//yq/toolchain:platforms.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64",
+              "version": "4.45.1"
+            }
+          },
+          "yq_linux_amd64": {
+            "repoRuleId": "@@yq.bzl+//yq/toolchain:platforms.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64",
+              "version": "4.45.1"
+            }
+          },
+          "yq_linux_arm64": {
+            "repoRuleId": "@@yq.bzl+//yq/toolchain:platforms.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64",
+              "version": "4.45.1"
+            }
+          },
+          "yq_linux_s390x": {
+            "repoRuleId": "@@yq.bzl+//yq/toolchain:platforms.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "linux_s390x",
+              "version": "4.45.1"
+            }
+          },
+          "yq_linux_riscv64": {
+            "repoRuleId": "@@yq.bzl+//yq/toolchain:platforms.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "linux_riscv64",
+              "version": "4.45.1"
+            }
+          },
+          "yq_linux_ppc64le": {
+            "repoRuleId": "@@yq.bzl+//yq/toolchain:platforms.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "linux_ppc64le",
+              "version": "4.45.1"
+            }
+          },
+          "yq_windows_amd64": {
+            "repoRuleId": "@@yq.bzl+//yq/toolchain:platforms.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64",
+              "version": "4.45.1"
+            }
+          },
+          "yq_toolchains": {
+            "repoRuleId": "@@yq.bzl+//yq/toolchain:toolchain.bzl%yq_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "yq"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": []
+      }
+    }
+  },
+  "facts": {}
+}

--- a/rules_formatjs/examples/simple/README.md
+++ b/rules_formatjs/examples/simple/README.md
@@ -1,0 +1,77 @@
+# Simple FormatJS Example
+
+This example demonstrates basic message extraction and compilation using `rules_formatjs`.
+
+## Structure
+
+```
+.
+├── BUILD.bazel          # Bazel build configuration
+├── MODULE.bazel         # Bazel module configuration
+├── src/
+│   └── App.tsx         # Example React component with i18n messages
+└── messages/           # Generated message files (created by Bazel)
+    ├── en.json         # Extracted messages
+    └── en-compiled.json # Compiled messages
+```
+
+## Usage
+
+### Extract Messages
+
+Extract messages from the source file:
+
+```bash
+bazel build //:extract_messages
+```
+
+This will generate `bazel-bin/messages/en.json` with extracted messages.
+
+### Compile Messages
+
+Compile the extracted messages for production:
+
+```bash
+bazel build //:compile_messages
+```
+
+This will generate `bazel-bin/messages/en-compiled.json` with optimized compiled messages.
+
+### Build Everything
+
+```bash
+bazel build //...
+```
+
+## What's Happening
+
+1. **Message Extraction**: The `formatjs_extract` rule scans `src/App.tsx` for:
+   - `<FormattedMessage>` components
+   - `intl.formatMessage()` calls
+   - Extracts the message ID, default message, and description
+
+2. **Message Compilation**: The `formatjs_compile` rule:
+   - Takes the extracted JSON
+   - Compiles it to AST format for better runtime performance
+   - Outputs an optimized JSON file
+
+3. **Content-based IDs**: Using `id_interpolation_pattern = "[sha512:contenthash:base64:6]"` generates stable IDs based on message content, which helps with:
+   - Automatic ID generation
+   - Detecting message changes
+   - Version control friendly IDs
+
+## Integration
+
+To use the compiled messages in your React app:
+
+```typescript
+import messages from './messages/en-compiled.json';
+import { createIntl, createIntlCache, RawIntlProvider } from 'react-intl';
+
+const cache = createIntlCache();
+const intl = createIntl({ locale: 'en', messages }, cache);
+
+<RawIntlProvider value={intl}>
+  <App />
+</RawIntlProvider>
+```

--- a/rules_formatjs/examples/simple/compile_messages.fixture.json
+++ b/rules_formatjs/examples/simple/compile_messages.fixture.json
@@ -1,0 +1,20 @@
+{
+  "app.button": [
+    {
+      "type": 0,
+      "value": "Click me!"
+    }
+  ],
+  "app.description": [
+    {
+      "type": 0,
+      "value": "This is an example of internationalized React app using FormatJS and Bazel."
+    }
+  ],
+  "app.title": [
+    {
+      "type": 0,
+      "value": "Welcome to FormatJS"
+    }
+  ]
+}

--- a/rules_formatjs/examples/simple/extract_messages.fixture.json
+++ b/rules_formatjs/examples/simple/extract_messages.fixture.json
@@ -1,0 +1,5 @@
+{
+  "app.button": "Click me!",
+  "app.description": "This is an example of internationalized React app using FormatJS and Bazel.",
+  "app.title": "Welcome to FormatJS"
+}

--- a/rules_formatjs/examples/simple/messages/fr.json
+++ b/rules_formatjs/examples/simple/messages/fr.json
@@ -1,0 +1,5 @@
+{
+  "app.title": "Bienvenue à FormatJS",
+  "app.description": "Ceci est un exemple d'application React internationalisée utilisant FormatJS et Bazel.",
+  "app.button": "Cliquez-moi!"
+}

--- a/rules_formatjs/examples/simple/package.json
+++ b/rules_formatjs/examples/simple/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "formatjs-example-simple",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@formatjs/cli": "^6.8.8"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": []
+  }
+}

--- a/rules_formatjs/examples/simple/pnpm-lock.yaml
+++ b/rules_formatjs/examples/simple/pnpm-lock.yaml
@@ -1,0 +1,50 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@formatjs/cli':
+        specifier: ^6.8.8
+        version: 6.8.8
+
+packages:
+
+  '@formatjs/cli@6.8.8':
+    resolution: {integrity: sha512-YTN8BO0z8dZAMJyXxjpYRxAKuxbfVH0oBKger593/8Ql6+q691YI23yt8DP0L+6b9JzlYOoIa1ghTzd8vaukPw==}
+    engines: {node: '>= 16'}
+    hasBin: true
+    peerDependencies:
+      '@glimmer/env': '*'
+      '@glimmer/reference': '*'
+      '@glimmer/syntax': ^0.95.0
+      '@glimmer/validator': '*'
+      '@vue/compiler-core': ^3.5.12
+      content-tag: '4'
+      ember-template-recast: ^6.1.5
+      vue: ^3.5.12
+    peerDependenciesMeta:
+      '@glimmer/env':
+        optional: true
+      '@glimmer/reference':
+        optional: true
+      '@glimmer/syntax':
+        optional: true
+      '@glimmer/validator':
+        optional: true
+      '@vue/compiler-core':
+        optional: true
+      content-tag:
+        optional: true
+      ember-template-recast:
+        optional: true
+      vue:
+        optional: true
+
+snapshots:
+
+  '@formatjs/cli@6.8.8': {}

--- a/rules_formatjs/examples/simple/src/App.tsx
+++ b/rules_formatjs/examples/simple/src/App.tsx
@@ -1,0 +1,37 @@
+import {FormattedMessage, useIntl} from 'react-intl'
+
+export function App() {
+  const intl = useIntl()
+
+  return (
+    <div>
+      <h1>
+        <FormattedMessage
+          id="app.title"
+          defaultMessage="Welcome to FormatJS"
+          description="Main application title"
+        />
+      </h1>
+      <p>
+        <FormattedMessage
+          id="app.description"
+          defaultMessage="This is an example of internationalized React app using FormatJS and Bazel."
+          description="Application description"
+        />
+      </p>
+      <button
+        onClick={() =>
+          alert(
+            intl.formatMessage({id: 'app.button', defaultMessage: 'Click me!'})
+          )
+        }
+      >
+        <FormattedMessage
+          id="app.button"
+          defaultMessage="Click me!"
+          description="Button text"
+        />
+      </button>
+    </div>
+  )
+}

--- a/rules_formatjs/examples/simple/tests_verify/BUILD.bazel
+++ b/rules_formatjs/examples/simple/tests_verify/BUILD.bazel
@@ -1,0 +1,118 @@
+"""Tests for formatjs_verify_test rule"""
+
+load("@rules_formatjs//formatjs:defs.bzl", "formatjs_verify_test")
+
+# Test 1: Valid translations should pass
+formatjs_verify_test(
+    name = "test_valid_translations",
+    formatjs_cli = "//:formatjs_cli",
+    source_locale = "en",
+    translations = [
+        "en.json",
+        "es.json",
+        "fr.json",
+    ],
+)
+
+# Test 2: Missing keys should fail (negative test)
+formatjs_verify_test(
+    name = "test_missing_keys_fails",
+    expected_exit_code = 1,  # Expect failure
+    formatjs_cli = "//:formatjs_cli",
+    source_locale = "en",
+    translations = [
+        "en.json",
+        "de_missing_keys.json",
+    ],
+)
+
+# Test 3: Extra keys should fail (negative test)
+formatjs_verify_test(
+    name = "test_extra_keys_fails",
+    expected_exit_code = 1,  # Expect failure
+    formatjs_cli = "//:formatjs_cli",
+    source_locale = "en",
+    translations = [
+        "en.json",
+        "it_extra_keys.json",
+    ],
+)
+
+# Test 4: Invalid format should fail (negative test)
+formatjs_verify_test(
+    name = "test_invalid_format_fails",
+    expected_exit_code = 1,  # Expect failure
+    formatjs_cli = "//:formatjs_cli",
+    source_locale = "en",
+    translations = [
+        "en.json",
+        "ja_invalid_format.json",
+    ],
+)
+
+# Test 5: Only check missing keys
+formatjs_verify_test(
+    name = "test_only_missing_keys",
+    check_extra_keys = False,
+    check_missing_keys = True,
+    check_structural_equality = False,
+    formatjs_cli = "//:formatjs_cli",
+    source_locale = "en",
+    translations = [
+        "en.json",
+        "it_extra_keys.json",  # Has extra keys but should pass because we're not checking
+    ],
+)
+
+# Test 6: Only check extra keys (expected to fail)
+formatjs_verify_test(
+    name = "test_only_extra_keys",
+    check_extra_keys = True,
+    check_missing_keys = False,
+    check_structural_equality = False,
+    formatjs_cli = "//:formatjs_cli",
+    source_locale = "en",
+    translations = [
+        "en.json",
+        "de_missing_keys.json",  # Missing keys but we're only checking for extra keys
+    ],
+)
+
+# Test 7: Disable all checks (should always pass)
+formatjs_verify_test(
+    name = "test_no_checks",
+    check_extra_keys = False,
+    check_missing_keys = False,
+    check_structural_equality = False,
+    formatjs_cli = "//:formatjs_cli",
+    source_locale = "en",
+    translations = [
+        "en.json",
+        "de_missing_keys.json",
+        "it_extra_keys.json",
+    ],
+)
+
+# Test 8: Multiple translations at once
+formatjs_verify_test(
+    name = "test_multiple_translations",
+    formatjs_cli = "//:formatjs_cli",
+    source_locale = "en",
+    translations = [
+        "en.json",
+        "es.json",
+        "fr.json",
+    ],
+)
+
+# Test 9: Explicitly provide source_locale to ensure proper verification
+formatjs_verify_test(
+    name = "test_with_source_locale",
+    formatjs_cli = "//:formatjs_cli",
+    source_locale = "en",
+    translations = [
+        "en.json",
+        "es.json",
+        "fr.json",
+    ],
+)

--- a/rules_formatjs/examples/simple/tests_verify/README.md
+++ b/rules_formatjs/examples/simple/tests_verify/README.md
@@ -1,0 +1,117 @@
+# formatjs_verify_test Tests
+
+This directory contains comprehensive tests for the `formatjs_verify_test` rule.
+
+## Test Files
+
+- **en.json**: Source locale with 3 messages (greeting, farewell, count)
+- **es.json**: Complete Spanish translation
+- **fr.json**: Complete French translation
+- **de_missing_keys.json**: German translation missing the "count" key
+- **it_extra_keys.json**: Italian translation with an extra "extra_key" key
+- **ja_invalid_format.json**: Japanese translation with structurally incorrect messages
+
+## Test Cases
+
+### Passing Tests (run with `bazel test //tests_verify:all`)
+
+1. **test_valid_translations**: Verifies that complete, valid translations pass all checks
+   - Tests: en.json, es.json, fr.json
+   - Expected: ✅ Pass
+
+2. **test_only_missing_keys**: Tests that we can selectively check only for missing keys
+   - Tests: en.json, it_extra_keys.json (has extra keys)
+   - Checks: `check_missing_keys=True`, others disabled
+   - Expected: ✅ Pass (extra keys ignored)
+
+3. **test_only_extra_keys**: Tests that we can selectively check only for extra keys
+   - Tests: en.json, de_missing_keys.json (missing keys)
+   - Checks: `check_extra_keys=True`, others disabled
+   - Expected: ✅ Pass (missing keys ignored)
+
+4. **test_no_checks**: Tests that disabling all checks allows any translations
+   - Tests: en.json, de_missing_keys.json, it_extra_keys.json
+   - Checks: All disabled
+   - Expected: ✅ Pass
+
+5. **test_multiple_translations**: Verifies checking multiple translations at once
+   - Tests: en.json, es.json, fr.json
+   - Expected: ✅ Pass
+
+6. **test_with_source_locale**: Tests explicit source_locale parameter
+   - Tests: en.json, es.json, fr.json
+   - Expected: ✅ Pass
+
+### Negative Tests (use `expected_exit_code=1`)
+
+These tests verify error detection by expecting the formatjs verify command to fail:
+
+7. **test_missing_keys_fails**: Verifies detection of missing translation keys
+   - Tests: en.json, de_missing_keys.json
+   - Expected exit code: 1
+   - Output: "Missing translation keys for locale de_missing_keys: count"
+   - Result: ✅ Pass (failure detected correctly)
+
+8. **test_extra_keys_fails**: Verifies detection of extra translation keys
+   - Tests: en.json, it_extra_keys.json
+   - Expected exit code: 1
+   - Output: "Extra translation keys for locale it_extra_keys: extra_key"
+   - Result: ✅ Pass (failure detected correctly)
+
+9. **test_invalid_format_fails**: Verifies detection of structural format mismatches
+   - Tests: en.json, ja_invalid_format.json
+   - Expected exit code: 1
+   - Output: "These translation keys for locale ja_invalid_format are structurally different from en"
+   - Result: ✅ Pass (failure detected correctly)
+
+## Running Tests
+
+```bash
+# Run all tests (including negative tests)
+bazel test //tests_verify:all
+
+# Run a specific test
+bazel test //tests_verify:test_valid_translations
+
+# Run a negative test with verbose output
+bazel test //tests_verify:test_missing_keys_fails --test_output=all
+bazel test //tests_verify:test_extra_keys_fails --test_output=all
+bazel test //tests_verify:test_invalid_format_fails --test_output=all
+```
+
+## Test Coverage
+
+These tests verify:
+
+- ✅ Complete, valid translations pass verification
+- ✅ Missing keys are detected (using `expected_exit_code=1`)
+- ✅ Extra keys are detected (using `expected_exit_code=1`)
+- ✅ Structural format mismatches are detected (using `expected_exit_code=1`)
+- ✅ Individual checks can be enabled/disabled independently
+- ✅ Multiple translations can be verified simultaneously
+- ✅ Source locale parameter works correctly
+- ✅ The `expected_exit_code` parameter allows testing for expected failures
+
+## Using `expected_exit_code`
+
+The `expected_exit_code` parameter allows you to write tests that verify translations **should** fail validation:
+
+```starlark
+# Test that incomplete translations are properly detected
+formatjs_verify_test(
+    name = "test_incomplete_translation",
+    source_locale = "en",
+    translations = [
+        "en.json",
+        "incomplete.json",  # Missing some keys
+    ],
+    expected_exit_code = 1,  # We expect this to fail
+    formatjs_cli = "//:formatjs_cli",
+)
+```
+
+When `expected_exit_code` is set to a non-zero value:
+
+- The test **passes** if the verify command exits with that code
+- The test **fails** if the verify command exits with a different code
+- Error messages from the verify command are still displayed

--- a/rules_formatjs/examples/simple/tests_verify/de_missing_keys.json
+++ b/rules_formatjs/examples/simple/tests_verify/de_missing_keys.json
@@ -1,0 +1,4 @@
+{
+  "greeting": "Hallo, {name}!",
+  "farewell": "Auf Wiedersehen!"
+}

--- a/rules_formatjs/examples/simple/tests_verify/en.json
+++ b/rules_formatjs/examples/simple/tests_verify/en.json
@@ -1,0 +1,5 @@
+{
+  "greeting": "Hello, {name}!",
+  "farewell": "Goodbye!",
+  "count": "You have {count, plural, =0 {no items} one {# item} other {# items}}."
+}

--- a/rules_formatjs/examples/simple/tests_verify/es.json
+++ b/rules_formatjs/examples/simple/tests_verify/es.json
@@ -1,0 +1,5 @@
+{
+  "greeting": "¡Hola, {name}!",
+  "farewell": "¡Adiós!",
+  "count": "Tienes {count, plural, =0 {ningún artículo} one {# artículo} other {# artículos}}."
+}

--- a/rules_formatjs/examples/simple/tests_verify/fr.json
+++ b/rules_formatjs/examples/simple/tests_verify/fr.json
@@ -1,0 +1,5 @@
+{
+  "greeting": "Bonjour, {name}!",
+  "farewell": "Au revoir!",
+  "count": "Vous avez {count, plural, =0 {aucun article} one {# article} other {# articles}}."
+}

--- a/rules_formatjs/examples/simple/tests_verify/it_extra_keys.json
+++ b/rules_formatjs/examples/simple/tests_verify/it_extra_keys.json
@@ -1,0 +1,6 @@
+{
+  "greeting": "Ciao, {name}!",
+  "farewell": "Arrivederci!",
+  "count": "Hai {count, plural, =0 {nessun articolo} one {# articolo} other {# articoli}}.",
+  "extra_key": "This should not be here"
+}

--- a/rules_formatjs/examples/simple/tests_verify/ja_invalid_format.json
+++ b/rules_formatjs/examples/simple/tests_verify/ja_invalid_format.json
@@ -1,0 +1,5 @@
+{
+  "greeting": "こんにちは、{invalid}!",
+  "farewell": "さようなら!",
+  "count": "You have {wrong_var} items."
+}

--- a/rules_formatjs/formatjs.bzl
+++ b/rules_formatjs/formatjs.bzl
@@ -1,0 +1,13 @@
+"""Public API for rules_formatjs
+
+Load this file to access FormatJS Bazel rules:
+
+```starlark
+load("@rules_formatjs//formatjs:defs.bzl", "formatjs_extract", "formatjs_compile")
+```
+"""
+
+load("//formatjs:defs.bzl", _formatjs_compile = "formatjs_compile", _formatjs_extract = "formatjs_extract")
+
+formatjs_extract = _formatjs_extract
+formatjs_compile = _formatjs_compile

--- a/rules_formatjs/formatjs/BUILD.bazel
+++ b/rules_formatjs/formatjs/BUILD.bazel
@@ -1,0 +1,9 @@
+"""FormatJS build rules"""
+
+exports_files([
+    "defs.bzl",
+    "extract.bzl",
+    "compile.bzl",
+    "aggregate.bzl",
+    "verify.bzl",
+])

--- a/rules_formatjs/formatjs/aggregate.bzl
+++ b/rules_formatjs/formatjs/aggregate.bzl
@@ -1,0 +1,238 @@
+"""Aspect for aggregating extracted messages across dependency trees
+
+This aspect collects all extracted messages from a target and its dependencies,
+merging them into a single JSON file.
+"""
+
+load(":extract.bzl", "FormatjsExtractInfo")
+
+def _merge_messages_impl(ctx):
+    """Merge multiple message JSON files into one using jq."""
+
+    # Collect all message files to merge
+    message_files = ctx.attr.message_files
+
+    if not message_files:
+        fail("No message files provided to merge")
+
+    # Create output file
+    out = ctx.actions.declare_file(ctx.attr.name + ".json")
+
+    # Build jq command to merge all JSON files
+    # Strategy: Use jq to merge objects, with later files overwriting earlier ones
+    jq_filter = "reduce inputs as $item (.; . * $item)"
+
+    args = ctx.actions.args()
+    args.add("-s")  # slurp mode - read all inputs into array
+    args.add(jq_filter)
+    args.add_all(message_files)
+
+    jq_toolchain = ctx.toolchains["@jq.bzl//jq/toolchain:type"]
+
+    ctx.actions.run(
+        executable = jq_toolchain.jqinfo.bin,
+        arguments = [args],
+        inputs = depset(message_files),
+        outputs = [out],
+        mnemonic = "MergeMessages",
+        progress_message = "Merging %d message files" % len(message_files),
+    )
+
+    return [DefaultInfo(files = depset([out]))]
+
+_merge_messages = rule(
+    implementation = _merge_messages_impl,
+    attrs = {
+        "message_files": attr.label_list(
+            allow_files = [".json"],
+            doc = "List of message JSON files to merge",
+        ),
+    },
+    toolchains = ["@jq.bzl//jq/toolchain:type"],
+)
+
+FormatjsAggregateInfo = provider(
+    doc = "Aggregated messages from a target and its dependencies",
+    fields = {
+        "messages": "depset of message JSON files",
+        "count": "Number of message files collected",
+    },
+)
+
+def _formatjs_aggregate_aspect_impl(target, ctx):
+    """Aspect implementation that collects messages from dependencies.
+
+    This aspect traverses the dependency graph and collects all FormatjsExtractInfo
+    providers, aggregating their message files.
+    """
+
+    messages = []
+
+    # Collect from this target if it provides FormatjsExtractInfo
+    if FormatjsExtractInfo in target:
+        messages.append(target[FormatjsExtractInfo].messages)
+
+    # Collect from dependencies
+    if hasattr(ctx.rule.attr, "deps"):
+        for dep in ctx.rule.attr.deps:
+            if FormatjsAggregateInfo in dep:
+                messages.extend(dep[FormatjsAggregateInfo].messages.to_list())
+
+    if hasattr(ctx.rule.attr, "srcs"):
+        for src in ctx.rule.attr.srcs:
+            if FormatjsAggregateInfo in src:
+                messages.extend(src[FormatjsAggregateInfo].messages.to_list())
+
+    # Create merged file if we have messages
+    merged_file = None
+    if messages:
+        # Create a unique name for the merged file
+        merged_file = ctx.actions.declare_file(
+            ctx.label.name + "_aggregated_messages.json",
+        )
+
+        # Build jq command to merge all JSON files
+        # Use jq to recursively merge all objects
+        args = ctx.actions.args()
+        args.add("-s")  # slurp mode
+        args.add("reduce .[] as $item ({}; . * $item)")  # merge strategy
+        args.add_all(messages)
+
+        jq_toolchain = ctx.toolchains["@jq.bzl//jq/toolchain:type"]
+
+        ctx.actions.run(
+            executable = jq_toolchain.jqinfo.bin,
+            arguments = [args],
+            inputs = depset(messages),
+            outputs = [merged_file],
+            mnemonic = "AggregateMessages",
+            progress_message = "Aggregating %d message files for %s" % (len(messages), ctx.label),
+        )
+
+    return [
+        FormatjsAggregateInfo(
+            messages = depset(messages),
+            count = len(messages),
+        ),
+        OutputGroupInfo(
+            aggregated_messages = depset([merged_file]) if merged_file else depset(),
+            all_messages = depset(messages),
+        ),
+    ]
+
+formatjs_aggregate_aspect = aspect(
+    implementation = _formatjs_aggregate_aspect_impl,
+    attr_aspects = ["deps", "srcs"],
+    toolchains = ["@jq.bzl//jq/toolchain:type"],
+    doc = """Aspect that aggregates extracted messages across dependencies.
+
+    This aspect collects all FormatJS extracted message files from a target and
+    its transitive dependencies, merging them into a single JSON file using jq.
+
+    The merge strategy uses jq's object multiplication (*) which merges objects
+    with later values overwriting earlier ones for duplicate keys.
+
+    Usage:
+        # Aggregate messages from a target and all its dependencies
+        bazel build //path/to:target \\
+            --aspects=@rules_formatjs//formatjs:aggregate.bzl%formatjs_aggregate_aspect \\
+            --output_groups=aggregated_messages
+
+        # Get all individual message files (not merged)
+        bazel build //path/to:target \\
+            --aspects=@rules_formatjs//formatjs:aggregate.bzl%formatjs_aggregate_aspect \\
+            --output_groups=all_messages
+
+    Output:
+        - aggregated_messages: Single merged JSON file with all messages
+        - all_messages: All individual message JSON files (not merged)
+
+    The aggregated file will be named: <target_name>_aggregated_messages.json
+    """,
+)
+
+def _formatjs_aggregate_impl(ctx):
+    """Implementation of the formatjs_aggregate rule.
+
+    This rule takes extract targets as deps. The formatjs_aggregate_aspect (attached to deps)
+    traverses the dependency graph and provides FormatjsAggregateInfo with all collected messages.
+    This rule then merges those messages into a single JSON file.
+    """
+
+    # Collect all messages from dependencies via the aspect
+    # The aspect runs on each dep and provides FormatjsAggregateInfo
+    all_messages = []
+    for dep in ctx.attr.deps:
+        if FormatjsAggregateInfo in dep:
+            # Get the messages collected by the aspect
+            all_messages.extend(dep[FormatjsAggregateInfo].messages.to_list())
+        else:
+            fail("Dependency %s does not provide FormatjsAggregateInfo. " % dep.label +
+                 "Make sure the formatjs_aggregate_aspect is applied (this should happen automatically).")
+
+    if not all_messages:
+        fail("No messages found in dependencies. Make sure deps contain formatjs_extract targets.")
+
+    # Create the final aggregated output file
+    output = ctx.actions.declare_file(ctx.attr.name + ".json")
+
+    # Use jq to merge all messages
+    jq_toolchain = ctx.toolchains["@jq.bzl//jq/toolchain:type"]
+
+    # Build command to merge JSON files using jq
+    input_files = " ".join([f.path for f in all_messages])
+    command = "{jq} -s 'reduce .[] as $item ({{}}; . * $item)' {inputs} > {output}".format(
+        jq = jq_toolchain.jqinfo.bin.path,
+        inputs = input_files,
+        output = output.path,
+    )
+
+    ctx.actions.run_shell(
+        command = command,
+        inputs = depset(all_messages),
+        outputs = [output],
+        tools = [jq_toolchain.jqinfo.bin],
+        mnemonic = "AggregateFormatjsMessages",
+        progress_message = "Aggregating %d message files into %s" % (len(all_messages), output.short_path),
+    )
+
+    return [
+        DefaultInfo(files = depset([output])),
+        FormatjsAggregateInfo(
+            messages = depset(all_messages),
+            count = len(all_messages),
+        ),
+    ]
+
+formatjs_aggregate = rule(
+    implementation = _formatjs_aggregate_impl,
+    attrs = {
+        "deps": attr.label_list(
+            doc = "Dependencies to aggregate messages from. Should be formatjs_extract targets.",
+            aspects = [formatjs_aggregate_aspect],
+        ),
+    },
+    toolchains = ["@jq.bzl//jq/toolchain:type"],
+    doc = """Rule that aggregates messages from dependencies.
+
+    This rule automatically applies the formatjs_aggregate_aspect to traverse
+    dependencies and collect all messages, then merges them into a single JSON file.
+
+    Example:
+        ```starlark
+        formatjs_aggregate(
+            name = "all_messages",
+            deps = [
+                "//module1:messages",
+                "//module2:messages",
+                "//module3:messages",
+            ],
+        )
+
+        # Simply build the target to get the aggregated messages:
+        # bazel build //:all_messages
+        #
+        # The output will be at: bazel-bin/all_messages.json
+        ```
+    """,
+)

--- a/rules_formatjs/formatjs/aspects.bzl
+++ b/rules_formatjs/formatjs/aspects.bzl
@@ -1,0 +1,157 @@
+"""Example aspects for use with formatjs_extract rule
+
+This module demonstrates how to create aspects that work with formatjs_extract.
+"""
+
+load(":extract.bzl", "FormatjsExtractInfo")
+
+def _message_stats_aspect_impl(target, ctx):
+    """Example aspect that collects statistics about extracted messages.
+
+    This aspect can be attached to formatjs_extract targets to gather
+    information about the extracted messages without modifying the rule itself.
+    """
+
+    # Only process targets that provide FormatjsExtractInfo
+    if FormatjsExtractInfo not in target:
+        return []
+
+    info = target[FormatjsExtractInfo]
+
+    # Count source files
+    src_count = len(info.srcs.to_list())
+
+    # Create a stats file
+    stats_file = ctx.actions.declare_file(ctx.label.name + "_stats.txt")
+    ctx.actions.write(
+        output = stats_file,
+        content = """Message Extraction Statistics
+=============================
+Target: {label}
+Source Files: {src_count}
+Messages File: {messages}
+ID Pattern: {pattern}
+""".format(
+            label = ctx.label,
+            src_count = src_count,
+            messages = info.messages.path,
+            pattern = info.id_interpolation_pattern or "default",
+        ),
+    )
+
+    return [
+        OutputGroupInfo(
+            message_stats = depset([stats_file]),
+        ),
+    ]
+
+message_stats_aspect = aspect(
+    implementation = _message_stats_aspect_impl,
+    doc = """Example aspect that collects statistics about extracted messages.
+
+    Usage:
+        bazel build //path/to:target --aspects=//formatjs:aspects.bzl%message_stats_aspect \\
+                                      --output_groups=message_stats
+    """,
+)
+
+def _message_validator_aspect_impl(target, ctx):
+    """Example aspect that validates extracted messages.
+
+    This could be extended to check for:
+    - Missing descriptions
+    - Duplicate IDs
+    - Consistency across files
+    - etc.
+    """
+
+    if FormatjsExtractInfo not in target:
+        return []
+
+    info = target[FormatjsExtractInfo]
+
+    # Create a validation report
+    validation_file = ctx.actions.declare_file(ctx.label.name + "_validation.txt")
+
+    # For now, just create a simple report
+    # In a real implementation, you'd parse the JSON and validate it
+    ctx.actions.run_shell(
+        outputs = [validation_file],
+        inputs = [info.messages],
+        command = """
+            echo "Validation Report for {label}" > {output}
+            echo "======================" >> {output}
+            echo "" >> {output}
+            echo "Messages file: {messages}" >> {output}
+            echo "Validation: PASSED" >> {output}
+            echo "" >> {output}
+            echo "To implement custom validation:" >> {output}
+            echo "1. Parse the JSON file" >> {output}
+            echo "2. Check for missing descriptions" >> {output}
+            echo "3. Check for duplicate IDs" >> {output}
+            echo "4. Validate message syntax" >> {output}
+        """.format(
+            label = ctx.label,
+            output = validation_file.path,
+            messages = info.messages.path,
+        ),
+    )
+
+    return [
+        OutputGroupInfo(
+            message_validation = depset([validation_file]),
+        ),
+    ]
+
+message_validator_aspect = aspect(
+    implementation = _message_validator_aspect_impl,
+    doc = """Example aspect that validates extracted messages.
+
+    Usage:
+        bazel build //path/to:target --aspects=//formatjs:aspects.bzl%message_validator_aspect \\
+                                      --output_groups=message_validation
+    """,
+)
+
+def _message_collector_aspect_impl(target, ctx):
+    """Example aspect that collects all messages from a dependency tree.
+
+    This aspect traverses the dependency graph and collects all extracted
+    messages into a single aggregated file.
+    """
+
+    messages = []
+
+    # Collect from this target if it provides FormatjsExtractInfo
+    if FormatjsExtractInfo in target:
+        messages.append(target[FormatjsExtractInfo].messages)
+
+    # Collect from dependencies
+    if hasattr(ctx.rule.attr, "deps"):
+        for dep in ctx.rule.attr.deps:
+            if OutputGroupInfo in dep and hasattr(dep[OutputGroupInfo], "all_messages"):
+                messages.extend(dep[OutputGroupInfo].all_messages.to_list())
+
+    # Create aggregated output if we have messages
+    if messages:
+        return [
+            OutputGroupInfo(
+                all_messages = depset(messages),
+            ),
+        ]
+
+    return []
+
+message_collector_aspect = aspect(
+    implementation = _message_collector_aspect_impl,
+    attr_aspects = ["deps"],
+    doc = """Example aspect that collects all messages from a dependency tree.
+
+    This aspect can be used to gather all extracted messages from a target
+    and all its dependencies, useful for creating combined translation files.
+
+    Usage:
+        bazel build //path/to:target --aspects=//formatjs:aspects.bzl%message_collector_aspect \\
+                                      --output_groups=all_messages
+    """,
+)

--- a/rules_formatjs/formatjs/compile.bzl
+++ b/rules_formatjs/formatjs/compile.bzl
@@ -1,0 +1,44 @@
+"""Rules for compiling messages using @formatjs/cli"""
+
+def formatjs_compile(
+        name,
+        src,
+        out = None,
+        ast = False,
+        format = "simple",
+        formatjs_cli = "@npm//@formatjs/cli/bin:formatjs",
+        **kwargs):
+    """Compile extracted messages into optimized formats.
+
+    Args:
+        name: Name of the target
+        src: Source JSON file with extracted messages
+        out: Output compiled JSON file (defaults to name + ".json")
+        ast: Whether to compile to AST format
+        format: Input format (simple, crowdin, smartling, transifex)
+        formatjs_cli: Label for the formatjs CLI tool. Defaults to @npm//@formatjs/cli/bin:formatjs
+        **kwargs: Additional arguments passed to the underlying rule
+    """
+    if not out:
+        out = name + ".json"
+
+    args = [
+        "compile",
+        "$(location %s)" % src,
+        "--out-file",
+        "$(location %s)" % out,
+        "--format",
+        format,
+    ]
+
+    if ast:
+        args.append("--ast")
+
+    native.genrule(
+        name = name,
+        srcs = [src],
+        outs = [out],
+        cmd = "BAZEL_BINDIR=. $(location %s) " % formatjs_cli + " ".join(args),
+        tools = [formatjs_cli],
+        **kwargs
+    )

--- a/rules_formatjs/formatjs/defs.bzl
+++ b/rules_formatjs/formatjs/defs.bzl
@@ -1,0 +1,27 @@
+"""Public API for FormatJS Bazel rules
+
+This module provides the main entry points for using FormatJS in Bazel builds.
+"""
+
+load(
+    ":aggregate.bzl",
+    _FormatjsAggregateInfo = "FormatjsAggregateInfo",
+    _formatjs_aggregate = "formatjs_aggregate",
+    _formatjs_aggregate_aspect = "formatjs_aggregate_aspect",
+)
+load(":compile.bzl", _formatjs_compile = "formatjs_compile")
+load(":extract.bzl", _FormatjsExtractInfo = "FormatjsExtractInfo", _formatjs_extract = "formatjs_extract")
+load(":verify.bzl", _formatjs_verify_test = "formatjs_verify_test")
+
+# Public API - Rules
+formatjs_extract = _formatjs_extract
+formatjs_compile = _formatjs_compile
+formatjs_aggregate = _formatjs_aggregate
+formatjs_verify_test = _formatjs_verify_test
+
+# Public API - Aspects
+formatjs_aggregate_aspect = _formatjs_aggregate_aspect
+
+# Public API - Providers
+FormatjsExtractInfo = _FormatjsExtractInfo
+FormatjsAggregateInfo = _FormatjsAggregateInfo

--- a/rules_formatjs/formatjs/extract.bzl
+++ b/rules_formatjs/formatjs/extract.bzl
@@ -1,0 +1,132 @@
+"""Rules for extracting messages from source files using @formatjs/cli"""
+
+FormatjsExtractInfo = provider(
+    doc = "Information about extracted FormatJS messages",
+    fields = {
+        "messages": "File containing extracted messages in JSON format",
+        "srcs": "depset of source files that were extracted from",
+        "id_interpolation_pattern": "Pattern used for message ID generation",
+    },
+)
+
+def _formatjs_extract_impl(ctx):
+    """Implementation of the formatjs_extract rule."""
+
+    # Determine output file
+    if ctx.attr.out:
+        out_file = ctx.actions.declare_file(ctx.attr.out)
+    else:
+        out_file = ctx.actions.declare_file(ctx.label.name + ".json")
+
+    # Build arguments for formatjs CLI
+    args = ctx.actions.args()
+    args.add("extract")
+    args.add_all(ctx.files.srcs)
+    args.add("--out-file", out_file)
+    args.add("--format", "simple")
+
+    if ctx.attr.id_interpolation_pattern:
+        args.add("--id-interpolation-pattern", ctx.attr.id_interpolation_pattern)
+
+    if ctx.attr.extract_from_format_message_call:
+        args.add("--extract-from-format-message-call")
+
+    for component in ctx.attr.additional_component_names:
+        args.add("--additional-component-names", component)
+
+    for function in ctx.attr.additional_function_names:
+        args.add("--additional-function-names", function)
+
+    # Run formatjs extract
+    ctx.actions.run(
+        executable = ctx.executable.formatjs_cli,
+        arguments = [args],
+        inputs = depset(ctx.files.srcs),
+        outputs = [out_file],
+        mnemonic = "FormatjsExtract",
+        progress_message = "Extracting messages from %{label}",
+        env = {
+            "BAZEL_BINDIR": ".",
+        },
+    )
+
+    return [
+        DefaultInfo(files = depset([out_file])),
+        FormatjsExtractInfo(
+            messages = out_file,
+            srcs = depset(ctx.files.srcs),
+            id_interpolation_pattern = ctx.attr.id_interpolation_pattern,
+        ),
+    ]
+
+_formatjs_extract_rule = rule(
+    implementation = _formatjs_extract_impl,
+    doc = """Extract messages from source files using @formatjs/cli.
+
+    This rule extracts internationalized messages from TypeScript, JavaScript, JSX, and TSX files.
+    It produces a JSON file containing all extracted messages with their IDs, default messages,
+    and descriptions.
+
+    Aspects can be attached to this rule to perform additional analysis or transformations
+    on the extracted messages or their source files.
+
+    Example:
+        ```starlark
+        formatjs_extract(
+            name = "messages",
+            srcs = glob(["src/**/*.tsx"]),
+            id_interpolation_pattern = "[sha512:contenthash:base64:6]",
+            extract_from_format_message_call = True,
+        )
+        ```
+    """,
+    attrs = {
+        "srcs": attr.label_list(
+            allow_files = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"],
+            doc = "Source files to extract messages from",
+            mandatory = True,
+        ),
+        "out": attr.string(
+            doc = "Output file name (defaults to target name + '.json')",
+        ),
+        "id_interpolation_pattern": attr.string(
+            doc = """Pattern for generating message IDs.
+            Example: '[sha512:contenthash:base64:6]' for content-based IDs""",
+        ),
+        "extract_from_format_message_call": attr.bool(
+            default = False,
+            doc = "Extract messages from formatMessage() function calls",
+        ),
+        "additional_component_names": attr.string_list(
+            default = [],
+            doc = "Additional React component names to extract messages from",
+        ),
+        "additional_function_names": attr.string_list(
+            default = [],
+            doc = "Additional function names to extract messages from",
+        ),
+        "deps": attr.label_list(
+            default = [],
+            doc = "Dependencies that this extraction depends on (for aspect propagation)",
+            providers = [[FormatjsExtractInfo], [DefaultInfo]],
+        ),
+        "formatjs_cli": attr.label(
+            mandatory = True,
+            executable = True,
+            cfg = "exec",
+            doc = "The formatjs CLI tool (typically @npm//@formatjs/cli/bin:formatjs)",
+        ),
+    },
+)
+
+def formatjs_extract(formatjs_cli = "@npm//@formatjs/cli/bin:formatjs", **kwargs):
+    """Macro wrapper for _formatjs_extract_rule that sets formatjs_cli from caller's context.
+
+    Args:
+        formatjs_cli: Label for the formatjs CLI tool. Defaults to @npm//@formatjs/cli/bin:formatjs
+        **kwargs: All other arguments are passed to the underlying rule
+    """
+    _formatjs_extract_rule(
+        formatjs_cli = formatjs_cli,
+        **kwargs
+    )

--- a/rules_formatjs/formatjs/verify.bzl
+++ b/rules_formatjs/formatjs/verify.bzl
@@ -1,0 +1,100 @@
+"""Rules for verifying message translations using @formatjs/cli"""
+
+def formatjs_verify_test(
+        name,
+        translations,
+        source_locale = None,
+        check_missing_keys = True,
+        check_extra_keys = True,
+        check_structural_equality = True,
+        expected_exit_code = 0,
+        formatjs_cli = "@npm//@formatjs/cli/bin:formatjs",
+        **kwargs):
+    """Verify that translation files are valid and complete.
+
+    This test rule uses the formatjs CLI's verify command to check that:
+    - All message IDs in the source locale exist in translation files (if check_missing_keys=True)
+    - Translation files don't contain extra message IDs (if check_extra_keys=True)
+    - Message formats are structurally valid (if check_structural_equality=True)
+
+    The translations list must include the source locale file. The source locale is identified
+    either by the source_locale parameter (e.g., "en") or defaults to the first file in the list.
+
+    Args:
+        name: Name of the test target
+        translations: List of translation JSON files to verify (must include source locale)
+        source_locale: Source locale identifier (e.g., "en"). If not provided, uses the first file.
+        check_missing_keys: Whether to check for missing keys in target locale (default: True)
+        check_extra_keys: Whether to check for extra keys in target locale (default: True)
+        check_structural_equality: Whether to check structural equality of messages (default: True)
+        expected_exit_code: Expected exit code from the verify command (default: 0 for success, 1 for expected failures)
+        formatjs_cli: Label for the formatjs CLI tool. Defaults to @npm//@formatjs/cli/bin:formatjs
+        **kwargs: Additional arguments passed to the underlying test rule
+    """
+
+    # Build verify command arguments
+    verify_flags = []
+    if source_locale:
+        verify_flags.append("--source-locale")
+        verify_flags.append(source_locale)
+    if check_missing_keys:
+        verify_flags.append("--missing-keys")
+    if check_extra_keys:
+        verify_flags.append("--extra-keys")
+    if check_structural_equality:
+        verify_flags.append("--structural-equality")
+
+    flags_str = " ".join(verify_flags)
+
+    # Create the test script content with all translation files as arguments
+    file_args = " ".join(["$$TRANS_FILE_%d" % i for i in range(len(translations))])
+
+    # Handle expected exit codes
+    if expected_exit_code == 0:
+        # Normal case: expect success
+        script_content = """#!/bin/bash
+set -euo pipefail
+export BAZEL_BINDIR=.
+$$FORMATJS_CLI verify {flags} {args}
+echo "✓ Translation verification passed"
+""".format(flags = flags_str, args = file_args)
+    else:
+        # Negative test case: expect failure with specific exit code
+        script_content = """#!/bin/bash
+set -uo pipefail
+export BAZEL_BINDIR=.
+set +e
+$$FORMATJS_CLI verify {flags} {args}
+ACTUAL_EXIT_CODE=$$?
+set -e
+
+if [ $$ACTUAL_EXIT_CODE -eq {expected_code} ]; then
+    echo "✓ Translation verification failed as expected (exit code {expected_code})"
+    exit 0
+else
+    echo "✗ Expected exit code {expected_code}, but got $$ACTUAL_EXIT_CODE"
+    exit 1
+fi
+""".format(flags = flags_str, args = file_args, expected_code = expected_exit_code)
+
+    script_name = name + "_test.sh"
+    native.genrule(
+        name = name + "_script",
+        outs = [script_name],
+        cmd = "cat > $@ << 'EOF'\n%s\nEOF\nchmod +x $@" % script_content,
+    )
+
+    # Set up env vars for the test
+    env_vars = {
+        "FORMATJS_CLI": "$(rootpath %s)" % formatjs_cli,
+    }
+    for i, t in enumerate(translations):
+        env_vars["TRANS_FILE_%d" % i] = "$(rootpath %s)" % t
+
+    native.sh_test(
+        name = name,
+        srcs = [script_name],
+        data = translations + [formatjs_cli],
+        env = env_vars,
+        **kwargs
+    )

--- a/rules_formatjs/metadata.json
+++ b/rules_formatjs/metadata.json
@@ -1,0 +1,12 @@
+{
+  "homepage": "https://github.com/formatjs/formatjs",
+  "maintainers": [
+    {
+      "name": "FormatJS Team",
+      "email": "noreply@formatjs.io"
+    }
+  ],
+  "repository": ["github:formatjs/formatjs"],
+  "versions": [],
+  "yanked_versions": {}
+}

--- a/rules_formatjs/package.json
+++ b/rules_formatjs/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@bazel/rules_formatjs",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Bazel rules for FormatJS",
+  "dependencies": {
+    "@formatjs/cli": "^6.8.8"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": []
+  }
+}

--- a/rules_formatjs/pnpm-lock.yaml
+++ b/rules_formatjs/pnpm-lock.yaml
@@ -1,0 +1,50 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@formatjs/cli':
+        specifier: ^6.8.8
+        version: 6.8.8
+
+packages:
+
+  '@formatjs/cli@6.8.8':
+    resolution: {integrity: sha512-YTN8BO0z8dZAMJyXxjpYRxAKuxbfVH0oBKger593/8Ql6+q691YI23yt8DP0L+6b9JzlYOoIa1ghTzd8vaukPw==}
+    engines: {node: '>= 16'}
+    hasBin: true
+    peerDependencies:
+      '@glimmer/env': '*'
+      '@glimmer/reference': '*'
+      '@glimmer/syntax': ^0.95.0
+      '@glimmer/validator': '*'
+      '@vue/compiler-core': ^3.5.12
+      content-tag: '4'
+      ember-template-recast: ^6.1.5
+      vue: ^3.5.12
+    peerDependenciesMeta:
+      '@glimmer/env':
+        optional: true
+      '@glimmer/reference':
+        optional: true
+      '@glimmer/syntax':
+        optional: true
+      '@glimmer/validator':
+        optional: true
+      '@vue/compiler-core':
+        optional: true
+      content-tag:
+        optional: true
+      ember-template-recast:
+        optional: true
+      vue:
+        optional: true
+
+snapshots:
+
+  '@formatjs/cli@6.8.8': {}


### PR DESCRIPTION
# Add rules_formatjs - Bazel rules for FormatJS internationalization

### TL;DR

Adds a new `rules_formatjs` directory with Bazel rules for FormatJS internationalization, enabling message extraction and compilation in Bazel builds.

### What changed?

- Added `rules_formatjs` directory with Bazel rules for FormatJS internationalization
- Created two main rules: `formatjs_extract` and `formatjs_compile` for message extraction and compilation
- Added support for aspects to enable advanced build graph analysis
- Included two complete examples:
  - `simple`: Basic message extraction and compilation
  - `aggregate`: Advanced message aggregation across modules
- Added GitHub workflow and BuildBuddy configuration for testing
- Updated `.commitlintrc.mjs` to include `rules_formatjs` in the list of packages

### How to test?

1. Run the simple example:
```bash
cd rules_formatjs/examples/simple
bazel build //...
```

2. Run the aggregate example:
```bash
cd rules_formatjs/examples/aggregate
bazel build //...
```

3. Run the GitHub workflow:
```bash
gh workflow run test-rules-formatjs.yml
```

### Why make this change?

This adds Bazel integration for FormatJS, enabling developers to:
- Extract internationalized messages from source files
- Compile messages for optimized runtime performance
- Integrate message extraction and compilation into their build process
- Analyze and transform messages using Bazel aspects
- Aggregate messages across multiple modules in a monorepo

The rules provide a type-safe, reproducible way to manage internationalization in JavaScript/TypeScript projects built with Bazel.