### PR TITLE
feat(eslint-plugin-formatjs): add prefer-full-sentence rule

### DIFF
--- a/packages/eslint-plugin-formatjs/index.ts
+++ b/packages/eslint-plugin-formatjs/index.ts
@@ -68,6 +68,10 @@ import {
   rule as noLiteralStringInObject,
   name as noLiteralStringInObjectName,
 } from './rules/no-literal-string-in-object.js'
+import {
+  rule as preferFullSentence,
+  name as preferFullSentenceName,
+} from './rules/prefer-full-sentence.js'
 
 import * as packageJsonNs from './package.json' with {type: 'json'}
 
@@ -96,6 +100,7 @@ const rules: ESLint.Plugin['rules'] = {
   [preferPoundInPluralName]: preferPoundInPlural,
   [noMissingIcuPluralOnePlaceholdersName]: noMissingIcuPluralOnePlaceholders,
   [noLiteralStringInObjectName]: noLiteralStringInObject,
+  [preferFullSentenceName]: preferFullSentence,
 }
 
 type Plugin = {
@@ -156,6 +161,7 @@ const configs: Plugin['configs'] = {
         },
       ],
       'formatjs/blocklist-elements': ['error', ['selectordinal']],
+      'formatjs/prefer-full-sentence': 'error',
     },
   },
   recommended: {
@@ -189,6 +195,7 @@ const configs: Plugin['configs'] = {
         },
       ],
       'formatjs/blocklist-elements': ['error', ['selectordinal']],
+      'formatjs/prefer-full-sentence': 'error',
     },
   },
 }

--- a/packages/eslint-plugin-formatjs/rules/prefer-full-sentence.ts
+++ b/packages/eslint-plugin-formatjs/rules/prefer-full-sentence.ts
@@ -1,0 +1,160 @@
+import {
+  type MessageFormatElement,
+  parse,
+  TYPE,
+} from '@formatjs/icu-messageformat-parser'
+import type {Node} from 'estree-jsx'
+import type {Rule} from 'eslint'
+import {extractMessages, getSettings} from '../util.js'
+import {CORE_MESSAGES} from '../messages.js'
+
+type WhitespaceIssue = 'leadingWhitespace' | 'trailingWhitespace'
+
+/**
+ * Get the first boundary element, recursing into tags since
+ * <b>hello</b> starts with the literal "hello".
+ */
+function getFirstBoundaryElement(
+  ast: MessageFormatElement[]
+): MessageFormatElement | null {
+  if (ast.length === 0) return null
+  const first = ast[0]
+  if (first.type === TYPE.tag) {
+    return getFirstBoundaryElement(first.children)
+  }
+  return first
+}
+
+/**
+ * Get the last boundary element, recursing into tags.
+ */
+function getLastBoundaryElement(
+  ast: MessageFormatElement[]
+): MessageFormatElement | null {
+  if (ast.length === 0) return null
+  const last = ast[ast.length - 1]
+  if (last.type === TYPE.tag) {
+    return getLastBoundaryElement(last.children)
+  }
+  return last
+}
+
+function findWhitespaceIssues(ast: MessageFormatElement[]): WhitespaceIssue[] {
+  const issues: WhitespaceIssue[] = []
+
+  const first = getFirstBoundaryElement(ast)
+  const last = getLastBoundaryElement(ast)
+
+  // Ignore messages that are only whitespace (edge case)
+  if (
+    first === last &&
+    first?.type === TYPE.literal &&
+    ast.length === 1 &&
+    first.value.trim() === ''
+  ) {
+    return issues
+  }
+
+  if (first?.type === TYPE.literal && /^\s/.test(first.value)) {
+    issues.push('leadingWhitespace')
+  }
+
+  if (last?.type === TYPE.literal && /\s$/.test(last.value)) {
+    issues.push('trailingWhitespace')
+  }
+
+  // Check each plural/select option branch independently
+  for (const element of ast) {
+    switch (element.type) {
+      case TYPE.plural:
+      case TYPE.select: {
+        for (const option of Object.values(element.options)) {
+          issues.push(...findWhitespaceIssues(option.value))
+        }
+        break
+      }
+    }
+  }
+
+  return issues
+}
+
+function checkNode(context: Rule.RuleContext, node: Node) {
+  const msgs = extractMessages(node, getSettings(context))
+
+  for (const [
+    {
+      message: {defaultMessage},
+      messageNode,
+    },
+  ] of msgs) {
+    if (!defaultMessage || !messageNode) {
+      continue
+    }
+
+    let ast: MessageFormatElement[]
+    try {
+      ast = parse(defaultMessage)
+    } catch (e) {
+      context.report({
+        node: messageNode,
+        messageId: 'parseError',
+        data: {error: e instanceof Error ? e.message : String(e)},
+      })
+      return
+    }
+
+    const issues = findWhitespaceIssues(ast)
+
+    // Deduplicate
+    const seen = new Set<string>()
+    for (const issue of issues) {
+      if (seen.has(issue)) continue
+      seen.add(issue)
+      context.report({
+        node: messageNode,
+        messageId: issue,
+      })
+    }
+  }
+}
+
+export const name = 'prefer-full-sentence'
+
+export const rule: Rule.RuleModule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Detects messages with leading/trailing whitespace, which suggests string concatenation instead of full sentences',
+      url: 'https://formatjs.github.io/docs/tooling/linter#prefer-full-sentence',
+    },
+    messages: {
+      ...CORE_MESSAGES,
+      leadingWhitespace:
+        'Messages should be full sentences — leading whitespace suggests string concatenation',
+      trailingWhitespace:
+        'Messages should be full sentences — trailing whitespace suggests string concatenation',
+    },
+    schema: [],
+  },
+  create(context) {
+    const callExpressionVisitor = (node: Node) => checkNode(context, node)
+
+    const parserServices = context.sourceCode.parserServices
+    if (parserServices?.defineTemplateBodyVisitor) {
+      return parserServices.defineTemplateBodyVisitor(
+        {
+          CallExpression: callExpressionVisitor,
+        },
+        {
+          CallExpression: callExpressionVisitor,
+        }
+      )
+    }
+    return {
+      JSXOpeningElement: (node: Node) => checkNode(context, node),
+      CallExpression: callExpressionVisitor,
+    }
+  },
+}

