### PR TITLE
docs: fix ESM imports throughout docs

### DIFF
--- a/docs/src/docs/polyfills/intl-displaynames.mdx
+++ b/docs/src/docs/polyfills/intl-displaynames.mdx
@@ -47,7 +47,7 @@ For `type: 'language'`, the `languageDisplay` option controls dialect formatting
 ### Example Usage
 
 ```js
-import '@formatjs/intl-displaynames/polyfill'
+import '@formatjs/intl-displaynames/polyfill.js'
 
 // Language names
 const languageNames = new Intl.DisplayNames(['en'], {type: 'language'})

--- a/docs/src/docs/polyfills/intl-durationformat.mdx
+++ b/docs/src/docs/polyfills/intl-durationformat.mdx
@@ -72,7 +72,7 @@ When set to `'auto'`, zero values are omitted. When set to `'always'`, zero valu
 ### Example Usage
 
 ```js
-import '@formatjs/intl-durationformat/polyfill'
+import '@formatjs/intl-durationformat/polyfill.js'
 
 const formatter = new Intl.DurationFormat('en', {
   style: 'long',

--- a/docs/src/docs/polyfills/intl-listformat.mdx
+++ b/docs/src/docs/polyfills/intl-listformat.mdx
@@ -31,7 +31,7 @@ This package is **fully compliant** with the ECMA-402 specification for `Intl.Li
 ### Example Usage
 
 ```js
-import '@formatjs/intl-listformat/polyfill'
+import '@formatjs/intl-listformat/polyfill.js'
 
 // Conjunction (and)
 const conjunctionFormatter = new Intl.ListFormat('en', {

--- a/docs/src/docs/polyfills/intl-locale.mdx
+++ b/docs/src/docs/polyfills/intl-locale.mdx
@@ -38,7 +38,7 @@ This package is **fully compliant** with the ECMA-402 specification for `Intl.Lo
 ### Example Usage
 
 ```js
-import '@formatjs/intl-locale/polyfill'
+import '@formatjs/intl-locale/polyfill.js'
 
 // Create locale
 const locale = new Intl.Locale('en-US')

--- a/docs/src/docs/polyfills/intl-numberformat.mdx
+++ b/docs/src/docs/polyfills/intl-numberformat.mdx
@@ -131,7 +131,7 @@ All **42 ECMA-402 sanctioned units** are fully supported:
 ### Example Usage
 
 ```js
-import '@formatjs/intl-numberformat/polyfill'
+import '@formatjs/intl-numberformat/polyfill.js'
 
 // Currency with accounting sign
 const currency = new Intl.NumberFormat('en', {

--- a/docs/src/docs/polyfills/intl-pluralrules.mdx
+++ b/docs/src/docs/polyfills/intl-pluralrules.mdx
@@ -30,7 +30,7 @@ This package is **fully compliant** with the ECMA-402 specification for `Intl.Pl
 ### Example Usage
 
 ```js
-import '@formatjs/intl-pluralrules/polyfill'
+import '@formatjs/intl-pluralrules/polyfill.js'
 
 const pr = new Intl.PluralRules('en')
 pr.select(0) // "other"

--- a/docs/src/docs/polyfills/intl-relativetimeformat.mdx
+++ b/docs/src/docs/polyfills/intl-relativetimeformat.mdx
@@ -73,7 +73,7 @@ The implementation automatically handles plural forms using `Intl.PluralRules`:
 ### Example Usage
 
 ```js
-import '@formatjs/intl-relativetimeformat/polyfill'
+import '@formatjs/intl-relativetimeformat/polyfill.js'
 
 // Basic usage with numeric: 'always' (default)
 const rtf = new Intl.RelativeTimeFormat('en', {style: 'long'})

--- a/docs/src/docs/polyfills/intl-segmenter.mdx
+++ b/docs/src/docs/polyfills/intl-segmenter.mdx
@@ -54,7 +54,7 @@ Each segment has:
 ### Example Usage
 
 ```js
-import '@formatjs/intl-segmenter/polyfill'
+import '@formatjs/intl-segmenter/polyfill.js'
 
 // Grapheme segmentation (user-perceived characters)
 const graphemeSegmenter = new Intl.Segmenter('en', {granularity: 'grapheme'})

--- a/docs/src/docs/tooling/ts-transformer.mdx
+++ b/docs/src/docs/tooling/ts-transformer.mdx
@@ -90,7 +90,7 @@ module.exports = {
         astTransformers: {
           before: [
             {
-              path: '@formatjs/ts-transformer/ts-jest-integration',
+              path: '@formatjs/ts-transformer/ts-jest-integration.js',
               options: {
                 // options
                 overrideIdFn: '[sha512:contenthash:base64:6]',


### PR DESCRIPTION
### TL;DR

Updated import paths in documentation to include `.js` extension for all polyfill imports.

Part of #6012

### What changed?

Added the `.js` extension to all polyfill import statements in the documentation files:

- Updated `@formatjs/intl-displaynames/polyfill` to `@formatjs/intl-displaynames/polyfill.js`
- Updated `@formatjs/intl-durationformat/polyfill` to `@formatjs/intl-durationformat/polyfill.js`
- Updated `@formatjs/intl-listformat/polyfill` to `@formatjs/intl-listformat/polyfill.js`
- Updated `@formatjs/intl-locale/polyfill` to `@formatjs/intl-locale/polyfill.js`
- Updated `@formatjs/intl-numberformat/polyfill` to `@formatjs/intl-numberformat/polyfill.js`
- Updated `@formatjs/intl-pluralrules/polyfill` to `@formatjs/intl-pluralrules/polyfill.js`
- Updated `@formatjs/intl-relativetimeformat/polyfill` to `@formatjs/intl-relativetimeformat/polyfill.js`
- Updated `@formatjs/intl-segmenter/polyfill` to `@formatjs/intl-segmenter/polyfill.js`
- Updated `@formatjs/ts-transformer/ts-jest-integration` to `@formatjs/ts-transformer/ts-jest-integration.js`

### How to test?

1. Review the documentation pages to ensure the import statements correctly include the `.js` extension
2. Verify that the code examples work when copied directly from the documentation

### Why make this change?

This change ensures compatibility with ESM imports in modern JavaScript environments where file extensions are required for proper module resolution. It helps users avoid import errors when following the documentation examples.