### PR TITLE
fix(eslint-plugin-formatjs): fix emoji false positives, fix #5957

### DIFF
--- a/packages/eslint-plugin-formatjs/BUILD.bazel
+++ b/packages/eslint-plugin-formatjs/BUILD.bazel
@@ -60,6 +60,7 @@ SRC_DEPS = [
     ":node_modules/picomatch",
     "//:node_modules/@types/node",
     "//:node_modules/@typescript-eslint/utils",
+    "//:node_modules/@unicode/unicode-17.0.0",
     "//:node_modules/eslint",
     "//:node_modules/typescript",
 ]

--- a/packages/eslint-plugin-formatjs/package.json
+++ b/packages/eslint-plugin-formatjs/package.json
@@ -11,6 +11,7 @@
     "@formatjs/ts-transformer": "workspace:*",
     "@types/picomatch": "^4.0.0",
     "@typescript-eslint/utils": "^8.52.0",
+    "@unicode/unicode-17.0.0": "^1.6.16",
     "magic-string": "^0.30.0",
     "picomatch": "2 || 3 || 4",
     "tslib": "^2.8.1"

--- a/packages/eslint-plugin-formatjs/tests/no-emoji.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/no-emoji.test.ts
@@ -4,6 +4,87 @@ import {rule, name} from '../rules/no-emoji.js'
 ruleTester.run(name, rule, {
   valid: [
     {
+      // Digits should NOT be flagged as emoji (issue #5957)
+      code: `import {defineMessage} from 'react-intl'
+  defineMessage({
+      defaultMessage: 'Step 1 of 5',
+      description: 'asd'
+  })`,
+      options: [],
+    },
+    {
+      // Hash symbol should NOT be flagged as emoji (issue #5957)
+      code: `import {defineMessage} from 'react-intl'
+  defineMessage({
+      defaultMessage: 'Use #hashtag',
+      description: 'asd'
+  })`,
+      options: [],
+    },
+    {
+      // Asterisk should NOT be flagged as emoji (issue #5957)
+      code: `import {defineMessage} from 'react-intl'
+  defineMessage({
+      defaultMessage: 'Required field *',
+      description: 'asd'
+  })`,
+      options: [],
+    },
+    {
+      // All digits should NOT be flagged (issue #5957)
+      code: `import {defineMessage} from 'react-intl'
+  defineMessage({
+      defaultMessage: 'Numbers: 0123456789',
+      description: 'asd'
+  })`,
+      options: [],
+    },
+    {
+      // Phone numbers should NOT be flagged (issue #5957)
+      code: `import {defineMessage} from 'react-intl'
+  defineMessage({
+      defaultMessage: 'Call us at 1-800-555-1234',
+      description: 'asd'
+  })`,
+      options: [],
+    },
+    {
+      // Copyright and trademark symbols (issue #5957)
+      code: `import {defineMessage} from 'react-intl'
+  defineMessage({
+      defaultMessage: '© 2024 Company. All rights reserved.',
+      description: 'asd'
+  })`,
+      options: [],
+    },
+    {
+      // Mixed text with #, *, and digits (issue #5957)
+      code: `import {defineMessage} from 'react-intl'
+  defineMessage({
+      defaultMessage: 'Task #1: Complete * 5 items',
+      description: 'asd'
+  })`,
+      options: [],
+    },
+    {
+      // Keycap symbols without variation selector (issue #5957)
+      code: `import {defineMessage} from 'react-intl'
+  defineMessage({
+      defaultMessage: 'Press # to continue',
+      description: 'asd'
+  })`,
+      options: [],
+    },
+    {
+      // Text with plain text arrows (issue #5957)
+      code: `import {defineMessage} from 'react-intl'
+  defineMessage({
+      defaultMessage: 'Go to Settings -> Profile',
+      description: 'asd'
+  })`,
+      options: [],
+    },
+    {
       code: `import {defineMessage} from 'react-intl'
   defineMessage({
       defaultMessage: 'a 😀',
@@ -64,12 +145,122 @@ ruleTester.run(name, rule, {
   })`,
       options: [{versionAbove: '12.0'}],
     },
+    {
+      // Unicode v0.6 - Smiling face - old emoji
+      code: `import {defineMessage} from 'react-intl'
+  defineMessage({
+      defaultMessage: 'a ☺',
+      description: 'asd'
+  })`,
+      options: [{versionAbove: '1.0'}],
+    },
+    {
+      // Unicode v1.0 - Grinning face
+      code: `import {defineMessage} from 'react-intl'
+  defineMessage({
+      defaultMessage: 'a 😀',
+      description: 'asd'
+  })`,
+      options: [{versionAbove: '3.0'}],
+    },
+    {
+      // Unicode v3.0 - Rolling on floor laughing
+      code: `import {defineMessage} from 'react-intl'
+  defineMessage({
+      defaultMessage: 'a 🤣',
+      description: 'asd'
+  })`,
+      options: [{versionAbove: '12.0'}],
+    },
+    {
+      // Unicode v12.0 - Yawning face (at threshold)
+      code: `import {defineMessage} from 'react-intl'
+  defineMessage({
+      defaultMessage: 'a 🥱',
+      description: 'asd'
+  })`,
+      options: [{versionAbove: '12.0'}],
+    },
+    {
+      // Unicode v13.0 - Smiling face with tear (valid with v14.0 threshold)
+      code: `import {defineMessage} from 'react-intl'
+  defineMessage({
+      defaultMessage: 'a 🥲',
+      description: 'asd'
+  })`,
+      options: [{versionAbove: '14.0'}],
+    },
+    {
+      // Unicode v14.0 - Melting face (valid with v15.0 threshold)
+      code: `import {defineMessage} from 'react-intl'
+  defineMessage({
+      defaultMessage: 'a 🫠',
+      description: 'asd'
+  })`,
+      options: [{versionAbove: '15.0'}],
+    },
   ],
   invalid: [
     {
       code: `import {defineMessage} from 'react-intl'
   defineMessage({
       defaultMessage: 'a 😀',
+      description: 'asd'
+  })`,
+      options: [],
+      errors: [
+        {
+          messageId: 'notAllowed',
+        },
+      ],
+    },
+    {
+      // Variation selector emoji SHOULD be detected (issue #5957)
+      code: `import {defineMessage} from 'react-intl'
+  defineMessage({
+      defaultMessage: 'I ❤️ this',
+      description: 'asd'
+  })`,
+      options: [],
+      errors: [
+        {
+          messageId: 'notAllowed',
+        },
+      ],
+    },
+    {
+      // Sun with variation selector SHOULD be detected (issue #5957)
+      code: `import {defineMessage} from 'react-intl'
+  defineMessage({
+      defaultMessage: 'Sunny day ☀️',
+      description: 'asd'
+  })`,
+      options: [],
+      errors: [
+        {
+          messageId: 'notAllowed',
+        },
+      ],
+    },
+    {
+      // Mixed content: digits should not trigger, but emoji should (issue #5957)
+      code: `import {defineMessage} from 'react-intl'
+  defineMessage({
+      defaultMessage: 'Step 1: Click 😀',
+      description: 'asd'
+  })`,
+      options: [],
+      errors: [
+        {
+          messageId: 'notAllowed',
+        },
+      ],
+    },
+    {
+      // Mixed content: # should not trigger, but emoji should (issue #5957)
+      code: `import {defineMessage} from 'react-intl'
+  defineMessage({
+      defaultMessage: 'Use #hashtag with 🎉',
       description: 'asd'
   })`,
       options: [],
@@ -174,6 +365,76 @@ ruleTester.run(name, rule, {
       errors: [
         {
           messageId: 'notAllowed',
+        },
+      ],
+    },
+    {
+      // Unicode v1.0 - Grinning face (blocked with v0.6 threshold)
+      code: `import {defineMessage} from 'react-intl'
+  defineMessage({
+      defaultMessage: 'a 😀',
+      description: 'asd'
+  })`,
+      options: [{versionAbove: '0.6'}],
+      errors: [
+        {
+          messageId: 'notAllowedAboveVersion',
+        },
+      ],
+    },
+    {
+      // Unicode v3.0 - Rolling on floor laughing (blocked with v1.0 threshold)
+      code: `import {defineMessage} from 'react-intl'
+  defineMessage({
+      defaultMessage: 'a 🤣',
+      description: 'asd'
+  })`,
+      options: [{versionAbove: '1.0'}],
+      errors: [
+        {
+          messageId: 'notAllowedAboveVersion',
+        },
+      ],
+    },
+    {
+      // Unicode v12.0 - Yawning face (blocked with v3.0 threshold)
+      code: `import {defineMessage} from 'react-intl'
+  defineMessage({
+      defaultMessage: 'a 🥱',
+      description: 'asd'
+  })`,
+      options: [{versionAbove: '3.0'}],
+      errors: [
+        {
+          messageId: 'notAllowedAboveVersion',
+        },
+      ],
+    },
+    {
+      // Unicode v14.0 - Melting face (blocked with v13.0 threshold)
+      code: `import {defineMessage} from 'react-intl'
+  defineMessage({
+      defaultMessage: 'a 🫠',
+      description: 'asd'
+  })`,
+      options: [{versionAbove: '13.0'}],
+      errors: [
+        {
+          messageId: 'notAllowedAboveVersion',
+        },
+      ],
+    },
+    {
+      // Unicode v15.0 - Donkey (blocked with v13.0 threshold)
+      code: `import {defineMessage} from 'react-intl'
+  defineMessage({
+      defaultMessage: 'a 🫏',
+      description: 'asd'
+  })`,
+      options: [{versionAbove: '13.0'}],
+      errors: [
+        {
+          messageId: 'notAllowedAboveVersion',
         },
       ],
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -557,7 +557,10 @@ importers:
         version: 4.0.2
       '@typescript-eslint/utils':
         specifier: ^8.52.0
-        version: 8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.2)
+        version: 8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)
+      '@unicode/unicode-17.0.0':
+        specifier: ^1.6.16
+        version: 1.6.16
       eslint:
         specifier: '9'
         version: 9.39.2(jiti@2.6.1)
@@ -1014,7 +1017,7 @@ importers:
         version: link:..
       ts-jest:
         specifier: ^29
-        version: 29.4.6(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.2)(jest-util@29.7.0)(jest@29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0))(typescript@5.8.2)
+        version: 29.4.6(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.2)(jest-util@29.7.0)(jest@29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0))(typescript@5.8.3)
 
   packages/utils:
     dependencies:
@@ -10778,6 +10781,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/project-service@8.53.0(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.53.0(typescript@5.8.3)
+      '@typescript-eslint/types': 8.53.0
+      debug: 4.4.3
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/rule-tester@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.2)':
     dependencies:
       '@typescript-eslint/parser': 8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.2)
@@ -10801,6 +10813,10 @@ snapshots:
     dependencies:
       typescript: 5.8.2
 
+  '@typescript-eslint/tsconfig-utils@8.53.0(typescript@5.8.3)':
+    dependencies:
+      typescript: 5.8.3
+
   '@typescript-eslint/types@8.53.0': {}
 
   '@typescript-eslint/typescript-estree@8.53.0(typescript@5.8.2)':
@@ -10818,6 +10834,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@8.53.0(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.53.0(typescript@5.8.3)
+      '@typescript-eslint/tsconfig-utils': 8.53.0(typescript@5.8.3)
+      '@typescript-eslint/types': 8.53.0
+      '@typescript-eslint/visitor-keys': 8.53.0
+      debug: 4.4.3
+      minimatch: 9.0.5
+      semver: 7.7.3
+      tinyglobby: 0.2.15
+      ts-api-utils: 2.4.0(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/utils@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
@@ -10826,6 +10857,17 @@ snapshots:
       '@typescript-eslint/typescript-estree': 8.53.0(typescript@5.8.2)
       eslint: 9.39.2(jiti@2.6.1)
       typescript: 5.8.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
+      '@typescript-eslint/scope-manager': 8.53.0
+      '@typescript-eslint/types': 8.53.0
+      '@typescript-eslint/typescript-estree': 8.53.0(typescript@5.8.3)
+      eslint: 9.39.2(jiti@2.6.1)
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -15446,6 +15488,10 @@ snapshots:
     dependencies:
       typescript: 5.8.2
 
+  ts-api-utils@2.4.0(typescript@5.8.3):
+    dependencies:
+      typescript: 5.8.3
+
   ts-interface-checker@0.1.13: {}
 
   ts-jest@29.4.6(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.2)(jest-util@29.7.0)(jest@29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0))(typescript@5.8.2):
@@ -15460,6 +15506,27 @@ snapshots:
       semver: 7.7.3
       type-fest: 4.41.0
       typescript: 5.8.2
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.28.6
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.28.6)
+      esbuild: 0.27.2
+      jest-util: 29.7.0
+
+  ts-jest@29.4.6(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.2)(jest-util@29.7.0)(jest@29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0))(typescript@5.8.3):
+    dependencies:
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      handlebars: 4.7.8
+      jest: 29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.7.3
+      type-fest: 4.41.0
+      typescript: 5.8.3
       yargs-parser: 21.1.1
     optionalDependencies:
       '@babel/core': 7.28.6
