### PR TITLE
fix(formatjs_cli): fix warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,7 +426,7 @@ dependencies = [
 
 [[package]]
 name = "formatjs_cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1942,11 +1942,11 @@
         "bzlTransitiveDigest": "WtIoVC11ie4SZ/RJIy/93jgE8KMXiwLBVrk6qhzuTCI=",
         "usagesDigest": "+2oxp30n7U2iCRyiQVVvn9Dm9XZaeUlnwnAuV9gqyVs=",
         "recordedFileInputs": {
-          "@@//Cargo.lock": "5edda031c0f42e09fa9866c079a46739c8e9a704faa7434dd494c4f666a5a938",
+          "@@//Cargo.lock": "cff8468583e698783fa691edbca5643bfa7925918d6ed6365792f62a147eddc8",
           "@@//Cargo.toml": "54ff38b0981299b3dc7f10c22a8504c8437c27edea7747f5f59a22d0a5b6b4b7",
           "@@//MODULE.bazel": "056f89f9c35545957b5b7ed035f78b257df275755d3298f747055946b5a5d360",
           "@@//packages/icu-messageformat-parser/integration-tests/Cargo.toml": "c15f4f2503b87826277cf06f759b6350feb16061dd823c41946b9aa2ea1af176",
-          "@@//rust/formatjs_cli/Cargo.toml": "252c9a2ca068e292306f3ff65e9708b1c849edbf6394bd7ba3bd1bea7d7754b2",
+          "@@//rust/formatjs_cli/Cargo.toml": "ccb8ef27d32df213f69a8bbf204f417857b57304a1e343992dd51e975f41f3a1",
           "@@//rust/icu_messageformat_parser/Cargo.toml": "6b67e9213dd58c024c2b4eb435822a88f58111d3a983027221743e981241f156",
           "@@//rust/icu_skeleton_parser/Cargo.toml": "b5056aa39250f0e19f54075eea8d24ff048f9f31e6c7378be86a4fb85401329a",
           "@@rules_rust++rust_host_tools+rust_host_tools//rust_host_tools": "ENOENT"

--- a/rust/formatjs_cli/Cargo.toml
+++ b/rust/formatjs_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "formatjs_cli"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 authors = ["FormatJS Team", "Long Ho <holevietlong@gmail.com>"]
 description = "Command-line interface for FormatJS - A Rust-based CLI for internationalization"

--- a/rust/formatjs_cli/src/extract.rs
+++ b/rust/formatjs_cli/src/extract.rs
@@ -8,7 +8,6 @@ use std::path::{Path, PathBuf};
 use crate::extractor::{MessageDescriptor, determine_source_type, extract_messages_from_source};
 use crate::formatters::Formatter;
 use crate::id_generator::generate_id;
-use serde_json::Value;
 
 /// Extract string messages from React components that use react-intl
 #[allow(clippy::too_many_arguments)]
@@ -423,7 +422,12 @@ const messages = defineMessages({
         assert!(json.is_object());
 
         // Get the keys and verify they are sorted
-        let keys: Vec<&str> = json.as_object().unwrap().keys().map(|s| s.as_str()).collect();
+        let keys: Vec<&str> = json
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(|s| s.as_str())
+            .collect();
         let mut sorted_keys = keys.clone();
         sorted_keys.sort();
 
@@ -485,12 +489,20 @@ const messages = defineMessages({
         let json: serde_json::Value = serde_json::from_str(&output_content).unwrap();
 
         // Get the keys and verify they are sorted
-        let keys: Vec<&str> = json.as_object().unwrap().keys().map(|s| s.as_str()).collect();
+        let keys: Vec<&str> = json
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(|s| s.as_str())
+            .collect();
         let mut sorted_keys = keys.clone();
         sorted_keys.sort();
 
         // Keys should be in alphabetical order
-        assert_eq!(keys, sorted_keys, "Keys should be sorted alphabetically with formatter");
+        assert_eq!(
+            keys, sorted_keys,
+            "Keys should be sorted alphabetically with formatter"
+        );
         assert_eq!(keys, vec!["alpha", "charlie", "zulu"]);
     }
 
@@ -547,10 +559,7 @@ const greeting = defineMessage({
         );
 
         // Verify message content
-        assert_eq!(
-            message["defaultMessage"].as_str().unwrap(),
-            "Hello World"
-        );
+        assert_eq!(message["defaultMessage"].as_str().unwrap(), "Hello World");
     }
 
     #[test]
@@ -670,10 +679,7 @@ const messages = defineMessages({
         assert_eq!(json.as_object().unwrap().len(), 2);
 
         // One should have the explicit ID
-        assert!(json
-            .as_object()
-            .unwrap()
-            .contains_key("explicit.id"));
+        assert!(json.as_object().unwrap().contains_key("explicit.id"));
 
         // The other should have a generated ID (6 characters)
         let generated_id = json
@@ -761,10 +767,7 @@ const msg = defineMessage({
         let id2 = json2.as_object().unwrap().keys().next().unwrap();
 
         // IDs should be different because description affects the hash
-        assert_ne!(
-            id1, id2,
-            "Description should affect the generated ID"
-        );
+        assert_ne!(id1, id2, "Description should affect the generated ID");
     }
 
     #[test]


### PR DESCRIPTION
### TL;DR

Bump formatjs_cli version from 0.1.0 to 0.1.1 and improve code formatting.

### What changed?

- Updated the version of `formatjs_cli` from 0.1.0 to 0.1.1 in both Cargo.toml and Cargo.lock
- Improved code formatting in the extract.rs file:
  - Removed an unused import for `serde_json::Value`
  - Fixed line breaks and indentation for better readability
  - Properly formatted multi-line method chains
  - Improved formatting of test assertions

### How to test?

- Verify that the package builds correctly with the new version
- Run the existing tests to ensure functionality remains intact

### Why make this change?

This change prepares for a new release version of the formatjs_cli package and improves code quality through better formatting. The removal of unused imports and consistent formatting enhances maintainability.