### PR TITLE
chore: drop tslib across all 27 packages

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -659,7 +659,7 @@
         "bzlTransitiveDigest": "na+5Su2V30iaLQCC3VoaneTLpArN3Of9pXPpDwtv3a0=",
         "usagesDigest": "Poc6aR0RvidJ/IlCHO+XuhdTUb8PcIKz/zhczsNKsEc=",
         "recordedFileInputs": {
-          "@@//package.json": "399f0cac9756c606b1589044c4caf8f894222ba139e84437df425705ebf2766b"
+          "@@//package.json": "1219fbe834b417095b99a5b5527c8b36214e2b01ba5d4da086a3159a0ac4249e"
         },
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -53,7 +53,6 @@ ts_project(
         "//:node_modules/react-dom",
         "//:node_modules/react-live",
         "//:node_modules/tailwind-merge",
-        "//:node_modules/tslib",
         "//:node_modules/typesense",
         "//:node_modules/vike",
         "//:node_modules/vike-react",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,6 @@
     "tinybench": "^6.0.0",
     "ts-loader": "^9.5.4",
     "tsd": "^0.33.0",
-    "tslib": "^2.8.1",
     "typescript": "5.9.3",
     "typesense": "2.1.0",
     "unidiff": "^1.0.4",

--- a/packages/babel-plugin-formatjs/package.json
+++ b/packages/babel-plugin-formatjs/package.json
@@ -19,8 +19,7 @@
     "@formatjs/ts-transformer": "workspace:*",
     "@types/babel__core": "^7.20.5",
     "@types/babel__helper-plugin-utils": "^7.10.3",
-    "@types/babel__traverse": "^7.28.0",
-    "tslib": "^2.8.1"
+    "@types/babel__traverse": "^7.28.0"
   },
   "bugs": "https://github.com/formatjs/formatjs/issues",
   "gitHead": "8b0baec8eda5002715cf893274fe59782fc2d371",

--- a/packages/cli-lib/BUILD.bazel
+++ b/packages/cli-lib/BUILD.bazel
@@ -101,7 +101,6 @@ esbuild(
     target = "node16",
     visibility = ["//packages/cli:__pkg__"],
     deps = [
-        "//:node_modules/tslib",
     ] + SRC_DEPS,
 )
 

--- a/packages/cli-lib/package.json
+++ b/packages/cli-lib/package.json
@@ -24,7 +24,6 @@
     "fs-extra": "^11.3.3",
     "json-stable-stringify": "^1.3.0",
     "loud-rejection": "^2",
