### PR TITLE
build: fix deps

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -658,7 +658,7 @@
         "bzlTransitiveDigest": "Sc7aQa6g7ahlDQkjOmGxXPdCRihodnBqKM4XBOjxPWk=",
         "usagesDigest": "tsxRjH5DN8xUnGoUELCp/xuIp04EwwlFAtYpnGb6Y+4=",
         "recordedFileInputs": {
-          "@@//package.json": "b1a7aa6e853d5350f972baf1ab9217447dcfc6a60bab692a1e599e5841d00026"
+          "@@//package.json": "332e9ecf220c9fee69cf0122a9bf70f94641176aab3e0890b409afad61e7f868"
         },
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "@types/babel__core": "^7.20.5",
     "@types/babel__helper-plugin-utils": "^7.10.3",
     "@types/babel__traverse": "^7.28.0",
-    "@types/eslint-scope": "^8.3.2",
     "@types/estree": "^1.0.8",
     "@types/fs-extra": "^11.0.4",
     "@types/lodash-es": "^4.17.12",
@@ -173,6 +172,11 @@
       "ember-template-recast": {
         "dependencies": {
           "commander": "*"
+        }
+      },
+      "vue-eslint-parser": {
+        "dependencies": {
+          "@types/eslint-scope": "*"
         }
       }
     },

--- a/packages/eslint-plugin-formatjs/BUILD.bazel
+++ b/packages/eslint-plugin-formatjs/BUILD.bazel
@@ -86,7 +86,6 @@ vitest(
     name = "unit_test",
     srcs = TESTS_BASE_SRCS + TEST_FILES,
     deps = SRC_DEPS + [
-        "//:node_modules/@types/eslint-scope",
         "//:node_modules/@typescript-eslint/parser",
         "//:node_modules/@typescript-eslint/rule-tester",
         "//:node_modules/vue-eslint-parser",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,7 +4,7 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-packageExtensionsChecksum: sha256-2u00D5OhHo4rE/oPfx/aF32sOJVYrgcITsFTfXRlaIw=
+packageExtensionsChecksum: sha256-lB61RuxLdvGVr0QvezZ6n1sxn81KdCiQ1gEg/OQvN2U=
 
 patchedDependencies:
   '@types/mdx':
@@ -126,9 +126,6 @@ importers:
       '@types/babel__traverse':
         specifier: ^7.28.0
         version: 7.28.0
-      '@types/eslint-scope':
-        specifier: ^8.3.2
-        version: 8.3.2
       '@types/estree':
         specifier: ^1.0.8
         version: 1.0.8
@@ -3427,17 +3424,11 @@ packages:
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
 
-  '@types/eslint-scope@8.3.2':
-    resolution: {integrity: sha512-ygPtnKRQjbXB6LKQ+m6SLyZDMgFeQFVNCkjUK/HivS58Ce6JBjxpVzHbE1+RS6pC5fP4FQg4qh8lvVSm2oxYZw==}
-
   '@types/eslint@7.29.0':
     resolution: {integrity: sha512-VNcvioYDH8/FxaeTKkM4/TiTwt6pBV9E3OfGmvaw8tPl0rrHCJ4Ll15HRT+pMiFAf/MLQvAzC+6RzUMEL9Ceng==}
 
   '@types/eslint@9.6.1':
     resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
-
-  '@types/esrecurse@4.3.1':
-    resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
@@ -4689,10 +4680,6 @@ packages:
   eslint-visitor-keys@4.2.1:
     resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  eslint-visitor-keys@5.0.0:
-    resolution: {integrity: sha512-A0XeIi7CXU7nPlfHS9loMYEKxUaONu/hTEzHTGba9Huu94Cq1hPivf+DE5erJozZOky0LfvXAyrV/tcswpLI0Q==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   eslint@9.39.2:
     resolution: {integrity: sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==}
@@ -10620,13 +10607,6 @@ snapshots:
       '@types/eslint': 9.6.1
       '@types/estree': 1.0.8
 
-  '@types/eslint-scope@8.3.2':
-    dependencies:
-      '@types/eslint': 9.6.1
-      '@types/esrecurse': 4.3.1
-      '@types/estree': 1.0.8
-      eslint-visitor-keys: 5.0.0
-
   '@types/eslint@7.29.0':
     dependencies:
       '@types/estree': 1.0.8
@@ -10636,8 +10616,6 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
       '@types/json-schema': 7.0.15
-
-  '@types/esrecurse@4.3.1': {}
 
   '@types/estree-jsx@1.0.5':
     dependencies:
@@ -12049,8 +12027,6 @@ snapshots:
   eslint-visitor-keys@3.4.3: {}
 
   eslint-visitor-keys@4.2.1: {}
-
-  eslint-visitor-keys@5.0.0: {}
 
   eslint@9.39.2(jiti@2.6.1):
     dependencies:
@@ -15895,6 +15871,7 @@ snapshots:
 
   vue-eslint-parser@10.2.0(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
+      '@types/eslint-scope': 3.7.7
       debug: 4.4.3
       eslint: 9.39.2(jiti@2.6.1)
       eslint-scope: 8.4.0


### PR DESCRIPTION
### TL;DR

Move `@types/eslint-scope` from root dependencies to `vue-eslint-parser` package extension.

### What changed?

- Removed `@types/eslint-scope` from the root `package.json` dependencies
- Added `@types/eslint-scope` as a dependency in the `vue-eslint-parser` package extension
- Updated the Bazel build file for `eslint-plugin-formatjs` to remove the direct dependency on `@types/eslint-scope`
- Updated lock files to reflect these changes

### How to test?

1. Run `pnpm install` to verify the dependency resolution works correctly
2. Build the `eslint-plugin-formatjs` package to ensure it compiles without errors
3. Run tests for the affected packages to ensure functionality is maintained

### Why make this change?

This change improves dependency management by moving the `@types/eslint-scope` type definition to where it's actually needed - as a dependency of `vue-eslint-parser`. This follows the principle of keeping dependencies scoped to the packages that require them rather than adding them to the root dependencies.