### PR TITLE
docs: make dark colour scheme default

### DIFF
--- a/docs/src/components/Admonition.tsx
+++ b/docs/src/components/Admonition.tsx
@@ -27,15 +27,12 @@ const typeToIcon = {
 } as const
 
 const typeToClassName = {
-  note: 'border-blue-500 bg-blue-50 text-blue-900 dark:bg-blue-950 dark:text-blue-100',
-  tip: 'border-green-500 bg-green-50 text-green-900 dark:bg-green-950 dark:text-green-100',
-  info: 'border-blue-500 bg-blue-50 text-blue-900 dark:bg-blue-950 dark:text-blue-100',
-  caution:
-    'border-yellow-500 bg-yellow-50 text-yellow-900 dark:bg-yellow-950 dark:text-yellow-100',
-  warning:
-    'border-orange-500 bg-orange-50 text-orange-900 dark:bg-orange-950 dark:text-orange-100',
-  danger:
-    'border-red-500 bg-red-50 text-red-900 dark:bg-red-950 dark:text-red-100',
+  note: 'border-blue-500 bg-blue-950 text-blue-100',
+  tip: 'border-green-500 bg-green-950 text-green-100',
+  info: 'border-blue-500 bg-blue-950 text-blue-100',
+  caution: 'border-yellow-500 bg-yellow-950 text-yellow-100',
+  warning: 'border-orange-500 bg-orange-950 text-orange-100',
+  danger: 'border-red-500 bg-red-950 text-red-100',
 } as const
 
 export default function Admonition({

--- a/docs/src/components/SearchBar.tsx
+++ b/docs/src/components/SearchBar.tsx
@@ -45,28 +45,28 @@ function getDocTypeBadge(docType: string): {bg: string; text: string} {
   switch (docType) {
     case 'guide':
       return {
-        bg: 'bg-blue-100 dark:bg-blue-900/30',
-        text: 'text-blue-700 dark:text-blue-300',
+        bg: 'bg-blue-900/30',
+        text: 'text-blue-300',
       }
     case 'api':
       return {
-        bg: 'bg-purple-100 dark:bg-purple-900/30',
-        text: 'text-purple-700 dark:text-purple-300',
+        bg: 'bg-purple-900/30',
+        text: 'text-purple-300',
       }
     case 'reference':
       return {
-        bg: 'bg-green-100 dark:bg-green-900/30',
-        text: 'text-green-700 dark:text-green-300',
+        bg: 'bg-green-900/30',
+        text: 'text-green-300',
       }
     case 'example':
       return {
-        bg: 'bg-orange-100 dark:bg-orange-900/30',
-        text: 'text-orange-700 dark:text-orange-300',
+        bg: 'bg-orange-900/30',
+        text: 'text-orange-300',
       }
     default:
       return {
-        bg: 'bg-gray-100 dark:bg-gray-900/30',
-        text: 'text-gray-700 dark:text-gray-300',
+        bg: 'bg-gray-900/30',
+        text: 'text-gray-300',
       }
   }
 }

--- a/docs/src/components/ui/alert.tsx
+++ b/docs/src/components/ui/alert.tsx
@@ -8,7 +8,7 @@ const alertConfig = {
     variant: {
       default: 'bg-background text-foreground',
       destructive:
-        'border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive',
+        'text-destructive border-destructive [&>svg]:text-destructive',
     },
   },
   defaultVariants: {


### PR DESCRIPTION
For admonitions and search they're set up with the tailwind dark colour scheme, but the site doesn't implement that, instead being all dark, making the admonitions difficult to read e.g. under this section https://formatjs.github.io/docs/react-intl#the-react-intl-module

Before:
<img width="929" height="137" alt="Screenshot 2026-01-14 at 16 13 01" src="https://github.com/user-attachments/assets/f4872c72-e7f4-402a-bf0c-64c090fae746" />

After:
<img width="929" height="137" alt="Screenshot 2026-01-14 at 16 13 22" src="https://github.com/user-attachments/assets/bd276e79-4a4d-4515-9f57-5355b252c098" />