@@ -15527,8 +15594,7 @@ snapshots:
 
   typescript@5.8.2: {}
 
-  typescript@5.8.3:
-    optional: true
+  typescript@5.8.3: {}
 
   typesense@2.1.0(@babel/runtime@7.28.6):
     dependencies:


### PR DESCRIPTION
### TL;DR

Fix emoji detection in eslint-plugin-formatjs to avoid false positives from non-emoji characters like #, *, digits, and text symbols.

### What changed?

- Replaced the generic `\p{Emoji}` regex with Unicode 17.0.0's `Emoji_Presentation` property data
- Added detection for variation selector characters (U+FE0F) to properly identify emoji like ❤️ and ☀️
- Updated the `hasEmoji()` and `extractEmojis()` functions to use the new detection approach
- Added comprehensive test cases for various emoji versions and edge cases
- Added dependency on `@unicode/unicode-17.0.0` package

### How to test?

- Verify that digits (0-9), special characters (#, *), and text symbols (©, ™, ®) are no longer falsely detected as emoji
- Confirm that variation selector emoji (❤️, ☀️) are properly detected
- Test with emoji from different Unicode versions to ensure correct version detection
- Check that emoji filtering by version works correctly

### Why make this change?

Fixes issue #5957 where the previous emoji detection was too broad, incorrectly flagging common characters like digits, hashtags, and asterisks as emoji. This caused false positives in the `no-emoji` ESLint rule, leading to unnecessary warnings for messages containing these characters. The new implementation provides more accurate emoji detection while maintaining support for all actual emoji characters.