### PR TITLE
Fix import now that the package is ESM

### DIFF
--- a/packages/intl-displaynames/abstract/CanonicalCodeForDisplayNames.ts
+++ b/packages/intl-displaynames/abstract/CanonicalCodeForDisplayNames.ts
@@ -4,7 +4,7 @@ import {
   IsWellFormedCurrencyCode,
 } from '@formatjs/ecma402-abstract'
 
-import {IsValidDateTimeFieldCode} from './IsValidDateTimeFieldCode'
+import {IsValidDateTimeFieldCode} from './IsValidDateTimeFieldCode.js'
 
 const UNICODE_REGION_SUBTAG_REGEX = /^([a-z]{2}|[0-9]{3})$/i
 const ALPHA_4 = /^[a-z]{4}$/i


### PR DESCRIPTION
The following error arises when building with Webpack:

```
ModuleNotFoundError: Module not found: Error: Can't resolve './IsValidDateTimeFieldCode' in '/fakepath/node_modules/@formatjs/intl-displaynames/abstract'
Did you mean 'IsValidDateTimeFieldCode.js'?
BREAKING CHANGE: The request './IsValidDateTimeFieldCode' failed to resolve only because it was resolved as fully specified
(probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
Add the extension to the request.
```

Adding the extension fixes the error.