### PR TITLE
perf(@formatjs/vite-plugin): apply Vite performance improvements

### DIFF
--- a/packages/vite-plugin/index.ts
+++ b/packages/vite-plugin/index.ts
@@ -5,10 +5,11 @@ export default function formatjsPlugin(options: Options = {}): Plugin {
   return {
     name: 'formatjs',
     enforce: 'pre',
-    transform(code, id) {
-      if (/node_modules/.test(id)) return
-      if (!/\.[jt]sx?$/.test(id)) return
-      return transform(code, id, options)
+    transform: {
+      filter: {id: {include: /\.[jt]sx?$/, exclude: /node_modules/}},
+      handler(code, id) {
+        return transform(code, id, options)
+      },
     },
   }
 }

--- a/packages/vite-plugin/transform.ts
+++ b/packages/vite-plugin/transform.ts
@@ -467,6 +467,6 @@ export function transform(
 
   return {
     code: s.toString(),
-    map: s.generateMap({hires: true}),
+    map: s.generateMap({hires: 'boundary'}),
   }
 }


### PR DESCRIPTION
Implements two of the three performance suggestions from #6069:

- Use Vite/Rolldown hook filter API to skip non-JS/TS and node_modules files at the native layer
- Switch MagicString source maps to `hires: 'boundary'` for fewer unnecessary mappings

The `Visitor` class from oxc-parser (suggestion 3) requires manual follow-up to verify the API.

Part of #6069

Generated with [Claude Code](https://claude.ai/code)