### PR TITLE
fix(@formatjs/cli-lib): remove ember-template-recast dep

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -658,7 +658,7 @@
         "bzlTransitiveDigest": "Sc7aQa6g7ahlDQkjOmGxXPdCRihodnBqKM4XBOjxPWk=",
         "usagesDigest": "tsxRjH5DN8xUnGoUELCp/xuIp04EwwlFAtYpnGb6Y+4=",
         "recordedFileInputs": {
-          "@@//package.json": "01579317bf34bf6a38e2f1f77e962ce6d895cdf516fe6797fbebef6492b705a3"
+          "@@//package.json": "0e1127a31aee898d2b48949660105c5d50311f05268434913faeaa2dbbdccb21"
         },
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "content-tag": "^4.1.0",
     "conventional-changelog-angular": "^8.1.0",
     "decimal.js": "^10.6.0",
-    "ember-template-recast": "^6.1.5",
     "eslint": "9.39.2",
     "fast-glob": "^3.3.3",
     "fs-extra": "^11.3.3",

--- a/packages/cli-lib/BUILD.bazel
+++ b/packages/cli-lib/BUILD.bazel
@@ -38,7 +38,6 @@ VUE_DEPS = [
 GLIMMER_HBS_DEPS = [
     "//:node_modules/@glimmer/syntax",
     "//:node_modules/content-tag",
-    "//:node_modules/ember-template-recast",
 ]
 
 SRC_DEPS = [
@@ -67,17 +66,9 @@ vitest(
     name = "unit_test",
     srcs = [":srcs"] + glob(
         ["tests/unit/**/*.test.ts"],
-        # TODO: Re-enable these tests after fixing ES module compatibility
-        # with @glimmer/syntax and ember-template-recast
-        exclude = [
-            "tests/unit/gts_extractor.test.ts",
-            "tests/unit/hbs_extractor.test.ts",
-            "tests/unit/vue_extractor.test.ts",
-        ],
     ),
     fixtures = glob(
-        ["tests/unit/**/*"],
-        exclude = ["tests/unit/**/*.test.ts"],
+        ["tests/unit/fixtures/**/*"],
     ),
     deps = SRC_DEPS,
 )
@@ -105,7 +96,6 @@ esbuild(
         "@glimmer/validator",
         "@vue/compiler-core",
         "content-tag",
-        "ember-template-recast",
         "source-map-support",
     ],
     platform = "node",

--- a/packages/cli-lib/package.json
+++ b/packages/cli-lib/package.json
@@ -28,7 +28,6 @@
     "@glimmer/syntax": "^0.84.3 || ^0.95.0",
     "@vue/compiler-core": "3.5.26",
     "content-tag": "^4.1.0",
-    "ember-template-recast": "^6.1.5",
     "vue": "3.5.26"
   },
   "bugs": "https://github.com/formatjs/formatjs/issues",
@@ -68,9 +67,6 @@
       "optional": true
     },
     "@glimmer/validator": {
-      "optional": true
-    },
-    "ember-template-recast": {
       "optional": true
     },
     "content-tag": {

--- a/packages/cli-lib/src/hbs_extractor.ts
+++ b/packages/cli-lib/src/hbs_extractor.ts
@@ -1,6 +1,5 @@
 import {type Opts} from '@formatjs/ts-transformer'
-import type {AST} from '@glimmer/syntax'
-import {transform} from 'ember-template-recast'
+import {preprocess, traverse, type AST, type ASTv1} from '@glimmer/syntax'
 
 function extractText(
   node: AST.MustacheStatement | AST.SubExpression,
@@ -46,18 +45,13 @@ export function parseFile(
   fileName: string,
   options: any
 ): void {
-  let visitor = function () {
-    return {
-      MustacheStatement(node: AST.MustacheStatement) {
-        extractText(node, fileName, options)
-      },
-      SubExpression(node: AST.SubExpression) {
-        extractText(node, fileName, options)
-      },
-    }
-  }
-
-  // SAFETY: ember-template-recast's types are out of date,
-  // but it does not affect runtime
-  transform(source, visitor as any)
+  const ast = preprocess(source)
+  traverse(ast, {
+    MustacheStatement(node: ASTv1.MustacheStatement) {
+      extractText(node, fileName, options)
+    },
+    SubExpression(node: ASTv1.SubExpression) {
+      extractText(node, fileName, options)
+    },
+  })
 }

--- a/packages/cli-lib/tests/unit/__snapshots__/gts_extractor.test.ts.snap
+++ b/packages/cli-lib/tests/unit/__snapshots__/gts_extractor.test.ts.snap
@@ -1,0 +1,87 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`gts_extractor > gjs files 1`] = `
+[
+  {
+    "defaultMessage": "js getter with an id",
+    "id": "getter-message",
+  },
+  {
+    "defaultMessage": "js getter with no id",
+    "id": "hdXT/o",
+  },
+  {
+    "defaultMessage": "G'day!, from a secondary component in the same GJS file",
+    "description": undefined,
+    "id": "FmytR9",
+  },
+  {
+    "defaultMessage": "in template",
+    "description": "in template desc",
+    "id": "7MCO2v",
+  },
+  {
+    "defaultMessage": "{connectorName, select, none {Install Service} other {Install {connectorName}} }",
+    "description": undefined,
+    "id": "lMXYqa",
+  },
+  {
+    "defaultMessage": "{connectorName, select, none {Install Service} other {Install {connectorName}} }",
+    "description": undefined,
+    "id": "lMXYqa",
+  },
+  {
+    "defaultMessage": "Very long message with multiple'' breaklines and multiple spaces '<a href={href}>' Link '</a>'",
+    "description": "Nice description",
+    "id": "mkhWoT",
+  },
+  {
+    "defaultMessage": "Very long message with multiple'' breaklines and multiple spaces '<a href={href}>' Link '</a>'",
+    "description": "Nice description",
+    "id": "mkhWoT",
+  },
+]
+`;
+
+exports[`gts_extractor > gts files 1`] = `
+[
+  {
+    "defaultMessage": "js getter with an id",
+    "id": "getter-message",
+  },
+  {
+    "defaultMessage": "js getter with no id",
+    "id": "hdXT/o",
+  },
+  {
+    "defaultMessage": "hello from a secondary component in the same file",
+    "description": undefined,
+    "id": "o1wtct",
+  },
+  {
+    "defaultMessage": "in template",
+    "description": "in template desc",
+    "id": "7MCO2v",
+  },
+  {
+    "defaultMessage": "{connectorName, select, none {Install Service} other {Install {connectorName}} }",
+    "description": undefined,
+    "id": "lMXYqa",
+  },
+  {
+    "defaultMessage": "{connectorName, select, none {Install Service} other {Install {connectorName}} }",
+    "description": undefined,
+    "id": "lMXYqa",
+  },
+  {
+    "defaultMessage": "Very long message with multiple'' breaklines and multiple spaces '<a href={href}>' Link '</a>'",
+    "description": "Nice description",
+    "id": "mkhWoT",
+  },
+  {
+    "defaultMessage": "Very long message with multiple'' breaklines and multiple spaces '<a href={href}>' Link '</a>'",
+    "description": "Nice description",
+    "id": "mkhWoT",
+  },
+]
+`;

--- a/packages/cli-lib/tests/unit/__snapshots__/hbs_extractor.test.ts.snap
+++ b/packages/cli-lib/tests/unit/__snapshots__/hbs_extractor.test.ts.snap
@@ -1,0 +1,31 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`hbs_extractor 1`] = `
+[
+  {
+    "defaultMessage": "in template",
+    "description": "in template desc",
+    "id": "7MCO2v",
+  },
+  {
+    "defaultMessage": "{connectorName, select, none {Install Service} other {Install {connectorName}} }",
+    "description": undefined,
+    "id": "lMXYqa",
+  },
+  {
+    "defaultMessage": "{connectorName, select, none {Install Service} other {Install {connectorName}} }",
+    "description": undefined,
+    "id": "lMXYqa",
+  },
+  {
+    "defaultMessage": "Very long message with multiple'' breaklines and multiple spaces '<a href={href}>' Link '</a>'",
+    "description": "Nice description",
+    "id": "mkhWoT",
+  },
+  {
+    "defaultMessage": "Very long message with multiple'' breaklines and multiple spaces '<a href={href}>' Link '</a>'",
+    "description": "Nice description",
+    "id": "mkhWoT",
+  },
+]
+`;

