### PR TITLE
feat(eslint-plugin-formatjs): add ESLint v10 support

### DIFF
--- a/.syncpackrc.json
+++ b/.syncpackrc.json
@@ -97,7 +97,7 @@
       "packages": [
         "eslint-plugin-formatjs"
       ],
-      "pinVersion": "9"
+      "pinVersion": "9 || 10"
     },
     {
       "label": "Typescript root",

--- a/packages/eslint-plugin-formatjs/package.json
+++ b/packages/eslint-plugin-formatjs/package.json
@@ -16,7 +16,7 @@
     "tslib": "^2.8.1"
   },
   "peerDependencies": {
-    "eslint": "9"
+    "eslint": "9 || 10"
   },
   "bugs": "https://github.com/formatjs/formatjs/issues",
   "homepage": "https://github.com/formatjs/formatjs#readme",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -559,7 +559,7 @@ importers:
         specifier: ^1.6.16
         version: 1.6.16
       eslint:
-        specifier: '9'
+        specifier: 9 || 10
         version: 9.39.2(jiti@2.6.1)
       magic-string:
         specifier: ^0.30.0


### PR DESCRIPTION
## Summary

- Widen eslint `peerDependencies` from `"9"` to `"9 || 10"` to support ESLint v10
- Update `.syncpackrc.json` pinVersion to match

Closes #6047

## Test plan

- [x] `syncpack lint` passes (all version groups valid)
- [x] Pre-commit hooks pass (syncpack fix-mismatches + format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)