### PR TITLE
refactor(deps): gazelle migration phase 1 — inline thin wrappers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,8 @@ For detailed architecture docs, package dependency hierarchies, CLDR data pipeli
 - `007a-007k` — Individual polyfill CLDR data pipelines
 - `migrations/` — Migration plans (e.g., gazelle migration)
 
+**When making structural changes to the build system, package dependencies, or CLDR data processing, update the relevant knowledge-base docs to keep them in sync.**
+
 ## Critical Rules
 
 ### 1. NEVER Run `bazel clean`

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -1,10 +1,11 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
+load("@aspect_rules_js//js:defs.bzl", "js_binary")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:http-server/package_json.bzl", http_server_bin = "bin")
 load("@npm//:vite/package_json.bzl", vite_bin = "bin")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_binary", "ts_run_binary")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_run_binary")
 load("//tools:tsconfig.bzl", "DOCS_TSCONFIG")
 
 npm_link_all_packages()
@@ -63,7 +64,7 @@ ts_project(
 generate_ide_tsconfig_json()
 
 # Build Typesense index tool
-ts_binary(
+js_binary(
     name = "build_typesense_index_tool",
     data = [
         "//:node_modules/@types/minimist",
@@ -73,10 +74,11 @@ ts_binary(
         "//:node_modules/minimist",
     ],
     entry_point = "scripts/build-typesense-index.ts",
+    node_options = ["--experimental-transform-types"],
 )
 
 # Upload Typesense index tool
-ts_binary(
+js_binary(
     name = "upload_typesense_index_tool",
     data = [
         "//:node_modules/@types/minimist",
@@ -85,6 +87,7 @@ ts_binary(
         "//:node_modules/typesense",
     ],
     entry_point = "scripts/upload-typesense-index.ts",
+    node_options = ["--experimental-transform-types"],
 )
 
 # Build Typesense index from MDX docs
@@ -100,7 +103,7 @@ ts_run_binary(
 )
 
 # Extract metadata tool
-ts_binary(
+js_binary(
     name = "extract_metadata_tool",
     data = [
         "//:node_modules/@types/minimist",
@@ -109,6 +112,7 @@ ts_binary(
         "//:node_modules/minimist",
     ],
     entry_point = "scripts/extract-metadata.ts",
+    node_options = ["--experimental-transform-types"],
 )
 
 # Extract metadata from MDX docs

--- a/knowledge-base/migrations/001-gazelle-migration.md
+++ b/knowledge-base/migrations/001-gazelle-migration.md
@@ -88,13 +88,13 @@ Currently dead code — the actual test logic is commented out. Only does `copy_
 
 ## Migration Phases
 
-### Phase 1: Inline thin wrappers
+### Phase 1: Inline thin wrappers (**DONE**)
 
 **Effort:** Low | **Risk:** Low
 
-- Replace `ts_binary` calls with `js_binary` + `--experimental-transform-types` directly in BUILD files
-- Remove `package_json_test` (dead code — test body is commented out)
-- Keep the `copy_to_bin(name = "package", srcs = ["package.json"])` if anything depends on it
+- ~~Replace `ts_binary` calls with `js_binary` + `--experimental-transform-types` directly in BUILD files~~ Done (9 BUILD files, 22 calls)
+- ~~Remove `package_json_test` (dead code — test body is commented out)~~ Done (28 BUILD files)
+- `copy_to_bin(name = "package", ...)` was only created inside the macro, nothing external depended on it — removed with the macro call
 
 ### Phase 2: Decompose `ts_compile` into stock rules
 

--- a/packages/babel-plugin-formatjs/BUILD.bazel
+++ b/packages/babel-plugin-formatjs/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "package_json_test", "ts_compile_node")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "ts_compile_node")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -57,11 +57,6 @@ vitest(
         "//:node_modules/@babel/preset-react",
         "//packages/babel-plugin-formatjs/tests/fixtures",
     ],
-)
-
-package_json_test(
-    name = "package_json_test",
-    deps = SRC_DEPS,
 )
 
 # Generate tsconfig.json with correct extends path

--- a/packages/bigdecimal/BUILD.bazel
+++ b/packages/bigdecimal/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "package_json_test", "ts_compile_node")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "ts_compile_node")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -50,11 +50,6 @@ vitest(
 )
 
 generate_ide_tsconfig_json()
-
-package_json_test(
-    name = "package_json_test",
-    deps = SRC_DEPS,
-)
 
 copy_to_bin(
     name = "srcs",

--- a/packages/cli-lib/BUILD.bazel
+++ b/packages/cli-lib/BUILD.bazel
@@ -2,7 +2,7 @@ load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "package_json_test", "ts_compile_node")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "ts_compile_node")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -107,11 +107,6 @@ esbuild(
     visibility = ["//packages/cli:__pkg__"],
     deps = [
     ] + SRC_DEPS,
-)
-
-package_json_test(
-    name = "package_json_test",
-    deps = SRC_DEPS,
 )
 
 copy_to_bin(

--- a/packages/ecma376/BUILD.bazel
+++ b/packages/ecma376/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "package_json_test", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "ts_compile")
 load("//tools:vitest.bzl", "vitest")
 
 exports_files([
@@ -42,11 +42,6 @@ generate_ide_tsconfig_json()
 vitest(
     name = "unit_test",
     srcs = SRCS + TESTS,
-    deps = SRC_DEPS,
-)
-
-package_json_test(
-    name = "package_json_test",
     deps = SRC_DEPS,
 )
 

--- a/packages/ecma402-abstract/BUILD.bazel
+++ b/packages/ecma402-abstract/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -73,11 +73,6 @@ generate_src_file(
         "//:node_modules/regenerate",
     ],
     entry_point = "scripts/regex-gen.ts",
-)
-
-package_json_test(
-    name = "package_json_test",
-    deps = SRC_DEPS,
 )
 
 copy_to_bin(

--- a/packages/editor/BUILD.bazel
+++ b/packages/editor/BUILD.bazel
@@ -64,8 +64,3 @@
 #         "packages/editor",
 #     ],
 # )
-
-# # package_json_test(
-# #     name="package_json_test",
-# #     deps=SRC_DEPS
-# # )

--- a/packages/eslint-plugin-formatjs/BUILD.bazel
+++ b/packages/eslint-plugin-formatjs/BUILD.bazel
@@ -2,7 +2,7 @@ load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_compile_node")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile_node")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -93,11 +93,6 @@ vitest(
 
 # Generate tsconfig.json with correct extends path
 generate_ide_tsconfig_json()
-
-package_json_test(
-    name = "package_json_test",
-    deps = SRC_DEPS,
-)
 
 copy_to_bin(
     name = "srcs",

--- a/packages/fast-memoize/BUILD.bazel
+++ b/packages/fast-memoize/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "package_json_test", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "ts_compile")
 
 npm_link_all_packages()
 
@@ -38,11 +38,6 @@ ts_compile(
 
 # Generate tsconfig.json with correct extends path
 generate_ide_tsconfig_json()
-
-package_json_test(
-    name = "package_json_test",
-    deps = SRC_DEPS,
-)
 
 copy_to_bin(
     name = "srcs",

--- a/packages/icu-messageformat-parser-wasm/BUILD.bazel
+++ b/packages/icu-messageformat-parser-wasm/BUILD.bazel
@@ -2,7 +2,7 @@ load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "package_json_test", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "ts_compile")
 load("//tools:tsconfig.bzl", "BASE_NODE_TSCONFIG")
 
 npm_link_all_packages()
@@ -49,11 +49,6 @@ npm_package(
 
 # Generate tsconfig.json with correct extends path
 generate_ide_tsconfig_json()
-
-package_json_test(
-    name = "package_json_test",
-    deps = SRC_DEPS,
-)
 
 copy_to_bin(
     name = "srcs",

--- a/packages/icu-messageformat-parser-wasm/benchmark/BUILD.bazel
+++ b/packages/icu-messageformat-parser-wasm/benchmark/BUILD.bazel
@@ -1,9 +1,9 @@
+load("@aspect_rules_js//js:defs.bzl", "js_binary")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "ts_binary")
 
 npm_link_all_packages()
 
-ts_binary(
+js_binary(
     name = "benchmark",
     data = [
         ":node_modules/@formatjs/icu-messageformat-parser",
@@ -11,4 +11,5 @@ ts_binary(
         "//:node_modules/tinybench",
     ],
     entry_point = "benchmark.ts",
+    node_options = ["--experimental-transform-types"],
 )

--- a/packages/icu-messageformat-parser/BUILD.bazel
+++ b/packages/icu-messageformat-parser/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -63,11 +63,6 @@ generate_src_file(
     src = "time-data.generated.ts",
     tags = ["cldr"],
     tool = "//packages/icu-messageformat-parser/tools:time_data_gen",
-)
-
-package_json_test(
-    name = "package_json_test",
-    deps = SRC_DEPS,
 )
 
 copy_to_bin(

--- a/packages/icu-messageformat-parser/benchmark/BUILD.bazel
+++ b/packages/icu-messageformat-parser/benchmark/BUILD.bazel
@@ -1,13 +1,14 @@
+load("@aspect_rules_js//js:defs.bzl", "js_binary")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "ts_binary")
 
 npm_link_all_packages()
 
-ts_binary(
+js_binary(
     name = "benchmark",
     data = [
         ":node_modules/@formatjs/icu-messageformat-parser",
         "//:node_modules/tinybench",
     ],
     entry_point = "benchmark.ts",
+    node_options = ["--experimental-transform-types"],
 )

--- a/packages/icu-messageformat-parser/tools/BUILD.bazel
+++ b/packages/icu-messageformat-parser/tools/BUILD.bazel
@@ -1,6 +1,6 @@
-load("//tools:index.bzl", "ts_binary")
+load("@aspect_rules_js//js:defs.bzl", "js_binary")
 
-ts_binary(
+js_binary(
     name = "regex_gen",
     data = [
         "global.ts",
@@ -8,19 +8,21 @@ ts_binary(
         "//:node_modules/regenerate",
     ],
     entry_point = "regex-gen.ts",
+    node_options = ["--experimental-transform-types"],
     visibility = [
         "//crates/icu_messageformat_parser:__pkg__",
         "//packages/icu-messageformat-parser:__subpackages__",
     ],
 )
 
-ts_binary(
+js_binary(
     name = "time_data_gen",
     data = [
         "//:node_modules/cldr-core",
         "//:node_modules/json-stable-stringify",
     ],
     entry_point = "time-data-gen.ts",
+    node_options = ["--experimental-transform-types"],
     visibility = [
         "//crates/icu_messageformat_parser:__pkg__",
         "//packages/icu-messageformat-parser:__subpackages__",

--- a/packages/icu-skeleton-parser/BUILD.bazel
+++ b/packages/icu-skeleton-parser/BUILD.bazel
@@ -2,7 +2,7 @@ load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -51,11 +51,6 @@ generate_src_file(
         "//:node_modules/regenerate",
     ],
     entry_point = "scripts/regex-gen.ts",
-)
-
-package_json_test(
-    name = "package_json_test",
-    deps = SRC_DEPS,
 )
 
 copy_to_bin(

--- a/packages/intl-datetimeformat/BUILD.bazel
+++ b/packages/intl-datetimeformat/BUILD.bazel
@@ -6,7 +6,7 @@ load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@rules_multirun//:defs.bzl", "multirun")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_compile", "ts_run_binary")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile", "ts_run_binary")
 load("//tools:vitest.bzl", "vitest")
 load(":defs.bzl", "ZONES")
 load(":index.bzl", "generate_dockerfile")
@@ -914,11 +914,6 @@ js_binary(
         "--experimental-transform-types",
     ],
     tags = ["manual"],
-)
-
-package_json_test(
-    name = "package_json_test",
-    deps = SRC_DEPS,
 )
 
 multirun(

--- a/packages/intl-displaynames/BUILD.bazel
+++ b/packages/intl-displaynames/BUILD.bazel
@@ -4,7 +4,7 @@ load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_compile", "ts_run_binary")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile", "ts_run_binary")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -783,11 +783,6 @@ esbuild(
     target = "es2020",
     deps = [
     ] + SRC_DEPS,
-)
-
-package_json_test(
-    name = "package_json_test",
-    deps = SRC_DEPS,
 )
 
 copy_to_bin(

--- a/packages/intl-durationformat/BUILD.bazel
+++ b/packages/intl-durationformat/BUILD.bazel
@@ -80,8 +80,3 @@ copy_to_bin(
     name = "srcs",
     srcs = SRCS,
 )
-
-# package_json_test(
-#     name="package_json_test",
-#     deps=SRC_DEPS
-# )

--- a/packages/intl-durationformat/benchmark/BUILD.bazel
+++ b/packages/intl-durationformat/benchmark/BUILD.bazel
@@ -1,48 +1,52 @@
+load("@aspect_rules_js//js:defs.bzl", "js_binary")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "ts_binary")
 
 npm_link_all_packages()
 
-ts_binary(
+js_binary(
     name = "benchmark",
     data = [
         ":node_modules/@formatjs/intl-durationformat",
         "//:node_modules/tinybench",
     ],
     entry_point = "benchmark.ts",
+    node_options = ["--experimental-transform-types"],
 )
 
-ts_binary(
+js_binary(
     name = "instantiation_benchmark",
     data = [
         ":node_modules/@formatjs/intl-durationformat",
         "//:node_modules/tinybench",
     ],
     entry_point = "instantiation-benchmark.ts",
+    node_options = ["--experimental-transform-types"],
 )
 
-ts_binary(
+js_binary(
     name = "profile",
     data = [
         ":node_modules/@formatjs/intl-durationformat",
     ],
     entry_point = "profile.ts",
+    node_options = ["--experimental-transform-types"],
 )
 
-ts_binary(
+js_binary(
     name = "profile_cpu",
     data = [
         ":node_modules/@formatjs/intl-durationformat",
     ],
     entry_point = "profile.ts",
     node_options = [
+        "--experimental-transform-types",
         "--cpu-prof",
         "--cpu-prof-interval=100",
         "--cpu-prof-dir=/tmp",
     ],
 )
 
-ts_binary(
+js_binary(
     name = "analyze_profile",
     data = [
         "//:node_modules/@types/minimist",
@@ -50,4 +54,5 @@ ts_binary(
         "//:node_modules/minimist",
     ],
     entry_point = "analyze-profile.ts",
+    node_options = ["--experimental-transform-types"],
 )

--- a/packages/intl-getcanonicallocales/BUILD.bazel
+++ b/packages/intl-getcanonicallocales/BUILD.bazel
@@ -2,7 +2,7 @@ load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -93,11 +93,6 @@ esbuild(
     target = "es6",
     deps = [
     ] + SRC_DEPS,
-)
-
-package_json_test(
-    name = "package_json_test",
-    deps = SRC_DEPS,
 )
 
 copy_to_bin(

--- a/packages/intl-listformat/BUILD.bazel
+++ b/packages/intl-listformat/BUILD.bazel
@@ -4,7 +4,7 @@ load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_compile", "ts_run_binary")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile", "ts_run_binary")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -771,11 +771,6 @@ esbuild(
     target = "es2020",
     deps = [
     ] + SRC_DEPS,
-)
-
-package_json_test(
-    name = "package_json_test",
-    deps = SRC_DEPS,
 )
 
 copy_to_bin(

--- a/packages/intl-locale/BUILD.bazel
+++ b/packages/intl-locale/BUILD.bazel
@@ -4,7 +4,7 @@ load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -91,11 +91,6 @@ esbuild(
     target = "es2020",
     deps = [
     ] + SRC_DEPS,
-)
-
-package_json_test(
-    name = "package_json_test",
-    deps = SRC_DEPS,
 )
 
 # character orders

--- a/packages/intl-localematcher/BUILD.bazel
+++ b/packages/intl-localematcher/BUILD.bazel
@@ -2,7 +2,7 @@ load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -45,10 +45,6 @@ vitest(
 
 # Generate tsconfig.json with correct extends path
 generate_ide_tsconfig_json()
-
-package_json_test(
-    name = "package_json_test",
-)
 
 generate_src_file(
     name = "regions",

--- a/packages/intl-localematcher/benchmark/BUILD.bazel
+++ b/packages/intl-localematcher/benchmark/BUILD.bazel
@@ -1,18 +1,19 @@
+load("@aspect_rules_js//js:defs.bzl", "js_binary")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "ts_binary")
 
 npm_link_all_packages()
 
-ts_binary(
+js_binary(
     name = "benchmark",
     data = [
         "//:node_modules/tinybench",
         "//packages/intl-localematcher:dist",
     ],
     entry_point = "benchmark.ts",
+    node_options = ["--experimental-transform-types"],
 )
 
-ts_binary(
+js_binary(
     name = "bestfit_benchmark",
     data = [
         ":node_modules/@formatjs/intl-localematcher",
@@ -20,23 +21,26 @@ ts_binary(
         "//:node_modules/tinybench",
     ],
     entry_point = "bestfit-benchmark.ts",
+    node_options = ["--experimental-transform-types"],
 )
 
-ts_binary(
+js_binary(
     name = "profile",
     data = [
         "//packages/intl-localematcher:dist",
     ],
     entry_point = "profile.ts",
+    node_options = ["--experimental-transform-types"],
 )
 
-ts_binary(
+js_binary(
     name = "profile_cpu",
     data = [
         "//packages/intl-localematcher:dist",
     ],
     entry_point = "profile.ts",
     node_options = [
+        "--experimental-transform-types",
         "--cpu-prof",
         "--cpu-prof-interval=100",
         "--cpu-prof-dir=/tmp",

--- a/packages/intl-messageformat/BUILD.bazel
+++ b/packages/intl-messageformat/BUILD.bazel
@@ -3,7 +3,7 @@ load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//js:defs.bzl", "js_binary")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "package_json_test", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "ts_compile")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -92,11 +92,6 @@ js_binary(
         "--experimental-transform-types",
     ],
     tags = ["manual"],
-)
-
-package_json_test(
-    name = "package_json_test",
-    deps = SRC_DEPS,
 )
 
 copy_to_bin(

--- a/packages/intl-numberformat/BUILD.bazel
+++ b/packages/intl-numberformat/BUILD.bazel
@@ -1,12 +1,13 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
+load("@aspect_rules_js//js:defs.bzl", "js_binary")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
 load("@rules_multirun//:defs.bzl", "multirun")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_binary", "ts_compile", "ts_run_binary")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile", "ts_run_binary")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -23,13 +24,14 @@ exports_files(
 
 PACKAGE_NAME = "intl-numberformat"
 
-ts_binary(
+js_binary(
     name = "generate-locale-test",
     data = [
         "//:node_modules/fs-extra",
         "//:node_modules/minimist",
     ],
     entry_point = "scripts/generate-locale-test.ts",
+    node_options = ["--experimental-transform-types"],
 )
 
 TEST_LOCALES = [
@@ -980,11 +982,6 @@ esbuild(
     target = "es2020",
     deps = [
     ] + SRC_DEPS,
-)
-
-package_json_test(
-    name = "package_json_test",
-    deps = SRC_DEPS,
 )
 
 copy_to_bin(

--- a/packages/intl-numberformat/benchmark/BUILD.bazel
+++ b/packages/intl-numberformat/benchmark/BUILD.bazel
@@ -1,9 +1,9 @@
+load("@aspect_rules_js//js:defs.bzl", "js_binary")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "ts_binary")
 
 npm_link_all_packages()
 
-ts_binary(
+js_binary(
     name = "benchmark",
     data = [
         "en.json",
@@ -11,18 +11,20 @@ ts_binary(
         "//:node_modules/tinybench",
     ],
     entry_point = "benchmark.ts",
+    node_options = ["--experimental-transform-types"],
 )
 
-ts_binary(
+js_binary(
     name = "profile",
     data = [
         "en.json",
         ":node_modules/@formatjs/intl-numberformat",
     ],
     entry_point = "profile.ts",
+    node_options = ["--experimental-transform-types"],
 )
 
-ts_binary(
+js_binary(
     name = "profile_cpu",
     data = [
         "en.json",
@@ -30,13 +32,14 @@ ts_binary(
     ],
     entry_point = "profile.ts",
     node_options = [
+        "--experimental-transform-types",
         "--cpu-prof",
         "--cpu-prof-interval=100",
         "--cpu-prof-dir=/tmp",
     ],
 )
 
-ts_binary(
+js_binary(
     name = "analyze_profile",
     data = [
         "//:node_modules/@types/minimist",
@@ -44,4 +47,5 @@ ts_binary(
         "//:node_modules/minimist",
     ],
     entry_point = "analyze-profile.ts",
+    node_options = ["--experimental-transform-types"],
 )

--- a/packages/intl-pluralrules/BUILD.bazel
+++ b/packages/intl-pluralrules/BUILD.bazel
@@ -4,7 +4,7 @@ load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_compile", "ts_run_binary")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile", "ts_run_binary")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -418,11 +418,6 @@ esbuild(
     # TODO: fix this and set it back to es5
     deps = [
     ] + SRC_DEPS,
-)
-
-package_json_test(
-    name = "package_json_test",
-    deps = SRC_DEPS,
 )
 
 copy_to_bin(

--- a/packages/intl-relativetimeformat/BUILD.bazel
+++ b/packages/intl-relativetimeformat/BUILD.bazel
@@ -4,7 +4,7 @@ load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_compile", "ts_run_binary")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile", "ts_run_binary")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -768,11 +768,6 @@ esbuild(
     target = "es2020",
     deps = [
     ] + SRC_DEPS,
-)
-
-package_json_test(
-    name = "package_json_test",
-    deps = SRC_DEPS,
 )
 
 copy_to_bin(

--- a/packages/intl/BUILD.bazel
+++ b/packages/intl/BUILD.bazel
@@ -4,7 +4,7 @@ load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:tsd/package_json.bzl", tsd_bin = "bin")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "package_json_test", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "ts_compile")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -58,11 +58,6 @@ vitest(
 
 # Generate tsconfig.json with correct extends path
 generate_ide_tsconfig_json()
-
-package_json_test(
-    name = "package_json_test",
-    deps = SRC_DEPS,
-)
 
 # TODO: make this a macro that paramtrizes on `.test-d.ts` files.
 copy_to_directory(

--- a/packages/react-intl/BUILD.bazel
+++ b/packages/react-intl/BUILD.bazel
@@ -4,7 +4,7 @@ load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:tsd/package_json.bzl", tsd_bin = "bin")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "package_json_test", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "ts_compile")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -91,11 +91,6 @@ vitest(
 
 # Generate tsconfig.json with correct extends path
 generate_ide_tsconfig_json()
-
-package_json_test(
-    name = "package_json_test",
-    deps = SRC_DEPS,
-)
 
 # TODO: make this a macro that paramtrizes on `.test-d.ts` files.
 copy_to_directory(

--- a/packages/svelte-intl/BUILD.bazel
+++ b/packages/svelte-intl/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "package_json_test", "ts_compile_node")
+load("//tools:index.bzl", "ts_compile_node")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -39,11 +39,6 @@ vitest(
     srcs = SRCS + glob([
         "tests/*.ts",
     ]),
-    deps = SRC_DEPS,
-)
-
-package_json_test(
-    name = "package_json_test",
     deps = SRC_DEPS,
 )
 

--- a/packages/ts-transformer/BUILD.bazel
+++ b/packages/ts-transformer/BUILD.bazel
@@ -2,7 +2,7 @@ load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "package_json_test", "ts_compile_node")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "ts_compile_node")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -68,11 +68,6 @@ vitest(
 
 # Generate tsconfig.json with correct extends path
 generate_ide_tsconfig_json()
-
-package_json_test(
-    name = "package_json_test",
-    deps = SRC_DEPS,
-)
 
 copy_to_bin(
     name = "srcs",

--- a/packages/unplugin/BUILD.bazel
+++ b/packages/unplugin/BUILD.bazel
@@ -5,7 +5,7 @@ load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "package_json_test")
+load("//tools:index.bzl", "generate_ide_tsconfig_json")
 load("//tools:oxc_transpiler.bzl", "oxc_transpiler")
 load("//tools:tsconfig.bzl", "ESNEXT_SKIP_LIB_CHECK_TSCONFIG")
 load("//tools:vitest.bzl", "vitest")
@@ -113,8 +113,3 @@ copy_to_bin(
 )
 
 generate_ide_tsconfig_json()
-
-package_json_test(
-    name = "package_json_test",
-    deps = SRC_DEPS,
-)

--- a/packages/utils/BUILD.bazel
+++ b/packages/utils/BUILD.bazel
@@ -3,7 +3,7 @@ load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -46,11 +46,6 @@ ts_compile(
 
 # Generate tsconfig.json with correct extends path
 generate_ide_tsconfig_json()
-
-package_json_test(
-    name = "package_json_test",
-    deps = SRC_DEPS,
-)
 
 vitest(
     name = "unit_test",

--- a/packages/vue-intl/BUILD.bazel
+++ b/packages/vue-intl/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "package_json_test", "ts_compile_node")
+load("//tools:index.bzl", "ts_compile_node")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -45,11 +45,6 @@ vitest(
         "//:node_modules/@vue/server-renderer",
         "//:node_modules/@vue/test-utils",
     ],
-)
-
-package_json_test(
-    name = "package_json_test",
-    deps = SRC_DEPS,
 )
 
 copy_to_bin(

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
-load("//tools:index.bzl", "ts_binary")
+load("@aspect_rules_js//js:defs.bzl", "js_binary")
 
 exports_files([
     "supported-locales-gen.ts",
@@ -17,12 +17,13 @@ copy_to_bin(
     visibility = ["//visibility:public"],
 )
 
-ts_binary(
+js_binary(
     name = "generate-supported-locales",
     data = [
         "//:node_modules/fs-extra",
         "//:node_modules/minimist",
     ],
     entry_point = "generate-supported-locales.ts",
+    node_options = ["--experimental-transform-types"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
## Summary

Gazelle migration phase 1: inline thin Bazel macro wrappers so `ts_project` targets can eventually be made visible to gazelle for automatic dependency management.

### Changes

**1. Replace `ts_binary` with `js_binary` (22 calls across 9 files)**

`ts_binary` was a thin wrapper that just added `--experimental-transform-types` to `node_options`. Now inlined directly:

```diff
-load("//tools:index.bzl", "ts_binary")
+load("@aspect_rules_js//js:defs.bzl", "js_binary")

-ts_binary(
+js_binary(
     name = "benchmark",
     entry_point = "benchmark.ts",
+    node_options = ["--experimental-transform-types"],
 )
```

**2. Remove `package_json_test` (28 files)**

Dead code — the actual test body was commented out. Only created a `copy_to_bin(name = "package")` target that nothing depended on.

**3. Update migration doc + CLAUDE.md**

- Mark phase 1 as done in `knowledge-base/migrations/001-gazelle-migration.md`
- Add knowledge-base update reminder to CLAUDE.md

### What's NOT changed

- `tools/index.bzl` is untouched — macros remain available for reference
- `ts_compile`, `ts_compile_node`, `vitest`, `generate_src_file` macros are untouched (phases 2-3)

## Test plan
- [x] `pnpm t` — all 495 tests pass
- [x] All lefthook pre-commit hooks pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)