--- a/packages/cli-lib/tests/unit/__snapshots__/vue_extractor.test.ts.snap
+++ b/packages/cli-lib/tests/unit/__snapshots__/vue_extractor.test.ts.snap
@@ -1,0 +1,36 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`vue_extractor 1`] = `
+[
+  {
+    "defaultMessage": "in template",
+    "description": "in template desc",
+    "id": "f6d14",
+  },
+  {
+    "defaultMessage": "in script",
+    "description": "in script desc",
+    "id": "1ebd4",
+  },
+]
+`;
+
+exports[`vue_extractor for bind attr 1`] = `
+[
+  {
+    "defaultMessage": "Delete",
+    "description": "delete button text",
+    "id": "0705a",
+  },
+  {
+    "defaultMessage": "Send the item to the trash.",
+    "description": "delete button title",
+    "id": "5b09c",
+  },
+  {
+    "defaultMessage": "The item has been deleted.",
+    "description": "delete result message",
+    "id": "8fba7",
+  },
+]
+`;

--- a/packages/cli-lib/tests/unit/gts_extractor.test.ts
+++ b/packages/cli-lib/tests/unit/gts_extractor.test.ts
@@ -1,13 +1,10 @@
 import {describe, test, expect} from 'vitest'
 import {type MessageDescriptor, interpolateName} from '@formatjs/ts-transformer'
