### PR TITLE
fix(@formatjs/unplugin): add flatten option to match babel-plugin-formatjs ID generation

### DIFF
--- a/packages/unplugin/BUILD.bazel
+++ b/packages/unplugin/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
@@ -10,6 +11,14 @@ load("//tools:tsconfig.bzl", "ESNEXT_SKIP_LIB_CHECK_TSCONFIG")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
+
+# Copy Rust CLI binary for conformance tests
+copy_file(
+    name = "rust_cli_copy",
+    src = "//crates/formatjs_cli",
+    out = "formatjs_cli",
+    visibility = ["//visibility:private"],
+)
 
 PACKAGE_NAME = "@formatjs/unplugin"
 
@@ -71,6 +80,19 @@ vitest(
     name = "unit_test",
     srcs = SRCS + glob(["tests/**/*.ts"]),
     deps = SRC_DEPS,
+)
+
+vitest(
+    name = "conformance_test",
+    srcs = SRCS + [
+        ":rust_cli_copy",
+    ] + glob(["conformance-tests/**/*.ts"]),
+    data = [
+        "//crates/formatjs_cli",
+    ],
+    deps = SRC_DEPS + [
+        "//:node_modules/@bazel/runfiles",
+    ],
 )
 
 npm_package(

--- a/packages/unplugin/conformance-tests/cli-unplugin-conformance.test.ts
+++ b/packages/unplugin/conformance-tests/cli-unplugin-conformance.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Conformance tests: formatjs_cli extract vs @formatjs/unplugin transform
+ *
+ * Verifies that the unplugin (with its default options: flatten=true,
+ * idInterpolationPattern='[sha512:contenthash:base64:6]') generates the same
+ * message IDs as `formatjs_cli extract --flatten`.
+ *
+ * This ensures that messages extracted at build time by the CLI and messages
+ * transformed at bundle time by the Vite/Rollup/esbuild plugin share identical
+ * IDs, preventing mismatches in production.
+ */
+import {exec as nodeExec} from 'child_process'
+import {mkdirSync, rmSync, writeFileSync} from 'fs'
+import {join, resolve} from 'path'
+import {promisify} from 'util'
+import {afterAll, beforeAll, describe, expect, test} from 'vitest'
+import {transform} from '../transform.js'
+import {resolveRustBinaryPath} from './rust-binary-utils.js'
+
+const exec = promisify(nodeExec)
+
+const RUST_BIN_PATH = resolveRustBinaryPath(import.meta.dirname)
+const ARTIFACT_PATH = resolve(import.meta.dirname, 'test_artifacts')
+
+/**
+ * Extract IDs that the unplugin inserted into the transformed code.
+ * Handles both JS form (id: "value") and JSX attribute form (id="value").
+ */
+function extractPluginIds(code: string): string[] {
+  const ids: string[] = []
+  for (const match of code.matchAll(/\bid(?::\s*|=)"([^"]+)"/g)) {
+    ids.push(match[1])
+  }
+  return ids.sort()
+}
+
+describe(
+  'formatjs_cli vs @formatjs/unplugin conformance',
+  () => {
+    if (!RUST_BIN_PATH) {
+      test.skip('Rust CLI not available — skipping conformance tests', () => {})
+      return
+    }
+
+    beforeAll(() => {
+      mkdirSync(ARTIFACT_PATH, {recursive: true})
+    })
+
+    afterAll(() => {
+      rmSync(ARTIFACT_PATH, {recursive: true, force: true})
+    })
+
+    /**
+     * Assert that `formatjs_cli extract --flatten` and the unplugin transform
+     * (default options: flatten=true) produce identical IDs for the given code.
+     */
+    async function assertConformance(code: string, filename: string) {
+      const tempFile = join(ARTIFACT_PATH, filename)
+      writeFileSync(tempFile, code)
+
+      // CLI: --flatten matches the plugin's default flatten=true
+      const {stdout} = await exec(
+        `"${RUST_BIN_PATH}" extract --flatten "${tempFile}"`
+      )
+      const cliOutput: Record<string, {defaultMessage: string}> =
+        JSON.parse(stdout)
+      const cliIds = Object.keys(cliOutput).sort()
+
+      // Plugin: default options (flatten=true, idInterpolationPattern=[sha512:contenthash:base64:6])
+      const result = transform(code, tempFile, {})
+      expect(result, 'unplugin should transform the code').toBeDefined()
+      const pluginIds = extractPluginIds(result!.code)
+
+      expect(pluginIds).toEqual(cliIds)
+    }
+
+    test('plain formatMessage without description', async () => {
+      await assertConformance(
+        `intl.formatMessage({defaultMessage: 'Hello World'})`,
+        'plain-no-desc.tsx'
+      )
+    })
+
+    test('plain formatMessage with description', async () => {
+      await assertConformance(
+        `intl.formatMessage({defaultMessage: 'Hello World', description: 'greeting'})`,
+        'plain-with-desc.tsx'
+      )
+    })
+
+    test('plural message — flatten hoists selectors', async () => {
+      await assertConformance(
+        `intl.formatMessage({defaultMessage: '{count, plural, one {# item} other {# items}}'})`,
+        'plural.tsx'
+      )
+    })
+
+    test('plural embedded in sentence — flatten produces full phrases', async () => {
+      await assertConformance(
+        `<FormattedMessage defaultMessage="Are you sure you want to delete {count,plural,one {this template} other {these # templates}}?" />`,
+        'plural-sentence.tsx'
+      )
+    })
+
+    test('JSX FormattedMessage with description', async () => {
+      await assertConformance(
+        `<FormattedMessage defaultMessage="Hello World" description="greeting" />`,
+        'jsx-with-desc.tsx'
+      )
+    })
+
+    test('defineMessages with multiple messages', async () => {
+      await assertConformance(
+        `defineMessages({
+  greeting: {defaultMessage: 'Hello', description: 'greeting'},
+  farewell: {defaultMessage: 'Goodbye', description: 'farewell'},
+})`,
+        'define-messages.tsx'
+      )
+    })
+
+    test('whitespace is normalized before ID generation', async () => {
+      await assertConformance(
+        `intl.formatMessage({defaultMessage: '  Hello   World  '})`,
+        'whitespace.tsx'
+      )
+    })
+  },
+  30000
+)

