### PR TITLE
feat(eslint-plugin-formatjs): add prefer-direction-agnostic stylesheet rule

### DIFF
--- a/docs/src/docs/tooling/linter.mdx
+++ b/docs/src/docs/tooling/linter.mdx
@@ -1,4 +1,4 @@
-This eslint plugin allows you to enforce certain rules in your ICU message.
+This eslint plugin allows you to enforce rules for ICU messages and related localization patterns in your source files.
 
 ## Usage
 
@@ -822,6 +822,53 @@ Use `<FormattedMessage>` instead of the imperative `intl.formatMessage(...)` if 
 #### Why
 
 Consistent coding style in JSX and less syntax clutter.
+
+### `prefer-direction-agnostic`
+
+Prefer CSS logical properties and direction-agnostic values over physical left/right styles so layouts work in both LTR and RTL contexts.
+
+This rule supports `.css`, `.scss`, `.sass`, and `.less` files and provides autofixes.
+
+#### Why
+
+- Physical directional styles such as `margin-left` and `right` do not adapt automatically for RTL layouts.
+- Logical properties like `margin-inline-start` and values like `text-align: start` are more robust across writing directions.
+- Autofix helps migrate existing stylesheets incrementally.
+
+#### Example
+
+```js
+export default [
+  {
+    plugins: {
+      formatjs,
+    },
+    rules: {
+      'formatjs/prefer-direction-agnostic': 'error',
+    },
+  },
+]
+```
+
+```css
+/* Bad */
+.card {
+  margin-left: 1rem;
+  padding-right: 2rem;
+  text-align: left;
+  right: 0;
+}
+
+/* Good */
+.card {
+  margin-inline-start: 1rem;
+  padding-inline-end: 2rem;
+  text-align: start;
+  inset-inline-end: 0;
+}
+```
+
+The rule also rewrites other physical directional properties, including border side properties and corner radii such as `border-top-left-radius` to `border-start-start-radius`.
 
 ### `prefer-full-sentence`
 