--- a/packages/eslint-plugin-formatjs/tests/prefer-full-sentence.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/prefer-full-sentence.test.ts
@@ -1,0 +1,130 @@
+import {name, rule} from '../rules/prefer-full-sentence.js'
+import {
+  defineMessage,
+  dynamicMessage,
+  emptyFnCall,
+  noMatch,
+  spreadJsx,
+} from './fixtures'
+import {ruleTester} from './util'
+
+ruleTester.run(name, rule, {
+  valid: [
+    defineMessage,
+    dynamicMessage,
+    noMatch,
+    spreadJsx,
+    emptyFnCall,
+    {
+      code: `
+      import {defineMessage} from 'react-intl'
+      defineMessage({
+        defaultMessage: 'Hello world'
+      })
+    `,
+    },
+    {
+      code: `
+      import {defineMessage} from 'react-intl'
+      defineMessage({
+        defaultMessage: 'Hello {name}'
+      })
+    `,
+    },
+    {
+      code: `
+      import {defineMessage} from 'react-intl'
+      defineMessage({
+        defaultMessage: '{count} items'
+      })
+    `,
+    },
+    // Plural branches without leading/trailing whitespace
+    {
+      code: `
+      import {defineMessage} from 'react-intl'
+      defineMessage({
+        defaultMessage: '{count, plural, one {# item} other {# items}}'
+      })
+    `,
+    },
+    // Select branches without leading/trailing whitespace
+    {
+      code: `
+      import {defineMessage} from 'react-intl'
+      defineMessage({
+        defaultMessage: '{gender, select, male {He said} female {She said} other {They said}}'
+      })
+    `,
+    },
+    // Message with only whitespace (edge case — ignored)
+    {
+      code: `
+      import {defineMessage} from 'react-intl'
+      defineMessage({
+        defaultMessage: ' '
+      })
+    `,
+    },
+  ],
+  invalid: [
+    // Leading whitespace
+    {
+      code: `import {defineMessage} from 'react-intl';defineMessage({defaultMessage: ' Hello world'})`,
+      errors: [{messageId: 'leadingWhitespace'}],
+    },
+    // Trailing whitespace
+    {
+      code: `import {defineMessage} from 'react-intl';defineMessage({defaultMessage: 'Hello world '})`,
+      errors: [{messageId: 'trailingWhitespace'}],
+    },
+    // Both leading and trailing whitespace
+    {
+      code: `import {defineMessage} from 'react-intl';defineMessage({defaultMessage: ' Hello world '})`,
+      errors: [
+        {messageId: 'leadingWhitespace'},
+        {messageId: 'trailingWhitespace'},
+      ],
+    },
+    // Leading whitespace before placeholder
+    {
+      code: `import {defineMessage} from 'react-intl';defineMessage({defaultMessage: ' {name} said hello'})`,
+      errors: [{messageId: 'leadingWhitespace'}],
+    },
+    // Trailing whitespace after placeholder
+    {
+      code: `import {defineMessage} from 'react-intl';defineMessage({defaultMessage: 'Hello {name} '})`,
+      errors: [{messageId: 'trailingWhitespace'}],
+    },
+    // JSX
+    {
+      code: `<FormattedMessage defaultMessage=" hello" />`,
+      errors: [{messageId: 'leadingWhitespace'}],
+    },
+    // Template literal
+    {
+      code: `import {defineMessage} from 'react-intl';defineMessage({defaultMessage: \` hello\`})`,
+      errors: [{messageId: 'leadingWhitespace'}],
+    },
+    // Leading whitespace inside plural branch
+    {
+      code: `
+      import {defineMessage} from 'react-intl'
+      defineMessage({
+        defaultMessage: '{count, plural, one { # item} other {# items}}'
+      })
+    `,
+      errors: [{messageId: 'leadingWhitespace'}],
+    },
+    // Trailing whitespace inside select branch
+    {
+      code: `
+      import {defineMessage} from 'react-intl'
+      defineMessage({
+        defaultMessage: '{gender, select, male {He said } other {They said}}'
+      })
+    `,
+      errors: [{messageId: 'trailingWhitespace'}],
+    },
+  ],
+})

