### PR TITLE
feat(@formatjs/ts-transformer): flatten before id generation, fix #3537

### DIFF
--- a/docs/src/docs/tooling/babel-plugin.mdx
+++ b/docs/src/docs/tooling/babel-plugin.mdx
@@ -112,3 +112,19 @@ Pre-parse `defaultMessage` into AST for faster runtime perf. This flag doesn't d
 ### **`preserveWhitespace`**
 
 When set to true, message trimming is disabled.
+
+### **`flatten`**
+
+Whether to hoist selectors & flatten sentences as much as possible. For example:
+
+```
+I have {count, plural, one{a dog} other{many dogs}}
+```
+
+becomes
+
+```
+{count, plural, one{I have a dog} other{I have many dogs}}
+```
+
+The goal is to provide as many full sentences as possible since fragmented sentences are not translator-friendly. This transformation is applied before ID generation when using `overrideIdFn` or `idInterpolationPattern`, ensuring the ID is based on the flattened message format.

--- a/docs/src/docs/tooling/ts-transformer.mdx
+++ b/docs/src/docs/tooling/ts-transformer.mdx
@@ -200,4 +200,20 @@ Callback that gets triggered whenever a `pragme` meta is encountered.
 
 Whether to preserve whitespace and newlines.
 
+### **`flatten`**
+
+Whether to hoist selectors & flatten sentences as much as possible. For example:
+
+```
+I have {count, plural, one{a dog} other{many dogs}}
+```
+
+becomes
+
+```
+{count, plural, one{I have a dog} other{I have many dogs}}
+```
+
+The goal is to provide as many full sentences as possible since fragmented sentences are not translator-friendly. This transformation is applied before ID generation when using `overrideIdFn`, ensuring the ID is based on the flattened message format.
+
 Take a look at [`compile.ts`](https://github.com/formatjs/formatjs/blob/main/packages/ts-transformer/examples/compile.ts) for example in integration.

--- a/packages/babel-plugin-formatjs/tests/fixtures/flattenWithOverrideIdFn.js
+++ b/packages/babel-plugin-formatjs/tests/fixtures/flattenWithOverrideIdFn.js
@@ -1,0 +1,11 @@
+import {defineMessages} from 'react-intl'
+
+defineMessages({
+  foo: {
+    defaultMessage: 'I have {count, plural, one{a dog} other{many dogs}}',
+  },
+  bar: {
+    defaultMessage:
+      '{topicCount, plural, one {# topic} other {# topics}} and {noteCount, plural, one {# note} other {# notes}}',
+  },
+})

--- a/packages/babel-plugin-formatjs/types.ts
+++ b/packages/babel-plugin-formatjs/types.ts
@@ -43,4 +43,5 @@ export interface Options {
   extractSourceLocation?: boolean
   ast?: boolean
   preserveWhitespace?: boolean
+  flatten?: boolean
 }

--- a/packages/babel-plugin-formatjs/visitors/call-expression.ts
+++ b/packages/babel-plugin-formatjs/visitors/call-expression.ts
@@ -71,6 +71,7 @@ export const visitor: VisitNodeFunction<PluginPass & State, t.CallExpression> =
       removeDefaultMessage,
       ast,
       preserveWhitespace,
+      flatten,
     } = opts as Options
     if (wasExtracted(path)) {
       return
@@ -114,7 +115,8 @@ export const visitor: VisitNodeFunction<PluginPass & State, t.CallExpression> =
         filename || undefined,
         idInterpolationPattern,
         overrideIdFn,
-        preserveWhitespace
+        preserveWhitespace,
+        flatten
       )
       storeMessage(
         descriptor,

--- a/packages/babel-plugin-formatjs/visitors/jsx-opening-element.ts
+++ b/packages/babel-plugin-formatjs/visitors/jsx-opening-element.ts
@@ -31,6 +31,7 @@ export const visitor: VisitNodeFunction<
     overrideIdFn,
     ast,
     preserveWhitespace,
+    flatten,
   } = opts as Options
 
   const {componentNames, messages} = this
@@ -75,7 +76,8 @@ export const visitor: VisitNodeFunction<
     filename || undefined,
     idInterpolationPattern,
     overrideIdFn,
