### PR TITLE
feat: buffer locale data for parallel polyfill + data loading

### DIFF
--- a/packages/intl-datetimeformat/polyfill-force.ts
+++ b/packages/intl-datetimeformat/polyfill-force.ts
@@ -50,3 +50,14 @@ defineProperty(Date.prototype, 'toLocaleTimeString', {
     }
   },
 })
+
+// Drain any locale data that was buffered before polyfill loaded
+const buf = (globalThis as Record<string, unknown>)
+  .__FORMATJS_DATETIMEFORMAT_DATA__ as
+  | Parameters<(typeof DateTimeFormat)['__addLocaleData']>[0][]
+  | undefined
+if (buf) {
+  for (const d of buf) DateTimeFormat.__addLocaleData(d)
+  delete (globalThis as Record<string, unknown>)
+    .__FORMATJS_DATETIMEFORMAT_DATA__
+}

--- a/packages/intl-datetimeformat/polyfill.ts
+++ b/packages/intl-datetimeformat/polyfill.ts
@@ -52,4 +52,15 @@ if (shouldPolyfill()) {
       }
     },
   })
+
+  // Drain any locale data that was buffered before polyfill loaded
+  const buf = (globalThis as Record<string, unknown>)
+    .__FORMATJS_DATETIMEFORMAT_DATA__ as
+    | Parameters<(typeof DateTimeFormat)['__addLocaleData']>[0][]
+    | undefined
+  if (buf) {
+    for (const d of buf) DateTimeFormat.__addLocaleData(d)
+    delete (globalThis as Record<string, unknown>)
+      .__FORMATJS_DATETIMEFORMAT_DATA__
+  }
 }

--- a/packages/intl-datetimeformat/scripts/cldr.ts
+++ b/packages/intl-datetimeformat/scripts/cldr.ts
@@ -19,6 +19,8 @@ function main(args: Args) {
 // prettier-ignore
 if (Intl.DateTimeFormat && typeof Intl.DateTimeFormat.__addLocaleData === 'function') {
   Intl.DateTimeFormat.__addLocaleData(${data})
+} else {
+  (globalThis.__FORMATJS_DATETIMEFORMAT_DATA__ = globalThis.__FORMATJS_DATETIMEFORMAT_DATA__ || []).push(${data})
 }
 `
     )

--- a/packages/intl-displaynames/polyfill-force.ts
+++ b/packages/intl-displaynames/polyfill-force.ts
@@ -6,3 +6,13 @@ Object.defineProperty(Intl, 'DisplayNames', {
   writable: true,
   configurable: true,
 })
+
+// Drain any locale data that was buffered before polyfill loaded
+const buf = (globalThis as Record<string, unknown>)
+  .__FORMATJS_DISPLAYNAMES_DATA__ as
+  | Parameters<(typeof DisplayNames)['__addLocaleData']>[0][]
+  | undefined
+if (buf) {
+  for (const d of buf) DisplayNames.__addLocaleData(d)
+  delete (globalThis as Record<string, unknown>).__FORMATJS_DISPLAYNAMES_DATA__
+}

--- a/packages/intl-displaynames/polyfill.ts
+++ b/packages/intl-displaynames/polyfill.ts
@@ -8,4 +8,15 @@ if (shouldPolyfill()) {
     writable: true,
     configurable: true,
   })
+
+  // Drain any locale data that was buffered before polyfill loaded
+  const buf = (globalThis as Record<string, unknown>)
+    .__FORMATJS_DISPLAYNAMES_DATA__ as
+    | Parameters<(typeof DisplayNames)['__addLocaleData']>[0][]
+    | undefined
+  if (buf) {
+    for (const d of buf) DisplayNames.__addLocaleData(d)
+    delete (globalThis as Record<string, unknown>)
+      .__FORMATJS_DISPLAYNAMES_DATA__
+  }
 }

--- a/packages/intl-displaynames/scripts/cldr.ts
+++ b/packages/intl-displaynames/scripts/cldr.ts
@@ -21,6 +21,8 @@ function main(args: Args) {
 // prettier-ignore
 if (Intl.DisplayNames && typeof Intl.DisplayNames.__addLocaleData === 'function') {
   Intl.DisplayNames.__addLocaleData(${data})
+} else {
+  (globalThis.__FORMATJS_DISPLAYNAMES_DATA__ = globalThis.__FORMATJS_DISPLAYNAMES_DATA__ || []).push(${data})
 }`
     )
     outputFileSync(join(outDir, locale + '.d.ts'), 'export {}')

--- a/packages/intl-listformat/polyfill-force.ts
+++ b/packages/intl-listformat/polyfill-force.ts
@@ -6,3 +6,13 @@ Object.defineProperty(Intl, 'ListFormat', {
   enumerable: false,
   configurable: true,
 })
+
+// Drain any locale data that was buffered before polyfill loaded
+const buf = (globalThis as Record<string, unknown>)
+  .__FORMATJS_LISTFORMAT_DATA__ as
+  | Parameters<(typeof ListFormat)['__addLocaleData']>[0][]
+  | undefined
+if (buf) {
+  for (const d of buf) ListFormat.__addLocaleData(d)
+  delete (globalThis as Record<string, unknown>).__FORMATJS_LISTFORMAT_DATA__
+}

