### PR TITLE
fix(react-intl): fix vitest DOM tests failing in Bazel sandbox

### DIFF
--- a/packages/react-intl/vitest.config.mjs
+++ b/packages/react-intl/vitest.config.mjs
@@ -5,4 +5,7 @@ export default defineConfig({
     jsx: 'automatic',
     jsxDev: true,
   },
+  resolve: {
+    preserveSymlinks: true,
+  },
 })

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -6,6 +6,12 @@ exports_files([
 ])
 
 copy_to_bin(
+    name = "vitest_config_mjs",
+    srcs = ["vitest.config.mjs"],
+    visibility = ["//visibility:public"],
+)
+
+copy_to_bin(
     name = "check-package-json",
     srcs = ["check-package-json.ts"],
     visibility = ["//visibility:public"],

--- a/tools/vitest.bzl
+++ b/tools/vitest.bzl
@@ -73,16 +73,23 @@ def vitest(
         transpiler = tsgo_bin.tsgo,
     )
 
+    # Use the shared base config for Bazel sandbox compatibility (preserveSymlinks).
+    # Packages with custom configs must also include resolve.preserveSymlinks: true.
+    base_config = "//tools:vitest_config_mjs"
+    actual_config = config if config else base_config
+
     vitest_bin.vitest_test(
         name = name,
-        data = srcs + deps + data + snapshots + fixtures + ([config] if config else []),
+        data = srcs + deps + data + snapshots + fixtures + [actual_config],
         size = size,
         flaky = flaky,
         tags = tags,
         no_copy_to_bin = no_copy_to_bin,
         args = [
             "run",
-        ] + (["--config", "$(rootpath %s)" % config] if config else []) + (["--dom"] if dom else []) + (["--testTimeout ", test_timeout] if test_timeout else []),
+            "--config",
+            "$(rootpath %s)" % actual_config,
+        ] + (["--dom"] if dom else []) + (["--testTimeout ", test_timeout] if test_timeout else []),
         **kwargs
     )
 

--- a/tools/vitest.config.mjs
+++ b/tools/vitest.config.mjs
@@ -1,0 +1,10 @@
+// Default vitest configuration for Bazel sandbox compatibility.
+// Preserves symlinks so Vite doesn't resolve Bazel runfile symlinks
+// to paths outside the sandbox (which breaks --dom/happy-dom tests).
+import {defineConfig} from 'vitest/config'
+
+export default defineConfig({
+  resolve: {
+    preserveSymlinks: true,
+  },
+})


### PR DESCRIPTION
## Summary

- Fix `react-intl:unit_test`, `react-intl/integration-tests:test`, and `vue-intl:unit_test` failing with "Cannot find module" errors in the Bazel sandbox
- Root cause: Vite's module loader resolves Bazel runfile symlinks to their real paths (outside the sandbox) when running in `--dom` (happy-dom) environment
- Fix: add `resolve.preserveSymlinks: true` to vitest config

## What changed

- **`tools/vitest.config.mjs`** (new) — shared base vitest config with `resolve.preserveSymlinks: true`
- **`tools/vitest.bzl`** — always pass the base config to vitest (packages with custom configs must include the setting themselves)
- **`tools/BUILD.bazel`** — expose the config file via `copy_to_bin`
- **`packages/react-intl/vitest.config.mjs`** — add `resolve.preserveSymlinks: true`

## Test plan

- [x] `bazel test //packages/react-intl:unit_test` — was FAILING, now PASSES (13 tests)
- [x] `bazel test //packages/react-intl/integration-tests:test` — was FAILING, now PASSES
- [x] `bazel test //packages/vue-intl:unit_test` — was FAILING, now PASSES (3 tests)
- [x] `pnpm t` — 484/484 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)