### PR TITLE
test(@formatjs/intl-datetimeformat): add test for #4270

### DIFF
--- a/packages/intl-datetimeformat/BUILD.bazel
+++ b/packages/intl-datetimeformat/BUILD.bazel
@@ -17,6 +17,7 @@ PACKAGE_NAME = "intl-datetimeformat"
 
 TEST_LOCALES = [
     "ar",
+    "bs",
     "de",
     "en",
     "en-GB",

--- a/packages/intl-datetimeformat/tests/format.test.ts
+++ b/packages/intl-datetimeformat/tests/format.test.ts
@@ -5,12 +5,13 @@ import {
   toLocaleString,
   toLocaleTimeString,
 } from '../src/to_locale_string'
+import * as bs from './locale-data/bs.json' with {type: 'json'}
 import * as en from './locale-data/en.json' with {type: 'json'}
 import * as ko from './locale-data/ko.json' with {type: 'json'}
 import * as ru from './locale-data/ru.json' with {type: 'json'}
 import {describe, expect, it} from 'vitest'
 // @ts-ignore
-DateTimeFormat.__addLocaleData(en, ko, ru)
+DateTimeFormat.__addLocaleData(bs, en, ko, ru)
 DateTimeFormat.__addTZData(allData)
 
 const tests: Array<{
@@ -382,5 +383,27 @@ describe('stand-alone month forms (issue #5134)', function () {
     expect(fmt.format(january)).toBe('15 января')
     expect(fmt.format(february)).toBe('15 февраля')
     expect(fmt.format(march)).toBe('15 марта')
+  })
+})
+
+// Test for issue #4270: Bosnian month formatting
+describe('Bosnian month formatting (issue #4270)', function () {
+  it('should format with full datetime options including long month', function () {
+    const date = new Date(Date.UTC(2024, 10, 15, 14, 30, 45)) // November 15, 2024, 14:30:45 UTC
+    const fmt = new DateTimeFormat('bs-BA', {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+      second: 'numeric',
+      timeZone: 'UTC',
+    })
+
+    const result = fmt.format(date)
+
+    // Should produce correct format with "novembar" for November (not "M11")
+    expect(result).toBe('petak, 15. novembar 2024., 14:30:45')
   })
 })

