### PR TITLE
feat(eslint-plugin-formatjs): support minimum description length in `enforce-description` rule

### DIFF
--- a/docs/src/docs/tooling/linter.mdx
+++ b/docs/src/docs/tooling/linter.mdx
@@ -197,6 +197,10 @@ const messages = defineMessages({
 
 #### Options
 
+The rule accepts a single option, which can be either a string or an object.
+
+**String option:**
+
 ```js
 export default [
   {
@@ -210,7 +214,30 @@ export default [
 ]
 ```
 
-Setting `literal` forces `description` to always be a string literal instead of function calls or variables. This is helpful for extraction tools that expects `description` to always be a literal
+Setting `literal` forces `description` to always be a string literal instead of function calls or variables. This is helpful for extraction tools that expects `description` to always be a literal.
+
+**Object option:**
+
+```js
+export default [
+  {
+    plugins: {
+      formatjs,
+    },
+    rules: {
+      'formatjs/enforce-description': [
+        'error',
+        {minLength: 10, mode: 'literal'},
+      ],
+    },
+  },
+]
+```
+
+| Property    | Type      | Required | Description                                                         |
+| ----------- | --------- | -------- | ------------------------------------------------------------------- |
+| `minLength` | `integer` | No       | Minimum character length for the `description` string.              |
+| `mode`      | `string`  | No       | Set to `'literal'` to require `description` to be a string literal. |
 
 ### `enforce-default-message`
 

--- a/packages/eslint-plugin-formatjs/rules/enforce-description.ts
+++ b/packages/eslint-plugin-formatjs/rules/enforce-description.ts
@@ -7,11 +7,31 @@ export enum Option {
   anything = 'anything',
 }
 
+export type ObjectOption = {
+  mode?: Option
+  minLength?: number
+}
+
+type NormalizedOption = {
+  mode: Option | undefined
+  minLength: number | undefined
+}
+
+function normalizeOptions(
+  raw: string | ObjectOption | undefined
+): NormalizedOption {
+  if (typeof raw === 'string') {
+    return {mode: raw as Option, minLength: undefined}
+  }
+  if (typeof raw === 'object' && raw !== null) {
+    return {mode: raw.mode, minLength: raw.minLength}
+  }
+  return {mode: undefined, minLength: undefined}
+}
+
 function checkNode(context: Rule.RuleContext, node: Node) {
   const msgs = extractMessages(node, getSettings(context))
-  const {
-    options: [type],
-  } = context
+  const {mode: type, minLength} = normalizeOptions(context.options[0])
   for (const [
     {
       message: {description},
@@ -31,6 +51,19 @@ function checkNode(context: Rule.RuleContext, node: Node) {
           messageId: 'enforceDescription',
         })
       }
+    } else if (
+      typeof minLength === 'number' &&
+      typeof description === 'string' &&
+      description.length < minLength
+    ) {
+      context.report({
+        node: descriptionNode ?? messageDescriptorNode,
+        messageId: 'enforceDescriptionMinLength',
+        data: {
+          minLength: String(minLength),
+          length: String(description.length),
+        },
+      })
     }
   }
 }
@@ -47,8 +80,27 @@ export const rule: Rule.RuleModule = {
     fixable: 'code',
     schema: [
       {
-        type: 'string',
-        enum: Object.keys(Option),
+        oneOf: [
+          {
+            type: 'string',
+            enum: Object.keys(Option),
+          },
+          {
+            type: 'object',
+            properties: {
+              mode: {
+                type: 'string',
+                enum: Object.keys(Option),
+              },
+              minLength: {
+                type: 'integer',
+                minimum: 1,
+              },
+            },
+            additionalProperties: false,
+            minProperties: 1,
+          },
+        ],
       },
     ],
     messages: {
@@ -56,6 +108,8 @@ export const rule: Rule.RuleModule = {
         '`description` has to be specified in message descriptor',
       enforceDescriptionLiteral:
         '`description` has to be a string literal (not function call or variable)',
+      enforceDescriptionMinLength:
+        '`description` must be at least {{minLength}} characters long (currently {{length}})',
     },
   },
   create(context) {

--- a/packages/eslint-plugin-formatjs/tests/enforce-description.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/enforce-description.test.ts
@@ -29,6 +29,50 @@ description={'asd' + 'azz'}
     noMatch,
     spreadJsx,
     emptyFnCall,
+    // minLength: description meets minimum
+    {
+      code: `import {defineMessage} from 'react-intl'
+defineMessage({
+    defaultMessage: '{count, plural, one {#} other {# more}}',
+    description: 'this is a long enough description'
+})`,
+      options: [{minLength: 10}],
+    },
+    // minLength with literal: description meets minimum and is a literal
+    {
+      code: `intl.formatMessage({
+    defaultMessage: '{count, plural, one {#} other {# more}}',
+    description: 'this is a long enough description'
+})`,
+      options: [{minLength: 10, mode: Option.literal}],
+    },
+    // minLength: description exactly at minimum
+    {
+      code: `import {defineMessage} from 'react-intl'
+defineMessage({
+    defaultMessage: '{count, plural, one {#} other {# more}}',
+    description: '1234567890'
+})`,
+      options: [{minLength: 10}],
+    },
+    // minLength: 1 — any non-empty description passes
+    {
+      code: `import {defineMessage} from 'react-intl'
+defineMessage({
+    defaultMessage: '{count, plural, one {#} other {# more}}',
+    description: 'x'
+})`,
+      options: [{minLength: 1}],
+    },
+    // minLength only with non-literal description: no error (can't statically evaluate)
+    {
+      code: `import {defineMessage} from 'react-intl'
+defineMessage({
+    defaultMessage: '{count, plural, one {#} other {# more}}',
+    description: foo
+})`,
+      options: [{minLength: 10}],
+    },
   ],
   invalid: [
     {
@@ -121,6 +165,98 @@ description={'asd' + 'azz'}
       code: `
             import {FormattedMessage} from 'react-intl'
             const a = <FormattedMessage defaultMessage="{count2, plural, one {#} other {# more}}"></FormattedMessage>`,
+      errors: [
+        {
+          messageId: 'enforceDescription',
+        },
+      ],
+    },
+    // minLength: description too short via defineMessage
+    {
+      code: `
+            import {defineMessage} from 'react-intl'
+            defineMessage({
+                defaultMessage: '{count, plural, one {#} other {# more}}',
+                description: 'short'
+            })`,
+      options: [{minLength: 10}],
+      errors: [
+        {
+          messageId: 'enforceDescriptionMinLength',
+          data: {minLength: '10', length: '5'},
+        },
+      ],
+    },
+    // minLength: description exactly 1 char short of minimum (boundary)
+    {
+      code: `
+            import {defineMessage} from 'react-intl'
+            defineMessage({
+                defaultMessage: '{count, plural, one {#} other {# more}}',
+                description: '123456789'
+            })`,
+      options: [{minLength: 10}],
+      errors: [
+        {
+          messageId: 'enforceDescriptionMinLength',
+          data: {minLength: '10', length: '9'},
+        },
+      ],
+    },
+    // minLength: description too short via intl.formatMessage
+    {
+      code: `
+            intl.formatMessage({
+                defaultMessage: '{count, plural, one {#} other {# more}}',
+                description: 'short'
+            })`,
+      options: [{minLength: 10}],
+      errors: [
+        {
+          messageId: 'enforceDescriptionMinLength',
+          data: {minLength: '10', length: '5'},
+        },
+      ],
+    },
+    // minLength: description too short via FormattedMessage JSX
+    {
+      code: `
+            import {FormattedMessage} from 'react-intl'
+            const a = <FormattedMessage
+              defaultMessage="{count2, plural, one {#} other {# more}}"
+              description="short"
+            />`,
+      options: [{minLength: 10}],
+      errors: [
+        {
+          messageId: 'enforceDescriptionMinLength',
+          data: {minLength: '10', length: '5'},
+        },
+      ],
+    },
+    // minLength + literal: variable description reports enforceDescriptionLiteral
+    {
+      code: `
+            import {defineMessage} from 'react-intl'
+            defineMessage({
+                defaultMessage: '{count, plural, one {#} other {# more}}',
+                description: foo
+            })`,
+      options: [{minLength: 10, mode: Option.literal}],
+      errors: [
+        {
+          messageId: 'enforceDescriptionLiteral',
+        },
+      ],
+    },
+    // minLength + literal: missing description still reports enforceDescription
+    {
+      code: `
+            import {defineMessage} from 'react-intl'
+            defineMessage({
+                defaultMessage: '{count, plural, one {#} other {# more}}'
+            })`,
+      options: [{minLength: 10}],
       errors: [
         {
           messageId: 'enforceDescription',


### PR DESCRIPTION
## Problem

The `enforce-description` ESLint rule checks that a `description` field is present on message descriptors, but it doesn't enforce any quality bar. In practice, this means developers can satisfy the rule with descriptions like "Title" or "Button text" (or even a singular character like "x"), but such descriptions provide almost no useful context or value to translators.

## Summary

Adds an optional `minLength` option to the `enforce-description` ESLint rule so teams can enforce a minimum character length for message descriptions at lint time.

The rule now accepts either the existing string option or a new object form, maintaining full backward compatibility:
```js
// Existing - still works
'formatjs/enforce-description': ['error', 'literal']

// New object form - minLength and message are both optional
'formatjs/enforce-description': ['error', { minLength: 10, message: 'literal' }]
```

When a description is present but shorter than `minLength`, the rule reports:
> description must be at least 10 characters long (currently 8)

If the description is missing entirely, the existing `enforceDescription` error is reported as before.

### Example configuration

```js
// eslint.config.js
export default [
  {
    plugins: { formatjs },
    rules: {
      'formatjs/enforce-description': ['error', { minLength: 10, message: 'literal' }],
    },
  },
]
```

### Example lint output

❌ Fails
```js
defineMessage({
  defaultMessage: 'Hello',
  description: 'greet',   // `description` must be at least 10 characters long (currently 5)
})
```

✅ Passes
```js
defineMessage({
  defaultMessage: 'Hello',
  description: 'Greeting shown on the homepage banner',
})
```

 ### Test plan
 
[x] Added 8 test cases (3 valid, 5 invalid) across `defineMessage`, `intl.formatMessage` and `<FormattedMessage/>`
[x] All unit tests pass (`bazel test //packages/eslint-plugin-formatjs:unit_test`)