### PR TITLE
fix(@formatjs/intl-datetimeformat): fix formatRange h24 midnight and hour12 duplication

### DIFF
--- a/packages/intl-datetimeformat/scripts/extract-dates.ts
+++ b/packages/intl-datetimeformat/scripts/extract-dates.ts
@@ -375,7 +375,11 @@ async function loadDatesFields(
       // LDML Spec (UTS #35): "If no exact match exists, check the fallback locale chain,
       // allowing adjustments to field widths and variant field types."
       // See: https://unicode.org/reports/tr35/tr35-dates.html#intervalFormats
-      if (!timeIntervalFormats || typeof timeIntervalFormats !== 'object') {
+      if (
+        !timeIntervalFormats ||
+        typeof timeIntervalFormats !== 'object' ||
+        Object.keys(timeIntervalFormats).length === 0
+      ) {
         // Convert between 12-hour (h/K) and 24-hour (H/k) hour symbols
         const alt24HourSkeleton = timeSkeleton
           .replace(/h/g, 'H')


### PR DESCRIPTION
Fixes #4535

## Summary

This PR fixes two bugs in `FormattedDateTimeRange` that were causing incorrect formatting:

1. **H24 midnight rendering**: Same-day ranges starting at midnight showing "24:00" instead of "00:00"
2. **Date duplication with hour12**: Date/day duplicated for any time range when `hour12: true`

## Changes

### Bug 1: H24 Midnight Rendering

**Root Cause**: The condition `!rangeFormatOptions?.isDifferentDate` meant "convert 0→24 when NOT in a range with different dates". Same-day ranges have `isDifferentDate: false`, causing unwanted conversion.

**Fix in `FormatDateTimePattern.ts`**:
- Changed from: `if (v === 0 && !rangeFormatOptions?.isDifferentDate)`
- Changed to: `if (v === 0 && !rangeFormatOptions)`
- Now 0→24 conversion only happens in non-range single-date formatting

**Example**:
- Before: `Sun, 3 May 2026, 24:00–24:45`
- After: `Sun, 3 May 2026, 00:00–00:45` ✓

### Bug 2: Hour12 Date Duplication

**Root Cause**: CLDR data synthesis fallback to alternate hour cycles (12hr ↔ 24hr) only checked if `timeIntervalFormats` was undefined or not an object, missing the case where it's an empty object `{}`.

**Fix in `extract-dates.ts`**:
- Added `Object.keys(timeIntervalFormats).length === 0` check
- Now properly triggers fallback when interval formats are empty
- Ensures 12-hour skeletons can use 24-hour interval patterns during data generation

**Example**:
- Before: `Wed, 18 Feb 2026, 7:00 am – Wed, 18 Feb 2026, 4:00 pm`
- After: `Wed, 18 Feb 2026, 7:00 am – 4:00 pm` ✓

## Tests

Added 3 comprehensive test cases:
1. Same-day midnight range (h24 format)
2. Same-period hour12 range (both PM)
3. Cross-period hour12 range (AM to PM)

## Breaking Changes

None. These are bug fixes that make behavior match user expectations and LDML specifications.

**Note:** The fix to `extract-dates.ts` requires regenerating locale data before merging.

Generated with [Claude Code](https://claude.ai/code)