--- a/packages/intl-datetimeformat/tests/locale-data/bs.json
+++ b/packages/intl-datetimeformat/tests/locale-data/bs.json
@@ -1,0 +1,5064 @@
+{
+  "data": {
+    "am": "a. m.",
+    "pm": "p. m.",
+    "weekday": {
+      "narrow": [
+        "N",
+        "P",
+        "U",
+        "S",
+        "Č",
+        "P",
+        "S"
+      ],
+      "short": [
+        "ned",
+        "pon",
+        "uto",
+        "sri",
+        "čet",
+        "pet",
+        "sub"
+      ],
+      "long": [
+        "nedjelja",
+        "ponedjeljak",
+        "utorak",
+        "srijeda",
+        "četvrtak",
+        "petak",
+        "subota"
+      ]
+    },
+    "era": {
+      "narrow": {
+        "BC": "p.n.e.",
+        "AD": "n. e."
+      },
+      "short": {
+        "BC": "p. n. e.",
+        "AD": "n. e."
+      },
+      "long": {
+        "BC": "prije nove ere",
+        "AD": "nove ere"
+      }
+    },
+    "month": {
+      "narrow": [
+        "jan",
+        "feb",
+        "mar",
+        "apr",
+        "may",
+        "jun",
+        "jul",
+        "aug",
+        "sep",
+        "okt",
+        "nov",
+        "dec"
+      ],
+      "short": [
+        "jan",
+        "feb",
+        "mar",
+        "apr",
+        "maj",
+        "jun",
+        "jul",
+        "aug",
+        "sep",
+        "okt",
+        "nov",
+        "dec"
+      ],
+      "long": [
+        "januar",
+        "februar",
+        "mart",
+        "april",
+        "maj",
+        "juni",
+        "juli",
+        "august",
+        "septembar",
+        "oktobar",
+        "novembar",
+        "decembar"
+      ]
+    },
+    "monthStandalone": {
+      "narrow": [
+        "j",
+        "f",
+        "m",
+        "a",
+        "m",
+        "j",
+        "j",
+        "a",
+        "s",
+        "o",
+        "n",
+        "d"
+      ],
+      "short": [
+        "jan",
+        "feb",
+        "mar",
+        "apr",
+        "maj",
+        "jun",
+        "jul",
+        "aug",
+        "sep",
+        "okt",
+        "nov",
+        "dec"
+      ],
+      "long": [
+        "januar",
+        "februar",
+        "mart",
+        "april",
+        "maj",
+        "juni",
+        "juli",
+        "august",
+        "septembar",
+        "oktobar",
+        "novembar",
+        "decembar"
+      ]
+    },
+    "timeZoneName": {
+      "Africa/Abidjan": {
+        "long": [
+          "Griničko vrijeme",
+          "Griničko vrijeme"
+        ],
+        "short": [
+          "GMT",
+          "GMT"
+        ]
+      },
+      "Africa/Accra": {
+        "long": [
+          "Griničko vrijeme",
+          "Griničko vrijeme"
+        ],
+        "short": [
+          "GMT",
+          "GMT"
+        ]
+      },
+      "Africa/Addis_Ababa": {
+        "long": [
+          "Istočnoafričko vrijeme",
+          "Istočnoafričko vrijeme"
+        ]
+      },
+      "Africa/Algiers": {
+        "long": [
+          "Centralnoevropsko standardno vrijeme",
+          "Centralnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "CET",
+          "CEST"
+        ]
+      },
+      "Africa/Asmera": {
+        "long": [
+          "Istočnoafričko vrijeme",
+          "Istočnoafričko vrijeme"
+        ]
+      },
+      "Africa/Bamako": {
+        "long": [
+          "Griničko vrijeme",
+          "Griničko vrijeme"
+        ],
+        "short": [
+          "GMT",
+          "GMT"
+        ]
+      },
+      "Africa/Bangui": {
+        "long": [
+          "Zapadnoafričko vrijeme",
+          "Zapadnoafričko vrijeme"
+        ]
+      },
+      "Africa/Banjul": {
+        "long": [
+          "Griničko vrijeme",
+          "Griničko vrijeme"
+        ],
+        "short": [
+          "GMT",
+          "GMT"
+        ]
+      },
+      "Africa/Bissau": {
+        "long": [
+          "Griničko vrijeme",
+          "Griničko vrijeme"
+        ],
+        "short": [
+          "GMT",
+          "GMT"
+        ]
+      },
+      "Africa/Blantyre": {
+        "long": [
+          "Centralnoafričko vrijeme",
+          "Centralnoafričko vrijeme"
+        ]
+      },
+      "Africa/Brazzaville": {
+        "long": [
+          "Zapadnoafričko vrijeme",
+          "Zapadnoafričko vrijeme"
+        ]
+      },
+      "Africa/Bujumbura": {
+        "long": [
+          "Centralnoafričko vrijeme",
+          "Centralnoafričko vrijeme"
+        ]
+      },
+      "Africa/Cairo": {
+        "long": [
+          "Istočnoevropsko standardno vrijeme",
+          "Istočnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "EET",
+          "EEST"
+        ]
+      },
+      "Africa/Casablanca": {
+        "long": [
+          "Zapadnoevropsko standardno vrijeme",
+          "Zapadnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "WET",
+          "WEST"
+        ]
+      },
+      "Africa/Ceuta": {
+        "long": [
+          "Centralnoevropsko standardno vrijeme",
+          "Centralnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "CET",
+          "CEST"
+        ]
+      },
+      "Africa/Conakry": {
+        "long": [
+          "Griničko vrijeme",
+          "Griničko vrijeme"
+        ],
+        "short": [
+          "GMT",
+          "GMT"
+        ]
+      },
+      "Africa/Dakar": {
+        "long": [
+          "Griničko vrijeme",
+          "Griničko vrijeme"
+        ],
+        "short": [
+          "GMT",
+          "GMT"
+        ]
+      },
+      "Africa/Dar_es_Salaam": {
+        "long": [
+          "Istočnoafričko vrijeme",
+          "Istočnoafričko vrijeme"
+        ]
+      },
+      "Africa/Djibouti": {
+        "long": [
+          "Istočnoafričko vrijeme",
+          "Istočnoafričko vrijeme"
+        ]
+      },
+      "Africa/Douala": {
+        "long": [
+          "Zapadnoafričko vrijeme",
+          "Zapadnoafričko vrijeme"
+        ]
+      },
+      "Africa/El_Aaiun": {
+        "long": [
+          "Zapadnoevropsko standardno vrijeme",
+          "Zapadnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "WET",
+          "WEST"
+        ]
+      },
+      "Africa/Freetown": {
+        "long": [
+          "Griničko vrijeme",
+          "Griničko vrijeme"
+        ],
+        "short": [
+          "GMT",
+          "GMT"
+        ]
+      },
+      "Africa/Gaborone": {
+        "long": [
+          "Centralnoafričko vrijeme",
+          "Centralnoafričko vrijeme"
+        ]
+      },
+      "Africa/Harare": {
+        "long": [
+          "Centralnoafričko vrijeme",
+          "Centralnoafričko vrijeme"
+        ]
+      },
+      "Africa/Johannesburg": {
+        "long": [
+          "Južnoafričko standardno vrijeme",
+          "Južnoafričko standardno vrijeme"
+        ]
+      },
+      "Africa/Juba": {
+        "long": [
+          "Centralnoafričko vrijeme",
+          "Centralnoafričko vrijeme"
+        ]
+      },
+      "Africa/Kampala": {
+        "long": [
+          "Istočnoafričko vrijeme",
+          "Istočnoafričko vrijeme"
+        ]
+      },
+      "Africa/Khartoum": {
+        "long": [
+          "Centralnoafričko vrijeme",
+          "Centralnoafričko vrijeme"
+        ]
+      },
+      "Africa/Kigali": {
+        "long": [
+          "Centralnoafričko vrijeme",
+          "Centralnoafričko vrijeme"
+        ]
+      },
+      "Africa/Kinshasa": {
+        "long": [
+          "Zapadnoafričko vrijeme",
+          "Zapadnoafričko vrijeme"
+        ]
+      },
+      "Africa/Lagos": {
+        "long": [
+          "Zapadnoafričko vrijeme",
+          "Zapadnoafričko vrijeme"
+        ]
+      },
+      "Africa/Libreville": {
+        "long": [
+          "Zapadnoafričko vrijeme",
+          "Zapadnoafričko vrijeme"
+        ]
+      },
+      "Africa/Lome": {
+        "long": [
+          "Griničko vrijeme",
+          "Griničko vrijeme"
+        ],
+        "short": [
+          "GMT",
+          "GMT"
+        ]
+      },
+      "Africa/Luanda": {
+        "long": [
+          "Zapadnoafričko vrijeme",
+          "Zapadnoafričko vrijeme"
+        ]
+      },
+      "Africa/Lubumbashi": {
+        "long": [
+          "Centralnoafričko vrijeme",
+          "Centralnoafričko vrijeme"
+        ]
+      },
+      "Africa/Lusaka": {
+        "long": [
+          "Centralnoafričko vrijeme",
+          "Centralnoafričko vrijeme"
+        ]
+      },
+      "Africa/Malabo": {
+        "long": [
+          "Zapadnoafričko vrijeme",
+          "Zapadnoafričko vrijeme"
+        ]
+      },
+      "Africa/Maputo": {
+        "long": [
+          "Centralnoafričko vrijeme",
+          "Centralnoafričko vrijeme"
+        ]
+      },
+      "Africa/Maseru": {
+        "long": [
+          "Južnoafričko standardno vrijeme",
+          "Južnoafričko standardno vrijeme"
+        ]
+      },
+      "Africa/Mbabane": {
+        "long": [
+          "Južnoafričko standardno vrijeme",
+          "Južnoafričko standardno vrijeme"
+        ]
+      },
+      "Africa/Mogadishu": {
+        "long": [
+          "Istočnoafričko vrijeme",
+          "Istočnoafričko vrijeme"
+        ]
+      },
+      "Africa/Monrovia": {
+        "long": [
+          "Griničko vrijeme",
+          "Griničko vrijeme"
+        ],
+        "short": [
+          "GMT",
+          "GMT"
+        ]
+      },
+      "Africa/Nairobi": {
+        "long": [
+          "Istočnoafričko vrijeme",
+          "Istočnoafričko vrijeme"
+        ]
+      },
+      "Africa/Ndjamena": {
+        "long": [
+          "Zapadnoafričko vrijeme",
+          "Zapadnoafričko vrijeme"
+        ]
+      },
+      "Africa/Niamey": {
+        "long": [
+          "Zapadnoafričko vrijeme",
+          "Zapadnoafričko vrijeme"
+        ]
+      },
+      "Africa/Nouakchott": {
+        "long": [
+          "Griničko vrijeme",
+          "Griničko vrijeme"
+        ],
+        "short": [
+          "GMT",
+          "GMT"
+        ]
+      },
+      "Africa/Ouagadougou": {
+        "long": [
+          "Griničko vrijeme",
+          "Griničko vrijeme"
+        ],
+        "short": [
+          "GMT",
+          "GMT"
+        ]
+      },
+      "Africa/Porto-Novo": {
+        "long": [
+          "Zapadnoafričko vrijeme",
+          "Zapadnoafričko vrijeme"
+        ]
+      },
+      "Africa/Sao_Tome": {
+        "long": [
+          "Griničko vrijeme",
+          "Griničko vrijeme"
+        ],
+        "short": [
+          "GMT",
+          "GMT"
+        ]
+      },
+      "Africa/Tripoli": {
+        "long": [
+          "Istočnoevropsko standardno vrijeme",
+          "Istočnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "EET",
+          "EEST"
+        ]
+      },
+      "Africa/Tunis": {
+        "long": [
+          "Centralnoevropsko standardno vrijeme",
+          "Centralnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "CET",
+          "CEST"
+        ]
+      },
+      "Africa/Windhoek": {
+        "long": [
+          "Centralnoafričko vrijeme",
+          "Centralnoafričko vrijeme"
+        ]
+      },
+      "America/Adak": {
+        "long": [
+          "Havajsko-aleućansko standardno vrijeme",
+          "Havajsko-aleućansko ljetno vrijeme"
+        ]
+      },
+      "America/Anchorage": {
+        "long": [
+          "Aljaskansko standardno vrijeme",
+          "Aljaskansko ljetno vrijeme"
+        ]
+      },
+      "America/Anguilla": {
+        "long": [
+          "Sjevernoameričko atlantsko standardno vrijeme",
+          "Sjevernoameričko atlantsko ljetno vrijeme"
+        ]
+      },
+      "America/Antigua": {
+        "long": [
+          "Sjevernoameričko atlantsko standardno vrijeme",
+          "Sjevernoameričko atlantsko ljetno vrijeme"
+        ]
+      },
+      "America/Araguaina": {
+        "long": [
+          "Brazilijsko standardno vrijeme",
+          "Brazilijsko ljetno vrijeme"
+        ]
+      },
+      "America/Aruba": {
+        "long": [
+          "Sjevernoameričko atlantsko standardno vrijeme",
+          "Sjevernoameričko atlantsko ljetno vrijeme"
+        ]
+      },
+      "America/Asuncion": {
+        "long": [
+          "Paragvajsko standardno vrijeme",
+          "Paragvajsko ljetno vrijeme"
+        ]
+      },
+      "America/Bahia": {
+        "long": [
+          "Brazilijsko standardno vrijeme",
+          "Brazilijsko ljetno vrijeme"
+        ]
+      },
+      "America/Bahia_Banderas": {
+        "long": [
+          "Sjevernoameričko centralno standardno vrijeme",
+          "Sjevernoameričko centralno ljetno vrijeme"
+        ]
+      },
+      "America/Barbados": {
+        "long": [
+          "Sjevernoameričko atlantsko standardno vrijeme",
+          "Sjevernoameričko atlantsko ljetno vrijeme"
+        ]
+      },
+      "America/Belem": {
+        "long": [
+          "Brazilijsko standardno vrijeme",
+          "Brazilijsko ljetno vrijeme"
+        ]
+      },
+      "America/Belize": {
+        "long": [
+          "Sjevernoameričko centralno standardno vrijeme",
+          "Sjevernoameričko centralno ljetno vrijeme"
+        ]
+      },
+      "America/Blanc-Sablon": {
+        "long": [
+          "Sjevernoameričko atlantsko standardno vrijeme",
+          "Sjevernoameričko atlantsko ljetno vrijeme"
+        ]
+      },
+      "America/Boa_Vista": {
+        "long": [
+          "Amazonsko standardno vrijeme",
+          "Amazonsko ljetno vrijeme"
+        ]
+      },
+      "America/Bogota": {
+        "long": [
+          "Kolumbijsko standardno vrijeme",
+          "Kolumbijsko ljetno vrijeme"
+        ]
+      },
+      "America/Boise": {
+        "long": [
+          "Sjevernoameričko planinsko standardno vrijeme",
+          "Sjevernoameričko planinsko ljetno vrijeme"
+        ]
+      },
+      "America/Buenos_Aires": {
+        "long": [
+          "Argentinsko standardno vrijeme",
+          "Argentinsko ljetno vrijeme"
+        ]
+      },
+      "America/Cambridge_Bay": {
+        "long": [
+          "Sjevernoameričko planinsko standardno vrijeme",
+          "Sjevernoameričko planinsko ljetno vrijeme"
+        ]
+      },
+      "America/Campo_Grande": {
+        "long": [
+          "Amazonsko standardno vrijeme",
+          "Amazonsko ljetno vrijeme"
+        ]
+      },
+      "America/Cancun": {
+        "long": [
+          "Sjevernoameričko istočno standardno vrijeme",
+          "Sjevernoameričko istočno ljetno vrijeme"
+        ]
+      },
+      "America/Caracas": {
+        "long": [
+          "Venecuelansko vrijeme",
+          "Venecuelansko vrijeme"
+        ]
+      },
+      "America/Catamarca": {
+        "long": [
+          "Argentinsko standardno vrijeme",
+          "Argentinsko ljetno vrijeme"
+        ]
+      },
+      "America/Cayenne": {
+        "long": [
+          "Francuskogvajansko vrijeme",
+          "Francuskogvajansko vrijeme"
+        ]
+      },
+      "America/Cayman": {
+        "long": [
+          "Sjevernoameričko istočno standardno vrijeme",
+          "Sjevernoameričko istočno ljetno vrijeme"
+        ]
+      },
+      "America/Chicago": {
+        "long": [
+          "Sjevernoameričko centralno standardno vrijeme",
+          "Sjevernoameričko centralno ljetno vrijeme"
+        ]
+      },
+      "America/Chihuahua": {
+        "long": [
+          "Sjevernoameričko centralno standardno vrijeme",
+          "Sjevernoameričko centralno ljetno vrijeme"
+        ]
+      },
+      "America/Ciudad_Juarez": {
+        "long": [
+          "Sjevernoameričko planinsko standardno vrijeme",
+          "Sjevernoameričko planinsko ljetno vrijeme"
+        ]
+      },
+      "America/Coral_Harbour": {
+        "long": [
+          "Sjevernoameričko istočno standardno vrijeme",
+          "Sjevernoameričko istočno ljetno vrijeme"
+        ]
+      },
+      "America/Cordoba": {
+        "long": [
+          "Argentinsko standardno vrijeme",
+          "Argentinsko ljetno vrijeme"
+        ]
+      },
+      "America/Costa_Rica": {
+        "long": [
+          "Sjevernoameričko centralno standardno vrijeme",
+          "Sjevernoameričko centralno ljetno vrijeme"
+        ]
+      },
+      "America/Coyhaique": {
+        "long": [
+          "Čileansko standardno vrijeme",
+          "Čileansko ljetno vrijeme"
+        ]
+      },
+      "America/Creston": {
+        "long": [
+          "Sjevernoameričko planinsko standardno vrijeme",
+          "Sjevernoameričko planinsko ljetno vrijeme"
+        ]
+      },
+      "America/Cuiaba": {
+        "long": [
+          "Amazonsko standardno vrijeme",
+          "Amazonsko ljetno vrijeme"
+        ]
+      },
+      "America/Curacao": {
+        "long": [
+          "Sjevernoameričko atlantsko standardno vrijeme",
+          "Sjevernoameričko atlantsko ljetno vrijeme"
+        ]
+      },
+      "America/Danmarkshavn": {
+        "long": [
+          "Griničko vrijeme",
+          "Griničko vrijeme"
+        ],
+        "short": [
+          "GMT",
+          "GMT"
+        ]
+      },
+      "America/Dawson": {
+        "long": [
+          "Jukonsko vrijeme",
+          "Jukonsko vrijeme"
+        ]
+      },
+      "America/Dawson_Creek": {
+        "long": [
+          "Sjevernoameričko planinsko standardno vrijeme",
+          "Sjevernoameričko planinsko ljetno vrijeme"
+        ]
+      },
+      "America/Denver": {
+        "long": [
+          "Sjevernoameričko planinsko standardno vrijeme",
+          "Sjevernoameričko planinsko ljetno vrijeme"
+        ]
+      },
+      "America/Detroit": {
+        "long": [
+          "Sjevernoameričko istočno standardno vrijeme",
+          "Sjevernoameričko istočno ljetno vrijeme"
+        ]
+      },
+      "America/Dominica": {
+        "long": [
+          "Sjevernoameričko atlantsko standardno vrijeme",
+          "Sjevernoameričko atlantsko ljetno vrijeme"
+        ]
+      },
+      "America/Edmonton": {
+        "long": [
+          "Sjevernoameričko planinsko standardno vrijeme",
+          "Sjevernoameričko planinsko ljetno vrijeme"
+        ]
+      },
+      "America/Eirunepe": {
+        "long": [
+          "Acre standardno vreme",
+          "Acre letnje računanje vremena"
+        ]
+      },
+      "America/El_Salvador": {
+        "long": [
+          "Sjevernoameričko centralno standardno vrijeme",
+          "Sjevernoameričko centralno ljetno vrijeme"
+        ]
+      },
+      "America/Fort_Nelson": {
+        "long": [
+          "Sjevernoameričko planinsko standardno vrijeme",
+          "Sjevernoameričko planinsko ljetno vrijeme"
+        ]
+      },
+      "America/Fortaleza": {
+        "long": [
+          "Brazilijsko standardno vrijeme",
+          "Brazilijsko ljetno vrijeme"
+        ]
+      },
+      "America/Glace_Bay": {
+        "long": [
+          "Sjevernoameričko atlantsko standardno vrijeme",
+          "Sjevernoameričko atlantsko ljetno vrijeme"
+        ]
+      },
+      "America/Goose_Bay": {
+        "long": [
+          "Sjevernoameričko atlantsko standardno vrijeme",
+          "Sjevernoameričko atlantsko ljetno vrijeme"
+        ]
+      },
+      "America/Grand_Turk": {
+        "long": [
+          "Sjevernoameričko istočno standardno vrijeme",
+          "Sjevernoameričko istočno ljetno vrijeme"
+        ]
+      },
+      "America/Grenada": {
+        "long": [
+          "Sjevernoameričko atlantsko standardno vrijeme",
+          "Sjevernoameričko atlantsko ljetno vrijeme"
+        ]
+      },
+      "America/Guadeloupe": {
+        "long": [
+          "Sjevernoameričko atlantsko standardno vrijeme",
+          "Sjevernoameričko atlantsko ljetno vrijeme"
+        ]
+      },
+      "America/Guatemala": {
+        "long": [
+          "Sjevernoameričko centralno standardno vrijeme",
+          "Sjevernoameričko centralno ljetno vrijeme"
+        ]
+      },
+      "America/Guayaquil": {
+        "long": [
+          "Ekvadorsko vrijeme",
+          "Ekvadorsko vrijeme"
+        ]
+      },
+      "America/Guyana": {
+        "long": [
+          "Gvajansko vrijeme",
+          "Gvajansko vrijeme"
+        ]
+      },
+      "America/Halifax": {
+        "long": [
+          "Sjevernoameričko atlantsko standardno vrijeme",
+          "Sjevernoameričko atlantsko ljetno vrijeme"
+        ]
+      },
+      "America/Havana": {
+        "long": [
+          "Kubansko standardno vrijeme",
+          "Kubansko ljetno vrijeme"
+        ]
+      },
+      "America/Hermosillo": {
+        "long": [
+          "Meksičko pacifičko standardno vrijeme",
+          "Meksičko pacifičko ljetno vrijeme"
+        ]
+      },
+      "America/Indianapolis": {
+        "long": [
+          "Sjevernoameričko istočno standardno vrijeme",
+          "Sjevernoameričko istočno ljetno vrijeme"
+        ]
+      },
+      "America/Inuvik": {
+        "long": [
+          "Sjevernoameričko planinsko standardno vrijeme",
+          "Sjevernoameričko planinsko ljetno vrijeme"
+        ]
+      },
+      "America/Iqaluit": {
+        "long": [
+          "Sjevernoameričko istočno standardno vrijeme",
+          "Sjevernoameričko istočno ljetno vrijeme"
+        ]
+      },
+      "America/Jamaica": {
+        "long": [
+          "Sjevernoameričko istočno standardno vrijeme",
+          "Sjevernoameričko istočno ljetno vrijeme"
+        ]
+      },
+      "America/Jujuy": {
+        "long": [
+          "Argentinsko standardno vrijeme",
+          "Argentinsko ljetno vrijeme"
+        ]
+      },
+      "America/Juneau": {
+        "long": [
+          "Aljaskansko standardno vrijeme",
+          "Aljaskansko ljetno vrijeme"
+        ]
+      },
+      "America/Kralendijk": {
+        "long": [
+          "Sjevernoameričko atlantsko standardno vrijeme",
+          "Sjevernoameričko atlantsko ljetno vrijeme"
+        ]
+      },
+      "America/La_Paz": {
+        "long": [
+          "Bolivijsko vrijeme",
+          "Bolivijsko vrijeme"
+        ]
+      },
+      "America/Lima": {
+        "long": [
+          "Peruansko standardno vrijeme",
+          "Peruansko ljetno vrijeme"
+        ]
+      },
+      "America/Los_Angeles": {
+        "long": [
+          "Sjevernoameričko pacifičko standardno vrijeme",
+          "Sjevernoameričko pacifičko ljetno vrijeme"
+        ]
+      },
+      "America/Louisville": {
+        "long": [
+          "Sjevernoameričko istočno standardno vrijeme",
+          "Sjevernoameričko istočno ljetno vrijeme"
+        ]
+      },
+      "America/Lower_Princes": {
+        "long": [
+          "Sjevernoameričko atlantsko standardno vrijeme",
+          "Sjevernoameričko atlantsko ljetno vrijeme"
+        ]
+      },
+      "America/Maceio": {
+        "long": [
+          "Brazilijsko standardno vrijeme",
+          "Brazilijsko ljetno vrijeme"
+        ]
+      },
+      "America/Managua": {
+        "long": [
+          "Sjevernoameričko centralno standardno vrijeme",
+          "Sjevernoameričko centralno ljetno vrijeme"
+        ]
+      },
+      "America/Manaus": {
+        "long": [
+          "Amazonsko standardno vrijeme",
+          "Amazonsko ljetno vrijeme"
+        ]
+      },
+      "America/Marigot": {
+        "long": [
+          "Sjevernoameričko atlantsko standardno vrijeme",
+          "Sjevernoameričko atlantsko ljetno vrijeme"
+        ]
+      },
+      "America/Martinique": {
+        "long": [
+          "Sjevernoameričko atlantsko standardno vrijeme",
+          "Sjevernoameričko atlantsko ljetno vrijeme"
+        ]
+      },
+      "America/Matamoros": {
+        "long": [
+          "Sjevernoameričko centralno standardno vrijeme",
+          "Sjevernoameričko centralno ljetno vrijeme"
+        ]
+      },
+      "America/Mazatlan": {
+        "long": [
+          "Meksičko pacifičko standardno vrijeme",
+          "Meksičko pacifičko ljetno vrijeme"
+        ]
+      },
+      "America/Mendoza": {
+        "long": [
+          "Argentinsko standardno vrijeme",
+          "Argentinsko ljetno vrijeme"
+        ]
+      },
+      "America/Menominee": {
+        "long": [
+          "Sjevernoameričko centralno standardno vrijeme",
+          "Sjevernoameričko centralno ljetno vrijeme"
+        ]
+      },
+      "America/Merida": {
+        "long": [
+          "Sjevernoameričko centralno standardno vrijeme",
+          "Sjevernoameričko centralno ljetno vrijeme"
+        ]
+      },
+      "America/Metlakatla": {
+        "long": [
+          "Aljaskansko standardno vrijeme",
+          "Aljaskansko ljetno vrijeme"
+        ]
+      },
+      "America/Mexico_City": {
+        "long": [
+          "Sjevernoameričko centralno standardno vrijeme",
+          "Sjevernoameričko centralno ljetno vrijeme"
+        ]
+      },
+      "America/Miquelon": {
+        "long": [
+          "Standardno vrijeme na Ostrvima Sveti Petar i Mikelon",
+          "Ljetno vrijeme na Ostrvima Sveti Petar i Mikelon"
+        ]
+      },
+      "America/Moncton": {
+        "long": [
+          "Sjevernoameričko atlantsko standardno vrijeme",
+          "Sjevernoameričko atlantsko ljetno vrijeme"
+        ]
+      },
+      "America/Monterrey": {
+        "long": [
+          "Sjevernoameričko centralno standardno vrijeme",
+          "Sjevernoameričko centralno ljetno vrijeme"
+        ]
+      },
+      "America/Montevideo": {
+        "long": [
+          "Urugvajsko standardno vrijeme",
+          "Urugvajsko ljetno vrijeme"
+        ]
+      },
+      "America/Montserrat": {
+        "long": [
+          "Sjevernoameričko atlantsko standardno vrijeme",
+          "Sjevernoameričko atlantsko ljetno vrijeme"
+        ]
+      },
+      "America/Nassau": {
+        "long": [
+          "Sjevernoameričko istočno standardno vrijeme",
+          "Sjevernoameričko istočno ljetno vrijeme"
+        ]
+      },
+      "America/New_York": {
+        "long": [
+          "Sjevernoameričko istočno standardno vrijeme",
+          "Sjevernoameričko istočno ljetno vrijeme"
+        ]
+      },
+      "America/Nome": {
+        "long": [
+          "Aljaskansko standardno vrijeme",
+          "Aljaskansko ljetno vrijeme"
+        ]
+      },
+      "America/Noronha": {
+        "long": [
+          "Standardno vrijeme na ostrvu Fernando di Noronja",
+          "Ljetno vrijeme na ostrvu Fernando di Noronja"
+        ]
+      },
+      "America/Ojinaga": {
+        "long": [
+          "Sjevernoameričko centralno standardno vrijeme",
+          "Sjevernoameričko centralno ljetno vrijeme"
+        ]
+      },
+      "America/Panama": {
+        "long": [
+          "Sjevernoameričko istočno standardno vrijeme",
+          "Sjevernoameričko istočno ljetno vrijeme"
+        ]
+      },
+      "America/Paramaribo": {
+        "long": [
+          "Surinamsko vrijeme",
+          "Surinamsko vrijeme"
+        ]
+      },
+      "America/Phoenix": {
+        "long": [
+          "Sjevernoameričko planinsko standardno vrijeme",
+          "Sjevernoameričko planinsko ljetno vrijeme"
+        ]
+      },
+      "America/Port_of_Spain": {
+        "long": [
+          "Sjevernoameričko atlantsko standardno vrijeme",
+          "Sjevernoameričko atlantsko ljetno vrijeme"
+        ]
+      },
+      "America/Port-au-Prince": {
+        "long": [
+          "Sjevernoameričko istočno standardno vrijeme",
+          "Sjevernoameričko istočno ljetno vrijeme"
+        ]
+      },
+      "America/Porto_Velho": {
+        "long": [
+          "Amazonsko standardno vrijeme",
+          "Amazonsko ljetno vrijeme"
+        ]
+      },
+      "America/Puerto_Rico": {
+        "long": [
+          "Sjevernoameričko atlantsko standardno vrijeme",
+          "Sjevernoameričko atlantsko ljetno vrijeme"
+        ]
+      },
+      "America/Punta_Arenas": {
+        "long": [
+          "Čileansko standardno vrijeme",
+          "Čileansko ljetno vrijeme"
+        ]
+      },
+      "America/Rankin_Inlet": {
+        "long": [
+          "Sjevernoameričko centralno standardno vrijeme",
+          "Sjevernoameričko centralno ljetno vrijeme"
+        ]
+      },
+      "America/Recife": {
+        "long": [
+          "Brazilijsko standardno vrijeme",
+          "Brazilijsko ljetno vrijeme"
+        ]
+      },
+      "America/Regina": {
+        "long": [
+          "Sjevernoameričko centralno standardno vrijeme",
+          "Sjevernoameričko centralno ljetno vrijeme"
+        ]
+      },
+      "America/Resolute": {
+        "long": [
+          "Sjevernoameričko centralno standardno vrijeme",
+          "Sjevernoameričko centralno ljetno vrijeme"
+        ]
+      },
+      "America/Rio_Branco": {
+        "long": [
+          "Acre standardno vreme",
+          "Acre letnje računanje vremena"
+        ]
+      },
+      "America/Santarem": {
+        "long": [
+          "Brazilijsko standardno vrijeme",
+          "Brazilijsko ljetno vrijeme"
+        ]
+      },
+      "America/Santiago": {
+        "long": [
+          "Čileansko standardno vrijeme",
+          "Čileansko ljetno vrijeme"
+        ]
+      },
+      "America/Santo_Domingo": {
+        "long": [
+          "Sjevernoameričko atlantsko standardno vrijeme",
+          "Sjevernoameričko atlantsko ljetno vrijeme"
+        ]
+      },
+      "America/Sao_Paulo": {
+        "long": [
+          "Brazilijsko standardno vrijeme",
+          "Brazilijsko ljetno vrijeme"
+        ]
+      },
+      "America/Sitka": {
+        "long": [
+          "Aljaskansko standardno vrijeme",
+          "Aljaskansko ljetno vrijeme"
+        ]
+      },
+      "America/St_Barthelemy": {
+        "long": [
+          "Sjevernoameričko atlantsko standardno vrijeme",
+          "Sjevernoameričko atlantsko ljetno vrijeme"
+        ]
+      },
+      "America/St_Johns": {
+        "long": [
+          "Njufaundlendsko standardno vrijeme",
+          "Njufaundlendsko ljetno vrijeme"
+        ]
+      },
+      "America/St_Kitts": {
+        "long": [
+          "Sjevernoameričko atlantsko standardno vrijeme",
+          "Sjevernoameričko atlantsko ljetno vrijeme"
+        ]
+      },
+      "America/St_Lucia": {
+        "long": [
+          "Sjevernoameričko atlantsko standardno vrijeme",
+          "Sjevernoameričko atlantsko ljetno vrijeme"
+        ]
+      },
+      "America/St_Thomas": {
+        "long": [
+          "Sjevernoameričko atlantsko standardno vrijeme",
+          "Sjevernoameričko atlantsko ljetno vrijeme"
+        ]
+      },
+      "America/St_Vincent": {
+        "long": [
+          "Sjevernoameričko atlantsko standardno vrijeme",
+          "Sjevernoameričko atlantsko ljetno vrijeme"
+        ]
+      },
+      "America/Swift_Current": {
+        "long": [
+          "Sjevernoameričko centralno standardno vrijeme",
+          "Sjevernoameričko centralno ljetno vrijeme"
+        ]
+      },
+      "America/Tegucigalpa": {
+        "long": [
+          "Sjevernoameričko centralno standardno vrijeme",
+          "Sjevernoameričko centralno ljetno vrijeme"
+        ]
+      },
+      "America/Thule": {
+        "long": [
+          "Sjevernoameričko atlantsko standardno vrijeme",
+          "Sjevernoameričko atlantsko ljetno vrijeme"
+        ]
+      },
+      "America/Tijuana": {
+        "long": [
+          "Sjevernoameričko pacifičko standardno vrijeme",
+          "Sjevernoameričko pacifičko ljetno vrijeme"
+        ]
+      },
+      "America/Toronto": {
+        "long": [
+          "Sjevernoameričko istočno standardno vrijeme",
+          "Sjevernoameričko istočno ljetno vrijeme"
+        ]
+      },
+      "America/Tortola": {
+        "long": [
+          "Sjevernoameričko atlantsko standardno vrijeme",
+          "Sjevernoameričko atlantsko ljetno vrijeme"
+        ]
+      },
+      "America/Vancouver": {
+        "long": [
+          "Sjevernoameričko pacifičko standardno vrijeme",
+          "Sjevernoameričko pacifičko ljetno vrijeme"
+        ]
+      },
+      "America/Whitehorse": {
+        "long": [
+          "Jukonsko vrijeme",
+          "Jukonsko vrijeme"
+        ]
+      },
+      "America/Winnipeg": {
+        "long": [
+          "Sjevernoameričko centralno standardno vrijeme",
+          "Sjevernoameričko centralno ljetno vrijeme"
+        ]
+      },
+      "America/Yakutat": {
+        "long": [
+          "Aljaskansko standardno vrijeme",
+          "Aljaskansko ljetno vrijeme"
+        ]
+      },
+      "Antarctica/Casey": {
+        "long": [
+          "Zapadnoaustralijsko standardno vrijeme",
+          "Zapadnoaustralijsko ljetno vrijeme"
+        ]
+      },
+      "Antarctica/Davis": {
+        "long": [
+          "Vrijeme stanice Davis",
+          "Vrijeme stanice Davis"
+        ]
+      },
+      "Antarctica/DumontDUrville": {
+        "long": [
+          "Vrijeme stanice Dumont-d’Urville",
+          "Vrijeme stanice Dumont-d’Urville"
+        ]
+      },
+      "Antarctica/Macquarie": {
+        "long": [
+          "Istočnoaustralijsko standardno vrijeme",
+          "Istočnoaustralijsko ljetno vrijeme"
+        ]
+      },
+      "Antarctica/Mawson": {
+        "long": [
+          "Vrijeme stanice Mawson",
+          "Vrijeme stanice Mawson"
+        ]
+      },
+      "Antarctica/McMurdo": {
+        "long": [
+          "Novozelandsko standardno vrijeme",
+          "Novozelandsko ljetno vrijeme"
+        ]
+      },
+      "Antarctica/Palmer": {
+        "long": [
+          "Čileansko standardno vrijeme",
+          "Čileansko ljetno vrijeme"
+        ]
+      },
+      "Antarctica/Rothera": {
+        "long": [
+          "Vrijeme stanice Rothera",
+          "Vrijeme stanice Rothera"
+        ]
+      },
+      "Antarctica/Syowa": {
+        "long": [
+          "Vrijeme stanice Syowa",
+          "Vrijeme stanice Syowa"
+        ]
+      },
+      "Antarctica/Troll": {
+        "long": [
+          "Griničko vrijeme",
+          "Griničko vrijeme"
+        ],
+        "short": [
+          "GMT",
+          "GMT"
+        ]
+      },
+      "Antarctica/Vostok": {
+        "long": [
+          "Vrijeme stanice Vostok",
+          "Vrijeme stanice Vostok"
+        ]
+      },
+      "Arctic/Longyearbyen": {
+        "long": [
+          "Centralnoevropsko standardno vrijeme",
+          "Centralnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "CET",
+          "CEST"
+        ]
+      },
+      "Asia/Aden": {
+        "long": [
+          "Arabijsko standardno vrijeme",
+          "Arabijsko ljetno vrijeme"
+        ]
+      },
+      "Asia/Almaty": {
+        "long": [
+          "kazahstansko vrijeme",
+          "kazahstansko vrijeme"
+        ]
+      },
+      "Asia/Amman": {
+        "long": [
+          "Istočnoevropsko standardno vrijeme",
+          "Istočnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "EET",
+          "EEST"
+        ]
+      },
+      "Asia/Anadyr": {
+        "long": [
+          "Petropavlovsk-Kamčatski standardno vreme",
+          "Petropavlovsk-Kamčatski letnje računanje vremena"
+        ]
+      },
+      "Asia/Aqtau": {
+        "long": [
+          "kazahstansko vrijeme",
+          "kazahstansko vrijeme"
+        ]
+      },
+      "Asia/Aqtobe": {
+        "long": [
+          "kazahstansko vrijeme",
+          "kazahstansko vrijeme"
+        ]
+      },
+      "Asia/Ashgabat": {
+        "long": [
+          "turkmenistansko standardno vrijeme",
+          "turkmenistansko ljetno vrijeme"
+        ]
+      },
+      "Asia/Atyrau": {
+        "long": [
+          "kazahstansko vrijeme",
+          "kazahstansko vrijeme"
+        ]
+      },
+      "Asia/Baghdad": {
+        "long": [
+          "Arabijsko standardno vrijeme",
+          "Arabijsko ljetno vrijeme"
+        ]
+      },
+      "Asia/Bahrain": {
+        "long": [
+          "Arabijsko standardno vrijeme",
+          "Arabijsko ljetno vrijeme"
+        ]
+      },
+      "Asia/Baku": {
+        "long": [
+          "Azerbejdžansko standardno vrijeme",
+          "Azerbejdžansko ljetno vrijeme"
+        ]
+      },
+      "Asia/Bangkok": {
+        "long": [
+          "Indokinesko vrijeme",
+          "Indokinesko vrijeme"
+        ]
+      },
+      "Asia/Barnaul": {
+        "long": [
+          "Krasnojarsko standardno vrijeme",
+          "Krasnojarsko ljetno vrijeme"
+        ]
+      },
+      "Asia/Beirut": {
+        "long": [
+          "Istočnoevropsko standardno vrijeme",
+          "Istočnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "EET",
+          "EEST"
+        ]
+      },
+      "Asia/Bishkek": {
+        "long": [
+          "kirgistansko vrijeme",
+          "kirgistansko vrijeme"
+        ]
+      },
+      "Asia/Brunei": {
+        "long": [
+          "Brunejsko vrijeme",
+          "Brunejsko vrijeme"
+        ]
+      },
+      "Asia/Calcutta": {
+        "long": [
+          "Indijsko standardno vrijeme",
+          "Indijsko standardno vrijeme"
+        ]
+      },
+      "Asia/Chita": {
+        "long": [
+          "Jakutsko standardno vrijeme",
+          "Jakutsko ljetno vrijeme"
+        ]
+      },
+      "Asia/Colombo": {
+        "long": [
+          "Indijsko standardno vrijeme",
+          "Indijsko standardno vrijeme"
+        ]
+      },
+      "Asia/Damascus": {
+        "long": [
+          "Istočnoevropsko standardno vrijeme",
+          "Istočnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "EET",
+          "EEST"
+        ]
+      },
+      "Asia/Dhaka": {
+        "long": [
+          "Bangladeško standardno vrijeme",
+          "Bangladeško ljetno vrijeme"
+        ]
+      },
+      "Asia/Dili": {
+        "long": [
+          "Istočnotimorsko vrijeme",
+          "Istočnotimorsko vrijeme"
+        ]
+      },
+      "Asia/Dubai": {
+        "long": [
+          "Zalivsko standardno vrijeme",
+          "Zalivsko standardno vrijeme"
+        ]
+      },
+      "Asia/Dushanbe": {
+        "long": [
+          "tadžikistansko vrijeme",
+          "tadžikistansko vrijeme"
+        ]
+      },
+      "Asia/Famagusta": {
+        "long": [
+          "Istočnoevropsko standardno vrijeme",
+          "Istočnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "EET",
+          "EEST"
+        ]
+      },
+      "Asia/Gaza": {
+        "long": [
+          "Istočnoevropsko standardno vrijeme",
+          "Istočnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "EET",
+          "EEST"
+        ]
+      },
+      "Asia/Hebron": {
+        "long": [
+          "Istočnoevropsko standardno vrijeme",
+          "Istočnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "EET",
+          "EEST"
+        ]
+      },
+      "Asia/Hong_Kong": {
+        "long": [
+          "Hongkonško standardno vrijeme",
+          "Hongkonško ljetno vrijeme"
+        ]
+      },
+      "Asia/Hovd": {
+        "long": [
+          "Hovdsko standardno vrijeme",
+          "Hovdsko ljetno vrijeme"
+        ]
+      },
+      "Asia/Irkutsk": {
+        "long": [
+          "Irkutsko standardno vrijeme",
+          "Irkutsko ljetno vrijeme"
+        ]
+      },
+      "Asia/Jakarta": {
+        "long": [
+          "Zapadnoindonezijsko vrijeme",
+          "Zapadnoindonezijsko vrijeme"
+        ]
+      },
+      "Asia/Jayapura": {
+        "long": [
+          "Istočnoindonezijsko vrijeme",
+          "Istočnoindonezijsko vrijeme"
+        ]
+      },
+      "Asia/Jerusalem": {
+        "long": [
+          "Izraelsko standardno vrijeme",
+          "Izraelsko ljetno vrijeme"
+        ]
+      },
+      "Asia/Kabul": {
+        "long": [
+          "Afganistansko vrijeme",
+          "Afganistansko vrijeme"
+        ]
+      },
+      "Asia/Kamchatka": {
+        "long": [
+          "Petropavlovsk-Kamčatski standardno vreme",
+          "Petropavlovsk-Kamčatski letnje računanje vremena"
+        ]
+      },
+      "Asia/Karachi": {
+        "long": [
+          "Pakistansko standardno vrijeme",
+          "Pakistansko ljetno vrijeme"
+        ]
+      },
+      "Asia/Katmandu": {
+        "long": [
+          "Nepalsko vrijeme",
+          "Nepalsko vrijeme"
+        ]
+      },
+      "Asia/Khandyga": {
+        "long": [
+          "Jakutsko standardno vrijeme",
+          "Jakutsko ljetno vrijeme"
+        ]
+      },
+      "Asia/Krasnoyarsk": {
+        "long": [
+          "Krasnojarsko standardno vrijeme",
+          "Krasnojarsko ljetno vrijeme"
+        ]
+      },
+      "Asia/Kuala_Lumpur": {
+        "long": [
+          "Malezijsko vrijeme",
+          "Malezijsko vrijeme"
+        ]
+      },
+      "Asia/Kuching": {
+        "long": [
+          "Malezijsko vrijeme",
+          "Malezijsko vrijeme"
+        ]
+      },
+      "Asia/Kuwait": {
+        "long": [
+          "Arabijsko standardno vrijeme",
+          "Arabijsko ljetno vrijeme"
+        ]
+      },
+      "Asia/Macau": {
+        "long": [
+          "Kinesko standardno vrijeme",
+          "Kinesko ljetno vrijeme"
+        ]
+      },
+      "Asia/Magadan": {
+        "long": [
+          "Magadansko standardno vrijeme",
+          "Magadansko ljetno vrijeme"
+        ]
+      },
+      "Asia/Makassar": {
+        "long": [
+          "Centralnoindonezijsko vrijeme",
+          "Centralnoindonezijsko vrijeme"
+        ]
+      },
+      "Asia/Manila": {
+        "long": [
+          "Filipinsko standardno vrijeme",
+          "Filipinsko ljetno vrijeme"
+        ]
+      },
+      "Asia/Muscat": {
+        "long": [
+          "Zalivsko standardno vrijeme",
+          "Zalivsko standardno vrijeme"
+        ]
+      },
+      "Asia/Nicosia": {
+        "long": [
+          "Istočnoevropsko standardno vrijeme",
+          "Istočnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "EET",
+          "EEST"
+        ]
+      },
+      "Asia/Novokuznetsk": {
+        "long": [
+          "Krasnojarsko standardno vrijeme",
+          "Krasnojarsko ljetno vrijeme"
+        ]
+      },
+      "Asia/Novosibirsk": {
+        "long": [
+          "Krasnojarsko standardno vrijeme",
+          "Krasnojarsko ljetno vrijeme"
+        ]
+      },
+      "Asia/Omsk": {
+        "long": [
+          "Omsko standardno vrijeme",
+          "Omsko ljetno vrijeme"
+        ]
+      },
+      "Asia/Oral": {
+        "long": [
+          "kazahstansko vrijeme",
+          "kazahstansko vrijeme"
+        ]
+      },
+      "Asia/Phnom_Penh": {
+        "long": [
+          "Indokinesko vrijeme",
+          "Indokinesko vrijeme"
+        ]
+      },
+      "Asia/Pontianak": {
+        "long": [
+          "Zapadnoindonezijsko vrijeme",
+          "Zapadnoindonezijsko vrijeme"
+        ]
+      },
+      "Asia/Pyongyang": {
+        "long": [
+          "Korejsko standardno vrijeme",
+          "Korejsko ljetno vrijeme"
+        ]
+      },
+      "Asia/Qatar": {
+        "long": [
+          "Arabijsko standardno vrijeme",
+          "Arabijsko ljetno vrijeme"
+        ]
+      },
+      "Asia/Qostanay": {
+        "long": [
+          "kazahstansko vrijeme",
+          "kazahstansko vrijeme"
+        ]
+      },
+      "Asia/Qyzylorda": {
+        "long": [
+          "kazahstansko vrijeme",
+          "kazahstansko vrijeme"
+        ]
+      },
+      "Asia/Rangoon": {
+        "long": [
+          "Mijanmarsko vrijeme",
+          "Mijanmarsko vrijeme"
+        ]
+      },
+      "Asia/Riyadh": {
+        "long": [
+          "Arabijsko standardno vrijeme",
+          "Arabijsko ljetno vrijeme"
+        ]
+      },
+      "Asia/Saigon": {
+        "long": [
+          "Indokinesko vrijeme",
+          "Indokinesko vrijeme"
+        ]
+      },
+      "Asia/Sakhalin": {
+        "long": [
+          "Magadansko standardno vrijeme",
+          "Magadansko ljetno vrijeme"
+        ]
+      },
+      "Asia/Samarkand": {
+        "long": [
+          "uzbekistansko standardno vrijeme",
+          "uzbekistansko ljetno vrijeme"
+        ]
+      },
+      "Asia/Seoul": {
+        "long": [
+          "Korejsko standardno vrijeme",
+          "Korejsko ljetno vrijeme"
+        ]
+      },
+      "Asia/Shanghai": {
+        "long": [
+          "Kinesko standardno vrijeme",
+          "Kinesko ljetno vrijeme"
+        ]
+      },
+      "Asia/Singapore": {
+        "long": [
+          "Singapursko standardno vrijeme",
+          "Singapursko standardno vrijeme"
+        ]
+      },
+      "Asia/Srednekolymsk": {
+        "long": [
+          "Magadansko standardno vrijeme",
+          "Magadansko ljetno vrijeme"
+        ]
+      },
+      "Asia/Taipei": {
+        "long": [
+          "Tajpejsko standardno vrijeme",
+          "Tajpejsko ljetno vrijeme"
+        ]
+      },
+      "Asia/Tashkent": {
+        "long": [
+          "uzbekistansko standardno vrijeme",
+          "uzbekistansko ljetno vrijeme"
+        ]
+      },
+      "Asia/Tbilisi": {
+        "long": [
+          "Gruzijsko standardno vrijeme",
+          "Gruzijsko ljetno vrijeme"
+        ]
+      },
+      "Asia/Tehran": {
+        "long": [
+          "Iransko standardno vrijeme",
+          "Iransko ljetno vrijeme"
+        ]
+      },
+      "Asia/Thimphu": {
+        "long": [
+          "Butansko vrijeme",
+          "Butansko vrijeme"
+        ]
+      },
+      "Asia/Tokyo": {
+        "long": [
+          "Japansko standardno vrijeme",
+          "Japansko ljetno vrijeme"
+        ]
+      },
+      "Asia/Tomsk": {
+        "long": [
+          "Krasnojarsko standardno vrijeme",
+          "Krasnojarsko ljetno vrijeme"
+        ]
+      },
+      "Asia/Ulaanbaatar": {
+        "long": [
+          "Ulanbatorsko standardno vrijeme",
+          "Ulanbatorsko ljetno vrijeme"
+        ]
+      },
+      "Asia/Ust-Nera": {
+        "long": [
+          "Vladivostočko standardno vrijeme",
+          "Vladivostočko ljetno vrijeme"
+        ]
+      },
+      "Asia/Vientiane": {
+        "long": [
+          "Indokinesko vrijeme",
+          "Indokinesko vrijeme"
+        ]
+      },
+      "Asia/Vladivostok": {
+        "long": [
+          "Vladivostočko standardno vrijeme",
+          "Vladivostočko ljetno vrijeme"
+        ]
+      },
+      "Asia/Yakutsk": {
+        "long": [
+          "Jakutsko standardno vrijeme",
+          "Jakutsko ljetno vrijeme"
+        ]
+      },
+      "Asia/Yekaterinburg": {
+        "long": [
+          "Jekaterinburško standardno vrijeme",
+          "Jekaterinburško ljetno vrijeme"
+        ]
+      },
+      "Asia/Yerevan": {
+        "long": [
+          "Armensko standardno vrijeme",
+          "Armensko ljetno vrijeme"
+        ]
+      },
+      "Atlantic/Azores": {
+        "long": [
+          "Azorsko standardno vrijeme",
+          "Azorsko ljetno vrijeme"
+        ]
+      },
+      "Atlantic/Bermuda": {
+        "long": [
+          "Sjevernoameričko atlantsko standardno vrijeme",
+          "Sjevernoameričko atlantsko ljetno vrijeme"
+        ]
+      },
+      "Atlantic/Canary": {
+        "long": [
+          "Zapadnoevropsko standardno vrijeme",
+          "Zapadnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "WET",
+          "WEST"
+        ]
+      },
+      "Atlantic/Cape_Verde": {
+        "long": [
+          "Zelenortsko standardno vrijeme",
+          "Zelenortsko ljetno vrijeme"
+        ]
+      },
+      "Atlantic/Faeroe": {
+        "long": [
+          "Zapadnoevropsko standardno vrijeme",
+          "Zapadnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "WET",
+          "WEST"
+        ]
+      },
+      "Atlantic/Madeira": {
+        "long": [
+          "Zapadnoevropsko standardno vrijeme",
+          "Zapadnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "WET",
+          "WEST"
+        ]
+      },
+      "Atlantic/Reykjavik": {
+        "long": [
+          "Griničko vrijeme",
+          "Griničko vrijeme"
+        ],
+        "short": [
+          "GMT",
+          "GMT"
+        ]
+      },
+      "Atlantic/South_Georgia": {
+        "long": [
+          "Južnodžordžijsko vrijeme",
+          "Južnodžordžijsko vrijeme"
+        ]
+      },
+      "Atlantic/St_Helena": {
+        "long": [
+          "Griničko vrijeme",
+          "Griničko vrijeme"
+        ],
+        "short": [
+          "GMT",
+          "GMT"
+        ]
+      },
+      "Atlantic/Stanley": {
+        "long": [
+          "Folklandsko standardno vrijeme",
+          "Folklandsko ljetno vrijeme"
+        ]
+      },
+      "Australia/Adelaide": {
+        "long": [
+          "Centralnoaustralijsko standardno vrijeme",
+          "Centralnoaustralijsko ljetno vrijeme"
+        ]
+      },
+      "Australia/Brisbane": {
+        "long": [
+          "Istočnoaustralijsko standardno vrijeme",
+          "Istočnoaustralijsko ljetno vrijeme"
+        ]
+      },
+      "Australia/Broken_Hill": {
+        "long": [
+          "Centralnoaustralijsko standardno vrijeme",
+          "Centralnoaustralijsko ljetno vrijeme"
+        ]
+      },
+      "Australia/Darwin": {
+        "long": [
+          "Centralnoaustralijsko standardno vrijeme",
+          "Centralnoaustralijsko ljetno vrijeme"
+        ]
+      },
+      "Australia/Eucla": {
+        "long": [
+          "Australijsko centralnozapadno standardno vrijeme",
+          "Australijsko centralnozapadno ljetno vrijeme"
+        ]
+      },
+      "Australia/Hobart": {
+        "long": [
+          "Istočnoaustralijsko standardno vrijeme",
+          "Istočnoaustralijsko ljetno vrijeme"
+        ]
+      },
+      "Australia/Lindeman": {
+        "long": [
+          "Istočnoaustralijsko standardno vrijeme",
+          "Istočnoaustralijsko ljetno vrijeme"
+        ]
+      },
+      "Australia/Lord_Howe": {
+        "long": [
+          "Standardno vrijeme na Ostrvu Lord Hau",
+          "Ljetno vrijeme na Ostrvu Lord Hau"
+        ]
+      },
+      "Australia/Melbourne": {
+        "long": [
+          "Istočnoaustralijsko standardno vrijeme",
+          "Istočnoaustralijsko ljetno vrijeme"
+        ]
+      },
+      "Australia/Perth": {
+        "long": [
+          "Zapadnoaustralijsko standardno vrijeme",
+          "Zapadnoaustralijsko ljetno vrijeme"
+        ]
+      },
+      "Australia/Sydney": {
+        "long": [
+          "Istočnoaustralijsko standardno vrijeme",
+          "Istočnoaustralijsko ljetno vrijeme"
+        ]
+      },
+      "Etc/GMT": {
+        "long": [
+          "Griničko vrijeme",
+          "Griničko vrijeme"
+        ],
+        "short": [
+          "GMT",
+          "GMT"
+        ]
+      },
+      "Europe/Amsterdam": {
+        "long": [
+          "Centralnoevropsko standardno vrijeme",
+          "Centralnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "CET",
+          "CEST"
+        ]
+      },
+      "Europe/Andorra": {
+        "long": [
+          "Centralnoevropsko standardno vrijeme",
+          "Centralnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "CET",
+          "CEST"
+        ]
+      },
+      "Europe/Astrakhan": {
+        "long": [
+          "Samara standardno vreme",
+          "Samara letnje računanje vremena"
+        ]
+      },
+      "Europe/Athens": {
+        "long": [
+          "Istočnoevropsko standardno vrijeme",
+          "Istočnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "EET",
+          "EEST"
+        ]
+      },
+      "Europe/Belgrade": {
+        "long": [
+          "Centralnoevropsko standardno vrijeme",
+          "Centralnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "CET",
+          "CEST"
+        ]
+      },
+      "Europe/Berlin": {
+        "long": [
+          "Centralnoevropsko standardno vrijeme",
+          "Centralnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "CET",
+          "CEST"
+        ]
+      },
+      "Europe/Bratislava": {
+        "long": [
+          "Centralnoevropsko standardno vrijeme",
+          "Centralnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "CET",
+          "CEST"
+        ]
+      },
+      "Europe/Brussels": {
+        "long": [
+          "Centralnoevropsko standardno vrijeme",
+          "Centralnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "CET",
+          "CEST"
+        ]
+      },
+      "Europe/Bucharest": {
+        "long": [
+          "Istočnoevropsko standardno vrijeme",
+          "Istočnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "EET",
+          "EEST"
+        ]
+      },
+      "Europe/Budapest": {
+        "long": [
+          "Centralnoevropsko standardno vrijeme",
+          "Centralnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "CET",
+          "CEST"
+        ]
+      },
+      "Europe/Busingen": {
+        "long": [
+          "Centralnoevropsko standardno vrijeme",
+          "Centralnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "CET",
+          "CEST"
+        ]
+      },
+      "Europe/Chisinau": {
+        "long": [
+          "Istočnoevropsko standardno vrijeme",
+          "Istočnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "EET",
+          "EEST"
+        ]
+      },
+      "Europe/Copenhagen": {
+        "long": [
+          "Centralnoevropsko standardno vrijeme",
+          "Centralnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "CET",
+          "CEST"
+        ]
+      },
+      "Europe/Dublin": {
+        "long": [
+          "Griničko vrijeme",
+          "Griničko vrijeme"
+        ],
+        "short": [
+          "GMT",
+          "GMT"
+        ]
+      },
+      "Europe/Gibraltar": {
+        "long": [
+          "Centralnoevropsko standardno vrijeme",
+          "Centralnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "CET",
+          "CEST"
+        ]
+      },
+      "Europe/Guernsey": {
+        "long": [
+          "Griničko vrijeme",
+          "Griničko vrijeme"
+        ],
+        "short": [
+          "GMT",
+          "GMT"
+        ]
+      },
+      "Europe/Helsinki": {
+        "long": [
+          "Istočnoevropsko standardno vrijeme",
+          "Istočnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "EET",
+          "EEST"
+        ]
+      },
+      "Europe/Isle_of_Man": {
+        "long": [
+          "Griničko vrijeme",
+          "Griničko vrijeme"
+        ],
+        "short": [
+          "GMT",
+          "GMT"
+        ]
+      },
+      "Europe/Istanbul": {
+        "long": [
+          "Turska standardno vreme",
+          "Turska letnje računanje vremena"
+        ]
+      },
+      "Europe/Jersey": {
+        "long": [
+          "Griničko vrijeme",
+          "Griničko vrijeme"
+        ],
+        "short": [
+          "GMT",
+          "GMT"
+        ]
+      },
+      "Europe/Kaliningrad": {
+        "long": [
+          "Istočnoevropsko standardno vrijeme",
+          "Istočnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "EET",
+          "EEST"
+        ]
+      },
+      "Europe/Kiev": {
+        "long": [
+          "Istočnoevropsko standardno vrijeme",
+          "Istočnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "EET",
+          "EEST"
+        ]
+      },
+      "Europe/Kirov": {
+        "long": [
+          "Moskovsko standardno vrijeme",
+          "Moskovsko ljetno vrijeme"
+        ]
+      },
+      "Europe/Lisbon": {
+        "long": [
+          "Zapadnoevropsko standardno vrijeme",
+          "Zapadnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "WET",
+          "WEST"
+        ]
+      },
+      "Europe/Ljubljana": {
+        "long": [
+          "Centralnoevropsko standardno vrijeme",
+          "Centralnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "CET",
+          "CEST"
+        ]
+      },
+      "Europe/London": {
+        "long": [
+          "Griničko vrijeme",
+          "Griničko vrijeme"
+        ],
+        "short": [
+          "GMT",
+          "GMT"
+        ]
+      },
+      "Europe/Luxembourg": {
+        "long": [
+          "Centralnoevropsko standardno vrijeme",
+          "Centralnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "CET",
+          "CEST"
+        ]
+      },
+      "Europe/Madrid": {
+        "long": [
+          "Centralnoevropsko standardno vrijeme",
+          "Centralnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "CET",
+          "CEST"
+        ]
+      },
+      "Europe/Malta": {
+        "long": [
+          "Centralnoevropsko standardno vrijeme",
+          "Centralnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "CET",
+          "CEST"
+        ]
+      },
+      "Europe/Mariehamn": {
+        "long": [
+          "Istočnoevropsko standardno vrijeme",
+          "Istočnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "EET",
+          "EEST"
+        ]
+      },
+      "Europe/Minsk": {
+        "long": [
+          "Moskovsko standardno vrijeme",
+          "Moskovsko ljetno vrijeme"
+        ]
+      },
+      "Europe/Monaco": {
+        "long": [
+          "Centralnoevropsko standardno vrijeme",
+          "Centralnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "CET",
+          "CEST"
+        ]
+      },
+      "Europe/Moscow": {
+        "long": [
+          "Moskovsko standardno vrijeme",
+          "Moskovsko ljetno vrijeme"
+        ]
+      },
+      "Europe/Oslo": {
+        "long": [
+          "Centralnoevropsko standardno vrijeme",
+          "Centralnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "CET",
+          "CEST"
+        ]
+      },
+      "Europe/Paris": {
+        "long": [
+          "Centralnoevropsko standardno vrijeme",
+          "Centralnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "CET",
+          "CEST"
+        ]
+      },
+      "Europe/Podgorica": {
+        "long": [
+          "Centralnoevropsko standardno vrijeme",
+          "Centralnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "CET",
+          "CEST"
+        ]
+      },
+      "Europe/Prague": {
+        "long": [
+          "Centralnoevropsko standardno vrijeme",
+          "Centralnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "CET",
+          "CEST"
+        ]
+      },
+      "Europe/Riga": {
+        "long": [
+          "Istočnoevropsko standardno vrijeme",
+          "Istočnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "EET",
+          "EEST"
+        ]
+      },
+      "Europe/Rome": {
+        "long": [
+          "Centralnoevropsko standardno vrijeme",
+          "Centralnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "CET",
+          "CEST"
+        ]
+      },
+      "Europe/Samara": {
+        "long": [
+          "Samara standardno vreme",
+          "Samara letnje računanje vremena"
+        ]
+      },
+      "Europe/San_Marino": {
+        "long": [
+          "Centralnoevropsko standardno vrijeme",
+          "Centralnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "CET",
+          "CEST"
+        ]
+      },
+      "Europe/Sarajevo": {
+        "long": [
+          "Centralnoevropsko standardno vrijeme",
+          "Centralnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "CET",
+          "CEST"
+        ]
+      },
+      "Europe/Saratov": {
+        "long": [
+          "Samara standardno vreme",
+          "Samara letnje računanje vremena"
+        ]
+      },
+      "Europe/Simferopol": {
+        "long": [
+          "Moskovsko standardno vrijeme",
+          "Moskovsko ljetno vrijeme"
+        ]
+      },
+      "Europe/Skopje": {
+        "long": [
+          "Centralnoevropsko standardno vrijeme",
+          "Centralnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "CET",
+          "CEST"
+        ]
+      },
+      "Europe/Sofia": {
+        "long": [
+          "Istočnoevropsko standardno vrijeme",
+          "Istočnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "EET",
+          "EEST"
+        ]
+      },
+      "Europe/Stockholm": {
+        "long": [
+          "Centralnoevropsko standardno vrijeme",
+          "Centralnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "CET",
+          "CEST"
+        ]
+      },
+      "Europe/Tallinn": {
+        "long": [
+          "Istočnoevropsko standardno vrijeme",
+          "Istočnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "EET",
+          "EEST"
+        ]
+      },
+      "Europe/Tirane": {
+        "long": [
+          "Centralnoevropsko standardno vrijeme",
+          "Centralnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "CET",
+          "CEST"
+        ]
+      },
+      "Europe/Ulyanovsk": {
+        "long": [
+          "Samara standardno vreme",
+          "Samara letnje računanje vremena"
+        ]
+      },
+      "Europe/Vaduz": {
+        "long": [
+          "Centralnoevropsko standardno vrijeme",
+          "Centralnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "CET",
+          "CEST"
+        ]
+      },
+      "Europe/Vatican": {
+        "long": [
+          "Centralnoevropsko standardno vrijeme",
+          "Centralnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "CET",
+          "CEST"
+        ]
+      },
+      "Europe/Vienna": {
+        "long": [
+          "Centralnoevropsko standardno vrijeme",
+          "Centralnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "CET",
+          "CEST"
+        ]
+      },
+      "Europe/Vilnius": {
+        "long": [
+          "Istočnoevropsko standardno vrijeme",
+          "Istočnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "EET",
+          "EEST"
+        ]
+      },
+      "Europe/Volgograd": {
+        "long": [
+          "Moskovsko standardno vrijeme",
+          "Moskovsko ljetno vrijeme"
+        ]
+      },
+      "Europe/Warsaw": {
+        "long": [
+          "Centralnoevropsko standardno vrijeme",
+          "Centralnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "CET",
+          "CEST"
+        ]
+      },
+      "Europe/Zagreb": {
+        "long": [
+          "Centralnoevropsko standardno vrijeme",
+          "Centralnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "CET",
+          "CEST"
+        ]
+      },
+      "Europe/Zurich": {
+        "long": [
+          "Centralnoevropsko standardno vrijeme",
+          "Centralnoevropsko ljetno vrijeme"
+        ],
+        "short": [
+          "CET",
+          "CEST"
+        ]
+      },
+      "Indian/Antananarivo": {
+        "long": [
+          "Istočnoafričko vrijeme",
+          "Istočnoafričko vrijeme"
+        ]
+      },
+      "Indian/Chagos": {
+        "long": [
+          "Vrijeme na Indijskom okeanu",
+          "Vrijeme na Indijskom okeanu"
+        ]
+      },
+      "Indian/Christmas": {
+        "long": [
+          "Vrijeme na Božićnom Ostrvu",
+          "Vrijeme na Božićnom Ostrvu"
+        ]
+      },
+      "Indian/Cocos": {
+        "long": [
+          "Vrijeme na Ostrvima Kokos",
+          "Vrijeme na Ostrvima Kokos"
+        ]
+      },
+      "Indian/Comoro": {
+        "long": [
+          "Istočnoafričko vrijeme",
+          "Istočnoafričko vrijeme"
+        ]
+      },
+      "Indian/Kerguelen": {
+        "long": [
+          "Vrijeme na Francuskoj Južnoj Teritoriji i Antarktiku",
+          "Vrijeme na Francuskoj Južnoj Teritoriji i Antarktiku"
+        ]
+      },
+      "Indian/Mahe": {
+        "long": [
+          "Sejšelsko vrijeme",
+          "Sejšelsko vrijeme"
+        ]
+      },
+      "Indian/Maldives": {
+        "long": [
+          "Maldivsko vrijeme",
+          "Maldivsko vrijeme"
+        ]
+      },
+      "Indian/Mauritius": {
+        "long": [
+          "Mauricijsko standardno vrijeme",
+          "Mauricijsko ljetno vrijeme"
+        ]
+      },
+      "Indian/Mayotte": {
+        "long": [
+          "Istočnoafričko vrijeme",
+          "Istočnoafričko vrijeme"
+        ]
+      },
+      "Indian/Reunion": {
+        "long": [
+          "Reunionsko vrijeme",
+          "Reunionsko vrijeme"
+        ]
+      },
+      "Pacific/Apia": {
+        "long": [
+          "Apijsko standardno vrijeme",
+          "Apijsko ljetno vrijeme"
+        ]
+      },
+      "Pacific/Auckland": {
+        "long": [
+          "Novozelandsko standardno vrijeme",
+          "Novozelandsko ljetno vrijeme"
+        ]
+      },
+      "Pacific/Bougainville": {
+        "long": [
+          "Vrijeme na Papui Novoj Gvineji",
+          "Vrijeme na Papui Novoj Gvineji"
+        ]
+      },
+      "Pacific/Chatham": {
+        "long": [
+          "Čatamsko standardno vrijeme",
+          "Čatamsko ljetno vrijeme"
+        ]
+      },
+      "Pacific/Easter": {
+        "long": [
+          "Uskršnjeostrvsko standardno vrijeme",
+          "Uskršnjeostrvsko ljetno vrijeme"
+        ]
+      },
+      "Pacific/Efate": {
+        "long": [
+          "Vanuatuansko standardno vrijeme",
+          "Vanuatuansko ljetno vrijeme"
+        ]
+      },
+      "Pacific/Enderbury": {
+        "long": [
+          "Vrijeme na Ostrvima Finiks",
+          "Vrijeme na Ostrvima Finiks"
+        ]
+      },
+      "Pacific/Fakaofo": {
+        "long": [
+          "Vrijeme na Ostrvu Tokelau",
+          "Vrijeme na Ostrvu Tokelau"
+        ]
+      },
+      "Pacific/Fiji": {
+        "long": [
+          "Standardno vrijeme na Fidžiju",
+          "Fidžijsko ljetno vrijeme"
+        ]
+      },
+      "Pacific/Funafuti": {
+        "long": [
+          "Tuvaluansko vrijeme",
+          "Tuvaluansko vrijeme"
+        ]
+      },
+      "Pacific/Galapagos": {
+        "long": [
+          "Galapagosko vrijeme",
+          "Galapagosko vrijeme"
+        ]
+      },
+      "Pacific/Gambier": {
+        "long": [
+          "Gambijersko vrijeme",
+          "Gambijersko vrijeme"
+        ]
+      },
+      "Pacific/Guadalcanal": {
+        "long": [
+          "Vrijeme na Solomonskim ostrvima",
+          "Vrijeme na Solomonskim ostrvima"
+        ]
+      },
+      "Pacific/Guam": {
+        "long": [
+          "Čamorsko standardno vrijeme",
+          "Čamorsko standardno vrijeme"
+        ]
+      },
+      "Pacific/Honolulu": {
+        "long": [
+          "Havajsko-aleućansko standardno vrijeme",
+          "Havajsko-aleućansko standardno vrijeme"
+        ]
+      },
+      "Pacific/Kiritimati": {
+        "long": [
+          "Vrijeme na Ostrvima Lajn",
+          "Vrijeme na Ostrvima Lajn"
+        ]
+      },
+      "Pacific/Kosrae": {
+        "long": [
+          "Vrijeme na Ostrvu Kosrae",
+          "Vrijeme na Ostrvu Kosrae"
+        ]
+      },
+      "Pacific/Kwajalein": {
+        "long": [
+          "Vrijeme na Maršalovim ostrvima",
+          "Vrijeme na Maršalovim ostrvima"
+        ]
+      },
+      "Pacific/Majuro": {
+        "long": [
+          "Vrijeme na Maršalovim ostrvima",
+          "Vrijeme na Maršalovim ostrvima"
+        ]
+      },
+      "Pacific/Marquesas": {
+        "long": [
+          "Vrijeme na Ostrvima Markiz",
+          "Vrijeme na Ostrvima Markiz"
+        ]
+      },
+      "Pacific/Midway": {
+        "long": [
+          "Samoansko standardno vrijeme",
+          "Samoansko ljetno vrijeme"
+        ]
+      },
+      "Pacific/Nauru": {
+        "long": [
+          "Vrijeme na Ostrvu Nauru",
+          "Vrijeme na Ostrvu Nauru"
+        ]
+      },
+      "Pacific/Niue": {
+        "long": [
+          "Vrijeme na Ostrvu Niue",
+          "Vrijeme na Ostrvu Niue"
+        ]
+      },
+      "Pacific/Norfolk": {
+        "long": [
+          "Norfolško standardno vrijeme",
+          "Norfolško ljetno vrijeme"
+        ]
+      },
+      "Pacific/Noumea": {
+        "long": [
+          "Novokaledonijsko standardno vrijeme",
+          "Novokaledonijsko ljetno vrijeme"
+        ]
+      },
+      "Pacific/Pago_Pago": {
+        "long": [
+          "Samoansko standardno vrijeme",
+          "Samoansko ljetno vrijeme"
+        ]
+      },
+      "Pacific/Palau": {
+        "long": [
+          "Vrijeme na Ostrvu Palau",
+          "Vrijeme na Ostrvu Palau"
+        ]
+      },
+      "Pacific/Pitcairn": {
+        "long": [
+          "Vrijeme na Ostrvima Pitkern",
+          "Vrijeme na Ostrvima Pitkern"
+        ]
+      },
+      "Pacific/Ponape": {
+        "long": [
+          "Vrijeme na Ostrvu Ponape",
+          "Vrijeme na Ostrvu Ponape"
+        ]
+      },
+      "Pacific/Port_Moresby": {
+        "long": [
+          "Vrijeme na Papui Novoj Gvineji",
+          "Vrijeme na Papui Novoj Gvineji"
+        ]
+      },
+      "Pacific/Rarotonga": {
+        "long": [
+          "Standardno vrijeme na Kukovim ostrvima",
+          "Poluljetno vrijeme na Kukovim ostrvima"
+        ]
+      },
+      "Pacific/Saipan": {
+        "long": [
+          "Čamorsko standardno vrijeme",
+          "Čamorsko standardno vrijeme"
+        ]
+      },
+      "Pacific/Tahiti": {
+        "long": [
+          "Tahićansko vrijeme",
+          "Tahićansko vrijeme"
+        ]
+      },
+      "Pacific/Tarawa": {
+        "long": [
+          "Vrijeme na Gilbertovim ostrvima",
+          "Vrijeme na Gilbertovim ostrvima"
+        ]
+      },
+      "Pacific/Tongatapu": {
+        "long": [
+          "Tongansko standardno vrijeme",
+          "Tongansko ljetno vrijeme"
+        ]
+      },
+      "Pacific/Truk": {
+        "long": [
+          "Čučko vrijeme",
+          "Čučko vrijeme"
+        ]
+      },
+      "Pacific/Wake": {
+        "long": [
+          "Vrijeme na Ostrvu Vejk",
+          "Vrijeme na Ostrvu Vejk"
+        ]
+      },
+      "Pacific/Wallis": {
+        "long": [
+          "Vrijeme na Ostrvima Valis i Futuna",
+          "Vrijeme na Ostrvima Valis i Futuna"
+        ]
+      },
+      "UTC": {
+        "long": [
+          "Koordinirano svjetsko vrijeme",
+          "Koordinirano svjetsko vrijeme"
+        ],
+        "short": [
+          "UTC",
+          "UTC"
+        ]
+      }
+    },
+    "gmtFormat": "GMT {0}",
+    "hourFormat": "+HH:mm; -HH:mm",
+    "dateFormat": {
+      "full": "EEEE, d. MMMM y.",
+      "long": "d. MMMM y.",
+      "medium": "d. MMM y.",
+      "short": "d. M. y."
+    },
+    "timeFormat": {
+      "full": "HH:mm:ss zzzz",
+      "long": "HH:mm:ss z",
+      "medium": "HH:mm:ss",
+      "short": "HH:mm"
+    },
+    "dateTimeFormat": {
+      "full": "{1}, {0}",
+      "long": "{1}, {0}",
+      "medium": "{1} {0}",
+      "short": "{1} {0}"
+    },
+    "formats": {
+      "gregory": {
+        "Bh": "h B",
+        "Bhm": "h:mm B",
+        "Bhms": "h:mm:ss B",
+        "d": "d.",
+        "E": "ccc",
+        "EBh": "E h B",
+        "EBhm": "E h:mm B",
+        "EBhms": "E h:mm:ss B",
+        "Ed": "E, d.",
+        "Eh": "E h a",
+        "Ehm": "E h:mm a",
+        "EHm": "E HH:mm",
+        "Ehms": "E h:mm:ss a",
+        "EHms": "E HH:mm:ss",
+        "Gy": "y. G",
+        "GyM": "G y-MM",
+        "GyMd": "d. M. y. G",
+        "GyMEd": "G y-MM-dd, E",
+        "GyMMM": "MMM y. G",
+        "GyMMMd": "d. MMM y. G",
+        "GyMMMEd": "E, d. MMM y. G",
+        "h": "h a",
+        "H": "HH",
+        "hm": "hh:mm a",
+        "Hm": "HH:mm",
+        "hms": "hh:mm:ss a",
+        "Hms": "HH:mm:ss",
+        "hmsv": "h:mm:ss a (v)",
+        "Hmsv": "HH:mm:ss (v)",
+        "hmv": "h:mm a (v)",
+        "Hmv": "HH:mm (v)",
+        "hv": "h a v",
+        "Hv": "HH'h' v",
+        "M": "L",
+        "Md": "d. M.",
+        "MEd": "E, d. M.",
+        "MMdd": "d. M.",
+        "MMM": "LLL",
+        "MMMd": "d. MMM",
+        "MMMEd": "E, d. MMM",
+        "MMMMd": "d. MMMM",
+        "MMMMEd": "E, d. MMMM",
+        "ms": "mm:ss",
+        "y": "y.",
+        "yM": "MM/y",
+        "yMd": "d. M. y.",
+        "yMEd": "E, d. M. y.",
+        "yMM": "M. y.",
+        "yMMM": "MMM y.",
+        "yMMMd": "d. MMM y.",
+        "yMMMEd": "E, d. MMM y.",
+        "yMMMM": "LLLL y.",
+        "EEEE, d. MMMM y.": "EEEE, d. MMMM y.",
+        "d. MMMM y.": "d. MMMM y.",
+        "d. MMM y.": "d. MMM y.",
+        "d. M. y.": "d. M. y.",
+        "HH:mm:ss zzzz": "HH:mm:ss zzzz",
+        "HH:mm:ss z": "HH:mm:ss z",
+        "HH:mm:ss": "HH:mm:ss",
+        "HH:mm": "HH:mm",
+        "EEEE, d. MMMM y., HH:mm:ss zzzz": "EEEE, d. MMMM y., HH:mm:ss zzzz",
+        "d. MMMM y., HH:mm:ss zzzz": "d. MMMM y., HH:mm:ss zzzz",
+        "d. MMM y. HH:mm:ss zzzz": "d. MMM y. HH:mm:ss zzzz",
+        "d. M. y. HH:mm:ss zzzz": "d. M. y. HH:mm:ss zzzz",
+        "d HH:mm:ss zzzz": "d. HH:mm:ss zzzz",
+        "E HH:mm:ss zzzz": "ccc HH:mm:ss zzzz",
+        "Ed HH:mm:ss zzzz": "E, d. HH:mm:ss zzzz",
+        "Gy HH:mm:ss zzzz": "y. G HH:mm:ss zzzz",
+        "GyM HH:mm:ss zzzz": "G y-MM HH:mm:ss zzzz",
+        "GyMd HH:mm:ss zzzz": "d. M. y. G HH:mm:ss zzzz",
+        "GyMEd HH:mm:ss zzzz": "G y-MM-dd, E HH:mm:ss zzzz",
+        "GyMMM HH:mm:ss zzzz": "MMM y. G HH:mm:ss zzzz",
+        "GyMMMd HH:mm:ss zzzz": "d. MMM y. G HH:mm:ss zzzz",
+        "GyMMMEd HH:mm:ss zzzz": "E, d. MMM y. G HH:mm:ss zzzz",
+        "M HH:mm:ss zzzz": "L HH:mm:ss zzzz",
+        "Md HH:mm:ss zzzz": "d. M. HH:mm:ss zzzz",
+        "MEd HH:mm:ss zzzz": "E, d. M. HH:mm:ss zzzz",
+        "MMdd HH:mm:ss zzzz": "d. M. HH:mm:ss zzzz",
+        "MMM HH:mm:ss zzzz": "LLL HH:mm:ss zzzz",
+        "MMMd HH:mm:ss zzzz": "d. MMM HH:mm:ss zzzz",
+        "MMMEd HH:mm:ss zzzz": "E, d. MMM HH:mm:ss zzzz",
+        "MMMMd, HH:mm:ss zzzz": "d. MMMM, HH:mm:ss zzzz",
+        "MMMMEd, HH:mm:ss zzzz": "E, d. MMMM, HH:mm:ss zzzz",
+        "y HH:mm:ss zzzz": "y. HH:mm:ss zzzz",
+        "yM HH:mm:ss zzzz": "MM/y HH:mm:ss zzzz",
+        "yMd HH:mm:ss zzzz": "d. M. y. HH:mm:ss zzzz",
+        "yMEd HH:mm:ss zzzz": "E, d. M. y. HH:mm:ss zzzz",
+        "yMM HH:mm:ss zzzz": "M. y. HH:mm:ss zzzz",
+        "yMMM HH:mm:ss zzzz": "MMM y. HH:mm:ss zzzz",
+        "yMMMd HH:mm:ss zzzz": "d. MMM y. HH:mm:ss zzzz",
+        "yMMMEd HH:mm:ss zzzz": "E, d. MMM y. HH:mm:ss zzzz",
+        "yMMMM, HH:mm:ss zzzz": "LLLL y., HH:mm:ss zzzz",
+        "EEEE, d. MMMM y., HH:mm:ss z": "EEEE, d. MMMM y., HH:mm:ss z",
+        "d. MMMM y., HH:mm:ss z": "d. MMMM y., HH:mm:ss z",
+        "d. MMM y. HH:mm:ss z": "d. MMM y. HH:mm:ss z",
+        "d. M. y. HH:mm:ss z": "d. M. y. HH:mm:ss z",
+        "d HH:mm:ss z": "d. HH:mm:ss z",
+        "E HH:mm:ss z": "ccc HH:mm:ss z",
+        "Ed HH:mm:ss z": "E, d. HH:mm:ss z",
+        "Gy HH:mm:ss z": "y. G HH:mm:ss z",
+        "GyM HH:mm:ss z": "G y-MM HH:mm:ss z",
+        "GyMd HH:mm:ss z": "d. M. y. G HH:mm:ss z",
+        "GyMEd HH:mm:ss z": "G y-MM-dd, E HH:mm:ss z",
+        "GyMMM HH:mm:ss z": "MMM y. G HH:mm:ss z",
+        "GyMMMd HH:mm:ss z": "d. MMM y. G HH:mm:ss z",
+        "GyMMMEd HH:mm:ss z": "E, d. MMM y. G HH:mm:ss z",
+        "M HH:mm:ss z": "L HH:mm:ss z",
+        "Md HH:mm:ss z": "d. M. HH:mm:ss z",
+        "MEd HH:mm:ss z": "E, d. M. HH:mm:ss z",
+        "MMdd HH:mm:ss z": "d. M. HH:mm:ss z",
+        "MMM HH:mm:ss z": "LLL HH:mm:ss z",
+        "MMMd HH:mm:ss z": "d. MMM HH:mm:ss z",
+        "MMMEd HH:mm:ss z": "E, d. MMM HH:mm:ss z",
+        "MMMMd, HH:mm:ss z": "d. MMMM, HH:mm:ss z",
+        "MMMMEd, HH:mm:ss z": "E, d. MMMM, HH:mm:ss z",
+        "y HH:mm:ss z": "y. HH:mm:ss z",
+        "yM HH:mm:ss z": "MM/y HH:mm:ss z",
+        "yMd HH:mm:ss z": "d. M. y. HH:mm:ss z",
+        "yMEd HH:mm:ss z": "E, d. M. y. HH:mm:ss z",
+        "yMM HH:mm:ss z": "M. y. HH:mm:ss z",
+        "yMMM HH:mm:ss z": "MMM y. HH:mm:ss z",
+        "yMMMd HH:mm:ss z": "d. MMM y. HH:mm:ss z",
+        "yMMMEd HH:mm:ss z": "E, d. MMM y. HH:mm:ss z",
+        "yMMMM, HH:mm:ss z": "LLLL y., HH:mm:ss z",
+        "EEEE, d. MMMM y., HH:mm:ss": "EEEE, d. MMMM y., HH:mm:ss",
+        "d. MMMM y., HH:mm:ss": "d. MMMM y., HH:mm:ss",
+        "d. MMM y. HH:mm:ss": "d. MMM y. HH:mm:ss",
+        "d. M. y. HH:mm:ss": "d. M. y. HH:mm:ss",
+        "d HH:mm:ss": "d. HH:mm:ss",
+        "E HH:mm:ss": "ccc HH:mm:ss",
+        "Ed HH:mm:ss": "E, d. HH:mm:ss",
+        "Gy HH:mm:ss": "y. G HH:mm:ss",
+        "GyM HH:mm:ss": "G y-MM HH:mm:ss",
+        "GyMd HH:mm:ss": "d. M. y. G HH:mm:ss",
+        "GyMEd HH:mm:ss": "G y-MM-dd, E HH:mm:ss",
+        "GyMMM HH:mm:ss": "MMM y. G HH:mm:ss",
+        "GyMMMd HH:mm:ss": "d. MMM y. G HH:mm:ss",
+        "GyMMMEd HH:mm:ss": "E, d. MMM y. G HH:mm:ss",
+        "M HH:mm:ss": "L HH:mm:ss",
+        "Md HH:mm:ss": "d. M. HH:mm:ss",
+        "MEd HH:mm:ss": "E, d. M. HH:mm:ss",
+        "MMdd HH:mm:ss": "d. M. HH:mm:ss",
+        "MMM HH:mm:ss": "LLL HH:mm:ss",
+        "MMMd HH:mm:ss": "d. MMM HH:mm:ss",
+        "MMMEd HH:mm:ss": "E, d. MMM HH:mm:ss",
+        "MMMMd, HH:mm:ss": "d. MMMM, HH:mm:ss",
+        "MMMMEd, HH:mm:ss": "E, d. MMMM, HH:mm:ss",
+        "y HH:mm:ss": "y. HH:mm:ss",
+        "yM HH:mm:ss": "MM/y HH:mm:ss",
+        "yMd HH:mm:ss": "d. M. y. HH:mm:ss",
+        "yMEd HH:mm:ss": "E, d. M. y. HH:mm:ss",
+        "yMM HH:mm:ss": "M. y. HH:mm:ss",
+        "yMMM HH:mm:ss": "MMM y. HH:mm:ss",
+        "yMMMd HH:mm:ss": "d. MMM y. HH:mm:ss",
+        "yMMMEd HH:mm:ss": "E, d. MMM y. HH:mm:ss",
+        "yMMMM, HH:mm:ss": "LLLL y., HH:mm:ss",
+        "EEEE, d. MMMM y., HH:mm": "EEEE, d. MMMM y., HH:mm",
+        "d. MMMM y., HH:mm": "d. MMMM y., HH:mm",
+        "d. MMM y. HH:mm": "d. MMM y. HH:mm",
+        "d. M. y. HH:mm": "d. M. y. HH:mm",
+        "d HH:mm": "d. HH:mm",
+        "E HH:mm": "ccc HH:mm",
+        "Ed HH:mm": "E, d. HH:mm",
+        "Gy HH:mm": "y. G HH:mm",
+        "GyM HH:mm": "G y-MM HH:mm",
+        "GyMd HH:mm": "d. M. y. G HH:mm",
+        "GyMEd HH:mm": "G y-MM-dd, E HH:mm",
+        "GyMMM HH:mm": "MMM y. G HH:mm",
+        "GyMMMd HH:mm": "d. MMM y. G HH:mm",
+        "GyMMMEd HH:mm": "E, d. MMM y. G HH:mm",
+        "M HH:mm": "L HH:mm",
+        "Md HH:mm": "d. M. HH:mm",
+        "MEd HH:mm": "E, d. M. HH:mm",
+        "MMdd HH:mm": "d. M. HH:mm",
+        "MMM HH:mm": "LLL HH:mm",
+        "MMMd HH:mm": "d. MMM HH:mm",
+        "MMMEd HH:mm": "E, d. MMM HH:mm",
+        "MMMMd, HH:mm": "d. MMMM, HH:mm",
+        "MMMMEd, HH:mm": "E, d. MMMM, HH:mm",
+        "y HH:mm": "y. HH:mm",
+        "yM HH:mm": "MM/y HH:mm",
+        "yMd HH:mm": "d. M. y. HH:mm",
+        "yMEd HH:mm": "E, d. M. y. HH:mm",
+        "yMM HH:mm": "M. y. HH:mm",
+        "yMMM HH:mm": "MMM y. HH:mm",
+        "yMMMd HH:mm": "d. MMM y. HH:mm",
+        "yMMMEd HH:mm": "E, d. MMM y. HH:mm",
+        "yMMMM, HH:mm": "LLLL y., HH:mm",
+        "EEEE, d. MMMM y., Bh": "EEEE, d. MMMM y., h B",
+        "d. MMMM y., Bh": "d. MMMM y., h B",
+        "d. MMM y. Bh": "d. MMM y. h B",
+        "d. M. y. Bh": "d. M. y. h B",
+        "d Bh": "d. h B",
+        "E Bh": "ccc h B",
+        "Ed Bh": "E, d. h B",
+        "Gy Bh": "y. G h B",
+        "GyM Bh": "G y-MM h B",
+        "GyMd Bh": "d. M. y. G h B",
+        "GyMEd Bh": "G y-MM-dd, E h B",
+        "GyMMM Bh": "MMM y. G h B",
+        "GyMMMd Bh": "d. MMM y. G h B",
+        "GyMMMEd Bh": "E, d. MMM y. G h B",
+        "M Bh": "L h B",
+        "Md Bh": "d. M. h B",
+        "MEd Bh": "E, d. M. h B",
+        "MMdd Bh": "d. M. h B",
+        "MMM Bh": "LLL h B",
+        "MMMd Bh": "d. MMM h B",
+        "MMMEd Bh": "E, d. MMM h B",
+        "MMMMd, Bh": "d. MMMM, h B",
+        "MMMMEd, Bh": "E, d. MMMM, h B",
+        "y Bh": "y. h B",
+        "yM Bh": "MM/y h B",
+        "yMd Bh": "d. M. y. h B",
+        "yMEd Bh": "E, d. M. y. h B",
+        "yMM Bh": "M. y. h B",
+        "yMMM Bh": "MMM y. h B",
+        "yMMMd Bh": "d. MMM y. h B",
+        "yMMMEd Bh": "E, d. MMM y. h B",
+        "yMMMM, Bh": "LLLL y., h B",
+        "EEEE, d. MMMM y., Bhm": "EEEE, d. MMMM y., h:mm B",
+        "d. MMMM y., Bhm": "d. MMMM y., h:mm B",
+        "d. MMM y. Bhm": "d. MMM y. h:mm B",
+        "d. M. y. Bhm": "d. M. y. h:mm B",
+        "d Bhm": "d. h:mm B",
+        "E Bhm": "ccc h:mm B",
+        "Ed Bhm": "E, d. h:mm B",
+        "Gy Bhm": "y. G h:mm B",
+        "GyM Bhm": "G y-MM h:mm B",
+        "GyMd Bhm": "d. M. y. G h:mm B",
+        "GyMEd Bhm": "G y-MM-dd, E h:mm B",
+        "GyMMM Bhm": "MMM y. G h:mm B",
+        "GyMMMd Bhm": "d. MMM y. G h:mm B",
+        "GyMMMEd Bhm": "E, d. MMM y. G h:mm B",
+        "M Bhm": "L h:mm B",
+        "Md Bhm": "d. M. h:mm B",
+        "MEd Bhm": "E, d. M. h:mm B",
+        "MMdd Bhm": "d. M. h:mm B",
+        "MMM Bhm": "LLL h:mm B",
+        "MMMd Bhm": "d. MMM h:mm B",
+        "MMMEd Bhm": "E, d. MMM h:mm B",
+        "MMMMd, Bhm": "d. MMMM, h:mm B",
+        "MMMMEd, Bhm": "E, d. MMMM, h:mm B",
+        "y Bhm": "y. h:mm B",
+        "yM Bhm": "MM/y h:mm B",
+        "yMd Bhm": "d. M. y. h:mm B",
+        "yMEd Bhm": "E, d. M. y. h:mm B",
+        "yMM Bhm": "M. y. h:mm B",
+        "yMMM Bhm": "MMM y. h:mm B",
+        "yMMMd Bhm": "d. MMM y. h:mm B",
+        "yMMMEd Bhm": "E, d. MMM y. h:mm B",
+        "yMMMM, Bhm": "LLLL y., h:mm B",
+        "EEEE, d. MMMM y., Bhms": "EEEE, d. MMMM y., h:mm:ss B",
+        "d. MMMM y., Bhms": "d. MMMM y., h:mm:ss B",
+        "d. MMM y. Bhms": "d. MMM y. h:mm:ss B",
+        "d. M. y. Bhms": "d. M. y. h:mm:ss B",
+        "d Bhms": "d. h:mm:ss B",
+        "E Bhms": "ccc h:mm:ss B",
+        "Ed Bhms": "E, d. h:mm:ss B",
+        "Gy Bhms": "y. G h:mm:ss B",
+        "GyM Bhms": "G y-MM h:mm:ss B",
+        "GyMd Bhms": "d. M. y. G h:mm:ss B",
+        "GyMEd Bhms": "G y-MM-dd, E h:mm:ss B",
+        "GyMMM Bhms": "MMM y. G h:mm:ss B",
+        "GyMMMd Bhms": "d. MMM y. G h:mm:ss B",
+        "GyMMMEd Bhms": "E, d. MMM y. G h:mm:ss B",
+        "M Bhms": "L h:mm:ss B",
+        "Md Bhms": "d. M. h:mm:ss B",
+        "MEd Bhms": "E, d. M. h:mm:ss B",
+        "MMdd Bhms": "d. M. h:mm:ss B",
+        "MMM Bhms": "LLL h:mm:ss B",
+        "MMMd Bhms": "d. MMM h:mm:ss B",
+        "MMMEd Bhms": "E, d. MMM h:mm:ss B",
+        "MMMMd, Bhms": "d. MMMM, h:mm:ss B",
+        "MMMMEd, Bhms": "E, d. MMMM, h:mm:ss B",
+        "y Bhms": "y. h:mm:ss B",
+        "yM Bhms": "MM/y h:mm:ss B",
+        "yMd Bhms": "d. M. y. h:mm:ss B",
+        "yMEd Bhms": "E, d. M. y. h:mm:ss B",
+        "yMM Bhms": "M. y. h:mm:ss B",
+        "yMMM Bhms": "MMM y. h:mm:ss B",
+        "yMMMd Bhms": "d. MMM y. h:mm:ss B",
+        "yMMMEd Bhms": "E, d. MMM y. h:mm:ss B",
+        "yMMMM, Bhms": "LLLL y., h:mm:ss B",
+        "EEEE, d. MMMM y., h": "EEEE, d. MMMM y., h a",
+        "d. MMMM y., h": "d. MMMM y., h a",
+        "d. MMM y. h": "d. MMM y. h a",
+        "d. M. y. h": "d. M. y. h a",
+        "d h": "d. h a",
+        "E h": "ccc h a",
+        "Ed h": "E, d. h a",
+        "Gy h": "y. G h a",
+        "GyM h": "G y-MM h a",
+        "GyMd h": "d. M. y. G h a",
+        "GyMEd h": "G y-MM-dd, E h a",
+        "GyMMM h": "MMM y. G h a",
+        "GyMMMd h": "d. MMM y. G h a",
+        "GyMMMEd h": "E, d. MMM y. G h a",
+        "M h": "L h a",
+        "Md h": "d. M. h a",
+        "MEd h": "E, d. M. h a",
+        "MMdd h": "d. M. h a",
+        "MMM h": "LLL h a",
+        "MMMd h": "d. MMM h a",
+        "MMMEd h": "E, d. MMM h a",
+        "MMMMd, h": "d. MMMM, h a",
+        "MMMMEd, h": "E, d. MMMM, h a",
+        "y h": "y. h a",
+        "yM h": "MM/y h a",
+        "yMd h": "d. M. y. h a",
+        "yMEd h": "E, d. M. y. h a",
+        "yMM h": "M. y. h a",
+        "yMMM h": "MMM y. h a",
+        "yMMMd h": "d. MMM y. h a",
+        "yMMMEd h": "E, d. MMM y. h a",
+        "yMMMM, h": "LLLL y., h a",
+        "EEEE, d. MMMM y., H": "EEEE, d. MMMM y., HH",
+        "d. MMMM y., H": "d. MMMM y., HH",
+        "d. MMM y. H": "d. MMM y. HH",
+        "d. M. y. H": "d. M. y. HH",
+        "d H": "d. HH",
+        "E H": "ccc HH",
+        "Ed H": "E, d. HH",
+        "Gy H": "y. G HH",
+        "GyM H": "G y-MM HH",
+        "GyMd H": "d. M. y. G HH",
+        "GyMEd H": "G y-MM-dd, E HH",
+        "GyMMM H": "MMM y. G HH",
+        "GyMMMd H": "d. MMM y. G HH",
+        "GyMMMEd H": "E, d. MMM y. G HH",
+        "M H": "L HH",
+        "Md H": "d. M. HH",
+        "MEd H": "E, d. M. HH",
+        "MMdd H": "d. M. HH",
+        "MMM H": "LLL HH",
+        "MMMd H": "d. MMM HH",
+        "MMMEd H": "E, d. MMM HH",
+        "MMMMd, H": "d. MMMM, HH",
+        "MMMMEd, H": "E, d. MMMM, HH",
+        "y H": "y. HH",
+        "yM H": "MM/y HH",
+        "yMd H": "d. M. y. HH",
+        "yMEd H": "E, d. M. y. HH",
+        "yMM H": "M. y. HH",
+        "yMMM H": "MMM y. HH",
+        "yMMMd H": "d. MMM y. HH",
+        "yMMMEd H": "E, d. MMM y. HH",
+        "yMMMM, H": "LLLL y., HH",
+        "EEEE, d. MMMM y., hm": "EEEE, d. MMMM y., hh:mm a",
+        "d. MMMM y., hm": "d. MMMM y., hh:mm a",
+        "d. MMM y. hm": "d. MMM y. hh:mm a",
+        "d. M. y. hm": "d. M. y. hh:mm a",
+        "d hm": "d. hh:mm a",
+        "E hm": "ccc hh:mm a",
+        "Ed hm": "E, d. hh:mm a",
+        "Gy hm": "y. G hh:mm a",
+        "GyM hm": "G y-MM hh:mm a",
+        "GyMd hm": "d. M. y. G hh:mm a",
+        "GyMEd hm": "G y-MM-dd, E hh:mm a",
+        "GyMMM hm": "MMM y. G hh:mm a",
+        "GyMMMd hm": "d. MMM y. G hh:mm a",
+        "GyMMMEd hm": "E, d. MMM y. G hh:mm a",
+        "M hm": "L hh:mm a",
+        "Md hm": "d. M. hh:mm a",
+        "MEd hm": "E, d. M. hh:mm a",
+        "MMdd hm": "d. M. hh:mm a",
+        "MMM hm": "LLL hh:mm a",
+        "MMMd hm": "d. MMM hh:mm a",
+        "MMMEd hm": "E, d. MMM hh:mm a",
+        "MMMMd, hm": "d. MMMM, hh:mm a",
+        "MMMMEd, hm": "E, d. MMMM, hh:mm a",
+        "y hm": "y. hh:mm a",
+        "yM hm": "MM/y hh:mm a",
+        "yMd hm": "d. M. y. hh:mm a",
+        "yMEd hm": "E, d. M. y. hh:mm a",
+        "yMM hm": "M. y. hh:mm a",
+        "yMMM hm": "MMM y. hh:mm a",
+        "yMMMd hm": "d. MMM y. hh:mm a",
+        "yMMMEd hm": "E, d. MMM y. hh:mm a",
+        "yMMMM, hm": "LLLL y., hh:mm a",
+        "EEEE, d. MMMM y., Hm": "EEEE, d. MMMM y., HH:mm",
+        "d. MMMM y., Hm": "d. MMMM y., HH:mm",
+        "d. MMM y. Hm": "d. MMM y. HH:mm",
+        "d. M. y. Hm": "d. M. y. HH:mm",
+        "d Hm": "d. HH:mm",
+        "E Hm": "ccc HH:mm",
+        "Ed Hm": "E, d. HH:mm",
+        "Gy Hm": "y. G HH:mm",
+        "GyM Hm": "G y-MM HH:mm",
+        "GyMd Hm": "d. M. y. G HH:mm",
+        "GyMEd Hm": "G y-MM-dd, E HH:mm",
+        "GyMMM Hm": "MMM y. G HH:mm",
+        "GyMMMd Hm": "d. MMM y. G HH:mm",
+        "GyMMMEd Hm": "E, d. MMM y. G HH:mm",
+        "M Hm": "L HH:mm",
+        "Md Hm": "d. M. HH:mm",
+        "MEd Hm": "E, d. M. HH:mm",
+        "MMdd Hm": "d. M. HH:mm",
+        "MMM Hm": "LLL HH:mm",
+        "MMMd Hm": "d. MMM HH:mm",
+        "MMMEd Hm": "E, d. MMM HH:mm",
+        "MMMMd, Hm": "d. MMMM, HH:mm",
+        "MMMMEd, Hm": "E, d. MMMM, HH:mm",
+        "y Hm": "y. HH:mm",
+        "yM Hm": "MM/y HH:mm",
+        "yMd Hm": "d. M. y. HH:mm",
+        "yMEd Hm": "E, d. M. y. HH:mm",
+        "yMM Hm": "M. y. HH:mm",
+        "yMMM Hm": "MMM y. HH:mm",
+        "yMMMd Hm": "d. MMM y. HH:mm",
+        "yMMMEd Hm": "E, d. MMM y. HH:mm",
+        "yMMMM, Hm": "LLLL y., HH:mm",
+        "EEEE, d. MMMM y., hms": "EEEE, d. MMMM y., hh:mm:ss a",
+        "d. MMMM y., hms": "d. MMMM y., hh:mm:ss a",
+        "d. MMM y. hms": "d. MMM y. hh:mm:ss a",
+        "d. M. y. hms": "d. M. y. hh:mm:ss a",
+        "d hms": "d. hh:mm:ss a",
+        "E hms": "ccc hh:mm:ss a",
+        "Ed hms": "E, d. hh:mm:ss a",
+        "Gy hms": "y. G hh:mm:ss a",
+        "GyM hms": "G y-MM hh:mm:ss a",
+        "GyMd hms": "d. M. y. G hh:mm:ss a",
+        "GyMEd hms": "G y-MM-dd, E hh:mm:ss a",
+        "GyMMM hms": "MMM y. G hh:mm:ss a",
+        "GyMMMd hms": "d. MMM y. G hh:mm:ss a",
+        "GyMMMEd hms": "E, d. MMM y. G hh:mm:ss a",
+        "M hms": "L hh:mm:ss a",
+        "Md hms": "d. M. hh:mm:ss a",
+        "MEd hms": "E, d. M. hh:mm:ss a",
+        "MMdd hms": "d. M. hh:mm:ss a",
+        "MMM hms": "LLL hh:mm:ss a",
+        "MMMd hms": "d. MMM hh:mm:ss a",
+        "MMMEd hms": "E, d. MMM hh:mm:ss a",
+        "MMMMd, hms": "d. MMMM, hh:mm:ss a",
+        "MMMMEd, hms": "E, d. MMMM, hh:mm:ss a",
+        "y hms": "y. hh:mm:ss a",
+        "yM hms": "MM/y hh:mm:ss a",
+        "yMd hms": "d. M. y. hh:mm:ss a",
+        "yMEd hms": "E, d. M. y. hh:mm:ss a",
+        "yMM hms": "M. y. hh:mm:ss a",
+        "yMMM hms": "MMM y. hh:mm:ss a",
+        "yMMMd hms": "d. MMM y. hh:mm:ss a",
+        "yMMMEd hms": "E, d. MMM y. hh:mm:ss a",
+        "yMMMM, hms": "LLLL y., hh:mm:ss a",
+        "EEEE, d. MMMM y., Hms": "EEEE, d. MMMM y., HH:mm:ss",
+        "d. MMMM y., Hms": "d. MMMM y., HH:mm:ss",
+        "d. MMM y. Hms": "d. MMM y. HH:mm:ss",
+        "d. M. y. Hms": "d. M. y. HH:mm:ss",
+        "d Hms": "d. HH:mm:ss",
+        "E Hms": "ccc HH:mm:ss",
+        "Ed Hms": "E, d. HH:mm:ss",
+        "Gy Hms": "y. G HH:mm:ss",
+        "GyM Hms": "G y-MM HH:mm:ss",
+        "GyMd Hms": "d. M. y. G HH:mm:ss",
+        "GyMEd Hms": "G y-MM-dd, E HH:mm:ss",
+        "GyMMM Hms": "MMM y. G HH:mm:ss",
+        "GyMMMd Hms": "d. MMM y. G HH:mm:ss",
+        "GyMMMEd Hms": "E, d. MMM y. G HH:mm:ss",
+        "M Hms": "L HH:mm:ss",
+        "Md Hms": "d. M. HH:mm:ss",
+        "MEd Hms": "E, d. M. HH:mm:ss",
+        "MMdd Hms": "d. M. HH:mm:ss",
+        "MMM Hms": "LLL HH:mm:ss",
+        "MMMd Hms": "d. MMM HH:mm:ss",
+        "MMMEd Hms": "E, d. MMM HH:mm:ss",
+        "MMMMd, Hms": "d. MMMM, HH:mm:ss",
+        "MMMMEd, Hms": "E, d. MMMM, HH:mm:ss",
+        "y Hms": "y. HH:mm:ss",
+        "yM Hms": "MM/y HH:mm:ss",
+        "yMd Hms": "d. M. y. HH:mm:ss",
+        "yMEd Hms": "E, d. M. y. HH:mm:ss",
+        "yMM Hms": "M. y. HH:mm:ss",
+        "yMMM Hms": "MMM y. HH:mm:ss",
+        "yMMMd Hms": "d. MMM y. HH:mm:ss",
+        "yMMMEd Hms": "E, d. MMM y. HH:mm:ss",
+        "yMMMM, Hms": "LLLL y., HH:mm:ss",
+        "EEEE, d. MMMM y., hmsv": "EEEE, d. MMMM y., h:mm:ss a (v)",
+        "d. MMMM y., hmsv": "d. MMMM y., h:mm:ss a (v)",
+        "d. MMM y. hmsv": "d. MMM y. h:mm:ss a (v)",
+        "d. M. y. hmsv": "d. M. y. h:mm:ss a (v)",
+        "d hmsv": "d. h:mm:ss a (v)",
+        "E hmsv": "ccc h:mm:ss a (v)",
+        "Ed hmsv": "E, d. h:mm:ss a (v)",
+        "Gy hmsv": "y. G h:mm:ss a (v)",
+        "GyM hmsv": "G y-MM h:mm:ss a (v)",
+        "GyMd hmsv": "d. M. y. G h:mm:ss a (v)",
+        "GyMEd hmsv": "G y-MM-dd, E h:mm:ss a (v)",
+        "GyMMM hmsv": "MMM y. G h:mm:ss a (v)",
+        "GyMMMd hmsv": "d. MMM y. G h:mm:ss a (v)",
+        "GyMMMEd hmsv": "E, d. MMM y. G h:mm:ss a (v)",
+        "M hmsv": "L h:mm:ss a (v)",
+        "Md hmsv": "d. M. h:mm:ss a (v)",
+        "MEd hmsv": "E, d. M. h:mm:ss a (v)",
+        "MMdd hmsv": "d. M. h:mm:ss a (v)",
+        "MMM hmsv": "LLL h:mm:ss a (v)",
+        "MMMd hmsv": "d. MMM h:mm:ss a (v)",
+        "MMMEd hmsv": "E, d. MMM h:mm:ss a (v)",
+        "MMMMd, hmsv": "d. MMMM, h:mm:ss a (v)",
+        "MMMMEd, hmsv": "E, d. MMMM, h:mm:ss a (v)",
+        "y hmsv": "y. h:mm:ss a (v)",
+        "yM hmsv": "MM/y h:mm:ss a (v)",
+        "yMd hmsv": "d. M. y. h:mm:ss a (v)",
+        "yMEd hmsv": "E, d. M. y. h:mm:ss a (v)",
+        "yMM hmsv": "M. y. h:mm:ss a (v)",
+        "yMMM hmsv": "MMM y. h:mm:ss a (v)",
+        "yMMMd hmsv": "d. MMM y. h:mm:ss a (v)",
+        "yMMMEd hmsv": "E, d. MMM y. h:mm:ss a (v)",
+        "yMMMM, hmsv": "LLLL y., h:mm:ss a (v)",
+        "EEEE, d. MMMM y., Hmsv": "EEEE, d. MMMM y., HH:mm:ss (v)",
+        "d. MMMM y., Hmsv": "d. MMMM y., HH:mm:ss (v)",
+        "d. MMM y. Hmsv": "d. MMM y. HH:mm:ss (v)",
+        "d. M. y. Hmsv": "d. M. y. HH:mm:ss (v)",
+        "d Hmsv": "d. HH:mm:ss (v)",
+        "E Hmsv": "ccc HH:mm:ss (v)",
+        "Ed Hmsv": "E, d. HH:mm:ss (v)",
+        "Gy Hmsv": "y. G HH:mm:ss (v)",
+        "GyM Hmsv": "G y-MM HH:mm:ss (v)",
+        "GyMd Hmsv": "d. M. y. G HH:mm:ss (v)",
+        "GyMEd Hmsv": "G y-MM-dd, E HH:mm:ss (v)",
+        "GyMMM Hmsv": "MMM y. G HH:mm:ss (v)",
+        "GyMMMd Hmsv": "d. MMM y. G HH:mm:ss (v)",
+        "GyMMMEd Hmsv": "E, d. MMM y. G HH:mm:ss (v)",
+        "M Hmsv": "L HH:mm:ss (v)",
+        "Md Hmsv": "d. M. HH:mm:ss (v)",
+        "MEd Hmsv": "E, d. M. HH:mm:ss (v)",
+        "MMdd Hmsv": "d. M. HH:mm:ss (v)",
+        "MMM Hmsv": "LLL HH:mm:ss (v)",
+        "MMMd Hmsv": "d. MMM HH:mm:ss (v)",
+        "MMMEd Hmsv": "E, d. MMM HH:mm:ss (v)",
+        "MMMMd, Hmsv": "d. MMMM, HH:mm:ss (v)",
+        "MMMMEd, Hmsv": "E, d. MMMM, HH:mm:ss (v)",
+        "y Hmsv": "y. HH:mm:ss (v)",
+        "yM Hmsv": "MM/y HH:mm:ss (v)",
+        "yMd Hmsv": "d. M. y. HH:mm:ss (v)",
+        "yMEd Hmsv": "E, d. M. y. HH:mm:ss (v)",
+        "yMM Hmsv": "M. y. HH:mm:ss (v)",
+        "yMMM Hmsv": "MMM y. HH:mm:ss (v)",
+        "yMMMd Hmsv": "d. MMM y. HH:mm:ss (v)",
+        "yMMMEd Hmsv": "E, d. MMM y. HH:mm:ss (v)",
+        "yMMMM, Hmsv": "LLLL y., HH:mm:ss (v)",
+        "EEEE, d. MMMM y., hmv": "EEEE, d. MMMM y., h:mm a (v)",
+        "d. MMMM y., hmv": "d. MMMM y., h:mm a (v)",
+        "d. MMM y. hmv": "d. MMM y. h:mm a (v)",
+        "d. M. y. hmv": "d. M. y. h:mm a (v)",
+        "d hmv": "d. h:mm a (v)",
+        "E hmv": "ccc h:mm a (v)",
+        "Ed hmv": "E, d. h:mm a (v)",
+        "Gy hmv": "y. G h:mm a (v)",
+        "GyM hmv": "G y-MM h:mm a (v)",
+        "GyMd hmv": "d. M. y. G h:mm a (v)",
+        "GyMEd hmv": "G y-MM-dd, E h:mm a (v)",
+        "GyMMM hmv": "MMM y. G h:mm a (v)",
+        "GyMMMd hmv": "d. MMM y. G h:mm a (v)",
+        "GyMMMEd hmv": "E, d. MMM y. G h:mm a (v)",
+        "M hmv": "L h:mm a (v)",
+        "Md hmv": "d. M. h:mm a (v)",
+        "MEd hmv": "E, d. M. h:mm a (v)",
+        "MMdd hmv": "d. M. h:mm a (v)",
+        "MMM hmv": "LLL h:mm a (v)",
+        "MMMd hmv": "d. MMM h:mm a (v)",
+        "MMMEd hmv": "E, d. MMM h:mm a (v)",
+        "MMMMd, hmv": "d. MMMM, h:mm a (v)",
+        "MMMMEd, hmv": "E, d. MMMM, h:mm a (v)",
+        "y hmv": "y. h:mm a (v)",
+        "yM hmv": "MM/y h:mm a (v)",
+        "yMd hmv": "d. M. y. h:mm a (v)",
+        "yMEd hmv": "E, d. M. y. h:mm a (v)",
+        "yMM hmv": "M. y. h:mm a (v)",
+        "yMMM hmv": "MMM y. h:mm a (v)",
+        "yMMMd hmv": "d. MMM y. h:mm a (v)",
+        "yMMMEd hmv": "E, d. MMM y. h:mm a (v)",
+        "yMMMM, hmv": "LLLL y., h:mm a (v)",
+        "EEEE, d. MMMM y., Hmv": "EEEE, d. MMMM y., HH:mm (v)",
+        "d. MMMM y., Hmv": "d. MMMM y., HH:mm (v)",
+        "d. MMM y. Hmv": "d. MMM y. HH:mm (v)",
+        "d. M. y. Hmv": "d. M. y. HH:mm (v)",
+        "d Hmv": "d. HH:mm (v)",
+        "E Hmv": "ccc HH:mm (v)",
+        "Ed Hmv": "E, d. HH:mm (v)",
+        "Gy Hmv": "y. G HH:mm (v)",
+        "GyM Hmv": "G y-MM HH:mm (v)",
+        "GyMd Hmv": "d. M. y. G HH:mm (v)",
+        "GyMEd Hmv": "G y-MM-dd, E HH:mm (v)",
+        "GyMMM Hmv": "MMM y. G HH:mm (v)",
+        "GyMMMd Hmv": "d. MMM y. G HH:mm (v)",
+        "GyMMMEd Hmv": "E, d. MMM y. G HH:mm (v)",
+        "M Hmv": "L HH:mm (v)",
+        "Md Hmv": "d. M. HH:mm (v)",
+        "MEd Hmv": "E, d. M. HH:mm (v)",
+        "MMdd Hmv": "d. M. HH:mm (v)",
+        "MMM Hmv": "LLL HH:mm (v)",
+        "MMMd Hmv": "d. MMM HH:mm (v)",
+        "MMMEd Hmv": "E, d. MMM HH:mm (v)",
+        "MMMMd, Hmv": "d. MMMM, HH:mm (v)",
+        "MMMMEd, Hmv": "E, d. MMMM, HH:mm (v)",
+        "y Hmv": "y. HH:mm (v)",
+        "yM Hmv": "MM/y HH:mm (v)",
+        "yMd Hmv": "d. M. y. HH:mm (v)",
+        "yMEd Hmv": "E, d. M. y. HH:mm (v)",
+        "yMM Hmv": "M. y. HH:mm (v)",
+        "yMMM Hmv": "MMM y. HH:mm (v)",
+        "yMMMd Hmv": "d. MMM y. HH:mm (v)",
+        "yMMMEd Hmv": "E, d. MMM y. HH:mm (v)",
+        "yMMMM, Hmv": "LLLL y., HH:mm (v)",
+        "EEEE, d. MMMM y., hv": "EEEE, d. MMMM y., h a v",
+        "d. MMMM y., hv": "d. MMMM y., h a v",
+        "d. MMM y. hv": "d. MMM y. h a v",
+        "d. M. y. hv": "d. M. y. h a v",
+        "d hv": "d. h a v",
+        "E hv": "ccc h a v",
+        "Ed hv": "E, d. h a v",
+        "Gy hv": "y. G h a v",
+        "GyM hv": "G y-MM h a v",
+        "GyMd hv": "d. M. y. G h a v",
+        "GyMEd hv": "G y-MM-dd, E h a v",
+        "GyMMM hv": "MMM y. G h a v",
+        "GyMMMd hv": "d. MMM y. G h a v",
+        "GyMMMEd hv": "E, d. MMM y. G h a v",
+        "M hv": "L h a v",
+        "Md hv": "d. M. h a v",
+        "MEd hv": "E, d. M. h a v",
+        "MMdd hv": "d. M. h a v",
+        "MMM hv": "LLL h a v",
+        "MMMd hv": "d. MMM h a v",
+        "MMMEd hv": "E, d. MMM h a v",
+        "MMMMd, hv": "d. MMMM, h a v",
+        "MMMMEd, hv": "E, d. MMMM, h a v",
+        "y hv": "y. h a v",
+        "yM hv": "MM/y h a v",
+        "yMd hv": "d. M. y. h a v",
+        "yMEd hv": "E, d. M. y. h a v",
+        "yMM hv": "M. y. h a v",
+        "yMMM hv": "MMM y. h a v",
+        "yMMMd hv": "d. MMM y. h a v",
+        "yMMMEd hv": "E, d. MMM y. h a v",
+        "yMMMM, hv": "LLLL y., h a v",
+        "EEEE, d. MMMM y., Hv": "EEEE, d. MMMM y., HH'h' v",
+        "d. MMMM y., Hv": "d. MMMM y., HH'h' v",
+        "d. MMM y. Hv": "d. MMM y. HH'h' v",
+        "d. M. y. Hv": "d. M. y. HH'h' v",
+        "d Hv": "d. HH'h' v",
+        "E Hv": "ccc HH'h' v",
+        "Ed Hv": "E, d. HH'h' v",
+        "Gy Hv": "y. G HH'h' v",
+        "GyM Hv": "G y-MM HH'h' v",
+        "GyMd Hv": "d. M. y. G HH'h' v",
+        "GyMEd Hv": "G y-MM-dd, E HH'h' v",
+        "GyMMM Hv": "MMM y. G HH'h' v",
+        "GyMMMd Hv": "d. MMM y. G HH'h' v",
+        "GyMMMEd Hv": "E, d. MMM y. G HH'h' v",
+        "M Hv": "L HH'h' v",
+        "Md Hv": "d. M. HH'h' v",
+        "MEd Hv": "E, d. M. HH'h' v",
+        "MMdd Hv": "d. M. HH'h' v",
+        "MMM Hv": "LLL HH'h' v",
+        "MMMd Hv": "d. MMM HH'h' v",
+        "MMMEd Hv": "E, d. MMM HH'h' v",
+        "MMMMd, Hv": "d. MMMM, HH'h' v",
+        "MMMMEd, Hv": "E, d. MMMM, HH'h' v",
+        "y Hv": "y. HH'h' v",
+        "yM Hv": "MM/y HH'h' v",
+        "yMd Hv": "d. M. y. HH'h' v",
+        "yMEd Hv": "E, d. M. y. HH'h' v",
+        "yMM Hv": "M. y. HH'h' v",
+        "yMMM Hv": "MMM y. HH'h' v",
+        "yMMMd Hv": "d. MMM y. HH'h' v",
+        "yMMMEd Hv": "E, d. MMM y. HH'h' v",
+        "yMMMM, Hv": "LLLL y., HH'h' v",
+        "EEEE, d. MMMM y., ms": "EEEE, d. MMMM y., mm:ss",
+        "d. MMMM y., ms": "d. MMMM y., mm:ss",
+        "d. MMM y. ms": "d. MMM y. mm:ss",
+        "d. M. y. ms": "d. M. y. mm:ss",
+        "d ms": "d. mm:ss",
+        "E ms": "ccc mm:ss",
+        "Ed ms": "E, d. mm:ss",
+        "Gy ms": "y. G mm:ss",
+        "GyM ms": "G y-MM mm:ss",
+        "GyMd ms": "d. M. y. G mm:ss",
+        "GyMEd ms": "G y-MM-dd, E mm:ss",
+        "GyMMM ms": "MMM y. G mm:ss",
+        "GyMMMd ms": "d. MMM y. G mm:ss",
+        "GyMMMEd ms": "E, d. MMM y. G mm:ss",
+        "M ms": "L mm:ss",
+        "Md ms": "d. M. mm:ss",
+        "MEd ms": "E, d. M. mm:ss",
+        "MMdd ms": "d. M. mm:ss",
+        "MMM ms": "LLL mm:ss",
+        "MMMd ms": "d. MMM mm:ss",
+        "MMMEd ms": "E, d. MMM mm:ss",
+        "MMMMd, ms": "d. MMMM, mm:ss",
+        "MMMMEd, ms": "E, d. MMMM, mm:ss",
+        "y ms": "y. mm:ss",
+        "yM ms": "MM/y mm:ss",
+        "yMd ms": "d. M. y. mm:ss",
+        "yMEd ms": "E, d. M. y. mm:ss",
+        "yMM ms": "M. y. mm:ss",
+        "yMMM ms": "MMM y. mm:ss",
+        "yMMMd ms": "d. MMM y. mm:ss",
+        "yMMMEd ms": "E, d. MMM y. mm:ss",
+        "yMMMM, ms": "LLLL y., mm:ss"
+      }
+    },
+    "intervalFormats": {
+      "intervalFormatFallback": "{0} – {1}",
+      "Bh": {
+        "B": "h B – h B",
+        "h": "h – h B"
+      },
+      "Bhm": {
+        "B": "h:mm B – h:mm B",
+        "h": "h:mm – h:mm B",
+        "m": "h:mm – h:mm B"
+      },
+      "d": {
+        "d": "d–d."
+      },
+      "Gy": {
+        "G": "y. G – y. G",
+        "y": "y–y. G"
+      },
+      "GyM": {
+        "G": "M. y. G – M. y. G",
+        "M": "M. y – M. y. G",
+        "y": "M. y – M. y. G"
+      },
+      "GyMd": {
+        "d": "d. M. y – d. M. y. G",
+        "G": "d. M. y. G – d. M. y. G",
+        "M": "d. M. y – d. M. y. G",
+        "y": "d. M. y – d. M. y. G"
+      },
+      "GyMEd": {
+        "d": "E, d. M. y – E, d. M. y. G",
+        "G": "E, d. M. y. G – E, d. M. y. G",
+        "M": "E, d. M. y – E, d. M. y. G",
+        "y": "E, d. M. y – E, d. M. y. G"
+      },
+      "GyMMM": {
+        "G": "MMM y. G – MMM y. G",
+        "M": "MMM – MMM y. G",
+        "y": "MMM y – MMM y. G"
+      },
+      "GyMMMd": {
+        "d": "d–d. MMM y. G",
+        "G": "d. MMM y. G – d. MMM y. G",
+        "M": "d. MMM – d. MMM y. G",
+        "y": "d. MMM y – d. MMM y. G"
+      },
+      "GyMMMEd": {
+        "d": "E, d. MMM – E, d. MMM y. G",
+        "G": "G y MMM d, E – G y MMM d, E",
+        "M": "G y MMM d, E – MMM d, E",
+        "y": "G y MMM d, E – y MMM d, E"
+      },
+      "h": {
+        "a": "h a – h a",
+        "h": "h–h a"
+      },
+      "H": {
+        "H": "HH – HH'h'"
+      },
+      "hm": {
+        "a": "h:mm a – h:mm a",
+        "h": "h:mm – h:mm a",
+        "m": "h:mm – h:mm a"
+      },
+      "Hm": {
+        "H": "HH:mm – HH:mm",
+        "m": "HH:mm – HH:mm"
+      },
+      "hmv": {
+        "a": "h:mm a – h:mm a v",
+        "h": "h:mm – h:mm a v",
+        "m": "h:mm – h:mm a v"
+      },
+      "Hmv": {
+        "H": "HH:mm – HH:mm v",
+        "m": "HH:mm – HH:mm v"
+      },
+      "hv": {
+        "a": "h a – h a v",
+        "h": "h – h 'h' a v"
+      },
+      "Hv": {
+        "H": "HH – HH 'h' v"
+      },
+      "M": {
+        "M": "M–M."
+      },
+      "Md": {
+        "d": "d. M – d. M.",
+        "M": "d. M – d. M."
+      },
+      "MEd": {
+        "d": "E, d. M – E, d. M.",
+        "M": "E, d. M – E, d. M."
+      },
+      "MMM": {
+        "M": "LLL–LLL"
+      },
+      "MMMd": {
+        "d": "d–d. MMM",
+        "M": "d. MMM – d. MMM"
+      },
+      "MMMEd": {
+        "d": "E, d – E, d. MMM",
+        "M": "E, d. MMM – E, d. MMM"
+      },
+      "y": {
+        "y": "y–y"
+      },
+      "yM": {
+        "M": "M. y – M. y.",
+        "y": "M. y – M. y."
+      },
+      "yMd": {
+        "d": "d. M. y – d. M. y.",
+        "M": "d. M. y – d. M. y.",
+        "y": "d. M. y – d. M. y."
+      },
+      "yMEd": {
+        "d": "E, d. M. y – E, d. M. y.",
+        "M": "E, d. M. y – E, d. M. y.",
+        "y": "E, d. M. y – E, d. M. y."
+      },
+      "yMMM": {
+        "M": "LLL – LLL y.",
+        "y": "LLL y – LLL y."
+      },
+      "yMMMd": {
+        "d": "d–d. MMM y.",
+        "M": "d. MMM – d. MMM y.",
+        "y": "d. MMM y – d. MMM y."
+      },
+      "yMMMEd": {
+        "d": "E, d – E, d. MMM y.",
+        "M": "E, d. MMM – E, d. MMM y.",
+        "y": "E, d. MMM y – E, d. MMM y."
+      },
+      "yMMMM": {
+        "M": "LLLL – LLLL y.",
+        "y": "LLLL y – LLLL y."
+      },
+      "EEEE, d. MMMM y., Bh": {
+        "B": "EEEE, d. MMMM y., h B – h B",
+        "h": "EEEE, d. MMMM y., h – h B"
+      },
+      "d. MMMM y., Bh": {
+        "B": "d. MMMM y., h B – h B",
+        "h": "d. MMMM y., h – h B"
+      },
+      "d. MMM y. Bh": {
+        "B": "d. MMM y. h B – h B",
+        "h": "d. MMM y. h – h B"
+      },
+      "d. M. y. Bh": {
+        "B": "d. M. y. h B – h B",
+        "h": "d. M. y. h – h B"
+      },
+      "d Bh": {
+        "B": "d. h B – h B",
+        "h": "d. h – h B"
+      },
+      "E Bh": {
+        "B": "ccc h B – h B",
+        "h": "ccc h – h B"
+      },
+      "Ed Bh": {
+        "B": "E, d. h B – h B",
+        "h": "E, d. h – h B"
+      },
+      "Gy Bh": {
+        "B": "y. G h B – h B",
+        "h": "y. G h – h B"
+      },
+      "GyM Bh": {
+        "B": "G y-MM h B – h B",
+        "h": "G y-MM h – h B"
+      },
+      "GyMd Bh": {
+        "B": "d. M. y. G h B – h B",
+        "h": "d. M. y. G h – h B"
+      },
+      "GyMEd Bh": {
+        "B": "G y-MM-dd, E h B – h B",
+        "h": "G y-MM-dd, E h – h B"
+      },
+      "GyMMM Bh": {
+        "B": "MMM y. G h B – h B",
+        "h": "MMM y. G h – h B"
+      },
+      "GyMMMd Bh": {
+        "B": "d. MMM y. G h B – h B",
+        "h": "d. MMM y. G h – h B"
+      },
+      "GyMMMEd Bh": {
+        "B": "E, d. MMM y. G h B – h B",
+        "h": "E, d. MMM y. G h – h B"
+      },
+      "M Bh": {
+        "B": "L h B – h B",
+        "h": "L h – h B"
+      },
+      "Md Bh": {
+        "B": "d. M. h B – h B",
+        "h": "d. M. h – h B"
+      },
+      "MEd Bh": {
+        "B": "E, d. M. h B – h B",
+        "h": "E, d. M. h – h B"
+      },
+      "MMdd Bh": {
+        "B": "d. M. h B – h B",
+        "h": "d. M. h – h B"
+      },
+      "MMM Bh": {
+        "B": "LLL h B – h B",
+        "h": "LLL h – h B"
+      },
+      "MMMd Bh": {
+        "B": "d. MMM h B – h B",
+        "h": "d. MMM h – h B"
+      },
+      "MMMEd Bh": {
+        "B": "E, d. MMM h B – h B",
+        "h": "E, d. MMM h – h B"
+      },
+      "MMMMd, Bh": {
+        "B": "d. MMMM, h B – h B",
+        "h": "d. MMMM, h – h B"
+      },
+      "MMMMEd, Bh": {
+        "B": "E, d. MMMM, h B – h B",
+        "h": "E, d. MMMM, h – h B"
+      },
+      "y Bh": {
+        "B": "y. h B – h B",
+        "h": "y. h – h B"
+      },
+      "yM Bh": {
+        "B": "MM/y h B – h B",
+        "h": "MM/y h – h B"
+      },
+      "yMd Bh": {
+        "B": "d. M. y. h B – h B",
+        "h": "d. M. y. h – h B"
+      },
+      "yMEd Bh": {
+        "B": "E, d. M. y. h B – h B",
+        "h": "E, d. M. y. h – h B"
+      },
+      "yMM Bh": {
+        "B": "M. y. h B – h B",
+        "h": "M. y. h – h B"
+      },
+      "yMMM Bh": {
+        "B": "MMM y. h B – h B",
+        "h": "MMM y. h – h B"
+      },
+      "yMMMd Bh": {
+        "B": "d. MMM y. h B – h B",
+        "h": "d. MMM y. h – h B"
+      },
+      "yMMMEd Bh": {
+        "B": "E, d. MMM y. h B – h B",
+        "h": "E, d. MMM y. h – h B"
+      },
+      "yMMMM, Bh": {
+        "B": "LLLL y., h B – h B",
+        "h": "LLLL y., h – h B"
+      },
+      "EEEE, d. MMMM y., Bhm": {
+        "B": "EEEE, d. MMMM y., h:mm B – h:mm B",
+        "h": "EEEE, d. MMMM y., h:mm – h:mm B",
+        "m": "EEEE, d. MMMM y., h:mm – h:mm B"
+      },
+      "d. MMMM y., Bhm": {
+        "B": "d. MMMM y., h:mm B – h:mm B",
+        "h": "d. MMMM y., h:mm – h:mm B",
+        "m": "d. MMMM y., h:mm – h:mm B"
+      },
+      "d. MMM y. Bhm": {
+        "B": "d. MMM y. h:mm B – h:mm B",
+        "h": "d. MMM y. h:mm – h:mm B",
+        "m": "d. MMM y. h:mm – h:mm B"
+      },
+      "d. M. y. Bhm": {
+        "B": "d. M. y. h:mm B – h:mm B",
+        "h": "d. M. y. h:mm – h:mm B",
+        "m": "d. M. y. h:mm – h:mm B"
+      },
+      "d Bhm": {
+        "B": "d. h:mm B – h:mm B",
+        "h": "d. h:mm – h:mm B",
+        "m": "d. h:mm – h:mm B"
+      },
+      "E Bhm": {
+        "B": "ccc h:mm B – h:mm B",
+        "h": "ccc h:mm – h:mm B",
+        "m": "ccc h:mm – h:mm B"
+      },
+      "Ed Bhm": {
+        "B": "E, d. h:mm B – h:mm B",
+        "h": "E, d. h:mm – h:mm B",
+        "m": "E, d. h:mm – h:mm B"
+      },
+      "Gy Bhm": {
+        "B": "y. G h:mm B – h:mm B",
+        "h": "y. G h:mm – h:mm B",
+        "m": "y. G h:mm – h:mm B"
+      },
+      "GyM Bhm": {
+        "B": "G y-MM h:mm B – h:mm B",
+        "h": "G y-MM h:mm – h:mm B",
+        "m": "G y-MM h:mm – h:mm B"
+      },
+      "GyMd Bhm": {
+        "B": "d. M. y. G h:mm B – h:mm B",
+        "h": "d. M. y. G h:mm – h:mm B",
+        "m": "d. M. y. G h:mm – h:mm B"
+      },
+      "GyMEd Bhm": {
+        "B": "G y-MM-dd, E h:mm B – h:mm B",
+        "h": "G y-MM-dd, E h:mm – h:mm B",
+        "m": "G y-MM-dd, E h:mm – h:mm B"
+      },
+      "GyMMM Bhm": {
+        "B": "MMM y. G h:mm B – h:mm B",
+        "h": "MMM y. G h:mm – h:mm B",
+        "m": "MMM y. G h:mm – h:mm B"
+      },
+      "GyMMMd Bhm": {
+        "B": "d. MMM y. G h:mm B – h:mm B",
+        "h": "d. MMM y. G h:mm – h:mm B",
+        "m": "d. MMM y. G h:mm – h:mm B"
+      },
+      "GyMMMEd Bhm": {
+        "B": "E, d. MMM y. G h:mm B – h:mm B",
+        "h": "E, d. MMM y. G h:mm – h:mm B",
+        "m": "E, d. MMM y. G h:mm – h:mm B"
+      },
+      "M Bhm": {
+        "B": "L h:mm B – h:mm B",
+        "h": "L h:mm – h:mm B",
+        "m": "L h:mm – h:mm B"
+      },
+      "Md Bhm": {
+        "B": "d. M. h:mm B – h:mm B",
+        "h": "d. M. h:mm – h:mm B",
+        "m": "d. M. h:mm – h:mm B"
+      },
+      "MEd Bhm": {
+        "B": "E, d. M. h:mm B – h:mm B",
+        "h": "E, d. M. h:mm – h:mm B",
+        "m": "E, d. M. h:mm – h:mm B"
+      },
+      "MMdd Bhm": {
+        "B": "d. M. h:mm B – h:mm B",
+        "h": "d. M. h:mm – h:mm B",
+        "m": "d. M. h:mm – h:mm B"
+      },
+      "MMM Bhm": {
+        "B": "LLL h:mm B – h:mm B",
+        "h": "LLL h:mm – h:mm B",
+        "m": "LLL h:mm – h:mm B"
+      },
+      "MMMd Bhm": {
+        "B": "d. MMM h:mm B – h:mm B",
+        "h": "d. MMM h:mm – h:mm B",
+        "m": "d. MMM h:mm – h:mm B"
+      },
+      "MMMEd Bhm": {
+        "B": "E, d. MMM h:mm B – h:mm B",
+        "h": "E, d. MMM h:mm – h:mm B",
+        "m": "E, d. MMM h:mm – h:mm B"
+      },
+      "MMMMd, Bhm": {
+        "B": "d. MMMM, h:mm B – h:mm B",
+        "h": "d. MMMM, h:mm – h:mm B",
+        "m": "d. MMMM, h:mm – h:mm B"
+      },
+      "MMMMEd, Bhm": {
+        "B": "E, d. MMMM, h:mm B – h:mm B",
+        "h": "E, d. MMMM, h:mm – h:mm B",
+        "m": "E, d. MMMM, h:mm – h:mm B"
+      },
+      "y Bhm": {
+        "B": "y. h:mm B – h:mm B",
+        "h": "y. h:mm – h:mm B",
+        "m": "y. h:mm – h:mm B"
+      },
+      "yM Bhm": {
+        "B": "MM/y h:mm B – h:mm B",
+        "h": "MM/y h:mm – h:mm B",
+        "m": "MM/y h:mm – h:mm B"
+      },
+      "yMd Bhm": {
+        "B": "d. M. y. h:mm B – h:mm B",
+        "h": "d. M. y. h:mm – h:mm B",
+        "m": "d. M. y. h:mm – h:mm B"
+      },
+      "yMEd Bhm": {
+        "B": "E, d. M. y. h:mm B – h:mm B",
+        "h": "E, d. M. y. h:mm – h:mm B",
+        "m": "E, d. M. y. h:mm – h:mm B"
+      },
+      "yMM Bhm": {
+        "B": "M. y. h:mm B – h:mm B",
+        "h": "M. y. h:mm – h:mm B",
+        "m": "M. y. h:mm – h:mm B"
+      },
+      "yMMM Bhm": {
+        "B": "MMM y. h:mm B – h:mm B",
+        "h": "MMM y. h:mm – h:mm B",
+        "m": "MMM y. h:mm – h:mm B"
+      },
+      "yMMMd Bhm": {
+        "B": "d. MMM y. h:mm B – h:mm B",
+        "h": "d. MMM y. h:mm – h:mm B",
+        "m": "d. MMM y. h:mm – h:mm B"
+      },
+      "yMMMEd Bhm": {
+        "B": "E, d. MMM y. h:mm B – h:mm B",
+        "h": "E, d. MMM y. h:mm – h:mm B",
+        "m": "E, d. MMM y. h:mm – h:mm B"
+      },
+      "yMMMM, Bhm": {
+        "B": "LLLL y., h:mm B – h:mm B",
+        "h": "LLLL y., h:mm – h:mm B",
+        "m": "LLLL y., h:mm – h:mm B"
+      },
+      "EEEE, d. MMMM y., h": {
+        "a": "EEEE, d. MMMM y., h a – h a",
+        "h": "EEEE, d. MMMM y., h–h a"
+      },
+      "d. MMMM y., h": {
+        "a": "d. MMMM y., h a – h a",
+        "h": "d. MMMM y., h–h a"
+      },
+      "d. MMM y. h": {
+        "a": "d. MMM y. h a – h a",
+        "h": "d. MMM y. h–h a"
+      },
+      "d. M. y. h": {
+        "a": "d. M. y. h a – h a",
+        "h": "d. M. y. h–h a"
+      },
+      "d h": {
+        "a": "d. h a – h a",
+        "h": "d. h–h a"
+      },
+      "E h": {
+        "a": "ccc h a – h a",
+        "h": "ccc h–h a"
+      },
+      "Ed h": {
+        "a": "E, d. h a – h a",
+        "h": "E, d. h–h a"
+      },
+      "Gy h": {
+        "a": "y. G h a – h a",
+        "h": "y. G h–h a"
+      },
+      "GyM h": {
+        "a": "G y-MM h a – h a",
+        "h": "G y-MM h–h a"
+      },
+      "GyMd h": {
+        "a": "d. M. y. G h a – h a",
+        "h": "d. M. y. G h–h a"
+      },
+      "GyMEd h": {
+        "a": "G y-MM-dd, E h a – h a",
+        "h": "G y-MM-dd, E h–h a"
+      },
+      "GyMMM h": {
+        "a": "MMM y. G h a – h a",
+        "h": "MMM y. G h–h a"
+      },
+      "GyMMMd h": {
+        "a": "d. MMM y. G h a – h a",
+        "h": "d. MMM y. G h–h a"
+      },
+      "GyMMMEd h": {
+        "a": "E, d. MMM y. G h a – h a",
+        "h": "E, d. MMM y. G h–h a"
+      },
+      "M h": {
+        "a": "L h a – h a",
+        "h": "L h–h a"
+      },
+      "Md h": {
+        "a": "d. M. h a – h a",
+        "h": "d. M. h–h a"
+      },
+      "MEd h": {
+        "a": "E, d. M. h a – h a",
+        "h": "E, d. M. h–h a"
+      },
+      "MMdd h": {
+        "a": "d. M. h a – h a",
+        "h": "d. M. h–h a"
+      },
+      "MMM h": {
+        "a": "LLL h a – h a",
+        "h": "LLL h–h a"
+      },
+      "MMMd h": {
+        "a": "d. MMM h a – h a",
+        "h": "d. MMM h–h a"
+      },
+      "MMMEd h": {
+        "a": "E, d. MMM h a – h a",
+        "h": "E, d. MMM h–h a"
+      },
+      "MMMMd, h": {
+        "a": "d. MMMM, h a – h a",
+        "h": "d. MMMM, h–h a"
+      },
+      "MMMMEd, h": {
+        "a": "E, d. MMMM, h a – h a",
+        "h": "E, d. MMMM, h–h a"
+      },
+      "y h": {
+        "a": "y. h a – h a",
+        "h": "y. h–h a"
+      },
+      "yM h": {
+        "a": "MM/y h a – h a",
+        "h": "MM/y h–h a"
+      },
+      "yMd h": {
+        "a": "d. M. y. h a – h a",
+        "h": "d. M. y. h–h a"
+      },
+      "yMEd h": {
+        "a": "E, d. M. y. h a – h a",
+        "h": "E, d. M. y. h–h a"
+      },
+      "yMM h": {
+        "a": "M. y. h a – h a",
+        "h": "M. y. h–h a"
+      },
+      "yMMM h": {
+        "a": "MMM y. h a – h a",
+        "h": "MMM y. h–h a"
+      },
+      "yMMMd h": {
+        "a": "d. MMM y. h a – h a",
+        "h": "d. MMM y. h–h a"
+      },
+      "yMMMEd h": {
+        "a": "E, d. MMM y. h a – h a",
+        "h": "E, d. MMM y. h–h a"
+      },
+      "yMMMM, h": {
+        "a": "LLLL y., h a – h a",
+        "h": "LLLL y., h–h a"
+      },
+      "EEEE, d. MMMM y., H": {
+        "H": "EEEE, d. MMMM y., HH – HH'h'"
+      },
+      "d. MMMM y., H": {
+        "H": "d. MMMM y., HH – HH'h'"
+      },
+      "d. MMM y. H": {
+        "H": "d. MMM y. HH – HH'h'"
+      },
+      "d. M. y. H": {
+        "H": "d. M. y. HH – HH'h'"
+      },
+      "d H": {
+        "H": "d. HH – HH'h'"
+      },
+      "E H": {
+        "H": "ccc HH – HH'h'"
+      },
+      "Ed H": {
+        "H": "E, d. HH – HH'h'"
+      },
+      "Gy H": {
+        "H": "y. G HH – HH'h'"
+      },
+      "GyM H": {
+        "H": "G y-MM HH – HH'h'"
+      },
+      "GyMd H": {
+        "H": "d. M. y. G HH – HH'h'"
+      },
+      "GyMEd H": {
+        "H": "G y-MM-dd, E HH – HH'h'"
+      },
+      "GyMMM H": {
+        "H": "MMM y. G HH – HH'h'"
+      },
+      "GyMMMd H": {
+        "H": "d. MMM y. G HH – HH'h'"
+      },
+      "GyMMMEd H": {
+        "H": "E, d. MMM y. G HH – HH'h'"
+      },
+      "M H": {
+        "H": "L HH – HH'h'"
+      },
+      "Md H": {
+        "H": "d. M. HH – HH'h'"
+      },
+      "MEd H": {
+        "H": "E, d. M. HH – HH'h'"
+      },
+      "MMdd H": {
+        "H": "d. M. HH – HH'h'"
+      },
+      "MMM H": {
+        "H": "LLL HH – HH'h'"
+      },
+      "MMMd H": {
+        "H": "d. MMM HH – HH'h'"
+      },
+      "MMMEd H": {
+        "H": "E, d. MMM HH – HH'h'"
+      },
+      "MMMMd, H": {
+        "H": "d. MMMM, HH – HH'h'"
+      },
+      "MMMMEd, H": {
+        "H": "E, d. MMMM, HH – HH'h'"
+      },
+      "y H": {
+        "H": "y. HH – HH'h'"
+      },
+      "yM H": {
+        "H": "MM/y HH – HH'h'"
+      },
+      "yMd H": {
+        "H": "d. M. y. HH – HH'h'"
+      },
+      "yMEd H": {
+        "H": "E, d. M. y. HH – HH'h'"
+      },
+      "yMM H": {
+        "H": "M. y. HH – HH'h'"
+      },
+      "yMMM H": {
+        "H": "MMM y. HH – HH'h'"
+      },
+      "yMMMd H": {
+        "H": "d. MMM y. HH – HH'h'"
+      },
+      "yMMMEd H": {
+        "H": "E, d. MMM y. HH – HH'h'"
+      },
+      "yMMMM, H": {
+        "H": "LLLL y., HH – HH'h'"
+      },
+      "EEEE, d. MMMM y., hm": {
+        "a": "EEEE, d. MMMM y., h:mm a – h:mm a",
+        "h": "EEEE, d. MMMM y., h:mm – h:mm a",
+        "m": "EEEE, d. MMMM y., h:mm – h:mm a"
+      },
+      "d. MMMM y., hm": {
+        "a": "d. MMMM y., h:mm a – h:mm a",
+        "h": "d. MMMM y., h:mm – h:mm a",
+        "m": "d. MMMM y., h:mm – h:mm a"
+      },
+      "d. MMM y. hm": {
+        "a": "d. MMM y. h:mm a – h:mm a",
+        "h": "d. MMM y. h:mm – h:mm a",
+        "m": "d. MMM y. h:mm – h:mm a"
+      },
+      "d. M. y. hm": {
+        "a": "d. M. y. h:mm a – h:mm a",
+        "h": "d. M. y. h:mm – h:mm a",
+        "m": "d. M. y. h:mm – h:mm a"
+      },
+      "d hm": {
+        "a": "d. h:mm a – h:mm a",
+        "h": "d. h:mm – h:mm a",
+        "m": "d. h:mm – h:mm a"
+      },
+      "E hm": {
+        "a": "ccc h:mm a – h:mm a",
+        "h": "ccc h:mm – h:mm a",
+        "m": "ccc h:mm – h:mm a"
+      },
+      "Ed hm": {
+        "a": "E, d. h:mm a – h:mm a",
+        "h": "E, d. h:mm – h:mm a",
+        "m": "E, d. h:mm – h:mm a"
+      },
+      "Gy hm": {
+        "a": "y. G h:mm a – h:mm a",
+        "h": "y. G h:mm – h:mm a",
+        "m": "y. G h:mm – h:mm a"
+      },
+      "GyM hm": {
+        "a": "G y-MM h:mm a – h:mm a",
+        "h": "G y-MM h:mm – h:mm a",
+        "m": "G y-MM h:mm – h:mm a"
+      },
+      "GyMd hm": {
+        "a": "d. M. y. G h:mm a – h:mm a",
+        "h": "d. M. y. G h:mm – h:mm a",
+        "m": "d. M. y. G h:mm – h:mm a"
+      },
+      "GyMEd hm": {
+        "a": "G y-MM-dd, E h:mm a – h:mm a",
+        "h": "G y-MM-dd, E h:mm – h:mm a",
+        "m": "G y-MM-dd, E h:mm – h:mm a"
+      },
+      "GyMMM hm": {
+        "a": "MMM y. G h:mm a – h:mm a",
+        "h": "MMM y. G h:mm – h:mm a",
+        "m": "MMM y. G h:mm – h:mm a"
+      },
+      "GyMMMd hm": {
+        "a": "d. MMM y. G h:mm a – h:mm a",
+        "h": "d. MMM y. G h:mm – h:mm a",
+        "m": "d. MMM y. G h:mm – h:mm a"
+      },
+      "GyMMMEd hm": {
+        "a": "E, d. MMM y. G h:mm a – h:mm a",
+        "h": "E, d. MMM y. G h:mm – h:mm a",
+        "m": "E, d. MMM y. G h:mm – h:mm a"
+      },
+      "M hm": {
+        "a": "L h:mm a – h:mm a",
+        "h": "L h:mm – h:mm a",
+        "m": "L h:mm – h:mm a"
+      },
+      "Md hm": {
+        "a": "d. M. h:mm a – h:mm a",
+        "h": "d. M. h:mm – h:mm a",
+        "m": "d. M. h:mm – h:mm a"
+      },
+      "MEd hm": {
+        "a": "E, d. M. h:mm a – h:mm a",
+        "h": "E, d. M. h:mm – h:mm a",
+        "m": "E, d. M. h:mm – h:mm a"
+      },
+      "MMdd hm": {
+        "a": "d. M. h:mm a – h:mm a",
+        "h": "d. M. h:mm – h:mm a",
+        "m": "d. M. h:mm – h:mm a"
+      },
+      "MMM hm": {
+        "a": "LLL h:mm a – h:mm a",
+        "h": "LLL h:mm – h:mm a",
+        "m": "LLL h:mm – h:mm a"
+      },
+      "MMMd hm": {
+        "a": "d. MMM h:mm a – h:mm a",
+        "h": "d. MMM h:mm – h:mm a",
+        "m": "d. MMM h:mm – h:mm a"
+      },
+      "MMMEd hm": {
+        "a": "E, d. MMM h:mm a – h:mm a",
+        "h": "E, d. MMM h:mm – h:mm a",
+        "m": "E, d. MMM h:mm – h:mm a"
+      },
+      "MMMMd, hm": {
+        "a": "d. MMMM, h:mm a – h:mm a",
+        "h": "d. MMMM, h:mm – h:mm a",
+        "m": "d. MMMM, h:mm – h:mm a"
+      },
+      "MMMMEd, hm": {
+        "a": "E, d. MMMM, h:mm a – h:mm a",
+        "h": "E, d. MMMM, h:mm – h:mm a",
+        "m": "E, d. MMMM, h:mm – h:mm a"
+      },
+      "y hm": {
+        "a": "y. h:mm a – h:mm a",
+        "h": "y. h:mm – h:mm a",
+        "m": "y. h:mm – h:mm a"
+      },
+      "yM hm": {
+        "a": "MM/y h:mm a – h:mm a",
+        "h": "MM/y h:mm – h:mm a",
+        "m": "MM/y h:mm – h:mm a"
+      },
+      "yMd hm": {
+        "a": "d. M. y. h:mm a – h:mm a",
+        "h": "d. M. y. h:mm – h:mm a",
+        "m": "d. M. y. h:mm – h:mm a"
+      },
+      "yMEd hm": {
+        "a": "E, d. M. y. h:mm a – h:mm a",
+        "h": "E, d. M. y. h:mm – h:mm a",
+        "m": "E, d. M. y. h:mm – h:mm a"
+      },
+      "yMM hm": {
+        "a": "M. y. h:mm a – h:mm a",
+        "h": "M. y. h:mm – h:mm a",
+        "m": "M. y. h:mm – h:mm a"
+      },
+      "yMMM hm": {
+        "a": "MMM y. h:mm a – h:mm a",
+        "h": "MMM y. h:mm – h:mm a",
+        "m": "MMM y. h:mm – h:mm a"
+      },
+      "yMMMd hm": {
+        "a": "d. MMM y. h:mm a – h:mm a",
+        "h": "d. MMM y. h:mm – h:mm a",
+        "m": "d. MMM y. h:mm – h:mm a"
+      },
+      "yMMMEd hm": {
+        "a": "E, d. MMM y. h:mm a – h:mm a",
+        "h": "E, d. MMM y. h:mm – h:mm a",
+        "m": "E, d. MMM y. h:mm – h:mm a"
+      },
+      "yMMMM, hm": {
+        "a": "LLLL y., h:mm a – h:mm a",
+        "h": "LLLL y., h:mm – h:mm a",
+        "m": "LLLL y., h:mm – h:mm a"
+      },
+      "EEEE, d. MMMM y., Hm": {
+        "H": "EEEE, d. MMMM y., HH:mm – HH:mm",
+        "m": "EEEE, d. MMMM y., HH:mm – HH:mm"
+      },
+      "d. MMMM y., Hm": {
+        "H": "d. MMMM y., HH:mm – HH:mm",
+        "m": "d. MMMM y., HH:mm – HH:mm"
+      },
+      "d. MMM y. Hm": {
+        "H": "d. MMM y. HH:mm – HH:mm",
+        "m": "d. MMM y. HH:mm – HH:mm"
+      },
+      "d. M. y. Hm": {
+        "H": "d. M. y. HH:mm – HH:mm",
+        "m": "d. M. y. HH:mm – HH:mm"
+      },
+      "d Hm": {
+        "H": "d. HH:mm – HH:mm",
+        "m": "d. HH:mm – HH:mm"
+      },
+      "E Hm": {
+        "H": "ccc HH:mm – HH:mm",
+        "m": "ccc HH:mm – HH:mm"
+      },
+      "Ed Hm": {
+        "H": "E, d. HH:mm – HH:mm",
+        "m": "E, d. HH:mm – HH:mm"
+      },
+      "Gy Hm": {
+        "H": "y. G HH:mm – HH:mm",
+        "m": "y. G HH:mm – HH:mm"
+      },
+      "GyM Hm": {
+        "H": "G y-MM HH:mm – HH:mm",
+        "m": "G y-MM HH:mm – HH:mm"
+      },
+      "GyMd Hm": {
+        "H": "d. M. y. G HH:mm – HH:mm",
+        "m": "d. M. y. G HH:mm – HH:mm"
+      },
+      "GyMEd Hm": {
+        "H": "G y-MM-dd, E HH:mm – HH:mm",
+        "m": "G y-MM-dd, E HH:mm – HH:mm"
+      },
+      "GyMMM Hm": {
+        "H": "MMM y. G HH:mm – HH:mm",
+        "m": "MMM y. G HH:mm – HH:mm"
+      },
+      "GyMMMd Hm": {
+        "H": "d. MMM y. G HH:mm – HH:mm",
+        "m": "d. MMM y. G HH:mm – HH:mm"
+      },
+      "GyMMMEd Hm": {
+        "H": "E, d. MMM y. G HH:mm – HH:mm",
+        "m": "E, d. MMM y. G HH:mm – HH:mm"
+      },
+      "M Hm": {
+        "H": "L HH:mm – HH:mm",
+        "m": "L HH:mm – HH:mm"
+      },
+      "Md Hm": {
+        "H": "d. M. HH:mm – HH:mm",
+        "m": "d. M. HH:mm – HH:mm"
+      },
+      "MEd Hm": {
+        "H": "E, d. M. HH:mm – HH:mm",
+        "m": "E, d. M. HH:mm – HH:mm"
+      },
+      "MMdd Hm": {
+        "H": "d. M. HH:mm – HH:mm",
+        "m": "d. M. HH:mm – HH:mm"
+      },
+      "MMM Hm": {
+        "H": "LLL HH:mm – HH:mm",
+        "m": "LLL HH:mm – HH:mm"
+      },
+      "MMMd Hm": {
+        "H": "d. MMM HH:mm – HH:mm",
+        "m": "d. MMM HH:mm – HH:mm"
+      },
+      "MMMEd Hm": {
+        "H": "E, d. MMM HH:mm – HH:mm",
+        "m": "E, d. MMM HH:mm – HH:mm"
+      },
+      "MMMMd, Hm": {
+        "H": "d. MMMM, HH:mm – HH:mm",
+        "m": "d. MMMM, HH:mm – HH:mm"
+      },
+      "MMMMEd, Hm": {
+        "H": "E, d. MMMM, HH:mm – HH:mm",
+        "m": "E, d. MMMM, HH:mm – HH:mm"
+      },
+      "y Hm": {
+        "H": "y. HH:mm – HH:mm",
+        "m": "y. HH:mm – HH:mm"
+      },
+      "yM Hm": {
+        "H": "MM/y HH:mm – HH:mm",
+        "m": "MM/y HH:mm – HH:mm"
+      },
+      "yMd Hm": {
+        "H": "d. M. y. HH:mm – HH:mm",
+        "m": "d. M. y. HH:mm – HH:mm"
+      },
+      "yMEd Hm": {
+        "H": "E, d. M. y. HH:mm – HH:mm",
+        "m": "E, d. M. y. HH:mm – HH:mm"
+      },
+      "yMM Hm": {
+        "H": "M. y. HH:mm – HH:mm",
+        "m": "M. y. HH:mm – HH:mm"
+      },
+      "yMMM Hm": {
+        "H": "MMM y. HH:mm – HH:mm",
+        "m": "MMM y. HH:mm – HH:mm"
+      },
+      "yMMMd Hm": {
+        "H": "d. MMM y. HH:mm – HH:mm",
+        "m": "d. MMM y. HH:mm – HH:mm"
+      },
+      "yMMMEd Hm": {
+        "H": "E, d. MMM y. HH:mm – HH:mm",
+        "m": "E, d. MMM y. HH:mm – HH:mm"
+      },
+      "yMMMM, Hm": {
+        "H": "LLLL y., HH:mm – HH:mm",
+        "m": "LLLL y., HH:mm – HH:mm"
+      },
+      "EEEE, d. MMMM y., hmv": {
+        "a": "EEEE, d. MMMM y., h:mm a – h:mm a v",
+        "h": "EEEE, d. MMMM y., h:mm – h:mm a v",
+        "m": "EEEE, d. MMMM y., h:mm – h:mm a v"
+      },
+      "d. MMMM y., hmv": {
+        "a": "d. MMMM y., h:mm a – h:mm a v",
+        "h": "d. MMMM y., h:mm – h:mm a v",
+        "m": "d. MMMM y., h:mm – h:mm a v"
+      },
+      "d. MMM y. hmv": {
+        "a": "d. MMM y. h:mm a – h:mm a v",
+        "h": "d. MMM y. h:mm – h:mm a v",
+        "m": "d. MMM y. h:mm – h:mm a v"
+      },
+      "d. M. y. hmv": {
+        "a": "d. M. y. h:mm a – h:mm a v",
+        "h": "d. M. y. h:mm – h:mm a v",
+        "m": "d. M. y. h:mm – h:mm a v"
+      },
+      "d hmv": {
+        "a": "d. h:mm a – h:mm a v",
+        "h": "d. h:mm – h:mm a v",
+        "m": "d. h:mm – h:mm a v"
+      },
+      "E hmv": {
+        "a": "ccc h:mm a – h:mm a v",
+        "h": "ccc h:mm – h:mm a v",
+        "m": "ccc h:mm – h:mm a v"
+      },
+      "Ed hmv": {
+        "a": "E, d. h:mm a – h:mm a v",
+        "h": "E, d. h:mm – h:mm a v",
+        "m": "E, d. h:mm – h:mm a v"
+      },
+      "Gy hmv": {
+        "a": "y. G h:mm a – h:mm a v",
+        "h": "y. G h:mm – h:mm a v",
+        "m": "y. G h:mm – h:mm a v"
+      },
+      "GyM hmv": {
+        "a": "G y-MM h:mm a – h:mm a v",
+        "h": "G y-MM h:mm – h:mm a v",
+        "m": "G y-MM h:mm – h:mm a v"
+      },
+      "GyMd hmv": {
+        "a": "d. M. y. G h:mm a – h:mm a v",
+        "h": "d. M. y. G h:mm – h:mm a v",
+        "m": "d. M. y. G h:mm – h:mm a v"
+      },
+      "GyMEd hmv": {
+        "a": "G y-MM-dd, E h:mm a – h:mm a v",
+        "h": "G y-MM-dd, E h:mm – h:mm a v",
+        "m": "G y-MM-dd, E h:mm – h:mm a v"
+      },
+      "GyMMM hmv": {
+        "a": "MMM y. G h:mm a – h:mm a v",
+        "h": "MMM y. G h:mm – h:mm a v",
+        "m": "MMM y. G h:mm – h:mm a v"
+      },
+      "GyMMMd hmv": {
+        "a": "d. MMM y. G h:mm a – h:mm a v",
+        "h": "d. MMM y. G h:mm – h:mm a v",
+        "m": "d. MMM y. G h:mm – h:mm a v"
+      },
+      "GyMMMEd hmv": {
+        "a": "E, d. MMM y. G h:mm a – h:mm a v",
+        "h": "E, d. MMM y. G h:mm – h:mm a v",
+        "m": "E, d. MMM y. G h:mm – h:mm a v"
+      },
+      "M hmv": {
+        "a": "L h:mm a – h:mm a v",
+        "h": "L h:mm – h:mm a v",
+        "m": "L h:mm – h:mm a v"
+      },
+      "Md hmv": {
+        "a": "d. M. h:mm a – h:mm a v",
+        "h": "d. M. h:mm – h:mm a v",
+        "m": "d. M. h:mm – h:mm a v"
+      },
+      "MEd hmv": {
+        "a": "E, d. M. h:mm a – h:mm a v",
+        "h": "E, d. M. h:mm – h:mm a v",
+        "m": "E, d. M. h:mm – h:mm a v"
+      },
+      "MMdd hmv": {
+        "a": "d. M. h:mm a – h:mm a v",
+        "h": "d. M. h:mm – h:mm a v",
+        "m": "d. M. h:mm – h:mm a v"
+      },
+      "MMM hmv": {
+        "a": "LLL h:mm a – h:mm a v",
+        "h": "LLL h:mm – h:mm a v",
+        "m": "LLL h:mm – h:mm a v"
+      },
+      "MMMd hmv": {
+        "a": "d. MMM h:mm a – h:mm a v",
+        "h": "d. MMM h:mm – h:mm a v",
+        "m": "d. MMM h:mm – h:mm a v"
+      },
+      "MMMEd hmv": {
+        "a": "E, d. MMM h:mm a – h:mm a v",
+        "h": "E, d. MMM h:mm – h:mm a v",
+        "m": "E, d. MMM h:mm – h:mm a v"
+      },
+      "MMMMd, hmv": {
+        "a": "d. MMMM, h:mm a – h:mm a v",
+        "h": "d. MMMM, h:mm – h:mm a v",
+        "m": "d. MMMM, h:mm – h:mm a v"
+      },
+      "MMMMEd, hmv": {
+        "a": "E, d. MMMM, h:mm a – h:mm a v",
+        "h": "E, d. MMMM, h:mm – h:mm a v",
+        "m": "E, d. MMMM, h:mm – h:mm a v"
+      },
+      "y hmv": {
+        "a": "y. h:mm a – h:mm a v",
+        "h": "y. h:mm – h:mm a v",
+        "m": "y. h:mm – h:mm a v"
+      },
+      "yM hmv": {
+        "a": "MM/y h:mm a – h:mm a v",
+        "h": "MM/y h:mm – h:mm a v",
+        "m": "MM/y h:mm – h:mm a v"
+      },
+      "yMd hmv": {
+        "a": "d. M. y. h:mm a – h:mm a v",
+        "h": "d. M. y. h:mm – h:mm a v",
+        "m": "d. M. y. h:mm – h:mm a v"
+      },
+      "yMEd hmv": {
+        "a": "E, d. M. y. h:mm a – h:mm a v",
+        "h": "E, d. M. y. h:mm – h:mm a v",
+        "m": "E, d. M. y. h:mm – h:mm a v"
+      },
+      "yMM hmv": {
+        "a": "M. y. h:mm a – h:mm a v",
+        "h": "M. y. h:mm – h:mm a v",
+        "m": "M. y. h:mm – h:mm a v"
+      },
+      "yMMM hmv": {
+        "a": "MMM y. h:mm a – h:mm a v",
+        "h": "MMM y. h:mm – h:mm a v",
+        "m": "MMM y. h:mm – h:mm a v"
+      },
+      "yMMMd hmv": {
+        "a": "d. MMM y. h:mm a – h:mm a v",
+        "h": "d. MMM y. h:mm – h:mm a v",
+        "m": "d. MMM y. h:mm – h:mm a v"
+      },
+      "yMMMEd hmv": {
+        "a": "E, d. MMM y. h:mm a – h:mm a v",
+        "h": "E, d. MMM y. h:mm – h:mm a v",
+        "m": "E, d. MMM y. h:mm – h:mm a v"
+      },
+      "yMMMM, hmv": {
+        "a": "LLLL y., h:mm a – h:mm a v",
+        "h": "LLLL y., h:mm – h:mm a v",
+        "m": "LLLL y., h:mm – h:mm a v"
+      },
+      "EEEE, d. MMMM y., Hmv": {
+        "H": "EEEE, d. MMMM y., HH:mm – HH:mm v",
+        "m": "EEEE, d. MMMM y., HH:mm – HH:mm v"
+      },
+      "d. MMMM y., Hmv": {
+        "H": "d. MMMM y., HH:mm – HH:mm v",
+        "m": "d. MMMM y., HH:mm – HH:mm v"
+      },
+      "d. MMM y. Hmv": {
+        "H": "d. MMM y. HH:mm – HH:mm v",
+        "m": "d. MMM y. HH:mm – HH:mm v"
+      },
+      "d. M. y. Hmv": {
+        "H": "d. M. y. HH:mm – HH:mm v",
+        "m": "d. M. y. HH:mm – HH:mm v"
+      },
+      "d Hmv": {
+        "H": "d. HH:mm – HH:mm v",
+        "m": "d. HH:mm – HH:mm v"
+      },
+      "E Hmv": {
+        "H": "ccc HH:mm – HH:mm v",
+        "m": "ccc HH:mm – HH:mm v"
+      },
+      "Ed Hmv": {
+        "H": "E, d. HH:mm – HH:mm v",
+        "m": "E, d. HH:mm – HH:mm v"
+      },
+      "Gy Hmv": {
+        "H": "y. G HH:mm – HH:mm v",
+        "m": "y. G HH:mm – HH:mm v"
+      },
+      "GyM Hmv": {
+        "H": "G y-MM HH:mm – HH:mm v",
+        "m": "G y-MM HH:mm – HH:mm v"
+      },
+      "GyMd Hmv": {
+        "H": "d. M. y. G HH:mm – HH:mm v",
+        "m": "d. M. y. G HH:mm – HH:mm v"
+      },
+      "GyMEd Hmv": {
+        "H": "G y-MM-dd, E HH:mm – HH:mm v",
+        "m": "G y-MM-dd, E HH:mm – HH:mm v"
+      },
+      "GyMMM Hmv": {
+        "H": "MMM y. G HH:mm – HH:mm v",
+        "m": "MMM y. G HH:mm – HH:mm v"
+      },
+      "GyMMMd Hmv": {
+        "H": "d. MMM y. G HH:mm – HH:mm v",
+        "m": "d. MMM y. G HH:mm – HH:mm v"
+      },
+      "GyMMMEd Hmv": {
+        "H": "E, d. MMM y. G HH:mm – HH:mm v",
+        "m": "E, d. MMM y. G HH:mm – HH:mm v"
+      },
+      "M Hmv": {
+        "H": "L HH:mm – HH:mm v",
+        "m": "L HH:mm – HH:mm v"
+      },
+      "Md Hmv": {
+        "H": "d. M. HH:mm – HH:mm v",
+        "m": "d. M. HH:mm – HH:mm v"
+      },
+      "MEd Hmv": {
+        "H": "E, d. M. HH:mm – HH:mm v",
+        "m": "E, d. M. HH:mm – HH:mm v"
+      },
+      "MMdd Hmv": {
+        "H": "d. M. HH:mm – HH:mm v",
+        "m": "d. M. HH:mm – HH:mm v"
+      },
+      "MMM Hmv": {
+        "H": "LLL HH:mm – HH:mm v",
+        "m": "LLL HH:mm – HH:mm v"
+      },
+      "MMMd Hmv": {
+        "H": "d. MMM HH:mm – HH:mm v",
+        "m": "d. MMM HH:mm – HH:mm v"
+      },
+      "MMMEd Hmv": {
+        "H": "E, d. MMM HH:mm – HH:mm v",
+        "m": "E, d. MMM HH:mm – HH:mm v"
+      },
+      "MMMMd, Hmv": {
+        "H": "d. MMMM, HH:mm – HH:mm v",
+        "m": "d. MMMM, HH:mm – HH:mm v"
+      },
+      "MMMMEd, Hmv": {
+        "H": "E, d. MMMM, HH:mm – HH:mm v",
+        "m": "E, d. MMMM, HH:mm – HH:mm v"
+      },
+      "y Hmv": {
+        "H": "y. HH:mm – HH:mm v",
+        "m": "y. HH:mm – HH:mm v"
+      },
+      "yM Hmv": {
+        "H": "MM/y HH:mm – HH:mm v",
+        "m": "MM/y HH:mm – HH:mm v"
+      },
+      "yMd Hmv": {
+        "H": "d. M. y. HH:mm – HH:mm v",
+        "m": "d. M. y. HH:mm – HH:mm v"
+      },
+      "yMEd Hmv": {
+        "H": "E, d. M. y. HH:mm – HH:mm v",
+        "m": "E, d. M. y. HH:mm – HH:mm v"
+      },
+      "yMM Hmv": {
+        "H": "M. y. HH:mm – HH:mm v",
+        "m": "M. y. HH:mm – HH:mm v"
+      },
+      "yMMM Hmv": {
+        "H": "MMM y. HH:mm – HH:mm v",
+        "m": "MMM y. HH:mm – HH:mm v"
+      },
+      "yMMMd Hmv": {
+        "H": "d. MMM y. HH:mm – HH:mm v",
+        "m": "d. MMM y. HH:mm – HH:mm v"
+      },
+      "yMMMEd Hmv": {
+        "H": "E, d. MMM y. HH:mm – HH:mm v",
+        "m": "E, d. MMM y. HH:mm – HH:mm v"
+      },
+      "yMMMM, Hmv": {
+        "H": "LLLL y., HH:mm – HH:mm v",
+        "m": "LLLL y., HH:mm – HH:mm v"
+      },
+      "EEEE, d. MMMM y., hv": {
+        "a": "EEEE, d. MMMM y., h a – h a v",
+        "h": "EEEE, d. MMMM y., h – h 'h' a v"
+      },
+      "d. MMMM y., hv": {
+        "a": "d. MMMM y., h a – h a v",
+        "h": "d. MMMM y., h – h 'h' a v"
+      },
+      "d. MMM y. hv": {
+        "a": "d. MMM y. h a – h a v",
+        "h": "d. MMM y. h – h 'h' a v"
+      },
+      "d. M. y. hv": {
+        "a": "d. M. y. h a – h a v",
+        "h": "d. M. y. h – h 'h' a v"
+      },
+      "d hv": {
+        "a": "d. h a – h a v",
+        "h": "d. h – h 'h' a v"
+      },
+      "E hv": {
+        "a": "ccc h a – h a v",
+        "h": "ccc h – h 'h' a v"
+      },
+      "Ed hv": {
+        "a": "E, d. h a – h a v",
+        "h": "E, d. h – h 'h' a v"
+      },
+      "Gy hv": {
+        "a": "y. G h a – h a v",
+        "h": "y. G h – h 'h' a v"
+      },
+      "GyM hv": {
+        "a": "G y-MM h a – h a v",
+        "h": "G y-MM h – h 'h' a v"
+      },
+      "GyMd hv": {
+        "a": "d. M. y. G h a – h a v",
+        "h": "d. M. y. G h – h 'h' a v"
+      },
+      "GyMEd hv": {
+        "a": "G y-MM-dd, E h a – h a v",
+        "h": "G y-MM-dd, E h – h 'h' a v"
+      },
+      "GyMMM hv": {
+        "a": "MMM y. G h a – h a v",
+        "h": "MMM y. G h – h 'h' a v"
+      },
+      "GyMMMd hv": {
+        "a": "d. MMM y. G h a – h a v",
+        "h": "d. MMM y. G h – h 'h' a v"
+      },
+      "GyMMMEd hv": {
+        "a": "E, d. MMM y. G h a – h a v",
+        "h": "E, d. MMM y. G h – h 'h' a v"
+      },
+      "M hv": {
+        "a": "L h a – h a v",
+        "h": "L h – h 'h' a v"
+      },
+      "Md hv": {
+        "a": "d. M. h a – h a v",
+        "h": "d. M. h – h 'h' a v"
+      },
+      "MEd hv": {
+        "a": "E, d. M. h a – h a v",
+        "h": "E, d. M. h – h 'h' a v"
+      },
+      "MMdd hv": {
+        "a": "d. M. h a – h a v",
+        "h": "d. M. h – h 'h' a v"
+      },
+      "MMM hv": {
+        "a": "LLL h a – h a v",
+        "h": "LLL h – h 'h' a v"
+      },
+      "MMMd hv": {
+        "a": "d. MMM h a – h a v",
+        "h": "d. MMM h – h 'h' a v"
+      },
+      "MMMEd hv": {
+        "a": "E, d. MMM h a – h a v",
+        "h": "E, d. MMM h – h 'h' a v"
+      },
+      "MMMMd, hv": {
+        "a": "d. MMMM, h a – h a v",
+        "h": "d. MMMM, h – h 'h' a v"
+      },
+      "MMMMEd, hv": {
+        "a": "E, d. MMMM, h a – h a v",
+        "h": "E, d. MMMM, h – h 'h' a v"
+      },
+      "y hv": {
+        "a": "y. h a – h a v",
+        "h": "y. h – h 'h' a v"
+      },
+      "yM hv": {
+        "a": "MM/y h a – h a v",
+        "h": "MM/y h – h 'h' a v"
+      },
+      "yMd hv": {
+        "a": "d. M. y. h a – h a v",
+        "h": "d. M. y. h – h 'h' a v"
+      },
+      "yMEd hv": {
+        "a": "E, d. M. y. h a – h a v",
+        "h": "E, d. M. y. h – h 'h' a v"
+      },
+      "yMM hv": {
+        "a": "M. y. h a – h a v",
+        "h": "M. y. h – h 'h' a v"
+      },
+      "yMMM hv": {
+        "a": "MMM y. h a – h a v",
+        "h": "MMM y. h – h 'h' a v"
+      },
+      "yMMMd hv": {
+        "a": "d. MMM y. h a – h a v",
+        "h": "d. MMM y. h – h 'h' a v"
+      },
+      "yMMMEd hv": {
+        "a": "E, d. MMM y. h a – h a v",
+        "h": "E, d. MMM y. h – h 'h' a v"
+      },
+      "yMMMM, hv": {
+        "a": "LLLL y., h a – h a v",
+        "h": "LLLL y., h – h 'h' a v"
+      },
+      "EEEE, d. MMMM y., Hv": {
+        "H": "EEEE, d. MMMM y., HH – HH 'h' v"
+      },
+      "d. MMMM y., Hv": {
+        "H": "d. MMMM y., HH – HH 'h' v"
+      },
+      "d. MMM y. Hv": {
+        "H": "d. MMM y. HH – HH 'h' v"
+      },
+      "d. M. y. Hv": {
+        "H": "d. M. y. HH – HH 'h' v"
+      },
+      "d Hv": {
+        "H": "d. HH – HH 'h' v"
+      },
+      "E Hv": {
+        "H": "ccc HH – HH 'h' v"
+      },
+      "Ed Hv": {
+        "H": "E, d. HH – HH 'h' v"
+      },
+      "Gy Hv": {
+        "H": "y. G HH – HH 'h' v"
+      },
+      "GyM Hv": {
+        "H": "G y-MM HH – HH 'h' v"
+      },
+      "GyMd Hv": {
+        "H": "d. M. y. G HH – HH 'h' v"
+      },
+      "GyMEd Hv": {
+        "H": "G y-MM-dd, E HH – HH 'h' v"
+      },
+      "GyMMM Hv": {
+        "H": "MMM y. G HH – HH 'h' v"
+      },
+      "GyMMMd Hv": {
+        "H": "d. MMM y. G HH – HH 'h' v"
+      },
+      "GyMMMEd Hv": {
+        "H": "E, d. MMM y. G HH – HH 'h' v"
+      },
+      "M Hv": {
+        "H": "L HH – HH 'h' v"
+      },
+      "Md Hv": {
+        "H": "d. M. HH – HH 'h' v"
+      },
+      "MEd Hv": {
+        "H": "E, d. M. HH – HH 'h' v"
+      },
+      "MMdd Hv": {
+        "H": "d. M. HH – HH 'h' v"
+      },
+      "MMM Hv": {
+        "H": "LLL HH – HH 'h' v"
+      },
+      "MMMd Hv": {
+        "H": "d. MMM HH – HH 'h' v"
+      },
+      "MMMEd Hv": {
+        "H": "E, d. MMM HH – HH 'h' v"
+      },
+      "MMMMd, Hv": {
+        "H": "d. MMMM, HH – HH 'h' v"
+      },
+      "MMMMEd, Hv": {
+        "H": "E, d. MMMM, HH – HH 'h' v"
+      },
+      "y Hv": {
+        "H": "y. HH – HH 'h' v"
+      },
+      "yM Hv": {
+        "H": "MM/y HH – HH 'h' v"
+      },
+      "yMd Hv": {
+        "H": "d. M. y. HH – HH 'h' v"
+      },
+      "yMEd Hv": {
+        "H": "E, d. M. y. HH – HH 'h' v"
+      },
+      "yMM Hv": {
+        "H": "M. y. HH – HH 'h' v"
+      },
+      "yMMM Hv": {
+        "H": "MMM y. HH – HH 'h' v"
+      },
+      "yMMMd Hv": {
+        "H": "d. MMM y. HH – HH 'h' v"
+      },
+      "yMMMEd Hv": {
+        "H": "E, d. MMM y. HH – HH 'h' v"
+      },
+      "yMMMM, Hv": {
+        "H": "LLLL y., HH – HH 'h' v"
+      }
+    },
+    "hourCycle": "h23",
+    "nu": [
+      "latn"
+    ],
+    "ca": [
+      "gregory"
+    ],
+    "hc": [
+      "h23",
+      "",
+      "h12"
+    ]
+  },
+  "locale": "bs"
+}


