### PR TITLE
fix(@formatjs/vite-plugin): handle transpiled react

### DIFF
--- a/packages/vite-plugin/integration-tests/__snapshots__/integration.test.ts.snap
+++ b/packages/vite-plugin/integration-tests/__snapshots__/integration.test.ts.snap
@@ -61,6 +61,22 @@ export { msg };
 "
 `;
 
+exports[`@formatjs/vite-plugin integration > compiled JSX: generates ids and removes descriptions 1`] = `
+"import { FormattedMessage } from "react-intl";
+import { jsx } from "react/jsx-runtime";
+function App() {
+	return jsx("div", { children: [jsx(FormattedMessage, {
+		id: "wdf0o2",
+		defaultMessage: "Welcome to our app"
+	}), jsx(FormattedMessage, {
+		id: "custom.id",
+		defaultMessage: "Custom ID message"
+	})] });
+}
+export { App };
+"
+`;
+
 exports[`@formatjs/vite-plugin integration > defineMessage: processes single descriptor 1`] = `
 "function defineMessage(msg$1) {
 	return msg$1;
@@ -146,5 +162,26 @@ exports[`@formatjs/vite-plugin integration > removeDefaultMessage option 1`] = `
 const greeting = intl.formatMessage({ id: "YyDw8T" });
 const farewell = intl.formatMessage({ id: "73dImr" });
 export { farewell, greeting };
+"
+`;
+
+exports[`@formatjs/vite-plugin integration > removeDescription for TSX 1`] = `
+"import { Component } from "react";
+import { FormattedMessage } from "react-intl";
+import { jsxDEV } from "react/jsx-dev-runtime";
+var _jsxFileName = "<source>";
+var Foo = class extends Component {
+	render() {
+		return /* @__PURE__ */ jsxDEV(FormattedMessage, {
+			id: "greeting-world",
+			defaultMessage: "Hello World!"
+		}, void 0, false, {
+			fileName: _jsxFileName,
+			lineNumber: 7,
+			columnNumber: 7
+		}, this);
+	}
+};
+export { Foo as default };
 "
 `;

--- a/packages/vite-plugin/integration-tests/fixtures/compiledJsx.js
+++ b/packages/vite-plugin/integration-tests/fixtures/compiledJsx.js
@@ -1,0 +1,18 @@
+import {FormattedMessage} from 'react-intl'
+import {jsx as _jsx} from 'react/jsx-runtime'
+
+export function App() {
+  return _jsx('div', {
+    children: [
+      _jsx(FormattedMessage, {
+        defaultMessage: 'Welcome to our app',
+        description: 'Welcome message',
+      }),
+      _jsx(FormattedMessage, {
+        id: 'custom.id',
+        defaultMessage: 'Custom ID message',
+        description: 'Has a custom ID',
+      }),
+    ],
+  })
+}

--- a/packages/vite-plugin/integration-tests/fixtures/removeDescription.tsx
+++ b/packages/vite-plugin/integration-tests/fixtures/removeDescription.tsx
@@ -1,0 +1,14 @@
+import React, {Component} from 'react'
+import {FormattedMessage} from 'react-intl'
+
+export default class Foo extends Component {
+  render() {
+    return (
+      <FormattedMessage
+        id="greeting-world"
+        description="Greeting to the world"
+        defaultMessage="Hello World!"
+      />
+    )
+  }
+}

--- a/packages/vite-plugin/integration-tests/integration.test.ts
+++ b/packages/vite-plugin/integration-tests/integration.test.ts
@@ -22,7 +22,12 @@ async function buildFixture(
         formats: ['es'],
       },
       rollupOptions: {
-        external: ['react', 'react/jsx-runtime', 'react/jsx-dev-runtime'],
+        external: [
+          'react',
+          'react/jsx-runtime',
+          'react/jsx-dev-runtime',
+          'react-intl',
+        ],
       },
       minify: false,
       outDir,
@@ -82,6 +87,16 @@ describe('@formatjs/vite-plugin integration', () => {
       overrideIdFn: (_id, defaultMessage, _description, _filePath) =>
         `custom_${defaultMessage?.replace(/\s+/g, '_')}`,
     })
+    expect(code).toMatchSnapshot()
+  })
+
+  test('compiled JSX: generates ids and removes descriptions', async () => {
+    const code = await buildFixture('compiledJsx.js')
+    expect(code).toMatchSnapshot()
+  })
+
+  test('removeDescription for TSX', async () => {
+    const code = await buildFixture('removeDescription.tsx')
     expect(code).toMatchSnapshot()
   })
 

