### PR TITLE
fix(eslint-plugin-formatjs): no-literal-string-in-jsx now ignores string with one space

### DIFF
--- a/packages/eslint-plugin-formatjs/rules/no-literal-string-in-jsx.ts
+++ b/packages/eslint-plugin-formatjs/rules/no-literal-string-in-jsx.ts
@@ -175,13 +175,15 @@ export const rule: Rule.RuleModule = {
 
     const checkJSXExpression = (node: Expression | PrivateIdentifier) => {
       // Check if this is either a string literal / template literal, or the concat of them.
-      // It also ignores the empty string.
+      // It also ignores an empty string, and a string with only one space.
       if (
         (node.type === 'Literal' &&
           typeof node.value === 'string' &&
-          node.value.length > 0) ||
+          node.value.length > 0 &&
+          node.value !== ' ') ||
         (node.type === 'TemplateLiteral' &&
-          (node.quasis.length > 1 || node.quasis[0].value.raw.length > 0))
+          (node.quasis.length > 1 || node.quasis[0].value.raw.length > 0) &&
+          (node.quasis.length > 1 || node.quasis[0].value.raw !== ' '))
       ) {
         context.report({
           node,

--- a/packages/eslint-plugin-formatjs/tests/no-literal-string-in-jsx.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/no-literal-string-in-jsx.test.ts
@@ -170,6 +170,14 @@ ruleTester.run(name, rule, {
       // Ignores empty attributes (as template literal expression in the attribute value).
       code: '<img alt={``} role="presentational" />',
     },
+    {
+      // Ignores a string with only one space (as literal expression in the attribute value).
+      code: '<p>{" "}</p>',
+    },
+    {
+      // Ignores a string with only one space(as template literal expression in the attribute value).
+      code: '<p>{` `}</p>',
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
Tools such as eslint/prettier can add `{' '}` characters to split up longer JSX lines.

Before:

```
<span><span>123</span> <span>456</span></span>
```

After:

```
<span>
  <span>123</span>{' '}
  <span>456</span>
</span>
```

`no-literal-string-in-jsx` flags this `{' '}` as an untranslated string, but there is nothing to translate there.

This PR updates the check so these one-character spaces are ignored.