### PR TITLE
feat(@formatjs/intl-getcanonicallocales): update to latest spec, handle arraylike objs

### DIFF
--- a/packages/intl-getcanonicallocales/index.ts
+++ b/packages/intl-getcanonicallocales/index.ts
@@ -3,29 +3,91 @@ import {emitUnicodeLocaleId} from './src/emitter.js'
 import {parseUnicodeLocaleId} from './src/parser.js'
 
 /**
+ * Check if value is an Intl.Locale object by checking for [[InitializedLocale]] internal slot
+ * We detect this by checking if it's an Intl.Locale instance
+ */
+function isLocaleObject(value: any): value is Intl.Locale {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof value.toString === 'function' &&
+    typeof value.baseName === 'string' &&
+    typeof value.language === 'string'
+  )
+}
+
+/**
  * https://tc39.es/ecma402/#sec-canonicalizelocalelist
  * @param locales
  */
-function CanonicalizeLocaleList(locales?: string[] | string): string[] {
+function CanonicalizeLocaleList(
+  locales?:
+    | string[]
+    | string
+    | Intl.Locale
+    | Intl.Locale[]
+    | ArrayLike<string | Intl.Locale>
+): string[] {
+  // Step 1-2: If locales is undefined, return empty list
   if (locales === undefined) {
     return []
   }
+
   const seen: string[] = []
-  if (typeof locales === 'string') {
-    locales = [locales]
+
+  // Step 3-4: Handle string or Locale object by wrapping in array
+  if (typeof locales === 'string' || isLocaleObject(locales)) {
+    locales = [locales as string | Intl.Locale]
   }
-  for (const locale of locales) {
+
+  // Step 5-6: Convert to object and get length for array-like objects
+  const O = Object(locales)
+  const len = typeof O.length === 'number' ? O.length : 0
+
+  // Step 7: Iterate through elements
+  for (let k = 0; k < len; k++) {
+    // Check if property exists
+    if (!(k in O)) {
+      continue
+    }
+
+    const kValue = O[k]
+
+    // Step 7c-d: Extract locale string
+    let tag: string
+    if (typeof kValue === 'string') {
+      tag = kValue
+    } else if (isLocaleObject(kValue)) {
+      // For Intl.Locale objects, use toString() which returns the canonicalized locale
+      tag = kValue.toString()
+    } else {
+      throw new TypeError(
+        `Invalid locale type: expected string or Intl.Locale, got ${typeof kValue}`
+      )
+    }
+
+    // Step 7e-g: Validate and canonicalize
     const canonicalizedTag = emitUnicodeLocaleId(
-      CanonicalizeUnicodeLocaleId(parseUnicodeLocaleId(locale))
+      CanonicalizeUnicodeLocaleId(parseUnicodeLocaleId(tag))
     )
+
+    // Step 7h: Deduplicate
     if (seen.indexOf(canonicalizedTag) < 0) {
       seen.push(canonicalizedTag)
     }
   }
+
   return seen
 }
 
-export function getCanonicalLocales(locales?: string[] | string): string[] {
+export function getCanonicalLocales(
+  locales?:
+    | string[]
+    | string
+    | Intl.Locale
+    | Intl.Locale[]
+    | ArrayLike<string | Intl.Locale>
+): string[] {
   return CanonicalizeLocaleList(locales)
 }
 

--- a/packages/intl-getcanonicallocales/tests/index.test.ts
+++ b/packages/intl-getcanonicallocales/tests/index.test.ts
@@ -21,4 +21,115 @@ describe('Intl.getCanonicalLocales', () => {
   it('canonicalizes twice', function () {
     expect(getCanonicalLocales('und-Armn-SU')).toEqual(['und-Armn-AM'])
   })
+
+  describe('Intl.Locale object support', () => {
+    it('should handle single Intl.Locale object', function () {
+      const locale = new Intl.Locale('en-US')
+      expect(getCanonicalLocales(locale)).toEqual(['en-US'])
+    })
+
+    it('should handle array of Intl.Locale objects', function () {
+      const locales = [new Intl.Locale('en-US'), new Intl.Locale('fr-FR')]
+      expect(getCanonicalLocales(locales)).toEqual(['en-US', 'fr-FR'])
+    })
+
+    it('should handle mixed array of strings and Intl.Locale objects', function () {
+      const locales = [
+        new Intl.Locale('en-US'),
+        'fr-FR',
+        new Intl.Locale('de-DE'),
+      ]
+      expect(getCanonicalLocales(locales)).toEqual(['en-US', 'fr-FR', 'de-DE'])
+    })
+
+    it('should canonicalize Intl.Locale objects with extensions', function () {
+      const locale = new Intl.Locale('en-US-u-ca-buddhist')
+      expect(getCanonicalLocales(locale)).toEqual(['en-US-u-ca-buddhist'])
+    })
+
+    it('should deduplicate Intl.Locale objects', function () {
+      const locales = [
+        new Intl.Locale('en-US'),
+        'en-US',
+        new Intl.Locale('en-US'),
+      ]
+      expect(getCanonicalLocales(locales)).toEqual(['en-US'])
+    })
+
+    it('should handle Intl.Locale with non-canonical input', function () {
+      const locale = new Intl.Locale('zh-hANs-sG')
+      expect(getCanonicalLocales(locale)).toEqual(['zh-Hans-SG'])
+    })
+  })
+
+  describe('Array-like object support', () => {
+    it('should handle array-like object with string locales', function () {
+      const arrayLike = {0: 'en-US', 1: 'fr-FR', length: 2}
+      expect(getCanonicalLocales(arrayLike)).toEqual(['en-US', 'fr-FR'])
+    })
+
+    it('should handle array-like object with Intl.Locale objects', function () {
+      const arrayLike = {
+        0: new Intl.Locale('en-US'),
+        1: new Intl.Locale('fr-FR'),
+        length: 2,
+      }
+      expect(getCanonicalLocales(arrayLike)).toEqual(['en-US', 'fr-FR'])
+    })
+
+    it('should handle array-like object with mixed types', function () {
+      const arrayLike = {
+        0: 'en-US',
+        1: new Intl.Locale('fr-FR'),
+        2: 'de-DE',
+        length: 3,
+      }
+      expect(getCanonicalLocales(arrayLike)).toEqual([
+        'en-US',
+        'fr-FR',
+        'de-DE',
+      ])
+    })
+
+    it('should handle sparse array-like objects', function () {
+      const arrayLike = {0: 'en-US', 2: 'de-DE', length: 3}
+      expect(getCanonicalLocales(arrayLike)).toEqual(['en-US', 'de-DE'])
+    })
+
+    it('should handle array-like object with length 0', function () {
+      const arrayLike = {0: 'en-US', length: 0}
+      expect(getCanonicalLocales(arrayLike)).toEqual([])
+    })
+
+    it('should deduplicate in array-like objects', function () {
+      const arrayLike = {0: 'en-US', 1: 'fr-FR', 2: 'en-US', length: 3}
+      expect(getCanonicalLocales(arrayLike)).toEqual(['en-US', 'fr-FR'])
+    })
+  })
+
+  describe('Error handling', () => {
+    it('should throw TypeError for invalid locale type in array', function () {
+      expect(() => getCanonicalLocales([123 as any])).toThrow(TypeError)
+    })
+
+    it('should throw TypeError for invalid locale type in array-like', function () {
+      const arrayLike = {0: 'en-US', 1: {not: 'a locale'}, length: 2}
+      expect(() => getCanonicalLocales(arrayLike as any)).toThrow(TypeError)
+    })
+
+    it('should throw RangeError for invalid locale string', function () {
+      // Empty string is not a valid locale
+      expect(() => getCanonicalLocales('')).toThrow(RangeError)
+    })
+
+    it('should throw RangeError for locale with underscore', function () {
+      expect(() => getCanonicalLocales('de_DE')).toThrow(RangeError)
+    })
+
+    it('should throw RangeError for duplicate variants', function () {
+      expect(() => getCanonicalLocales('de-gregory-gregory')).toThrow(
+        RangeError
+      )
+    })
+  })
 })


### PR DESCRIPTION
### TL;DR

Added support for Intl.Locale objects and array-like objects in getCanonicalLocales.

### What changed?

- Enhanced `getCanonicalLocales` to accept Intl.Locale objects as input
- Added support for array-like objects as input parameters
- Implemented proper type checking for all input types
- Improved error handling with more specific error messages
- Updated the function signature to reflect the new supported parameter types
- Added comprehensive test cases for all new functionality

### How to test?

Run the test suite which includes new tests for:
- Single Intl.Locale object input
- Arrays of Intl.Locale objects
- Mixed arrays of strings and Intl.Locale objects
- Array-like objects with various content types
- Error cases for invalid inputs

Examples:
```js
// Test with Intl.Locale objects
getCanonicalLocales(new Intl.Locale('en-US'))
getCanonicalLocales([new Intl.Locale('en-US'), new Intl.Locale('fr-FR')])

// Test with array-like objects
getCanonicalLocales({0: 'en-US', 1: 'fr-FR', length: 2})
```

### Why make this change?

This change brings the implementation closer to the ECMAScript specification, which allows for Intl.Locale objects as input to getCanonicalLocales. It also improves compatibility with array-like objects, making the function more flexible and robust in different usage scenarios.