### PR TITLE
fix(@formatjs/vite-plugin): wrap JSX defaultMessage AST in expression container

### DIFF
--- a/packages/vite-plugin/tests/transform.test.ts
+++ b/packages/vite-plugin/tests/transform.test.ts
@@ -111,11 +111,11 @@ describe('@formatjs/vite-plugin transform', () => {
     })
 
     test('wraps JSX defaultMessage AST in expression container', () => {
-      const input = `<FormattedMessage defaultMessage="Hello World" />`
+      const input = `<FormattedMessage id="test" defaultMessage="Hello World" />`
       const output = t(input, {ast: true})
-      // Should use JSX expression container syntax {[...]} not bare [...]
-      expect(output).toContain('defaultMessage={[')
-      expect(output).toContain('"type"')
+      expect(output).toBe(
+        `<FormattedMessage id="test" defaultMessage={[{"type":0,"value":"Hello World"}]} />`
+      )
     })
   })
 

--- a/packages/vite-plugin/tests/transform.test.ts
+++ b/packages/vite-plugin/tests/transform.test.ts
@@ -109,6 +109,14 @@ describe('@formatjs/vite-plugin transform', () => {
       expect(output).toContain('"type"')
       expect(output).not.toContain('description')
     })
+
+    test('wraps JSX defaultMessage AST in expression container', () => {
+      const input = `<FormattedMessage defaultMessage="Hello World" />`
+      const output = t(input, {ast: true})
+      // Should use JSX expression container syntax {[...]} not bare [...]
+      expect(output).toContain('defaultMessage={[')
+      expect(output).toContain('"type"')
+    })
   })
 
   describe('defineMessages', () => {

--- a/packages/vite-plugin/transform.ts
+++ b/packages/vite-plugin/transform.ts
@@ -259,10 +259,11 @@ export function transform(
       } else if (defaultMessage) {
         if (preParseAst) {
           const parsed = parse(defaultMessage)
+          const jsonStr = JSON.stringify(parsed)
           s.overwrite(
             locations.defaultMessage.start,
             locations.defaultMessage.end,
-            JSON.stringify(parsed)
+            isJSX ? `{${jsonStr}}` : jsonStr
           )
         } else if (defaultMessage !== locations.defaultMessage.value) {
           // Whitespace was normalized, update the value


### PR DESCRIPTION
When `ast: true` is enabled in the vite-plugin, the `defaultMessage` prop in JSX elements was being replaced with a bare JSON array, producing invalid JSX:

```jsx
<FormattedMessage defaultMessage=[{"type":0,"value":"Hello World"}] />
```

The fix wraps the serialized AST in a JSX expression container `{...}` when in JSX context:

```jsx
<FormattedMessage defaultMessage={[{"type":0,"value":"Hello World"}]} />
```

Fixes #6042

Generated with [Claude Code](https://claude.ai/code)