--- a/packages/eslint-plugin-formatjs/BUILD.bazel
+++ b/packages/eslint-plugin-formatjs/BUILD.bazel
@@ -49,6 +49,7 @@ SRCS = glob(["rules/*.ts"]) + [
     "emoji-utils.ts",
     "emoji-data.generated.ts",
     "package.json",
+    "sugarss.d.ts",
 ]
 
 SRC_DEPS = [
@@ -57,6 +58,10 @@ SRC_DEPS = [
     ":node_modules/@types/picomatch",
     ":node_modules/magic-string",
     ":node_modules/picomatch",
+    ":node_modules/postcss",
+    ":node_modules/postcss-less",
+    ":node_modules/postcss-scss",
+    ":node_modules/sugarss",
     "//:node_modules/@types/node",
     "//:node_modules/@types/estree-jsx",
     "//:node_modules/@unicode/unicode-17.0.0",

--- a/packages/eslint-plugin-formatjs/index.ts
+++ b/packages/eslint-plugin-formatjs/index.ts
@@ -61,6 +61,10 @@ import {
   name as preferFormattedMessageName,
 } from './rules/prefer-formatted-message.js'
 import {
+  rule as preferDirectionAgnostic,
+  name as preferDirectionAgnosticName,
+} from './rules/prefer-direction-agnostic.js'
+import {
   rule as preferPoundInPlural,
   name as preferPoundInPluralName,
 } from './rules/prefer-pound-in-plural.js'
@@ -96,6 +100,7 @@ const rules: ESLint.Plugin['rules'] = {
   [noMultipleWhitespacesName]: noMultipleWhitespaces,
   [noOffsetName]: noOffset,
   [noUselessMessageName]: noUselessMessage,
+  [preferDirectionAgnosticName]: preferDirectionAgnostic,
   [preferFormattedMessageName]: preferFormattedMessage,
   [preferPoundInPluralName]: preferPoundInPlural,
   [noMissingIcuPluralOnePlaceholdersName]: noMissingIcuPluralOnePlaceholders,

--- a/packages/eslint-plugin-formatjs/package.json
+++ b/packages/eslint-plugin-formatjs/package.json
@@ -13,7 +13,14 @@
     "@unicode/unicode-17.0.0": "^1.6.16",
     "magic-string": "^0.30.0",
     "picomatch": "2 || 3 || 4",
+    "postcss": "^8.5.6",
+    "postcss-less": "^6.0.0",
+    "postcss-scss": "^4.0.9",
+    "sugarss": "^5.0.0",
     "tslib": "^2.8.1"
+  },
+  "devDependencies": {
+    "@types/postcss-less": "^4.0.7"
   },
   "peerDependencies": {
     "eslint": "9 || 10"

--- a/packages/eslint-plugin-formatjs/rules/prefer-direction-agnostic.ts
+++ b/packages/eslint-plugin-formatjs/rules/prefer-direction-agnostic.ts
@@ -1,0 +1,210 @@
+import postcss from 'postcss'
+import * as postcssLess from 'postcss-less'
+import * as postcssScss from 'postcss-scss'
+import * as sugarss from 'sugarss'
+import type {Rule} from 'eslint'
+
+export const name = 'prefer-direction-agnostic'
+
+const PROPERTY_REPLACEMENTS = new Map<string, string>([
+  ['left', 'inset-inline-start'],
+  ['right', 'inset-inline-end'],
+  ['margin-left', 'margin-inline-start'],
+  ['margin-right', 'margin-inline-end'],
+  ['padding-left', 'padding-inline-start'],
+  ['padding-right', 'padding-inline-end'],
+  ['border-left', 'border-inline-start'],
+  ['border-right', 'border-inline-end'],
+  ['border-left-color', 'border-inline-start-color'],
+  ['border-right-color', 'border-inline-end-color'],
+  ['border-left-style', 'border-inline-start-style'],
+  ['border-right-style', 'border-inline-end-style'],
+  ['border-left-width', 'border-inline-start-width'],
+  ['border-right-width', 'border-inline-end-width'],
+  ['border-top-left-radius', 'border-start-start-radius'],
+  ['border-top-right-radius', 'border-start-end-radius'],
+  ['border-bottom-left-radius', 'border-end-start-radius'],
+  ['border-bottom-right-radius', 'border-end-end-radius'],
+])
+
+const VALUE_REPLACEMENTS = new Map<string, Record<string, string>>([
+  ['text-align', {left: 'start', right: 'end'}],
+  ['float', {left: 'inline-start', right: 'inline-end'}],
+  ['clear', {left: 'inline-start', right: 'inline-end'}],
+])
+
+type SupportedExtension = '.css' | '.scss' | '.sass' | '.less'
+
+type Violation = {
+  messageId: 'preferProperty' | 'preferValue'
+  data: {
+    actual: string
+    replacement: string
+  }
+  range: [number, number]
+}
+
+function getSupportedExtension(
+  filename: string
+): SupportedExtension | undefined {
+  const normalized = filename.toLowerCase()
+  if (normalized.endsWith('.css')) {
+    return '.css'
+  }
+  if (normalized.endsWith('.scss')) {
+    return '.scss'
+  }
+  if (normalized.endsWith('.sass')) {
+    return '.sass'
+  }
+  if (normalized.endsWith('.less')) {
+    return '.less'
+  }
+  return undefined
+}
+
+function getLineStartOffsets(text: string): number[] {
+  const offsets = [0]
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] === '\n') {
+      offsets.push(i + 1)
+    }
+  }
+  return offsets
+}
+
+function getIndexFromPosition(
+  lineStartOffsets: number[],
+  line: number,
+  column: number
+): number {
+  return lineStartOffsets[line - 1] + column - 1
+}
+
+function parseStylesheet(
+  text: string,
+  filename: string,
+  extension: SupportedExtension
+) {
+  switch (extension) {
+    case '.scss':
+      return postcssScss.parse(text, {from: filename})
+    case '.sass':
+      return sugarss.parse(text, {from: filename})
+    case '.less':
+      return postcssLess.parse(text, {from: filename})
+    default:
+      return postcss.parse(text, {from: filename})
+  }
+}
+
+function collectViolations(
+  text: string,
+  filename: string,
+  extension: SupportedExtension
+): Violation[] {
+  const root = parseStylesheet(text, filename, extension)
+  const lineStartOffsets = getLineStartOffsets(text)
+  const violations: Violation[] = []
+
+  root.walkDecls(decl => {
+    if (!decl.source?.start) {
+      return
+    }
+
+    const prop = decl.prop.toLowerCase()
+    const propReplacement = PROPERTY_REPLACEMENTS.get(prop)
+    const propStart = getIndexFromPosition(
+      lineStartOffsets,
+      decl.source.start.line,
+      decl.source.start.column
+    )
+    const propEnd = propStart + decl.prop.length
+
+    if (propReplacement) {
+      violations.push({
+        messageId: 'preferProperty',
+        data: {actual: prop, replacement: propReplacement},
+        range: [propStart, propEnd],
+      })
+    }
+
+    const valueReplacements = VALUE_REPLACEMENTS.get(prop)
+    if (!valueReplacements) {
+      return
+    }
+
+    const value = decl.value.trim().toLowerCase()
+    const valueReplacement = valueReplacements[value]
+    if (!valueReplacement) {
+      return
+    }
+
+    const between = decl.raws.between ?? ':'
+    const valueStart = propStart + decl.prop.length + between.length
+    violations.push({
+      messageId: 'preferValue',
+      data: {actual: value, replacement: valueReplacement},
+      range: [valueStart, valueStart + decl.value.length],
+    })
+  })
+
+  return violations
+}
+
+export const rule: Rule.RuleModule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Prefer direction-agnostic CSS logical properties and values for RTL support',
+      url: 'https://formatjs.github.io/docs/tooling/linter#prefer-direction-agnostic',
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      preferProperty:
+        'Use the direction-agnostic property "{{replacement}}" instead of "{{actual}}".',
+      preferValue:
+        'Use the direction-agnostic value "{{replacement}}" instead of "{{actual}}".',
+    },
+  },
+  create(context) {
+    const filename = context.filename
+    const extension = getSupportedExtension(filename)
+
+    if (!extension) {
+      return {}
+    }
+
+    return {
+      Program() {
+        const sourceCode = context.sourceCode
+
+        let violations: Violation[]
+        try {
+          violations = collectViolations(sourceCode.text, filename, extension)
+        } catch {
+          return
+        }
+
+        for (const violation of violations) {
+          context.report({
+            loc: {
+              start: sourceCode.getLocFromIndex(violation.range[0]),
+              end: sourceCode.getLocFromIndex(violation.range[1]),
+            },
+            messageId: violation.messageId,
+            data: violation.data,
+            fix(fixer) {
+              return fixer.replaceTextRange(
+                violation.range,
+                violation.data.replacement
+              )
+            },
+          })
+        }
+      },
+    }
+  },
+}