--- a/packages/unplugin/conformance-tests/rust-binary-utils.ts
+++ b/packages/unplugin/conformance-tests/rust-binary-utils.ts
@@ -1,0 +1,30 @@
+import {resolve} from 'path'
+import {Runfiles} from '@bazel/runfiles'
+
+/**
+ * Resolves the path to the Rust CLI binary.
+ *
+ * This utility handles two scenarios:
+ * 1. Snapshot update mode: Binary is copied to packages/unplugin directory via copy_file rule
+ * 2. Normal test mode: Binary is available via Bazel runfiles
+ *
+ * @param dirname - The import.meta.dirname of the test file
+ * @returns The path to the Rust binary, or undefined if not found
+ */
+export function resolveRustBinaryPath(dirname: string): string | undefined {
+  // Try to find Rust binary:
+  // 1. Check parent directory (packages/unplugin/formatjs_cli, for snapshot update mode)
+  const localRustBin = resolve(dirname, '../formatjs_cli')
+  if (require('fs').existsSync(localRustBin)) {
+    return localRustBin
+  }
+
+  // 2. Use runfiles (for normal Bazel test mode)
+  try {
+    const runfiles = new Runfiles()
+    return runfiles.resolveWorkspaceRelative('crates/formatjs_cli/formatjs_cli')
+  } catch {
+    console.warn('Rust CLI not available, conformance tests will be skipped')
+    return undefined
+  }
+}