-import {readFile} from 'fs-extra/esm'
+import {readFile} from 'node:fs/promises'
 import {join} from 'path'
 import {parseFile} from '../../src/gts_extractor'
 
-// TODO: Fix ES module compatibility issue with @glimmer/syntax and ember-template-recast
-// These tests are disabled because ember-template-recast uses require() to import @glimmer/syntax
-// which is an ES module, causing "require() of ES Module not supported" errors in Vitest
-describe.skip('gts_extractor', () => {
+describe('gts_extractor', () => {
   test('gts files', async function () {
     let messages: MessageDescriptor[] = []
     const fixturePath = join(__dirname, './fixtures/comp.gts')
@@ -34,48 +31,7 @@ describe.skip('gts_extractor', () => {
           }
         ),
     })
-    expect(messages).toMatchInlineSnapshot(`
-      [
-        {
-          "defaultMessage": "js getter with an id",
-          "id": "getter-message",
-        },
-        {
-          "defaultMessage": "js getter with no id",
-          "id": "hdXT/o",
-        },
-        {
-          "defaultMessage": "hello from a secondary component in the same file",
-          "description": undefined,
-          "id": "o1wtct",
-        },
-        {
-          "defaultMessage": "in template",
-          "description": "in template desc",
-          "id": "7MCO2v",
-        },
-        {
-          "defaultMessage": "{connectorName, select, none {Install Service} other {Install {connectorName}} }",
-          "description": undefined,
-          "id": "lMXYqa",
-        },
-        {
-          "defaultMessage": "{connectorName, select, none {Install Service} other {Install {connectorName}} }",
-          "description": undefined,
-          "id": "lMXYqa",
-        },
-        {
-          "defaultMessage": "Very long message with multiple'' breaklines and multiple spaces '<a href={href}>' Link '</a>'",
-          "description": "Nice description",
-          "id": "mkhWoT",
-        },
-        {
-          "defaultMessage": "Very long message with multiple'' breaklines and multiple spaces '<a href={href}>' Link '</a>'",
-          "description": "Nice description",
-          "id": "mkhWoT",
-        },
-      ]
-    `)
+    expect(messages).toMatchSnapshot()
   })
 
   test('gjs files', async function () {
@@ -104,47 +60,6 @@ describe.skip('gts_extractor', () => {
           }
         ),
     })
-    expect(messages).toMatchInlineSnapshot(`
-      [
-        {
-          "defaultMessage": "js getter with an id",
-          "id": "getter-message",
-        },
-        {
-          "defaultMessage": "js getter with no id",
-          "id": "hdXT/o",
-        },
-        {
-          "defaultMessage": "G'day!, from a secondary component in the same GJS file",
-          "description": undefined,
-          "id": "FmytR9",
-        },
-        {
-          "defaultMessage": "in template",
-          "description": "in template desc",
-          "id": "7MCO2v",
-        },
-        {
-          "defaultMessage": "{connectorName, select, none {Install Service} other {Install {connectorName}} }",
-          "description": undefined,
-          "id": "lMXYqa",
-        },
-        {
-          "defaultMessage": "{connectorName, select, none {Install Service} other {Install {connectorName}} }",
-          "description": undefined,
-          "id": "lMXYqa",
-        },
-        {
-          "defaultMessage": "Very long message with multiple'' breaklines and multiple spaces '<a href={href}>' Link '</a>'",
-          "description": "Nice description",
-          "id": "mkhWoT",
-        },
-        {
-          "defaultMessage": "Very long message with multiple'' breaklines and multiple spaces '<a href={href}>' Link '</a>'",
-          "description": "Nice description",
-          "id": "mkhWoT",
-        },
-      ]
-    `)
+    expect(messages).toMatchSnapshot()
   })
 })

--- a/packages/cli-lib/tests/unit/hbs_extractor.test.ts
+++ b/packages/cli-lib/tests/unit/hbs_extractor.test.ts
@@ -1,13 +1,10 @@
 import {test, expect} from 'vitest'
 import {type MessageDescriptor, interpolateName} from '@formatjs/ts-transformer'
-import {readFile} from 'fs-extra/esm'
+import {readFile} from 'node:fs/promises'
 import {join} from 'path'
 import {parseFile} from '../../src/hbs_extractor'
 
