### PR TITLE
perf: add CLI benchmark

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -644,7 +644,7 @@
         "bzlTransitiveDigest": "u2i6cw9UufcXbPuESBB66WdqYKm1KTFsDORyv0HawHo=",
         "usagesDigest": "tsxRjH5DN8xUnGoUELCp/xuIp04EwwlFAtYpnGb6Y+4=",
         "recordedFileInputs": {
-          "@@//package.json": "bc28291a23b28fdd0ec1080dfaef8489371cf752032df5e59d5207cd74a8d5f4"
+          "@@//package.json": "10838e1520f853b583154521068a07a1f2ed6876b91dfaca471857e4853a18dc"
         },
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/benchmarks/cli-comparison/BUILD.bazel
+++ b/benchmarks/cli-comparison/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_run_binary")
+load("@npm//:defs.bzl", "npm_link_all_packages")
+
+npm_link_all_packages()
+
+# Generate test files (100K files with mixed message formats)
+# Includes defineMessage, defineMessages, formatMessage, and FormattedMessage patterns
+js_run_binary(
+    name = "generate",
+    srcs = ["generate-test-files.mjs"],
+    chdir = package_name(),
+    env = {"NUM_FILES": "100000"},
+    out_dirs = ["test-files"],
+    tags = ["manual"],
+    tool = "//:node_modules/node",
+)
+
+# Benchmark binary
+js_binary(
+    name = "benchmark",
+    data = [
+        "benchmark-tinybench.mjs",
+        ":generate",  # Test files as data dependency
+        "//:node_modules/@bazel/runfiles",
+        "//:node_modules/tinybench",
+        "//packages/cli:bin",
+        "//rust/formatjs_cli",
+    ],
+    entry_point = "benchmark-tinybench.mjs",
+    tags = ["manual"],
+)