-    preserveWhitespace
+    preserveWhitespace,
+    flatten
   )
 
   storeMessage(

--- a/packages/cli-lib/src/extract.ts
+++ b/packages/cli-lib/src/extract.ts
@@ -7,9 +7,6 @@ import {outputFile} from 'fs-extra/esm'
 import {debug, getStdinAsString, warn, writeStdout} from './console_utils.js'
 import * as stringifyNs from 'json-stable-stringify'
 
-import {parse} from '@formatjs/icu-messageformat-parser'
-import {hoistSelectors} from '@formatjs/icu-messageformat-parser/manipulator.js'
-import {printAST} from '@formatjs/icu-messageformat-parser/printer.js'
 import {Formatter, resolveBuiltinFormatter} from './formatters/index.js'
 import {parseScript} from './parse_script.js'
 import {readFile} from 'fs/promises'
@@ -196,7 +193,7 @@ export async function extract(
   files: readonly string[],
   extractOpts: ExtractOpts
 ): Promise<string> {
-  const {throws, readFromStdin, flatten, ...opts} = extractOpts
+  const {throws, readFromStdin, ...opts} = extractOpts
   let rawResults: Array<ExtractionResult | undefined> = []
   try {
     if (readFromStdin) {
@@ -270,9 +267,8 @@ ${JSON.stringify(message, undefined, 2)}`
   const results: Record<string, Omit<MessageDescriptor, 'id'>> = {}
   const messages = Array.from(extractedMessages.values())
   for (const {id, ...msg} of messages) {
-    if (flatten && msg.defaultMessage) {
-      msg.defaultMessage = printAST(hoistSelectors(parse(msg.defaultMessage)))
-    }
+    // GH #3537: flatten is now applied during extraction in the babel plugin,
+    // so we don't need to apply it again here. The messages are already flattened.
     results[id] = msg
   }
   if (typeof formatter.serialize === 'function') {

--- a/packages/cli/integration-tests/extract/flattenWithIdPattern/actual.js
+++ b/packages/cli/integration-tests/extract/flattenWithIdPattern/actual.js
@@ -1,0 +1,11 @@
+import {defineMessages} from 'react-intl'
+
+defineMessages({
+  foo: {
+    defaultMessage: 'I have {count, plural, one{a dog} other{many dogs}}',
+  },
+  bar: {
+    defaultMessage:
+      '{topicCount, plural, one {# topic} other {# topics}} and {noteCount, plural, one {# note} other {# notes}}',
+  },
+})

--- a/packages/cli/integration-tests/extract/integration.test.ts
+++ b/packages/cli/integration-tests/extract/integration.test.ts
@@ -344,3 +344,34 @@ test('GH #4471: Optional chaining with generics in formatMessage', async () => {
     await readJSON(join(ARTIFACT_PATH, 'optionalChaining/actual.json'))
   ).toMatchSnapshot()
 })
+
+// https://github.com/formatjs/formatjs/issues/3537
+test('GH #3537: flatten with id-interpolation-pattern (content-based IDs)', async () => {
+  const result = await exec(
+    `${BIN_PATH} extract --throws --flatten --id-interpolation-pattern '[sha512:contenthash:base64:6]' '${join(
+      __dirname,
+      'flattenWithIdPattern/actual.js'
+    )}'`
+  )
+
+  // Parse the JSON output
+  const extracted = JSON.parse(result.stdout)
+
+  // Verify messages are flattened
+  const messages = Object.values(extracted) as Array<{defaultMessage: string}>
+  const sortedMessages = messages.sort((a, b) =>
+    a.defaultMessage.localeCompare(b.defaultMessage)
+  )
+
+  // Check that both messages are flattened correctly
+  expect(sortedMessages).toEqual([
+    {
+      defaultMessage:
+        '{count,plural,one{I have a dog} other{I have many dogs}}',
+    },
+    {
+      defaultMessage:
+        '{topicCount,plural,one{{noteCount,plural,one{{topicCount, number} topic and # note} other{{topicCount, number} topic and # notes}}} other{{noteCount,plural,one{{topicCount, number} topics and # note} other{{topicCount, number} topics and # notes}}}}',
+    },
+  ])
+}, 20000)


### PR DESCRIPTION
### TL;DR

Fix issue #3537 by applying message flattening before ID generation in babel-plugin-formatjs.

### What changed?

- Added `flatten` option to babel-plugin-formatjs types
- Modified `evaluateMessageDescriptor` to apply flattening before calling `overrideIdFn`
- Passed the flatten option through the visitor functions
- Updated the CLI to leverage the flattening done in the babel plugin instead of applying it afterward
- Added tests to verify that flattened messages are correctly passed to `overrideIdFn`

### How to test?

1. Run the new test case: `GH #3537: flatten with overrideIdFn`
2. Verify that when using both `flatten` and `overrideIdFn` options, the ID is generated based on the flattened message
3. Check the CLI integration test for flattening with ID interpolation pattern

### Why make this change?

Fixes issue #3537 where message IDs were being generated based on the original message format rather than the flattened version. This caused inconsistencies when using content-based IDs with flattened messages, as the ID was based on the pre-flattened content while the output contained the flattened message. By applying flattening before ID generation, we ensure that the ID is based on the same content that will be in the final output.