### PR TITLE
feat(@formatjs/intl-locale): support variants per latest spec

### DIFF
--- a/packages/intl-getcanonicallocales/index.ts
+++ b/packages/intl-getcanonicallocales/index.ts
@@ -5,6 +5,12 @@ import {parseUnicodeLocaleId} from './src/parser.js'
 /**
  * Check if value is an Intl.Locale object by checking for [[InitializedLocale]] internal slot
  * We detect this by checking if it's an Intl.Locale instance
+ *
+ * Per ECMA-402 #sec-canonicalizelocalelist step 7.c:
+ * "If Type(kValue) is Object and kValue has an [[InitializedLocale]] internal slot, then
+ *  Let tag be kValue.[[Locale]]"
+ *
+ * https://tc39.es/ecma402/#sec-canonicalizelocalelist
  */
 function isLocaleObject(value: any): value is Intl.Locale {
   return (
@@ -36,11 +42,14 @@ function CanonicalizeLocaleList(
   const seen: string[] = []
 
   // Step 3-4: Handle string or Locale object by wrapping in array
+  // Per spec: "If Type(locales) is String or Type(locales) is Object and locales has an
+  // [[InitializedLocale]] internal slot, then Let O be CreateArrayFromList(« locales »)"
   if (typeof locales === 'string' || isLocaleObject(locales)) {
     locales = [locales as string | Intl.Locale]
   }
 
   // Step 5-6: Convert to object and get length for array-like objects
+  // Per spec: "Let O be ? ToObject(locales)" and "Let len be ? ToLength(? Get(O, "length"))"
   const O = Object(locales)
   const len = typeof O.length === 'number' ? O.length : 0
 

--- a/packages/intl-locale/index.ts
+++ b/packages/intl-locale/index.ts
@@ -667,6 +667,24 @@ export class Locale {
     return parseUnicodeLanguageId(locale).region
   }
 
+  /**
+   * Returns the variant subtags of the locale, or undefined if none exist.
+   * Multiple variants are joined with hyphens in alphabetical order.
+   *
+   * Added in ECMA-402 via PR #960 to align with other subtag accessors.
+   * @see https://tc39.es/ecma402/#sec-Intl.Locale.prototype.variants
+   * @see https://github.com/tc39/ecma402/pull/960
+   * @see https://github.com/tc39/ecma402/issues/900
+   */
+  public get variants(): string | undefined {
+    const locale = getInternalSlots(this).locale
+    const variants = parseUnicodeLanguageId(locale).variants
+    if (!variants || variants.length === 0) {
+      return undefined
+    }
+    return variants.join('-')
+  }
+
   public get firstDayOfWeek(): string | undefined {
     const internalSlots = getInternalSlots(this)
     if (!HasOwnProperty(internalSlots, 'initializedLocale')) {

--- a/packages/intl-locale/should-polyfill.ts
+++ b/packages/intl-locale/should-polyfill.ts
@@ -10,6 +10,26 @@ function hasIntlGetCanonicalLocalesBug(): boolean {
 }
 
 /**
+ * Check if Intl.Locale is missing the variants property.
+ * This property was added to ECMA-402 via PR #960.
+ * https://github.com/tc39/ecma402/pull/960
+ * https://github.com/tc39/ecma402/issues/900
+ */
+function hasVariantsProperty(): boolean {
+  try {
+    const locale = new (Intl as any).Locale('en-US-posix')
+    // Check if variants property exists
+    const descriptor = Object.getOwnPropertyDescriptor(
+      Object.getPrototypeOf(locale),
+      'variants'
+    )
+    return descriptor !== undefined && typeof descriptor.get === 'function'
+  } catch {
+    return false
+  }
+}
+
+/**
  * Check if Intl.Locale is missing critical methods from the Intl Locale Info proposal.
  * Firefox has an incomplete implementation that lacks getWeekInfo() and other methods.
  * https://github.com/formatjs/formatjs/issues/5112
@@ -45,6 +65,7 @@ export function shouldPolyfill(): boolean {
   return (
     !('Locale' in Intl) ||
     hasIntlGetCanonicalLocalesBug() ||
-    hasIncompleteLocaleInfo()
+    hasIncompleteLocaleInfo() ||
+    !hasVariantsProperty()
   )
 }

--- a/packages/intl-locale/tests/index.test.ts
+++ b/packages/intl-locale/tests/index.test.ts
@@ -106,6 +106,49 @@ describe('intl-locale', () => {
   it('has static polyfilled property', function () {
     expect(Locale.polyfilled).toBe(true)
   })
+
+  describe('variants property', () => {
+    it('should return undefined for locale without variants', function () {
+      expect(new Locale('en-US').variants).toBe(undefined)
+    })
+
+    it('should return variant string for locale with single variant', function () {
+      expect(new Locale('ca-valencia').variants).toBe('valencia')
+    })
+
+    it('should return hyphen-joined variants for locale with multiple variants', function () {
+      // Note: variants are sorted alphabetically during canonicalization
+      const locale = new Locale('de-DE-1996-1901')
+      expect(locale.variants).toBe('1901-1996')
+    })
+
+    it('should return undefined for locale with only language', function () {
+      expect(new Locale('en').variants).toBe(undefined)
+    })
+
+    it('should return variant for locale with script', function () {
+      expect(new Locale('en-Latn-fonipa').variants).toBe('fonipa')
+    })
+
+    it('should handle fonipa variant', function () {
+      expect(new Locale('en-fonipa').variants).toBe('fonipa')
+    })
+
+    it('should preserve multiple variants in correct order after canonicalization', function () {
+      const locale = new Locale('de-DE-1901-1996')
+      expect(locale.variants).toBe('1901-1996')
+    })
+
+    it('should return variant for locale with extensions', function () {
+      const locale = new Locale('ca-valencia-u-ca-gregory')
+      expect(locale.variants).toBe('valencia')
+    })
+
+    it('should handle numeric variant 1606nict', function () {
+      const locale = new Locale('fr-1606nict')
+      expect(locale.variants).toBe('1606nict')
+    })
+  })
 })
 
 test('getWeekInfo', function () {


### PR DESCRIPTION
### TL;DR

Added the `variants` property to `Intl.Locale` and improved documentation for `CanonicalizeLocaleList`.

### What changed?

- Added the `variants` getter to the `Intl.Locale` class that returns variant subtags joined with hyphens in alphabetical order
- Added detection for the `variants` property in the `shouldPolyfill` function
- Added comprehensive tests for the new `variants` property with various locale scenarios
- Enhanced documentation in `intl-getcanonicallocales` with ECMA-402 spec references for better clarity

### How to test?

- Run the new test cases that verify the `variants` property works correctly:
  - Returns `undefined` for locales without variants
  - Returns the variant string for locales with a single variant
  - Returns hyphen-joined variants in alphabetical order for locales with multiple variants
  - Handles various locale formats with scripts, extensions, and numeric variants

### Why make this change?

This change implements the `variants` property that was added to ECMA-402 via PR #960 to align with other subtag accessors. The property provides access to the variant subtags of a locale, which was previously missing from the implementation. This brings the polyfill in line with the latest ECMA-402 specification.

References:
- https://tc39.es/ecma402/#sec-Intl.Locale.prototype.variants
- https://github.com/tc39/ecma402/pull/960
- https://github.com/tc39/ecma402/issues/900