### PR TITLE
fix(@formatjs/intl-durationformat): add global Intl.DurationFormat type declarations

### DIFF
--- a/packages/intl-durationformat/index.ts
+++ b/packages/intl-durationformat/index.ts
@@ -1,1 +1,33 @@
+import type {
+  DurationFormat as DurationFormatType,
+  DurationFormatOptions,
+  DurationFormatPart,
+  DurationInput,
+  ResolvedDurationFormatOptions,
+} from './src/types.js'
+
+declare global {
+  namespace Intl {
+    interface DurationFormat extends DurationFormatType {}
+    var DurationFormat: {
+      prototype: DurationFormat
+      new (
+        locales?: string | string[],
+        options?: DurationFormatOptions
+      ): DurationFormat
+      supportedLocalesOf(
+        locales: string | string[],
+        options?: Pick<DurationFormatOptions, 'localeMatcher'>
+      ): string[]
+    }
+  }
+}
+
+export type {
+  DurationFormatOptions,
+  DurationFormatPart,
+  DurationInput,
+  ResolvedDurationFormatOptions,
+}
+
 export * from './src/core.js'


### PR DESCRIPTION
## Summary

- Add `declare global { namespace Intl { ... } }` block to augment the global `Intl` namespace with `DurationFormat` types
- TypeScript (as of 5.8) doesn't include `Intl.DurationFormat` types, so importing the polyfill globally didn't provide type declarations

After this fix, `new Intl.DurationFormat('en')` will have proper type support when the polyfill is imported.

Fixes #6013

## Test plan

- [x] All unit tests pass
- [x] All typecheck tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)