--- a/packages/eslint-plugin-formatjs/sugarss.d.ts
+++ b/packages/eslint-plugin-formatjs/sugarss.d.ts
@@ -1,0 +1,8 @@
+declare module 'sugarss' {
+  import type {Parser, ProcessOptions, Root} from 'postcss'
+
+  export function parse(css: string, opts?: ProcessOptions): Root
+
+  const sugarss: Parser<Root>
+  export default sugarss
+}

--- a/packages/eslint-plugin-formatjs/tests/prefer-direction-agnostic.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/prefer-direction-agnostic.test.ts
@@ -1,0 +1,308 @@
+import {RuleTester} from 'eslint'
+import {describe, it} from 'vitest'
+import {name, rule} from '../rules/prefer-direction-agnostic.js'
+import {stylesheetParser} from './stylesheet-parser'
+
+RuleTester.describe = describe
+RuleTester.it = it
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: stylesheetParser,
+  },
+})
+
+ruleTester.run(name, rule, {
+  valid: [
+    {
+      code: '.foo { margin-inline-start: 1rem; text-align: start; }',
+      filename: 'styles.css',
+    },
+    {
+      code: '.foo { border-inline-end-color: red; clear: inline-end; }',
+      filename: 'styles.less',
+    },
+    {
+      code: '.foo\n  padding-inline-end: 8px\n  float: inline-start\n',
+      filename: 'styles.sass',
+    },
+    {
+      code: '.foo { margin-left: 1rem; }',
+      filename: 'component.tsx',
+    },
+    {
+      code: '/* right: 0; */\n.foo { content: "margin-left"; }',
+      filename: 'styles.css',
+    },
+    {
+      code: '// margin-left: 1rem;\n$offset-left: 4px;\n.foo { text-align: start; }',
+      filename: 'styles.scss',
+    },
+    {
+      code: '@sidebar-width: 20px;\n.foo { clear: inline-start; }',
+      filename: 'styles.less',
+    },
+    {
+      code: '.foo\n  // padding-right: 4px\n  $space-left: 8px\n  content: "left"\n',
+      filename: 'styles.sass',
+    },
+    {
+      code: '@media (min-width: 40rem) { .foo { margin-inline-end: 1rem; } }',
+      filename: 'styles.css',
+    },
+  ],
+  invalid: [
+    {
+      code: '.foo { margin-left: 1rem; }',
+      filename: 'styles.css',
+      output: '.foo { margin-inline-start: 1rem; }',
+      errors: [
+        {
+          messageId: 'preferProperty',
+          data: {
+            actual: 'margin-left',
+            replacement: 'margin-inline-start',
+          },
+        },
+      ],
+    },
+    {
+      code: '.foo { text-align: right; float: left; }',
+      filename: 'styles.scss',
+      output: '.foo { text-align: end; float: inline-start; }',
+      errors: [
+        {
+          messageId: 'preferValue',
+          data: {
+            actual: 'right',
+            replacement: 'end',
+          },
+        },
+        {
+          messageId: 'preferValue',
+          data: {
+            actual: 'left',
+            replacement: 'inline-start',
+          },
+        },
+      ],
+    },
+    {
+      code: '.foo { border-top-left-radius: 4px; right: 0; }',
+      filename: 'styles.less',
+      output: '.foo { border-start-start-radius: 4px; inset-inline-end: 0; }',
+      errors: [
+        {
+          messageId: 'preferProperty',
+          data: {
+            actual: 'border-top-left-radius',
+            replacement: 'border-start-start-radius',
+          },
+        },
+        {
+          messageId: 'preferProperty',
+          data: {
+            actual: 'right',
+            replacement: 'inset-inline-end',
+          },
+        },
+      ],
+    },
+    {
+      code: '.foo\n  margin-right: 1rem\n  text-align: left\n',
+      filename: 'styles.sass',
+      output: '.foo\n  margin-inline-end: 1rem\n  text-align: start\n',
+      errors: [
+        {
+          messageId: 'preferProperty',
+          data: {
+            actual: 'margin-right',
+            replacement: 'margin-inline-end',
+          },
+        },
+        {
+          messageId: 'preferValue',
+          data: {
+            actual: 'left',
+            replacement: 'start',
+          },
+        },
+      ],
+    },
+    {
+      code: '/* margin-left: 1rem; */\n.foo { padding-right: 1rem; }',
+      filename: 'styles.css',
+      output: '/* margin-left: 1rem; */\n.foo { padding-inline-end: 1rem; }',
+      errors: [
+        {
+          messageId: 'preferProperty',
+          data: {
+            actual: 'padding-right',
+            replacement: 'padding-inline-end',
+          },
+        },
+      ],
+    },
+    {
+      code: '.foo { left: 0; border-left-width: 1px; clear: right; }',
+      filename: 'styles.css',
+      output:
+        '.foo { inset-inline-start: 0; border-inline-start-width: 1px; clear: inline-end; }',
+      errors: [
+        {
+          messageId: 'preferProperty',
+          data: {
+            actual: 'left',
+            replacement: 'inset-inline-start',
+          },
+        },
+        {
+          messageId: 'preferProperty',
+          data: {
+            actual: 'border-left-width',
+            replacement: 'border-inline-start-width',
+          },
+        },
+        {
+          messageId: 'preferValue',
+          data: {
+            actual: 'right',
+            replacement: 'inline-end',
+          },
+        },
+      ],
+    },
+    {
+      code: '// right: 0;\n.foo { margin-left: 1rem; text-align: left; }\n',
+      filename: 'styles.scss',
+      output:
+        '// right: 0;\n.foo { margin-inline-start: 1rem; text-align: start; }\n',
+      errors: [
+        {
+          messageId: 'preferProperty',
+          data: {
+            actual: 'margin-left',
+            replacement: 'margin-inline-start',
+          },
+        },
+        {
+          messageId: 'preferValue',
+          data: {
+            actual: 'left',
+            replacement: 'start',
+          },
+        },
+      ],
+    },
+    {
+      code: '@gap: 1rem;\n.foo { border-right-style: solid; float: right; }\n',
+      filename: 'styles.less',
+      output:
+        '@gap: 1rem;\n.foo { border-inline-end-style: solid; float: inline-end; }\n',
+      errors: [
+        {
+          messageId: 'preferProperty',
+          data: {
+            actual: 'border-right-style',
+            replacement: 'border-inline-end-style',
+          },
+        },
+        {
+          messageId: 'preferValue',
+          data: {
+            actual: 'right',
+            replacement: 'inline-end',
+          },
+        },
+      ],
+    },
+    {
+      code: '.card\n  border-bottom-right-radius: 12px\n  float: left\n  // margin-right: 1rem\n',
+      filename: 'styles.sass',
+      output:
+        '.card\n  border-end-end-radius: 12px\n  float: inline-start\n  // margin-right: 1rem\n',
+      errors: [
+        {
+          messageId: 'preferProperty',
+          data: {
+            actual: 'border-bottom-right-radius',
+            replacement: 'border-end-end-radius',
+          },
+        },
+        {
+          messageId: 'preferValue',
+          data: {
+            actual: 'left',
+            replacement: 'inline-start',
+          },
+        },
+      ],
+    },
+    {
+      code: '.foo { margin-left: 1rem; padding-right: 2rem; border-right-color: red; }',
+      filename: 'styles.css',
+      output:
+        '.foo { margin-inline-start: 1rem; padding-inline-end: 2rem; border-inline-end-color: red; }',
+      errors: [
+        {
+          messageId: 'preferProperty',
+          data: {
+            actual: 'margin-left',
+            replacement: 'margin-inline-start',
+          },
+        },
+        {
+          messageId: 'preferProperty',
+          data: {
+            actual: 'padding-right',
+            replacement: 'padding-inline-end',
+          },
+        },
+        {
+          messageId: 'preferProperty',
+          data: {
+            actual: 'border-right-color',
+            replacement: 'border-inline-end-color',
+          },
+        },
+      ],
+    },
+    {
+      code: '@media (min-width: 40rem) { .foo { text-align: left !important; } }',
+      filename: 'styles.css',
+      output:
+        '@media (min-width: 40rem) { .foo { text-align: start !important; } }',
+      errors: [
+        {
+          messageId: 'preferValue',
+          data: {
+            actual: 'left',
+            replacement: 'start',
+          },
+        },
+      ],
+    },
+    {
+      code: '$gap: 1rem;\n.container {\n  .item { margin-left: $gap; }\n  text-align: right;\n}\n',
+      filename: 'styles.scss',
+      output:
+        '$gap: 1rem;\n.container {\n  .item { margin-inline-start: $gap; }\n  text-align: end;\n}\n',
+      errors: [
+        {
+          messageId: 'preferProperty',
+          data: {
+            actual: 'margin-left',
+            replacement: 'margin-inline-start',
+          },
+        },
+        {
+          messageId: 'preferValue',
+          data: {
+            actual: 'right',
+            replacement: 'end',
+          },
+        },
+      ],
+    },
+  ],
+})