--- a/packages/unplugin/tests/transform.test.ts
+++ b/packages/unplugin/tests/transform.test.ts
@@ -221,6 +221,52 @@ describe('@formatjs/unplugin transform', () => {
     })
   })
 
+  describe('flatten', () => {
+    test('normalizes ICU format and generates ID from flattened message', () => {
+      // Message is a top-level plural: ICU format is normalized (spaces removed around commas/braces)
+      // This ensures the ID matches formatjs extract with --flatten (Rust CLI: 14X+wqft)
+      const input = `<FormattedMessage defaultMessage="{numberOfConsultations, plural, one {# consultation} other {# consultations}}" />`
+      const result = t(input, {
+        idInterpolationPattern: '[sha512:contenthash:base64:8]',
+        flatten: true,
+      })
+      // The flattened message removes spaces in structural positions
+      expect(result).toContain(
+        `defaultMessage="{numberOfConsultations,plural,one{# consultation} other{# consultations}}"`
+      )
+      // ID is generated from the flattened message (matches Rust CLI formatjs extract --flatten)
+      expect(result).toContain('id="14X+wqft"')
+    })
+
+    test('hoists select/plural patterns to full sentences', () => {
+      const input = `<FormattedMessage defaultMessage="Are you sure you want to delete {count,plural,one {this report template} other {these # report templates}}?" />`
+      const result = t(input, {flatten: true})
+      // Hoisted form: plural wraps the full sentence
+      expect(result).toContain(
+        `defaultMessage="{count,plural,one{Are you sure you want to delete this report template?} other{Are you sure you want to delete these # report templates?}}"`
+      )
+    })
+
+    test('generates different ID with flatten vs without', () => {
+      const input = `<FormattedMessage defaultMessage="{foo, plural, one {item} other {items}}" />`
+      const withFlatten = t(input, {flatten: true})
+      const withoutFlatten = t(input, {flatten: false})
+      const idWithFlatten = withFlatten.match(/id="([^"]+)"/)?.[1]
+      const idWithoutFlatten = withoutFlatten.match(/id="([^"]+)"/)?.[1]
+      expect(idWithFlatten).toBeDefined()
+      expect(idWithoutFlatten).toBeDefined()
+      expect(idWithFlatten).not.toBe(idWithoutFlatten)
+    })
+
+    test('flatten is a no-op for plain messages without selectors', () => {
+      // Plain messages are not affected by hoisting
+      const input = `<FormattedMessage defaultMessage="Hello {name}" />`
+      const withFlatten = t(input, {flatten: true})
+      const withoutFlatten = t(input, {flatten: false})
+      expect(withFlatten).toBe(withoutFlatten)
+    })
+  })
+
   describe('whitespace', () => {
     test('normalizes whitespace in defaultMessage by default', () => {
       const input = `intl.formatMessage({id: 'test', defaultMessage: '  Hello   World  '})`

--- a/packages/unplugin/tests/transform.test.ts
+++ b/packages/unplugin/tests/transform.test.ts
@@ -1,5 +1,6 @@
 import {describe, expect, test} from 'vitest'
 import {transform, type Options} from '../transform.js'
+import {interpolateName} from '@formatjs/ts-transformer'
 
 function t(
   code: string,
@@ -226,24 +227,27 @@ describe('@formatjs/unplugin transform', () => {
       // Message is a top-level plural: ICU format is normalized (spaces removed around commas/braces)
       // This ensures the ID matches formatjs extract with --flatten (Rust CLI: 14X+wqft)
       const input = `<FormattedMessage defaultMessage="{numberOfConsultations, plural, one {# consultation} other {# consultations}}" />`
-      const result = t(input, {
-        idInterpolationPattern: '[sha512:contenthash:base64:8]',
-        flatten: true,
-      })
-      // The flattened message removes spaces in structural positions
-      expect(result).toContain(
-        `defaultMessage="{numberOfConsultations,plural,one{# consultation} other{# consultations}}"`
+      expect(
+        t(input, {
+          idInterpolationPattern: '[sha512:contenthash:base64:8]',
+          flatten: true,
+        })
+      ).toBe(
+        `<FormattedMessage id="14X+wqft" defaultMessage="{numberOfConsultations,plural,one{# consultation} other{# consultations}}" />`
       )
-      // ID is generated from the flattened message (matches Rust CLI formatjs extract --flatten)
-      expect(result).toContain('id="14X+wqft"')
     })
 
     test('hoists select/plural patterns to full sentences', () => {
       const input = `<FormattedMessage defaultMessage="Are you sure you want to delete {count,plural,one {this report template} other {these # report templates}}?" />`
-      const result = t(input, {flatten: true})
-      // Hoisted form: plural wraps the full sentence
-      expect(result).toContain(
-        `defaultMessage="{count,plural,one{Are you sure you want to delete this report template?} other{Are you sure you want to delete these # report templates?}}"`
+      const flattenedMsg =
+        '{count,plural,one{Are you sure you want to delete this report template?} other{Are you sure you want to delete these # report templates?}}'
+      const expectedId = interpolateName(
+        {resourcePath: '/path/to/file.tsx'} as any,
+        '[sha512:contenthash:base64:6]',
+        {content: flattenedMsg}
+      )
+      expect(t(input, {flatten: true})).toBe(
+        `<FormattedMessage id="${expectedId}" defaultMessage="${flattenedMsg}" />`
       )
     })
 

--- a/packages/unplugin/transform.ts
+++ b/packages/unplugin/transform.ts
@@ -51,7 +51,7 @@ export function transform(
     additionalFunctionNames = [],
     ast: preParseAst = false,
     preserveWhitespace = false,
-    flatten = false,
+    flatten = true,
   } = options
 
   const componentNames = new Set([

--- a/packages/unplugin/transform.ts
+++ b/packages/unplugin/transform.ts
@@ -3,6 +3,8 @@ import type {CallExpression, JSXOpeningElement} from 'oxc-parser'
 import MagicString from 'magic-string'
 import {interpolateName} from '@formatjs/ts-transformer'
 import {parse} from '@formatjs/icu-messageformat-parser'
+import {hoistSelectors} from '@formatjs/icu-messageformat-parser/manipulator.js'
+import {printAST} from '@formatjs/icu-messageformat-parser/printer.js'
 
 export interface Options {
   overrideIdFn?: (
@@ -17,6 +19,7 @@ export interface Options {
   additionalFunctionNames?: string[]
   ast?: boolean
   preserveWhitespace?: boolean
+  flatten?: boolean
 }
 
 const DEFAULT_ID_INTERPOLATION_PATTERN = '[sha512:contenthash:base64:6]'
@@ -48,6 +51,7 @@ export function transform(
     additionalFunctionNames = [],
     ast: preParseAst = false,
     preserveWhitespace = false,
+    flatten = false,
   } = options
 
   const componentNames = new Set([
@@ -195,6 +199,16 @@ export function transform(
     // Normalize whitespace on defaultMessage
     if (defaultMessage && !preserveWhitespace) {
       defaultMessage = defaultMessage.trim().replace(/\s+/gm, ' ')
+    }
+
+    // Apply flatten transformation (hoist selectors + normalize ICU format via printAST)
+    // This must happen before ID generation so the ID matches formatjs extract and babel-plugin-formatjs
+    if (flatten && defaultMessage) {
+      try {
+        defaultMessage = printAST(hoistSelectors(parse(defaultMessage)))
+      } catch (e) {
+        // If parsing fails, keep the original message
+      }
     }
 
     // Generate ID


### PR DESCRIPTION
When `flatten=true`, apply `printAST(hoistSelectors(parse(message)))` before generating the ID, matching the behavior of babel-plugin-formatjs and the Rust formatjs_cli. Previously the Vite plugin only applied simple whitespace normalization, producing a different hash input and therefore different IDs.

Fixes #6177

Generated with [Claude Code](https://claude.ai/code)