--- a/packages/intl-listformat/polyfill.ts
+++ b/packages/intl-listformat/polyfill.ts
@@ -7,4 +7,14 @@ if (shouldPolyfill()) {
     enumerable: false,
     configurable: true,
   })
+
+  // Drain any locale data that was buffered before polyfill loaded
+  const buf = (globalThis as Record<string, unknown>)
+    .__FORMATJS_LISTFORMAT_DATA__ as
+    | Parameters<(typeof ListFormat)['__addLocaleData']>[0][]
+    | undefined
+  if (buf) {
+    for (const d of buf) ListFormat.__addLocaleData(d)
+    delete (globalThis as Record<string, unknown>).__FORMATJS_LISTFORMAT_DATA__
+  }
 }

--- a/packages/intl-listformat/scripts/cldr.ts
+++ b/packages/intl-listformat/scripts/cldr.ts
@@ -21,6 +21,8 @@ function main(args: Args) {
 // prettier-ignore
 if (Intl.ListFormat && typeof Intl.ListFormat.__addLocaleData === 'function') {
   Intl.ListFormat.__addLocaleData(${data})
+} else {
+  (globalThis.__FORMATJS_LISTFORMAT_DATA__ = globalThis.__FORMATJS_LISTFORMAT_DATA__ || []).push(${data})
 }`
     )
     outputFileSync(join(outDir, locale + '.d.ts'), 'export {}')

--- a/packages/intl-numberformat/polyfill-force.ts
+++ b/packages/intl-numberformat/polyfill-force.ts
@@ -14,3 +14,13 @@ defineProperty(Number.prototype, 'toLocaleString', {
     return _toLocaleString(this, locales, options)
   },
 })
+
+// Drain any locale data that was buffered before polyfill loaded
+const buf = (globalThis as Record<string, unknown>)
+  .__FORMATJS_NUMBERFORMAT_DATA__ as
+  | Parameters<(typeof NumberFormat)['__addLocaleData']>[0][]
+  | undefined
+if (buf) {
+  for (const d of buf) NumberFormat.__addLocaleData(d)
+  delete (globalThis as Record<string, unknown>).__FORMATJS_NUMBERFORMAT_DATA__
+}

--- a/packages/intl-numberformat/polyfill.ts
+++ b/packages/intl-numberformat/polyfill.ts
@@ -16,4 +16,15 @@ if (shouldPolyfill()) {
       return _toLocaleString(this, locales, options)
     },
   })
+
+  // Drain any locale data that was buffered before polyfill loaded
+  const buf = (globalThis as Record<string, unknown>)
+    .__FORMATJS_NUMBERFORMAT_DATA__ as
+    | Parameters<(typeof NumberFormat)['__addLocaleData']>[0][]
+    | undefined
+  if (buf) {
+    for (const d of buf) NumberFormat.__addLocaleData(d)
+    delete (globalThis as Record<string, unknown>)
+      .__FORMATJS_NUMBERFORMAT_DATA__
+  }
 }

--- a/packages/intl-numberformat/scripts/cldr.ts
+++ b/packages/intl-numberformat/scripts/cldr.ts
@@ -20,6 +20,8 @@ function main(args: Args) {
 // prettier-ignore
 if (Intl.NumberFormat && typeof Intl.NumberFormat.__addLocaleData === 'function') {
   Intl.NumberFormat.__addLocaleData(${data})
+} else {
+  (globalThis.__FORMATJS_NUMBERFORMAT_DATA__ = globalThis.__FORMATJS_NUMBERFORMAT_DATA__ || []).push(${data})
 }`
     )
     outputFileSync(join(outDir, locale + '.d.ts'), 'export {}')

--- a/packages/intl-pluralrules/polyfill-force.ts
+++ b/packages/intl-pluralrules/polyfill-force.ts
@@ -6,3 +6,13 @@ Object.defineProperty(Intl, 'PluralRules', {
   enumerable: false,
   configurable: true,
 })
+
+// Drain any locale data that was buffered before polyfill loaded
+const buf = (globalThis as Record<string, unknown>)
+  .__FORMATJS_PLURALRULES_DATA__ as
+  | Parameters<(typeof PluralRules)['__addLocaleData']>[0][]
+  | undefined
+if (buf) {
+  for (const d of buf) PluralRules.__addLocaleData(d)
+  delete (globalThis as Record<string, unknown>).__FORMATJS_PLURALRULES_DATA__
+}

--- a/packages/intl-pluralrules/polyfill.ts
+++ b/packages/intl-pluralrules/polyfill.ts
@@ -8,4 +8,14 @@ if (shouldPolyfill()) {
     enumerable: false,
     configurable: true,
   })