-// TODO: Fix ES module compatibility issue with @glimmer/syntax and ember-template-recast
-// This test is disabled because ember-template-recast uses require() to import @glimmer/syntax
-// which is an ES module, causing "require() of ES Module not supported" errors in Vitest
-test.skip('hbs_extractor', async function () {
+test('hbs_extractor', async function () {
   let messages: MessageDescriptor[] = []
   const fixturePath = join(__dirname, './fixtures/comp.hbs')
   parseFile(await readFile(fixturePath, 'utf8'), fixturePath, {
@@ -33,33 +30,5 @@ test.skip('hbs_extractor', async function () {
         }
       ),
   })
-  expect(messages).toMatchInlineSnapshot(`
-    [
-      {
-        "defaultMessage": "in template",
-        "description": "in template desc",
-        "id": "7MCO2v",
-      },
-      {
-        "defaultMessage": "{connectorName, select, none {Install Service} other {Install {connectorName}} }",
-        "description": undefined,
-        "id": "lMXYqa",
-      },
-      {
-        "defaultMessage": "{connectorName, select, none {Install Service} other {Install {connectorName}} }",
-        "description": undefined,
-        "id": "lMXYqa",
-      },
-      {
-        "defaultMessage": "Very long message with multiple'' breaklines and multiple spaces '<a href={href}>' Link '</a>'",
-        "description": "Nice description",
-        "id": "mkhWoT",
-      },
-      {
-        "defaultMessage": "Very long message with multiple'' breaklines and multiple spaces '<a href={href}>' Link '</a>'",
-        "description": "Nice description",
-        "id": "mkhWoT",
-      },
-    ]
-  `)
+  expect(messages).toMatchSnapshot()
 })

--- a/packages/cli-lib/tests/unit/vue_extractor.test.ts
+++ b/packages/cli-lib/tests/unit/vue_extractor.test.ts
@@ -2,14 +2,14 @@ import {test, expect} from 'vitest'
 import {type MessageDescriptor} from '@formatjs/ts-transformer'
 import {parseScript} from '../../src/parse_script'
 import {parseFile} from '../../src/vue_extractor'
-import {readFile} from 'fs-extra/esm'
 import {join} from 'path'
+import {readFileSync} from 'fs'
 
 test('vue_extractor', async function () {
   let messages: MessageDescriptor[] = []
   const fixturePath = join(__dirname, './fixtures/comp.vue')
   parseFile(
-    await readFile(fixturePath, 'utf8'),
+    readFileSync(fixturePath, 'utf8'),
     fixturePath,
     parseScript({
       additionalFunctionNames: ['$formatMessage'],
@@ -26,7 +26,7 @@ test('vue_extractor for bind attr', async function () {
   let messages: MessageDescriptor[] = []
   const fixturePath = join(__dirname, './fixtures/bind.vue')
   parseFile(
-    await readFile(fixturePath, 'utf8'),
+    readFileSync(fixturePath, 'utf8'),
     fixturePath,
     parseScript({
       additionalFunctionNames: ['$formatMessage'],

--- a/packages/cli/integration-tests/BUILD.bazel
+++ b/packages/cli/integration-tests/BUILD.bazel
@@ -15,7 +15,6 @@ copy_file(
 GLIMMER_HBS_DEPS = [
     "//:node_modules/@glimmer/syntax",
     "//:node_modules/content-tag",
-    "//:node_modules/ember-template-recast",
 ]
 
 # Export fixtures for use by Rust CLI integration tests

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,7 +14,6 @@
     "@glimmer/syntax": "^0.84.3 || ^0.95.0",
     "@vue/compiler-core": "3.5.26",
     "content-tag": "^4.1.0",
-    "ember-template-recast": "^6.1.5",
     "vue": "3.5.26"
   },
   "bin": {
@@ -56,9 +55,6 @@
       "optional": true
     },
     "@glimmer/validator": {
-      "optional": true
-    },
-    "ember-template-recast": {
       "optional": true
     },
     "content-tag": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,9 +237,6 @@ importers:
       decimal.js:
         specifier: ^10.6.0
         version: 10.6.0
-      ember-template-recast:
-        specifier: ^6.1.5
-        version: 6.1.5
       eslint:
         specifier: 9.39.2
         version: 9.39.2(jiti@2.6.1)
@@ -461,9 +458,6 @@ importers:
       content-tag:
         specifier: ^4.1.0
         version: 4.1.0
-      ember-template-recast:
-        specifier: ^6.1.5
-        version: 6.1.5
       vue:
         specifier: 3.5.26
         version: 3.5.26(typescript@5.8.3)
@@ -507,9 +501,6 @@ importers:
       content-tag:
         specifier: ^4.1.0
         version: 4.1.0
-      ember-template-recast:
-        specifier: ^6.1.5
-        version: 6.1.5
       fast-glob:
         specifier: ^3.3.3
         version: 3.3.3
@@ -578,7 +569,7 @@ importers:
         version: 4.0.2
       '@typescript-eslint/utils':
         specifier: ^8.52.0
-        version: 8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.2)
+        version: 8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)
       eslint:
         specifier: '9'
         version: 9.39.2(jiti@2.6.1)
@@ -1035,7 +1026,7 @@ importers:
         version: link:..
       ts-jest:
         specifier: ^29
-        version: 29.4.6(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.2)(jest-util@29.7.0)(jest@29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0))(typescript@5.8.2)
+        version: 29.4.6(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.2)(jest-util@29.7.0)(jest@29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0))(typescript@5.8.3)
 
   packages/utils:
     dependencies:
@@ -2030,9 +2021,6 @@ packages:
   '@glimmer/reference@0.84.3':
     resolution: {integrity: sha512-lV+p/aWPVC8vUjmlvYVU7WQJsLh319SdXuAWoX/SE3pq340BJlAJiEcAc6q52y9JNhT57gMwtjMX96W5Xcx/qw==}
 
-  '@glimmer/syntax@0.84.3':
-    resolution: {integrity: sha512-ioVbTic6ZisLxqTgRBL2PCjYZTFIwobifCustrozRU2xGDiYvVIL0vt25h2c1ioDsX59UgVlDkIK4YTAQQSd2A==}
-
   '@glimmer/syntax@0.95.0':
     resolution: {integrity: sha512-W/PHdODnpONsXjbbdY9nedgIHpglMfOzncf/moLVrKIcCfeQhw2vG07Rs/YW8KeJCgJRCLkQsi+Ix7XvrurGAg==}
 
@@ -2047,9 +2035,6 @@ packages:
 
   '@glimmer/wire-format@0.94.8':
     resolution: {integrity: sha512-A+Cp5m6vZMAEu0Kg/YwU2dJZXyYxVJs2zI57d3CP6NctmX7FsT8WjViiRUmt5abVmMmRH5b8BUovqY6GSMAdrw==}
-
-  '@handlebars/parser@2.0.0':
-    resolution: {integrity: sha512-EP9uEDZv/L5Qh9IWuMUGJRfwhXJ4h1dqKTT4/3+tY0eu7sPis7xh23j61SYUnNF4vqCQvvUXpDo9Bh/+q1zASA==}
 
   '@handlebars/parser@2.2.2':
     resolution: {integrity: sha512-n/SZW+12rwikx/f8YcSv9JCi5p9vn1Bnts9ZtVvfErG4h0gbjHI1H1ZMhVUnaOC7yzFc6PtsCKIK8XeTnL90Gw==}
@@ -3961,12 +3946,6 @@ packages:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
 
-  async-promise-queue@1.0.5:
-    resolution: {integrity: sha512-xi0aQ1rrjPWYmqbwr18rrSKbSaXIeIwSd1J4KAgVfkq8utNbdZoht7GfvfY6swFUAMJ9obkc4WPJmtGwl+B8dw==}
-
-  async@2.6.4:
-    resolution: {integrity: sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==}
-
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
 
@@ -4040,9 +4019,6 @@ packages:
     resolution: {integrity: sha512-a1eIFi4R9ySrbiMuyTGx5e92uRH5tQY6kArNcFaKBUleIoLjdjBg7Zxm3Mqm3Kmkf27HLR/1fnxX9q8GQ7Iavg==}
     engines: {node: '>= 0.6.0'}
 
-  base64-js@1.5.1:
-    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
-
   base64id@2.0.0:
     resolution: {integrity: sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==}
     engines: {node: ^4.5.0 || >= 5.9}
@@ -4057,9 +4033,6 @@ packages:
 
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
-
-  bl@4.1.0:
-    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
   blob@0.0.5:
     resolution: {integrity: sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==}
@@ -4088,9 +4061,6 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
-
-  buffer@5.7.1:
-    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -4231,10 +4201,6 @@ packages:
     peerDependencies:
       cldr-core: 48.1.0
 
-  cli-cursor@3.1.0:
-    resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
-    engines: {node: '>=8'}
-
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
     engines: {node: '>=18'}
@@ -4257,10 +4223,6 @@ packages:
   cliui@9.0.1:
     resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
     engines: {node: '>=20'}
-
-  clone@1.0.4:
-    resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
-    engines: {node: '>=0.8'}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -4289,10 +4251,6 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
-  colors@1.4.0:
-    resolution: {integrity: sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==}
-    engines: {node: '>=0.1.90'}
-
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
@@ -4318,10 +4276,6 @@ packages:
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
-
-  commander@8.3.0:
-    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
-    engines: {node: '>= 12'}
 
   compare-func@2.0.0:
     resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
@@ -4467,14 +4421,6 @@ packages:
     resolution: {integrity: sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==}
     engines: {node: '>=12'}
 
-  debug@2.6.9:
-    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
   debug@3.1.0:
     resolution: {integrity: sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==}
     peerDependencies:
@@ -4537,9 +4483,6 @@ packages:
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
-
-  defaults@1.0.4:
-    resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
 
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
@@ -4619,11 +4562,6 @@ packages:
 
   electron-to-chromium@1.5.267:
     resolution: {integrity: sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==}
-
-  ember-template-recast@6.1.5:
-    resolution: {integrity: sha512-VnRN8FzEHQnw/5rCv6Wnq8MVYXbGQbFY+rEufvWV+FO/IsxMahGEud4MYWtTA2q8iG+qJFrDQefNvQ//7MI7Qw==}
-    engines: {node: 12.* || 14.* || >= 16.*}
-    hasBin: true
 
   emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
@@ -5274,9 +5212,6 @@ packages:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
-  ieee754@1.2.1:
-    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
-
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -5386,10 +5321,6 @@ packages:
 
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
-
-  is-interactive@1.0.0:
-    resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
-    engines: {node: '>=8'}
 
   is-interactive@2.0.0:
     resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
@@ -5929,9 +5860,6 @@ packages:
   lodash.upperfirst@4.3.1:
     resolution: {integrity: sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==}
 
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
-
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
@@ -6433,10 +6361,6 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
-  ora@5.4.1:
-    resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
-    engines: {node: '>=10'}
-
   ora@8.2.0:
     resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
     engines: {node: '>=18'}
@@ -6825,10 +6749,6 @@ packages:
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
-  readable-stream@3.6.2:
-    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
-    engines: {node: '>= 6'}
-
   recast@0.17.6:
     resolution: {integrity: sha512-yoQRMRrK1lszNtbkGyM4kN45AwylV5hMiuEveUBlxytUViWevjvX6w+tzJt1LH4cfUhWt4NZvy3ThIhu6+m5wQ==}
     engines: {node: '>= 4'}
@@ -6949,10 +6869,6 @@ packages:
     resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
     engines: {node: '>= 0.4'}
     hasBin: true
-
-  restore-cursor@3.1.0:
-    resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
-    engines: {node: '>=8'}
 
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
@@ -7268,9 +7184,6 @@ packages:
 
   string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
-
-  string_decoder@1.3.0:
-    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
@@ -7929,9 +7842,6 @@ packages:
     resolution: {integrity: sha512-e6vZvY6xboSwLz2GD36c16+O/2Z6fKvIf4pOXptw2rY9MVwE/TXc6RGqxD3I3x0a28lwBY7DE+76uTPSsBrrCA==}
     engines: {node: '>=10.13.0'}
 
-  wcwidth@1.0.1:
-    resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
-
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
@@ -7993,9 +7903,6 @@ packages:
 
   wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
-
-  workerpool@6.5.1:
-    resolution: {integrity: sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==}
 
   wouter@3.9.0:
     resolution: {integrity: sha512-sF/od/PIgqEQBQcrN7a2x3MX6MQE6nW0ygCfy9hQuUkuB28wEZuu/6M5GyqkrrEu9M6jxdkgE12yDFsQMKos4Q==}
@@ -9269,14 +9176,6 @@ snapshots:
       '@glimmer/util': 0.84.3
       '@glimmer/validator': 0.84.3
 
-  '@glimmer/syntax@0.84.3':
-    dependencies:
-      '@glimmer/env': 0.1.7
-      '@glimmer/interfaces': 0.84.3
-      '@glimmer/util': 0.84.3
-      '@handlebars/parser': 2.0.0
-      simple-html-tokenizer: 0.5.11
-
   '@glimmer/syntax@0.95.0':
     dependencies:
       '@glimmer/env': 0.1.7
@@ -9304,8 +9203,6 @@ snapshots:
   '@glimmer/wire-format@0.94.8':
     dependencies:
       '@glimmer/interfaces': 0.94.6
-
-  '@handlebars/parser@2.0.0': {}
 
   '@handlebars/parser@2.2.2': {}
 
@@ -10916,6 +10813,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/project-service@8.53.0(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.53.0(typescript@5.8.3)
+      '@typescript-eslint/types': 8.53.0
+      debug: 4.4.3
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/rule-tester@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.2)':
     dependencies:
       '@typescript-eslint/parser': 8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.2)
@@ -10939,6 +10845,10 @@ snapshots:
     dependencies:
       typescript: 5.8.2
 
+  '@typescript-eslint/tsconfig-utils@8.53.0(typescript@5.8.3)':
+    dependencies:
+      typescript: 5.8.3
+
   '@typescript-eslint/types@8.53.0': {}
 
   '@typescript-eslint/typescript-estree@8.53.0(typescript@5.8.2)':
@@ -10956,6 +10866,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@8.53.0(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.53.0(typescript@5.8.3)
+      '@typescript-eslint/tsconfig-utils': 8.53.0(typescript@5.8.3)
+      '@typescript-eslint/types': 8.53.0
+      '@typescript-eslint/visitor-keys': 8.53.0
+      debug: 4.4.3
+      minimatch: 9.0.5
+      semver: 7.7.3
+      tinyglobby: 0.2.15
+      ts-api-utils: 2.4.0(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/utils@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
@@ -10964,6 +10889,17 @@ snapshots:
       '@typescript-eslint/typescript-estree': 8.53.0(typescript@5.8.2)
       eslint: 9.39.2(jiti@2.6.1)
       typescript: 5.8.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
+      '@typescript-eslint/scope-manager': 8.53.0
+      '@typescript-eslint/types': 8.53.0
+      '@typescript-eslint/typescript-estree': 8.53.0(typescript@5.8.3)
+      eslint: 9.39.2(jiti@2.6.1)
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -11339,17 +11275,6 @@ snapshots:
 
   astring@1.9.0: {}
 
-  async-promise-queue@1.0.5:
-    dependencies:
-      async: 2.6.4
-      debug: 2.6.9
-    transitivePeerDependencies:
-      - supports-color
-
-  async@2.6.4:
-    dependencies:
-      lodash: 4.17.21
-
   async@3.2.6: {}
 
   asynckit@0.4.0: {}
@@ -11462,8 +11387,6 @@ snapshots:
 
   base64-arraybuffer@0.1.4: {}
 
-  base64-js@1.5.1: {}
-
   base64id@2.0.0: {}
 
   baseline-browser-mapping@2.9.14: {}
@@ -11473,12 +11396,6 @@ snapshots:
       safe-buffer: 5.1.2
 
   before-after-hook@4.0.0: {}
-
-  bl@4.1.0:
-    dependencies:
-      buffer: 5.7.1
-      inherits: 2.0.4
-      readable-stream: 3.6.2
 
   blob@0.0.5: {}
 
@@ -11512,11 +11429,6 @@ snapshots:
       node-int64: 0.4.0
 
   buffer-from@1.1.2: {}
-
-  buffer@5.7.1:
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
 
   cac@6.7.14: {}
 
@@ -11642,10 +11554,6 @@ snapshots:
     dependencies:
       cldr-core: 48.1.0
 
-  cli-cursor@3.1.0:
-    dependencies:
-      restore-cursor: 3.1.0
-
   cli-cursor@5.0.0:
     dependencies:
       restore-cursor: 5.1.0
@@ -11672,8 +11580,6 @@ snapshots:
       strip-ansi: 7.1.2
       wrap-ansi: 9.0.2
 
-  clone@1.0.4: {}
-
   clsx@2.1.1: {}
 
   co@4.6.0: {}
@@ -11694,8 +11600,6 @@ snapshots:
 
   color-name@1.1.4: {}
 
-  colors@1.4.0: {}
-
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
@@ -11711,8 +11615,6 @@ snapshots:
   commander@2.20.3: {}
 
   commander@4.1.1: {}
-
-  commander@8.3.0: {}
 
   compare-func@2.0.0:
     dependencies:
@@ -11876,10 +11778,6 @@ snapshots:
       whatwg-url: 11.0.0
     optional: true
 
-  debug@2.6.9:
-    dependencies:
-      ms: 2.0.0
-
   debug@3.1.0:
     dependencies:
       ms: 2.0.0
@@ -11916,10 +11814,6 @@ snapshots:
   deepmerge-ts@7.1.5: {}
 
   deepmerge@4.3.1: {}
-
-  defaults@1.0.4:
-    dependencies:
-      clone: 1.0.4
 
   define-data-property@1.1.4:
     dependencies:
@@ -11987,22 +11881,6 @@ snapshots:
       fast-check: 3.23.2
 
   electron-to-chromium@1.5.267: {}
-
-  ember-template-recast@6.1.5:
-    dependencies:
-      '@glimmer/reference': 0.84.3
-      '@glimmer/syntax': 0.84.3
-      '@glimmer/validator': 0.84.3
-      async-promise-queue: 1.0.5
-      colors: 1.4.0
-      commander: 8.3.0
-      globby: 11.1.0
-      ora: 5.4.1
-      slash: 3.0.0
-      tmp: 0.2.5
-      workerpool: 6.5.1
-    transitivePeerDependencies:
-      - supports-color
 
   emittery@0.13.1: {}
 
@@ -12881,8 +12759,6 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  ieee754@1.2.1: {}
-
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -12958,8 +12834,6 @@ snapshots:
       is-extglob: 2.1.1
 
   is-hexadecimal@2.0.1: {}
-
-  is-interactive@1.0.0: {}
 
   is-interactive@2.0.0: {}
 
@@ -13635,8 +13509,6 @@ snapshots:
   lodash.uniq@4.5.0: {}
 
   lodash.upperfirst@4.3.1: {}
-
-  lodash@4.17.21: {}
 
   log-symbols@4.1.0:
     dependencies:
@@ -14445,18 +14317,6 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
-  ora@5.4.1:
-    dependencies:
-      bl: 4.1.0
-      chalk: 4.1.2
-      cli-cursor: 3.1.0
-      cli-spinners: 2.9.2
-      is-interactive: 1.0.0
-      is-unicode-supported: 0.1.0
-      log-symbols: 4.1.0
-      strip-ansi: 6.0.1
-      wcwidth: 1.0.1
-
   ora@8.2.0:
     dependencies:
       chalk: 5.6.2
@@ -14857,12 +14717,6 @@ snapshots:
       string_decoder: 1.1.1
       util-deprecate: 1.0.2
 
-  readable-stream@3.6.2:
-    dependencies:
-      inherits: 2.0.4
-      string_decoder: 1.3.0
-      util-deprecate: 1.0.2
-
   recast@0.17.6:
     dependencies:
       ast-types: 0.12.4
@@ -15061,11 +14915,6 @@ snapshots:
       is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
-
-  restore-cursor@3.1.0:
-    dependencies:
-      onetime: 5.1.2
-      signal-exit: 3.0.7
 
   restore-cursor@5.1.0:
     dependencies:
@@ -15436,10 +15285,6 @@ snapshots:
     dependencies:
       safe-buffer: 5.1.2
 
-  string_decoder@1.3.0:
-    dependencies:
-      safe-buffer: 5.2.1
-
   stringify-entities@4.0.4:
     dependencies:
       character-entities-html4: 2.1.0
@@ -15678,6 +15523,10 @@ snapshots:
     dependencies:
       typescript: 5.8.2
 
+  ts-api-utils@2.4.0(typescript@5.8.3):
+    dependencies:
+      typescript: 5.8.3
+
   ts-interface-checker@0.1.13: {}
 
   ts-jest@29.4.6(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.2)(jest-util@29.7.0)(jest@29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0))(typescript@5.8.2):
@@ -15692,6 +15541,27 @@ snapshots:
       semver: 7.7.3
       type-fest: 4.41.0
       typescript: 5.8.2
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.28.6
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.28.6)
+      esbuild: 0.27.2
+      jest-util: 29.7.0
+
+  ts-jest@29.4.6(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.2)(jest-util@29.7.0)(jest@29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0))(typescript@5.8.3):
+    dependencies:
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      handlebars: 4.7.8
+      jest: 29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.7.3
+      type-fest: 4.41.0
+      typescript: 5.8.3
       yargs-parser: 21.1.1
     optionalDependencies:
       '@babel/core': 7.28.6
@@ -15759,8 +15629,7 @@ snapshots:
 
   typescript@5.8.2: {}
 
-  typescript@5.8.3:
-    optional: true
+  typescript@5.8.3: {}
 
   typesense@2.1.0(@babel/runtime@7.28.6):
     dependencies:
@@ -16120,10 +15989,6 @@ snapshots:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
 
-  wcwidth@1.0.1:
-    dependencies:
-      defaults: 1.0.4
-
   web-namespaces@2.0.1: {}
 
   webidl-conversions@7.0.0:
@@ -16197,8 +16062,6 @@ snapshots:
   word-wrap@1.2.5: {}
 
   wordwrap@1.0.0: {}
-
-  workerpool@6.5.1: {}
 
   wouter@3.9.0(react@19.2.3):
     dependencies:


### PR DESCRIPTION
### TL;DR

Replace `ember-template-recast` with direct usage of `@glimmer/syntax` for Handlebars template parsing.

### What changed?

- Removed `ember-template-recast` dependency from all packages
- Modified `hbs_extractor.ts` to use `@glimmer/syntax` directly for parsing Handlebars templates
- Re-enabled previously disabled tests for Glimmer/Handlebars template extraction
- Updated test snapshots to reflect the new implementation
- Changed file system imports to use Node.js native `fs/promises` instead of `fs-extra/esm`

### How to test?

1. Run the unit tests for the Handlebars and GTS extractors:
   ```
   bazel test //packages/cli-lib:unit_test
   ```
2. Verify that the previously disabled tests now pass
3. Test the CLI with Handlebars templates to ensure extraction still works correctly

### Why make this change?

The `ember-template-recast` package was causing compatibility issues with ES modules, as it uses CommonJS `require()` to import `@glimmer/syntax` which is an ES module. This was preventing tests from running properly in the test environment. 

By directly using `@glimmer/syntax` for parsing Handlebars templates, we eliminate this compatibility issue while maintaining the same functionality. This change simplifies our dependencies and fixes the ES module compatibility problems that were previously causing tests to be disabled.