--- a/packages/vite-plugin/integration-tests/__snapshots__/integration.test.ts.snap
+++ b/packages/vite-plugin/integration-tests/__snapshots__/integration.test.ts.snap
@@ -61,6 +61,22 @@ export { msg };
 "
 `;
 
+exports[`@formatjs/vite-plugin integration > compiled JSX: generates ids and removes descriptions 1`] = `
+"import { FormattedMessage } from "react-intl";
+import { jsx } from "react/jsx-runtime";
+function App() {
+	return jsx("div", { children: [jsx(FormattedMessage, {
+		id: "wdf0o2",
+		defaultMessage: "Welcome to our app"
+	}), jsx(FormattedMessage, {
+		id: "custom.id",
+		defaultMessage: "Custom ID message"
+	})] });
+}
+export { App };
+"
+`;
+
 exports[`@formatjs/vite-plugin integration > defineMessage: processes single descriptor 1`] = `
 "function defineMessage(msg$1) {
 	return msg$1;
@@ -146,5 +162,26 @@ exports[`@formatjs/vite-plugin integration > removeDefaultMessage option 1`] = `
 const greeting = intl.formatMessage({ id: "YyDw8T" });
 const farewell = intl.formatMessage({ id: "73dImr" });
 export { farewell, greeting };
+"
+`;
+
+exports[`@formatjs/vite-plugin integration > removeDescription for TSX 1`] = `
+"import { Component } from "react";
+import { FormattedMessage } from "react-intl";
+import { jsxDEV } from "react/jsx-dev-runtime";
+var _jsxFileName = "<source>";
+var Foo = class extends Component {
+	render() {
+		return /* @__PURE__ */ jsxDEV(FormattedMessage, {
+			id: "greeting-world",
+			defaultMessage: "Hello World!"
+		}, void 0, false, {
+			fileName: _jsxFileName,
+			lineNumber: 7,
+			columnNumber: 7
+		}, this);
+	}
+};
+export { Foo as default };
 "
 `;

--- a/packages/vite-plugin/integration-tests/fixtures/compiledJsx.js
+++ b/packages/vite-plugin/integration-tests/fixtures/compiledJsx.js
@@ -1,0 +1,18 @@
+import {FormattedMessage} from 'react-intl'
+import {jsx as _jsx} from 'react/jsx-runtime'
+
+export function App() {
+  return _jsx('div', {
+    children: [
+      _jsx(FormattedMessage, {
+        defaultMessage: 'Welcome to our app',
+        description: 'Welcome message',
+      }),
+      _jsx(FormattedMessage, {
+        id: 'custom.id',
+        defaultMessage: 'Custom ID message',
+        description: 'Has a custom ID',
+      }),
+    ],
+  })
+}

--- a/packages/vite-plugin/integration-tests/fixtures/removeDescription.tsx
+++ b/packages/vite-plugin/integration-tests/fixtures/removeDescription.tsx
@@ -1,0 +1,14 @@
+import React, {Component} from 'react'
+import {FormattedMessage} from 'react-intl'
+
+export default class Foo extends Component {
+  render() {
+    return (
+      <FormattedMessage
+        id="greeting-world"
+        description="Greeting to the world"
+        defaultMessage="Hello World!"
+      />
+    )
+  }
+}