-    "tslib": "^2.8.1",
     "typescript": "^5.6.0"
   },
   "peerDependencies": {

--- a/packages/ecma376/package.json
+++ b/packages/ecma376/package.json
@@ -12,9 +12,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "dependencies": {
-    "tslib": "^2.8.1"
-  },
+  "dependencies": {},
   "bugs": "https://github.com/formatjs/formatjs/issues",
   "homepage": "https://github.com/formatjs/formatjs#readme",
   "keywords": [

--- a/packages/ecma402-abstract/package.json
+++ b/packages/ecma402-abstract/package.json
@@ -13,8 +13,7 @@
   "dependencies": {
     "@formatjs/fast-memoize": "workspace:*",
     "@formatjs/intl-localematcher": "workspace:*",
-    "decimal.js": "^10.6.0",
-    "tslib": "^2.8.1"
+    "decimal.js": "^10.6.0"
   },
   "bugs": "https://github.com/formatjs/formatjs/issues",
   "gitHead": "a7842673d8ad205171ad7c8cb8bb2f318b427c0c",

--- a/packages/eslint-plugin-formatjs/package.json
+++ b/packages/eslint-plugin-formatjs/package.json
@@ -15,8 +15,7 @@
     "@types/picomatch": "^4.0.0",
     "@unicode/unicode-17.0.0": "^1.6.16",
     "magic-string": "^0.30.0",
-    "picomatch": "2 || 3 || 4",
-    "tslib": "^2.8.1"
+    "picomatch": "2 || 3 || 4"
   },
   "peerDependencies": {
     "eslint": "9 || 10"

--- a/packages/fast-memoize/package.json
+++ b/packages/fast-memoize/package.json
@@ -10,9 +10,7 @@
   "exports": {
     ".": "./index.js"
   },
-  "dependencies": {
-    "tslib": "^2.8.1"
-  },
+  "dependencies": {},
   "bugs": "https://github.com/formatjs/formatjs/issues",
   "homepage": "https://github.com/formatjs/formatjs#readme",
   "keywords": [

--- a/packages/icu-messageformat-parser/package.json
+++ b/packages/icu-messageformat-parser/package.json
@@ -12,8 +12,7 @@
   },
   "dependencies": {
     "@formatjs/ecma402-abstract": "workspace:*",
-    "@formatjs/icu-skeleton-parser": "workspace:*",
-    "tslib": "^2.8.1"
+    "@formatjs/icu-skeleton-parser": "workspace:*"
   },
   "repository": {
     "type": "git",

--- a/packages/icu-skeleton-parser/package.json
+++ b/packages/icu-skeleton-parser/package.json
@@ -8,8 +8,7 @@
     ".": "./index.js"
   },
   "dependencies": {
-    "@formatjs/ecma402-abstract": "workspace:*",
-    "tslib": "^2.8.1"
+    "@formatjs/ecma402-abstract": "workspace:*"
   },
   "repository": {
     "type": "git",

--- a/packages/intl-datetimeformat/BUILD.bazel
+++ b/packages/intl-datetimeformat/BUILD.bazel
@@ -899,7 +899,6 @@ esbuild(
     entry_point = "polyfill.ts",
     target = "es6",
     deps = [
-        "//:node_modules/tslib",
     ] + SRC_DEPS,
 )
 

--- a/packages/intl-datetimeformat/package.json
+++ b/packages/intl-datetimeformat/package.json
@@ -19,8 +19,7 @@
   "dependencies": {
     "@formatjs/ecma402-abstract": "workspace:*",
     "@formatjs/intl-localematcher": "workspace:*",
-    "decimal.js": "^10.6.0",
-    "tslib": "^2.8.1"
+    "decimal.js": "^10.6.0"
   },
   "devDependencies": {
     "@formatjs/intl-getcanonicallocales": "workspace:*",

--- a/packages/intl-displaynames/BUILD.bazel
+++ b/packages/intl-displaynames/BUILD.bazel
@@ -782,7 +782,6 @@ esbuild(
     entry_point = "polyfill.ts",
     target = "es6",
     deps = [
-        "//:node_modules/tslib",
     ] + SRC_DEPS,
 )
 

--- a/packages/intl-displaynames/package.json
+++ b/packages/intl-displaynames/package.json
@@ -16,8 +16,7 @@
   },
   "dependencies": {
     "@formatjs/ecma402-abstract": "workspace:*",
-    "@formatjs/intl-localematcher": "workspace:*",
-    "tslib": "^2.8.1"
+    "@formatjs/intl-localematcher": "workspace:*"
   },
   "devDependencies": {
     "@formatjs/intl-getcanonicallocales": "workspace:*",

--- a/packages/intl-durationformat/package.json
+++ b/packages/intl-durationformat/package.json
@@ -14,8 +14,7 @@
   },
   "dependencies": {
     "@formatjs/ecma402-abstract": "workspace:*",
-    "@formatjs/intl-localematcher": "workspace:*",
-    "tslib": "^2.8.1"
+    "@formatjs/intl-localematcher": "workspace:*"
   },
   "bugs": "https://github.com/formatjs/formatjs/issues",
   "homepage": "https://github.com/formatjs/formatjs#readme",

--- a/packages/intl-getcanonicallocales/BUILD.bazel
+++ b/packages/intl-getcanonicallocales/BUILD.bazel
@@ -92,7 +92,6 @@ esbuild(
     entry_point = "polyfill.ts",
     target = "es6",
     deps = [
-        "//:node_modules/tslib",
     ] + SRC_DEPS,
 )
 

--- a/packages/intl-getcanonicallocales/package.json
+++ b/packages/intl-getcanonicallocales/package.json
@@ -12,9 +12,7 @@
     "./polyfill-force.js": "./polyfill-force.js",
     "./should-polyfill.js": "./should-polyfill.js"
   },
-  "dependencies": {
-    "tslib": "^2.8.1"
-  },
+  "dependencies": {},
   "bugs": "https://github.com/formatjs/formatjs/issues",
   "homepage": "https://github.com/formatjs/formatjs#readme",
   "keywords": [

--- a/packages/intl-listformat/BUILD.bazel
+++ b/packages/intl-listformat/BUILD.bazel
@@ -769,7 +769,6 @@ esbuild(
     srcs = [":srcs"],
     entry_point = "polyfill.ts",
     deps = [
-        "//:node_modules/tslib",
     ] + SRC_DEPS,
 )
 

--- a/packages/intl-listformat/package.json
+++ b/packages/intl-listformat/package.json
@@ -16,8 +16,7 @@
   },
   "dependencies": {
     "@formatjs/ecma402-abstract": "workspace:*",
-    "@formatjs/intl-localematcher": "workspace:*",
-    "tslib": "^2.8.1"
+    "@formatjs/intl-localematcher": "workspace:*"
   },
   "devDependencies": {
     "@formatjs/intl-getcanonicallocales": "workspace:*",

--- a/packages/intl-locale/BUILD.bazel
+++ b/packages/intl-locale/BUILD.bazel
@@ -90,7 +90,6 @@ esbuild(
     entry_point = "polyfill.ts",
     target = "es6",
     deps = [
-        "//:node_modules/tslib",
     ] + SRC_DEPS,
 )
 

--- a/packages/intl-locale/package.json
+++ b/packages/intl-locale/package.json
@@ -15,8 +15,7 @@
   "dependencies": {
     "@formatjs/ecma402-abstract": "workspace:*",
     "@formatjs/intl-getcanonicallocales": "workspace:*",
-    "@formatjs/intl-supportedvaluesof": "workspace:*",
-    "tslib": "^2.8.1"
+    "@formatjs/intl-supportedvaluesof": "workspace:*"
   },
   "bugs": "https://github.com/formatjs/formatjs/issues",
   "homepage": "https://github.com/formatjs/formatjs#readme",

--- a/packages/intl-localematcher/package.json
+++ b/packages/intl-localematcher/package.json
@@ -11,8 +11,7 @@
     ".": "./index.js"
   },
   "dependencies": {
-    "@formatjs/fast-memoize": "workspace:*",
-    "tslib": "^2.8.1"
+    "@formatjs/fast-memoize": "workspace:*"
   },
   "bugs": "https://github.com/formatjs/formatjs/issues",
   "homepage": "https://github.com/formatjs/formatjs#readme",

--- a/packages/intl-messageformat/package.json
+++ b/packages/intl-messageformat/package.json
@@ -13,8 +13,7 @@
   "dependencies": {
     "@formatjs/ecma402-abstract": "workspace:*",
     "@formatjs/fast-memoize": "workspace:*",
-    "@formatjs/icu-messageformat-parser": "workspace:*",
-    "tslib": "^2.8.1"
+    "@formatjs/icu-messageformat-parser": "workspace:*"
   },
   "bugs": "https://github.com/formatjs/formatjs/issues",
   "contributors": [

--- a/packages/intl-numberformat/BUILD.bazel
+++ b/packages/intl-numberformat/BUILD.bazel
@@ -979,7 +979,6 @@ esbuild(
     entry_point = "polyfill.ts",
     target = "es6",
     deps = [
-        "//:node_modules/tslib",
     ] + SRC_DEPS,
 )
 

--- a/packages/intl-numberformat/package.json
+++ b/packages/intl-numberformat/package.json
@@ -16,8 +16,7 @@
   "dependencies": {
     "@formatjs/ecma402-abstract": "workspace:*",
     "@formatjs/intl-localematcher": "workspace:*",
-    "decimal.js": "^10.6.0",
-    "tslib": "^2.8.1"
+    "decimal.js": "^10.6.0"
   },
   "devDependencies": {
     "@formatjs/intl-getcanonicallocales": "workspace:*",

--- a/packages/intl-pluralrules/BUILD.bazel
+++ b/packages/intl-pluralrules/BUILD.bazel
@@ -417,7 +417,6 @@ esbuild(
     target = "es6",
     # TODO: fix this and set it back to es5
     deps = [
-        "//:node_modules/tslib",
     ] + SRC_DEPS,
 )
 

--- a/packages/intl-pluralrules/package.json
+++ b/packages/intl-pluralrules/package.json
@@ -17,8 +17,7 @@
   "dependencies": {
     "@formatjs/ecma402-abstract": "workspace:*",
     "@formatjs/intl-localematcher": "workspace:*",
-    "decimal.js": "^10.6.0",
-    "tslib": "^2.8.1"
+    "decimal.js": "^10.6.0"
   },
   "devDependencies": {
     "@formatjs/intl-getcanonicallocales": "workspace:*",

--- a/packages/intl-relativetimeformat/BUILD.bazel
+++ b/packages/intl-relativetimeformat/BUILD.bazel
@@ -767,7 +767,6 @@ esbuild(
     entry_point = "polyfill.ts",
     target = "es6",
     deps = [
-        "//:node_modules/tslib",
     ] + SRC_DEPS,
 )
 

--- a/packages/intl-relativetimeformat/package.json
+++ b/packages/intl-relativetimeformat/package.json
@@ -16,8 +16,7 @@
   },
   "dependencies": {
     "@formatjs/ecma402-abstract": "workspace:*",
-    "@formatjs/intl-localematcher": "workspace:*",
-    "tslib": "^2.8.1"
+    "@formatjs/intl-localematcher": "workspace:*"
   },
   "devDependencies": {
     "@formatjs/intl-getcanonicallocales": "workspace:*",

--- a/packages/intl-segmenter/BUILD.bazel
+++ b/packages/intl-segmenter/BUILD.bazel
@@ -130,7 +130,6 @@ esbuild(
     entry_point = "polyfill.ts",
     target = "es6",
     deps = [
-        "//:node_modules/tslib",
     ] + SRC_DEPS,
 )
 

--- a/packages/intl-segmenter/package.json
+++ b/packages/intl-segmenter/package.json
@@ -12,8 +12,7 @@
   },
   "dependencies": {
     "@formatjs/ecma402-abstract": "workspace:*",
-    "@formatjs/intl-localematcher": "workspace:*",
-    "tslib": "^2.8.1"
+    "@formatjs/intl-localematcher": "workspace:*"
   },
   "bugs": "https://github.com/formatjs/formatjs/issues",
   "homepage": "https://github.com/formatjs/formatjs",

--- a/packages/intl-supportedvaluesof/BUILD.bazel
+++ b/packages/intl-supportedvaluesof/BUILD.bazel
@@ -125,7 +125,6 @@ esbuild(
     srcs = [":srcs"],
     entry_point = "polyfill.ts",
     deps = [
-        "//:node_modules/tslib",
     ] + SRC_DEPS,
 )
 

--- a/packages/intl-supportedvaluesof/package.json
+++ b/packages/intl-supportedvaluesof/package.json
@@ -14,8 +14,7 @@
   },
   "dependencies": {
     "@formatjs/ecma402-abstract": "workspace:*",
-    "@formatjs/fast-memoize": "workspace:*",
-    "tslib": "^2.8.1"
+    "@formatjs/fast-memoize": "workspace:*"
   },
   "bugs": "https://github.com/formatjs/formatjs/issues",
   "homepage": "https://github.com/formatjs/formatjs#readme",

--- a/packages/intl/package.json
+++ b/packages/intl/package.json
@@ -14,8 +14,7 @@
     "@formatjs/ecma402-abstract": "workspace:*",
     "@formatjs/fast-memoize": "workspace:*",
     "@formatjs/icu-messageformat-parser": "workspace:*",
-    "intl-messageformat": "workspace:*",
-    "tslib": "^2.8.1"
+    "intl-messageformat": "workspace:*"
   },
   "peerDependencies": {
     "typescript": "^5.6.0"

--- a/packages/react-intl/examples/BUILD.bazel
+++ b/packages/react-intl/examples/BUILD.bazel
@@ -21,7 +21,6 @@ EXAMPLES_SRC_DEPS = [
     "//:node_modules/@types/react-dom",
     "//:node_modules/react",
     "//:node_modules/react-dom",
-    "//:node_modules/tslib",
 ]
 
 ts_project(

--- a/packages/react-intl/integration-tests/BUILD.bazel
+++ b/packages/react-intl/integration-tests/BUILD.bazel
@@ -13,7 +13,6 @@ TEST_DEPS = [
     "//:node_modules/@types/react",
     "//:node_modules/react-dom",
     "//:node_modules/react",
-    "//:node_modules/tslib",
 ]
 
 vitest(

--- a/packages/react-intl/package.json
+++ b/packages/react-intl/package.json
@@ -16,8 +16,7 @@
     "@formatjs/intl": "workspace:*",
     "@types/hoist-non-react-statics": "^3.3.1",
     "hoist-non-react-statics": "^3.3.2",
-    "intl-messageformat": "workspace:*",
-    "tslib": "^2.8.1"
+    "intl-messageformat": "workspace:*"
   },
   "peerDependencies": {
     "@types/react": "19",

--- a/packages/ts-transformer/package.json
+++ b/packages/ts-transformer/package.json
@@ -16,7 +16,6 @@
     "@formatjs/icu-messageformat-parser": "workspace:*",
     "@types/node": "^22.19.5",
     "json-stable-stringify": "^1.3.0",
-    "tslib": "^2.8.1",
     "typescript": "^5.6.0"
   },
   "devDependencies": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -10,8 +10,7 @@
     ".": "./index.js"
   },
   "dependencies": {
-    "@formatjs/fast-memoize": "workspace:*",
-    "tslib": "^2.8.1"
+    "@formatjs/fast-memoize": "workspace:*"
   },
   "devDependencies": {
     "fast-xml-parser": "^5.0.9"

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -13,8 +13,7 @@
     "@formatjs/icu-messageformat-parser": "workspace:*",
     "@formatjs/ts-transformer": "workspace:*",
     "magic-string": "^0.30.0",
-    "oxc-parser": "^0.114.0",
-    "tslib": "^2.8.1"
+    "oxc-parser": "^0.114.0"
   },
   "peerDependencies": {
     "vite": ">=7"

--- a/packages/vue-intl/package.json
+++ b/packages/vue-intl/package.json
@@ -12,8 +12,7 @@
   "dependencies": {
     "@babel/types": "^7.28.5",
     "@formatjs/icu-messageformat-parser": "workspace:*",
-    "@formatjs/intl": "workspace:*",
-    "tslib": "^2.8.1"
+    "@formatjs/intl": "workspace:*"
   },
   "peerDependencies": {
     "vue": "^3.5.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -349,9 +349,6 @@ importers:
       tsd:
         specifier: ^0.33.0
         version: 0.33.0
-      tslib:
-        specifier: ^2.8.1
-        version: 2.8.1
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -432,9 +429,6 @@ importers:
       '@types/babel__traverse':
         specifier: ^7.28.0
         version: 7.28.0
-      tslib:
-        specifier: ^2.8.1
-        version: 2.8.1
 
   packages/babel-plugin-formatjs/integration-tests:
     dependencies:
@@ -505,9 +499,6 @@ importers:
       loud-rejection:
         specifier: ^2
         version: 2.2.0
-      tslib:
-        specifier: ^2.8.1
-        version: 2.8.1
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
@@ -527,11 +518,7 @@ importers:
         specifier: workspace:*
         version: link:..
 
-  packages/ecma376:
-    dependencies:
-      tslib:
-        specifier: ^2.8.1
-        version: 2.8.1
+  packages/ecma376: {}
 
   packages/ecma402-abstract:
     dependencies:
@@ -544,9 +531,6 @@ importers:
       decimal.js:
         specifier: ^10.6.0
         version: 10.6.0
-      tslib:
-        specifier: ^2.8.1
-        version: 2.8.1
 
   packages/eslint-plugin-formatjs:
     dependencies:
@@ -571,9 +555,6 @@ importers:
       picomatch:
         specifier: 2 || 3 || 4
         version: 4.0.3
-      tslib:
-        specifier: ^2.8.1
-        version: 2.8.1
 
   packages/eslint-plugin-formatjs/integration-tests:
     dependencies:
@@ -587,11 +568,7 @@ importers:
         specifier: workspace:*
         version: link:../../react-intl
 
-  packages/fast-memoize:
-    dependencies:
-      tslib:
-        specifier: ^2.8.1
-        version: 2.8.1
+  packages/fast-memoize: {}
 
   packages/icu-messageformat-parser:
     dependencies:
@@ -601,9 +578,6 @@ importers:
       '@formatjs/icu-skeleton-parser':
         specifier: workspace:*
         version: link:../icu-skeleton-parser
-      tslib:
-        specifier: ^2.8.1
-        version: 2.8.1
 
   packages/icu-messageformat-parser-wasm:
     dependencies:
@@ -643,9 +617,6 @@ importers:
       '@formatjs/ecma402-abstract':
         specifier: workspace:*
         version: link:../ecma402-abstract
-      tslib:
-        specifier: ^2.8.1
-        version: 2.8.1
 
   packages/intl:
     dependencies:
@@ -661,9 +632,6 @@ importers:
       intl-messageformat:
         specifier: workspace:*
         version: link:../intl-messageformat
-      tslib:
-        specifier: ^2.8.1
-        version: 2.8.1
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
@@ -679,9 +647,6 @@ importers:
       decimal.js:
         specifier: ^10.6.0
         version: 10.6.0
-      tslib:
-        specifier: ^2.8.1
-        version: 2.8.1
     devDependencies:
       '@formatjs/intl-getcanonicallocales':
         specifier: workspace:*
@@ -698,9 +663,6 @@ importers:
       '@formatjs/intl-localematcher':
         specifier: workspace:*
         version: link:../intl-localematcher
-      tslib:
-        specifier: ^2.8.1
-        version: 2.8.1
     devDependencies:
       '@formatjs/intl-getcanonicallocales':
         specifier: workspace:*
@@ -717,9 +679,6 @@ importers:
       '@formatjs/intl-localematcher':
         specifier: workspace:*
         version: link:../intl-localematcher
-      tslib:
-        specifier: ^2.8.1
-        version: 2.8.1
 
   packages/intl-durationformat/benchmark:
     devDependencies:
@@ -727,11 +686,7 @@ importers:
         specifier: workspace:*
         version: link:..
 
-  packages/intl-getcanonicallocales:
-    dependencies:
-      tslib:
-        specifier: ^2.8.1
-        version: 2.8.1
+  packages/intl-getcanonicallocales: {}
 
   packages/intl-listformat:
     dependencies:
@@ -741,9 +696,6 @@ importers:
       '@formatjs/intl-localematcher':
         specifier: workspace:*
         version: link:../intl-localematcher
-      tslib:
-        specifier: ^2.8.1
-        version: 2.8.1
     devDependencies:
       '@formatjs/intl-getcanonicallocales':
         specifier: workspace:*
@@ -763,18 +715,12 @@ importers:
       '@formatjs/intl-supportedvaluesof':
         specifier: workspace:*
         version: link:../intl-supportedvaluesof
-      tslib:
-        specifier: ^2.8.1
-        version: 2.8.1
 
   packages/intl-localematcher:
     dependencies:
       '@formatjs/fast-memoize':
         specifier: workspace:*
         version: link:../fast-memoize
-      tslib:
-        specifier: ^2.8.1
-        version: 2.8.1
 
   packages/intl-localematcher/benchmark:
     devDependencies:
@@ -793,9 +739,6 @@ importers:
       '@formatjs/icu-messageformat-parser':
         specifier: workspace:*
         version: link:../icu-messageformat-parser
-      tslib:
-        specifier: ^2.8.1
-        version: 2.8.1
 
   packages/intl-numberformat:
     dependencies:
@@ -808,9 +751,6 @@ importers:
       decimal.js:
         specifier: ^10.6.0
         version: 10.6.0
-      tslib:
-        specifier: ^2.8.1
-        version: 2.8.1
     devDependencies:
       '@formatjs/intl-getcanonicallocales':
         specifier: workspace:*
@@ -839,9 +779,6 @@ importers:
       decimal.js:
         specifier: ^10.6.0
         version: 10.6.0
-      tslib:
-        specifier: ^2.8.1
-        version: 2.8.1
     devDependencies:
       '@formatjs/intl-getcanonicallocales':
         specifier: workspace:*
@@ -858,9 +795,6 @@ importers:
       '@formatjs/intl-localematcher':
         specifier: workspace:*
         version: link:../intl-localematcher
-      tslib:
-        specifier: ^2.8.1
-        version: 2.8.1
     devDependencies:
       '@formatjs/intl-getcanonicallocales':
         specifier: workspace:*
@@ -880,9 +814,6 @@ importers:
       '@formatjs/intl-localematcher':
         specifier: workspace:*
         version: link:../intl-localematcher
-      tslib:
-        specifier: ^2.8.1
-        version: 2.8.1
 
   packages/intl-supportedvaluesof:
     dependencies:
@@ -892,9 +823,6 @@ importers:
       '@formatjs/fast-memoize':
         specifier: workspace:*
         version: link:../fast-memoize
-      tslib:
-        specifier: ^2.8.1
-        version: 2.8.1
 
   packages/react-intl:
     dependencies:
@@ -922,9 +850,6 @@ importers:
       react:
         specifier: '19'
         version: 19.2.3
-      tslib:
-        specifier: ^2.8.1
-        version: 2.8.1
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
@@ -997,9 +922,6 @@ importers:
       json-stable-stringify:
         specifier: ^1.3.0
         version: 1.3.0
-      tslib:
-        specifier: ^2.8.1
-        version: 2.8.1
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
@@ -1022,9 +944,6 @@ importers:
       '@formatjs/fast-memoize':
         specifier: workspace:*
         version: link:../fast-memoize
-      tslib:
-        specifier: ^2.8.1
-        version: 2.8.1
     devDependencies:
       fast-xml-parser:
         specifier: ^5.0.9
@@ -1044,9 +963,6 @@ importers:
       oxc-parser:
         specifier: ^0.114.0
         version: 0.114.0
-      tslib:
-        specifier: ^2.8.1
-        version: 2.8.1
       vite:
         specifier: '>=7'
         version: 7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
@@ -1068,9 +984,6 @@ importers:
       '@formatjs/intl':
         specifier: workspace:*
         version: link:../intl
-      tslib:
-        specifier: ^2.8.1
-        version: 2.8.1
       vue:
         specifier: ^3.5.0
         version: 3.5.27(typescript@5.9.3)

--- a/tools/index.bzl
+++ b/tools/index.bzl
@@ -18,7 +18,6 @@ def ts_compile_node(name, srcs, deps = [], data = [], visibility = None):
         data: add data deps like internal transitive deps
         visibility: visibility
     """
-    deps = deps + ["//:node_modules/tslib"]
 
     # Type check only with tsgo (fast, parallel)
     ts_project(
@@ -60,7 +59,6 @@ def ts_compile(name, srcs, deps = [], visibility = None):
         deps: deps
         visibility: visibility
     """
-    deps = deps + ["//:node_modules/tslib"]
 
     # Always build ESM bundle
     # Type check only with tsgo (fast, parallel)

--- a/tools/tsconfig.bzl
+++ b/tools/tsconfig.bzl
@@ -31,7 +31,7 @@ BASE_TSCONFIG = {
         "allowSyntheticDefaultImports": False,
         "noFallthroughCasesInSwitch": True,
         "verbatimModuleSyntax": True,
-        "importHelpers": True,
+        "importHelpers": False,
         "isolatedDeclarations": True,
         "rewriteRelativeImportExtensions": True,
         "jsx": "react-jsx",

--- a/tools/vitest.bzl
+++ b/tools/vitest.bzl
@@ -42,7 +42,6 @@ def vitest(
     """
 
     deps = deps + [
-        "//:node_modules/tslib",
         "//:node_modules/vitest",
         "//:node_modules/vite",
         "//:node_modules/@types/node",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "allowSyntheticDefaultImports": false,
     "declaration": true,
     "esModuleInterop": false,
-    "importHelpers": true,
+    "importHelpers": false,
     "isolatedDeclarations": true,
     "jsx": "react-jsx",
     "lib": [


### PR DESCRIPTION
## Summary

- Set `importHelpers: false` in tsconfig — oxc-transform handles transpilation independently of tsc, so tslib helpers were never used in the compiled output
- Remove `tslib` from all 27 package.json `dependencies`
- Remove `tslib` from root `devDependencies`
- Remove `tslib` from all `BUILD.bazel` files and Bazel macros (`tools/index.bzl`, `tools/vitest.bzl`)
- Update `pnpm-lock.yaml`

This removes a runtime dependency from all published packages (9.3M weekly `intl-messageformat` installs).

## Test plan

- [x] 483/484 tests pass (`pnpm t`)
- [x] 1 pre-existing failure (`vite-plugin/integration-tests:integration_test_typecheck_typecheck_test`) — rollup/vite type incompatibility, unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)