### PR DESCRIPTION
### TL;DR

Add Bosnian (bs) locale support to DateTimeFormat to fix month formatting issues.

### What changed?

- Added Bosnian (bs) locale to the test locales in BUILD.bazel
- Added Bosnian locale data (bs.json) with proper month names and formatting rules
- Added a test case that verifies Bosnian month formatting works correctly
- Updated the DateTimeFormat.__addLocaleData call to include the new Bosnian locale

### How to test?

Run the new test case that verifies Bosnian month formatting:
```javascript
// Test for issue #4270: Bosnian month formatting
describe('Bosnian month formatting (issue #4270)', function () {
  it('should format with full datetime options including long month', function () {
    const date = new Date(Date.UTC(2024, 10, 15, 14, 30, 45));
    const fmt = new DateTimeFormat('bs-BA', {
      weekday: 'long',
      year: 'numeric',
      month: 'long',
      day: 'numeric',
      hour: 'numeric',
      minute: 'numeric',
      second: 'numeric',
      timeZone: 'UTC',
    });

    const result = fmt.format(date);
    expect(result).toBe('petak, 15. novembar 2024., 14:30:45');
  });
});
```

### Why make this change?

This change fixes issue #4270 where Bosnian month formatting was not working correctly. Previously, Bosnian dates would display month numbers (like "M11") instead of the proper month names (like "novembar"). By adding the Bosnian locale data with correct month names and formatting rules, dates can now be properly formatted in Bosnian.