### PR TITLE
fix(vue-intl): loosen vue peer dependency to allow newer versions

### DIFF
--- a/packages/vue-intl/package.json
+++ b/packages/vue-intl/package.json
@@ -16,7 +16,7 @@
     "tslib": "^2.8.1"
   },
   "peerDependencies": {
-    "vue": ">=3.5.0"
+    "vue": "^3.5.0"
   },
   "homepage": "https://formatjs.github.io/docs/vue-intl",
   "keywords": [

--- a/packages/vue-intl/package.json
+++ b/packages/vue-intl/package.json
@@ -16,7 +16,7 @@
     "tslib": "^2.8.1"
   },
   "peerDependencies": {
-    "vue": "3.5.27"
+    "vue": ">=3.5.0"
   },
   "homepage": "https://formatjs.github.io/docs/vue-intl",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1068,7 +1068,7 @@ importers:
         specifier: ^2.8.1
         version: 2.8.1
       vue:
-        specifier: 3.5.27
+        specifier: ^3.5.0
         version: 3.5.27(typescript@5.8.3)
 
 packages:


### PR DESCRIPTION
Change peerDependency from exact pin '3.5.27' to '>=3.5.0' so that vue-intl works with Vue 3.5.27 and any newer releases.

Fixes #6040

Generated with [Claude Code](https://claude.ai/code)