### PR TITLE
fix(deps): disable bazelisk cache to fix stale Bazel version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.18.0
         with:
-          bazelisk-cache: true
+          bazelisk-cache: false
           disk-cache: ${{ github.workflow }}
           repository-cache: true
 

--- a/.github/workflows/rust-cli-release.yml
+++ b/.github/workflows/rust-cli-release.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.18.0
         with:
-          bazelisk-cache: true
+          bazelisk-cache: false
           disk-cache: ${{ github.workflow }}-${{ matrix.platform }}
           repository-cache: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.18.0
         with:
-          bazelisk-cache: true
+          bazelisk-cache: false
           disk-cache: ${{ github.workflow }}
           repository-cache: true
 
@@ -68,7 +68,7 @@ jobs:
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.18.0
         with:
-          bazelisk-cache: true
+          bazelisk-cache: false
           disk-cache: ${{ github.workflow }}-${{ matrix.os }}
           repository-cache: true
 

--- a/.github/workflows/typesense-index.yml
+++ b/.github/workflows/typesense-index.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: bazel-contrib/setup-bazel@0.18.0
         with:
           # Avoid downloading Bazel every time.
-          bazelisk-cache: true
+          bazelisk-cache: false
           # Store build cache per workflow.
           disk-cache: ${{ github.workflow }}
           # Share repository cache between workflows.

--- a/.github/workflows/verify-hooks.yml
+++ b/.github/workflows/verify-hooks.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.18.0
         with:
-          bazelisk-cache: true
+          bazelisk-cache: false
           disk-cache: ${{ github.workflow }}
           repository-cache: true
 

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: bazel-contrib/setup-bazel@0.18.0
         with:
           # Avoid downloading Bazel every time.
-          bazelisk-cache: true
+          bazelisk-cache: false
           # Store build cache per workflow.
           disk-cache: ${{ github.workflow }}
           # Share repository cache between workflows.


### PR DESCRIPTION
## Problem
CI is running Bazel **8.1.0** despite `.bazelversion` specifying **9.0.1**. The `setup-bazel` bazelisk cache was poisoned — it cached the Bazel 8.1.0 binary under the hash for `.bazelversion` content `9.0.1`, and every subsequent run restores the wrong binary.

This causes `aspect_rules_js` v3 upgrade (#6135) to fail because Bazel 8.1.0 doesn't support `repo_name = None` in `bazel_dep()`.

## Fix
Disable `bazelisk-cache` in all 6 workflows. Bazelisk download is ~2-3 seconds, so the cache savings are negligible compared to the risk of version mismatch.

## Affected workflows
- `.github/workflows/test.yml` (2 jobs)
- `.github/workflows/verify-hooks.yml`
- `.github/workflows/release.yml`
- `.github/workflows/rust-cli-release.yml`
- `.github/workflows/website.yml`
- `.github/workflows/typesense-index.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)