### PR TITLE
feat(formatjs_cli): add base62 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "formatjs_cli"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "base64",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1966,10 +1966,10 @@
         "bzlTransitiveDigest": "z2M3+XLYXYfqQcsjpzig9AXjoCtdl+ltikYxXCQ6Y9Q=",
         "usagesDigest": "+2oxp30n7U2iCRyiQVVvn9Dm9XZaeUlnwnAuV9gqyVs=",
         "recordedFileInputs": {
-          "@@//Cargo.lock": "d56cc18f5f84fb4e07c77824ea085da3b67f0e3207d639a793ed8006362402f3",
+          "@@//Cargo.lock": "a2c55e23c199b995f98f222d3fe58bd1d9a6f9672d80602f587237f8f31bd526",
           "@@//Cargo.toml": "4e0e0629ddbf521db0ad31e9ad8cd8805f29b141f7edaaa560af34e5f325f882",
           "@@//MODULE.bazel": "69e68bc92ee5fb9b6cfab9c606886646298b57cd37e78763d6b8ef22b4d77d40",
-          "@@//crates/formatjs_cli/Cargo.toml": "75422a60b533c2a75402de5c97721377b656fb4dae2eb877a01afb3dbcb0e61a",
+          "@@//crates/formatjs_cli/Cargo.toml": "43e6cbae0c680bd6549f688a2a50bba5d4ab47c8fd526ae539193c36b07c4b49",
           "@@//crates/icu_messageformat_parser/Cargo.toml": "9a3bc46e71f0aeffb992d30028167369ba852816f7b1416c70d78ca511d6967f",
           "@@//crates/icu_skeleton_parser/Cargo.toml": "eac4ca44b47b0fde5ae7f4afcdb6e7d4951eac75eb44db7349b2ba912a9840da",
           "@@//packages/icu-messageformat-parser/integration-tests/Cargo.toml": "4068f7ef5d7095eb8ef3bd392e3200e3e4f60a13fea2e462a3c24b0fbfe2516c",

--- a/crates/formatjs_cli/Cargo.toml
+++ b/crates/formatjs_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "formatjs_cli"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2024"
 authors = ["FormatJS Team", "Long Ho <holevietlong@gmail.com>"]
 description = "Command-line interface for FormatJS - A Rust-based CLI for internationalization"


### PR DESCRIPTION
### TL;DR

Added support for base62 encoding in message ID generation to provide alphanumeric-only IDs.

### What changed?

- Implemented a new `encode_base62` function to encode hash digests using only alphanumeric characters (0-9, A-Z, a-z)
- Updated the `generate_id` function to support three distinct encoding options:
  - `base64`: Standard base64 encoding (may contain +/)
  - `base64url`: URL-safe base64 encoding (uses -_ instead of +/)
  - `base62`: Alphanumeric-only encoding (0-9, A-Z, a-z)
- Added comprehensive tests for the new base62 encoding and clarified differences between encoding types
- Fixed documentation to reflect the new encoding options

### How to test?

Run the new tests that verify:
- Base62 encoding produces alphanumeric-only IDs
- Base62 IDs are deterministic (same input produces same ID)
- Base62 encoding produces different output than base64 and hex
- Base62 encoding works with various ID lengths

You can also manually test by running the CLI with a pattern like:
```
formatjs extract --id-interpolation-pattern "[sha512:contenthash:base62:10]" --out-file messages.json source.js
```

### Why make this change?

Base62 encoding provides several advantages:
- Creates IDs that are alphanumeric-only, making them safer to use in various contexts
- Avoids special characters (+/=) from base64 and base64url that might require escaping in some environments
- Provides a more compact representation than hex encoding while maintaining compatibility with systems that only support alphanumeric characters