--- a/packages/vite-plugin/tests/transform.test.ts
+++ b/packages/vite-plugin/tests/transform.test.ts
@@ -235,6 +235,64 @@ describe('@formatjs/vite-plugin transform', () => {
     })
   })
 
+  describe('compiled JSX', () => {
+    test('handles _jsx(FormattedMessage, { ... })', () => {
+      const input = `_jsx(FormattedMessage, { defaultMessage: 'Hello World', description: 'greeting' })`
+      const output = t(input)
+      expect(output).toContain('id:')
+      expect(output).not.toContain('description')
+    })
+
+    test('handles jsxDEV(FormattedMessage, { ... })', () => {
+      const input = `jsxDEV(FormattedMessage, { defaultMessage: 'Hello World', description: 'greeting' })`
+      const output = t(input)
+      expect(output).toContain('id:')
+      expect(output).not.toContain('description')
+    })
+
+    test('handles _jsxs(FormattedMessage, { ... })', () => {
+      const input = `_jsxs(FormattedMessage, { defaultMessage: 'Hello World', description: 'greeting' })`
+      const output = t(input)
+      expect(output).toContain('id:')
+      expect(output).not.toContain('description')
+    })
+
+    test('handles React.createElement(FormattedMessage, { ... })', () => {
+      const input = `React.createElement(FormattedMessage, { defaultMessage: 'Hello World', description: 'greeting' })`
+      const output = t(input)
+      expect(output).toContain('id:')
+      expect(output).not.toContain('description')
+    })
+
+    test('preserves existing id in compiled JSX', () => {
+      const input = `_jsx(FormattedMessage, { id: 'my.id', defaultMessage: 'Hello', description: 'greeting' })`
+      const output = t(input)
+      expect(output).toContain('"my.id"')
+      expect(output).not.toContain('description')
+    })
+
+    test('does not process unknown components in compiled JSX', () => {
+      const input = `_jsx(UnknownComponent, { defaultMessage: 'Hello', description: 'greeting' })`
+      const output = t(input)
+      expect(output).toContain('description')
+    })
+
+    test('handles additional component names in compiled JSX', () => {
+      const input = `_jsx(CustomMessage, { defaultMessage: 'Hello', description: 'greeting' })`
+      const output = t(input, {additionalComponentNames: ['CustomMessage']})
+      expect(output).toContain('id:')
+      expect(output).not.toContain('description')
+    })
+
+    test('removeDefaultMessage works with compiled JSX', () => {
+      const input = `_jsx(FormattedMessage, { id: 'test', defaultMessage: 'Hello', description: 'greeting' })`
+      const output = t(input, {removeDefaultMessage: true})
+      expect(output).not.toContain('defaultMessage')
+      expect(output).not.toContain('description')
+      expect(output).toContain('"test"')
+    })
+  })
+
   describe('no-op cases', () => {
     test('returns undefined for files with no descriptors', () => {
       const code = `const x = 1; console.log(x);`


### PR DESCRIPTION
### TL;DR

Add support for compiled JSX in the FormatJS Vite plugin to properly handle message extraction from compiled React components.

### What changed?

- Added support for detecting and processing FormattedMessage components in compiled JSX code
- Implemented handling for various JSX runtime functions (`_jsx`, `jsxs`, `jsxDEV`, `createElement`, etc.)
- Added functionality to generate IDs and remove descriptions from compiled JSX components
- Added tests for compiled JSX support, including snapshot tests and unit tests
- Added test fixtures for compiled JSX and TSX files

### How to test?

1. Run the integration tests to verify the compiled JSX functionality:
   ```
   cd packages/vite-plugin
   npm test
   ```

2. Test with a React application that uses compiled JSX with FormattedMessage components:
   ```jsx
   // Example of compiled JSX that should now work
   _jsx(FormattedMessage, {
     defaultMessage: 'Welcome to our app',
     description: 'Welcome message',
   })
   ```

### Why make this change?

The FormatJS Vite plugin previously couldn't properly extract messages from compiled JSX code, which is the format produced by many build tools. This change ensures that internationalization works correctly in applications using compiled JSX, allowing the plugin to:

1. Generate IDs for FormattedMessage components in compiled code
2. Remove descriptions as configured
3. Handle various JSX runtime functions used by different React versions and build tools

This enhancement improves compatibility with different React build configurations and ensures consistent message extraction across all JSX formats.