--- a/packages/vite-plugin/integration-tests/integration.test.ts
+++ b/packages/vite-plugin/integration-tests/integration.test.ts
@@ -22,7 +22,12 @@ async function buildFixture(
         formats: ['es'],
       },
       rollupOptions: {
-        external: ['react', 'react/jsx-runtime', 'react/jsx-dev-runtime'],
+        external: [
+          'react',
+          'react/jsx-runtime',
+          'react/jsx-dev-runtime',
+          'react-intl',
+        ],
       },
       minify: false,
       outDir,
@@ -82,6 +87,16 @@ describe('@formatjs/vite-plugin integration', () => {
       overrideIdFn: (_id, defaultMessage, _description, _filePath) =>
         `custom_${defaultMessage?.replace(/\s+/g, '_')}`,
     })
+    expect(code).toMatchSnapshot()
+  })
+
+  test('compiled JSX: generates ids and removes descriptions', async () => {
+    const code = await buildFixture('compiledJsx.js')
+    expect(code).toMatchSnapshot()
+  })
+
+  test('removeDescription for TSX', async () => {
+    const code = await buildFixture('removeDescription.tsx')
     expect(code).toMatchSnapshot()
   })
 

--- a/packages/vite-plugin/tests/transform.test.ts
+++ b/packages/vite-plugin/tests/transform.test.ts
@@ -235,6 +235,64 @@ describe('@formatjs/vite-plugin transform', () => {
     })
   })
 
+  describe('compiled JSX', () => {
+    test('handles _jsx(FormattedMessage, { ... })', () => {
+      const input = `_jsx(FormattedMessage, { defaultMessage: 'Hello World', description: 'greeting' })`
+      const output = t(input)
+      expect(output).toContain('id:')
+      expect(output).not.toContain('description')
+    })
+
+    test('handles jsxDEV(FormattedMessage, { ... })', () => {
+      const input = `jsxDEV(FormattedMessage, { defaultMessage: 'Hello World', description: 'greeting' })`
+      const output = t(input)
+      expect(output).toContain('id:')
+      expect(output).not.toContain('description')
+    })
+
+    test('handles _jsxs(FormattedMessage, { ... })', () => {
+      const input = `_jsxs(FormattedMessage, { defaultMessage: 'Hello World', description: 'greeting' })`
+      const output = t(input)
+      expect(output).toContain('id:')
+      expect(output).not.toContain('description')
+    })
+
+    test('handles React.createElement(FormattedMessage, { ... })', () => {
+      const input = `React.createElement(FormattedMessage, { defaultMessage: 'Hello World', description: 'greeting' })`
+      const output = t(input)
+      expect(output).toContain('id:')
+      expect(output).not.toContain('description')
+    })
+
+    test('preserves existing id in compiled JSX', () => {
+      const input = `_jsx(FormattedMessage, { id: 'my.id', defaultMessage: 'Hello', description: 'greeting' })`
+      const output = t(input)
+      expect(output).toContain('"my.id"')
+      expect(output).not.toContain('description')
+    })
+
+    test('does not process unknown components in compiled JSX', () => {
+      const input = `_jsx(UnknownComponent, { defaultMessage: 'Hello', description: 'greeting' })`
+      const output = t(input)
+      expect(output).toContain('description')
+    })
+
+    test('handles additional component names in compiled JSX', () => {
+      const input = `_jsx(CustomMessage, { defaultMessage: 'Hello', description: 'greeting' })`
+      const output = t(input, {additionalComponentNames: ['CustomMessage']})
+      expect(output).toContain('id:')
+      expect(output).not.toContain('description')
+    })
+
+    test('removeDefaultMessage works with compiled JSX', () => {
+      const input = `_jsx(FormattedMessage, { id: 'test', defaultMessage: 'Hello', description: 'greeting' })`
+      const output = t(input, {removeDefaultMessage: true})
+      expect(output).not.toContain('defaultMessage')
+      expect(output).not.toContain('description')
+      expect(output).toContain('"test"')
+    })
+  })
+
   describe('no-op cases', () => {
     test('returns undefined for files with no descriptors', () => {
       const code = `const x = 1; console.log(x);`


### PR DESCRIPTION
## Summary
- Adds a new `prefer-full-sentence` ESLint rule that detects messages with leading/trailing whitespace, which suggests string concatenation instead of full, self-contained ICU messages
- Recursively checks plural/select option branches for the same issue
- Registered in both `strict` and `recommended` configs as `'error'`

## Test plan
- [x] Added 20 test cases (11 valid, 9 invalid) covering standard messages, placeholders, plural/select branches, JSX, and template literals
- [x] All 406 tests pass (`bazel test //packages/eslint-plugin-formatjs:unit_test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)