### PR TITLE
docs: fix live editor

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -644,7 +644,7 @@
         "bzlTransitiveDigest": "u2i6cw9UufcXbPuESBB66WdqYKm1KTFsDORyv0HawHo=",
         "usagesDigest": "tsxRjH5DN8xUnGoUELCp/xuIp04EwwlFAtYpnGb6Y+4=",
         "recordedFileInputs": {
-          "@@//package.json": "807c36a071af08a368376e9da1f526af1793a53b4ac5ab8c1d94b60e13e83f49"
+          "@@//package.json": "bc28291a23b28fdd0ec1080dfaef8489371cf752032df5e59d5207cd74a8d5f4"
         },
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/docs/src/components/LiveCodeBlock.tsx
+++ b/docs/src/components/LiveCodeBlock.tsx
@@ -19,6 +19,8 @@ const scope = {
   useMemo: React.useMemo,
   useCallback: React.useCallback,
   Fragment: React.Fragment,
+  defineMessages: ReactIntl.defineMessages,
+
   // ReactIntl exports
   FormattedMessage: ReactIntl.FormattedMessage,
   FormattedDate: ReactIntl.FormattedDate,
@@ -133,7 +135,7 @@ export function LiveCodeBlock({
     const isJSX = code.startsWith('<')
 
     // Wrap non-JSX code in a fragment to render the result
-    return isJSX ? code : `<>{${code}}</>`
+    return isJSX ? code : `<>{function(){${code}}()}</>`
   }, [])
 
   return (

--- a/docs/src/docs/intl.mdx
+++ b/docs/src/docs/intl.mdx
@@ -481,7 +481,6 @@ function () {
 with `ReactElement`
 
 ```ts live
-function () {
   const messages = defineMessages({
     greeting: {
       id: 'app.greeting',
@@ -491,7 +490,6 @@ function () {
   })
 
   return intl.formatMessage(messages.greeting, {name: <b>Eric</b>})
-}
 ```
 
 with rich text formatting

--- a/docs/src/docs/react-intl/api.mdx
+++ b/docs/src/docs/react-intl/api.mdx
@@ -515,7 +515,7 @@ This function will return a formatted message string. It expects a `MessageDescr
 
 If a translated message with the `id` has been passed to the `<IntlProvider>` via its `messages` prop it will be formatted, otherwise it will fallback to formatting `defaultMessage`. See: [Message Formatting Fallbacks](#message-formatting-fallbacks) for more details.
 
-<LiveCodeBlock code={`() => {
+<LiveCodeBlock code={`
   const messages = defineMessages({
     greeting: {
       id: 'app.greeting',
@@ -525,12 +525,12 @@ If a translated message with the `id` has been passed to the `<IntlProvider>` vi
   })
 
 return <div>{intl.formatMessage(messages.greeting, {name: 'Eric'})}</div>
-}
+
 `} />
 
 with `ReactElement`
 
-<LiveCodeBlock code={`() => {
+<LiveCodeBlock code={`
   const messages = defineMessages({
     greeting: {
       id: 'app.greeting',
@@ -540,12 +540,12 @@ with `ReactElement`
   })
 
 return <div>{intl.formatMessage(messages.greeting, {name: <b>Eric</b>})}</div>
-}
+
 `} />
 
 with rich text formatting
 
-<LiveCodeBlock code={`() => {
+<LiveCodeBlock code={`
   const messages = defineMessages({
     greeting: {
       id: 'app.greeting',
@@ -558,7 +558,7 @@ return <div>{intl.formatMessage(messages.greeting, {
 name: 'Eric',
 bold: str => <b>{str}</b>,
 })}</div>
-}
+
 `} />
 
 The message we defined using [`defineMessages`](#definemessages) to support extraction via `babel-plugin-formatjs`, but it doesn't have to be if you're not using the Babel plugin.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "prepare": "lefthook install",
     "prerelease": "LEFTHOOK=0 lerna version --yes --no-private",
     "test": "syncpack lint && oxlint --config .oxlintrc.json && bazel test //...",
-    "website": "bazel run //docs:serve"
+    "website": "ibazel run //docs:serve"
   },
   "devDependencies": {
     "@babel/core": "^7.26.10",


### PR DESCRIPTION
### TL;DR

Fixed LiveCodeBlock component to properly handle non-JSX code examples and added `defineMessages` to the available scope for live code blocks.

### What changed?

- Modified the LiveCodeBlock component to wrap non-JSX code in a self-executing function for proper rendering
- Added `defineMessages` from ReactIntl to the component scope
- Updated code examples in the documentation to work with the new implementation
- Changed the website script in package.json to use `ibazel` for incremental builds

### How to test?

1. Run `npm run website` to start the documentation site with hot reloading
2. Navigate to the intl.mdx and react-intl/api.mdx pages
3. Verify that the live code examples with `defineMessages` now render correctly
4. Test both JSX and non-JSX code examples to ensure they display properly

### Why make this change?

The previous implementation of LiveCodeBlock couldn't properly handle non-JSX code that used `defineMessages` from ReactIntl. This change ensures that code examples in the documentation render correctly and provides a better developer experience with incremental builds when working on the documentation site.