### PR TITLE
fix(@formatjs/ts-transformer): throws when message desc values are not statically analyzable, fix #4235

### DIFF
--- a/packages/cli/integration-tests/extract/integration.test.ts
+++ b/packages/cli/integration-tests/extract/integration.test.ts
@@ -256,6 +256,15 @@ test('invalid syntax should throw', async () => {
   }).rejects.toThrowError('TS1005')
 }, 20000)
 
+// https://github.com/formatjs/formatjs/issues/4235
+test('#4235: non-static defaultMessage should throw with --throws', async () => {
+  await expect(async () => {
+    await exec(
+      `${BIN_PATH} extract --throws '${join(__dirname, 'typescript/non-static.tsx')}'`
+    )
+  }).rejects.toThrowError(/defaultMessage.*must be a string literal/i)
+}, 20000)
+
 test('whitespace and newlines should be preserved', async () => {
   process.chdir(__dirname)
   await expect(

--- a/packages/cli/integration-tests/extract/typescript/non-static.tsx
+++ b/packages/cli/integration-tests/extract/typescript/non-static.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import {FormattedMessage} from 'react-intl'
+
+// #4235: Non-static strings should throw an error when --throws is used
+export function NonStaticMessages() {
+  const dynamicValue = Math.random()
+
+  return (
+    <div>
+      {/* This should throw an error - template literal with expression */}
+      <FormattedMessage
+        defaultMessage={`${dynamicValue} not statically analyzable`}
+      />
+
+      {/* This should also throw - variable concatenation */}
+      <FormattedMessage defaultMessage={`Value: ${dynamicValue}`} />
+
+      {/* This should throw - variable reference */}
+      <FormattedMessage defaultMessage={dynamicValue as any} />
+    </div>
+  )
+}

--- a/packages/ts-transformer/src/transform.ts
+++ b/packages/ts-transformer/src/transform.ts
@@ -426,7 +426,24 @@ function extractMessageDescriptor(
                 msg.description = result
                 break
             }
+          } else if (
+            MESSAGE_DESC_KEYS.includes(name.text as keyof MessageDescriptor) &&
+            name.text !== 'description'
+          ) {
+            // Non-static expression for defaultMessage or id
+            throw new Error(
+              `[FormatJS] \`${name.text}\` must be a string literal or statically evaluable expression to be extracted.`
+            )
           }
+        }
+        // Non-static JSX expression for defaultMessage or id
+        else if (
+          MESSAGE_DESC_KEYS.includes(name.text as keyof MessageDescriptor) &&
+          name.text !== 'description'
+        ) {
+          throw new Error(
+            `[FormatJS] \`${name.text}\` must be a string literal to be extracted.`
+          )
         }
       }
       // {defaultMessage: 'asd' + bar'}
@@ -444,6 +461,14 @@ function extractMessageDescriptor(
               msg.description = result
               break
           }
+        } else if (
+          MESSAGE_DESC_KEYS.includes(name.text as keyof MessageDescriptor) &&
+          name.text !== 'description'
+        ) {
+          // Non-static expression for defaultMessage or id
+          throw new Error(
+            `[FormatJS] \`${name.text}\` must be a string literal or statically evaluable expression to be extracted.`
+          )
         }
       }
       // description: {custom: 1}
@@ -452,6 +477,15 @@ function extractMessageDescriptor(
         name.text === 'description'
       ) {
         msg.description = objectLiteralExpressionToObj(ts, initializer)
+      }
+      // Non-static value for defaultMessage or id
+      else if (
+        MESSAGE_DESC_KEYS.includes(name.text as keyof MessageDescriptor) &&
+        name.text !== 'description'
+      ) {
+        throw new Error(
+          `[FormatJS] \`${name.text}\` must be a string literal to be extracted.`
+        )
       }
     }
   })

--- a/packages/ts-transformer/tests/fixtures/nonStaticMessages.tsx
+++ b/packages/ts-transformer/tests/fixtures/nonStaticMessages.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import {FormattedMessage, useIntl} from 'react-intl'
+
+// #4235: Non-static strings should throw an error
+export function NonStaticMessages() {
+  const dynamicValue = Math.random()
+  const intl = useIntl()
+
+  return (
+    <div>
+      {/* This should throw an error - template literal with expression */}
+      <FormattedMessage
+        defaultMessage={`${dynamicValue} not statically analyzable`}
+      />
+
+      {/* This should also throw - variable concatenation */}
+      <FormattedMessage defaultMessage={`Value: ${dynamicValue}`} />
+
+      {/* This should throw - variable reference */}
+      <FormattedMessage defaultMessage={dynamicValue as any} />
+
+      {/* formatMessage with non-static string should also throw */}
+      {intl.formatMessage({
+        defaultMessage: `Dynamic: ${dynamicValue}`,
+      })}
+    </div>
+  )
+}

--- a/packages/ts-transformer/tests/index.test.ts
+++ b/packages/ts-transformer/tests/index.test.ts
@@ -708,6 +708,12 @@ describe('emit asserts for', function () {
       },
     ])
   })
+
+  it('GH #4235 - non-static defaultMessage should throw', async function () {
+    await expect(
+      compile(join(FIXTURES_DIR, 'nonStaticMessages.tsx'), {})
+    ).rejects.toThrow(/\[FormatJS\] `defaultMessage` must be a string literal/)
+  })
 })
 
 async function compile(filePath: string, options?: Partial<Opts>) {


### PR DESCRIPTION
## Fix: Extract non-static `defaultMessage` and `id` should throw error with `--throws` flag

Fixes #4235

### Problem

The formatjs CLI was silently succeeding when encountering non-static `defaultMessage` or `id` values instead of throwing an error when the `--throws` flag was used. This resulted in:
- Exit code 0 (success) instead of 1 (failure)
- Empty JSON output `{}` instead of an error message
- No indication that messages were being skipped due to non-static values

This was problematic because developers expect `--throws` to fail the build when messages can't be statically extracted, but the CLI was silently omitting them instead.

### Solution

Modified the TypeScript transformer to throw errors when encountering non-static values for `defaultMessage` or `id` fields. The fix adds validation at four strategic locations in the extraction pipeline:

1. After template literal evaluation (if non-static)
2. In JSX expression catch-all (for any unhandled expression type)
3. After binary expression evaluation (if non-static)  
4. In final catch-all (for any unhandled expression type)

The error messages differentiate between:
- `"must be a string literal or statically evaluable expression"` for binary expressions
- `"must be a string literal"` for other expression types

**Examples of non-static values that now throw errors:**
```tsx
// Template literal with expression
<FormattedMessage defaultMessage={`${dynamicValue} text`} />

// Variable concatenation
<FormattedMessage defaultMessage={`Value: ${variable}`} />

// Variable reference
<FormattedMessage defaultMessage={variable} />

// formatMessage with non-static string
intl.formatMessage({ defaultMessage: `Dynamic: ${value}` })
