### PR TITLE
feat(@formatjs/ecma402-abstract): migrate from decimal.js to @formatjs/bigdecimal

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "clsx": "^2.1.1",
     "content-tag": "^4.1.0",
     "conventional-changelog-angular": "^8.1.0",
-    "decimal.js": "^10.6.0",
     "esbuild": "^0.27.0",
     "eslint": "10.0.3",
     "fast-glob": "^3.3.3",

--- a/packages/bigdecimal/index.ts
+++ b/packages/bigdecimal/index.ts
@@ -221,9 +221,15 @@ export class BigDecimal {
     return bd
   }
 
+  // Auto-coerce to BigDecimal for decimal.js compat
+  private static _coerce(v: BigDecimal | number | string | bigint): BigDecimal {
+    return v instanceof BigDecimal ? v : new BigDecimal(v)
+  }
+
   // --- Arithmetic ---
 
-  times(other: BigDecimal): BigDecimal {
+  times(y: BigDecimal | number | string | bigint): BigDecimal {
+    const other = BigDecimal._coerce(y)
     if (this._special || other._special) {
       return this._specialArith(other, 'times')
     }
@@ -239,7 +245,8 @@ export class BigDecimal {
     return BigDecimal._create(nm, ne, SpecialValue.NONE, false)
   }
 
-  div(other: BigDecimal): BigDecimal {
+  div(y: BigDecimal | number | string | bigint): BigDecimal {
+    const other = BigDecimal._coerce(y)
     if (this._special || other._special) {
       return this._specialArith(other, 'div')
     }
@@ -267,7 +274,8 @@ export class BigDecimal {
     return BigDecimal._create(nm, ne, SpecialValue.NONE, false)
   }
 
-  plus(other: BigDecimal): BigDecimal {
+  plus(y: BigDecimal | number | string | bigint): BigDecimal {
+    const other = BigDecimal._coerce(y)
     if (this._special || other._special) {
       return this._specialArith(other, 'plus')
     }
@@ -296,11 +304,12 @@ export class BigDecimal {
     return BigDecimal._create(nm, ne, SpecialValue.NONE, false)
   }
 
-  minus(other: BigDecimal): BigDecimal {
-    return this.plus(other.negated())
+  minus(y: BigDecimal | number | string | bigint): BigDecimal {
+    return this.plus(BigDecimal._coerce(y).negated())
   }
 
-  mod(other: BigDecimal): BigDecimal {
+  mod(y: BigDecimal | number | string | bigint): BigDecimal {
+    const other = BigDecimal._coerce(y)
     if (this._special || other._special) {
       if (
         this._special === SpecialValue.NAN ||
@@ -500,7 +509,8 @@ export class BigDecimal {
 
   // --- Comparison ---
 
-  eq(other: BigDecimal): boolean {
+  eq(y: BigDecimal | number | string | bigint): boolean {
+    const other = BigDecimal._coerce(y)
     if (
       this._special === SpecialValue.NAN ||
       other._special === SpecialValue.NAN
@@ -559,23 +569,23 @@ export class BigDecimal {
     return 0
   }
 
-  lessThan(other: BigDecimal): boolean {
-    const c = this._compareTo(other)
+  lessThan(y: BigDecimal | number | string | bigint): boolean {
+    const c = this._compareTo(BigDecimal._coerce(y))
     return c === -1
   }
 
-  greaterThan(other: BigDecimal): boolean {
-    const c = this._compareTo(other)
+  greaterThan(y: BigDecimal | number | string | bigint): boolean {
+    const c = this._compareTo(BigDecimal._coerce(y))
     return c === 1
   }
 
-  lessThanOrEqualTo(other: BigDecimal): boolean {
-    const c = this._compareTo(other)
+  lessThanOrEqualTo(y: BigDecimal | number | string | bigint): boolean {
+    const c = this._compareTo(BigDecimal._coerce(y))
     return c === 0 || c === -1
   }
 
-  greaterThanOrEqualTo(other: BigDecimal): boolean {
-    const c = this._compareTo(other)
+  greaterThanOrEqualTo(y: BigDecimal | number | string | bigint): boolean {
+    const c = this._compareTo(BigDecimal._coerce(y))
     return c === 0 || c === 1
   }
 
@@ -616,6 +626,10 @@ export class BigDecimal {
   }
 
   // --- Conversion ---
+
+  toJSON(): string {
+    return this.toString()
+  }
 
   toNumber(): number {
     if (this._special === SpecialValue.NAN) return NaN
@@ -659,13 +673,14 @@ export class BigDecimal {
 
   // --- Static ---
 
-  static pow(base: number | BigDecimal, exp: number): BigDecimal {
+  static pow(base: number | BigDecimal, exp: number | BigDecimal): BigDecimal {
+    const n = typeof exp === 'number' ? exp : exp.toNumber()
     if (typeof base === 'number' && base === 10) {
       // Trivial: 10^n = mantissa=1, exponent=n
-      return BigDecimal._create(1n, exp, SpecialValue.NONE, false)
+      return BigDecimal._create(1n, n, SpecialValue.NONE, false)
     }
     const bd = base instanceof BigDecimal ? base : new BigDecimal(base)
-    return bd.pow(exp)
+    return bd.pow(n)
   }
 
   static set(_config: Record<string, unknown>): void {
@@ -755,3 +770,7 @@ export class BigDecimal {
     return BigDecimal._create(0n, 0, SpecialValue.NAN, false)
   }
 }
+
+// Alias for drop-in decimal.js compatibility
+export {BigDecimal as Decimal}
+export default BigDecimal

--- a/packages/ecma402-abstract/262.ts
+++ b/packages/ecma402-abstract/262.ts
@@ -1,4 +1,4 @@
-import {Decimal} from 'decimal.js'
+import {Decimal} from '@formatjs/bigdecimal'
 import {ZERO} from './constants.js'
 import {invariant} from './utils.js'
 /**

--- a/packages/ecma402-abstract/BUILD.bazel
+++ b/packages/ecma402-abstract/BUILD.bazel
@@ -33,7 +33,7 @@ SRCS = glob(
 SRC_DEPS = [
     ":node_modules/@formatjs/intl-localematcher",
     ":node_modules/@formatjs/fast-memoize",
-    "//:node_modules/decimal.js",
+    ":node_modules/@formatjs/bigdecimal",
 ]
 
 ts_compile(

--- a/packages/ecma402-abstract/NumberFormat/ApplyUnsignedRoundingMode.ts
+++ b/packages/ecma402-abstract/NumberFormat/ApplyUnsignedRoundingMode.ts
@@ -1,4 +1,4 @@
-import type {Decimal} from 'decimal.js'
+import type {Decimal} from '@formatjs/bigdecimal'
 import {type UnsignedRoundingModeType} from '../types/number.js'
 import {invariant} from '../utils.js'
 

--- a/packages/ecma402-abstract/NumberFormat/ComputeExponent.ts
+++ b/packages/ecma402-abstract/NumberFormat/ComputeExponent.ts
@@ -1,4 +1,4 @@
-import {Decimal} from 'decimal.js'
+import {Decimal} from '@formatjs/bigdecimal'
 import {type NumberFormatInternal} from '../types/number.js'
 import {ComputeExponentForMagnitude} from './ComputeExponentForMagnitude.js'
 import {FormatNumericToString} from './FormatNumericToString.js'

--- a/packages/ecma402-abstract/NumberFormat/ComputeExponentForMagnitude.ts
+++ b/packages/ecma402-abstract/NumberFormat/ComputeExponentForMagnitude.ts
@@ -1,13 +1,10 @@
-import {Decimal} from 'decimal.js'
+import type {Decimal} from '@formatjs/bigdecimal'
 import {
   type DecimalFormatNum,
   type NumberFormatInternal,
 } from '../types/number.js'
 import {invariant} from '../utils.js'
 import {getPowerOf10} from './decimal-cache.js'
-Decimal.set({
-  toExpPos: 100,
-})
 /**
  * The abstract operation ComputeExponentForMagnitude computes an exponent by which to scale a
  * number of the given magnitude (power of ten of the most significant digit) according to the

--- a/packages/ecma402-abstract/NumberFormat/FormatNumeric.ts
+++ b/packages/ecma402-abstract/NumberFormat/FormatNumeric.ts
@@ -1,4 +1,4 @@
-import type {Decimal} from 'decimal.js'
+import type {Decimal} from '@formatjs/bigdecimal'
 import {type NumberFormatInternal} from '../types/number.js'
 import {PartitionNumberPattern} from './PartitionNumberPattern.js'
 

--- a/packages/ecma402-abstract/NumberFormat/FormatNumericRange.ts
+++ b/packages/ecma402-abstract/NumberFormat/FormatNumericRange.ts
@@ -1,4 +1,4 @@
-import type {Decimal} from 'decimal.js'
+import type {Decimal} from '@formatjs/bigdecimal'
 import {type NumberFormatInternal} from '../types/number.js'
 import {PartitionNumberRangePattern} from './PartitionNumberRangePattern.js'
 

--- a/packages/ecma402-abstract/NumberFormat/FormatNumericRangeToParts.ts
+++ b/packages/ecma402-abstract/NumberFormat/FormatNumericRangeToParts.ts
@@ -1,4 +1,4 @@
-import type {Decimal} from 'decimal.js'
+import type {Decimal} from '@formatjs/bigdecimal'
 import {
   type NumberFormatInternal,
   type NumberRangeToParts,

--- a/packages/ecma402-abstract/NumberFormat/FormatNumericToParts.ts
+++ b/packages/ecma402-abstract/NumberFormat/FormatNumericToParts.ts
@@ -1,4 +1,4 @@
-import type {Decimal} from 'decimal.js'
+import type {Decimal} from '@formatjs/bigdecimal'
 import {ArrayCreate} from '../262.js'
 import {
   type NumberFormatInternal,

--- a/packages/ecma402-abstract/NumberFormat/FormatNumericToString.ts
+++ b/packages/ecma402-abstract/NumberFormat/FormatNumericToString.ts
@@ -1,4 +1,4 @@
-import type {Decimal} from 'decimal.js'
+import type {Decimal} from '@formatjs/bigdecimal'
 import {NEGATIVE_ZERO, ZERO} from '../constants.js'
 import {
   type NumberFormatDigitInternalSlots,

--- a/packages/ecma402-abstract/NumberFormat/PartitionNumberPattern.ts
+++ b/packages/ecma402-abstract/NumberFormat/PartitionNumberPattern.ts
@@ -1,4 +1,4 @@
-import type {Decimal} from 'decimal.js'
+import type {Decimal} from '@formatjs/bigdecimal'
 import {
   type NumberFormatInternal,
   type NumberFormatPart,

--- a/packages/ecma402-abstract/NumberFormat/PartitionNumberRangePattern.ts
+++ b/packages/ecma402-abstract/NumberFormat/PartitionNumberRangePattern.ts
@@ -1,4 +1,4 @@
-import type {Decimal} from 'decimal.js'
+import type {Decimal} from '@formatjs/bigdecimal'
 import {
   type NumberFormatInternal,
   type NumberFormatPart,

--- a/packages/ecma402-abstract/NumberFormat/ToRawFixed.ts
+++ b/packages/ecma402-abstract/NumberFormat/ToRawFixed.ts
@@ -1,4 +1,4 @@
-import {Decimal} from 'decimal.js'
+import type {Decimal} from '@formatjs/bigdecimal'
 import {
   type RawNumberFormatResult,
   type UnsignedRoundingModeType,
@@ -6,11 +6,6 @@ import {
 import {repeat} from '../utils.js'
 import {ApplyUnsignedRoundingMode} from './ApplyUnsignedRoundingMode.js'
 import {getPowerOf10} from './decimal-cache.js'
-
-//IMPL: Setting Decimal configuration
-Decimal.set({
-  toExpPos: 100,
-})
 
 //IMPL: Helper function to calculate raw fixed value
 function ToRawFixedFn(n: Decimal, f: number) {

--- a/packages/ecma402-abstract/NumberFormat/ToRawPrecision.ts
+++ b/packages/ecma402-abstract/NumberFormat/ToRawPrecision.ts
@@ -1,4 +1,4 @@
-import type {Decimal} from 'decimal.js'
+import type {Decimal} from '@formatjs/bigdecimal'
 import {ZERO} from '../constants.js'
 import {
   type RawNumberFormatResult,

--- a/packages/ecma402-abstract/NumberFormat/decimal-cache.ts
+++ b/packages/ecma402-abstract/NumberFormat/decimal-cache.ts
@@ -1,4 +1,4 @@
-import {Decimal} from 'decimal.js'
+import {Decimal} from '@formatjs/bigdecimal'
 import {memoize} from '@formatjs/fast-memoize'
 
 /**

--- a/packages/ecma402-abstract/NumberFormat/format_to_parts.ts
+++ b/packages/ecma402-abstract/NumberFormat/format_to_parts.ts
@@ -1,4 +1,4 @@
-import {Decimal} from 'decimal.js'
+import {Decimal} from '@formatjs/bigdecimal'
 import {S_UNICODE_REGEX} from '../regex.generated.js'
 import {
   type DecimalFormatNum,

--- a/packages/ecma402-abstract/ToIntlMathematicalValue.ts
+++ b/packages/ecma402-abstract/ToIntlMathematicalValue.ts
@@ -1,4 +1,4 @@
-import {Decimal} from 'decimal.js'
+import {Decimal} from '@formatjs/bigdecimal'
 import {ToPrimitive} from './262.js'
 
 /**

--- a/packages/ecma402-abstract/constants.ts
+++ b/packages/ecma402-abstract/constants.ts
@@ -1,4 +1,4 @@
-import {Decimal} from 'decimal.js'
+import {Decimal} from '@formatjs/bigdecimal'
 
 export const TEN: Decimal = new Decimal(10)
 export const ZERO: Decimal = new Decimal(0)

--- a/packages/ecma402-abstract/package.json
+++ b/packages/ecma402-abstract/package.json
@@ -11,9 +11,9 @@
     ".": "./index.js"
   },
   "dependencies": {
+    "@formatjs/bigdecimal": "workspace:*",
     "@formatjs/fast-memoize": "workspace:*",
-    "@formatjs/intl-localematcher": "workspace:*",
-    "decimal.js": "^10.6.0"
+    "@formatjs/intl-localematcher": "workspace:*"
   },
   "bugs": "https://github.com/formatjs/formatjs/issues",
   "gitHead": "a7842673d8ad205171ad7c8cb8bb2f318b427c0c",

--- a/packages/ecma402-abstract/tests/ApplyUnsignedRoundingMode.test.ts
+++ b/packages/ecma402-abstract/tests/ApplyUnsignedRoundingMode.test.ts
@@ -1,4 +1,4 @@
-import Decimal from 'decimal.js'
+import Decimal from '@formatjs/bigdecimal'
 import {ApplyUnsignedRoundingMode} from '../NumberFormat/ApplyUnsignedRoundingMode.js'
 import {describe, expect, it} from 'vitest'
 describe('ApplyUnsignedRoundingMode', () => {

--- a/packages/ecma402-abstract/tests/FormatNumericRange.test.ts
+++ b/packages/ecma402-abstract/tests/FormatNumericRange.test.ts
@@ -1,4 +1,4 @@
-import Decimal from 'decimal.js'
+import Decimal from '@formatjs/bigdecimal'
 import {FormatNumericRange} from '../NumberFormat/FormatNumericRange.js'
 import {getInternalSlots} from './utils.js'
 import {describe, expect, it} from 'vitest'

--- a/packages/ecma402-abstract/tests/FormatNumericRangeToParts.test.ts
+++ b/packages/ecma402-abstract/tests/FormatNumericRangeToParts.test.ts
@@ -1,4 +1,4 @@
-import Decimal from 'decimal.js'
+import Decimal from '@formatjs/bigdecimal'
 import {FormatNumericRangeToParts} from '../NumberFormat/FormatNumericRangeToParts.js'
 import {getInternalSlots} from './utils.js'
 import {describe, expect, it} from 'vitest'

--- a/packages/ecma402-abstract/tests/PartitionNumberPattern.test.ts
+++ b/packages/ecma402-abstract/tests/PartitionNumberPattern.test.ts
@@ -1,4 +1,4 @@
-import Decimal from 'decimal.js'
+import Decimal from '@formatjs/bigdecimal'
 import {PartitionNumberPattern} from '../NumberFormat/PartitionNumberPattern.js'
 import {getInternalSlots} from './utils.js'
 import {describe, expect, test, it} from 'vitest'

--- a/packages/ecma402-abstract/tests/PartitionNumberRangePattern.test.ts
+++ b/packages/ecma402-abstract/tests/PartitionNumberRangePattern.test.ts
@@ -1,4 +1,4 @@
-import Decimal from 'decimal.js'
+import Decimal from '@formatjs/bigdecimal'
 import {PartitionNumberRangePattern} from '../NumberFormat/PartitionNumberRangePattern.js'
 import {getInternalSlots} from './utils.js'
 import {describe, expect, test} from 'vitest'

--- a/packages/ecma402-abstract/tests/ToRawFixed.test.tsx
+++ b/packages/ecma402-abstract/tests/ToRawFixed.test.tsx
@@ -1,4 +1,4 @@
-import Decimal from 'decimal.js'
+import Decimal from '@formatjs/bigdecimal'
 import {ToRawFixed} from '../NumberFormat/ToRawFixed'
 import {expect, it, test} from 'vitest'
 test('ToRawFixed(9.99, 0, 1)', () => {

--- a/packages/ecma402-abstract/tests/ToRawPrecision.test.tsx
+++ b/packages/ecma402-abstract/tests/ToRawPrecision.test.tsx
@@ -1,4 +1,4 @@
-import Decimal from 'decimal.js'
+import Decimal from '@formatjs/bigdecimal'
 import {ToRawPrecision} from '../NumberFormat/ToRawPrecision'
 import {describe, expect, it} from 'vitest'
 

--- a/packages/ecma402-abstract/types/number.ts
+++ b/packages/ecma402-abstract/types/number.ts
@@ -1,4 +1,4 @@
-import type {Decimal} from 'decimal.js'
+import type {Decimal} from '@formatjs/bigdecimal'
 import {type LocaleData} from './core.js'
 import {type LDMLPluralRule} from './plural-rules.js'
 

--- a/packages/intl-datetimeformat/BUILD.bazel
+++ b/packages/intl-datetimeformat/BUILD.bazel
@@ -66,7 +66,7 @@ TESTS = glob([
 SRC_DEPS = [
     ":node_modules/@formatjs/ecma402-abstract",
     ":node_modules/@formatjs/intl-localematcher",
-    "//:node_modules/decimal.js",
+    ":node_modules/@formatjs/bigdecimal",
 ]
 
 TEST_DEPS = SRC_DEPS + [
@@ -897,7 +897,7 @@ esbuild(
     name = "polyfill.iife",
     srcs = [":srcs"],
     entry_point = "polyfill.ts",
-    target = "es6",
+    target = "es2020",
     deps = [
     ] + SRC_DEPS,
 )

--- a/packages/intl-datetimeformat/package.json
+++ b/packages/intl-datetimeformat/package.json
@@ -17,9 +17,9 @@
     "./locale-data": "./locale-data"
   },
   "dependencies": {
+    "@formatjs/bigdecimal": "workspace:*",
     "@formatjs/ecma402-abstract": "workspace:*",
-    "@formatjs/intl-localematcher": "workspace:*",
-    "decimal.js": "^10.6.0"
+    "@formatjs/intl-localematcher": "workspace:*"
   },
   "devDependencies": {
     "@formatjs/intl-getcanonicallocales": "workspace:*",

--- a/packages/intl-datetimeformat/src/abstract/FormatDateTime.ts
+++ b/packages/intl-datetimeformat/src/abstract/FormatDateTime.ts
@@ -1,5 +1,5 @@
 import {type DateTimeFormat} from '@formatjs/ecma402-abstract'
-import type Decimal from 'decimal.js'
+import type Decimal from '@formatjs/bigdecimal'
 import {PartitionDateTimePattern} from './PartitionDateTimePattern.js'
 
 /**

--- a/packages/intl-datetimeformat/src/abstract/FormatDateTimePattern.ts
+++ b/packages/intl-datetimeformat/src/abstract/FormatDateTimePattern.ts
@@ -7,7 +7,7 @@ import {
   createMemoizedNumberFormat,
 } from '@formatjs/ecma402-abstract'
 
-import Decimal from 'decimal.js'
+import Decimal from '@formatjs/bigdecimal'
 import {ToLocalTime, type ToLocalTimeImplDetails} from './ToLocalTime.js'
 import {DATE_TIME_PROPS} from './utils.js'
 

--- a/packages/intl-datetimeformat/src/abstract/FormatDateTimeRange.ts
+++ b/packages/intl-datetimeformat/src/abstract/FormatDateTimeRange.ts
@@ -1,4 +1,4 @@
-import type Decimal from 'decimal.js'
+import type Decimal from '@formatjs/bigdecimal'
 import {type FormatDateTimePatternImplDetails} from './FormatDateTimePattern.js'
 import {PartitionDateTimeRangePattern} from './PartitionDateTimeRangePattern.js'
 import {type ToLocalTimeImplDetails} from './ToLocalTime.js'

--- a/packages/intl-datetimeformat/src/abstract/FormatDateTimeRangeToParts.ts
+++ b/packages/intl-datetimeformat/src/abstract/FormatDateTimeRangeToParts.ts
@@ -1,5 +1,5 @@
 import {type IntlDateTimeFormatPart} from '@formatjs/ecma402-abstract'
-import type {Decimal} from 'decimal.js'
+import type {Decimal} from '@formatjs/bigdecimal'
 import {type FormatDateTimePatternImplDetails} from './FormatDateTimePattern.js'
 import {PartitionDateTimeRangePattern} from './PartitionDateTimeRangePattern.js'
 import {type ToLocalTimeImplDetails} from './ToLocalTime.js'

--- a/packages/intl-datetimeformat/src/abstract/FormatDateTimeToParts.ts
+++ b/packages/intl-datetimeformat/src/abstract/FormatDateTimeToParts.ts
@@ -2,7 +2,7 @@ import {
   ArrayCreate,
   type IntlDateTimeFormatPart,
 } from '@formatjs/ecma402-abstract'
-import type Decimal from 'decimal.js'
+import type Decimal from '@formatjs/bigdecimal'
 import {PartitionDateTimePattern} from './PartitionDateTimePattern.js'
 
 /**

--- a/packages/intl-datetimeformat/src/abstract/PartitionDateTimePattern.ts
+++ b/packages/intl-datetimeformat/src/abstract/PartitionDateTimePattern.ts
@@ -6,7 +6,7 @@ import {
   PartitionPattern,
   TimeClip,
 } from '@formatjs/ecma402-abstract'
-import type Decimal from 'decimal.js'
+import type Decimal from '@formatjs/bigdecimal'
 import {
   FormatDateTimePattern,
   type FormatDateTimePatternImplDetails,

--- a/packages/intl-datetimeformat/src/abstract/PartitionDateTimeRangePattern.ts
+++ b/packages/intl-datetimeformat/src/abstract/PartitionDateTimeRangePattern.ts
@@ -7,7 +7,7 @@ import {
   type TABLE_2,
   TimeClip,
 } from '@formatjs/ecma402-abstract'
-import type Decimal from 'decimal.js'
+import type Decimal from '@formatjs/bigdecimal'
 import {
   FormatDateTimePattern,
   type FormatDateTimePatternImplDetails,

--- a/packages/intl-datetimeformat/src/abstract/ToLocalTime.ts
+++ b/packages/intl-datetimeformat/src/abstract/ToLocalTime.ts
@@ -10,7 +10,7 @@ import {
   invariant,
   msFromTime,
 } from '@formatjs/ecma402-abstract'
-import type Decimal from 'decimal.js'
+import type Decimal from '@formatjs/bigdecimal'
 
 // Cached regex patterns for performance
 const OFFSET_TIMEZONE_PREFIX_REGEX = /^[+-]/

--- a/packages/intl-datetimeformat/src/core.ts
+++ b/packages/intl-datetimeformat/src/core.ts
@@ -13,7 +13,7 @@ import {
   defineProperty,
   invariant,
 } from '@formatjs/ecma402-abstract'
-import Decimal from 'decimal.js'
+import Decimal from '@formatjs/bigdecimal'
 import {FormatDateTime} from './abstract/FormatDateTime.js'
 import {FormatDateTimeRange} from './abstract/FormatDateTimeRange.js'
 import {FormatDateTimeRangeToParts} from './abstract/FormatDateTimeRangeToParts.js'

--- a/packages/intl-displaynames/BUILD.bazel
+++ b/packages/intl-displaynames/BUILD.bazel
@@ -737,7 +737,7 @@ esbuild(
     name = "test262-polyfill",
     srcs = [":srcs"],
     entry_point = "test262-main.ts",
-    target = "es6",
+    target = "es2020",
     deps = SRC_DEPS,
 )
 
@@ -780,7 +780,7 @@ esbuild(
     name = "polyfill.iife",
     srcs = [":srcs"],
     entry_point = "polyfill.ts",
-    target = "es6",
+    target = "es2020",
     deps = [
     ] + SRC_DEPS,
 )

--- a/packages/intl-listformat/BUILD.bazel
+++ b/packages/intl-listformat/BUILD.bazel
@@ -728,7 +728,7 @@ esbuild(
     name = "test262-polyfill",
     srcs = [":srcs"],
     entry_point = "polyfill-force.ts",
-    target = "es6",
+    target = "es2020",
     deps = SRC_DEPS,
 )
 
@@ -768,6 +768,7 @@ esbuild(
     name = "polyfill.iife",
     srcs = [":srcs"],
     entry_point = "polyfill.ts",
+    target = "es2020",
     deps = [
     ] + SRC_DEPS,
 )

--- a/packages/intl-locale/BUILD.bazel
+++ b/packages/intl-locale/BUILD.bazel
@@ -54,7 +54,7 @@ esbuild(
     name = "test262-polyfill",
     srcs = [":srcs"],
     entry_point = "polyfill-force.ts",
-    target = "es6",
+    target = "es2020",
     deps = SRC_DEPS,
 )
 
@@ -88,7 +88,7 @@ esbuild(
     name = "polyfill.iife",
     srcs = [":srcs"],
     entry_point = "polyfill.ts",
-    target = "es6",
+    target = "es2020",
     deps = [
     ] + SRC_DEPS,
 )

--- a/packages/intl-messageformat/BUILD.bazel
+++ b/packages/intl-messageformat/BUILD.bazel
@@ -60,7 +60,7 @@ esbuild(
         "globalName": "IntlMessageFormat",
     },
     entry_point = "index.ts",
-    target = "es6",
+    target = "es2020",
     deps = SRC_DEPS,
 )
 

--- a/packages/intl-numberformat/BUILD.bazel
+++ b/packages/intl-numberformat/BUILD.bazel
@@ -93,7 +93,7 @@ SRCS = glob(
 SRC_DEPS = [
     ":node_modules/@formatjs/ecma402-abstract",
     ":node_modules/@formatjs/intl-localematcher",
-    "//:node_modules/decimal.js",
+    ":node_modules/@formatjs/bigdecimal",
 ]
 
 TEST_DEPS = SRC_DEPS + [
@@ -937,7 +937,7 @@ esbuild(
     name = "test262-polyfill",
     srcs = [":srcs"],
     entry_point = "test262-main.ts",
-    target = "es6",
+    target = "es2020",
     deps = [
         ":node_modules/@formatjs/intl-getcanonicallocales",
         ":node_modules/@formatjs/intl-locale",
@@ -977,7 +977,7 @@ esbuild(
     name = "polyfill.iife",
     srcs = [":srcs"],
     entry_point = "polyfill.ts",
-    target = "es6",
+    target = "es2020",
     deps = [
     ] + SRC_DEPS,
 )

--- a/packages/intl-numberformat/package.json
+++ b/packages/intl-numberformat/package.json
@@ -14,9 +14,9 @@
     "./locale-data": "./locale-data"
   },
   "dependencies": {
+    "@formatjs/bigdecimal": "workspace:*",
     "@formatjs/ecma402-abstract": "workspace:*",
-    "@formatjs/intl-localematcher": "workspace:*",
-    "decimal.js": "^10.6.0"
+    "@formatjs/intl-localematcher": "workspace:*"
   },
   "devDependencies": {
     "@formatjs/intl-getcanonicallocales": "workspace:*",

--- a/packages/intl-numberformat/src/core.ts
+++ b/packages/intl-numberformat/src/core.ts
@@ -17,7 +17,7 @@ import {
 import {currencyDigitsData} from './currency-digits.generated.js'
 import {numberingSystemNames} from './numbering-systems.generated.js'
 // eslint-disable-next-line import/no-cycle
-import type Decimal from 'decimal.js'
+import type Decimal from '@formatjs/bigdecimal'
 import getInternalSlots from './get_internal_slots.js'
 import {
   type NumberFormatConstructor,

--- a/packages/intl-numberformat/src/types.ts
+++ b/packages/intl-numberformat/src/types.ts
@@ -6,7 +6,7 @@ import {
   type RawNumberLocaleData,
   type ResolvedNumberFormatOptions,
 } from '@formatjs/ecma402-abstract'
-import type Decimal from 'decimal.js'
+import type Decimal from '@formatjs/bigdecimal'
 
 // Public --------------------------------------------------------------------------------------------------------------
 

--- a/packages/intl-numberformat/tests/format_to_parts.test.ts
+++ b/packages/intl-numberformat/tests/format_to_parts.test.ts
@@ -1,6 +1,6 @@
 import {it, expect} from 'vitest'
 import {_formatToParts} from '@formatjs/ecma402-abstract'
-import Decimal from 'decimal.js'
+import Decimal from '@formatjs/bigdecimal'
 
 function format(...args: Parameters<typeof _formatToParts>): string {
   return _formatToParts(...args)

--- a/packages/intl-pluralrules/BUILD.bazel
+++ b/packages/intl-pluralrules/BUILD.bazel
@@ -267,7 +267,7 @@ TESTS = glob([
 SRC_DEPS = [
     ":node_modules/@formatjs/ecma402-abstract",
     ":node_modules/@formatjs/intl-localematcher",
-    "//:node_modules/decimal.js",
+    ":node_modules/@formatjs/bigdecimal",
 ]
 
 ts_compile(
@@ -375,7 +375,7 @@ esbuild(
     name = "test262-polyfill",
     srcs = [":srcs"],
     entry_point = "test262-main.ts",
-    target = "es6",
+    target = "es2020",
     deps = SRC_DEPS,
 )
 
@@ -414,7 +414,7 @@ esbuild(
     name = "polyfill.iife",
     srcs = [":srcs"],
     entry_point = "polyfill.ts",
-    target = "es6",
+    target = "es2020",
     # TODO: fix this and set it back to es5
     deps = [
     ] + SRC_DEPS,

--- a/packages/intl-pluralrules/abstract/GetOperands.ts
+++ b/packages/intl-pluralrules/abstract/GetOperands.ts
@@ -1,5 +1,5 @@
 import {invariant, ToNumber, ZERO} from '@formatjs/ecma402-abstract'
-import type Decimal from 'decimal.js'
+import type Decimal from '@formatjs/bigdecimal'
 
 /**
  * CLDR Spec: Operands as defined in https://unicode.org/reports/tr35/tr35-numbers.html#Operands

--- a/packages/intl-pluralrules/abstract/ResolvePlural.ts
+++ b/packages/intl-pluralrules/abstract/ResolvePlural.ts
@@ -6,7 +6,7 @@ import {
   type PluralRulesInternal,
   Type,
 } from '@formatjs/ecma402-abstract'
-import Decimal from 'decimal.js'
+import Decimal from '@formatjs/bigdecimal'
 import {GetOperands, type OperandsRecord} from './GetOperands.js'
 
 /**

--- a/packages/intl-pluralrules/abstract/ResolvePluralRange.ts
+++ b/packages/intl-pluralrules/abstract/ResolvePluralRange.ts
@@ -4,7 +4,7 @@ import {
   type PluralRulesInternal,
   Type,
 } from '@formatjs/ecma402-abstract'
-import type Decimal from 'decimal.js'
+import type Decimal from '@formatjs/bigdecimal'
 import {type OperandsRecord} from './GetOperands.js'
 import {ResolvePluralInternal} from './ResolvePlural.js'
 

--- a/packages/intl-pluralrules/index.ts
+++ b/packages/intl-pluralrules/index.ts
@@ -7,7 +7,7 @@ import {
   SupportedLocales,
   ToIntlMathematicalValue,
 } from '@formatjs/ecma402-abstract'
-import type Decimal from 'decimal.js'
+import type Decimal from '@formatjs/bigdecimal'
 import {type OperandsRecord} from './abstract/GetOperands.js'
 import {InitializePluralRules} from './abstract/InitializePluralRules.js'
 import {ResolvePlural} from './abstract/ResolvePlural.js'

--- a/packages/intl-pluralrules/package.json
+++ b/packages/intl-pluralrules/package.json
@@ -15,9 +15,9 @@
     "./locale-data": "./locale-data"
   },
   "dependencies": {
+    "@formatjs/bigdecimal": "workspace:*",
     "@formatjs/ecma402-abstract": "workspace:*",
-    "@formatjs/intl-localematcher": "workspace:*",
-    "decimal.js": "^10.6.0"
+    "@formatjs/intl-localematcher": "workspace:*"
   },
   "devDependencies": {
     "@formatjs/intl-getcanonicallocales": "workspace:*",

--- a/packages/intl-relativetimeformat/BUILD.bazel
+++ b/packages/intl-relativetimeformat/BUILD.bazel
@@ -726,7 +726,7 @@ esbuild(
     name = "test262-polyfill",
     srcs = [":srcs"],
     entry_point = "test262-main.ts",
-    target = "es6",
+    target = "es2020",
     deps = SRC_DEPS,
 )
 
@@ -765,7 +765,7 @@ esbuild(
     name = "polyfill.iife",
     srcs = [":srcs"],
     entry_point = "polyfill.ts",
-    target = "es6",
+    target = "es2020",
     deps = [
     ] + SRC_DEPS,
 )

--- a/packages/intl-segmenter/BUILD.bazel
+++ b/packages/intl-segmenter/BUILD.bazel
@@ -92,7 +92,7 @@ esbuild(
     name = "test262-polyfill",
     srcs = [":srcs"],
     entry_point = "test262-main.ts",
-    target = "es6",
+    target = "es2020",
     deps = SRC_DEPS,
 )
 
@@ -128,7 +128,7 @@ esbuild(
     name = "polyfill.iife",
     srcs = [":srcs"],
     entry_point = "polyfill.ts",
-    target = "es6",
+    target = "es2020",
     deps = [
     ] + SRC_DEPS,
 )

--- a/packages/intl-supportedvaluesof/BUILD.bazel
+++ b/packages/intl-supportedvaluesof/BUILD.bazel
@@ -124,6 +124,7 @@ esbuild(
     name = "polyfill.iife",
     srcs = [":srcs"],
     entry_point = "polyfill.ts",
+    target = "es2020",
     deps = [
     ] + SRC_DEPS,
 )

--- a/packages/react-intl/BUILD.bazel
+++ b/packages/react-intl/BUILD.bazel
@@ -69,7 +69,7 @@ esbuild(
     },
     entry_point = "index.ts",
     external = ["react"],
-    target = "es6",
+    target = "es2020",
     deps = SRC_DEPS,
 )
 

--- a/packages/react-intl/examples/BUILD.bazel
+++ b/packages/react-intl/examples/BUILD.bazel
@@ -46,6 +46,7 @@ esbuild(
     },
     entry_point = "examples-lib/index.js",
     format = "iife",
+    target = "es2020",
     deps = [":examples-esm"] + EXAMPLES_SRC_DEPS,
 )
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,9 +243,6 @@ importers:
       conventional-changelog-angular:
         specifier: ^8.1.0
         version: 8.3.0
-      decimal.js:
-        specifier: ^10.6.0
-        version: 10.6.0
       esbuild:
         specifier: ^0.27.0
         version: 0.27.4
@@ -547,15 +544,15 @@ importers:
 
   packages/ecma402-abstract:
     dependencies:
+      '@formatjs/bigdecimal':
+        specifier: workspace:*
+        version: link:../bigdecimal
       '@formatjs/fast-memoize':
         specifier: workspace:*
         version: link:../fast-memoize
       '@formatjs/intl-localematcher':
         specifier: workspace:*
         version: link:../intl-localematcher
-      decimal.js:
-        specifier: ^10.6.0
-        version: 10.6.0
 
   packages/eslint-plugin-formatjs:
     dependencies:
@@ -663,15 +660,15 @@ importers:
 
   packages/intl-datetimeformat:
     dependencies:
+      '@formatjs/bigdecimal':
+        specifier: workspace:*
+        version: link:../bigdecimal
       '@formatjs/ecma402-abstract':
         specifier: workspace:*
         version: link:../ecma402-abstract
       '@formatjs/intl-localematcher':
         specifier: workspace:*
         version: link:../intl-localematcher
-      decimal.js:
-        specifier: ^10.6.0
-        version: 10.6.0
     devDependencies:
       '@formatjs/intl-getcanonicallocales':
         specifier: workspace:*
@@ -767,15 +764,15 @@ importers:
 
   packages/intl-numberformat:
     dependencies:
+      '@formatjs/bigdecimal':
+        specifier: workspace:*
+        version: link:../bigdecimal
       '@formatjs/ecma402-abstract':
         specifier: workspace:*
         version: link:../ecma402-abstract
       '@formatjs/intl-localematcher':
         specifier: workspace:*
         version: link:../intl-localematcher
-      decimal.js:
-        specifier: ^10.6.0
-        version: 10.6.0
     devDependencies:
       '@formatjs/intl-getcanonicallocales':
         specifier: workspace:*
@@ -795,15 +792,15 @@ importers:
 
   packages/intl-pluralrules:
     dependencies:
+      '@formatjs/bigdecimal':
+        specifier: workspace:*
+        version: link:../bigdecimal
       '@formatjs/ecma402-abstract':
         specifier: workspace:*
         version: link:../ecma402-abstract
       '@formatjs/intl-localematcher':
         specifier: workspace:*
         version: link:../intl-localematcher
-      decimal.js:
-        specifier: ^10.6.0
-        version: 10.6.0
     devDependencies:
       '@formatjs/intl-getcanonicallocales':
         specifier: workspace:*
@@ -12778,7 +12775,8 @@ snapshots:
 
   decamelize@1.2.0: {}
 
-  decimal.js@10.6.0: {}
+  decimal.js@10.6.0:
+    optional: true
 
   decode-named-character-reference@1.2.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Replaces `decimal.js` (128KB ESM) with `@formatjs/bigdecimal` across 13 packages and 41 source files
- Removes `decimal.js` from all `package.json` dependencies
- Adds drop-in compatibility to `@formatjs/bigdecimal`: `Decimal` alias export, default export, auto-coercion of `number | string | bigint` args, `toJSON()` for serialization
- Updates all esbuild polyfill IIFE bundle targets from `es6` to `es2020` (required for BigInt support)
- Removes `Decimal.set({toExpPos: 100})` no-op calls

## Affected packages
- `@formatjs/bigdecimal` (add Decimal alias, auto-coercion, toJSON)
- `@formatjs/ecma402-abstract` (migrate imports, swap dependency)
- `@formatjs/intl-numberformat` (migrate imports, swap dependency)
- `@formatjs/intl-datetimeformat` (migrate imports, swap dependency)
- `@formatjs/intl-pluralrules` (migrate imports, swap dependency)
- `@formatjs/intl-displaynames` (esbuild target es6 → es2020)
- `@formatjs/intl-listformat` (esbuild target es6 → es2020)
- `@formatjs/intl-locale` (esbuild target es6 → es2020)
- `@formatjs/intl-relativetimeformat` (esbuild target es6 → es2020)
- `@formatjs/intl-segmenter` (esbuild target es6 → es2020)
- `@formatjs/intl-supportedvaluesof` (esbuild target added es2020)
- `intl-messageformat` (esbuild target es6 → es2020)
- `react-intl` (esbuild target es6 → es2020)

## Breaking change
Polyfill IIFE bundles now target ES2020 instead of ES6. Environments using these polyfills must support BigInt (Chrome 67+, Firefox 68+, Safari 14+, Node.js 10.3+).

## Test plan
- [x] `pnpm t` — all 498 tests pass (0 regressions)
- [x] All ecma402-abstract unit tests (98/98) pass with BigDecimal
- [x] All typecheck tests pass
- [x] All esbuild polyfill bundles build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)