--- a/benchmarks/cli-comparison/README.md
+++ b/benchmarks/cli-comparison/README.md
@@ -1,0 +1,210 @@
+# FormatJS CLI Benchmark: Rust vs TypeScript
+
+This benchmark compares the performance of the Rust CLI implementation against the TypeScript CLI for the `extract` command.
+
+## Overview
+
+The benchmark:
+
+- Generates 100,000 TypeScript/React files with ICU MessageFormat messages
+- Tests all message extraction patterns:
+  - `defineMessage` - individual message definitions
+  - `defineMessages` - grouped message definitions
+  - `intl.formatMessage()` - imperative formatting
+  - `<FormattedMessage />` - JSX component formatting
+- Message complexity distribution: 40% simple, 30% with variables, 15% plural, 10% select, 5% complex nested
+- Measures execution time, throughput (messages/second), and statistical confidence
+
+## Benchmark Results
+
+### Test Environment
+
+- **OS**: macOS 25.2.0 (Darwin)
+- **CPU**: Apple Silicon
+- **Node.js**: v24.12.0
+- **Date**: 2026-01-04
+
+### Results (1,000 files, 9,656 messages)
+
+| Metric                 | TypeScript | Rust     | Speedup   |
+| ---------------------- | ---------- | -------- | --------- |
+| **Mean Time**          | 601.63ms   | 131.77ms | **4.57x** |
+| **Operations/sec**     | 1.66       | 7.59     | **4.57x** |
+| **Messages/sec**       | 16,050     | 73,279   | **4.57x** |
+| **Margin of Error**    | ±31.94ms   | ±2.82ms  | -         |
+| **Samples**            | 9          | 38       | -         |
+| **Messages Extracted** | 9,656      | 9,656    | ✓         |
+
+**Summary**: The Rust CLI is **4.57x faster** (356.6% faster) than the TypeScript CLI, processing 73,279 messages/second vs 16,050 messages/second.
+
+These results include all message extraction patterns: `defineMessage`, `defineMessages`, `intl.formatMessage()`, and `<FormattedMessage />`.
+
+## Quick Start
+
+### Option 1: Using the convenience script (Recommended)
+
+```bash
+cd benchmarks/cli-comparison
+./run-benchmark.sh
+```
+
+This script will:
+
+1. Build both TypeScript and Rust CLIs
+2. Generate 100K test files (if not already present)
+3. Run the benchmark with statistical analysis
+
+### Option 2: Manual steps
+
+```bash
+# From the repository root
+
+# 1. Generate test files (100K files with mixed message formats)
+bazel build //benchmarks/cli-comparison:generate
+
+# 2. Build both CLIs
+bazel build //packages/cli:bin
+bazel build //rust/formatjs_cli --compilation_mode=opt
+
+# 3. Run the benchmark
+cd benchmarks/cli-comparison
+node benchmark-tinybench.mjs
+```
+
+### Option 3: Using Bazel
+
+```bash
+# Build and run via Bazel
+bazel run //benchmarks/cli-comparison:benchmark
+```
+
+The benchmark script automatically looks for test files and CLIs in `bazel-bin/` output directories.
+
+## How It Works
+
+### Test File Generation
+
+The generator creates realistic React/TypeScript files with a mix of message patterns:
+
+```tsx
+// 25% defineMessages (grouped)
+const messages = defineMessages({
+  greeting: {
+    id: 'msg_0_0',
+    defaultMessage: 'Hello, World!',
+    description: 'Greeting message',
+  },
+})
+
+// 25% defineMessage (individual)
+const greeting = defineMessage({
+  id: 'msg_1_0',
+  defaultMessage: 'Welcome, {name}!',
+  description: 'Welcome message',
+})
+
+// 25% intl.formatMessage (imperative)
+const message = intl.formatMessage({
+  id: 'msg_2_0',
+  defaultMessage: 'You have {count, plural, one {# item} other {# items}}',
+})
+
+// 25% FormattedMessage (JSX)
+<FormattedMessage
+  id="msg_3_0"
+  defaultMessage="Order is {status, select, pending {processing} shipped {in transit} other {unknown}}"
+/>
+```
+
+### Message Complexity
+
+Messages include various ICU MessageFormat features:
+
+- **Simple**: `"Hello, World!"`
+- **Variables**: `"Welcome, {name}!"`
+- **Plural**: `"{count, plural, one {# item} other {# items}}"`
+- **Select**: `"{status, select, active {Active} inactive {Inactive} other {Unknown}}"`
+- **Complex**: Nested plural/select with rich text markup
+
+### Benchmark Methodology
+
+Uses [tinybench](https://github.com/tinylibs/tinybench) for statistical benchmarking:
+
+- **Warmup**: 1 second, 1 iteration
+- **Measurement**: 5 seconds minimum, at least 3 iterations
+- **Metrics**: Mean time, margin of error, operations/sec, messages/sec
+- **Validation**: Both CLIs must extract identical message counts
+
+## Output
+
+```
+================================================================================
+BENCHMARK RESULTS
+================================================================================
+
+📊 Performance Metrics:
+────────────────────────────────────────────────────────────────────────────────
+Metric                                        TypeScript                 Rust           Ratio
+────────────────────────────────────────────────────────────────────────────────
+Mean Time (ms)                                    601.63               131.77           4.57x
+Operations/sec                                      1.66                 7.59           4.57x
+Messages/sec                                       16,050               73,279           4.57x
+Margin of Error (ms)                              ±31.94                ±2.82               -
+Samples                                                9                   38               -
+Messages Extracted                                 9,656                9,656               -
+────────────────────────────────────────────────────────────────────────────────
+
+✨ Summary:
+   🚀 Rust is 4.57x faster (356.6% faster)
+   📈 7.59 ops/sec vs 1.66 ops/sec
+   💬 Processes 73,279 msg/s vs 16,050 msg/s
+   ✓ Both extracted 9,656 messages
+```
+
+Results are saved to `benchmark-results.json` with detailed statistics.
+
+## Troubleshooting
+
+### "Rust CLI not found"
+
+```bash
+bazel build //rust/formatjs_cli --compilation_mode=opt
+```
+
+### "TypeScript CLI not found"
+
+```bash
+bazel build //packages/cli:bin
+```
+
+### "Test files not found"
+
+```bash
+bazel build //benchmarks/cli-comparison:generate
+```
+
+### "Cannot find module 'tinybench'"
+
+```bash
+cd benchmarks/cli-comparison
+pnpm install
+```
+
+### Out of memory with 100K files
+
+Reduce the file count in BUILD.bazel:
+
+```python
+env = {"NUM_FILES": "10000"},  # Reduce from 100000 to 10000
+```
+
+## System Requirements
+
+- **Node.js**: v18 or later
+- **Bazel**: Latest version
+- **Memory**: At least 4GB available RAM
+- **Disk**: ~2GB for test files (100K files)
+
+## License
+
+Same as the main FormatJS project (MIT).

--- a/benchmarks/cli-comparison/benchmark-results.json
+++ b/benchmarks/cli-comparison/benchmark-results.json
@@ -1,0 +1,28 @@
+{
+  "timestamp": "2026-01-04T16:53:38.221Z",
+  "testFiles": {
+    "count": 1000,
+    "messages": 9656,
+    "pattern": "/Users/longho/src/formatjs/bazel-bin/benchmarks/cli-comparison/test-files/**/*.tsx"
+  },
+  "typescript": {
+    "mean": 601.6272822222221,
+    "marginOfError": 31.94,
+    "opsPerSec": 1.6621586645909978,
+    "messagesPerSec": 16049.804065290675,
+    "samples": 9,
+    "rme": 5.30959347502743
+  },
+  "rust": {
+    "mean": 131.77019302631572,
+    "marginOfError": 2.82,
+    "opsPerSec": 7.588969683001761,
+    "messagesPerSec": 73279.091259065,
+    "samples": 38,
+    "rme": 2.143856692003947
+  },
+  "comparison": {
+    "speedup": 4.565731205251187,
+    "percentFaster": 356.6
+  }
+}

--- a/benchmarks/cli-comparison/benchmark-tinybench.mjs
+++ b/benchmarks/cli-comparison/benchmark-tinybench.mjs
@@ -1,0 +1,280 @@
+#!/usr/bin/env node
+/**
+ * Benchmark script using tinybench to compare Rust CLI vs TypeScript CLI performance
+ */
+
+import {Bench} from 'tinybench'
+import {execSync} from 'child_process'
+import fs from 'fs'
+import path from 'path'
+import {fileURLToPath} from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+// Try to use Bazel runfiles if available, otherwise fall back to bazel-bin
+let TEST_FILES_DIR, TS_CLI, RUST_CLI
+
+try {
+  // Try importing @bazel/runfiles for proper Bazel sandbox support
+  const {Runfiles} = await import('@bazel/runfiles')
+  const runfiles = Runfiles.create()
+
+  // Resolve paths through runfiles
+  TEST_FILES_DIR = runfiles.resolve(
+    '_main/benchmarks/cli-comparison/test-files'
+  )
+  TS_CLI = runfiles.resolve('_main/packages/cli/bin/formatjs')
+  RUST_CLI = runfiles.resolve('_main/rust/formatjs_cli/formatjs_cli')
+} catch {
+  // Fall back to bazel-bin for manual execution
+  const BAZEL_BIN = path.join(__dirname, '../../bazel-bin')
+  TEST_FILES_DIR = path.join(BAZEL_BIN, 'benchmarks/cli-comparison/test-files')
+  TS_CLI = path.join(BAZEL_BIN, 'packages/cli/bin/formatjs')
+  RUST_CLI = path.join(BAZEL_BIN, 'rust/formatjs_cli/formatjs_cli')
+}
+
+const OUTPUT_DIR = path.join(__dirname, 'benchmark-output')
+
+// Check if TypeScript CLI is built
+if (!fs.existsSync(TS_CLI)) {
+  console.error('❌ Error: TypeScript CLI not found. Please build it first:')
+  console.error('  bazel build //packages/cli:bin')
+  process.exit(1)
+}
+
+// Check if Rust CLI is built
+if (!fs.existsSync(RUST_CLI)) {
+  console.error('❌ Error: Rust CLI not found. Please build it first:')
+  console.error('  bazel build //rust/formatjs_cli --compilation_mode=opt')
+  process.exit(1)
+}
+
+// Check if test files exist
+if (!fs.existsSync(TEST_FILES_DIR)) {
+  console.error('❌ Error: Test files not found. Please generate them first:')
+  console.error('  bazel build //benchmarks/cli-comparison:generate')
+  console.error(`  (Looking for test files at: ${TEST_FILES_DIR})`)
+  process.exit(1)
+}
+
+// Clean and create output directory
+try {
+  fs.rmSync(OUTPUT_DIR, {recursive: true})
+} catch {
+  // Directory doesn't exist, that's fine
+}
+fs.mkdirSync(OUTPUT_DIR, {recursive: true})
+
+// Count test files
+function countFiles(dir, count = 0) {
+  const files = fs.readdirSync(dir)
+  for (const file of files) {
+    const filePath = path.join(dir, file)
+    const stat = fs.statSync(filePath)
+    if (stat.isDirectory()) {
+      count = countFiles(filePath, count)
+    } else if (file.endsWith('.tsx')) {
+      count++
+    }
+  }
+  return count
+}
+
+const fileCount = countFiles(TEST_FILES_DIR)
+const pattern = path.join(TEST_FILES_DIR, '**/*.tsx')
+
+console.log('🔥 FormatJS CLI Benchmark: Rust vs TypeScript (using tinybench)')
+console.log('='.repeat(80))
+console.log(
+  `\n📁 Test files: ${fileCount.toLocaleString()} TypeScript/React files`
+)
+console.log(`📂 Test directory: ${TEST_FILES_DIR}`)
+console.log('\n⏱️  Running benchmarks...\n')
+
+// Create benchmark suite
+const bench = new Bench({
+  time: 5000, // Run for 5 seconds minimum per benchmark
+  iterations: 3, // At least 3 iterations
+  warmupTime: 1000, // 1 second warmup
+  warmupIterations: 1,
+})
+
+let tsMessageCount = 0
+let rustMessageCount = 0
+
+// TypeScript CLI benchmark
+bench.add('TypeScript CLI', () => {
+  const outputFile = path.join(OUTPUT_DIR, `typescript-${Date.now()}.json`)
+  const command = `"${TS_CLI}" extract "${pattern}" --out-file "${outputFile}"`
+
+  try {
+    execSync(command, {
+      stdio: 'pipe',
+      maxBuffer: 1024 * 1024 * 100, // 100MB buffer
+    })
+
+    // Count messages on first run
+    if (tsMessageCount === 0) {
+      const output = JSON.parse(fs.readFileSync(outputFile, 'utf8'))
+      tsMessageCount = Object.keys(output).length
+    }
+
+    // Clean up output file
+    fs.unlinkSync(outputFile)
+  } catch (error) {
+    console.error('Error running TypeScript CLI:', error.message)
+    throw error
+  }
+})
+
+// Rust CLI benchmark
+bench.add('Rust CLI', () => {
+  const outputFile = path.join(OUTPUT_DIR, `rust-${Date.now()}.json`)
+  const command = `"${RUST_CLI}" extract "${pattern}" --out-file "${outputFile}"`
+
+  try {
+    execSync(command, {
+      stdio: 'pipe',
+      maxBuffer: 1024 * 1024 * 100, // 100MB buffer
+    })
+
+    // Count messages on first run
+    if (rustMessageCount === 0) {
+      const output = JSON.parse(fs.readFileSync(outputFile, 'utf8'))
+      rustMessageCount = Object.keys(output).length
+    }
+
+    // Clean up output file
+    fs.unlinkSync(outputFile)
+  } catch (error) {
+    console.error('Error running Rust CLI:', error.message)
+    throw error
+  }
+})
+
+// Run benchmarks
+await bench.run()
+
+// Display results
+console.log('\n' + '='.repeat(80))
+console.log('BENCHMARK RESULTS')
+console.log('='.repeat(80))
+
+const tsResult = bench.tasks.find(t => t.name === 'TypeScript CLI')
+const rustResult = bench.tasks.find(t => t.name === 'Rust CLI')
+
+if (!tsResult?.result || !rustResult?.result) {
+  console.log('\n⚠️  Benchmark incomplete - one or more runs failed')
+  process.exit(1)
+}
+
+// Calculate metrics
+const tsMean = tsResult.result.mean // Already in ms
+const rustMean = rustResult.result.mean // Already in ms
+const speedup = tsMean / rustMean
+
+const tsMsgPerSec = tsMessageCount / (tsMean / 1000)
+const rustMsgPerSec = rustMessageCount / (rustMean / 1000)
+
+console.log('\n📊 Performance Metrics:')
+console.log('─'.repeat(80))
+console.log(
+  `${'Metric'.padEnd(35)} ${'TypeScript'.padStart(20)} ${'Rust'.padStart(20)} ${'Ratio'.padStart(15)}`
+)
+console.log('─'.repeat(80))
+
+// Mean execution time
+console.log(
+  `${'Mean Time (ms)'.padEnd(35)} ${`${tsMean.toFixed(2)}`.padStart(20)} ${`${rustMean.toFixed(2)}`.padStart(20)} ${`${speedup.toFixed(2)}x`.padStart(15)}`
+)
+
+// Operations per second
+const tsOpsPerSec = 1000 / tsMean
+const rustOpsPerSec = 1000 / rustMean
+console.log(
+  `${'Operations/sec'.padEnd(35)} ${`${tsOpsPerSec.toFixed(2)}`.padStart(20)} ${`${rustOpsPerSec.toFixed(2)}`.padStart(20)} ${`${(rustOpsPerSec / tsOpsPerSec).toFixed(2)}x`.padStart(15)}`
+)
+
+// Messages per second
+console.log(
+  `${'Messages/sec'.padEnd(35)} ${`${tsMsgPerSec.toFixed(0)}`.padStart(20)} ${`${rustMsgPerSec.toFixed(0)}`.padStart(20)} ${`${(rustMsgPerSec / tsMsgPerSec).toFixed(2)}x`.padStart(15)}`
+)
+
+// Margin of error
+const tsError = ((tsResult.result.rme / 100) * tsMean).toFixed(2)
+const rustError = ((rustResult.result.rme / 100) * rustMean).toFixed(2)
+console.log(
+  `${'Margin of Error (ms)'.padEnd(35)} ${`±${tsError}`.padStart(20)} ${`±${rustError}`.padStart(20)} ${'-'.padStart(15)}`
+)
+
+// Sample size
+console.log(
+  `${'Samples'.padEnd(35)} ${`${tsResult.result.samples.length}`.padStart(20)} ${`${rustResult.result.samples.length}`.padStart(20)} ${'-'.padStart(15)}`
+)
+
+// Messages extracted
+console.log(
+  `${'Messages Extracted'.padEnd(35)} ${`${tsMessageCount.toLocaleString()}`.padStart(20)} ${`${rustMessageCount.toLocaleString()}`.padStart(20)} ${'-'.padStart(15)}`
+)
+
+console.log('─'.repeat(80))
+
+// Statistical significance
+const tsHz = 1000 / tsMean
+const rustHz = 1000 / rustMean
+const percentFaster = ((speedup - 1) * 100).toFixed(1)
+
+console.log('\n✨ Summary:')
+console.log(
+  `   🚀 Rust is ${speedup.toFixed(2)}x faster (${percentFaster}% faster)`
+)
+console.log(`   📈 ${rustHz.toFixed(2)} ops/sec vs ${tsHz.toFixed(2)} ops/sec`)
+console.log(
+  `   💬 Processes ${rustMsgPerSec.toLocaleString()} msg/s vs ${tsMsgPerSec.toLocaleString()} msg/s`
+)
+
+if (Math.abs(tsMessageCount - rustMessageCount) > 0) {
+  console.log(
+    `   ⚠️  Message count differs: TS=${tsMessageCount}, Rust=${rustMessageCount}`
+  )
+} else {
+  console.log(`   ✓ Both extracted ${tsMessageCount.toLocaleString()} messages`)
+}
+
+// Save results
+const resultsFile = path.join(__dirname, 'benchmark-results.json')
+const results = {
+  timestamp: new Date().toISOString(),
+  testFiles: {
+    count: fileCount,
+    messages: tsMessageCount,
+    pattern: pattern,
+  },
+  typescript: {
+    mean: tsMean,
+    marginOfError: parseFloat(tsError),
+    opsPerSec: tsOpsPerSec,
+    messagesPerSec: tsMsgPerSec,
+    samples: tsResult.result.samples.length,
+    rme: tsResult.result.rme,
+  },
+  rust: {
+    mean: rustMean,
+    marginOfError: parseFloat(rustError),
+    opsPerSec: rustOpsPerSec,
+    messagesPerSec: rustMsgPerSec,
+    samples: rustResult.result.samples.length,
+    rme: rustResult.result.rme,
+  },
+  comparison: {
+    speedup: speedup,
+    percentFaster: parseFloat(percentFaster),
+  },
+}
+
+fs.writeFileSync(resultsFile, JSON.stringify(results, null, 2))
+console.log(`\n📄 Detailed results saved to: ${resultsFile}`)
+
+console.log('\n' + '='.repeat(80))
+console.log('✅ Benchmark complete!')
+console.log('='.repeat(80) + '\n')

--- a/benchmarks/cli-comparison/generate-test-files.mjs
+++ b/benchmarks/cli-comparison/generate-test-files.mjs
@@ -1,0 +1,266 @@
+#!/usr/bin/env node
+/**
+ * Generates test files with a mix of simple and complex ICU MessageFormat messages
+ * for benchmarking the Rust CLI vs TypeScript CLI
+ */
+
+import fs from 'fs/promises'
+import path from 'path'
+import {fileURLToPath} from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+// Configuration
+const NUM_FILES = process.env.NUM_FILES
+  ? parseInt(process.env.NUM_FILES)
+  : 100_000
+const OUTPUT_DIR = path.join(__dirname, 'test-files')
+const FILES_PER_DIR = 1000 // Split into subdirectories to avoid filesystem limits
+
+// Message templates - mix of simple and complex
+const MESSAGE_TEMPLATES = {
+  simple: [
+    'Hello, World!',
+    'Welcome to our application',
+    'Click here to continue',
+    'Loading...',
+    'Save changes',
+    'Cancel',
+    'Are you sure?',
+    'Success!',
+    'Error occurred',
+    'Please try again',
+  ],
+  withVariables: [
+    'Hello, {name}!',
+    'You have {count} unread messages',
+    'Welcome back, {username}',
+    'Last login: {date}',
+    'Your balance is {amount}',
+    '{user} sent you a message',
+    'Expires on {expiryDate}',
+    'Created by {author} on {date}',
+  ],
+  plural: [
+    '{count, plural, one {# item} other {# items}}',
+    '{count, plural, =0 {No messages} one {# message} other {# messages}}',
+    '{numPhotos, plural, =0 {no photos} =1 {one photo} other {# photos}}',
+    'You have {count, plural, one {# new notification} other {# new notifications}}',
+    '{taskCount, plural, =0 {No tasks} one {# task remaining} other {# tasks remaining}}',
+  ],
+  select: [
+    '{gender, select, male {He} female {She} other {They}} liked your post',
+    '{status, select, active {Active user} inactive {Inactive} other {Unknown status}}',
+    'Order is {orderStatus, select, pending {being processed} shipped {on the way} delivered {completed} other {unknown}}',
+  ],
+  complex: [
+    '{count, plural, one {You have # message from {sender}} other {You have # messages}}',
+    '{numPhotos, plural, =0 {<bold>{name}</bold> has no photos} =1 {<bold>{name}</bold> has one photo} other {<bold>{name}</bold> has # photos}}',
+    '{gender, select, male {He has {count, plural, one {# item} other {# items}}} female {She has {count, plural, one {# item} other {# items}}} other {They have {count, plural, one {# item} other {# items}}}}',
+    'Welcome <link>back</link>, {username}! You have {msgCount, plural, =0 {no new messages} one {# new message} other {# new messages}} and {taskCount, plural, =0 {no pending tasks} one {# pending task} other {# pending tasks}}.',
+    '{itemCount, plural, =0 {Your cart is empty} one {You have <bold>{itemCount}</bold> item in your cart for <price>{total}</price>} other {You have <bold>{itemCount}</bold> items in your cart for <price>{total}</price>}}',
+  ],
+}
+
+// Distribution: 40% simple, 30% with variables, 15% plural, 10% select, 5% complex
+const MESSAGE_DISTRIBUTION = [
+  {type: 'simple', weight: 40},
+  {type: 'withVariables', weight: 30},
+  {type: 'plural', weight: 15},
+  {type: 'select', weight: 10},
+  {type: 'complex', weight: 5},
+]
+
+function selectRandomMessage() {
+  const random = Math.random() * 100
+  let cumulative = 0
+
+  for (const {type, weight} of MESSAGE_DISTRIBUTION) {
+    cumulative += weight
+    if (random < cumulative) {
+      const templates = MESSAGE_TEMPLATES[type]
+      return templates[Math.floor(Math.random() * templates.length)]
+    }
+  }
+
+  return MESSAGE_TEMPLATES.simple[0]
+}
+
+function generateFileContent(fileIndex) {
+  const numMessages = Math.floor(Math.random() * 10) + 5 // 5-15 messages per file
+
+  const messages = []
+  for (let i = 0; i < numMessages; i++) {
+    const messageId = `msg_${fileIndex}_${i}`
+    const defaultMessage = selectRandomMessage()
+    messages.push({
+      id: messageId,
+      defaultMessage,
+      description: `Message ${i} in file ${fileIndex}`,
+    })
+  }
+
+  // Mix different patterns: defineMessages, defineMessage, formatMessage, FormattedMessage
+  const formatType = fileIndex % 4
+
+  if (formatType === 0) {
+    // defineMessages pattern (group of messages)
+    const imports = `import {defineMessages} from 'react-intl'\n\n`
+    const messagesObj = messages
+      .map(
+        msg => `  ${msg.id}: {
+    id: '${msg.id}',
+    defaultMessage: '${msg.defaultMessage.replace(/'/g, "\\'")}',
+    description: '${msg.description}',
+  }`
+      )
+      .join(',\n')
+
+    const component = `
+const messages = defineMessages({
+${messagesObj}
+})
+
+export function Component${fileIndex}() {
+  return <div>{/* Component content */}</div>
+}
+`
+    return imports + component
+  } else if (formatType === 1) {
+    // defineMessage pattern (individual messages)
+    const imports = `import {defineMessage} from 'react-intl'\n\n`
+    const messageDefs = messages
+      .map(
+        msg => `const ${msg.id} = defineMessage({
+  id: '${msg.id}',
+  defaultMessage: '${msg.defaultMessage.replace(/'/g, "\\'")}',
+  description: '${msg.description}',
+})`
+      )
+      .join('\n\n')
+
+    const component = `
+export function Component${fileIndex}() {
+  return <div>{/* Component content */}</div>
+}
+`
+    return imports + messageDefs + component
+  } else if (formatType === 2) {
+    // formatMessage pattern (intl.formatMessage)
+    const imports = `import {useIntl} from 'react-intl'\n\n`
+    const formatCalls = messages
+      .map(
+        msg =>
+          `  const ${msg.id} = intl.formatMessage({
+    id: '${msg.id}',
+    defaultMessage: '${msg.defaultMessage.replace(/'/g, "\\'")}',
+    description: '${msg.description}',
+  })`
+      )
+      .join('\n')
+
+    const component = `
+export function Component${fileIndex}() {
+  const intl = useIntl()
+${formatCalls}
+  return <div>{/* Component content */}</div>
+}
+`
+    return imports + component
+  } else {
+    // FormattedMessage pattern (JSX component)
+    const imports = `import {FormattedMessage} from 'react-intl'\n\n`
+    const jsxMessages = messages
+      .map(
+        msg =>
+          `      <FormattedMessage
+        id="${msg.id}"
+        defaultMessage="${msg.defaultMessage.replace(/"/g, '&quot;')}"
+        description="${msg.description}"
+      />`
+      )
+      .join('\n')
+
+    const component = `
+export function Component${fileIndex}() {
+  return (
+    <div>
+${jsxMessages}
+    </div>
+  )
+}
+`
+    return imports + component
+  }
+}
+
+async function generateFiles() {
+  console.log(`Generating ${NUM_FILES.toLocaleString()} test files...`)
+  console.time('Generation time')
+
+  // Clean and recreate output directory
+  try {
+    await fs.rm(OUTPUT_DIR, {recursive: true})
+  } catch {
+    // Directory doesn't exist, that's fine
+  }
+  await fs.mkdir(OUTPUT_DIR, {recursive: true})
+
+  // Generate files in batches
+  const numSubdirs = Math.ceil(NUM_FILES / FILES_PER_DIR)
+
+  for (let dirIndex = 0; dirIndex < numSubdirs; dirIndex++) {
+    const subdirName = `batch_${dirIndex.toString().padStart(4, '0')}`
+    const subdirPath = path.join(OUTPUT_DIR, subdirName)
+    await fs.mkdir(subdirPath, {recursive: true})
+
+    const filesInThisDir = Math.min(
+      FILES_PER_DIR,
+      NUM_FILES - dirIndex * FILES_PER_DIR
+    )
+
+    // Generate files in parallel batches of 100 to avoid overwhelming the system
+    const BATCH_SIZE = 100
+    for (let batch = 0; batch < filesInThisDir; batch += BATCH_SIZE) {
+      const batchEnd = Math.min(batch + BATCH_SIZE, filesInThisDir)
+      const promises = []
+
+      for (let i = batch; i < batchEnd; i++) {
+        const fileIndex = dirIndex * FILES_PER_DIR + i
+        const fileName = `file_${fileIndex.toString().padStart(6, '0')}.tsx`
+        const filePath = path.join(subdirPath, fileName)
+        const content = generateFileContent(fileIndex)
+        promises.push(fs.writeFile(filePath, content, 'utf8'))
+      }
+
+      await Promise.all(promises)
+    }
+
+    if ((dirIndex + 1) % 10 === 0) {
+      const progress = ((dirIndex + 1) / numSubdirs) * 100
+      console.log(
+        `Progress: ${progress.toFixed(1)}% (${((dirIndex + 1) * FILES_PER_DIR).toLocaleString()} files)`
+      )
+    }
+  }
+
+  console.timeEnd('Generation time')
+  console.log(
+    `✓ Generated ${NUM_FILES.toLocaleString()} files in ${OUTPUT_DIR}`
+  )
+
+  // Generate summary statistics
+  console.log('\nFile structure:')
+  console.log(`  - ${numSubdirs} subdirectories`)
+  console.log(`  - ${FILES_PER_DIR} files per subdirectory`)
+  console.log('\nMessage distribution:')
+  MESSAGE_DISTRIBUTION.forEach(({type, weight}) => {
+    console.log(`  - ${type}: ${weight}%`)
+  })
+}
+
+// Run generator
+generateFiles().catch(err => {
+  console.error('Error generating files:', err)
+  process.exit(1)
+})

--- a/benchmarks/cli-comparison/package.json
+++ b/benchmarks/cli-comparison/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@formatjs/cli-benchmark",
+  "description": "Benchmark comparing Rust CLI vs TypeScript CLI performance",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/benchmarks/cli-comparison/run-benchmark.sh
+++ b/benchmarks/cli-comparison/run-benchmark.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Run the FormatJS CLI benchmark: Rust vs TypeScript
+set -e
+
+echo "🔥 FormatJS CLI Benchmark Runner"
+echo "=================================="
+echo ""
+
+# Check if we're in the right directory
+if [ ! -f "benchmark-tinybench.mjs" ]; then
+  echo "❌ Error: Must be run from benchmarks/cli-comparison directory"
+  exit 1
+fi
+
+cd ../..
+
+# Step 1: Build both CLIs
+echo "📦 Step 1/3: Building CLIs..."
+echo "  - Building TypeScript CLI..."
+bazel build //packages/cli:bin
+
+echo "  - Building Rust CLI (optimized)..."
+bazel build //rust/formatjs_cli --compilation_mode=opt
+
+# Step 2: Generate test files
+echo ""
+echo "📁 Step 2/3: Generating test files..."
+if [ -d "bazel-bin/benchmarks/cli-comparison/test-files" ]; then
+  echo "  ✓ Test files already exist, skipping generation"
+else
+  echo "  - Generating 100,000 test files (this may take a few minutes)..."
+  bazel build //benchmarks/cli-comparison:generate
+fi
+
+# Step 3: Run benchmark
+echo ""
+echo "⏱️  Step 3/3: Running benchmark with tinybench..."
+echo ""
+cd benchmarks/cli-comparison
+node benchmark-tinybench.mjs
+
+echo ""
+echo "✅ Benchmark complete!"
+echo ""
+echo "📊 Results saved to:"
+echo "  - benchmark-results.json (detailed statistics)"
+echo "  - Console output above (formatted results)"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -439,6 +439,8 @@ importers:
         specifier: ^3.5.0
         version: 3.9.0(react@19.0.0)
 
+  benchmarks/cli-comparison: {}
+
   docs:
     devDependencies:
       intl-messageformat:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,4 +6,5 @@ packages:
   - 'packages/*/benchmark'
   - 'website'
   - 'docs'
+  - 'benchmarks/*'
   - '!packages/editor'


### PR DESCRIPTION
### TL;DR

Add benchmarking suite to compare Rust CLI vs TypeScript CLI performance for message extraction.

### What changed?

- Added a new benchmark directory `benchmarks/cli-comparison` with:
  - A test file generator that creates TypeScript/React files with various message formats
  - A benchmarking script using tinybench for statistical analysis
  - A convenience shell script for running the benchmark
  - Detailed README with results showing the Rust CLI is ~4.5x faster
  - Bazel build configuration for the benchmark

### How to test?

1. Run the benchmark using the convenience script:
```bash
cd benchmarks/cli-comparison
./run-benchmark.sh
```

Or manually:
```bash
# Build both CLIs
bazel build //packages/cli:bin
bazel build //rust/formatjs_cli --compilation_mode=opt

# Generate test files
bazel build //benchmarks/cli-comparison:generate

# Run benchmark
cd benchmarks/cli-comparison
node benchmark-tinybench.mjs
```

### Why make this change?

This benchmark provides quantitative performance data comparing the Rust and TypeScript CLI implementations. The results show the Rust CLI is significantly faster (4.57x) at message extraction, processing over 73,000 messages per second compared to 16,000 messages per second with the TypeScript implementation. This data helps validate the performance benefits of the Rust rewrite and provides a baseline for future optimizations.