--- a/packages/eslint-plugin-formatjs/tests/stylesheet-parser.ts
+++ b/packages/eslint-plugin-formatjs/tests/stylesheet-parser.ts
@@ -1,0 +1,41 @@
+import type {Linter} from 'eslint'
+
+function getLoc(text: string, index: number) {
+  let line = 1
+  let column = 0
+
+  for (let i = 0; i < index; i++) {
+    if (text[i] === '\n') {
+      line++
+      column = 0
+    } else {
+      column++
+    }
+  }
+
+  return {line, column}
+}
+
+export const stylesheetParser: Linter.Parser = {
+  parseForESLint(code) {
+    return {
+      ast: {
+        type: 'Program',
+        body: [],
+        comments: [],
+        sourceType: 'module',
+        tokens: [],
+        range: [0, code.length],
+        loc: {
+          start: {line: 1, column: 0},
+          end: getLoc(code, code.length),
+        },
+      },
+      services: {},
+      scopeManager: null,
+      visitorKeys: {
+        Program: [],
+      },
+    }
+  },
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,7 +110,7 @@ importers:
         version: 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tailwindcss/vite':
         specifier: ^4.1.18
-        version: 4.1.18(rolldown-vite@7.3.1(@types/node@22.19.7)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.18(rolldown-vite@7.3.1(@types/node@22.19.7)(esbuild@0.27.2)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -179,7 +179,7 @@ importers:
         version: 1.6.16
       '@vitejs/plugin-react-oxc':
         specifier: ^0.4.3
-        version: 0.4.3(rolldown-vite@7.3.1(@types/node@22.19.7)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 0.4.3(rolldown-vite@7.3.1(@types/node@22.19.7)(esbuild@0.27.2)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       '@vue/compiler-core':
         specifier: ^3.5.0
         version: 3.5.27
@@ -359,16 +359,16 @@ importers:
         version: 1.0.4
       vike:
         specifier: ^0.4.251
-        version: 0.4.252(react-streaming@0.4.15(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(rolldown-vite@7.3.1(@types/node@22.19.7)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 0.4.252(react-streaming@0.4.15(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(rolldown-vite@7.3.1(@types/node@22.19.7)(esbuild@0.27.2)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       vike-react:
         specifier: ^0.6.18
-        version: 0.6.18(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vike@0.4.252(react-streaming@0.4.15(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(rolldown-vite@7.3.1(@types/node@22.19.7)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)))
+        version: 0.6.18(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vike@0.4.252(react-streaming@0.4.15(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(rolldown-vite@7.3.1(@types/node@22.19.7)(esbuild@0.27.2)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)))
       vite:
         specifier: npm:rolldown-vite@7.3.1
-        version: rolldown-vite@7.3.1(@types/node@22.19.7)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+        version: rolldown-vite@7.3.1(@types/node@22.19.7)(esbuild@0.27.2)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.7)(happy-dom@20.3.4)(jiti@2.6.1)(jsdom@20.0.3)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.7)(happy-dom@20.3.4)(jiti@2.6.1)(jsdom@20.0.3)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
       vue:
         specifier: ^3.5.0
         version: 3.5.27(typescript@5.9.3)
@@ -567,9 +567,25 @@ importers:
       picomatch:
         specifier: 2 || 3 || 4
         version: 4.0.3
+      postcss:
+        specifier: ^8.5.6
+        version: 8.5.6
+      postcss-less:
+        specifier: ^6.0.0
+        version: 6.0.0(postcss@8.5.6)
+      postcss-scss:
+        specifier: ^4.0.9
+        version: 4.0.9(postcss@8.5.6)
+      sugarss:
+        specifier: ^5.0.0
+        version: 5.0.1(postcss@8.5.6)
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
+    devDependencies:
+      '@types/postcss-less':
+        specifier: ^4.0.7
+        version: 4.0.7
 
   packages/eslint-plugin-formatjs/integration-tests:
     dependencies:
@@ -1045,7 +1061,7 @@ importers:
         version: 2.8.1
       vite:
         specifier: '>=7'
-        version: 7.3.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+        version: 7.3.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/vite-plugin/integration-tests:
     dependencies:
@@ -3721,6 +3737,9 @@ packages:
 
   '@types/picomatch@4.0.2':
     resolution: {integrity: sha512-qHHxQ+P9PysNEGbALT8f8YOSHW0KJu6l2xU8DYY0fu/EmGxXdVnuTLvFUvBgPJMSqXq29SYHveejeAha+4AYgA==}
+
+  '@types/postcss-less@4.0.7':
+    resolution: {integrity: sha512-trNnU5PNmvMGysyge5Tc7W4CpaU+HHVu9XcGFX9eBlIGcg+NJP6lLJcUna6jjh8/TMjAe0k5mY0+jNRkZLYoaQ==}
 
   '@types/prismjs@1.26.5':
     resolution: {integrity: sha512-AUZTa7hQ2KY5L7AmtSiqxlhWxb4ina0yd8hNbl4TWuqnv/pFP0nDMb3YrfSBf4hJVGLh2YEIBfKaBW/9UEl6IQ==}
@@ -6772,6 +6791,18 @@ packages:
     resolution: {integrity: sha512-rEwq/ZHlJIKw++XtLAO8PPuOQA/zaPJOZJ37BVuN97nLpMJeuDVLVGRwbFoBgLudgdTMP2hdRJP++H+8QOA3vg==}
     engines: {node: '>= 10.12'}
 
+  postcss-less@6.0.0:
+    resolution: {integrity: sha512-FPX16mQLyEjLzEuuJtxA8X3ejDLNGGEG503d2YGZR5Ask1SpDN8KmZUMpzCvyalWRywAn1n1VOA5dcqfCLo5rg==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      postcss: ^8.3.5
+
+  postcss-scss@4.0.9:
+    resolution: {integrity: sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.4.29
+
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -7433,6 +7464,12 @@ packages:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
+
+  sugarss@5.0.1:
+    resolution: {integrity: sha512-ctS5RYCBVvPoZAnzIaX5QSShK8ZiZxD5HUqSxlusvEMC+QZQIPCPOIJg6aceFX+K2rf4+SH89eu++h1Zmsr2nw==}
+    engines: {node: '>=18.0'}
+    peerDependencies:
+      postcss: ^8.3.3
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -10830,12 +10867,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.1.18
       '@tailwindcss/oxide-win32-x64-msvc': 4.1.18
 
-  '@tailwindcss/vite@4.1.18(rolldown-vite@7.3.1(@types/node@22.19.7)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@tailwindcss/vite@4.1.18(rolldown-vite@7.3.1(@types/node@22.19.7)(esbuild@0.27.2)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@tailwindcss/node': 4.1.18
       '@tailwindcss/oxide': 4.1.18
       tailwindcss: 4.1.18
-      vite: rolldown-vite@7.3.1(@types/node@22.19.7)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: rolldown-vite@7.3.1(@types/node@22.19.7)(esbuild@0.27.2)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
 
   '@testing-library/dom@10.4.0':
     dependencies:
@@ -11009,6 +11046,10 @@ snapshots:
 
   '@types/picomatch@4.0.2': {}
 
+  '@types/postcss-less@4.0.7':
+    dependencies:
+      postcss: 8.5.6
+
   '@types/prismjs@1.26.5': {}
 
   '@types/react-dom@19.2.3(@types/react@19.2.8)':
@@ -11167,10 +11208,10 @@ snapshots:
 
   '@unicode/unicode-17.0.0@1.6.16': {}
 
-  '@vitejs/plugin-react-oxc@0.4.3(rolldown-vite@7.3.1(@types/node@22.19.7)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitejs/plugin-react-oxc@0.4.3(rolldown-vite@7.3.1(@types/node@22.19.7)(esbuild@0.27.2)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.47
-      vite: rolldown-vite@7.3.1(@types/node@22.19.7)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: rolldown-vite@7.3.1(@types/node@22.19.7)(esbuild@0.27.2)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -11180,14 +11221,14 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/mocker@3.2.4(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.7(@types/node@22.19.7)(typescript@5.9.3)
-      vite: 7.3.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -14792,6 +14833,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  postcss-less@6.0.0(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+
+  postcss-scss@4.0.9(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+
   postcss@8.5.6:
     dependencies:
       nanoid: 3.3.11
@@ -15179,7 +15228,7 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rolldown-vite@7.3.1(@types/node@22.19.7)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2):
+  rolldown-vite@7.3.1(@types/node@22.19.7)(esbuild@0.27.2)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@oxc-project/runtime': 0.101.0
       fdir: 6.5.0(picomatch@4.0.3)
@@ -15193,6 +15242,7 @@ snapshots:
       esbuild: 0.27.2
       fsevents: 2.3.3
       jiti: 2.6.1
+      sugarss: 5.0.1(postcss@8.5.6)
       terser: 5.44.1
       tsx: 4.21.0
       yaml: 2.8.2
@@ -15590,6 +15640,10 @@ snapshots:
       pirates: 4.0.7
       tinyglobby: 0.2.15
       ts-interface-checker: 0.1.13
+
+  sugarss@5.0.1(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
 
   supports-color@7.2.0:
     dependencies:
@@ -16033,14 +16087,14 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vike-react@0.6.18(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vike@0.4.252(react-streaming@0.4.15(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(rolldown-vite@7.3.1(@types/node@22.19.7)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))):
+  vike-react@0.6.18(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vike@0.4.252(react-streaming@0.4.15(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(rolldown-vite@7.3.1(@types/node@22.19.7)(esbuild@0.27.2)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))):
     dependencies:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       react-streaming: 0.4.15(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      vike: 0.4.252(react-streaming@0.4.15(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(rolldown-vite@7.3.1(@types/node@22.19.7)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      vike: 0.4.252(react-streaming@0.4.15(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(rolldown-vite@7.3.1(@types/node@22.19.7)(esbuild@0.27.2)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
 
-  vike@0.4.252(react-streaming@0.4.15(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(rolldown-vite@7.3.1(@types/node@22.19.7)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)):
+  vike@0.4.252(react-streaming@0.4.15(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(rolldown-vite@7.3.1(@types/node@22.19.7)(esbuild@0.27.2)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@babel/core': 7.28.6
       '@babel/types': 7.28.6
@@ -16061,17 +16115,17 @@ snapshots:
       tinyglobby: 0.2.15
     optionalDependencies:
       react-streaming: 0.4.15(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      vite: rolldown-vite@7.3.1(@types/node@22.19.7)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: rolldown-vite@7.3.1(@types/node@22.19.7)(esbuild@0.27.2)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
-  vite-node@3.2.4(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2):
+  vite-node@3.2.4(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -16086,7 +16140,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2):
+  vite@7.3.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
@@ -16099,15 +16153,16 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.30.2
+      sugarss: 5.0.1(postcss@8.5.6)
       terser: 5.44.1
       tsx: 4.21.0
       yaml: 2.8.2
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.19.7)(happy-dom@20.3.4)(jiti@2.6.1)(jsdom@20.0.3)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.19.7)(happy-dom@20.3.4)(jiti@2.6.1)(jsdom@20.0.3)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 3.2.4(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -16125,8 +16180,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
-      vite-node: 3.2.4(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite-node: 3.2.4(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12


### PR DESCRIPTION
Adds a new prefer-direction-agnostic ESLint rule to help catch physical CSS directional styles that break RTL layouts.

This rule:

- checks .css, .scss, .sass, and .less files
- flags properties like margin-left, padding-right, left, right, and directional border/corner styles
- flags values like text-align: left/right, float: left/right, and clear: left/right
- provides autofixes to logical equivalents such as margin-inline-start, inset-inline-end, and text-align: start/end

More broadly, this moves us toward keeping i18n-related linting in eslint-plugin-formatjs, including stylesheet rules that directly affect localization and RTL support.