+
+  // Drain any locale data that was buffered before polyfill loaded
+  const buf = (globalThis as Record<string, unknown>)
+    .__FORMATJS_PLURALRULES_DATA__ as
+    | Parameters<(typeof PluralRules)['__addLocaleData']>[0][]
+    | undefined
+  if (buf) {
+    for (const d of buf) PluralRules.__addLocaleData(d)
+    delete (globalThis as Record<string, unknown>).__FORMATJS_PLURALRULES_DATA__
+  }
 }

--- a/packages/intl-pluralrules/scripts/cldr.ts
+++ b/packages/intl-pluralrules/scripts/cldr.ts
@@ -19,6 +19,8 @@ function main(args: Args) {
 // prettier-ignore
 if (Intl.PluralRules && typeof Intl.PluralRules.__addLocaleData === 'function') {
   Intl.PluralRules.__addLocaleData(${data})
+} else {
+  (globalThis.__FORMATJS_PLURALRULES_DATA__ = globalThis.__FORMATJS_PLURALRULES_DATA__ || []).push(${data})
 }
 `
     )

--- a/packages/intl-relativetimeformat/polyfill-force.ts
+++ b/packages/intl-relativetimeformat/polyfill-force.ts
@@ -5,3 +5,14 @@ Object.defineProperty(Intl, 'RelativeTimeFormat', {
   enumerable: false,
   configurable: true,
 })
+
+// Drain any locale data that was buffered before polyfill loaded
+const buf = (globalThis as Record<string, unknown>)
+  .__FORMATJS_RELATIVETIMEFORMAT_DATA__ as
+  | Parameters<(typeof RelativeTimeFormat)['__addLocaleData']>[0][]
+  | undefined
+if (buf) {
+  for (const d of buf) RelativeTimeFormat.__addLocaleData(d)
+  delete (globalThis as Record<string, unknown>)
+    .__FORMATJS_RELATIVETIMEFORMAT_DATA__
+}

--- a/packages/intl-relativetimeformat/polyfill.ts
+++ b/packages/intl-relativetimeformat/polyfill.ts
@@ -7,4 +7,15 @@ if (shouldPolyfill()) {
     enumerable: false,
     configurable: true,
   })
+
+  // Drain any locale data that was buffered before polyfill loaded
+  const buf = (globalThis as Record<string, unknown>)
+    .__FORMATJS_RELATIVETIMEFORMAT_DATA__ as
+    | Parameters<(typeof RelativeTimeFormat)['__addLocaleData']>[0][]
+    | undefined
+  if (buf) {
+    for (const d of buf) RelativeTimeFormat.__addLocaleData(d)
+    delete (globalThis as Record<string, unknown>)
+      .__FORMATJS_RELATIVETIMEFORMAT_DATA__
+  }
 }

--- a/packages/intl-relativetimeformat/scripts/cldr.ts
+++ b/packages/intl-relativetimeformat/scripts/cldr.ts
@@ -18,6 +18,8 @@ function main(args: Args) {
 // prettier-ignore
 if (Intl.RelativeTimeFormat && typeof Intl.RelativeTimeFormat.__addLocaleData === 'function') {
   Intl.RelativeTimeFormat.__addLocaleData(${data})
+} else {
+  (globalThis.__FORMATJS_RELATIVETIMEFORMAT_DATA__ = globalThis.__FORMATJS_RELATIVETIMEFORMAT_DATA__ || []).push(${data})
 }
 `
     )


### PR DESCRIPTION
## Summary

- Locale data files previously silently dropped data if loaded before the polyfill itself, forcing sequential loading (polyfill → locale data) and doubling initialization time on slow networks
- Adds a per-polyfill global buffer (`globalThis.__FORMATJS_<NAME>_DATA__`) so locale data files push to the buffer when the polyfill isn't ready yet
- When the polyfill loads, it drains the buffer and deletes it — non-breaking, existing sequential usage still works

### Affected packages (18 files across 6 packages)
- `@formatjs/intl-numberformat`
- `@formatjs/intl-datetimeformat`
- `@formatjs/intl-pluralrules`
- `@formatjs/intl-listformat`
- `@formatjs/intl-relativetimeformat`
- `@formatjs/intl-displaynames`

### Changes per package
1. **`scripts/cldr.ts`** — locale data generation template adds an `else` branch that buffers data to `globalThis`
2. **`polyfill.ts`** — drains the global buffer after registering the polyfill
3. **`polyfill-force.ts`** — same drain logic after unconditional polyfill registration

Fixes #4457

## Test plan

- [x] `bazel test //packages/intl-numberformat:unit_tests --test_output=errors` — PASSED
- [x] `bazel test //packages/intl-datetimeformat:unit_test --test_output=errors` — PASSED
- [x] `bazel test //packages/intl-pluralrules:unit_test --test_output=errors` — PASSED
- [x] `bazel test //packages/intl-listformat:unit_test --test_output=errors` — PASSED
- [x] `bazel test //packages/intl-relativetimeformat:unit_test --test_output=errors` — PASSED
- [x] `bazel test //packages/intl-displaynames:unit_test --test_output=errors` — PASSED
- [x] `pnpm t` — 493/493 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)