### PR TITLE
fix(deps): add bigdecimal and svelte-intl to PACKAGES_TO_DIST

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -28,6 +28,7 @@ genrule(
 
 PACKAGES_TO_DIST = [
     "//packages/babel-plugin-formatjs",
+    "//packages/bigdecimal",
     "//packages/cli-lib",
     "//packages/cli",
     "//packages/ecma376",
@@ -52,6 +53,7 @@ PACKAGES_TO_DIST = [
     "//packages/intl-segmenter",
     "//packages/intl",
     "//packages/react-intl",
+    "//packages/svelte-intl",
     "//packages/ts-transformer",
     "//packages/unplugin",
     "//packages/utils",


### PR DESCRIPTION
## Summary
- Add `@formatjs/bigdecimal` to `PACKAGES_TO_DIST` — it's a dependency of `ecma402-abstract`, `intl-datetimeformat`, `intl-numberformat`, and `intl-pluralrules` but was missing, causing `pnpm -r publish` to fail with `ERR_PNPM_CANNOT_RESOLVE_WORKSPACE_PROTOCOL`
- Add `@formatjs/svelte-intl` to `PACKAGES_TO_DIST` — similarly missing from the release distribution

Fixes the release workflow failure: https://github.com/formatjs/formatjs/actions/runs/23274718131/job/67675219330

## Test plan
- [ ] Merge and verify the release workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)