### PR TITLE
build: rm tsx, use --experimental-transform-types

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -658,7 +658,7 @@
         "bzlTransitiveDigest": "Sc7aQa6g7ahlDQkjOmGxXPdCRihodnBqKM4XBOjxPWk=",
         "usagesDigest": "tsxRjH5DN8xUnGoUELCp/xuIp04EwwlFAtYpnGb6Y+4=",
         "recordedFileInputs": {
-          "@@//package.json": "2178e8a1103bec6a10d6d258eeaf634706c3c0353c21384cef9726993c6e4321"
+          "@@//package.json": "43626c95790bc502314f812381ea42b9abfafdbfbb14a71648ee098a2daff813"
         },
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/package.json
+++ b/package.json
@@ -119,7 +119,6 @@
     "ts-loader": "^9.5.4",
     "tsd": "^0.33.0",
     "tslib": "^2.8.1",
-    "tsx": "^4.21.0",
     "typescript": "5.8.2",
     "typesense": "2.1.0",
     "unidiff": "^1.0.4",

--- a/packages/babel-plugin-formatjs/integration-tests/vue/integration.test.ts
+++ b/packages/babel-plugin-formatjs/integration-tests/vue/integration.test.ts
@@ -51,7 +51,7 @@ test('dummy', async function () {
           throw new Error('err compiling')
         }
         const outFile = join(
-          statsJson.outputPath || __dirname,
+          statsJson.outputPath || import.meta.dirname,
           statsJson.assets?.[0].name || 'out.js'
         )
         expect(readFileSync(outFile, 'utf-8')).toContain(

--- a/packages/babel-plugin-formatjs/tests/index.test.ts
+++ b/packages/babel-plugin-formatjs/tests/index.test.ts
@@ -5,7 +5,7 @@ import plugin from '../index.js'
 import {type Options, type ExtractedMessageDescriptor} from '../types.js'
 import {expect, test} from 'vitest'
 function transformAndCheck(fn: string, opts: Options = {}) {
-  const filePath = path.join(__dirname, 'fixtures', `${fn}.js`)
+  const filePath = path.join(import.meta.dirname, 'fixtures', `${fn}.js`)
   const messages: ExtractedMessageDescriptor[] = []
   const meta = {}
   const {code} = transform(filePath, {
@@ -107,7 +107,7 @@ test('idInterpolationPattern default', function () {
 })
 
 test('GH #2663', function () {
-  const filePath = path.join(__dirname, 'fixtures', `2663.js`)
+  const filePath = path.join(import.meta.dirname, 'fixtures', `2663.js`)
   const messages: ExtractedMessageDescriptor[] = []
   const meta = {}
 
@@ -175,7 +175,11 @@ test('preserveWhitespace', function () {
 })
 
 test('extractSourceLocation', function () {
-  const filePath = path.join(__dirname, 'fixtures', 'extractSourceLocation.js')
+  const filePath = path.join(
+    import.meta.dirname,
+    'fixtures',
+    'extractSourceLocation.js'
+  )
   const messages: ExtractedMessageDescriptor[] = []
   const meta = {}
 
@@ -196,13 +200,13 @@ test('extractSourceLocation', function () {
 
 test('Properly throws parse errors', () => {
   expect(() =>
-    transform(path.join(__dirname, 'fixtures', 'icuSyntax.js'))
+    transform(path.join(import.meta.dirname, 'fixtures', 'icuSyntax.js'))
   ).toThrow('SyntaxError: MALFORMED_ARGUMENT')
 })
 
 test('GH #4161 - flatten error should include file and line information', () => {
   expect(() =>
-    transform(path.join(__dirname, 'fixtures', 'flattenError.js'), {
+    transform(path.join(import.meta.dirname, 'fixtures', 'flattenError.js'), {
       flatten: true,
     })
   ).toThrow(

--- a/packages/cli-lib/src/cli.ts
+++ b/packages/cli-lib/src/cli.ts
@@ -1,5 +1,6 @@
 import {program} from 'commander'
-import {sync as globSync} from 'fast-glob'
+import * as glob from 'fast-glob'
+const globSync = glob.sync
 import loudRejection from 'loud-rejection'
 import compile, {type CompileCLIOpts, type Opts} from './compile.js'
 import compileFolder from './compile_folder.js'

--- a/packages/cli-lib/tests/unit/gts_extractor.test.ts
+++ b/packages/cli-lib/tests/unit/gts_extractor.test.ts
@@ -7,7 +7,7 @@ import {parseFile} from '../../src/gts_extractor'
 describe('gts_extractor', () => {
   test('gts files', async function () {
     let messages: MessageDescriptor[] = []
-    const fixturePath = join(__dirname, './fixtures/comp.gts')
+    const fixturePath = join(import.meta.dirname, './fixtures/comp.gts')
     parseFile(await readFile(fixturePath, 'utf8'), fixturePath, {
       onMsgExtracted(_: any, msgs: any) {
         messages = messages.concat(msgs)
@@ -36,7 +36,7 @@ describe('gts_extractor', () => {
 
   test('gjs files', async function () {
     let messages: MessageDescriptor[] = []
-    const fixturePath = join(__dirname, './fixtures/comp.gjs')
+    const fixturePath = join(import.meta.dirname, './fixtures/comp.gjs')
     parseFile(await readFile(fixturePath, 'utf8'), fixturePath, {
       onMsgExtracted(_: any, msgs: any) {
         messages = messages.concat(msgs)

--- a/packages/cli-lib/tests/unit/hbs_extractor.test.ts
+++ b/packages/cli-lib/tests/unit/hbs_extractor.test.ts
@@ -6,7 +6,7 @@ import {parseFile} from '../../src/hbs_extractor'
 
 test('hbs_extractor', async function () {
   let messages: MessageDescriptor[] = []
-  const fixturePath = join(__dirname, './fixtures/comp.hbs')
+  const fixturePath = join(import.meta.dirname, './fixtures/comp.hbs')
   parseFile(await readFile(fixturePath, 'utf8'), fixturePath, {
     onMsgExtracted(_: any, msgs: any) {
       messages = messages.concat(msgs)

--- a/packages/cli-lib/tests/unit/vue_extractor.test.ts
+++ b/packages/cli-lib/tests/unit/vue_extractor.test.ts
@@ -7,7 +7,7 @@ import {readFileSync} from 'fs'
 
 test('vue_extractor', async function () {
   let messages: MessageDescriptor[] = []
-  const fixturePath = join(__dirname, './fixtures/comp.vue')
+  const fixturePath = join(import.meta.dirname, './fixtures/comp.vue')
   parseFile(
     readFileSync(fixturePath, 'utf8'),
     fixturePath,
@@ -24,7 +24,7 @@ test('vue_extractor', async function () {
 
 test('vue_extractor for bind attr', async function () {
   let messages: MessageDescriptor[] = []
-  const fixturePath = join(__dirname, './fixtures/bind.vue')
+  const fixturePath = join(import.meta.dirname, './fixtures/bind.vue')
   parseFile(
     readFileSync(fixturePath, 'utf8'),
     fixturePath,

--- a/packages/cli/integration-tests/compile/integration.test.ts
+++ b/packages/cli/integration-tests/compile/integration.test.ts
@@ -7,9 +7,9 @@ import {resolveRustBinaryPath} from '../rust-binary-utils'
 const exec = promisify(nodeExec)
 
 const TS_BIN_PATH = require.resolve('@formatjs/cli/bin/formatjs')
-const RUST_BIN_PATH = resolveRustBinaryPath(__dirname)
+const RUST_BIN_PATH = resolveRustBinaryPath(import.meta.dirname)
 
-const ARTIFACT_PATH = resolve(__dirname, 'test_artifacts')
+const ARTIFACT_PATH = resolve(import.meta.dirname, 'test_artifacts')
 
 describe.each([
   {name: 'TypeScript', binPath: TS_BIN_PATH, isRust: false},
@@ -21,13 +21,13 @@ describe.each([
 
   test('basic case: empty json', async () => {
     await expect(
-      exec(`${binPath} compile ${join(__dirname, 'lang/empty.json')}`)
+      exec(`${binPath} compile ${join(import.meta.dirname, 'lang/empty.json')}`)
     ).resolves.toMatchSnapshot()
   }, 20000)
 
   test('normal json', async () => {
     await expect(
-      exec(`${binPath} compile ${join(__dirname, 'lang/en.json')}`)
+      exec(`${binPath} compile ${join(import.meta.dirname, 'lang/en.json')}`)
     ).resolves.toMatchSnapshot()
   }, 20000)
 
@@ -35,7 +35,7 @@ describe.each([
     await expect(
       exec(
         `${binPath} compile --ast --pseudo-locale xx-LS ${join(
-          __dirname,
+          import.meta.dirname,
           'lang/en.json'
         )}`
       )
@@ -46,7 +46,7 @@ describe.each([
     await expect(
       exec(
         `${binPath} compile --ast --pseudo-locale xx-HA ${join(
-          __dirname,
+          import.meta.dirname,
           'lang/en.json'
         )}`
       )
@@ -57,7 +57,7 @@ describe.each([
     await expect(
       exec(
         `${binPath} compile --ast --pseudo-locale xx-AC ${join(
-          __dirname,
+          import.meta.dirname,
           'lang/en.json'
         )}`
       )
@@ -68,7 +68,7 @@ describe.each([
     await expect(
       exec(
         `${binPath} compile --ast --pseudo-locale en-XA ${join(
-          __dirname,
+          import.meta.dirname,
           'lang/en.json'
         )}`
       )
@@ -79,7 +79,7 @@ describe.each([
     await expect(
       exec(
         `${binPath} compile --ast --pseudo-locale en-XB ${join(
-          __dirname,
+          import.meta.dirname,
           'lang/en.json'
         )}`
       )
@@ -92,9 +92,9 @@ describe.each([
       await expect(
         exec(
           `${binPath} compile ${join(
-            __dirname,
+            import.meta.dirname,
             'lang/en-format.json'
-          )} --format ${join(__dirname, '../formatter.js')}`
+          )} --format ${join(import.meta.dirname, '../formatter.js')}`
         )
       ).resolves.toMatchSnapshot()
     },
@@ -105,7 +105,7 @@ describe.each([
     await expect(
       exec(
         `${binPath} compile ${join(
-          __dirname,
+          import.meta.dirname,
           'lang/en-transifex.json'
         )} --format transifex`
       )
@@ -116,7 +116,7 @@ describe.each([
     await expect(
       exec(
         `${binPath} compile ${join(
-          __dirname,
+          import.meta.dirname,
           'lang/en-smartling.json'
         )} --format smartling`
       )
@@ -127,7 +127,7 @@ describe.each([
     await expect(
       exec(
         `${binPath} compile ${join(
-          __dirname,
+          import.meta.dirname,
           'lang/en-simple.json'
         )} --format simple`
       )
@@ -138,7 +138,7 @@ describe.each([
     await expect(
       exec(
         `${binPath} compile ${join(
-          __dirname,
+          import.meta.dirname,
           'lang/en-lokalise.json'
         )} --format lokalise`
       )
@@ -149,7 +149,7 @@ describe.each([
     await expect(
       exec(
         `${binPath} compile ${join(
-          __dirname,
+          import.meta.dirname,
           'lang/en-crowdin.json'
         )} --format crowdin`
       )
@@ -159,7 +159,7 @@ describe.each([
   test('malformed ICU message json', async () => {
     await expect(
       exec(
-        `${binPath} compile ${join(__dirname, 'lang/malformed-messages.json')}`
+        `${binPath} compile ${join(import.meta.dirname, 'lang/malformed-messages.json')}`
       )
     ).rejects.toThrowError('SyntaxError: EXPECT_ARGUMENT_CLOSING_BRACE')
   }, 20000)
@@ -167,7 +167,7 @@ describe.each([
   test('skipped malformed ICU message json', async () => {
     const result = await exec(
       `${binPath} compile  --skip-errors ${join(
-        __dirname,
+        import.meta.dirname,
         'lang/malformed-messages.json'
       )}`
     )
@@ -179,7 +179,9 @@ describe.each([
 
   test('AST', async () => {
     await expect(
-      exec(`${binPath} compile --ast ${join(__dirname, 'lang/en.json')}`)
+      exec(
+        `${binPath} compile --ast ${join(import.meta.dirname, 'lang/en.json')}`
+      )
     ).resolves.toMatchSnapshot()
   }, 20000)
 
@@ -188,7 +190,7 @@ describe.each([
     await expect(
       exec(
         `${binPath} compile ${join(
-          __dirname,
+          import.meta.dirname,
           'lang/en.json'
         )} --out-file ${outFilePath}`
       )
@@ -201,7 +203,7 @@ describe.each([
     await expect(
       exec(
         `${binPath} compile --ast ${join(
-          __dirname,
+          import.meta.dirname,
           'lang/en.json'
         )} --out-file ${outFilePath}`
       )
@@ -214,7 +216,7 @@ describe.each([
     await expect(
       exec(
         `${binPath} compile --ignore-tag ${join(
-          __dirname,
+          import.meta.dirname,
           'lang/html-messages.json'
         )} --out-file ${outFilePath}`
       )
@@ -224,13 +226,15 @@ describe.each([
 
   test('compile glob', async () => {
     await expect(
-      exec(`${binPath} compile "${join(__dirname, 'glob/*.json')}"`)
+      exec(`${binPath} compile "${join(import.meta.dirname, 'glob/*.json')}"`)
     ).resolves.toMatchSnapshot()
   })
 
   test('compile glob with conflict', async () => {
     await expect(
-      exec(`${binPath} compile "${join(__dirname, 'glob-conflict/*.json')}"`)
+      exec(
+        `${binPath} compile "${join(import.meta.dirname, 'glob-conflict/*.json')}"`
+      )
     ).rejects.toThrowError(
       'Conflicting ID "a1d12" with different translation found in these 2 files'
     )

--- a/packages/cli/integration-tests/compile_folder/integration.test.ts
+++ b/packages/cli/integration-tests/compile_folder/integration.test.ts
@@ -1,5 +1,6 @@
 import {exec as nodeExec} from 'child_process'
-import {sync as globSync} from 'fast-glob'
+import glob from 'fast-glob'
+const globSync = glob.sync
 import {mkdtempSync} from 'fs'
 import {readJSON} from 'fs-extra/esm'
 import {basename, join} from 'path'
@@ -14,10 +15,10 @@ test('basic case: help', async () => {
 })
 
 test('basic case', async () => {
-  const inputFiles = globSync(`${__dirname}/lang/*.json`)
+  const inputFiles = globSync(`${import.meta.dirname}/lang/*.json`)
   const outFolder = mkdtempSync('formatjs-cli')
   await exec(
-    `${BIN_PATH} compile-folder ${join(__dirname, 'lang')} ${outFolder}`
+    `${BIN_PATH} compile-folder ${join(import.meta.dirname, 'lang')} ${outFolder}`
   )
 
   const outputFiles = globSync(`${outFolder}/*.json`)

--- a/packages/cli/integration-tests/extract-glimmer/integration.test.ts
+++ b/packages/cli/integration-tests/extract-glimmer/integration.test.ts
@@ -8,7 +8,7 @@ const BIN_PATH = require.resolve('@formatjs/cli/bin/formatjs')
 
 test('gjs', async () => {
   const {stdout} = await exec(
-    `${BIN_PATH} extract '${join(__dirname, '*.gjs')}'`
+    `${BIN_PATH} extract '${join(import.meta.dirname, '*.gjs')}'`
   )
 
   expect(JSON.parse(stdout)).toEqual({
@@ -39,7 +39,7 @@ test('gjs', async () => {
 
 test('gts', async () => {
   const {stdout} = await exec(
-    `${BIN_PATH} extract '${join(__dirname, '*.gts')}'`
+    `${BIN_PATH} extract '${join(import.meta.dirname, '*.gts')}'`
   )
 
   expect(JSON.parse(stdout)).toEqual({
@@ -70,7 +70,7 @@ test('gts', async () => {
 
 test('hbs', async () => {
   const {stdout} = await exec(
-    `${BIN_PATH} extract '${join(__dirname, '*.hbs')}'`
+    `${BIN_PATH} extract '${join(import.meta.dirname, '*.hbs')}'`
   )
 
   expect(JSON.parse(stdout)).toEqual({

--- a/packages/cli/integration-tests/extract-vue/integration.test.ts
+++ b/packages/cli/integration-tests/extract-vue/integration.test.ts
@@ -8,7 +8,7 @@ const BIN_PATH = require.resolve('@formatjs/cli/bin/formatjs')
 
 test('vue', async () => {
   const {stdout} = await exec(
-    `${BIN_PATH} extract '${join(__dirname, '*.vue')}'`
+    `${BIN_PATH} extract '${join(import.meta.dirname, '*.vue')}'`
   )
 
   expect(JSON.parse(stdout)).toEqual({

--- a/packages/cli/integration-tests/extract/integration.test.ts
+++ b/packages/cli/integration-tests/extract/integration.test.ts
@@ -8,12 +8,12 @@ import {resolveRustBinaryPath} from '../rust-binary-utils'
 const exec = promisify(nodeExec)
 
 const TS_BIN_PATH = require.resolve('@formatjs/cli/bin/formatjs')
-const RUST_BIN_PATH = resolveRustBinaryPath(__dirname)
+const RUST_BIN_PATH = resolveRustBinaryPath(import.meta.dirname)
 
-const ARTIFACT_PATH = resolve(__dirname, 'test_artifacts')
+const ARTIFACT_PATH = resolve(import.meta.dirname, 'test_artifacts')
 
 beforeEach(async () => {
-  await mkdirp(join(__dirname, 'test_artifacts'))
+  await mkdirp(join(import.meta.dirname, 'test_artifacts'))
   await remove(ARTIFACT_PATH)
 })
 
@@ -29,7 +29,7 @@ describe.each([
     await expect(
       exec(
         `${binPath} extract --throws ${join(
-          __dirname,
+          import.meta.dirname,
           'defineMessages/actual.jsx'
         )}`
       )
@@ -40,7 +40,7 @@ describe.each([
     await expect(
       exec(
         `${binPath} extract --flatten --throws ${join(
-          __dirname,
+          import.meta.dirname,
           'defineMessages/actual.jsx'
         )}`
       )
@@ -49,12 +49,14 @@ describe.each([
 
   test('[glob] basic case: defineMessages -> stdout', async () => {
     await expect(
-      exec(`${binPath} extract ${join(__dirname, 'defineMessages/*.jsx')}`)
+      exec(
+        `${binPath} extract ${join(import.meta.dirname, 'defineMessages/*.jsx')}`
+      )
     ).resolves.toMatchSnapshot()
   }, 20000)
 
   test('basic case: defineMessages -> out-file', async () => {
-    process.chdir(__dirname)
+    process.chdir(import.meta.dirname)
     await expect(
       exec(
         `${binPath} extract defineMessages/actual.jsx --out-file ${ARTIFACT_PATH}/defineMessages/actual.json`
@@ -67,7 +69,7 @@ describe.each([
   }, 20000)
 
   test('basic case: inFile', async () => {
-    process.chdir(__dirname)
+    process.chdir(import.meta.dirname)
     await expect(
       exec(
         `${binPath} extract --in-file inFile.txt --out-file ${ARTIFACT_PATH}/infile-actual.json`
@@ -80,7 +82,7 @@ describe.each([
   })
 
   test('basic case: defineMessages -> out-file with  --additional-function-names', async () => {
-    process.chdir(__dirname)
+    process.chdir(import.meta.dirname)
     await expect(
       exec(
         `${binPath} extract defineMessages/actual.jsx --additional-function-names t --out-file ${ARTIFACT_PATH}/defineMessages/actual.json`
@@ -93,7 +95,7 @@ describe.each([
   }, 20000)
 
   test('basic case: defineMessages -> out-file with location', async () => {
-    process.chdir(__dirname)
+    process.chdir(import.meta.dirname)
     await expect(
       exec(
         `${binPath} extract defineMessages/actual.jsx --extract-source-location --out-file ${ARTIFACT_PATH}/defineMessages/actual.json`
@@ -107,14 +109,16 @@ describe.each([
 
   test('typescript -> stdout', async () => {
     await expect(
-      exec(`${binPath} extract ${join(__dirname, 'typescript/actual.tsx')}`)
+      exec(
+        `${binPath} extract ${join(import.meta.dirname, 'typescript/actual.tsx')}`
+      )
     ).resolves.toMatchSnapshot()
   }, 20000)
 
   test('typescript -> stdout with --additional-function-names', async () => {
     await expect(
       exec(
-        `${binPath} extract --additional-function-names t ${join(__dirname, 'typescript/actual.tsx')}`
+        `${binPath} extract --additional-function-names t ${join(import.meta.dirname, 'typescript/actual.tsx')}`
       )
     ).resolves.toMatchSnapshot()
   }, 20000)
@@ -123,7 +127,7 @@ describe.each([
     await expect(
       exec(
         `${binPath} extract --pragma intl ${join(
-          __dirname,
+          import.meta.dirname,
           'typescript/pragma.tsx'
         )}`
       )
@@ -136,9 +140,9 @@ describe.each([
       await expect(
         exec(
           `${binPath} extract ${join(
-            __dirname,
+            import.meta.dirname,
             'typescript/actual.tsx'
-          )} --format ${join(__dirname, '../formatter.js')}`
+          )} --format ${join(import.meta.dirname, '../formatter.js')}`
         )
       ).resolves.toMatchSnapshot()
     },
@@ -149,7 +153,7 @@ describe.each([
     await expect(
       exec(
         `${binPath} extract ${join(
-          __dirname,
+          import.meta.dirname,
           'typescript/actual.tsx'
         )} --format transifex`
       )
@@ -160,7 +164,7 @@ describe.each([
     await expect(
       exec(
         `${binPath} extract ${join(
-          __dirname,
+          import.meta.dirname,
           'typescript/actual.tsx'
         )} --format simple`
       )
@@ -171,7 +175,7 @@ describe.each([
     await expect(
       exec(
         `${binPath} extract ${join(
-          __dirname,
+          import.meta.dirname,
           'typescript/actual.tsx'
         )} --format lokalise`
       )
@@ -182,7 +186,7 @@ describe.each([
     await expect(
       exec(
         `${binPath} extract ${join(
-          __dirname,
+          import.meta.dirname,
           'typescript/actual.tsx'
         )} --format crowdin`
       )
@@ -193,7 +197,7 @@ describe.each([
     await expect(
       exec(
         `${binPath} extract ${join(
-          __dirname,
+          import.meta.dirname,
           'typescript/actual.tsx'
         )} --format smartling`
       )
@@ -206,7 +210,7 @@ describe.each([
     await expect(
       exec(
         `${binPath} extract --throws ${join(
-          __dirname,
+          import.meta.dirname,
           'typescript/actual.tsx'
         )} ${ignore}`
       )
@@ -215,7 +219,7 @@ describe.each([
 
   test('ignore -> stdout JS', async () => {
     const jsResult = await exec(
-      `${binPath} extract '${join(__dirname, 'defineMessages/*.jsx')}' ${ignore}`
+      `${binPath} extract '${join(import.meta.dirname, 'defineMessages/*.jsx')}' ${ignore}`
     )
     expect(JSON.parse(jsResult.stdout)).toMatchSnapshot()
     expect(jsResult.stderr).toBe('')
@@ -223,7 +227,7 @@ describe.each([
 
   test('duplicated descriptor ids shows warning', async () => {
     const {stderr, stdout} = await exec(
-      `${binPath} extract '${join(__dirname, 'duplicated/*.tsx')}'`
+      `${binPath} extract '${join(import.meta.dirname, 'duplicated/*.tsx')}'`
     )
     expect(JSON.parse(stdout)).toMatchSnapshot()
     expect(stderr).toContain('Duplicate message id: "foo"')
@@ -232,7 +236,7 @@ describe.each([
   test('duplicated descriptor ids throws', async () => {
     await expect(async () => {
       await exec(
-        `${binPath} extract --throws '${join(__dirname, 'duplicated/*.tsx')}'`
+        `${binPath} extract --throws '${join(import.meta.dirname, 'duplicated/*.tsx')}'`
       )
     }).rejects.toThrowError('Duplicate message id: "foo"')
   }, 20000)
@@ -241,7 +245,7 @@ describe.each([
     await expect(
       exec(
         `${binPath} extract --throws '${join(
-          __dirname,
+          import.meta.dirname,
           'nonDuplicated/*.tsx'
         )}' --out-file ${ARTIFACT_PATH}/nonDuplicated/actual.json`
       )
@@ -255,7 +259,7 @@ describe.each([
   test('invalid syntax should throw', async () => {
     await expect(async () => {
       await exec(
-        `${binPath} extract --throws '${join(__dirname, 'typescript/err.tsx')}'`
+        `${binPath} extract --throws '${join(import.meta.dirname, 'typescript/err.tsx')}'`
       )
     }).rejects.toThrowError(isRust ? /Parse error/i : /TS1005/)
   }, 20000)
@@ -264,17 +268,17 @@ describe.each([
   test('#4235: non-static defaultMessage should throw with --throws', async () => {
     await expect(async () => {
       await exec(
-        `${binPath} extract --throws '${join(__dirname, 'typescript/non-static.tsx')}'`
+        `${binPath} extract --throws '${join(import.meta.dirname, 'typescript/non-static.tsx')}'`
       )
     }).rejects.toThrowError(/defaultMessage.*must be a string literal/i)
   }, 20000)
 
   test('whitespace and newlines should be preserved', async () => {
-    process.chdir(__dirname)
+    process.chdir(import.meta.dirname)
     await expect(
       exec(
         `${binPath} extract '${join(
-          __dirname,
+          import.meta.dirname,
           'typescript/actual.tsx'
         )}' --out-file ${ARTIFACT_PATH}/defineMessages/actual.json`
       )
@@ -290,7 +294,7 @@ describe.each([
     await expect(
       exec(
         `${binPath} extract --throws '${join(
-          __dirname,
+          import.meta.dirname,
           'typescript/ts47.tsx'
         )}' --out-file ${ARTIFACT_PATH}/typescript/ts47.json`
       )
@@ -306,7 +310,7 @@ describe.each([
     await expect(
       exec(
         `${binPath} extract --throws '${join(
-          __dirname,
+          import.meta.dirname,
           'typescript/importMeta.mts'
         )}' --out-file ${ARTIFACT_PATH}/typescript/importMeta.json`
       )
@@ -322,7 +326,7 @@ describe.each([
     await expect(
       exec(
         `${binPath} extract --throws '${join(
-          __dirname,
+          import.meta.dirname,
           'taggedTemplates/actual.tsx'
         )}' --out-file ${ARTIFACT_PATH}/taggedTemplates/actual.json`
       )
@@ -338,7 +342,7 @@ describe.each([
     await expect(
       exec(
         `${binPath} extract --throws '${join(
-          __dirname,
+          import.meta.dirname,
           'optionalChaining/actual.tsx'
         )}' --out-file ${ARTIFACT_PATH}/optionalChaining/actual.json`
       )
@@ -353,7 +357,7 @@ describe.each([
   test('GH #3537: flatten with id-interpolation-pattern (content-based IDs)', async () => {
     const result = await exec(
       `${binPath} extract --throws --flatten --id-interpolation-pattern '[sha512:contenthash:base64:6]' '${join(
-        __dirname,
+        import.meta.dirname,
         'flattenWithIdPattern/actual.js'
       )}'`
     )

--- a/packages/cli/integration-tests/rust-binary-utils.ts
+++ b/packages/cli/integration-tests/rust-binary-utils.ts
@@ -8,7 +8,7 @@ import {Runfiles} from '@bazel/runfiles'
  * 1. Snapshot update mode: Binary is copied to integration-tests directory via copy_file rule
  * 2. Normal test mode: Binary is available via Bazel runfiles
  *
- * @param dirname - The __dirname of the test file
+ * @param dirname - The import.meta.dirname of the test file
  * @returns The path to the Rust binary, or undefined if not found
  */
 export function resolveRustBinaryPath(dirname: string): string | undefined {

--- a/packages/cli/integration-tests/verify/integration.test.ts
+++ b/packages/cli/integration-tests/verify/integration.test.ts
@@ -7,7 +7,7 @@ import {resolveRustBinaryPath} from '../rust-binary-utils'
 const exec = promisify(nodeExec)
 
 const TS_BIN_PATH = require.resolve('@formatjs/cli/bin/formatjs')
-const RUST_BIN_PATH = resolveRustBinaryPath(__dirname)
+const RUST_BIN_PATH = resolveRustBinaryPath(import.meta.dirname)
 
 describe.each([
   {name: 'TypeScript', binPath: TS_BIN_PATH, isRust: false},
@@ -16,7 +16,7 @@ describe.each([
   test('missing keys pass', async () => {
     await expect(
       exec(
-        `${binPath} verify --source-locale en-US --ignore '${join(__dirname, 'missing-keys', 'fixtures1', 'es.json')}' --missing-keys '${join(__dirname, 'missing-keys', 'fixtures1', '*.json')}'`
+        `${binPath} verify --source-locale en-US --ignore '${join(import.meta.dirname, 'missing-keys', 'fixtures1', 'es.json')}' --missing-keys '${join(import.meta.dirname, 'missing-keys', 'fixtures1', '*.json')}'`
       )
     ).resolves.toBeTruthy()
   }, 20000)
@@ -24,7 +24,7 @@ describe.each([
   test('missing keys fail', async () => {
     await expect(
       exec(
-        `${binPath} verify --source-locale en-US --missing-keys '${join(__dirname, 'missing-keys', 'fixtures2', '*.json')}'`
+        `${binPath} verify --source-locale en-US --missing-keys '${join(import.meta.dirname, 'missing-keys', 'fixtures2', '*.json')}'`
       )
     ).rejects.toThrow(/Missing translation keys for locale fr-FR:\nfoo/)
   }, 20000)
@@ -32,7 +32,7 @@ describe.each([
   test('missing keys fail missing source', async () => {
     await expect(
       exec(
-        `${binPath} verify --source-locale en-US --missing-keys '${join(__dirname, 'missing-keys', 'fixtures3', '*.json')}'`
+        `${binPath} verify --source-locale en-US --missing-keys '${join(import.meta.dirname, 'missing-keys', 'fixtures3', '*.json')}'`
       )
     ).rejects.toThrow(/ Missing source en-US.json file/)
   }, 20000)
@@ -40,7 +40,7 @@ describe.each([
   test('missing keys fail nested key', async () => {
     await expect(
       exec(
-        `${binPath} verify --source-locale en-US --missing-keys '${join(__dirname, 'missing-keys', 'fixtures4', '*.json')}'`
+        `${binPath} verify --source-locale en-US --missing-keys '${join(import.meta.dirname, 'missing-keys', 'fixtures4', '*.json')}'`
       )
     ).rejects.toThrow(
       /Missing translation keys for locale fr-FR:\nbaz\nbaz.qux/
@@ -50,7 +50,7 @@ describe.each([
   test('structural equality pass', async () => {
     await expect(
       exec(
-        `${binPath} verify --source-locale en-US --structural-equality '${join(__dirname, 'structural-equality', 'fixtures1', '*.json')}'`
+        `${binPath} verify --source-locale en-US --structural-equality '${join(import.meta.dirname, 'structural-equality', 'fixtures1', '*.json')}'`
       )
     ).resolves.toBeTruthy()
   }, 20000)
@@ -69,7 +69,7 @@ describe.each([
 7: EXPECT_ARGUMENT_CLOSING_BRACE`
     await expect(
       exec(
-        `${binPath} verify --source-locale en-US --structural-equality '${join(__dirname, 'structural-equality', 'fixtures2', '*.json')}'`
+        `${binPath} verify --source-locale en-US --structural-equality '${join(import.meta.dirname, 'structural-equality', 'fixtures2', '*.json')}'`
       )
     ).rejects.toThrow(errMessage)
   }, 20000)
@@ -77,7 +77,7 @@ describe.each([
   test('extra keys pass', async () => {
     await expect(
       exec(
-        `${binPath} verify --source-locale en-US --extra-keys '${join(__dirname, 'extra-keys', 'fixtures1', '*.json')}'`
+        `${binPath} verify --source-locale en-US --extra-keys '${join(import.meta.dirname, 'extra-keys', 'fixtures1', '*.json')}'`
       )
     ).resolves.toBeTruthy()
   }, 20000)
@@ -85,7 +85,7 @@ describe.each([
   test('extra keys fail', async () => {
     await expect(
       exec(
-        `${binPath} verify --source-locale en-US --extra-keys '${join(__dirname, 'extra-keys', 'fixtures2', '*.json')}'`
+        `${binPath} verify --source-locale en-US --extra-keys '${join(import.meta.dirname, 'extra-keys', 'fixtures2', '*.json')}'`
       )
     ).rejects.toThrow(/Extra translation keys for locale fr-FR:\nboo/)
   }, 20000)

--- a/packages/ecma402-abstract/scripts/digit-mapping.ts
+++ b/packages/ecma402-abstract/scripts/digit-mapping.ts
@@ -106,6 +106,6 @@ function main(args: Args) {
   )
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist<Args>(process.argv))
 }

--- a/packages/ecma402-abstract/scripts/regex-gen.ts
+++ b/packages/ecma402-abstract/scripts/regex-gen.ts
@@ -1,6 +1,9 @@
 import {outputFileSync} from 'fs-extra/esm'
 import minimist from 'minimist'
 import regenerate from 'regenerate'
+import {createRequire} from 'node:module'
+
+const require = createRequire(import.meta.url)
 
 function main(args: minimist.ParsedArgs) {
   const symbolSeparator = regenerate().add(
@@ -14,6 +17,6 @@ export const S_UNICODE_REGEX: RegExp = /${symbolSeparator.toString()}/
   )
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist(process.argv))
 }

--- a/packages/icu-messageformat-parser/integration-tests/run-parser.ts
+++ b/packages/icu-messageformat-parser/integration-tests/run-parser.ts
@@ -8,7 +8,7 @@ interface Args extends minimist.ParsedArgs {
 }
 
 function run({input, out}: Args) {
-  console.log(__dirname)
+  console.log(import.meta.dirname)
   const sections = readFileSync(input, 'utf-8').split('\n---\n')
   const message = sections[0]
   const snapshotOptions = JSON.parse(sections[1])
@@ -33,6 +33,6 @@ function run({input, out}: Args) {
   )
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   run(minimist<Args>(process.argv.slice(2)))
 }

--- a/packages/icu-messageformat-parser/tools/regex-gen.ts
+++ b/packages/icu-messageformat-parser/tools/regex-gen.ts
@@ -1,7 +1,10 @@
 import {outputFileSync} from 'fs-extra/esm'
 import minimist from 'minimist'
 import regenerate from 'regenerate'
-import './global'
+import {createRequire} from 'node:module'
+import './global.ts'
+
+const require = createRequire(import.meta.url)
 
 function generateTypeScript(
   spaceSeparator: regenerate,
@@ -54,6 +57,6 @@ function main(args: minimist.ParsedArgs) {
   outputFileSync(outFile, content)
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist(process.argv))
 }

--- a/packages/icu-messageformat-parser/tools/time-data-gen.ts
+++ b/packages/icu-messageformat-parser/tools/time-data-gen.ts
@@ -1,4 +1,4 @@
-import * as rawTimeData from 'cldr-core/supplemental/timeData.json' with {type: 'json'}
+import rawTimeData from 'cldr-core/supplemental/timeData.json' with {type: 'json'}
 import {outputFileSync} from 'fs-extra/esm'
 import minimist from 'minimist'
 import stringify from 'json-stable-stringify'

--- a/packages/icu-skeleton-parser/scripts/regex-gen.ts
+++ b/packages/icu-skeleton-parser/scripts/regex-gen.ts
@@ -1,7 +1,10 @@
 import {outputFileSync} from 'fs-extra/esm'
 import minimist from 'minimist'
 import regenerate from 'regenerate'
-import './global'
+import {createRequire} from 'node:module'
+import './global.ts'
+
+const require = createRequire(import.meta.url)
 
 function main(args: minimist.ParsedArgs) {
   const set = regenerate().add(
@@ -14,6 +17,6 @@ export const WHITE_SPACE_REGEX: RegExp = /${set.toString()}/i`
   )
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist(process.argv))
 }

--- a/packages/intl-datetimeformat/BUILD.bazel
+++ b/packages/intl-datetimeformat/BUILD.bazel
@@ -909,12 +909,10 @@ js_binary(
     data = [":srcs"] + SRC_DEPS + [
         "tests/locale-data/en.json",
         "//:node_modules/tinybench",
-        "//:node_modules/tsx",
     ],
     entry_point = "tests/benchmark.ts",
     node_options = [
-        "--import",
-        "tsx",
+        "--experimental-transform-types",
     ],
     tags = ["manual"],
 )

--- a/packages/intl-datetimeformat/scripts/cldr-raw.ts
+++ b/packages/intl-datetimeformat/scripts/cldr-raw.ts
@@ -1,4 +1,4 @@
-import {extractDatesFields, getAllLocales} from './extract-dates.js'
+import {extractDatesFields, getAllLocales} from './extract-dates.ts'
 import {join} from 'path'
 import {outputJSONSync} from 'fs-extra/esm'
 
@@ -19,6 +19,6 @@ async function main(args: minimist.ParsedArgs) {
     )
   )
 }
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   ;(async () => main(minimist(process.argv)))()
 }

--- a/packages/intl-datetimeformat/scripts/cldr.ts
+++ b/packages/intl-datetimeformat/scripts/cldr.ts
@@ -25,6 +25,6 @@ if (Intl.DateTimeFormat && typeof Intl.DateTimeFormat.__addLocaleData === 'funct
     outputFileSync(join(outDir, locale + '.d.ts'), 'export {}')
   })
 }
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist<Args>(process.argv))
 }

--- a/packages/intl-datetimeformat/scripts/link.ts
+++ b/packages/intl-datetimeformat/scripts/link.ts
@@ -21,6 +21,6 @@ export default ${stringify(linkMap, {space: 2})}`
   )
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist(process.argv))
 }

--- a/packages/intl-datetimeformat/scripts/process-zdump.ts
+++ b/packages/intl-datetimeformat/scripts/process-zdump.ts
@@ -3,8 +3,8 @@ import {outputFileSync} from 'fs-extra/esm'
 import stringify from 'json-stable-stringify'
 import minimist from 'minimist'
 import {promisify} from 'util'
-import {pack} from '../src/packer'
-import {type UnpackedData, type ZoneData} from '../src/types'
+import {pack} from '../src/packer.ts'
+import {type UnpackedData, type ZoneData} from '../src/types.ts'
 
 const readFile = promisify(_readFile)
 const SPACE_REGEX = /[\s\t]+/
@@ -425,6 +425,6 @@ export default data`
   }
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist(process.argv))
 }

--- a/packages/intl-datetimeformat/scripts/test-locale-data-gen.ts
+++ b/packages/intl-datetimeformat/scripts/test-locale-data-gen.ts
@@ -1,7 +1,8 @@
 import {join, basename} from 'path'
 import {copyFileSync} from 'fs-extra/esm'
 import minimist from 'minimist'
-import {sync as globSync} from 'fast-glob'
+import glob from 'fast-glob'
+const globSync = glob.sync
 
 function main(args: minimist.ParsedArgs) {
   const {cldrFolder, locales: localesToGen = '', out} = args
@@ -14,6 +15,6 @@ function main(args: minimist.ParsedArgs) {
   // Dist all json locale files to testDataDir
   copyFileSync(join(cldrFolder, `${locales[0]}.json`), out)
 }
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist(process.argv))
 }

--- a/packages/intl-datetimeformat/scripts/test262-main-gen.ts
+++ b/packages/intl-datetimeformat/scripts/test262-main-gen.ts
@@ -19,13 +19,13 @@ function main(args: Args) {
     `/* @generated */
 // @ts-nocheck
 import './polyfill-force.js'
-import allData from './src/data/all-tz.generated.js'
+import allData from './src/data/all-tz.generated.ts'
 defineProperty(Intl, 'DateTimeFormat', {value: DateTimeFormat})
 Intl.DateTimeFormat.__addLocaleData(${allData.join(',\n')})
 Intl.DateTimeFormat.__addTZData(allData)`
   )
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist<Args>(process.argv))
 }

--- a/packages/intl-datetimeformat/scripts/zic.ts
+++ b/packages/intl-datetimeformat/scripts/zic.ts
@@ -13,6 +13,6 @@ async function main(args: minimist.ParsedArgs) {
   }
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist(process.argv))
 }

--- a/packages/intl-datetimeformat/scripts/zone.ts
+++ b/packages/intl-datetimeformat/scripts/zone.ts
@@ -19,6 +19,6 @@ export default ${JSON.stringify(Array.from(zones), undefined, 2)}`
   )
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist(process.argv))
 }

--- a/packages/intl-datetimeformat/src/packer.ts
+++ b/packages/intl-datetimeformat/src/packer.ts
@@ -1,4 +1,4 @@
-import {type UnpackedData, type PackedData} from './types.js'
+import {type UnpackedData, type PackedData} from './types.ts'
 import {type UnpackedZoneData} from '@formatjs/ecma402-abstract'
 
 export function pack(data: UnpackedData): PackedData {

--- a/packages/intl-datetimeformat/test262-main.ts
+++ b/packages/intl-datetimeformat/test262-main.ts
@@ -1,7 +1,7 @@
 /* @generated */
 // @ts-nocheck
 import './polyfill-force.js'
-import allData from './src/data/all-tz.generated.js'
+import allData from './src/data/all-tz.generated.ts'
 defineProperty(Intl, 'DateTimeFormat', {value: DateTimeFormat})
 Intl.DateTimeFormat.__addLocaleData(
   {

--- a/packages/intl-datetimeformat/tests/benchmark.ts
+++ b/packages/intl-datetimeformat/tests/benchmark.ts
@@ -1,5 +1,5 @@
 import {Bench} from 'tinybench'
-import * as en from './locale-data/en.json' with {type: 'json'}
+import en from './locale-data/en.json' with {type: 'json'}
 import allData from '../src/data/all-tz.generated'
 import {DateTimeFormat} from '../src/core'
 DateTimeFormat.__addTZData(allData)

--- a/packages/intl-datetimeformat/tests/format-range.test.ts
+++ b/packages/intl-datetimeformat/tests/format-range.test.ts
@@ -2,11 +2,11 @@ import '@formatjs/intl-getcanonicallocales/polyfill.js'
 import '@formatjs/intl-locale/polyfill.js'
 import {DateTimeFormat} from '../src/core'
 import allData from '../src/data/all-tz.generated'
-import * as enGB from './locale-data/en-GB.json' with {type: 'json'}
-import * as en from './locale-data/en.json' with {type: 'json'}
-import * as fa from './locale-data/fa.json' with {type: 'json'}
-import * as nl from './locale-data/nl.json' with {type: 'json'}
-import * as zhHans from './locale-data/zh-Hans.json' with {type: 'json'}
+import enGB from './locale-data/en-GB.json' with {type: 'json'}
+import en from './locale-data/en.json' with {type: 'json'}
+import fa from './locale-data/fa.json' with {type: 'json'}
+import nl from './locale-data/nl.json' with {type: 'json'}
+import zhHans from './locale-data/zh-Hans.json' with {type: 'json'}
 import {describe, expect, it, test} from 'vitest'
 // @ts-ignore
 DateTimeFormat.__addLocaleData(en, enGB, zhHans, fa, nl)

--- a/packages/intl-datetimeformat/tests/format.test.ts
+++ b/packages/intl-datetimeformat/tests/format.test.ts
@@ -5,10 +5,10 @@ import {
   toLocaleString,
   toLocaleTimeString,
 } from '../src/to_locale_string'
-import * as bs from './locale-data/bs.json' with {type: 'json'}
-import * as en from './locale-data/en.json' with {type: 'json'}
-import * as ko from './locale-data/ko.json' with {type: 'json'}
-import * as ru from './locale-data/ru.json' with {type: 'json'}
+import bs from './locale-data/bs.json' with {type: 'json'}
+import en from './locale-data/en.json' with {type: 'json'}
+import ko from './locale-data/ko.json' with {type: 'json'}
+import ru from './locale-data/ru.json' with {type: 'json'}
 import {describe, expect, it} from 'vitest'
 // @ts-ignore
 DateTimeFormat.__addLocaleData(bs, en, ko, ru)

--- a/packages/intl-datetimeformat/tests/ftp-main.test.ts
+++ b/packages/intl-datetimeformat/tests/ftp-main.test.ts
@@ -1,7 +1,7 @@
-import * as en from './locale-data/en.json' with {type: 'json'}
-import * as pl from './locale-data/pl.json' with {type: 'json'}
-import * as de from './locale-data/de.json' with {type: 'json'}
-import * as ar from './locale-data/ar.json' with {type: 'json'}
+import en from './locale-data/en.json' with {type: 'json'}
+import pl from './locale-data/pl.json' with {type: 'json'}
+import de from './locale-data/de.json' with {type: 'json'}
+import ar from './locale-data/ar.json' with {type: 'json'}
 import allData from '../src/data/all-tz.generated'
 import {DateTimeFormat} from '../src/core'
 import {type IntlDateTimeFormatPart} from '@formatjs/ecma402-abstract'

--- a/packages/intl-datetimeformat/tests/index.test.ts
+++ b/packages/intl-datetimeformat/tests/index.test.ts
@@ -2,12 +2,12 @@ import '@formatjs/intl-getcanonicallocales/polyfill.js'
 import '@formatjs/intl-locale/polyfill.js'
 import {DateTimeFormat} from '../src/core'
 import allData from '../src/data/all-tz.generated'
-import * as enCA from './locale-data/en-CA.json' with {type: 'json'}
-import * as enGB from './locale-data/en-GB.json' with {type: 'json'}
-import * as en from './locale-data/en.json' with {type: 'json'}
-import * as fa from './locale-data/fa.json' with {type: 'json'}
-import * as ja from './locale-data/ja.json' with {type: 'json'}
-import * as zhHans from './locale-data/zh-Hans.json' with {type: 'json'}
+import enCA from './locale-data/en-CA.json' with {type: 'json'}
+import enGB from './locale-data/en-GB.json' with {type: 'json'}
+import en from './locale-data/en.json' with {type: 'json'}
+import fa from './locale-data/fa.json' with {type: 'json'}
+import ja from './locale-data/ja.json' with {type: 'json'}
+import zhHans from './locale-data/zh-Hans.json' with {type: 'json'}
 import {describe, expect, it, afterEach} from 'vitest'
 // @ts-ignore
 DateTimeFormat.__addLocaleData(en, enGB, enCA, ja, zhHans, fa)

--- a/packages/intl-datetimeformat/tests/offset-timezone.test.ts
+++ b/packages/intl-datetimeformat/tests/offset-timezone.test.ts
@@ -2,8 +2,8 @@ import '@formatjs/intl-getcanonicallocales/polyfill.js'
 import '@formatjs/intl-locale/polyfill.js'
 import {DateTimeFormat} from '../src/core'
 import allData from '../src/data/all-tz.generated'
-import * as enGB from './locale-data/en-GB.json' with {type: 'json'}
-import * as en from './locale-data/en.json' with {type: 'json'}
+import enGB from './locale-data/en-GB.json' with {type: 'json'}
+import en from './locale-data/en.json' with {type: 'json'}
 import {describe, expect, it, afterEach} from 'vitest'
 
 // @ts-ignore

--- a/packages/intl-displaynames/scripts/cldr-raw.ts
+++ b/packages/intl-displaynames/scripts/cldr-raw.ts
@@ -1,4 +1,4 @@
-import {extractDisplayNames, getAllLocales} from './extract-displaynames.js'
+import {extractDisplayNames, getAllLocales} from './extract-displaynames.ts'
 import {join} from 'path'
 import {outputFileSync} from 'fs-extra/esm'
 import stringify from 'json-stable-stringify'
@@ -23,6 +23,6 @@ async function main(args: minimist.ParsedArgs) {
   )
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   ;(async () => main(minimist(process.argv)))()
 }

--- a/packages/intl-displaynames/scripts/cldr.ts
+++ b/packages/intl-displaynames/scripts/cldr.ts
@@ -27,6 +27,6 @@ if (Intl.DisplayNames && typeof Intl.DisplayNames.__addLocaleData === 'function'
   })
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist<Args>(process.argv))
 }

--- a/packages/intl-displaynames/scripts/extract-displaynames.ts
+++ b/packages/intl-displaynames/scripts/extract-displaynames.ts
@@ -1,13 +1,16 @@
 import {type DisplayNamesData} from '@formatjs/ecma402-abstract'
-import * as AVAILABLE_LOCALES from 'cldr-core/availableLocales.json' with {type: 'json'}
+import AVAILABLE_LOCALES from 'cldr-core/availableLocales.json' with {type: 'json'}
 import glob from 'fast-glob'
 import {dirname, resolve} from 'path'
+import {createRequire} from 'node:module'
 import type * as LanguagesJSON from 'cldr-localenames-full/main/en/languages.json' with {type: 'json'}
 import type * as TerritoriesJSON from 'cldr-localenames-full/main/en/territories.json' with {type: 'json'}
 import type * as ScriptsJSON from 'cldr-localenames-full/main/en/scripts.json' with {type: 'json'}
 import type * as LocaleDisplayNamesJSON from 'cldr-localenames-full/main/en/localeDisplayNames.json' with {type: 'json'}
 import type * as CurrenciesJSON from 'cldr-numbers-full/main/en/currencies.json' with {type: 'json'}
 import type * as DateFieldsJSON from 'cldr-dates-full/main/en/dateFields.json' with {type: 'json'}
+
+const require = createRequire(import.meta.url)
 
 // CLDR JSON types
 type LanguageRawData =
@@ -206,20 +209,38 @@ async function loadDisplayNames(
 ): Promise<DisplayNamesData | undefined> {
   try {
     const [
-      languages,
-      territories,
-      scripts,
-      localeDisplayNames,
-      currencies,
-      dateFields,
+      languagesImport,
+      territoriesImport,
+      scriptsImport,
+      localeDisplayNamesImport,
+      currenciesImport,
+      dateFieldsImport,
     ] = await Promise.all([
-      import(`cldr-localenames-full/main/${locale}/languages.json`),
-      import(`cldr-localenames-full/main/${locale}/territories.json`),
-      import(`cldr-localenames-full/main/${locale}/scripts.json`),
-      import(`cldr-localenames-full/main/${locale}/localeDisplayNames.json`),
-      import(`cldr-numbers-full/main/${locale}/currencies.json`),
-      import(`cldr-dates-full/main/${locale}/dateFields.json`),
+      import(`cldr-localenames-full/main/${locale}/languages.json`, {
+        with: {type: 'json'},
+      }) as Promise<{default: typeof LanguagesJSON}>,
+      import(`cldr-localenames-full/main/${locale}/territories.json`, {
+        with: {type: 'json'},
+      }) as Promise<{default: typeof TerritoriesJSON}>,
+      import(`cldr-localenames-full/main/${locale}/scripts.json`, {
+        with: {type: 'json'},
+      }) as Promise<{default: typeof ScriptsJSON}>,
+      import(`cldr-localenames-full/main/${locale}/localeDisplayNames.json`, {
+        with: {type: 'json'},
+      }) as Promise<{default: typeof LocaleDisplayNamesJSON}>,
+      import(`cldr-numbers-full/main/${locale}/currencies.json`, {
+        with: {type: 'json'},
+      }) as Promise<{default: typeof CurrenciesJSON}>,
+      import(`cldr-dates-full/main/${locale}/dateFields.json`, {
+        with: {type: 'json'},
+      }) as Promise<{default: typeof DateFieldsJSON}>,
     ])
+    const languages = languagesImport.default
+    const territories = territoriesImport.default
+    const scripts = scriptsImport.default
+    const localeDisplayNames = localeDisplayNamesImport.default
+    const currencies = currenciesImport.default
+    const dateFields = dateFieldsImport.default
     const langData: LanguageRawData =
       languages.main[locale].localeDisplayNames.languages
     const regionData: RegionRawData =

--- a/packages/intl-displaynames/scripts/test-locale-data-gen.ts
+++ b/packages/intl-displaynames/scripts/test-locale-data-gen.ts
@@ -1,7 +1,8 @@
 import {join, basename} from 'path'
 import {copyFileSync} from 'fs-extra/esm'
 import minimist from 'minimist'
-import {sync as globSync} from 'fast-glob'
+import glob from 'fast-glob'
+const globSync = glob.sync
 
 function main(args: minimist.ParsedArgs) {
   const {cldrFolder, locales: localesToGen = '', out} = args
@@ -14,6 +15,6 @@ function main(args: minimist.ParsedArgs) {
   copyFileSync(join(cldrFolder, `${locales[0]}.json`), out)
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist(process.argv))
 }

--- a/packages/intl-displaynames/scripts/test262-main-gen.ts
+++ b/packages/intl-displaynames/scripts/test262-main-gen.ts
@@ -24,6 +24,6 @@ if (Intl.DisplayNames && typeof Intl.DisplayNames.__addLocaleData === 'function'
   )
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist<Args>(process.argv))
 }

--- a/packages/intl-displaynames/tests/index.test.ts
+++ b/packages/intl-displaynames/tests/index.test.ts
@@ -4,8 +4,8 @@ import '@formatjs/intl-locale/polyfill.js'
 import {DisplayNames} from '../index.js'
 import {describe, expect, it} from 'vitest'
 
-import * as en from './locale-data/en.json' with {type: 'json'}
-import * as zh from './locale-data/zh.json' with {type: 'json'}
+import en from './locale-data/en.json' with {type: 'json'}
+import zh from './locale-data/zh.json' with {type: 'json'}
 DisplayNames.__addLocaleData(en, zh)
 
 describe('.of()', () => {

--- a/packages/intl-durationformat/scripts/time-separators.ts
+++ b/packages/intl-durationformat/scripts/time-separators.ts
@@ -2,8 +2,8 @@ import {outputFileSync} from 'fs-extra/esm'
 import stringify from 'json-stable-stringify'
 import minimist from 'minimist'
 
-import type arData from 'cldr-numbers-full/main/ar/numbers.json'
-import {getAllLocales} from './utils.js'
+import type arData from 'cldr-numbers-full/main/ar/numbers.json' with {type: 'json'}
+import {getAllLocales} from './utils.ts'
 
 type RawData = typeof arData
 
@@ -30,9 +30,11 @@ async function main(args: Args) {
 
   const locales = await getAllLocales()
   for (const locale of locales) {
-    const rawData: RawData = await import(
-      `cldr-numbers-full/main/${locale}/numbers.json`
-    )
+    const rawDataImport = (await import(
+      `cldr-numbers-full/main/${locale}/numbers.json`,
+      {with: {type: 'json'}}
+    )) as {default: RawData}
+    const rawData = rawDataImport.default
     const numbersData = rawData.main[locale as 'ar'].numbers
     const numberingSystems = [
       numbersData.defaultNumberingSystem,
@@ -69,6 +71,6 @@ export const TIME_SEPARATORS = ${stringify(result, {space: 2})} as const
   )
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist<Args>(process.argv))
 }

--- a/packages/intl-durationformat/scripts/utils.ts
+++ b/packages/intl-durationformat/scripts/utils.ts
@@ -1,5 +1,8 @@
 import glob from 'fast-glob'
 import {resolve, dirname} from 'path'
+import {createRequire} from 'node:module'
+
+const require = createRequire(import.meta.url)
 
 export async function getAllLocales(): Promise<string[]> {
   const fns = await glob('*/localeDisplayNames.json', {

--- a/packages/intl-getcanonicallocales/scripts/aliases.ts
+++ b/packages/intl-getcanonicallocales/scripts/aliases.ts
@@ -1,5 +1,5 @@
 import {outputFileSync} from 'fs-extra/esm'
-import * as aliases from 'cldr-core/supplemental/aliases.json' with {type: 'json'}
+import aliases from 'cldr-core/supplemental/aliases.json' with {type: 'json'}
 import minimist from 'minimist'
 import stringify from 'json-stable-stringify'
 
@@ -62,6 +62,6 @@ export const variantAlias: Record<string, string> = ${stringify(
   )
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist(process.argv))
 }

--- a/packages/intl-getcanonicallocales/scripts/likely-subtags.ts
+++ b/packages/intl-getcanonicallocales/scripts/likely-subtags.ts
@@ -1,6 +1,6 @@
 import {outputFileSync} from 'fs-extra/esm'
 import minimist from 'minimist'
-import * as likelySubtags from 'cldr-core/supplemental/likelySubtags.json' with {type: 'json'}
+import likelySubtags from 'cldr-core/supplemental/likelySubtags.json' with {type: 'json'}
 import stringify from 'json-stable-stringify'
 function main({out}: minimist.ParsedArgs) {
   outputFileSync(
@@ -15,6 +15,6 @@ export const likelySubtags: Record<string, string> = ${stringify(
   )
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist(process.argv))
 }

--- a/packages/intl-listformat/scripts/cldr-raw.ts
+++ b/packages/intl-listformat/scripts/cldr-raw.ts
@@ -1,4 +1,4 @@
-import {extractLists, getAllLocales} from './extract-list.js'
+import {extractLists, getAllLocales} from './extract-list.ts'
 import {join} from 'path'
 import {outputFileSync} from 'fs-extra/esm'
 import stringify from 'json-stable-stringify'
@@ -23,6 +23,6 @@ async function main(args: minimist.ParsedArgs) {
   )
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   ;(async () => main(minimist(process.argv)))()
 }

--- a/packages/intl-listformat/scripts/cldr.ts
+++ b/packages/intl-listformat/scripts/cldr.ts
@@ -27,6 +27,6 @@ if (Intl.ListFormat && typeof Intl.ListFormat.__addLocaleData === 'function') {
   })
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist<Args>(process.argv))
 }

--- a/packages/intl-listformat/scripts/extract-list.ts
+++ b/packages/intl-listformat/scripts/extract-list.ts
@@ -4,9 +4,12 @@
  * See the accompanying LICENSE file for terms.
  */
 'use strict'
-import * as ListPatterns from 'cldr-misc-full/main/en/listPatterns.json' with {type: 'json'}
+import ListPatterns from 'cldr-misc-full/main/en/listPatterns.json' with {type: 'json'}
 import glob from 'fast-glob'
 import {resolve, dirname} from 'path'
+import {createRequire} from 'node:module'
+
+const require = createRequire(import.meta.url)
 import {
   type ListPatternFieldsData,
   type ListPattern,
@@ -46,10 +49,10 @@ async function loadListPatterns(
   locale: string
 ): Promise<ListPatternFieldsData> {
   const patterns = (
-    (await import(
-      `cldr-misc-full/main/${locale}/listPatterns.json`
-    )) as typeof ListPatterns
-  ).main[locale as 'en'].listPatterns
+    (await import(`cldr-misc-full/main/${locale}/listPatterns.json`, {
+      with: {type: 'json'},
+    })) as {default: typeof ListPatterns}
+  ).default.main[locale as 'en'].listPatterns
   return {
     conjunction: {
       long: serializeToPatternData(patterns['listPattern-type-standard']),

--- a/packages/intl-listformat/scripts/test-locale-data-gen.ts
+++ b/packages/intl-listformat/scripts/test-locale-data-gen.ts
@@ -1,6 +1,7 @@
 import {join, basename} from 'path'
 import {copyFileSync} from 'fs-extra/esm'
-import {sync as globSync} from 'fast-glob'
+import glob from 'fast-glob'
+const globSync = glob.sync
 import minimist from 'minimist'
 
 function main(args: minimist.ParsedArgs) {
@@ -13,6 +14,6 @@ function main(args: minimist.ParsedArgs) {
   copyFileSync(join(cldrFolder, `${locales[0]}.json`), out)
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist(process.argv))
 }

--- a/packages/intl-listformat/scripts/test262-main-gen.ts
+++ b/packages/intl-listformat/scripts/test262-main-gen.ts
@@ -24,6 +24,6 @@ if (Intl.ListFormat && typeof Intl.ListFormat.__addLocaleData === 'function') {
   )
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist<Args>(process.argv))
 }

--- a/packages/intl-listformat/tests/index.test.ts
+++ b/packages/intl-listformat/tests/index.test.ts
@@ -1,11 +1,11 @@
 import '@formatjs/intl-getcanonicallocales/polyfill.js'
 import '@formatjs/intl-locale/polyfill.js'
 import ListFormat from '../index.js'
-import * as en from './locale-data/en.json' with {type: 'json'}
-import * as enAI from './locale-data/en-AI.json' with {type: 'json'}
-import * as zh from './locale-data/zh.json' with {type: 'json'}
-import * as zhHant from './locale-data/zh-Hant.json' with {type: 'json'}
-import * as zhHans from './locale-data/zh-Hans.json' with {type: 'json'}
+import en from './locale-data/en.json' with {type: 'json'}
+import enAI from './locale-data/en-AI.json' with {type: 'json'}
+import zh from './locale-data/zh.json' with {type: 'json'}
+import zhHant from './locale-data/zh-Hant.json' with {type: 'json'}
+import zhHans from './locale-data/zh-Hans.json' with {type: 'json'}
 import {describe, expect, it} from 'vitest'
 ListFormat.__addLocaleData(en, enAI, zh, zhHans, zhHant)
 

--- a/packages/intl-listformat/tests/supported-locales-of.test.ts
+++ b/packages/intl-listformat/tests/supported-locales-of.test.ts
@@ -1,11 +1,11 @@
 import '@formatjs/intl-getcanonicallocales/polyfill.js'
 import '@formatjs/intl-locale/polyfill.js'
 import ListFormat from '../index.js'
-import * as en from './locale-data/en.json' with {type: 'json'}
-import * as enAI from './locale-data/en-AI.json' with {type: 'json'}
-import * as zh from './locale-data/zh.json' with {type: 'json'}
-import * as zhHant from './locale-data/zh-Hant.json' with {type: 'json'}
-import * as zhHans from './locale-data/zh-Hans.json' with {type: 'json'}
+import en from './locale-data/en.json' with {type: 'json'}
+import enAI from './locale-data/en-AI.json' with {type: 'json'}
+import zh from './locale-data/zh.json' with {type: 'json'}
+import zhHant from './locale-data/zh-Hant.json' with {type: 'json'}
+import zhHans from './locale-data/zh-Hans.json' with {type: 'json'}
 import {describe, expect, it} from 'vitest'
 ListFormat.__addLocaleData(en, enAI, zh, zhHans, zhHant)
 

--- a/packages/intl-locale/scripts/calendars.ts
+++ b/packages/intl-locale/scripts/calendars.ts
@@ -1,9 +1,9 @@
 import minimist from 'minimist'
 import {outputFileSync} from 'fs-extra/esm'
 
-import * as rawCalendarPreferenceData from 'cldr-core/supplemental/calendarPreferenceData.json' with {type: 'json'}
+import rawCalendarPreferenceData from 'cldr-core/supplemental/calendarPreferenceData.json' with {type: 'json'}
 
-import type {Args} from './common-types.js'
+import type {Args} from './common-types.ts'
 import stringify from 'json-stable-stringify'
 
 const {calendarPreferenceData} = rawCalendarPreferenceData.supplemental
@@ -22,6 +22,6 @@ export type CalendarsKey = keyof typeof calendars`
   )
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist<Args>(process.argv))
 }

--- a/packages/intl-locale/scripts/character-orders.ts
+++ b/packages/intl-locale/scripts/character-orders.ts
@@ -1,9 +1,9 @@
 import {outputFileSync} from 'fs-extra/esm'
 import stringify from 'json-stable-stringify'
 import minimist from 'minimist'
-import {getAllLocales} from './utils.js'
+import {getAllLocales} from './utils.ts'
 
-import type {Args} from './common-types.js'
+import type {Args} from './common-types.ts'
 
 type CharacterOrder = 'left-to-right' | 'right-to-left'
 
@@ -35,8 +35,11 @@ async function main(args: Args) {
 
   const locales = await getAllLocales()
   for (const locale of locales) {
-    const layoutData = await import(`cldr-misc-full/main/${locale}/layout.json`)
-    const characterOrder = getCharacterOrder(layoutData, locale)
+    const layoutDataImport = (await import(
+      `cldr-misc-full/main/${locale}/layout.json`,
+      {with: {type: 'json'}}
+    )) as {default: CldrMiscLayout}
+    const characterOrder = getCharacterOrder(layoutDataImport.default, locale)
     if (characterOrder) {
       characterOrders[locale] = characterOrder
     }
@@ -66,6 +69,6 @@ export type CharacterOrder = '${possibleValues.join("' | '")}'
   )
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist<Args>(process.argv))
 }

--- a/packages/intl-locale/scripts/hour-cycles.ts
+++ b/packages/intl-locale/scripts/hour-cycles.ts
@@ -1,9 +1,9 @@
 import minimist from 'minimist'
 import {outputFileSync} from 'fs-extra/esm'
 import stringify from 'json-stable-stringify'
-import * as rawTimeData from 'cldr-core/supplemental/timeData.json' with {type: 'json'}
+import rawTimeData from 'cldr-core/supplemental/timeData.json' with {type: 'json'}
 
-import type {Args} from './common-types.js'
+import type {Args} from './common-types.ts'
 
 const {timeData} = rawTimeData.supplemental
 
@@ -44,6 +44,6 @@ export type HourCyclesKey = keyof typeof hourCycles`
   )
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist<Args>(process.argv))
 }

--- a/packages/intl-locale/scripts/timezones.ts
+++ b/packages/intl-locale/scripts/timezones.ts
@@ -1,9 +1,9 @@
 import minimist from 'minimist'
 import {outputFileSync} from 'fs-extra/esm'
 import stringify from 'json-stable-stringify'
-import * as rawTimezones from 'cldr-bcp47/bcp47/timezone.json' with {type: 'json'}
+import rawTimezones from 'cldr-bcp47/bcp47/timezone.json' with {type: 'json'}
 
-import type {Args} from './common-types.js'
+import type {Args} from './common-types.ts'
 
 type Tz = typeof rawTimezones.keyword.u.tz & {
   _alias: never
@@ -83,6 +83,6 @@ export type TimezonesTerritory = keyof typeof timezones`
   )
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist<Args>(process.argv))
 }

--- a/packages/intl-locale/scripts/utils.ts
+++ b/packages/intl-locale/scripts/utils.ts
@@ -1,5 +1,8 @@
 import glob from 'fast-glob'
 import {resolve, dirname} from 'path'
+import {createRequire} from 'node:module'
+
+const require = createRequire(import.meta.url)
 
 export async function getAllLocales(): Promise<string[]> {
   const fns = await glob('*/localeDisplayNames.json', {

--- a/packages/intl-locale/scripts/week-data.ts
+++ b/packages/intl-locale/scripts/week-data.ts
@@ -1,11 +1,11 @@
 import {outputFileSync} from 'fs-extra/esm'
 import minimist from 'minimist'
 
-import * as rawTerritoryInfo from 'cldr-core/supplemental/territoryInfo.json' with {type: 'json'}
-import * as rawWeekData from 'cldr-core/supplemental/weekData.json' with {type: 'json'}
+import rawTerritoryInfo from 'cldr-core/supplemental/territoryInfo.json' with {type: 'json'}
+import rawWeekData from 'cldr-core/supplemental/weekData.json' with {type: 'json'}
 
 import stringify from 'json-stable-stringify'
-import type {Args} from './common-types.js'
+import type {Args} from './common-types.ts'
 
 type WeekInfoInternal = {
   firstDay: number
@@ -97,6 +97,6 @@ export type WeekInfoInternal = typeof weekData[WeekDataKey]`
   )
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist<Args>(process.argv))
 }

--- a/packages/intl-localematcher/scripts/regions-gen.ts
+++ b/packages/intl-localematcher/scripts/regions-gen.ts
@@ -1,4 +1,4 @@
-import rawData from 'cldr-core/supplemental/territoryContainment.json'
+import rawData from 'cldr-core/supplemental/territoryContainment.json' with {type: 'json'}
 import {outputFileSync} from 'fs-extra/esm'
 import stringify from 'json-stable-stringify'
 import minimist from 'minimist'
@@ -66,6 +66,6 @@ export const regions: Record<string, string[]> = ${stringify(data, {
     })}`
   )
 }
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist<Args>(process.argv))
 }

--- a/packages/intl-messageformat/BUILD.bazel
+++ b/packages/intl-messageformat/BUILD.bazel
@@ -86,12 +86,10 @@ js_binary(
         "//:node_modules/@formatjs/intl-localematcher",
         "//:node_modules/@formatjs/intl-pluralrules",
         "//:node_modules/tinybench",
-        "//:node_modules/tsx",
     ],
     entry_point = "tests/benchmark.ts",
     node_options = [
-        "--import",
-        "tsx",
+        "--experimental-transform-types",
     ],
     tags = ["manual"],
 )

--- a/packages/intl-numberformat/benchmark/benchmark.ts
+++ b/packages/intl-numberformat/benchmark/benchmark.ts
@@ -1,7 +1,7 @@
 import {Bench} from 'tinybench'
 import {NumberFormat} from '@formatjs/intl-numberformat'
 // @ts-ignore
-import * as en from './en.json' with {type: 'json'}
+import en from './en.json' with {type: 'json'}
 // @ts-ignore
 NumberFormat.__addLocaleData(en)
 

--- a/packages/intl-numberformat/benchmark/profile.ts
+++ b/packages/intl-numberformat/benchmark/profile.ts
@@ -1,6 +1,6 @@
 import {NumberFormat} from '@formatjs/intl-numberformat'
 // @ts-ignore
-import * as en from './en.json' with {type: 'json'}
+import en from './en.json' with {type: 'json'}
 // @ts-ignore
 NumberFormat.__addLocaleData(en)
 

--- a/packages/intl-numberformat/scripts/cldr-raw.ts
+++ b/packages/intl-numberformat/scripts/cldr-raw.ts
@@ -1,10 +1,10 @@
-import {generateDataForLocales as extractCurrencies} from './extract-currencies.js'
-import {generateDataForLocales as extractUnits} from './extract-units.js'
-import {generateDataForLocales as extractNumbers} from './extract-numbers.js'
+import {generateDataForLocales as extractCurrencies} from './extract-currencies.ts'
+import {generateDataForLocales as extractUnits} from './extract-units.ts'
+import {generateDataForLocales as extractNumbers} from './extract-numbers.ts'
 import {join} from 'path'
 import {outputFileSync} from 'fs-extra/esm'
 import stringify from 'json-stable-stringify'
-import * as AVAILABLE_LOCALES from 'cldr-core/availableLocales.json' with {type: 'json'}
+import AVAILABLE_LOCALES from 'cldr-core/availableLocales.json' with {type: 'json'}
 import minimist from 'minimist'
 
 async function main(args: minimist.ParsedArgs) {
@@ -44,6 +44,6 @@ async function main(args: minimist.ParsedArgs) {
   }
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   ;(async () => main(minimist(process.argv)))()
 }

--- a/packages/intl-numberformat/scripts/cldr.ts
+++ b/packages/intl-numberformat/scripts/cldr.ts
@@ -26,6 +26,6 @@ if (Intl.NumberFormat && typeof Intl.NumberFormat.__addLocaleData === 'function'
   })
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist<Args>(process.argv))
 }

--- a/packages/intl-numberformat/scripts/currency-digits.ts
+++ b/packages/intl-numberformat/scripts/currency-digits.ts
@@ -1,5 +1,5 @@
 import minimist from 'minimist'
-import {extractCurrencyDigits} from './extract-currencies.js'
+import {extractCurrencyDigits} from './extract-currencies.ts'
 import {outputFileSync} from 'fs-extra/esm'
 import stringify from 'json-stable-stringify'
 function main(args: minimist.ParsedArgs) {
@@ -14,6 +14,6 @@ function main(args: minimist.ParsedArgs) {
   )
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist(process.argv))
 }

--- a/packages/intl-numberformat/scripts/extract-currencies.ts
+++ b/packages/intl-numberformat/scripts/extract-currencies.ts
@@ -4,16 +4,20 @@
  * See the accompanying LICENSE file for terms.
  */
 'use strict'
-import * as CurrenciesData from 'cldr-numbers-full/main/en/currencies.json' with {type: 'json'}
-import * as supplementalCurrencyData from 'cldr-core/supplemental/currencyData.json' with {type: 'json'}
-import {sync as globSync} from 'fast-glob'
+import CurrenciesData from 'cldr-numbers-full/main/en/currencies.json' with {type: 'json'}
+import supplementalCurrencyData from 'cldr-core/supplemental/currencyData.json' with {type: 'json'}
+import glob from 'fast-glob'
+const globSync = glob.sync
 import {resolve, dirname} from 'path'
+import {createRequire} from 'node:module'
+
+const require = createRequire(import.meta.url)
 import {
   type CurrencyData,
   type LDMLPluralRuleMap,
 } from '@formatjs/ecma402-abstract'
-import * as AVAILABLE_LOCALES from 'cldr-core/availableLocales.json' with {type: 'json'}
-import {collapseSingleValuePluralRule, PLURAL_RULES} from './utils.js'
+import AVAILABLE_LOCALES from 'cldr-core/availableLocales.json' with {type: 'json'}
+import {collapseSingleValuePluralRule, PLURAL_RULES} from './utils.ts'
 
 export type Currencies =
   (typeof CurrenciesData)['main']['en']['numbers']['currencies']
@@ -48,10 +52,10 @@ async function loadCurrencies(
   locale: string
 ): Promise<Record<string, CurrencyData>> {
   const currencies = (
-    (await import(
-      `cldr-numbers-full/main/${locale}/currencies.json`
-    )) as typeof CurrenciesData
-  ).main[locale as 'en'].numbers.currencies
+    (await import(`cldr-numbers-full/main/${locale}/currencies.json`, {
+      with: {type: 'json'},
+    })) as {default: typeof CurrenciesData}
+  ).default.main[locale as 'en'].numbers.currencies
   return (Object.keys(currencies) as Array<keyof typeof currencies>).reduce(
     (all: Record<string, CurrencyData>, isoCode) => {
       const d = currencies[isoCode] as Currencies['USD']

--- a/packages/intl-numberformat/scripts/extract-numbers.ts
+++ b/packages/intl-numberformat/scripts/extract-numbers.ts
@@ -3,8 +3,8 @@
  * Copyrights licensed under the New BSD License.
  * See the accompanying LICENSE file for terms.
  */
-import * as NumbersData from 'cldr-numbers-full/main/ar/numbers.json' with {type: 'json'}
-import * as numberingSystems from 'cldr-core/supplemental/numberingSystems.json' with {type: 'json'}
+import NumbersData from 'cldr-numbers-full/main/ar/numbers.json' with {type: 'json'}
+import numberingSystems from 'cldr-core/supplemental/numberingSystems.json' with {type: 'json'}
 import {
   type RawNumberData,
   type SymbolsData,
@@ -13,8 +13,8 @@ import {
   type RawCurrencyData,
   invariant,
 } from '@formatjs/ecma402-abstract'
-import * as AVAILABLE_LOCALES from 'cldr-core/availableLocales.json' with {type: 'json'}
-import {collapseSingleValuePluralRule, PLURAL_RULES} from './utils.js'
+import AVAILABLE_LOCALES from 'cldr-core/availableLocales.json' with {type: 'json'}
+import {collapseSingleValuePluralRule, PLURAL_RULES} from './utils.ts'
 
 export type Numbers = (typeof NumbersData)['main']['ar']['numbers']
 
@@ -132,10 +132,10 @@ async function loadNumbers(locale: string): Promise<RawNumberData> {
   try {
     return extractNumbers(
       (
-        (await import(
-          `cldr-numbers-full/main/${locale}/numbers.json`
-        )) as typeof NumbersData
-      ).main[locale as 'ar'].numbers
+        (await import(`cldr-numbers-full/main/${locale}/numbers.json`, {
+          with: {type: 'json'},
+        })) as {default: typeof NumbersData}
+      ).default.main[locale as 'ar'].numbers
     )
   } catch (e) {
     console.error('Issue processing numbers data for ' + locale)

--- a/packages/intl-numberformat/scripts/extract-units.ts
+++ b/packages/intl-numberformat/scripts/extract-units.ts
@@ -12,9 +12,9 @@ import {
   IsWellFormedUnitIdentifier,
   type UnitData,
 } from '@formatjs/ecma402-abstract'
-import * as UnitsData from 'cldr-units-full/main/en/units.json' with {type: 'json'}
-import * as AVAILABLE_LOCALES from 'cldr-core/availableLocales.json' with {type: 'json'}
-import {collapseSingleValuePluralRule, PLURAL_RULES} from './utils.js'
+import UnitsData from 'cldr-units-full/main/en/units.json' with {type: 'json'}
+import AVAILABLE_LOCALES from 'cldr-core/availableLocales.json' with {type: 'json'}
+import {collapseSingleValuePluralRule, PLURAL_RULES} from './utils.ts'
 
 export type Units = (typeof UnitsData)['main']['en']['units']
 
@@ -31,10 +31,10 @@ function extractUnitPattern(d: Units['long']['volume-gallon']) {
 
 async function loadUnits(locale: string): Promise<UnitDataTable> {
   const units = (
-    (await import(
-      `cldr-units-full/main/${locale}/units.json`
-    )) as typeof UnitsData
-  ).main[locale as 'en'].units
+    (await import(`cldr-units-full/main/${locale}/units.json`, {
+      with: {type: 'json'},
+    })) as {default: typeof UnitsData}
+  ).default.main[locale as 'en'].units
 
   invariant(
     !!(

--- a/packages/intl-numberformat/scripts/generate-locale-test.ts
+++ b/packages/intl-numberformat/scripts/generate-locale-test.ts
@@ -26,13 +26,13 @@ function main(args: Args) {
 
   const content = `import "@formatjs/intl-pluralrules/locale-data/${pluralLocale}.js"
 import { test } from "./${type}Test"
-import * as localeData from "../locale-data/${locale}.json" with {type: 'json'}
+import localeData from "../locale-data/${locale}.json" with {type: 'json'}
 test("${locale}", localeData);
 `
 
   outputFileSync(out, content)
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist<Args>(process.argv))
 }

--- a/packages/intl-numberformat/scripts/numbering-systems.ts
+++ b/packages/intl-numberformat/scripts/numbering-systems.ts
@@ -1,6 +1,6 @@
 import minimist from 'minimist'
 import {outputFileSync} from 'fs-extra/esm'
-import {extractNumberingSystemNames} from './extract-numbers.js'
+import {extractNumberingSystemNames} from './extract-numbers.ts'
 function main(args: minimist.ParsedArgs) {
   const {out} = args
 
@@ -13,6 +13,6 @@ function main(args: minimist.ParsedArgs) {
   )
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist(process.argv))
 }

--- a/packages/intl-numberformat/scripts/test-locale-data-gen.ts
+++ b/packages/intl-numberformat/scripts/test-locale-data-gen.ts
@@ -1,7 +1,8 @@
 import {join, basename} from 'path'
 import {copyFileSync} from 'fs-extra/esm'
 import minimist from 'minimist'
-import {sync as globSync} from 'fast-glob'
+import glob from 'fast-glob'
+const globSync = glob.sync
 
 function main(args: minimist.ParsedArgs) {
   const {cldrFolder, locales: localesToGen = '', out} = args
@@ -15,6 +16,6 @@ function main(args: minimist.ParsedArgs) {
   copyFileSync(join(cldrFolder, `${locales[0]}.json`), out)
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist(process.argv))
 }

--- a/packages/intl-numberformat/scripts/test262-main-gen.ts
+++ b/packages/intl-numberformat/scripts/test262-main-gen.ts
@@ -17,13 +17,13 @@ function main(args: Args) {
     out,
     `// @generated
 // @ts-nocheck
-import './polyfill-force';
+import './polyfill-force.ts';
 if (Intl.NumberFormat && typeof Intl.NumberFormat.__addLocaleData === 'function') {
   Intl.NumberFormat.__addLocaleData(${allData.join(',\n')})
 }`
   )
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist<Args>(process.argv))
 }

--- a/packages/intl-numberformat/scripts/units-constants.ts
+++ b/packages/intl-numberformat/scripts/units-constants.ts
@@ -15,6 +15,6 @@ function main(args: minimist.ParsedArgs) {
   )
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist(process.argv))
 }

--- a/packages/intl-numberformat/test262-main.ts
+++ b/packages/intl-numberformat/test262-main.ts
@@ -1,6 +1,6 @@
 // @generated
 // @ts-nocheck
-import './polyfill-force'
+import './polyfill-force.ts'
 if (
   Intl.NumberFormat &&
   typeof Intl.NumberFormat.__addLocaleData === 'function'

--- a/packages/intl-numberformat/tests/currency-code.test.ts
+++ b/packages/intl-numberformat/tests/currency-code.test.ts
@@ -1,7 +1,7 @@
 import {it, expect} from 'vitest'
 import '@formatjs/intl-getcanonicallocales/polyfill.js'
 import '@formatjs/intl-locale/polyfill.js'
-import * as en from './locale-data/en.json' with {type: 'json'}
+import en from './locale-data/en.json' with {type: 'json'}
 import {NumberFormat} from '../src/core'
 NumberFormat.__addLocaleData(en as any)
 

--- a/packages/intl-numberformat/tests/currency/da.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/da.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/da.js'
 import {test} from './currencyTest'
-import * as localeData from '../locale-data/da.json' with {type: 'json'}
+import localeData from '../locale-data/da.json' with {type: 'json'}
 test('da', localeData)

--- a/packages/intl-numberformat/tests/currency/de.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/de.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/de.js'
 import {test} from './currencyTest'
-import * as localeData from '../locale-data/de.json' with {type: 'json'}
+import localeData from '../locale-data/de.json' with {type: 'json'}
 test('de', localeData)

--- a/packages/intl-numberformat/tests/currency/en-BS.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/en-BS.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/en.js'
 import {test} from './currencyTest'
-import * as localeData from '../locale-data/en-BS.json' with {type: 'json'}
+import localeData from '../locale-data/en-BS.json' with {type: 'json'}
 test('en-BS', localeData)

--- a/packages/intl-numberformat/tests/currency/en-GB.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/en-GB.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/en.js'
 import {test} from './currencyTest'
-import * as localeData from '../locale-data/en-GB.json' with {type: 'json'}
+import localeData from '../locale-data/en-GB.json' with {type: 'json'}
 test('en-GB', localeData)

--- a/packages/intl-numberformat/tests/currency/en.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/en.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/en.js'
 import {test} from './currencyTest'
-import * as localeData from '../locale-data/en.json' with {type: 'json'}
+import localeData from '../locale-data/en.json' with {type: 'json'}
 test('en', localeData)

--- a/packages/intl-numberformat/tests/currency/es.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/es.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/es.js'
 import {test} from './currencyTest'
-import * as localeData from '../locale-data/es.json' with {type: 'json'}
+import localeData from '../locale-data/es.json' with {type: 'json'}
 test('es', localeData)

--- a/packages/intl-numberformat/tests/currency/fr.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/fr.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/fr.js'
 import {test} from './currencyTest'
-import * as localeData from '../locale-data/fr.json' with {type: 'json'}
+import localeData from '../locale-data/fr.json' with {type: 'json'}
 test('fr', localeData)

--- a/packages/intl-numberformat/tests/currency/id.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/id.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/id.js'
 import {test} from './currencyTest'
-import * as localeData from '../locale-data/id.json' with {type: 'json'}
+import localeData from '../locale-data/id.json' with {type: 'json'}
 test('id', localeData)

--- a/packages/intl-numberformat/tests/currency/it.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/it.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/it.js'
 import {test} from './currencyTest'
-import * as localeData from '../locale-data/it.json' with {type: 'json'}
+import localeData from '../locale-data/it.json' with {type: 'json'}
 test('it', localeData)

--- a/packages/intl-numberformat/tests/currency/ja.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/ja.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/ja.js'
 import {test} from './currencyTest'
-import * as localeData from '../locale-data/ja.json' with {type: 'json'}
+import localeData from '../locale-data/ja.json' with {type: 'json'}
 test('ja', localeData)

--- a/packages/intl-numberformat/tests/currency/ko.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/ko.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/ko.js'
 import {test} from './currencyTest'
-import * as localeData from '../locale-data/ko.json' with {type: 'json'}
+import localeData from '../locale-data/ko.json' with {type: 'json'}
 test('ko', localeData)

--- a/packages/intl-numberformat/tests/currency/ms.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/ms.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/ms.js'
 import {test} from './currencyTest'
-import * as localeData from '../locale-data/ms.json' with {type: 'json'}
+import localeData from '../locale-data/ms.json' with {type: 'json'}
 test('ms', localeData)

--- a/packages/intl-numberformat/tests/currency/nb.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/nb.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/nb.js'
 import {test} from './currencyTest'
-import * as localeData from '../locale-data/nb.json' with {type: 'json'}
+import localeData from '../locale-data/nb.json' with {type: 'json'}
 test('nb', localeData)

--- a/packages/intl-numberformat/tests/currency/nl.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/nl.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/nl.js'
 import {test} from './currencyTest'
-import * as localeData from '../locale-data/nl.json' with {type: 'json'}
+import localeData from '../locale-data/nl.json' with {type: 'json'}
 test('nl', localeData)

--- a/packages/intl-numberformat/tests/currency/pl.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/pl.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/pl.js'
 import {test} from './currencyTest'
-import * as localeData from '../locale-data/pl.json' with {type: 'json'}
+import localeData from '../locale-data/pl.json' with {type: 'json'}
 test('pl', localeData)

--- a/packages/intl-numberformat/tests/currency/pt.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/pt.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/pt.js'
 import {test} from './currencyTest'
-import * as localeData from '../locale-data/pt.json' with {type: 'json'}
+import localeData from '../locale-data/pt.json' with {type: 'json'}
 test('pt', localeData)

--- a/packages/intl-numberformat/tests/currency/ru.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/ru.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/ru.js'
 import {test} from './currencyTest'
-import * as localeData from '../locale-data/ru.json' with {type: 'json'}
+import localeData from '../locale-data/ru.json' with {type: 'json'}
 test('ru', localeData)

--- a/packages/intl-numberformat/tests/currency/sv.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/sv.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/sv.js'
 import {test} from './currencyTest'
-import * as localeData from '../locale-data/sv.json' with {type: 'json'}
+import localeData from '../locale-data/sv.json' with {type: 'json'}
 test('sv', localeData)

--- a/packages/intl-numberformat/tests/currency/th.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/th.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/th.js'
 import {test} from './currencyTest'
-import * as localeData from '../locale-data/th.json' with {type: 'json'}
+import localeData from '../locale-data/th.json' with {type: 'json'}
 test('th', localeData)

--- a/packages/intl-numberformat/tests/currency/tr.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/tr.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/tr.js'
 import {test} from './currencyTest'
-import * as localeData from '../locale-data/tr.json' with {type: 'json'}
+import localeData from '../locale-data/tr.json' with {type: 'json'}
 test('tr', localeData)

--- a/packages/intl-numberformat/tests/currency/uk.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/uk.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/uk.js'
 import {test} from './currencyTest'
-import * as localeData from '../locale-data/uk.json' with {type: 'json'}
+import localeData from '../locale-data/uk.json' with {type: 'json'}
 test('uk', localeData)

--- a/packages/intl-numberformat/tests/currency/zh.generated.test.ts
+++ b/packages/intl-numberformat/tests/currency/zh.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/zh.js'
 import {test} from './currencyTest'
-import * as localeData from '../locale-data/zh.json' with {type: 'json'}
+import localeData from '../locale-data/zh.json' with {type: 'json'}
 test('zh', localeData)

--- a/packages/intl-numberformat/tests/decimal/da.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/da.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/da.js'
 import {test} from './decimalTest'
-import * as localeData from '../locale-data/da.json' with {type: 'json'}
+import localeData from '../locale-data/da.json' with {type: 'json'}
 test('da', localeData)

--- a/packages/intl-numberformat/tests/decimal/de.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/de.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/de.js'
 import {test} from './decimalTest'
-import * as localeData from '../locale-data/de.json' with {type: 'json'}
+import localeData from '../locale-data/de.json' with {type: 'json'}
 test('de', localeData)

--- a/packages/intl-numberformat/tests/decimal/en-BS.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/en-BS.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/en.js'
 import {test} from './decimalTest'
-import * as localeData from '../locale-data/en-BS.json' with {type: 'json'}
+import localeData from '../locale-data/en-BS.json' with {type: 'json'}
 test('en-BS', localeData)

--- a/packages/intl-numberformat/tests/decimal/en-GB.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/en-GB.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/en.js'
 import {test} from './decimalTest'
-import * as localeData from '../locale-data/en-GB.json' with {type: 'json'}
+import localeData from '../locale-data/en-GB.json' with {type: 'json'}
 test('en-GB', localeData)

--- a/packages/intl-numberformat/tests/decimal/en.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/en.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/en.js'
 import {test} from './decimalTest'
-import * as localeData from '../locale-data/en.json' with {type: 'json'}
+import localeData from '../locale-data/en.json' with {type: 'json'}
 test('en', localeData)

--- a/packages/intl-numberformat/tests/decimal/es.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/es.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/es.js'
 import {test} from './decimalTest'
-import * as localeData from '../locale-data/es.json' with {type: 'json'}
+import localeData from '../locale-data/es.json' with {type: 'json'}
 test('es', localeData)

--- a/packages/intl-numberformat/tests/decimal/fr.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/fr.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/fr.js'
 import {test} from './decimalTest'
-import * as localeData from '../locale-data/fr.json' with {type: 'json'}
+import localeData from '../locale-data/fr.json' with {type: 'json'}
 test('fr', localeData)

--- a/packages/intl-numberformat/tests/decimal/id.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/id.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/id.js'
 import {test} from './decimalTest'
-import * as localeData from '../locale-data/id.json' with {type: 'json'}
+import localeData from '../locale-data/id.json' with {type: 'json'}
 test('id', localeData)

--- a/packages/intl-numberformat/tests/decimal/it.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/it.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/it.js'
 import {test} from './decimalTest'
-import * as localeData from '../locale-data/it.json' with {type: 'json'}
+import localeData from '../locale-data/it.json' with {type: 'json'}
 test('it', localeData)

--- a/packages/intl-numberformat/tests/decimal/ja.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/ja.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/ja.js'
 import {test} from './decimalTest'
-import * as localeData from '../locale-data/ja.json' with {type: 'json'}
+import localeData from '../locale-data/ja.json' with {type: 'json'}
 test('ja', localeData)

--- a/packages/intl-numberformat/tests/decimal/ko.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/ko.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/ko.js'
 import {test} from './decimalTest'
-import * as localeData from '../locale-data/ko.json' with {type: 'json'}
+import localeData from '../locale-data/ko.json' with {type: 'json'}
 test('ko', localeData)

--- a/packages/intl-numberformat/tests/decimal/ms.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/ms.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/ms.js'
 import {test} from './decimalTest'
-import * as localeData from '../locale-data/ms.json' with {type: 'json'}
+import localeData from '../locale-data/ms.json' with {type: 'json'}
 test('ms', localeData)

--- a/packages/intl-numberformat/tests/decimal/nb.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/nb.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/nb.js'
 import {test} from './decimalTest'
-import * as localeData from '../locale-data/nb.json' with {type: 'json'}
+import localeData from '../locale-data/nb.json' with {type: 'json'}
 test('nb', localeData)

--- a/packages/intl-numberformat/tests/decimal/nl.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/nl.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/nl.js'
 import {test} from './decimalTest'
-import * as localeData from '../locale-data/nl.json' with {type: 'json'}
+import localeData from '../locale-data/nl.json' with {type: 'json'}
 test('nl', localeData)

--- a/packages/intl-numberformat/tests/decimal/pl.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/pl.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/pl.js'
 import {test} from './decimalTest'
-import * as localeData from '../locale-data/pl.json' with {type: 'json'}
+import localeData from '../locale-data/pl.json' with {type: 'json'}
 test('pl', localeData)

--- a/packages/intl-numberformat/tests/decimal/pt.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/pt.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/pt.js'
 import {test} from './decimalTest'
-import * as localeData from '../locale-data/pt.json' with {type: 'json'}
+import localeData from '../locale-data/pt.json' with {type: 'json'}
 test('pt', localeData)

--- a/packages/intl-numberformat/tests/decimal/ru.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/ru.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/ru.js'
 import {test} from './decimalTest'
-import * as localeData from '../locale-data/ru.json' with {type: 'json'}
+import localeData from '../locale-data/ru.json' with {type: 'json'}
 test('ru', localeData)

--- a/packages/intl-numberformat/tests/decimal/sv.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/sv.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/sv.js'
 import {test} from './decimalTest'
-import * as localeData from '../locale-data/sv.json' with {type: 'json'}
+import localeData from '../locale-data/sv.json' with {type: 'json'}
 test('sv', localeData)

--- a/packages/intl-numberformat/tests/decimal/th.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/th.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/th.js'
 import {test} from './decimalTest'
-import * as localeData from '../locale-data/th.json' with {type: 'json'}
+import localeData from '../locale-data/th.json' with {type: 'json'}
 test('th', localeData)

--- a/packages/intl-numberformat/tests/decimal/tr.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/tr.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/tr.js'
 import {test} from './decimalTest'
-import * as localeData from '../locale-data/tr.json' with {type: 'json'}
+import localeData from '../locale-data/tr.json' with {type: 'json'}
 test('tr', localeData)

--- a/packages/intl-numberformat/tests/decimal/uk.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/uk.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/uk.js'
 import {test} from './decimalTest'
-import * as localeData from '../locale-data/uk.json' with {type: 'json'}
+import localeData from '../locale-data/uk.json' with {type: 'json'}
 test('uk', localeData)

--- a/packages/intl-numberformat/tests/decimal/zh.generated.test.ts
+++ b/packages/intl-numberformat/tests/decimal/zh.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/zh.js'
 import {test} from './decimalTest'
-import * as localeData from '../locale-data/zh.json' with {type: 'json'}
+import localeData from '../locale-data/zh.json' with {type: 'json'}
 test('zh', localeData)

--- a/packages/intl-numberformat/tests/fast-path-optimizations.test.ts
+++ b/packages/intl-numberformat/tests/fast-path-optimizations.test.ts
@@ -1,6 +1,6 @@
 import {describe, it, expect} from 'vitest'
 import {NumberFormat} from '../src/core'
-import * as en from './locale-data/en.json' with {type: 'json'}
+import en from './locale-data/en.json' with {type: 'json'}
 NumberFormat.__addLocaleData(en as any)
 
 describe('Fast-path optimizations', () => {

--- a/packages/intl-numberformat/tests/notation-compact-ko-KR.test.ts
+++ b/packages/intl-numberformat/tests/notation-compact-ko-KR.test.ts
@@ -3,7 +3,7 @@ import {type NumberFormatPart} from '@formatjs/ecma402-abstract'
 import '@formatjs/intl-pluralrules/locale-data/ko'
 import '@formatjs/intl-pluralrules/polyfill.js'
 import {NumberFormat} from '../src/core'
-import * as ko from './locale-data/ko.json' with {type: 'json'}
+import ko from './locale-data/ko.json' with {type: 'json'}
 NumberFormat.__addLocaleData(ko as any)
 
 const tests: Array<[number, NumberFormatPart[]]> = [

--- a/packages/intl-numberformat/tests/notation-compact-zh-TW.test.ts
+++ b/packages/intl-numberformat/tests/notation-compact-zh-TW.test.ts
@@ -4,8 +4,8 @@ import '@formatjs/intl-locale/polyfill.js'
 import '@formatjs/intl-pluralrules/polyfill.js'
 import '@formatjs/intl-pluralrules/locale-data/zh'
 import '@formatjs/intl-pluralrules/polyfill.js'
-import * as zh from './locale-data/zh.json' with {type: 'json'}
-import * as zhHant from './locale-data/zh-Hant.json' with {type: 'json'}
+import zh from './locale-data/zh.json' with {type: 'json'}
+import zhHant from './locale-data/zh-Hant.json' with {type: 'json'}
 import {NumberFormat} from '../src/core'
 NumberFormat.__addLocaleData(zh as any, zhHant as any)
 

--- a/packages/intl-numberformat/tests/percent/da.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/da.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/da.js'
 import {test} from './percentTest'
-import * as localeData from '../locale-data/da.json' with {type: 'json'}
+import localeData from '../locale-data/da.json' with {type: 'json'}
 test('da', localeData)

--- a/packages/intl-numberformat/tests/percent/de.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/de.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/de.js'
 import {test} from './percentTest'
-import * as localeData from '../locale-data/de.json' with {type: 'json'}
+import localeData from '../locale-data/de.json' with {type: 'json'}
 test('de', localeData)

--- a/packages/intl-numberformat/tests/percent/en-BS.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/en-BS.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/en.js'
 import {test} from './percentTest'
-import * as localeData from '../locale-data/en-BS.json' with {type: 'json'}
+import localeData from '../locale-data/en-BS.json' with {type: 'json'}
 test('en-BS', localeData)

--- a/packages/intl-numberformat/tests/percent/en-GB.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/en-GB.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/en.js'
 import {test} from './percentTest'
-import * as localeData from '../locale-data/en-GB.json' with {type: 'json'}
+import localeData from '../locale-data/en-GB.json' with {type: 'json'}
 test('en-GB', localeData)

--- a/packages/intl-numberformat/tests/percent/en.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/en.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/en.js'
 import {test} from './percentTest'
-import * as localeData from '../locale-data/en.json' with {type: 'json'}
+import localeData from '../locale-data/en.json' with {type: 'json'}
 test('en', localeData)

--- a/packages/intl-numberformat/tests/percent/es.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/es.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/es.js'
 import {test} from './percentTest'
-import * as localeData from '../locale-data/es.json' with {type: 'json'}
+import localeData from '../locale-data/es.json' with {type: 'json'}
 test('es', localeData)

--- a/packages/intl-numberformat/tests/percent/fr.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/fr.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/fr.js'
 import {test} from './percentTest'
-import * as localeData from '../locale-data/fr.json' with {type: 'json'}
+import localeData from '../locale-data/fr.json' with {type: 'json'}
 test('fr', localeData)

--- a/packages/intl-numberformat/tests/percent/id.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/id.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/id.js'
 import {test} from './percentTest'
-import * as localeData from '../locale-data/id.json' with {type: 'json'}
+import localeData from '../locale-data/id.json' with {type: 'json'}
 test('id', localeData)

--- a/packages/intl-numberformat/tests/percent/it.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/it.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/it.js'
 import {test} from './percentTest'
-import * as localeData from '../locale-data/it.json' with {type: 'json'}
+import localeData from '../locale-data/it.json' with {type: 'json'}
 test('it', localeData)

--- a/packages/intl-numberformat/tests/percent/ja.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/ja.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/ja.js'
 import {test} from './percentTest'
-import * as localeData from '../locale-data/ja.json' with {type: 'json'}
+import localeData from '../locale-data/ja.json' with {type: 'json'}
 test('ja', localeData)

--- a/packages/intl-numberformat/tests/percent/ko.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/ko.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/ko.js'
 import {test} from './percentTest'
-import * as localeData from '../locale-data/ko.json' with {type: 'json'}
+import localeData from '../locale-data/ko.json' with {type: 'json'}
 test('ko', localeData)

--- a/packages/intl-numberformat/tests/percent/ms.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/ms.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/ms.js'
 import {test} from './percentTest'
-import * as localeData from '../locale-data/ms.json' with {type: 'json'}
+import localeData from '../locale-data/ms.json' with {type: 'json'}
 test('ms', localeData)

--- a/packages/intl-numberformat/tests/percent/nb.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/nb.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/nb.js'
 import {test} from './percentTest'
-import * as localeData from '../locale-data/nb.json' with {type: 'json'}
+import localeData from '../locale-data/nb.json' with {type: 'json'}
 test('nb', localeData)

--- a/packages/intl-numberformat/tests/percent/nl.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/nl.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/nl.js'
 import {test} from './percentTest'
-import * as localeData from '../locale-data/nl.json' with {type: 'json'}
+import localeData from '../locale-data/nl.json' with {type: 'json'}
 test('nl', localeData)

--- a/packages/intl-numberformat/tests/percent/pl.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/pl.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/pl.js'
 import {test} from './percentTest'
-import * as localeData from '../locale-data/pl.json' with {type: 'json'}
+import localeData from '../locale-data/pl.json' with {type: 'json'}
 test('pl', localeData)

--- a/packages/intl-numberformat/tests/percent/pt.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/pt.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/pt.js'
 import {test} from './percentTest'
-import * as localeData from '../locale-data/pt.json' with {type: 'json'}
+import localeData from '../locale-data/pt.json' with {type: 'json'}
 test('pt', localeData)

--- a/packages/intl-numberformat/tests/percent/ru.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/ru.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/ru.js'
 import {test} from './percentTest'
-import * as localeData from '../locale-data/ru.json' with {type: 'json'}
+import localeData from '../locale-data/ru.json' with {type: 'json'}
 test('ru', localeData)

--- a/packages/intl-numberformat/tests/percent/sv.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/sv.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/sv.js'
 import {test} from './percentTest'
-import * as localeData from '../locale-data/sv.json' with {type: 'json'}
+import localeData from '../locale-data/sv.json' with {type: 'json'}
 test('sv', localeData)

--- a/packages/intl-numberformat/tests/percent/th.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/th.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/th.js'
 import {test} from './percentTest'
-import * as localeData from '../locale-data/th.json' with {type: 'json'}
+import localeData from '../locale-data/th.json' with {type: 'json'}
 test('th', localeData)

--- a/packages/intl-numberformat/tests/percent/tr.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/tr.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/tr.js'
 import {test} from './percentTest'
-import * as localeData from '../locale-data/tr.json' with {type: 'json'}
+import localeData from '../locale-data/tr.json' with {type: 'json'}
 test('tr', localeData)

--- a/packages/intl-numberformat/tests/percent/uk.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/uk.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/uk.js'
 import {test} from './percentTest'
-import * as localeData from '../locale-data/uk.json' with {type: 'json'}
+import localeData from '../locale-data/uk.json' with {type: 'json'}
 test('uk', localeData)

--- a/packages/intl-numberformat/tests/percent/zh.generated.test.ts
+++ b/packages/intl-numberformat/tests/percent/zh.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/zh.js'
 import {test} from './percentTest'
-import * as localeData from '../locale-data/zh.json' with {type: 'json'}
+import localeData from '../locale-data/zh.json' with {type: 'json'}
 test('zh', localeData)

--- a/packages/intl-numberformat/tests/signDisplay-currency-zh-TW.test.ts
+++ b/packages/intl-numberformat/tests/signDisplay-currency-zh-TW.test.ts
@@ -3,8 +3,8 @@ import '@formatjs/intl-getcanonicallocales/polyfill.js'
 import '@formatjs/intl-locale/polyfill.js'
 import '@formatjs/intl-pluralrules/polyfill.js'
 import '@formatjs/intl-pluralrules/locale-data/zh'
-import * as zh from './locale-data/zh.json' with {type: 'json'}
-import * as zhHant from './locale-data/zh-Hant.json' with {type: 'json'}
+import zh from './locale-data/zh.json' with {type: 'json'}
+import zhHant from './locale-data/zh-Hant.json' with {type: 'json'}
 import {NumberFormat} from '../src/core'
 NumberFormat.__addLocaleData(zh as any, zhHant as any)
 const tests = [

--- a/packages/intl-numberformat/tests/signDisplay-zh-TW.test.ts
+++ b/packages/intl-numberformat/tests/signDisplay-zh-TW.test.ts
@@ -3,8 +3,8 @@ import '@formatjs/intl-getcanonicallocales/polyfill.js'
 import '@formatjs/intl-locale/polyfill.js'
 import '@formatjs/intl-pluralrules/polyfill.js'
 import '@formatjs/intl-pluralrules/locale-data/zh'
-import * as zh from './locale-data/zh.json' with {type: 'json'}
-import * as zhHant from './locale-data/zh-Hant.json' with {type: 'json'}
+import zh from './locale-data/zh.json' with {type: 'json'}
+import zhHant from './locale-data/zh-Hant.json' with {type: 'json'}
 import {NumberFormat} from '../src/core'
 NumberFormat.__addLocaleData(zh as any, zhHant as any)
 

--- a/packages/intl-numberformat/tests/unit-zh-TW.test.ts
+++ b/packages/intl-numberformat/tests/unit-zh-TW.test.ts
@@ -4,8 +4,8 @@ import '@formatjs/intl-locale/polyfill.js'
 import '@formatjs/intl-pluralrules/locale-data/zh'
 import '@formatjs/intl-pluralrules/polyfill.js'
 import {NumberFormat} from '../src/core'
-import * as zhHant from './locale-data/zh-Hant.json' with {type: 'json'}
-import * as zh from './locale-data/zh.json' with {type: 'json'}
+import zhHant from './locale-data/zh-Hant.json' with {type: 'json'}
+import zh from './locale-data/zh.json' with {type: 'json'}
 NumberFormat.__addLocaleData(zh as any, zhHant as any)
 
 const tests: Array<

--- a/packages/intl-numberformat/tests/unit/da.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/da.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/da.js'
 import {test} from './unitTest'
-import * as localeData from '../locale-data/da.json' with {type: 'json'}
+import localeData from '../locale-data/da.json' with {type: 'json'}
 test('da', localeData)

--- a/packages/intl-numberformat/tests/unit/de.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/de.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/de.js'
 import {test} from './unitTest'
-import * as localeData from '../locale-data/de.json' with {type: 'json'}
+import localeData from '../locale-data/de.json' with {type: 'json'}
 test('de', localeData)

--- a/packages/intl-numberformat/tests/unit/en-BS.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/en-BS.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/en.js'
 import {test} from './unitTest'
-import * as localeData from '../locale-data/en-BS.json' with {type: 'json'}
+import localeData from '../locale-data/en-BS.json' with {type: 'json'}
 test('en-BS', localeData)

--- a/packages/intl-numberformat/tests/unit/en-GB.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/en-GB.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/en.js'
 import {test} from './unitTest'
-import * as localeData from '../locale-data/en-GB.json' with {type: 'json'}
+import localeData from '../locale-data/en-GB.json' with {type: 'json'}
 test('en-GB', localeData)

--- a/packages/intl-numberformat/tests/unit/en.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/en.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/en.js'
 import {test} from './unitTest'
-import * as localeData from '../locale-data/en.json' with {type: 'json'}
+import localeData from '../locale-data/en.json' with {type: 'json'}
 test('en', localeData)

--- a/packages/intl-numberformat/tests/unit/es.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/es.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/es.js'
 import {test} from './unitTest'
-import * as localeData from '../locale-data/es.json' with {type: 'json'}
+import localeData from '../locale-data/es.json' with {type: 'json'}
 test('es', localeData)

--- a/packages/intl-numberformat/tests/unit/fr.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/fr.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/fr.js'
 import {test} from './unitTest'
-import * as localeData from '../locale-data/fr.json' with {type: 'json'}
+import localeData from '../locale-data/fr.json' with {type: 'json'}
 test('fr', localeData)

--- a/packages/intl-numberformat/tests/unit/id.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/id.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/id.js'
 import {test} from './unitTest'
-import * as localeData from '../locale-data/id.json' with {type: 'json'}
+import localeData from '../locale-data/id.json' with {type: 'json'}
 test('id', localeData)

--- a/packages/intl-numberformat/tests/unit/it.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/it.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/it.js'
 import {test} from './unitTest'
-import * as localeData from '../locale-data/it.json' with {type: 'json'}
+import localeData from '../locale-data/it.json' with {type: 'json'}
 test('it', localeData)

--- a/packages/intl-numberformat/tests/unit/ja.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/ja.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/ja.js'
 import {test} from './unitTest'
-import * as localeData from '../locale-data/ja.json' with {type: 'json'}
+import localeData from '../locale-data/ja.json' with {type: 'json'}
 test('ja', localeData)

--- a/packages/intl-numberformat/tests/unit/ko.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/ko.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/ko.js'
 import {test} from './unitTest'
-import * as localeData from '../locale-data/ko.json' with {type: 'json'}
+import localeData from '../locale-data/ko.json' with {type: 'json'}
 test('ko', localeData)

--- a/packages/intl-numberformat/tests/unit/ms.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/ms.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/ms.js'
 import {test} from './unitTest'
-import * as localeData from '../locale-data/ms.json' with {type: 'json'}
+import localeData from '../locale-data/ms.json' with {type: 'json'}
 test('ms', localeData)

--- a/packages/intl-numberformat/tests/unit/nb.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/nb.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/nb.js'
 import {test} from './unitTest'
-import * as localeData from '../locale-data/nb.json' with {type: 'json'}
+import localeData from '../locale-data/nb.json' with {type: 'json'}
 test('nb', localeData)

--- a/packages/intl-numberformat/tests/unit/nl.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/nl.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/nl.js'
 import {test} from './unitTest'
-import * as localeData from '../locale-data/nl.json' with {type: 'json'}
+import localeData from '../locale-data/nl.json' with {type: 'json'}
 test('nl', localeData)

--- a/packages/intl-numberformat/tests/unit/pl.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/pl.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/pl.js'
 import {test} from './unitTest'
-import * as localeData from '../locale-data/pl.json' with {type: 'json'}
+import localeData from '../locale-data/pl.json' with {type: 'json'}
 test('pl', localeData)

--- a/packages/intl-numberformat/tests/unit/pt.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/pt.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/pt.js'
 import {test} from './unitTest'
-import * as localeData from '../locale-data/pt.json' with {type: 'json'}
+import localeData from '../locale-data/pt.json' with {type: 'json'}
 test('pt', localeData)

--- a/packages/intl-numberformat/tests/unit/ru.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/ru.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/ru.js'
 import {test} from './unitTest'
-import * as localeData from '../locale-data/ru.json' with {type: 'json'}
+import localeData from '../locale-data/ru.json' with {type: 'json'}
 test('ru', localeData)

--- a/packages/intl-numberformat/tests/unit/sv.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/sv.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/sv.js'
 import {test} from './unitTest'
-import * as localeData from '../locale-data/sv.json' with {type: 'json'}
+import localeData from '../locale-data/sv.json' with {type: 'json'}
 test('sv', localeData)

--- a/packages/intl-numberformat/tests/unit/th.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/th.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/th.js'
 import {test} from './unitTest'
-import * as localeData from '../locale-data/th.json' with {type: 'json'}
+import localeData from '../locale-data/th.json' with {type: 'json'}
 test('th', localeData)

--- a/packages/intl-numberformat/tests/unit/tr.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/tr.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/tr.js'
 import {test} from './unitTest'
-import * as localeData from '../locale-data/tr.json' with {type: 'json'}
+import localeData from '../locale-data/tr.json' with {type: 'json'}
 test('tr', localeData)

--- a/packages/intl-numberformat/tests/unit/uk.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/uk.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/uk.js'
 import {test} from './unitTest'
-import * as localeData from '../locale-data/uk.json' with {type: 'json'}
+import localeData from '../locale-data/uk.json' with {type: 'json'}
 test('uk', localeData)

--- a/packages/intl-numberformat/tests/unit/zh.generated.test.ts
+++ b/packages/intl-numberformat/tests/unit/zh.generated.test.ts
@@ -1,4 +1,4 @@
 import '@formatjs/intl-pluralrules/locale-data/zh.js'
 import {test} from './unitTest'
-import * as localeData from '../locale-data/zh.json' with {type: 'json'}
+import localeData from '../locale-data/zh.json' with {type: 'json'}
 test('zh', localeData)

--- a/packages/intl-numberformat/tests/value-tonumber.test.ts
+++ b/packages/intl-numberformat/tests/value-tonumber.test.ts
@@ -1,7 +1,7 @@
 import {describe, it, expect} from 'vitest'
 import '@formatjs/intl-pluralrules/polyfill.js'
 import '@formatjs/intl-pluralrules/locale-data/en'
-import * as en from './locale-data/en.json' with {type: 'json'}
+import en from './locale-data/en.json' with {type: 'json'}
 import {NumberFormat} from '../src/core'
 NumberFormat.__addLocaleData(en as any)
 const toNumberResults = [

--- a/packages/intl-pluralrules/scripts/cldr-raw.ts
+++ b/packages/intl-pluralrules/scripts/cldr-raw.ts
@@ -2,11 +2,11 @@ import {join} from 'path'
 import {outputFileSync} from 'fs-extra/esm'
 import serialize from 'serialize-javascript'
 import {type LDMLPluralRule} from '@formatjs/ecma402-abstract'
-import plurals from 'cldr-core/supplemental/plurals.json'
-import ordinals from 'cldr-core/supplemental/ordinals.json'
-import pluralRanges from 'cldr-core/supplemental/pluralRanges.json'
+import plurals from 'cldr-core/supplemental/plurals.json' with {type: 'json'}
+import ordinals from 'cldr-core/supplemental/ordinals.json' with {type: 'json'}
+import pluralRanges from 'cldr-core/supplemental/pluralRanges.json' with {type: 'json'}
 import minimist from 'minimist'
-import {PluralRulesCompiler} from './plural-rules-compiler.js'
+import {PluralRulesCompiler} from './plural-rules-compiler.ts'
 
 const cardinalsData = plurals.supplemental['plurals-type-cardinal']
 const ordinalsData = ordinals.supplemental['plurals-type-ordinal']
@@ -123,6 +123,6 @@ export const supportedLocales: string[] = ${JSON.stringify(locales)}
     )
   }
 }
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist<Args>(process.argv))
 }

--- a/packages/intl-pluralrules/scripts/cldr.ts
+++ b/packages/intl-pluralrules/scripts/cldr.ts
@@ -25,6 +25,6 @@ if (Intl.PluralRules && typeof Intl.PluralRules.__addLocaleData === 'function') 
     outputFileSync(join(outDir, locale + '.d.ts'), 'export {}')
   })
 }
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist<Args>(process.argv))
 }

--- a/packages/intl-pluralrules/scripts/test262-main-gen.ts
+++ b/packages/intl-pluralrules/scripts/test262-main-gen.ts
@@ -17,13 +17,13 @@ function main(args: Args) {
     `/* @generated */
 // prettier-ignore
 // @ts-nocheck
-import './polyfill-force'
+import './polyfill-force.ts'
 if (Intl.PluralRules && typeof Intl.PluralRules.__addLocaleData === 'function') {
   Intl.PluralRules.__addLocaleData(${allData.join(',\n')})
 }
 `
   )
 }
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist<Args>(process.argv))
 }

--- a/packages/intl-pluralrules/test262-main.ts
+++ b/packages/intl-pluralrules/test262-main.ts
@@ -1,7 +1,7 @@
 /* @generated */
 // prettier-ignore
 // @ts-nocheck
-import './polyfill-force'
+import './polyfill-force.ts'
 if (
   Intl.PluralRules &&
   typeof Intl.PluralRules.__addLocaleData === 'function'

--- a/packages/intl-relativetimeformat/scripts/cldr-raw.ts
+++ b/packages/intl-relativetimeformat/scripts/cldr-raw.ts
@@ -1,4 +1,4 @@
-import {extractRelativeFields, getAllLocales} from './extract-relative.js'
+import {extractRelativeFields, getAllLocales} from './extract-relative.ts'
 import {join} from 'path'
 import {outputFileSync} from 'fs-extra/esm'
 import stringify from 'json-stable-stringify'

--- a/packages/intl-relativetimeformat/scripts/test-locale-data-gen.ts
+++ b/packages/intl-relativetimeformat/scripts/test-locale-data-gen.ts
@@ -1,7 +1,8 @@
 import {join, basename} from 'path'
 import {copyFileSync} from 'fs-extra/esm'
 import minimist from 'minimist'
-import {sync as globSync} from 'fast-glob'
+import glob from 'fast-glob'
+const globSync = glob.sync
 function main(args: minimist.ParsedArgs) {
   const {cldrFolder, locales: localesToGen = '', out} = args
   const allFiles = globSync(join(cldrFolder, '*.json'))
@@ -13,6 +14,6 @@ function main(args: minimist.ParsedArgs) {
   copyFileSync(join(cldrFolder, `${locales[0]}.json`), out)
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist(process.argv))
 }

--- a/packages/intl-relativetimeformat/tests/index.test.ts
+++ b/packages/intl-relativetimeformat/tests/index.test.ts
@@ -3,11 +3,11 @@ import '@formatjs/intl-locale/polyfill.js'
 import '@formatjs/intl-pluralrules/polyfill.js'
 import '@formatjs/intl-pluralrules/locale-data/zh'
 import '@formatjs/intl-pluralrules/locale-data/en'
-import * as zh from './locale-data/zh.json' with {type: 'json'}
-import * as zhHant from './locale-data/zh-Hant.json' with {type: 'json'}
-import * as zhHans from './locale-data/zh-Hans.json' with {type: 'json'}
-import * as en from './locale-data/en.json' with {type: 'json'}
-import * as enAI from './locale-data/en-AI.json' with {type: 'json'}
+import zh from './locale-data/zh.json' with {type: 'json'}
+import zhHant from './locale-data/zh-Hant.json' with {type: 'json'}
+import zhHans from './locale-data/zh-Hans.json' with {type: 'json'}
+import en from './locale-data/en.json' with {type: 'json'}
+import enAI from './locale-data/en-AI.json' with {type: 'json'}
 import RelativeTimeFormat from '../index.js'
 import {describe, expect, it} from 'vitest'
 RelativeTimeFormat.__addLocaleData(en, enAI, zh, zhHans, zhHant)

--- a/packages/intl-relativetimeformat/tests/supported-locales-of.test.ts
+++ b/packages/intl-relativetimeformat/tests/supported-locales-of.test.ts
@@ -3,11 +3,11 @@ import '@formatjs/intl-locale/polyfill.js'
 import '@formatjs/intl-pluralrules/polyfill.js'
 import '@formatjs/intl-pluralrules/locale-data/en'
 import '@formatjs/intl-pluralrules/locale-data/zh'
-import * as zh from './locale-data/zh.json' with {type: 'json'}
-import * as zhHant from './locale-data/zh-Hant.json' with {type: 'json'}
-import * as zhHans from './locale-data/zh-Hans.json' with {type: 'json'}
-import * as en from './locale-data/en.json' with {type: 'json'}
-import * as enAI from './locale-data/en-AI.json' with {type: 'json'}
+import zh from './locale-data/zh.json' with {type: 'json'}
+import zhHant from './locale-data/zh-Hant.json' with {type: 'json'}
+import zhHans from './locale-data/zh-Hans.json' with {type: 'json'}
+import en from './locale-data/en.json' with {type: 'json'}
+import enAI from './locale-data/en-AI.json' with {type: 'json'}
 import RelativeTimeFormat from '../index.js'
 import {describe, expect, it} from 'vitest'
 RelativeTimeFormat.__addLocaleData(en, enAI, zh, zhHans, zhHant)

--- a/packages/intl-segmenter/scripts/generate-cldr-segmentation-rules.ts
+++ b/packages/intl-segmenter/scripts/generate-cldr-segmentation-rules.ts
@@ -132,9 +132,11 @@ const getGranularity = (
 const cldrSegmentationRules = async () => {
   const rules: Record<string, SegmentationsJson> = {}
   for (const locale of SEGMENTATION_LOCALES) {
-    rules[locale] = await import(
-      `cldr-segments-full/segments/${locale}/suppressions.json`
-    )
+    const imported = (await import(
+      `cldr-segments-full/segments/${locale}/suppressions.json`,
+      {with: {type: 'json'}}
+    )) as {default: SegmentationsJson}
+    rules[locale] = imported.default
   }
 
   return rules as {

--- a/packages/intl-supportedvaluesof/scripts/calendars.ts
+++ b/packages/intl-supportedvaluesof/scripts/calendars.ts
@@ -1,6 +1,7 @@
 import minimist from 'minimist'
 import {outputFileSync} from 'fs-extra/esm'
-import {keyword} from 'cldr-bcp47/bcp47/calendar.json'
+import calendarData from 'cldr-bcp47/bcp47/calendar.json' with {type: 'json'}
+const {keyword} = calendarData
 function main(args: minimist.ParsedArgs) {
   const {out} = args
   const calendars = Object.keys(keyword.u.ca).filter(k => !k.startsWith('_'))
@@ -16,6 +17,6 @@ export type Calendar = typeof calendars[number]
   )
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist(process.argv))
 }

--- a/packages/intl-supportedvaluesof/scripts/collations.ts
+++ b/packages/intl-supportedvaluesof/scripts/collations.ts
@@ -1,6 +1,7 @@
 import minimist from 'minimist'
 import {outputFileSync} from 'fs-extra/esm'
-import {keyword} from 'cldr-bcp47/bcp47/collation.json'
+import collationData from 'cldr-bcp47/bcp47/collation.json' with {type: 'json'}
+const {keyword} = collationData
 function main(args: minimist.ParsedArgs) {
   const {out} = args
   const collations = Object.keys(keyword.u.co).filter(k => !k.startsWith('_'))
@@ -16,6 +17,6 @@ export type Collation = typeof collations[number]
   )
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist(process.argv))
 }

--- a/packages/intl-supportedvaluesof/scripts/currencies.ts
+++ b/packages/intl-supportedvaluesof/scripts/currencies.ts
@@ -1,6 +1,7 @@
 import minimist from 'minimist'
 import {outputFileSync} from 'fs-extra/esm'
-import {main as data} from 'cldr-numbers-full/main/en/currencies.json'
+import currenciesData from 'cldr-numbers-full/main/en/currencies.json' with {type: 'json'}
+const {main: data} = currenciesData
 function main(args: minimist.ParsedArgs) {
   const {out} = args
   const currencies = Object.keys(data.en.numbers.currencies)
@@ -16,6 +17,6 @@ export type Currency = typeof currencies[number]
   )
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist(process.argv))
 }

--- a/packages/intl-supportedvaluesof/scripts/timezones.ts
+++ b/packages/intl-supportedvaluesof/scripts/timezones.ts
@@ -17,6 +17,6 @@ export type Timezone = typeof timezones[number]
   )
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist<Args>(process.argv))
 }

--- a/packages/intl-supportedvaluesof/scripts/units.ts
+++ b/packages/intl-supportedvaluesof/scripts/units.ts
@@ -18,6 +18,6 @@ export type Unit = typeof units[number]`
   )
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist<Args>(process.argv))
 }

--- a/packages/ts-transformer/examples/compile.ts
+++ b/packages/ts-transformer/examples/compile.ts
@@ -14,7 +14,7 @@ const CJS_CONFIG: ts.CompilerOptions = {
   noUnusedParameters: true,
   stripInternal: true,
   declaration: true,
-  baseUrl: __dirname,
+  baseUrl: import.meta.dirname,
   target: ts.ScriptTarget.ES2015,
 }
 

--- a/packages/ts-transformer/integration-tests/vue/integration.test.ts
+++ b/packages/ts-transformer/integration-tests/vue/integration.test.ts
@@ -10,7 +10,7 @@ test('tranpilation', async function () {
       {
         entry: require.resolve('./fixtures/main.ts'),
         output: {
-          path: __dirname,
+          path: import.meta.dirname,
           filename: 'out.js',
         },
         module: {
@@ -63,7 +63,7 @@ test('tranpilation', async function () {
           throw new Error('err compiling')
         }
         const outFile = join(
-          statsJson.outputPath || __dirname,
+          statsJson.outputPath || import.meta.dirname,
           statsJson.assets?.[0].name || 'out.js'
         )
         const outFileContent = readFileSync(outFile, 'utf-8')

--- a/packages/ts-transformer/tests/index.test.ts
+++ b/packages/ts-transformer/tests/index.test.ts
@@ -7,7 +7,7 @@ import {describe, it, expect} from 'vitest'
 
 const readFile = promisify(readFileAsync)
 
-const FIXTURES_DIR = join(__dirname, 'fixtures')
+const FIXTURES_DIR = join(import.meta.dirname, 'fixtures')
 
 describe('emit asserts for', function () {
   it('additionalComponentNames', async function () {

--- a/packages/utils/tools/extract-default-currency.ts
+++ b/packages/utils/tools/extract-default-currency.ts
@@ -1,4 +1,5 @@
-import {supplemental} from 'cldr-core/supplemental/currencyData.json'
+import currencyData from 'cldr-core/supplemental/currencyData.json' with {type: 'json'}
+const {supplemental} = currencyData
 import {outputFileSync} from 'fs-extra/esm'
 import minimist from 'minimist'
 
@@ -30,6 +31,6 @@ function main(args: Args) {
   )
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist<Args>(process.argv))
 }

--- a/packages/utils/tools/extract-default-locale.ts
+++ b/packages/utils/tools/extract-default-locale.ts
@@ -1,4 +1,5 @@
-import {supplemental} from 'cldr-core/supplemental/likelySubtags.json'
+import likelySubtagsData from 'cldr-core/supplemental/likelySubtags.json' with {type: 'json'}
+const {supplemental} = likelySubtagsData
 import {outputFileSync} from 'fs-extra/esm'
 import minimist from 'minimist'
 
@@ -25,6 +26,6 @@ function main(args: Args) {
   )
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist<Args>(process.argv))
 }

--- a/packages/utils/tools/extract-minor-currency-units.ts
+++ b/packages/utils/tools/extract-minor-currency-units.ts
@@ -40,6 +40,6 @@ function main({input, out}: Args) {
   )
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist<Args>(process.argv))
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -339,9 +339,6 @@ importers:
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
-      tsx:
-        specifier: ^4.21.0
-        version: 4.21.0
       typescript:
         specifier: 5.8.2
         version: 5.8.2
@@ -554,7 +551,7 @@ importers:
         version: 4.0.2
       '@typescript-eslint/utils':
         specifier: ^8.52.0
-        version: 8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.2)
+        version: 8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)
       '@unicode/unicode-17.0.0':
         specifier: ^1.6.16
         version: 1.6.16
@@ -1014,7 +1011,7 @@ importers:
         version: link:..
       ts-jest:
         specifier: ^29
-        version: 29.4.6(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.2)(jest-util@29.7.0)(jest@29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0))(typescript@5.8.2)
+        version: 29.4.6(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.2)(jest-util@29.7.0)(jest@29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0))(typescript@5.8.3)
 
   packages/utils:
     dependencies:
@@ -10760,6 +10757,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/project-service@8.53.0(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.53.0(typescript@5.8.3)
+      '@typescript-eslint/types': 8.53.0
+      debug: 4.4.3
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/rule-tester@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.2)':
     dependencies:
       '@typescript-eslint/parser': 8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.2)
@@ -10783,6 +10789,10 @@ snapshots:
     dependencies:
       typescript: 5.8.2
 
+  '@typescript-eslint/tsconfig-utils@8.53.0(typescript@5.8.3)':
+    dependencies:
+      typescript: 5.8.3
+
   '@typescript-eslint/types@8.53.0': {}
 
   '@typescript-eslint/typescript-estree@8.53.0(typescript@5.8.2)':
@@ -10800,6 +10810,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@8.53.0(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.53.0(typescript@5.8.3)
+      '@typescript-eslint/tsconfig-utils': 8.53.0(typescript@5.8.3)
+      '@typescript-eslint/types': 8.53.0
+      '@typescript-eslint/visitor-keys': 8.53.0
+      debug: 4.4.3
+      minimatch: 9.0.5
+      semver: 7.7.3
+      tinyglobby: 0.2.15
+      ts-api-utils: 2.4.0(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/utils@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
@@ -10808,6 +10833,17 @@ snapshots:
       '@typescript-eslint/typescript-estree': 8.53.0(typescript@5.8.2)
       eslint: 9.39.2(jiti@2.6.1)
       typescript: 5.8.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
+      '@typescript-eslint/scope-manager': 8.53.0
+      '@typescript-eslint/types': 8.53.0
+      '@typescript-eslint/typescript-estree': 8.53.0(typescript@5.8.3)
+      eslint: 9.39.2(jiti@2.6.1)
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -12308,6 +12344,7 @@ snapshots:
   get-tsconfig@4.13.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
+    optional: true
 
   git-raw-commits@4.0.0:
     dependencies:
@@ -14809,7 +14846,8 @@ snapshots:
 
   resolve-from@5.0.0: {}
 
-  resolve-pkg-maps@1.0.0: {}
+  resolve-pkg-maps@1.0.0:
+    optional: true
 
   resolve.exports@2.0.3: {}
 
@@ -15426,6 +15464,10 @@ snapshots:
     dependencies:
       typescript: 5.8.2
 
+  ts-api-utils@2.4.0(typescript@5.8.3):
+    dependencies:
+      typescript: 5.8.3
+
   ts-interface-checker@0.1.13: {}
 
   ts-jest@29.4.6(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.2)(jest-util@29.7.0)(jest@29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0))(typescript@5.8.2):
@@ -15440,6 +15482,27 @@ snapshots:
       semver: 7.7.3
       type-fest: 4.41.0
       typescript: 5.8.2
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.28.6
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.28.6)
+      esbuild: 0.27.2
+      jest-util: 29.7.0
+
+  ts-jest@29.4.6(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.2)(jest-util@29.7.0)(jest@29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0))(typescript@5.8.3):
+    dependencies:
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      handlebars: 4.7.8
+      jest: 29.7.0(@types/node@22.19.7)(babel-plugin-macros@3.1.0)
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.7.3
+      type-fest: 4.41.0
+      typescript: 5.8.3
       yargs-parser: 21.1.1
     optionalDependencies:
       '@babel/core': 7.28.6
@@ -15481,6 +15544,7 @@ snapshots:
       get-tsconfig: 4.13.0
     optionalDependencies:
       fsevents: 2.3.3
+    optional: true
 
   type-check@0.4.0:
     dependencies:
@@ -15507,8 +15571,7 @@ snapshots:
 
   typescript@5.8.2: {}
 
-  typescript@5.8.3:
-    optional: true
+  typescript@5.8.3: {}
 
   typesense@2.1.0(@babel/runtime@7.28.6):
     dependencies:

--- a/tools/check-package-json.ts
+++ b/tools/check-package-json.ts
@@ -2,6 +2,9 @@ import {readJSONSync} from 'fs-extra/esm'
 import minimist from 'minimist'
 import {isEqual} from 'lodash-es'
 import stringify from 'json-stable-stringify'
+import {createRequire} from 'node:module'
+
+const require = createRequire(import.meta.url)
 const unidiff = require('unidiff')
 
 interface Args {
@@ -66,6 +69,6 @@ function main(args: Args) {
   process.exit(1)
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist<Args>(process.argv.slice(2)))
 }

--- a/tools/generate-supported-locales.ts
+++ b/tools/generate-supported-locales.ts
@@ -22,6 +22,6 @@ function main(args: Args) {
   outputFileSync(out, content)
 }
 
-if (require.main === module) {
+if (import.meta.filename === process.argv[1]) {
   main(minimist<Args>(process.argv.slice(2)))
 }

--- a/tools/index.bzl
+++ b/tools/index.bzl
@@ -104,12 +104,9 @@ def ts_binary(name, data = [], node_options = [], **kwargs):
     """
     js_binary(
         name = name,
-        data = data + [
-            "//:node_modules/tsx",
-        ],
+        data = data,
         node_options = node_options + [
-            "--import",
-            "tsx",
+            "--experimental-transform-types",
         ],
         **kwargs
     )

--- a/tools/oxc-transpiler/index.mjs
+++ b/tools/oxc-transpiler/index.mjs
@@ -72,11 +72,25 @@ for (let i = 0; i < args.length; i += 2) {
       process.exit(1)
     }
 
+    // Rewrite relative .ts/.tsx imports to .js (equivalent to rewriteRelativeImportExtensions)
+    // This transforms: import './types.ts' -> import './types.js'
+    // Only affects relative imports (starting with ./ or ../)
+    let outputCode = result.code.replace(
+      /((?:import|export)\s+(?:(?:[\w{}\s*,]+)\s+from\s+)?["'])(\.\.?\/[^"']+)(\.ts)(x?)(["'])/g,
+      '$1$2.js$5'
+    )
+
+    // Also handle dynamic imports: import('./types.ts') -> import('./types.js')
+    outputCode = outputCode.replace(
+      /(import\s*\(\s*["'])(\.\.?\/[^"']+)(\.ts)(x?)(["']\s*\))/g,
+      '$1$2.js$5'
+    )
+
     // Resolve output path the same way as input
     const resolvedOutputPath = pathToExecroot + outputFile
 
     // Write JS output to the specified output file (creates directories automatically)
-    outputFileSync(resolvedOutputPath, result.code, 'utf-8')
+    outputFileSync(resolvedOutputPath, outputCode, 'utf-8')
 
     // Write .d.ts file if declaration was generated
     if (result.declaration) {

--- a/tools/tsconfig.bzl
+++ b/tools/tsconfig.bzl
@@ -33,6 +33,7 @@ BASE_TSCONFIG = {
         "verbatimModuleSyntax": True,
         "importHelpers": True,
         "isolatedDeclarations": True,
+        "rewriteRelativeImportExtensions": True,
         "jsx": "react-jsx",
     },
     "exclude": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,6 +27,7 @@
     "noUnusedParameters": true,
     "preserveConstEnums": true,
     "resolveJsonModule": true,
+    "rewriteRelativeImportExtensions": true,
     "strict": true,
     "target": "es5",
     "verbatimModuleSyntax": true


### PR DESCRIPTION
### TL;DR

Migrate codebase to use native TypeScript ESM imports with import.meta.dirname instead of __dirname

### What changed?

- Replaced `__dirname` with `import.meta.dirname` throughout the codebase
- Updated import statements to use ESM-compatible syntax
- Changed `* as module` imports to default imports where appropriate
- Replaced `require.main === module` checks with `import.meta.filename === process.argv[1]`
- Added proper type annotations for dynamic imports
- Removed dependency on `tsx` package
- Updated Node.js options to use `--experimental-transform-types` instead of tsx
- Added `rewriteRelativeImportExtensions: true` to tsconfig

### How to test?

1. Run the test suite to ensure all functionality works as expected
2. Verify that scripts can be executed directly with Node.js using the `--experimental-transform-types` flag
3. Check that all imports resolve correctly in both development and production environments

### Why make this change?

This change modernizes the codebase to use native ESM features in TypeScript, improving compatibility with the Node.js ESM loader. By removing the dependency on the `tsx` package and using Node.js's built-in TypeScript support via the `--experimental-transform-types` flag, the project reduces external dependencies and aligns with modern JavaScript practices. This approach provides better long-term maintainability and prepares the codebase for future Node.js versions where ESM is the standard module system.