### PR TITLE
docs(react-intl): add retroactive upgrade guides for 6.x, 7.x, 8.x

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -130,6 +130,13 @@ Each document in Typesense has the following fields:
   - 🟠 Example - Code examples and samples
 - **Section labels**: Shows which part of docs each result is from
 
+## Adding Documentation Pages
+
+When adding new MDX pages to `src/docs/`, you must also:
+
+1. Add the page to the sidebar navigation in `src/utils/navigation.ts`
+2. Regenerate docs metadata: `bazel run //docs:docs_metadata`
+
 ## File Structure
 
 ```
@@ -140,6 +147,8 @@ docs/
 ├── src/
 │   ├── components/
 │   │   └── SearchBar.tsx            # Typesense search UI
+│   ├── utils/
+│   │   └── navigation.ts           # Sidebar navigation tree
 │   └── docs/                        # MDX documentation files
 ├── .env.example                     # Environment variable template
 ├── .env                            # Your keys (gitignored)

--- a/docs/src/docs-metadata.generated.json
+++ b/docs/src/docs-metadata.generated.json
@@ -147,6 +147,18 @@
     "title": "Upgrade Guide 5.x",
     "description": "- Rich text formatting callback function is no longer variadic."
   },
+  "react-intl/upgrade-guide-6.x": {
+    "title": "Upgrade Guide 6.x",
+    "description": "react-intl v6 fixes type compatibility issues with React 18. If you are using TypeScript, you may see new type errors if you were relying on the previou..."
+  },
+  "react-intl/upgrade-guide-7.x": {
+    "title": "Upgrade Guide 7.x",
+    "description": "@formatjs/intl-displaynames and @formatjs/intl-listformat have been removed from react-intl's dependencies. This reduces the package size, but means you..."
+  },
+  "react-intl/upgrade-guide-8.x": {
+    "title": "Upgrade Guide 8.x",
+    "description": "react-intl v8 requires React 19. If you are using React 18 or below, stay on react-intl v7."
+  },
   "tooling/babel-plugin": {
     "title": "Babel Plugin",
     "description": "Process string messages for translation from modules that use react-intl, specifically:"

--- a/docs/src/docs/react-intl/upgrade-guide-6.x.mdx
+++ b/docs/src/docs/react-intl/upgrade-guide-6.x.mdx
@@ -1,0 +1,29 @@
+## Breaking API Changes
+
+### React 18 type fixes
+
+`react-intl` v6 fixes type compatibility issues with React 18. If you are using TypeScript, you may see new type errors if you were relying on the previous (incorrect) types.
+
+### `@formatjs/cli` packaged as a single file
+
+`@formatjs/cli` is now packaged into a single file. `@vue/compiler-core` has been moved to `peerDependencies`, so if you use Vue you need to install it manually:
+
+```bash
+npm install @vue/compiler-core
+```
+
+## New Features
+
+### `onWarn` callback
+
+`IntlProvider` now accepts an `onWarn` prop for handling warning messages (added in 5.25.0, available from 6.x):
+
+```tsx
+<IntlProvider locale="en" onWarn={msg => console.warn(msg)}>
+  {children}
+</IntlProvider>
+```
+
+### Global context memoization
+
+Starting in 6.3.0, the `IntlContext` is memoized into a global (`window.__REACT_INTL_CONTEXT__`) to handle cases where multiple copies of `react-intl` exist in the bundle. You can opt out of this behavior by setting `window.__REACT_INTL_BYPASS_GLOBAL_CONTEXT__ = true` before mounting.

--- a/docs/src/docs/react-intl/upgrade-guide-7.x.mdx
+++ b/docs/src/docs/react-intl/upgrade-guide-7.x.mdx
@@ -1,0 +1,43 @@
+## Breaking API Changes
+
+### Polyfill packages removed from dependencies
+
+`@formatjs/intl-displaynames` and `@formatjs/intl-listformat` have been removed from `react-intl`'s dependencies. This reduces the package size, but means you need to install these polyfills separately if your target environments don't support `Intl.DisplayNames` or `Intl.ListFormat` natively.
+
+### TypeScript 5 required
+
+Since the polyfill packages were removed, `react-intl` now relies on the native TypeScript type definitions for `Intl.DisplayNames` and `Intl.ListFormat`, which are only available starting from TypeScript 5.
+
+Before:
+
+```json
+{
+  "devDependencies": {
+    "typescript": "^4.7"
+  }
+}
+```
+
+After:
+
+```json
+{
+  "devDependencies": {
+    "typescript": "^5.0"
+  }
+}
+```
+
+### `@formatjs/ecma402-abstract` removed from direct dependencies
+
+`react-intl` no longer directly depends on `@formatjs/ecma402-abstract`. Instead, it uses native TypeScript `Intl` type definitions. If you were importing types from `@formatjs/ecma402-abstract` through `react-intl`, import them directly instead.
+
+## New Features
+
+### React 19 support
+
+Starting in 7.0.2, `react-intl` supports React 19 as a peer dependency. The React peer dependency was relaxed in 7.1.4 to include React 19.
+
+### `dateTimeRange` format key
+
+Starting in 7.1.0, a new `dateTimeRange` format key is available for use with `FormattedDateTimeRange`.

--- a/docs/src/docs/react-intl/upgrade-guide-8.x.mdx
+++ b/docs/src/docs/react-intl/upgrade-guide-8.x.mdx
@@ -1,0 +1,68 @@
+## Breaking API Changes
+
+### React 18 and below no longer supported
+
+`react-intl` v8 requires React 19. If you are using React 18 or below, stay on `react-intl` v7.
+
+Before:
+
+```json
+{
+  "dependencies": {
+    "react": "^16.6.0 || ^17 || ^18",
+    "react-intl": "^7"
+  }
+}
+```
+
+After:
+
+```json
+{
+  "dependencies": {
+    "react": "^19",
+    "react-intl": "^8"
+  }
+}
+```
+
+### Converted to ESM
+
+`react-intl` is now a pure ESM package (`"type": "module"` in package.json). If you are using CommonJS, you will need to use dynamic `import()` or update your project to ESM.
+
+### Rich text wraps with Fragment instead of cloneElement
+
+Rich text elements are now wrapped with `React.Fragment` instead of using `React.cloneElement`. This fixes [#5135](https://github.com/formatjs/formatjs/issues/5135) and avoids deprecation warnings in React 19 where `cloneElement` is discouraged.
+
+If you were relying on props being merged via `cloneElement` in rich text callbacks, you may need to update your code:
+
+Before (v7 — used cloneElement internally):
+
+```tsx
+intl.formatMessage(
+  {defaultMessage: 'Hello <b>world</b>'},
+  {b: chunks => <strong className="bold">{chunks}</strong>}
+)
+```
+
+After (v8 — same API, but internal wrapping uses Fragment):
+
+The API is the same. This is only a breaking change if you relied on internal cloneElement behavior for prop merging.
+
+### `@types/react` moved to peer dependencies
+
+`@types/react` is now a peer dependency instead of a direct dependency. Make sure it's installed in your project:
+
+```bash
+npm install --save-dev @types/react
+```
+
+### Polyfill sub-dependencies converted to ESM
+
+Several transitive dependencies (`@formatjs/intl-getcanonicallocales`, `@formatjs/intl-pluralrules`, `@formatjs/intl-locale`, `@formatjs/intl-numberformat`, `@formatjs/intl-datetimeformat`) have also been converted to ESM.
+
+## New Features
+
+### Strict `format` overrides typing
+
+`FormattedDate`, `FormattedTime`, `FormattedDateParts`, and `FormattedTimeParts` now support strict typing for the `format` prop via global `FormatjsIntl.Formats` type overrides. `FormattedTime` and `FormattedTimeParts` now correctly use the `time` Formats override instead of `date`.

--- a/docs/src/utils/navigation.ts
+++ b/docs/src/utils/navigation.ts
@@ -58,6 +58,9 @@ export function getNavigationTree(): NavSection[] {
         {title: 'Upgrade Guide 3.x', path: 'react-intl/upgrade-guide-3.x'},
         {title: 'Upgrade Guide 4.x', path: 'react-intl/upgrade-guide-4.x'},
         {title: 'Upgrade Guide 5.x', path: 'react-intl/upgrade-guide-5.x'},
+        {title: 'Upgrade Guide 6.x', path: 'react-intl/upgrade-guide-6.x'},
+        {title: 'Upgrade Guide 7.x', path: 'react-intl/upgrade-guide-7.x'},
+        {title: 'Upgrade Guide 8.x', path: 'react-intl/upgrade-guide-8.x'},
       ],
     },
     {


### PR DESCRIPTION
## Summary

- Add missing upgrade guides for react-intl major versions 6.x, 7.x, and 8.x
- **6.x**: React 18 type fixes, `@vue/compiler-core` moved to peerDeps, global context memoization
- **7.x**: Polyfill packages removed from deps, TypeScript 5 required, React 19 support
- **8.x**: React 18 dropped, ESM conversion, Fragment wrapping instead of cloneElement, `@types/react` to peerDeps

## Test plan

- [x] `bazel run //docs:docs_metadata` — regenerated successfully
- [x] Docs metadata test should pass with updated generated file

🤖 Generated with [Claude Code](https://claude.com/claude-code)