### PR TITLE
chore: add exports fields to tooling packages

### DIFF
--- a/UPCOMING.md
+++ b/UPCOMING.md
@@ -1,0 +1,45 @@
+# Upcoming Improvements
+
+## High Impact, High Feasibility
+
+### 1. React Server Components / React 19 Modernization
+- `IntlProvider` is still a class component (`PureComponent`). Convert to functional.
+- No `"use client"` directives anywhere — blocks RSC usage in Next.js App Router
+- `injectIntl` HOC still depends on `hoist-non-react-statics` (deprecated pattern)
+- Create a `react-intl/server` export for server-side formatting without context
+
+### 2. Vite Plugin Adoption (689/week vs 276K for babel-plugin)
+- ~~Missing `"exports"` field in `package.json`~~ (Done — #6080)
+- Consider an `unplugin`-based approach to cover Webpack, Vite, Rollup, esbuild, Rspack with one codebase
+- Better docs with Next.js + Vite, Remix, SvelteKit examples
+
+### 3. Vue `$t` Helper (Pinned Issue #3444, open 4+ years)
+- Strong community demand for concise `$fm`, `$fn`, `$fd` helpers
+
+### 4. Drop `tslib` Across All 27 Packages
+- Modern TS 5.x can emit helpers inline. Removes a runtime dep from 9.3M weekly `intl-messageformat` installs.
+
+## Medium Impact, Strategic
+
+### 5. MessageFormat 2.0 (`Intl.MessageFormat` Polyfill)
+- TC39 proposal progressing. Being the reference polyfill for MF2 would be a major strategic win.
+
+### 6. `decimal.js` Bundle Size in `ecma402-abstract`
+- 127KB dependency flowing into every polyfill. Evaluate if a lighter approach (native `BigInt`, lazy loading) is possible.
+
+### 7. Rust CLI: Vue/GTS Extraction
+- TS CLI has extractors for Vue, Handlebars, GlimmerJS that the Rust CLI lacks. Full parity would let us deprecate the TS CLI.
+
+### 8. Framework Integrations: Svelte, Solid
+- Only React and Vue have first-party integrations. Lingui already supports Svelte. Thin wrappers around `@formatjs/intl` core would be straightforward.
+
+## Maintenance / Cleanup
+
+### 9. ~~Missing `"exports"` Fields~~ (Done — #6080)
+Added `"exports"` to vite-plugin, babel-plugin, ts-transformer, eslint-plugin, cli-lib. Also added missing `"types"` to cli-lib. Skipped cli (binary-only package).
+
+### 10. Documentation Gaps
+No guides for: Next.js App Router + RSC, React Native + Hermes, migration from i18next/Lingui, performance tuning. The SWC plugin docs are a 1-line stub.
+
+### 11. ~~`@types/react` Peer Dep~~ (Won't fix)
+`react-intl` pins `"@types/react": "19"` — intentional, React 18 is no longer supported.

--- a/packages/babel-plugin-formatjs/package.json
+++ b/packages/babel-plugin-formatjs/package.json
@@ -6,6 +6,9 @@
   "author": "Long Ho <holevietlong@gmail.com>",
   "type": "module",
   "types": "index.d.ts",
+  "exports": {
+    ".": "./index.js"
+  },
   "dependencies": {
     "@babel/core": "^7.28.5",
     "@babel/helper-plugin-utils": "^7.27.1",

--- a/packages/cli-lib/package.json
+++ b/packages/cli-lib/package.json
@@ -5,6 +5,10 @@
   "license": "MIT",
   "author": "Linjie Ding <linjie@airtable.com>",
   "type": "module",
+  "types": "index.d.ts",
+  "exports": {
+    ".": "./index.js"
+  },
   "engines": {
     "node": ">= 20.12.0"
   },

--- a/packages/eslint-plugin-formatjs/package.json
+++ b/packages/eslint-plugin-formatjs/package.json
@@ -6,6 +6,9 @@
   "author": "Long Ho <holevietlong@gmail.com>",
   "type": "module",
   "types": "index.d.ts",
+  "exports": {
+    ".": "./index.js"
+  },
   "dependencies": {
     "@formatjs/icu-messageformat-parser": "workspace:*",
     "@formatjs/ts-transformer": "workspace:*",

--- a/packages/ts-transformer/package.json
+++ b/packages/ts-transformer/package.json
@@ -6,6 +6,9 @@
   "author": "Long Ho <holevietlong@gmail.com>",
   "type": "module",
   "types": "index.d.ts",
+  "exports": {
+    ".": "./index.js"
+  },
   "engines": {
     "node": ">= 20.12.0"
   },

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -6,6 +6,9 @@
   "author": "Long Ho <holevietlong@gmail.com>",
   "type": "module",
   "types": "index.d.ts",
+  "exports": {
+    ".": "./index.js"
+  },
   "dependencies": {
     "@formatjs/icu-messageformat-parser": "workspace:*",
     "@formatjs/ts-transformer": "workspace:*",


### PR DESCRIPTION
## Summary
- Add `"exports": { ".": "./index.js" }` to 5 tooling packages that were missing it: `babel-plugin-formatjs`, `@formatjs/cli-lib`, `eslint-plugin-formatjs`, `@formatjs/ts-transformer`, `@formatjs/vite-plugin`
- Add missing `"types": "index.d.ts"` to `@formatjs/cli-lib`
- Improves compatibility with modern bundlers and ESM resolution

## Test plan
- [x] `pnpm install` — lockfile unchanged
- [x] `bazel test` on all 5 affected packages — all pass
- [x] `pnpm t` — full suite (484 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)