### PR TITLE
fix(eslint-plugin-formatjs): restore ability to import util module

### DIFF
--- a/packages/eslint-plugin-formatjs/package.json
+++ b/packages/eslint-plugin-formatjs/package.json
@@ -7,7 +7,8 @@
   "type": "module",
   "types": "index.d.ts",
   "exports": {
-    ".": "./index.js"
+    ".": "./index.js",
+    "./util": "./util.js"
   },
   "dependencies": {
     "@formatjs/icu-messageformat-parser": "workspace:*",


### PR DESCRIPTION
Prior to 6.3.0, we were able to `import { extractMessages, getSettings } from 'eslint-plugin-formatjs/util.js'`, and we did this to define some custom rules that are specific to our workflows.

After https://github.com/formatjs/formatjs/pull/6080, that import is failing.

Can we restore the ability to import the util module?