### PR TITLE
perf(@formatjs/vite-plugin): use oxc-parser Visitor for AST traversal

### DIFF
--- a/packages/vite-plugin/tests/transform.test.ts
+++ b/packages/vite-plugin/tests/transform.test.ts
@@ -315,6 +315,90 @@ describe('@formatjs/vite-plugin transform', () => {
     })
   })
 
+  describe('nested AST traversal', () => {
+    test('processes descriptors inside arrow functions', () => {
+      const input = `const fn = () => intl.formatMessage({defaultMessage: 'Hello', description: 'greeting'})`
+      const output = t(input)
+      expect(output).toContain('id:')
+      expect(output).not.toContain('description')
+    })
+
+    test('processes descriptors inside nested function calls', () => {
+      const input = `console.log(intl.formatMessage({defaultMessage: 'Hello', description: 'greeting'}))`
+      const output = t(input)
+      expect(output).toContain('id:')
+      expect(output).not.toContain('description')
+    })
+
+    test('processes descriptors inside class methods', () => {
+      const input = `class Foo {
+  render() {
+    return intl.formatMessage({defaultMessage: 'Hello', description: 'greeting'})
+  }
+}`
+      const output = t(input)
+      expect(output).toContain('id:')
+      expect(output).not.toContain('description')
+    })
+
+    test('processes descriptors inside conditional expressions', () => {
+      const input = `const msg = condition ? intl.formatMessage({defaultMessage: 'Yes', description: 'd1'}) : intl.formatMessage({defaultMessage: 'No', description: 'd2'})`
+      const output = t(input)
+      const idMatches = output.match(/id:\s*"[^"]+"/g)
+      expect(idMatches).toHaveLength(2)
+      expect(output).not.toContain('description')
+    })
+
+    test('processes deeply nested JSX', () => {
+      const input = `<div><span><FormattedMessage defaultMessage="Hello" description="greeting" /></span></div>`
+      const output = t(input)
+      expect(output).toContain('id=')
+      expect(output).not.toContain('description')
+    })
+
+    test('processes mixed call types in one file', () => {
+      const input = `
+const msg1 = intl.formatMessage({defaultMessage: 'Hello', description: 'd1'})
+const msg2 = defineMessage({defaultMessage: 'World', description: 'd2'})
+const msgs = defineMessages({
+  a: {defaultMessage: 'A', description: 'd3'},
+  b: {defaultMessage: 'B', description: 'd4'}
+})
+const el = <FormattedMessage defaultMessage="JSX" description="d5" />
+const compiled = _jsx(FormattedMessage, {defaultMessage: 'Compiled', description: 'd6'})
+`
+      const output = t(input)
+      const idMatches = output.match(/id[=:]\s*"[^"]+"/g)
+      expect(idMatches).toHaveLength(6)
+      expect(output).not.toContain('description')
+    })
+
+    test('processes descriptors inside if/else blocks', () => {
+      const input = `function foo() {
+  if (condition) {
+    return intl.formatMessage({defaultMessage: 'Yes', description: 'd1'})
+  } else {
+    return intl.formatMessage({defaultMessage: 'No', description: 'd2'})
+  }
+}`
+      const output = t(input)
+      const idMatches = output.match(/id:\s*"[^"]+"/g)
+      expect(idMatches).toHaveLength(2)
+      expect(output).not.toContain('description')
+    })
+
+    test('processes descriptors inside array/object literals', () => {
+      const input = `const arr = [
+  intl.formatMessage({defaultMessage: 'First', description: 'd1'}),
+  intl.formatMessage({defaultMessage: 'Second', description: 'd2'}),
+]`
+      const output = t(input)
+      const idMatches = output.match(/id:\s*"[^"]+"/g)
+      expect(idMatches).toHaveLength(2)
+      expect(output).not.toContain('description')
+    })
+  })
+
   describe('overrideIdFn', () => {
     test('receives all arguments', () => {
       let receivedArgs: any

--- a/packages/vite-plugin/transform.ts
+++ b/packages/vite-plugin/transform.ts
@@ -1,4 +1,5 @@
-import {parseSync} from 'oxc-parser'
+import {parseSync, Visitor} from 'oxc-parser'
+import type {CallExpression, JSXOpeningElement} from 'oxc-parser'
 import MagicString from 'magic-string'
 import {interpolateName} from '@formatjs/ts-transformer'
 import {parse} from '@formatjs/icu-messageformat-parser'
@@ -374,94 +375,71 @@ export function transform(
     return undefined
   }
 
-  function walk(node: any): void {
-    if (!node || typeof node !== 'object') return
+  function handleCallExpression(node: CallExpression): void {
+    const calleeName = getCalleeName(node.callee)
 
-    if (
-      node.type === 'CallExpression' ||
-      node.type === 'OptionalCallExpression'
-    ) {
-      const calleeName = getCalleeName(node.callee)
-
-      // Handle compiled JSX: _jsx(FormattedMessage, { id, description, defaultMessage })
-      if (calleeName && jsxRuntimeFunctions.has(calleeName)) {
-        const firstArg = node.arguments?.[0]
-        const componentName =
-          firstArg?.type === 'Identifier' ? firstArg.name : undefined
-        if (componentName && componentNames.has(componentName)) {
-          const propsArg = node.arguments?.[1]
-          if (propsArg?.type === 'ObjectExpression') {
-            const result = extractDescriptor(propsArg)
-            if (result) {
-              processDescriptor(result.descriptor, result.locations, false)
-            }
+    // Handle compiled JSX: _jsx(FormattedMessage, { id, description, defaultMessage })
+    if (calleeName && jsxRuntimeFunctions.has(calleeName)) {
+      const firstArg = node.arguments?.[0]
+      const componentName =
+        firstArg?.type === 'Identifier' ? firstArg.name : undefined
+      if (componentName && componentNames.has(componentName)) {
+        const propsArg = node.arguments?.[1]
+        if (propsArg?.type === 'ObjectExpression') {
+          const result = extractDescriptor(propsArg)
+          if (result) {
+            processDescriptor(result.descriptor, result.locations, false)
           }
         }
       }
+    }
 
-      if (calleeName && functionNames.has(calleeName)) {
-        if (calleeName === 'defineMessages') {
-          // Process each value in the object
-          const arg = node.arguments?.[0]
-          if (arg?.type === 'ObjectExpression') {
-            for (const prop of arg.properties) {
-              if (
-                (prop.type === 'Property' || prop.type === 'ObjectProperty') &&
-                prop.value?.type === 'ObjectExpression'
-              ) {
-                const result = extractDescriptor(prop.value)
-                if (result) {
-                  processDescriptor(result.descriptor, result.locations, false)
-                }
+    if (calleeName && functionNames.has(calleeName)) {
+      if (calleeName === 'defineMessages') {
+        // Process each value in the object
+        const arg = node.arguments?.[0]
+        if (arg?.type === 'ObjectExpression') {
+          for (const prop of arg.properties) {
+            if (
+              prop.type === 'Property' &&
+              prop.value?.type === 'ObjectExpression'
+            ) {
+              const result = extractDescriptor(prop.value)
+              if (result) {
+                processDescriptor(result.descriptor, result.locations, false)
               }
             }
           }
-        } else if (
-          calleeName === 'defineMessage' ||
-          calleeName === 'formatMessage' ||
-          calleeName === '$t' ||
-          calleeName === '$formatMessage' ||
-          functionNames.has(calleeName)
-        ) {
-          const arg = node.arguments?.[0]
-          if (arg?.type === 'ObjectExpression') {
-            const result = extractDescriptor(arg)
-            if (result) {
-              processDescriptor(result.descriptor, result.locations, false)
-            }
+        }
+      } else {
+        const arg = node.arguments?.[0]
+        if (arg?.type === 'ObjectExpression') {
+          const result = extractDescriptor(arg)
+          if (result) {
+            processDescriptor(result.descriptor, result.locations, false)
           }
         }
-      }
-    }
-
-    if (node.type === 'JSXOpeningElement') {
-      const name =
-        node.name?.type === 'JSXIdentifier' ? node.name.name : undefined
-      if (name && componentNames.has(name)) {
-        const result = extractJSXDescriptor(node)
-        if (result) {
-          processDescriptor(result.descriptor, result.locations, true)
-        }
-      }
-    }
-
-    // Walk children
-    for (const key of Object.keys(node)) {
-      if (key === 'start' || key === 'end' || key === 'type') continue
-      const child = node[key]
-      if (Array.isArray(child)) {
-        for (const item of child) {
-          if (item && typeof item === 'object' && item.type) {
-            walk(item)
-          }
-        }
-      } else if (child && typeof child === 'object' && child.type) {
-        walk(child)
       }
     }
   }
 
-  walk(program)
+  function handleJSXOpeningElement(node: JSXOpeningElement): void {
+    const name =
+      node.name?.type === 'JSXIdentifier' ? node.name.name : undefined
+    if (name && componentNames.has(name)) {
+      const result = extractJSXDescriptor(node)
+      if (result) {
+        processDescriptor(result.descriptor, result.locations, true)
+      }
+    }
+  }
+
+  const visitor = new Visitor({
+    CallExpression: handleCallExpression,
+    JSXOpeningElement: handleJSXOpeningElement,
+  })
+
+  visitor.visit(program)
 
   if (!s) return undefined
 


### PR DESCRIPTION
## Summary
- Replace manual `walk()` function with oxc-parser's built-in `Visitor` class, which knows exactly which AST properties to traverse per node type
- Eliminates generic `Object.keys(node)` iteration and temporary array creation for every node
- Also simplifies a redundant `else if` condition (all listed names were already in `functionNames`)

Implements suggestion 3 from #6069 (cc @sapphi-red).
Closes #6069

## Test plan
- [x] All 484 existing tests pass (`pnpm t`)
- [x] Added 8 new test cases for nested AST traversal scenarios (arrow functions, class methods, conditionals, deeply nested JSX, mixed call types, if/else blocks, array literals)

🤖 Generated with [Claude Code](https://claude.com/claude-code)