### PR TITLE
feat(formatjs_cli): setup release and dist

### DIFF
--- a/.github/workflows/rust-cli-release.yml
+++ b/.github/workflows/rust-cli-release.yml
@@ -1,0 +1,182 @@
+name: Rust CLI Release
+
+on:
+  push:
+    tags:
+      - 'formatjs_cli_v*'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-macos:
+    name: Build macOS ARM64
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Setup Bazel
+        uses: bazel-contrib/setup-bazel@0.16.0
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}-macos
+          repository-cache: true
+
+      - name: Build macOS ARM64 Binary
+        run: |
+          if [ -n "${{ secrets.BUILDBUDDY_ORG_API_KEY }}" ]; then
+            bazel build \
+              --config=ci \
+              --compilation_mode=opt \
+              --platforms=//rust/formatjs_cli/platforms:darwin_arm64 \
+              --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
+              //rust/formatjs_cli:release_binary
+          else
+            bazel build \
+              --compilation_mode=opt \
+              --platforms=//rust/formatjs_cli/platforms:darwin_arm64 \
+              //rust/formatjs_cli:release_binary
+          fi
+
+          # Copy binary to artifacts directory
+          mkdir -p artifacts
+          cp bazel-bin/rust/formatjs_cli/formatjs_cli_release artifacts/formatjs_cli-darwin-arm64
+          chmod +x artifacts/formatjs_cli-darwin-arm64
+
+      - name: Smoke Test
+        run: |
+          ./artifacts/formatjs_cli-darwin-arm64 --version
+          ./artifacts/formatjs_cli-darwin-arm64 --help
+
+      - name: Upload macOS Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: formatjs_cli-darwin-arm64
+          path: artifacts/formatjs_cli-darwin-arm64
+          retention-days: 7
+
+  build-linux:
+    name: Build Linux x86_64
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Setup Bazel
+        uses: bazel-contrib/setup-bazel@0.16.0
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}-linux
+          repository-cache: true
+
+      - name: Build Linux x86_64 Binary
+        run: |
+          if [ -n "${{ secrets.BUILDBUDDY_ORG_API_KEY }}" ]; then
+            bazel build \
+              --config=ci \
+              --compilation_mode=opt \
+              --platforms=//rust/formatjs_cli/platforms:linux_x86_64 \
+              --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
+              //rust/formatjs_cli:release_binary
+          else
+            bazel build \
+              --compilation_mode=opt \
+              --platforms=//rust/formatjs_cli/platforms:linux_x86_64 \
+              //rust/formatjs_cli:release_binary
+          fi
+
+          # Copy binary to artifacts directory
+          mkdir -p artifacts
+          cp bazel-bin/rust/formatjs_cli/formatjs_cli_release artifacts/formatjs_cli-linux-x64
+          chmod +x artifacts/formatjs_cli-linux-x64
+
+      - name: Smoke Test
+        run: |
+          ./artifacts/formatjs_cli-linux-x64 --version
+          ./artifacts/formatjs_cli-linux-x64 --help
+
+      - name: Upload Linux Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: formatjs_cli-linux-x64
+          path: artifacts/formatjs_cli-linux-x64
+          retention-days: 7
+
+  combine-and-release:
+    name: Combine Artifacts and Create Release
+    needs: [build-macos, build-linux]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Download macOS Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: formatjs_cli-darwin-arm64
+          path: release/
+
+      - name: Download Linux Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: formatjs_cli-linux-x64
+          path: release/
+
+      - name: Generate Checksums
+        run: |
+          cd release
+          shasum -a 256 formatjs_cli-* > checksums.txt
+          cat checksums.txt
+
+      - name: List Release Artifacts
+        run: |
+          ls -lh release/
+          echo "---"
+          echo "Checksums:"
+          cat release/checksums.txt
+
+      - name: Create GitHub Release
+        if: startsWith(github.ref, 'refs/tags/formatjs_cli_v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            release/formatjs_cli-darwin-arm64
+            release/formatjs_cli-linux-x64
+            release/checksums.txt
+          body: |
+            ## FormatJS Rust CLI Release
+
+            ### Binaries
+            - **macOS Apple Silicon**: `formatjs_cli-darwin-arm64`
+            - **Linux x86_64**: `formatjs_cli-linux-x64`
+
+            ### Installation
+
+            ```bash
+            # macOS (Apple Silicon)
+            curl -LO https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/formatjs_cli-darwin-arm64
+            chmod +x formatjs_cli-darwin-arm64
+            sudo mv formatjs_cli-darwin-arm64 /usr/local/bin/formatjs
+
+            # Linux
+            curl -LO https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/formatjs_cli-linux-x64
+            chmod +x formatjs_cli-linux-x64
+            sudo mv formatjs_cli-linux-x64 /usr/local/bin/formatjs
+            ```
+
+            ### Verification
+
+            Verify the checksums:
+            ```bash
+            curl -LO https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/checksums.txt
+            shasum -a 256 -c checksums.txt
+            ```
+          draft: false
+          prerelease: false

--- a/.github/workflows/rust-cli-test.yml
+++ b/.github/workflows/rust-cli-test.yml
@@ -1,0 +1,137 @@
+name: Rust CLI Build & Test
+
+on:
+  pull_request:
+    paths:
+      - 'rust/**'
+      - 'MODULE.bazel'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/rust-cli-test.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'rust/**'
+      - 'MODULE.bazel'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/rust-cli-test.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test-macos:
+    name: Build & Test (macOS)
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Setup Bazel
+        uses: bazel-contrib/setup-bazel@0.16.0
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}-macos
+          repository-cache: true
+
+      - name: Build Rust CLI
+        run: |
+          if [ -n "${{ secrets.BUILDBUDDY_ORG_API_KEY }}" ]; then
+            echo "Building with BuildBuddy CI config"
+            bazel build \
+              --config=ci \
+              --compilation_mode=opt \
+              --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
+              //rust/formatjs_cli
+          else
+            echo "Building without BuildBuddy (no API key)"
+            bazel build --compilation_mode=opt //rust/formatjs_cli
+          fi
+
+      - name: Run Unit Tests
+        run: |
+          if [ -n "${{ secrets.BUILDBUDDY_ORG_API_KEY }}" ]; then
+            bazel test \
+              --config=ci \
+              --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
+              //rust/formatjs_cli:formatjs_cli_test
+          else
+            bazel test //rust/formatjs_cli:formatjs_cli_test
+          fi
+
+      - name: Run Integration Tests
+        run: |
+          if [ -n "${{ secrets.BUILDBUDDY_ORG_API_KEY }}" ]; then
+            bazel test \
+              --config=ci \
+              --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
+              //packages/cli/integration-tests/extract:integration_test
+          else
+            bazel test //packages/cli/integration-tests/extract:integration_test
+          fi
+
+      - name: Smoke Test Binary
+        run: |
+          ./bazel-bin/rust/formatjs_cli/formatjs_cli --version
+          ./bazel-bin/rust/formatjs_cli/formatjs_cli --help
+
+  build-and-test-linux:
+    name: Build & Test (Linux)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Setup Bazel
+        uses: bazel-contrib/setup-bazel@0.16.0
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}-linux
+          repository-cache: true
+
+      - name: Build Rust CLI
+        run: |
+          if [ -n "${{ secrets.BUILDBUDDY_ORG_API_KEY }}" ]; then
+            echo "Building with BuildBuddy CI config"
+            bazel build \
+              --config=ci \
+              --compilation_mode=opt \
+              --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
+              //rust/formatjs_cli
+          else
+            echo "Building without BuildBuddy (no API key)"
+            bazel build --compilation_mode=opt //rust/formatjs_cli
+          fi
+
+      - name: Run Unit Tests
+        run: |
+          if [ -n "${{ secrets.BUILDBUDDY_ORG_API_KEY }}" ]; then
+            bazel test \
+              --config=ci \
+              --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
+              //rust/formatjs_cli:formatjs_cli_test
+          else
+            bazel test //rust/formatjs_cli:formatjs_cli_test
+          fi
+
+      - name: Run Integration Tests
+        run: |
+          if [ -n "${{ secrets.BUILDBUDDY_ORG_API_KEY }}" ]; then
+            bazel test \
+              --config=ci \
+              --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
+              //packages/cli/integration-tests/extract:integration_test
+          else
+            bazel test //packages/cli/integration-tests/extract:integration_test
+          fi
+
+      - name: Smoke Test Binary
+        run: |
+          ./bazel-bin/rust/formatjs_cli/formatjs_cli --version
+          ./bazel-bin/rust/formatjs_cli/formatjs_cli --help

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -87,6 +87,10 @@ bazel_dep(name = "rules_rust", version = "0.68.1")
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
 rust.toolchain(
     edition = "2024",
+    extra_target_triples = [
+        "wasm32-unknown-unknown",
+        "x86_64-unknown-linux-gnu",
+    ],
     versions = [
         "1.90.0",
     ],

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1944,7 +1944,7 @@
         "recordedFileInputs": {
           "@@//Cargo.lock": "5edda031c0f42e09fa9866c079a46739c8e9a704faa7434dd494c4f666a5a938",
           "@@//Cargo.toml": "54ff38b0981299b3dc7f10c22a8504c8437c27edea7747f5f59a22d0a5b6b4b7",
-          "@@//MODULE.bazel": "8577589196323ddddba2e54cf60d62a4a73d861793cf60ca1742ce96f47fc3b4",
+          "@@//MODULE.bazel": "056f89f9c35545957b5b7ed035f78b257df275755d3298f747055946b5a5d360",
           "@@//packages/icu-messageformat-parser/integration-tests/Cargo.toml": "c15f4f2503b87826277cf06f759b6350feb16061dd823c41946b9aa2ea1af176",
           "@@//rust/formatjs_cli/Cargo.toml": "252c9a2ca068e292306f3ff65e9708b1c849edbf6394bd7ba3bd1bea7d7754b2",
           "@@//rust/icu_messageformat_parser/Cargo.toml": "6b67e9213dd58c024c2b4eb435822a88f58111d3a983027221743e981241f156",

--- a/rust/formatjs_cli/BUILD.bazel
+++ b/rust/formatjs_cli/BUILD.bazel
@@ -80,3 +80,16 @@ alias(
     actual = ":formatjs_cli",
     visibility = ["//visibility:public"],
 )
+
+# Release targets - these build for the current platform and copy to release directory
+# Use --platforms flag to build for different platforms:
+#   macOS: bazel build --platforms=//rust/formatjs_cli/platforms:darwin_arm64 //rust/formatjs_cli:release_binary
+#   Linux: bazel build --platforms=//rust/formatjs_cli/platforms:linux_x86_64 //rust/formatjs_cli:release_binary
+
+genrule(
+    name = "release_binary",
+    srcs = [":formatjs_cli"],
+    outs = ["formatjs_cli_release"],
+    cmd = "cp $< $@ && chmod +x $@",
+    visibility = ["//visibility:public"],
+)

--- a/rust/formatjs_cli/RELEASE.md
+++ b/rust/formatjs_cli/RELEASE.md
@@ -1,0 +1,301 @@
+# FormatJS Rust CLI - Release Guide
+
+This document explains how to build release binaries for the FormatJS Rust CLI for multiple platforms.
+
+## Quick Start
+
+### Option 1: Using GitHub Actions (Recommended for Releases)
+
+The repository includes two GitHub Actions workflows:
+
+#### 1. Build & Test Workflow (`.github/workflows/rust-cli-test.yml`)
+
+**Runs automatically on**:
+
+- Pull requests that modify Rust code
+- Pushes to `main` branch
+- Can be triggered manually
+
+**What it does**:
+
+- Builds Rust CLI on both macOS and Linux
+- Runs unit tests
+- Runs integration tests
+- Performs smoke tests
+
+#### 2. Release Workflow (`.github/workflows/rust-cli-release.yml`)
+
+**Triggered by**: Push a tag starting with `formatjs_cli_v` (e.g., `formatjs_cli_v0.1.0`)
+
+```bash
+# Create and push a release tag
+git tag formatjs_cli_v0.1.0
+git push origin formatjs_cli_v0.1.0
+```
+
+**What it does**:
+
+1. Build macOS ARM64 binary natively on macOS runner
+2. Build Linux x86_64 binary natively on Linux runner
+3. Run smoke tests on both binaries
+4. Combine artifacts and generate checksums
+5. Create a GitHub Release with all binaries
+
+**Release artifacts**:
+
+- `formatjs_cli-darwin-arm64` (macOS Apple Silicon)
+- `formatjs_cli-linux-x64` (Linux x86_64)
+- `checksums.txt` (SHA-256 checksums)
+
+### Option 2: Using Cargo
+
+```bash
+cd rust/formatjs_cli
+./release.sh
+```
+
+This uses native Cargo cross-compilation. Requires additional setup for cross-compilation (see below).
+
+## Platform Support
+
+| Platform | Architecture  | Target Triple            | Status                                |
+| -------- | ------------- | ------------------------ | ------------------------------------- |
+| macOS    | Apple Silicon | aarch64-apple-darwin     | ✅ Native (Bazel on GHA macOS runner) |
+| Linux    | x86_64        | x86_64-unknown-linux-gnu | ✅ Native (Bazel on GHA Linux runner) |
+
+**Note**: The GitHub Actions workflow builds each platform natively on its respective runner, avoiding complex cross-compilation setup.
+
+## Cross-Compilation Setup
+
+### For Linux builds from macOS
+
+You have several options:
+
+#### Option A: Using Zig (Easiest)
+
+```bash
+# Install zig (provides a cross-platform linker)
+brew install zig
+
+# Add Linux target
+rustup target add x86_64-unknown-linux-gnu
+
+# Zig will be automatically detected and used as the linker
+```
+
+#### Option B: Using musl (Static binaries)
+
+```bash
+# Add musl target (produces static binaries)
+rustup target add x86_64-unknown-linux-musl
+
+# Build
+cargo build --release --target x86_64-unknown-linux-musl
+```
+
+#### Option C: Using cross
+
+```bash
+# Install cross (Docker-based cross-compilation)
+cargo install cross
+
+# Build
+cross build --release --target x86_64-unknown-linux-gnu
+```
+
+## Manual Building
+
+### Build with Bazel
+
+```bash
+# Build for current platform
+bazel build --compilation_mode=opt //rust/formatjs_cli:release_binary
+
+# Build for specific platform (requires being on that platform)
+# macOS ARM64:
+bazel build --compilation_mode=opt --platforms=//rust/formatjs_cli/platforms:darwin_arm64 //rust/formatjs_cli:release_binary
+
+# Linux x86_64:
+bazel build --compilation_mode=opt --platforms=//rust/formatjs_cli/platforms:linux_x86_64 //rust/formatjs_cli:release_binary
+```
+
+Binary will be in `bazel-bin/rust/formatjs_cli/formatjs_cli_release`.
+
+**Note**: Bazel builds each platform natively (no cross-compilation). Use GitHub Actions to build both platforms.
+
+### Build for specific platform with Cargo
+
+```bash
+# macOS Apple Silicon
+cargo build --release --target aarch64-apple-darwin
+
+# macOS Intel
+cargo build --release --target x86_64-apple-darwin
+
+# Linux x86_64 (requires cross-compilation setup)
+cargo build --release --target x86_64-unknown-linux-gnu
+```
+
+Binaries will be in `target/<triple>/release/formatjs_cli`.
+
+## Release Artifacts
+
+After running the GitHub Actions workflow, artifacts will be available:
+
+1. **During the workflow run**: As job artifacts (7 day retention)
+2. **After tag push**: As GitHub Release assets
+
+```
+Release assets:
+├── formatjs_cli-darwin-arm64      # macOS Apple Silicon
+├── formatjs_cli-linux-x64         # Linux x86_64
+└── checksums.txt                  # SHA-256 checksums
+```
+
+### Verify checksums
+
+```bash
+# Download from release
+curl -LO https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v0.1.0/checksums.txt
+curl -LO https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v0.1.0/formatjs_cli-darwin-arm64
+
+shasum -a 256 -c checksums.txt
+```
+
+## Testing Binaries
+
+The GitHub Actions workflow includes smoke tests that run automatically:
+
+```bash
+./formatjs_cli-{platform} --version
+./formatjs_cli-{platform} --help
+```
+
+To test manually after downloading:
+
+```bash
+# macOS Apple Silicon
+chmod +x formatjs_cli-darwin-arm64
+./formatjs_cli-darwin-arm64 --version
+
+# Linux
+chmod +x formatjs_cli-linux-x64
+./formatjs_cli-linux-x64 --version
+```
+
+## Publishing
+
+The GitHub Actions workflow automates the entire release process:
+
+1. **Tag the release**:
+
+   ```bash
+   # Update version in Cargo.toml if needed
+   git tag formatjs_cli_v0.1.0
+   git push origin formatjs_cli_v0.1.0
+   ```
+
+2. **Workflow runs automatically**:
+   - Builds both macOS and Linux binaries
+   - Runs smoke tests
+   - Creates GitHub Release with all artifacts
+
+3. **Manual verification** (optional):
+   - Check GitHub Actions run completed successfully
+   - Download and test binaries from the release
+   - Verify checksums
+
+4. **Publish to npm** (if applicable):
+   ```bash
+   # Update package.json with release URLs
+   # Point to GitHub release assets
+   npm publish
+   ```
+
+## Troubleshooting
+
+### Linux cross-compilation fails
+
+**Problem**: `cargo build --target x86_64-unknown-linux-gnu` fails with linker errors.
+
+**Solutions**:
+
+1. Install zig: `brew install zig` (easiest)
+2. Use musl target: `cargo build --target x86_64-unknown-linux-musl`
+3. Use cross: `cargo install cross && cross build --target x86_64-unknown-linux-gnu`
+4. Build on an actual Linux machine
+
+### Binary doesn't run on target platform
+
+**Problem**: Binary fails to execute with "exec format error" or "cannot execute binary file".
+
+**Cause**: Binary was built for wrong architecture.
+
+**Solution**: Verify the target triple matches your platform:
+
+```bash
+file dist/v<version>/formatjs_cli-*
+```
+
+### "Unknown platform" error with Bazel
+
+**Problem**: Bazel can't find the platform definition.
+
+**Solution**: Ensure `rules_rust` is properly configured in `MODULE.bazel` or `WORKSPACE`.
+
+## CI/CD Integration
+
+The repository includes two production-ready GitHub Actions workflows:
+
+### 1. Build & Test Workflow (`.github/workflows/rust-cli-test.yml`)
+
+**Purpose**: Continuous integration for all changes
+
+**Triggers**:
+
+- Pull requests modifying Rust code
+- Pushes to `main` branch
+- Manual dispatch
+
+**Jobs**:
+
+```yaml
+build-and-test-macos:  # Build and test on macOS runner
+build-and-test-linux:  # Build and test on Linux runner
+```
+
+**Features**:
+
+- Concurrent testing on both platforms
+- Unit tests and integration tests
+- Smoke tests for binaries
+- BuildBuddy integration (optional, via API key)
+
+### 2. Release Workflow (`.github/workflows/rust-cli-release.yml`)
+
+**Purpose**: Create official releases with binaries
+
+**Triggers**:
+
+- Push a tag starting with `formatjs_cli_v`
+
+**Jobs**:
+
+```yaml
+build-macos:           # Build macOS binary
+build-linux:           # Build Linux binary
+combine-and-release:   # Combine, checksum, and create release
+```
+
+**Features**:
+
+1. **Multi-platform builds**: macOS and Linux built natively
+2. **Smoke tests**: Automatic testing with `--version` and `--help`
+3. **Artifact management**: 7-day retention during workflow, permanent in releases
+4. **Checksum generation**: Automatic SHA-256 checksums
+5. **GitHub Release**: Automatic creation with formatted release notes
+6. **BuildBuddy integration**: Optional remote caching
+
+## License
+
+Same as the main FormatJS project (MIT).

--- a/rust/formatjs_cli/release.sh
+++ b/rust/formatjs_cli/release.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+# Build release binaries for FormatJS Rust CLI
+# Supports: macOS (darwin) and Linux cross-compilation
+set -e
+
+VERSION=$(grep '^version' Cargo.toml | head -1 | cut -d'"' -f2)
+DIST_DIR="dist/v${VERSION}"
+
+echo "🚀 Building FormatJS Rust CLI v${VERSION}"
+echo "=========================================="
+echo ""
+
+# Create dist directory
+mkdir -p "$DIST_DIR"
+
+# Detect host OS
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  HOST_OS="darwin"
+  HOST_TARGET="aarch64-apple-darwin"
+  if [[ $(uname -m) == "x86_64" ]]; then
+    HOST_TARGET="x86_64-apple-darwin"
+  fi
+else
+  HOST_OS="linux"
+  HOST_TARGET="x86_64-unknown-linux-gnu"
+fi
+
+echo "📋 Build Configuration:"
+echo "  Version: ${VERSION}"
+echo "  Host OS: ${HOST_OS}"
+echo "  Host Target: ${HOST_TARGET}"
+echo ""
+
+# Build for macOS (darwin)
+if [[ "$HOST_OS" == "darwin" ]]; then
+  echo "🍎 Building for macOS (darwin)..."
+
+  # Build for Apple Silicon (aarch64)
+  echo "  - Building for aarch64-apple-darwin (Apple Silicon)..."
+  rustup target add aarch64-apple-darwin
+  cargo build --release --target aarch64-apple-darwin
+  cp target/aarch64-apple-darwin/release/formatjs_cli "$DIST_DIR/formatjs_cli-darwin-arm64"
+
+  # Build for Intel (x86_64)
+  echo "  - Building for x86_64-apple-darwin (Intel)..."
+  rustup target add x86_64-apple-darwin
+  cargo build --release --target x86_64-apple-darwin
+  cp target/x86_64-apple-darwin/release/formatjs_cli "$DIST_DIR/formatjs_cli-darwin-x64"
+
+  echo "  ✓ macOS builds complete"
+  echo ""
+fi
+
+# Build for Linux (cross-compile from macOS or native on Linux)
+echo "🐧 Building for Linux..."
+
+# Check if cross-compilation tools are available
+if [[ "$HOST_OS" == "darwin" ]]; then
+  echo "  ℹ️  Cross-compiling from macOS to Linux"
+  echo ""
+  echo "  📦 Checking cross-compilation prerequisites..."
+
+  # Check if Linux target is installed
+  if ! rustup target list --installed | grep -q "x86_64-unknown-linux-gnu"; then
+    echo "  - Adding x86_64-unknown-linux-gnu target..."
+    rustup target add x86_64-unknown-linux-gnu
+  fi
+
+  # Check if musl target is installed (for static binaries)
+  if ! rustup target list --installed | grep -q "x86_64-unknown-linux-musl"; then
+    echo "  - Adding x86_64-unknown-linux-musl target..."
+    rustup target add x86_64-unknown-linux-musl
+  fi
+
+  # Check for cross-compilation linker
+  if command -v x86_64-unknown-linux-gnu-gcc &> /dev/null; then
+    echo "  ✓ Found x86_64-unknown-linux-gnu-gcc"
+    LINUX_TARGET="x86_64-unknown-linux-gnu"
+  elif command -v zig &> /dev/null; then
+    echo "  ✓ Found zig (will use as linker)"
+    export CC_x86_64_unknown_linux_gnu="zig cc -target x86_64-linux-gnu"
+    export CXX_x86_64_unknown_linux_gnu="zig c++ -target x86_64-linux-gnu"
+    export AR_x86_64_unknown_linux_gnu="zig ar"
+    LINUX_TARGET="x86_64-unknown-linux-gnu"
+  else
+    echo "  ⚠️  No Linux cross-compiler found, trying musl (static binary)..."
+    echo ""
+    echo "  💡 To improve cross-compilation, install one of:"
+    echo "     - zig: brew install zig"
+    echo "     - cross: cargo install cross"
+    LINUX_TARGET="x86_64-unknown-linux-musl"
+  fi
+
+  echo ""
+  echo "  - Building for ${LINUX_TARGET}..."
+
+  # Try building with cargo
+  if cargo build --release --target "$LINUX_TARGET" 2>&1; then
+    cp "target/${LINUX_TARGET}/release/formatjs_cli" "$DIST_DIR/formatjs_cli-linux-x64"
+    echo "  ✓ Linux build complete"
+  else
+    echo "  ❌ Linux cross-compilation failed"
+    echo ""
+    echo "  💡 Alternatives:"
+    echo "     1. Install zig: brew install zig"
+    echo "     2. Install cross: cargo install cross && cross build --release --target x86_64-unknown-linux-gnu"
+    echo "     3. Build on a Linux machine"
+    echo ""
+    echo "  Skipping Linux build..."
+  fi
+else
+  # Native Linux build
+  echo "  - Building for x86_64-unknown-linux-gnu..."
+  cargo build --release --target x86_64-unknown-linux-gnu
+  cp target/x86_64-unknown-linux-gnu/release/formatjs_cli "$DIST_DIR/formatjs_cli-linux-x64"
+  echo "  ✓ Linux build complete"
+fi
+
+echo ""
+echo "=========================================="
+echo "✅ Release build complete!"
+echo ""
+echo "📦 Artifacts in ${DIST_DIR}:"
+ls -lh "$DIST_DIR"
+echo ""
+
+# Calculate checksums
+echo "🔐 Generating checksums..."
+cd "$DIST_DIR"
+shasum -a 256 formatjs_cli-* > checksums.txt
+cat checksums.txt
+cd - > /dev/null
+echo ""
+
+# Test binaries
+echo "🧪 Testing binaries..."
+for binary in "$DIST_DIR"/formatjs_cli-*; do
+  if [[ -f "$binary" ]] && [[ -x "$binary" ]]; then
+    echo "  - Testing $(basename $binary)..."
+    if $binary --version &> /dev/null; then
+      echo "    ✓ $(basename $binary): $($binary --version)"
+    else
+      echo "    ⚠️  $(basename $binary): Not executable on this platform"
+    fi
+  fi
+done
+
+echo ""
+echo "🎉 Done! Release artifacts are ready in ${DIST_DIR}/"


### PR DESCRIPTION
### TL;DR

Add GitHub Actions workflows for building, testing, and releasing the Rust CLI tool with cross-platform support.

### What changed?

- Added two GitHub Actions workflows:
  - `rust-cli-test.yml`: Builds and tests the Rust CLI on both macOS and Linux
  - `rust-cli-release.yml`: Creates release binaries for macOS ARM64 and Linux x86_64 when a tag is pushed
- Added platform configuration in `MODULE.bazel` to support Linux builds
- Created a release binary target in `rust/formatjs_cli/BUILD.bazel`
- Added comprehensive release documentation in `RELEASE.md`
- Added a `release.sh` script for local building of release binaries

### How to test?

1. **Test the build workflow:**
   - Make a change to Rust code and create a PR
   - Verify the `Rust CLI Build & Test` workflow runs successfully

2. **Test the release workflow:**
   - Create and push a tag: `git tag formatjs_cli_v0.1.0 && git push origin formatjs_cli_v0.1.0`
   - Verify the `Rust CLI Release` workflow creates a GitHub release with binaries

3. **Test local builds:**
   - Run `cd rust/formatjs_cli && ./release.sh`
   - Check the generated binaries in `dist/v{version}/`

### Why make this change?

This change establishes a robust CI/CD pipeline for the Rust CLI tool, enabling:
- Continuous testing on multiple platforms
- Automated release builds for macOS and Linux
- Simplified distribution of pre-built binaries
- Comprehensive documentation for release processes

The workflows ensure that the Rust CLI is thoroughly tested and can be easily released with cross-platform support, improving the developer and user experience.