### PR TITLE
fix(@formatjs/intl-numberformat): handle massive numbers, fix #4236

### DIFF
--- a/packages/ecma402-abstract/NumberFormat/ComputeExponentForMagnitude.ts
+++ b/packages/ecma402-abstract/NumberFormat/ComputeExponentForMagnitude.ts
@@ -50,7 +50,18 @@ export function ComputeExponentForMagnitude(
         return 0
       }
       if (num > thresholds[thresholds.length - 1]) {
-        return thresholds[thresholds.length - 1].length - 1
+        // GH #4236: When number exceeds max threshold, use the exponent
+        // corresponding to the largest available threshold in locale data.
+        // Calculate exponent the same way as for normal thresholds (lines 70-73).
+        const magnitudeKey = thresholds[thresholds.length - 1]
+        const compactPattern = thresholdMap[magnitudeKey].other
+        if (compactPattern === '0') {
+          return 0
+        }
+        return (
+          magnitudeKey.length -
+          thresholdMap[magnitudeKey].other.match(/0+/)![0].length
+        )
       }
       const i = thresholds.indexOf(num)
       if (i === -1) {

--- a/packages/ecma402-abstract/NumberFormat/format_to_parts.ts
+++ b/packages/ecma402-abstract/NumberFormat/format_to_parts.ts
@@ -555,7 +555,7 @@ function getCompactDisplayPattern(
   numberingSystem: string
 ): string | null {
   const {roundedNumber, sign, magnitude} = numberResult
-  const magnitudeKey = String(10 ** magnitude) as DecimalFormatNum
+  let magnitudeKey = String(10 ** magnitude) as DecimalFormatNum
   const defaultNumberingSystem = data.numbers.nu[0]
 
   let pattern: string
@@ -566,7 +566,20 @@ function getCompactDisplayPattern(
       byNumberingSystem[defaultNumberingSystem]
 
     // NOTE: compact notation ignores currencySign!
-    const compactPluralRules = currencyData.short?.[magnitudeKey]
+    let compactPluralRules = currencyData.short?.[magnitudeKey]
+    // GH #4236: If magnitude exceeds available patterns, use the largest available
+    if (!compactPluralRules) {
+      const thresholds = Object.keys(
+        currencyData.short || {}
+      ) as DecimalFormatNum[]
+      if (
+        thresholds.length > 0 &&
+        magnitudeKey > thresholds[thresholds.length - 1]
+      ) {
+        magnitudeKey = thresholds[thresholds.length - 1]
+        compactPluralRules = currencyData.short?.[magnitudeKey]
+      }
+    }
     if (!compactPluralRules) {
       return null
     }
@@ -577,7 +590,20 @@ function getCompactDisplayPattern(
       byNumberingSystem[numberingSystem] ||
       byNumberingSystem[defaultNumberingSystem]
 
-    const compactPlaralRule = byCompactDisplay[compactDisplay][magnitudeKey]
+    let compactPlaralRule = byCompactDisplay[compactDisplay][magnitudeKey]
+    // GH #4236: If magnitude exceeds available patterns, use the largest available
+    if (!compactPlaralRule) {
+      const thresholds = Object.keys(
+        byCompactDisplay[compactDisplay]
+      ) as DecimalFormatNum[]
+      if (
+        thresholds.length > 0 &&
+        magnitudeKey > thresholds[thresholds.length - 1]
+      ) {
+        magnitudeKey = thresholds[thresholds.length - 1]
+        compactPlaralRule = byCompactDisplay[compactDisplay][magnitudeKey]
+      }
+    }
     if (!compactPlaralRule) {
       return null
     }

--- a/packages/intl-numberformat/tests/misc.test.ts
+++ b/packages/intl-numberformat/tests/misc.test.ts
@@ -437,3 +437,31 @@ test('#4359 roundingIncrement with fraction digits', () => {
   expect(nf.format(1.222)).toBe('1.20')
   expect(nf.format(1.227)).toBe('1.25')
 })
+
+// https://github.com/formatjs/formatjs/issues/4236
+// Bug fixed: formatting very large numbers (> 1000 trillion) with compact notation
+test('#4236 compact notation with very large numbers (quadrillion scale)', () => {
+  const formatter = new NumberFormat('en', {
+    notation: 'compact',
+    compactDisplay: 'short',
+    maximumFractionDigits: 2,
+    minimumFractionDigits: 0,
+  })
+
+  // Test cases for various magnitudes
+  expect(formatter.format(1e12)).toBe('1T') // 1 trillion
+  expect(formatter.format(1.5e12)).toBe('1.5T') // 1.5 trillion
+  expect(formatter.format(1e13)).toBe('10T') // 10 trillion
+  expect(formatter.format(1e14)).toBe('100T') // 100 trillion
+
+  // Numbers >= 1000 trillion (1e15) should use the largest available pattern
+  // 1.75682e15 = 1,756,820,000,000,000 (1.757 quadrillion) → 1756.82T
+  expect(formatter.format(1.75682e15)).toBe('1756.82T')
+
+  // 1e15 = 1,000,000,000,000,000 (1 quadrillion) → 1000T
+  expect(formatter.format(1e15)).toBe('1000T')
+
+  // Even larger numbers should continue to use the T suffix
+  expect(formatter.format(1e16)).toBe('10000T') // 10 quadrillion
+  expect(formatter.format(5.5e16)).toBe('55000T') // 55 quadrillion
+})


### PR DESCRIPTION
### TL;DR

Fix compact number formatting for very large numbers that exceed available locale patterns.

### What changed?

- Modified `ComputeExponentForMagnitude` to correctly calculate the exponent when a number exceeds the maximum threshold
- Updated `getCompactDisplayPattern` to use the largest available pattern when formatting numbers that exceed the available magnitude patterns
- Added fallback logic for both currency and non-currency compact formatting

### How to test?

Run the new test cases that verify compact notation works correctly with very large numbers:
- Verify that numbers like 1 trillion (1e12) format as "1T"
- Verify that numbers exceeding 1000 trillion (1e15) format correctly using the largest available pattern (e.g., "1000T")
- Verify that even larger numbers (e.g., 10 quadrillion) continue to use the appropriate suffix

### Why make this change?

Fixes issue #4236 where very large numbers (greater than 1000 trillion) were not formatting correctly with compact notation. Previously, when a number exceeded the largest available threshold in locale data, the formatting would fail to apply the correct exponent calculation. This change ensures that even numbers beyond the explicit thresholds in locale data are formatted consistently using the largest available pattern.