### PR TITLE
chore: remove unused aspect_rules_lint dependency

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -122,10 +122,6 @@ register_toolchains(
     "@rules_rust//rust/private/dummy_cc_toolchain:dummy_cc_wasm32_toolchain",
 )
 
-######### Lint rules #########
-
-bazel_dep(name = "aspect_rules_lint", version = "1.10.2")
-
 ######### Java rules #########
 
 bazel_dep(name = "rules_java", version = "9.6.1")


### PR DESCRIPTION
## Summary
- Remove `aspect_rules_lint` from `MODULE.bazel` — it's declared but never used in any `BUILD.bazel` or `.bzl` file

🤖 Generated with [Claude Code](https://claude.com/claude-code)