### PR TITLE
fix(eslint-plugin-formatjs): remove obsolete @types/eslint

### DIFF
--- a/.syncpackrc.json
+++ b/.syncpackrc.json
@@ -80,8 +80,7 @@
     {
       "label": "ESLint",
       "dependencies": [
-        "eslint",
-        "@types/eslint"
+        "eslint"
       ],
       "packages": [
         "eslint-plugin-formatjs"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "@types/babel__core": "^7.20.5",
     "@types/babel__helper-plugin-utils": "^7.10.3",
     "@types/babel__traverse": "^7.28.0",
-    "@types/eslint": "^9.6.1",
     "@types/eslint-scope": "^8.3.2",
     "@types/estree": "^1.0.8",
     "@types/fs-extra": "^11.0.4",

--- a/packages/eslint-plugin-formatjs/BUILD.bazel
+++ b/packages/eslint-plugin-formatjs/BUILD.bazel
@@ -58,7 +58,6 @@ SRC_DEPS = [
     ":node_modules/@types/picomatch",
     ":node_modules/magic-string",
     ":node_modules/picomatch",
-    "//:node_modules/@types/eslint",
     "//:node_modules/@types/node",
     "//:node_modules/@typescript-eslint/utils",
     "//:node_modules/eslint",

--- a/packages/eslint-plugin-formatjs/package.json
+++ b/packages/eslint-plugin-formatjs/package.json
@@ -16,7 +16,6 @@
     "tslib": "^2.8.1"
   },
   "peerDependencies": {
-    "@types/eslint": "9",
     "eslint": "9"
   },
   "bugs": "https://github.com/formatjs/formatjs/issues",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,9 +144,6 @@ importers:
       '@types/babel__traverse':
         specifier: ^7.28.0
         version: 7.28.0
-      '@types/eslint':
-        specifier: ^9.6.1
-        version: 9.6.1
       '@types/eslint-scope':
         specifier: ^8.3.2
         version: 8.3.2
@@ -618,9 +615,6 @@ importers:
       '@formatjs/ts-transformer':
         specifier: workspace:*
         version: link:../ts-transformer
-      '@types/eslint':
-        specifier: '9'
-        version: 9.6.1
       '@types/picomatch':
         specifier: ^4.0.0
         version: 4.0.2


### PR DESCRIPTION
eslint@9 comes with its own types.  @types/eslint is unmaintained, no longer compatible with current eslint, and causes spurious type errors when installed.

- https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70735

---

Minimal reproduction:

**`eslint.config.mjs`**

```js
// @ts-check
import { FlatCompat } from "@eslint/eslintrc";
import { defineConfig } from "eslint/config";
const compat = new FlatCompat({ baseDirectory: "." });
export default defineConfig(compat.config({}));
```

```console
$ pnpm i @eslint/eslintrc eslint eslint-plugin-formatjs typescript
$ pnpm exec tsc --allowJs --module nodenext --noEmit eslint.config.mjs 
eslint.config.mjs:5:29 - error TS2345: Argument of type 'Config<RulesRecord>[]' is not assignable to parameter of type 'InfiniteArray<ConfigWithExtends>'.
  Type 'Config<RulesRecord>[]' is not assignable to type 'InfiniteArray<ConfigWithExtends>[]'.
    Type 'Config<RulesRecord>' is not assignable to type 'InfiniteArray<ConfigWithExtends>'.
      Type 'Config<RulesRecord>' is not assignable to type 'ConfigWithExtends'.
        Types of property 'languageOptions' are incompatible.
          Type 'import("/tmp/u/node_modules/.pnpm/@types+eslint@9.6.1/node_modules/@types/eslint/index").Linter.LanguageOptions' is not assignable to type 'import("/tmp/u/node_modules/.pnpm/@eslint+core@0.17.0/node_modules/@eslint/core/dist/cjs/types").LanguageOptions'.
            Index signature for type 'string' is missing in type 'LanguageOptions'.

5 export default defineConfig(compat.config({}));
                              ~~~~~~~~~~~~~~~~~


Found 1 error in eslint.config.mjs:5
```