### PR TITLE
fix: add locale-data directory export for variable dynamic imports

### DIFF
--- a/packages/intl-datetimeformat/package.json
+++ b/packages/intl-datetimeformat/package.json
@@ -13,7 +13,8 @@
     "./should-polyfill.js": "./should-polyfill.js",
     "./add-all-tz.js": "./add-all-tz.js",
     "./add-golden-tz.js": "./add-golden-tz.js",
-    "./locale-data/*": "./locale-data/*"
+    "./locale-data/*": "./locale-data/*",
+    "./locale-data": "./locale-data"
   },
   "dependencies": {
     "@formatjs/ecma402-abstract": "workspace:*",

--- a/packages/intl-displaynames/package.json
+++ b/packages/intl-displaynames/package.json
@@ -11,7 +11,8 @@
     "./polyfill.js": "./polyfill.js",
     "./polyfill-force.js": "./polyfill-force.js",
     "./should-polyfill.js": "./should-polyfill.js",
-    "./locale-data/*": "./locale-data/*"
+    "./locale-data/*": "./locale-data/*",
+    "./locale-data": "./locale-data"
   },
   "dependencies": {
     "@formatjs/ecma402-abstract": "workspace:*",

--- a/packages/intl-listformat/package.json
+++ b/packages/intl-listformat/package.json
@@ -11,7 +11,8 @@
     "./polyfill.js": "./polyfill.js",
     "./polyfill-force.js": "./polyfill-force.js",
     "./should-polyfill.js": "./should-polyfill.js",
-    "./locale-data/*": "./locale-data/*"
+    "./locale-data/*": "./locale-data/*",
+    "./locale-data": "./locale-data"
   },
   "dependencies": {
     "@formatjs/ecma402-abstract": "workspace:*",

--- a/packages/intl-numberformat/package.json
+++ b/packages/intl-numberformat/package.json
@@ -10,7 +10,8 @@
     "./polyfill.js": "./polyfill.js",
     "./polyfill-force.js": "./polyfill-force.js",
     "./should-polyfill.js": "./should-polyfill.js",
-    "./locale-data/*": "./locale-data/*"
+    "./locale-data/*": "./locale-data/*",
+    "./locale-data": "./locale-data"
   },
   "dependencies": {
     "@formatjs/ecma402-abstract": "workspace:*",

--- a/packages/intl-pluralrules/package.json
+++ b/packages/intl-pluralrules/package.json
@@ -11,7 +11,8 @@
     "./polyfill.js": "./polyfill.js",
     "./polyfill-force.js": "./polyfill-force.js",
     "./should-polyfill.js": "./should-polyfill.js",
-    "./locale-data/*": "./locale-data/*"
+    "./locale-data/*": "./locale-data/*",
+    "./locale-data": "./locale-data"
   },
   "dependencies": {
     "@formatjs/ecma402-abstract": "workspace:*",

--- a/packages/intl-relativetimeformat/package.json
+++ b/packages/intl-relativetimeformat/package.json
@@ -11,7 +11,8 @@
     "./polyfill.js": "./polyfill.js",
     "./polyfill-force.js": "./polyfill-force.js",
     "./should-polyfill.js": "./should-polyfill.js",
-    "./locale-data/*": "./locale-data/*"
+    "./locale-data/*": "./locale-data/*",
+    "./locale-data": "./locale-data"
   },
   "dependencies": {
     "@formatjs/ecma402-abstract": "workspace:*",


### PR DESCRIPTION
Add `./locale-data` to the exports field in all polyfill packages to support webpack variable dynamic imports with template literals.

when using a template literal like `await import(`@formatjs/intl-datetimeformat/locale-data/${locale}.js`)`, webpack resolves the non-dynamic prefix `./locale-data` against the package exports map. Without this entry, webpack cannot find the locale-data directory and fails to compile.

Fixes #6060

Generated with [Claude Code](https://claude.ai/code)