### PR TITLE
fix(deps): remove typescript peer dependencies

### DIFF
--- a/packages/intl/package.json
+++ b/packages/intl/package.json
@@ -16,9 +16,6 @@
     "@formatjs/icu-messageformat-parser": "workspace:*",
     "intl-messageformat": "workspace:*"
   },
-  "peerDependencies": {
-    "typescript": "^5.6.0"
-  },
   "bugs": "https://github.com/formatjs/formatjs/issues",
   "homepage": "https://formatjs.github.io",
   "keywords": [
@@ -34,10 +31,5 @@
     "translate",
     "translation"
   ],
-  "peerDependenciesMeta": {
-    "typescript": {
-      "optional": true
-    }
-  },
   "repository": "git@github.com:formatjs/formatjs.git"
 }

--- a/packages/react-intl/package.json
+++ b/packages/react-intl/package.json
@@ -19,8 +19,7 @@
   },
   "peerDependencies": {
     "@types/react": "19",
-    "react": "19",
-    "typescript": "^5.6.0"
+    "react": "19"
   },
   "bugs": "https://github.com/formatjs/formatjs/issues",
   "contributors": [
@@ -137,10 +136,5 @@
     "translate",
     "translation"
   ],
-  "peerDependenciesMeta": {
-    "typescript": {
-      "optional": true
-    }
-  },
   "repository": "git@github.com:formatjs/formatjs.git"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -654,9 +654,6 @@ importers:
       intl-messageformat:
         specifier: workspace:*
         version: link:../intl-messageformat
-      typescript:
-        specifier: ^5.6.0
-        version: 5.9.3
 
   packages/intl-datetimeformat:
     dependencies:
@@ -866,9 +863,6 @@ importers:
       react:
         specifier: '19'
         version: 19.2.3
-      typescript:
-        specifier: ^5.6.0
-        version: 5.9.3
 
   packages/react-intl/examples:
     devDependencies:


### PR DESCRIPTION
Fixes #6179

To my understanding, it's not typical to have typescript as a library peer dependency. Any typescript version compatibility issues will arise at build time. Peer dependencies are more valuable when ensuring runtime compatibility issues.