### PR TITLE
refactor(deps): gazelle migration phases 2-3 — decompose ts_compile and vitest macros

### DIFF
--- a/knowledge-base/migrations/001-gazelle-migration.md
+++ b/knowledge-base/migrations/001-gazelle-migration.md
@@ -96,11 +96,13 @@ Currently dead code — the actual test logic is commented out. Only does `copy_
 - ~~Remove `package_json_test` (dead code — test body is commented out)~~ Done (28 BUILD files)
 - `copy_to_bin(name = "package", ...)` was only created inside the macro, nothing external depended on it — removed with the macro call
 
-### Phase 2: Decompose `ts_compile` into stock rules
+### Phase 2: Decompose `ts_compile` into stock rules (**DONE**)
 
 **Effort:** Medium | **Risk:** Medium
 
-Replace each `ts_compile(name = "dist", srcs, deps)` with explicit targets:
+Replaced all `ts_compile` (21 packages) and `ts_compile_node` (7 packages) calls with explicit inline targets. Each macro expanded to 3 targets: ts_project (typecheck), ts_project (transpile), js_library (bundle).
+
+Example expansion:
 
 ```python
 # Gazelle manages deps on this target

--- a/packages/babel-plugin-formatjs/BUILD.bazel
+++ b/packages/babel-plugin-formatjs/BUILD.bazel
@@ -44,6 +44,7 @@ SRC_DEPS = [
 ]
 
 ts_project(
+    # Type-check only (tsgo, no emit)
     name = "dist-esm-esnext-typecheck",
     srcs = [":srcs"],
     declaration = True,
@@ -55,6 +56,7 @@ ts_project(
 )
 
 ts_project(
+    # Transpile to JS + .d.ts (oxc-transform)
     name = "dist-esm-esnext",
     srcs = [":srcs"],
     declaration = True,

--- a/packages/babel-plugin-formatjs/BUILD.bazel
+++ b/packages/babel-plugin-formatjs/BUILD.bazel
@@ -1,7 +1,12 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "ts_compile_node")
+load("//tools:index.bzl", "generate_ide_tsconfig_json")
+load("//tools:oxc_transpiler.bzl", "oxc_transpiler")
+load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -38,10 +43,34 @@ SRC_DEPS = [
     "//:node_modules/@types/babel__traverse",
 ]
 
-ts_compile_node(
-    name = "dist",
+ts_project(
+    name = "dist-esm-esnext-typecheck",
     srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = ESNEXT_TSCONFIG,
     deps = SRC_DEPS,
+)
+
+ts_project(
+    name = "dist-esm-esnext",
+    srcs = [":srcs"],
+    declaration = True,
+    declaration_transpiler = oxc_transpiler,
+    resolve_json_module = True,
+    transpiler = oxc_transpiler,
+    tsconfig = ESNEXT_TSCONFIG,
+    deps = SRC_DEPS + ["//:node_modules/oxc-transform"],
+)
+
+js_library(
+    name = "dist",
+    srcs = [
+        "package.json",
+        ":dist-esm-esnext",
+    ],
 )
 
 vitest(

--- a/packages/bigdecimal/BUILD.bazel
+++ b/packages/bigdecimal/BUILD.bazel
@@ -1,7 +1,12 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "ts_compile_node")
+load("//tools:index.bzl", "generate_ide_tsconfig_json")
+load("//tools:oxc_transpiler.bzl", "oxc_transpiler")
+load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -37,10 +42,34 @@ TESTS = glob([
 
 TEST_DEPS = SRC_DEPS
 
-ts_compile_node(
-    name = "dist",
+ts_project(
+    name = "dist-esm-esnext-typecheck",
     srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = ESNEXT_TSCONFIG,
     deps = SRC_DEPS,
+)
+
+ts_project(
+    name = "dist-esm-esnext",
+    srcs = [":srcs"],
+    declaration = True,
+    declaration_transpiler = oxc_transpiler,
+    resolve_json_module = True,
+    transpiler = oxc_transpiler,
+    tsconfig = ESNEXT_TSCONFIG,
+    deps = SRC_DEPS + ["//:node_modules/oxc-transform"],
+)
+
+js_library(
+    name = "dist",
+    srcs = [
+        "package.json",
+        ":dist-esm-esnext",
+    ],
 )
 
 vitest(

--- a/packages/bigdecimal/BUILD.bazel
+++ b/packages/bigdecimal/BUILD.bazel
@@ -43,6 +43,7 @@ TESTS = glob([
 TEST_DEPS = SRC_DEPS
 
 ts_project(
+    # Type-check only (tsgo, no emit)
     name = "dist-esm-esnext-typecheck",
     srcs = [":srcs"],
     declaration = True,
@@ -54,6 +55,7 @@ ts_project(
 )
 
 ts_project(
+    # Transpile to JS + .d.ts (oxc-transform)
     name = "dist-esm-esnext",
     srcs = [":srcs"],
     declaration = True,

--- a/packages/cli-lib/BUILD.bazel
+++ b/packages/cli-lib/BUILD.bazel
@@ -1,8 +1,13 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "ts_compile_node")
+load("//tools:index.bzl", "generate_ide_tsconfig_json")
+load("//tools:oxc_transpiler.bzl", "oxc_transpiler")
+load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -59,10 +64,34 @@ SRC_DEPS = [
     "//:node_modules/typescript",
 ] + VUE_DEPS + SVELTE_DEPS + GLIMMER_HBS_DEPS
 
-ts_compile_node(
-    name = "dist",
+ts_project(
+    name = "dist-esm-esnext-typecheck",
     srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = ESNEXT_TSCONFIG,
     deps = SRC_DEPS,
+)
+
+ts_project(
+    name = "dist-esm-esnext",
+    srcs = [":srcs"],
+    declaration = True,
+    declaration_transpiler = oxc_transpiler,
+    resolve_json_module = True,
+    transpiler = oxc_transpiler,
+    tsconfig = ESNEXT_TSCONFIG,
+    deps = SRC_DEPS + ["//:node_modules/oxc-transform"],
+)
+
+js_library(
+    name = "dist",
+    srcs = [
+        "package.json",
+        ":dist-esm-esnext",
+    ],
 )
 
 vitest(

--- a/packages/cli-lib/BUILD.bazel
+++ b/packages/cli-lib/BUILD.bazel
@@ -65,6 +65,7 @@ SRC_DEPS = [
 ] + VUE_DEPS + SVELTE_DEPS + GLIMMER_HBS_DEPS
 
 ts_project(
+    # Type-check only (tsgo, no emit)
     name = "dist-esm-esnext-typecheck",
     srcs = [":srcs"],
     declaration = True,
@@ -76,6 +77,7 @@ ts_project(
 )
 
 ts_project(
+    # Transpile to JS + .d.ts (oxc-transform)
     name = "dist-esm-esnext",
     srcs = [":srcs"],
     declaration = True,

--- a/packages/ecma376/BUILD.bazel
+++ b/packages/ecma376/BUILD.bazel
@@ -1,6 +1,11 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "ts_compile")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
+load("//tools:index.bzl", "generate_ide_tsconfig_json")
+load("//tools:oxc_transpiler.bzl", "oxc_transpiler")
+load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
 load("//tools:vitest.bzl", "vitest")
 
 exports_files([
@@ -30,10 +35,34 @@ SRC_DEPS = [
 
 TESTS = glob(["tests/*"])
 
-ts_compile(
-    name = "dist",
+ts_project(
+    name = "dist-esm-typecheck",
     srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = BASE_TSCONFIG,
     deps = SRC_DEPS,
+)
+
+ts_project(
+    name = "dist-esm",
+    srcs = [":srcs"],
+    declaration = True,
+    declaration_transpiler = oxc_transpiler,
+    resolve_json_module = True,
+    transpiler = oxc_transpiler,
+    tsconfig = BASE_TSCONFIG,
+    deps = SRC_DEPS + ["//:node_modules/oxc-transform"],
+)
+
+js_library(
+    name = "dist",
+    srcs = [
+        "package.json",
+        ":dist-esm",
+    ],
 )
 
 # Generate tsconfig.json with correct extends path

--- a/packages/ecma376/BUILD.bazel
+++ b/packages/ecma376/BUILD.bazel
@@ -36,6 +36,7 @@ SRC_DEPS = [
 TESTS = glob(["tests/*"])
 
 ts_project(
+    # Type-check only (tsgo, no emit)
     name = "dist-esm-typecheck",
     srcs = [":srcs"],
     declaration = True,
@@ -47,6 +48,7 @@ ts_project(
 )
 
 ts_project(
+    # Transpile to JS + .d.ts (oxc-transform)
     name = "dist-esm",
     srcs = [":srcs"],
     declaration = True,

--- a/packages/ecma402-abstract/BUILD.bazel
+++ b/packages/ecma402-abstract/BUILD.bazel
@@ -42,6 +42,7 @@ SRC_DEPS = [
 ]
 
 ts_project(
+    # Type-check only (tsgo, no emit)
     name = "dist-esm-typecheck",
     srcs = [":srcs"],
     declaration = True,
@@ -53,6 +54,7 @@ ts_project(
 )
 
 ts_project(
+    # Transpile to JS + .d.ts (oxc-transform)
     name = "dist-esm",
     srcs = [":srcs"],
     declaration = True,

--- a/packages/ecma402-abstract/BUILD.bazel
+++ b/packages/ecma402-abstract/BUILD.bazel
@@ -1,7 +1,12 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file")
+load("//tools:oxc_transpiler.bzl", "oxc_transpiler")
+load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -36,10 +41,34 @@ SRC_DEPS = [
     ":node_modules/@formatjs/bigdecimal",
 ]
 
-ts_compile(
-    name = "dist",
+ts_project(
+    name = "dist-esm-typecheck",
     srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = BASE_TSCONFIG,
     deps = SRC_DEPS,
+)
+
+ts_project(
+    name = "dist-esm",
+    srcs = [":srcs"],
+    declaration = True,
+    declaration_transpiler = oxc_transpiler,
+    resolve_json_module = True,
+    transpiler = oxc_transpiler,
+    tsconfig = BASE_TSCONFIG,
+    deps = SRC_DEPS + ["//:node_modules/oxc-transform"],
+)
+
+js_library(
+    name = "dist",
+    srcs = [
+        "package.json",
+        ":dist-esm",
+    ],
 )
 
 vitest(

--- a/packages/eslint-plugin-formatjs/BUILD.bazel
+++ b/packages/eslint-plugin-formatjs/BUILD.bazel
@@ -1,8 +1,13 @@
 load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile_node")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file")
+load("//tools:oxc_transpiler.bzl", "oxc_transpiler")
+load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -64,10 +69,34 @@ SRC_DEPS = [
     "//:node_modules/typescript",
 ]
 
-ts_compile_node(
-    name = "dist",
+ts_project(
+    name = "dist-esm-esnext-typecheck",
     srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = ESNEXT_TSCONFIG,
     deps = SRC_DEPS,
+)
+
+ts_project(
+    name = "dist-esm-esnext",
+    srcs = [":srcs"],
+    declaration = True,
+    declaration_transpiler = oxc_transpiler,
+    resolve_json_module = True,
+    transpiler = oxc_transpiler,
+    tsconfig = ESNEXT_TSCONFIG,
+    deps = SRC_DEPS + ["//:node_modules/oxc-transform"],
+)
+
+js_library(
+    name = "dist",
+    srcs = [
+        "package.json",
+        ":dist-esm-esnext",
+    ],
 )
 
 TESTS_BASE_SRCS = [":srcs"] + glob(

--- a/packages/eslint-plugin-formatjs/BUILD.bazel
+++ b/packages/eslint-plugin-formatjs/BUILD.bazel
@@ -70,6 +70,7 @@ SRC_DEPS = [
 ]
 
 ts_project(
+    # Type-check only (tsgo, no emit)
     name = "dist-esm-esnext-typecheck",
     srcs = [":srcs"],
     declaration = True,
@@ -81,6 +82,7 @@ ts_project(
 )
 
 ts_project(
+    # Transpile to JS + .d.ts (oxc-transform)
     name = "dist-esm-esnext",
     srcs = [":srcs"],
     declaration = True,

--- a/packages/fast-memoize/BUILD.bazel
+++ b/packages/fast-memoize/BUILD.bazel
@@ -36,6 +36,7 @@ SRC_DEPS = [
 ]
 
 ts_project(
+    # Type-check only (tsgo, no emit)
     name = "dist-esm-typecheck",
     srcs = [":srcs"],
     declaration = True,
@@ -47,6 +48,7 @@ ts_project(
 )
 
 ts_project(
+    # Transpile to JS + .d.ts (oxc-transform)
     name = "dist-esm",
     srcs = [":srcs"],
     declaration = True,

--- a/packages/fast-memoize/BUILD.bazel
+++ b/packages/fast-memoize/BUILD.bazel
@@ -1,7 +1,12 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json")
+load("//tools:oxc_transpiler.bzl", "oxc_transpiler")
+load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
 
 npm_link_all_packages()
 
@@ -30,10 +35,34 @@ SRCS = glob([
 SRC_DEPS = [
 ]
 
-ts_compile(
-    name = "dist",
+ts_project(
+    name = "dist-esm-typecheck",
     srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = BASE_TSCONFIG,
     deps = SRC_DEPS,
+)
+
+ts_project(
+    name = "dist-esm",
+    srcs = [":srcs"],
+    declaration = True,
+    declaration_transpiler = oxc_transpiler,
+    resolve_json_module = True,
+    transpiler = oxc_transpiler,
+    tsconfig = BASE_TSCONFIG,
+    deps = SRC_DEPS + ["//:node_modules/oxc-transform"],
+)
+
+js_library(
+    name = "dist",
+    srcs = [
+        "package.json",
+        ":dist-esm",
+    ],
 )
 
 # Generate tsconfig.json with correct extends path

--- a/packages/icu-messageformat-parser-wasm/BUILD.bazel
+++ b/packages/icu-messageformat-parser-wasm/BUILD.bazel
@@ -30,6 +30,7 @@ SRC_DEPS = [
 ]
 
 ts_project(
+    # Type-check only (tsgo, no emit)
     name = "dist-esm-typecheck",
     srcs = [
         ":srcs",
@@ -44,6 +45,7 @@ ts_project(
 )
 
 ts_project(
+    # Transpile to JS + .d.ts (oxc-transform)
     name = "dist-esm",
     srcs = [
         ":srcs",

--- a/packages/icu-messageformat-parser-wasm/BUILD.bazel
+++ b/packages/icu-messageformat-parser-wasm/BUILD.bazel
@@ -1,8 +1,12 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json")
+load("//tools:oxc_transpiler.bzl", "oxc_transpiler")
 load("//tools:tsconfig.bzl", "BASE_NODE_TSCONFIG")
 
 npm_link_all_packages()
@@ -25,14 +29,40 @@ SRC_DEPS = [
     "//:node_modules/@types/node",
 ]
 
-ts_compile(
-    name = "dist",
+ts_project(
+    name = "dist-esm-typecheck",
     srcs = [
         ":srcs",
         ":wasm_files",
     ],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
     tsconfig = BASE_NODE_TSCONFIG,
     deps = SRC_DEPS,
+)
+
+ts_project(
+    name = "dist-esm",
+    srcs = [
+        ":srcs",
+        ":wasm_files",
+    ],
+    declaration = True,
+    declaration_transpiler = oxc_transpiler,
+    resolve_json_module = True,
+    transpiler = oxc_transpiler,
+    tsconfig = BASE_NODE_TSCONFIG,
+    deps = SRC_DEPS + ["//:node_modules/oxc-transform"],
+)
+
+js_library(
+    name = "dist",
+    srcs = [
+        "package.json",
+        ":dist-esm",
+    ],
 )
 
 npm_package(

--- a/packages/icu-messageformat-parser/BUILD.bazel
+++ b/packages/icu-messageformat-parser/BUILD.bazel
@@ -1,7 +1,12 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file")
+load("//tools:oxc_transpiler.bzl", "oxc_transpiler")
+load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -31,10 +36,34 @@ SRC_DEPS = [
     ":node_modules/@formatjs/icu-skeleton-parser",
 ]
 
-ts_compile(
-    name = "dist",
+ts_project(
+    name = "dist-esm-typecheck",
     srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = BASE_TSCONFIG,
     deps = SRC_DEPS,
+)
+
+ts_project(
+    name = "dist-esm",
+    srcs = [":srcs"],
+    declaration = True,
+    declaration_transpiler = oxc_transpiler,
+    resolve_json_module = True,
+    transpiler = oxc_transpiler,
+    tsconfig = BASE_TSCONFIG,
+    deps = SRC_DEPS + ["//:node_modules/oxc-transform"],
+)
+
+js_library(
+    name = "dist",
+    srcs = [
+        "package.json",
+        ":dist-esm",
+    ],
 )
 
 vitest(

--- a/packages/icu-messageformat-parser/BUILD.bazel
+++ b/packages/icu-messageformat-parser/BUILD.bazel
@@ -37,6 +37,7 @@ SRC_DEPS = [
 ]
 
 ts_project(
+    # Type-check only (tsgo, no emit)
     name = "dist-esm-typecheck",
     srcs = [":srcs"],
     declaration = True,
@@ -48,6 +49,7 @@ ts_project(
 )
 
 ts_project(
+    # Transpile to JS + .d.ts (oxc-transform)
     name = "dist-esm",
     srcs = [":srcs"],
     declaration = True,

--- a/packages/icu-skeleton-parser/BUILD.bazel
+++ b/packages/icu-skeleton-parser/BUILD.bazel
@@ -33,6 +33,7 @@ SRC_DEPS = [
 ]
 
 ts_project(
+    # Type-check only (tsgo, no emit)
     name = "dist-esm-typecheck",
     srcs = [":srcs"],
     declaration = True,
@@ -44,6 +45,7 @@ ts_project(
 )
 
 ts_project(
+    # Transpile to JS + .d.ts (oxc-transform)
     name = "dist-esm",
     srcs = [":srcs"],
     declaration = True,

--- a/packages/icu-skeleton-parser/BUILD.bazel
+++ b/packages/icu-skeleton-parser/BUILD.bazel
@@ -1,8 +1,13 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file")
+load("//tools:oxc_transpiler.bzl", "oxc_transpiler")
+load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -27,10 +32,34 @@ SRC_DEPS = [
     ":node_modules/@formatjs/ecma402-abstract",
 ]
 
-ts_compile(
-    name = "dist",
+ts_project(
+    name = "dist-esm-typecheck",
     srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = BASE_TSCONFIG,
     deps = SRC_DEPS,
+)
+
+ts_project(
+    name = "dist-esm",
+    srcs = [":srcs"],
+    declaration = True,
+    declaration_transpiler = oxc_transpiler,
+    resolve_json_module = True,
+    transpiler = oxc_transpiler,
+    tsconfig = BASE_TSCONFIG,
+    deps = SRC_DEPS + ["//:node_modules/oxc-transform"],
+)
+
+js_library(
+    name = "dist",
+    srcs = [
+        "package.json",
+        ":dist-esm",
+    ],
 )
 
 vitest(

--- a/packages/intl-datetimeformat/BUILD.bazel
+++ b/packages/intl-datetimeformat/BUILD.bazel
@@ -80,6 +80,7 @@ TEST_DEPS = SRC_DEPS + [
 ]
 
 ts_project(
+    # Type-check only (tsgo, no emit)
     name = "dist-esm-typecheck",
     srcs = [":srcs"],
     declaration = True,
@@ -91,6 +92,7 @@ ts_project(
 )
 
 ts_project(
+    # Transpile to JS + .d.ts (oxc-transform)
     name = "dist-esm",
     srcs = [":srcs"],
     declaration = True,

--- a/packages/intl-datetimeformat/BUILD.bazel
+++ b/packages/intl-datetimeformat/BUILD.bazel
@@ -1,12 +1,16 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
-load("@aspect_rules_js//js:defs.bzl", "js_binary")
+load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@rules_multirun//:defs.bzl", "multirun")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile", "ts_run_binary")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_run_binary")
+load("//tools:oxc_transpiler.bzl", "oxc_transpiler")
+load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
 load("//tools:vitest.bzl", "vitest")
 load(":defs.bzl", "ZONES")
 load(":index.bzl", "generate_dockerfile")
@@ -75,10 +79,34 @@ TEST_DEPS = SRC_DEPS + [
     "//:node_modules/@types/node",
 ]
 
-ts_compile(
-    name = "dist",
+ts_project(
+    name = "dist-esm-typecheck",
     srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = BASE_TSCONFIG,
     deps = SRC_DEPS,
+)
+
+ts_project(
+    name = "dist-esm",
+    srcs = [":srcs"],
+    declaration = True,
+    declaration_transpiler = oxc_transpiler,
+    resolve_json_module = True,
+    transpiler = oxc_transpiler,
+    tsconfig = BASE_TSCONFIG,
+    deps = SRC_DEPS + ["//:node_modules/oxc-transform"],
+)
+
+js_library(
+    name = "dist",
+    srcs = [
+        "package.json",
+        ":dist-esm",
+    ],
 )
 
 vitest(

--- a/packages/intl-displaynames/BUILD.bazel
+++ b/packages/intl-displaynames/BUILD.bazel
@@ -61,6 +61,7 @@ TEST_DEPS = SRC_DEPS + [
 ]
 
 ts_project(
+    # Type-check only (tsgo, no emit)
     name = "dist-esm-typecheck",
     srcs = [":srcs"],
     declaration = True,
@@ -72,6 +73,7 @@ ts_project(
 )
 
 ts_project(
+    # Transpile to JS + .d.ts (oxc-transform)
     name = "dist-esm",
     srcs = [":srcs"],
     declaration = True,

--- a/packages/intl-displaynames/BUILD.bazel
+++ b/packages/intl-displaynames/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile", "ts_run_binary")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_run_binary")
+load("//tools:oxc_transpiler.bzl", "oxc_transpiler")
+load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -55,10 +60,34 @@ TEST_DEPS = SRC_DEPS + [
     ":node_modules/@formatjs/intl-locale",
 ]
 
-ts_compile(
-    name = "dist",
+ts_project(
+    name = "dist-esm-typecheck",
     srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = BASE_TSCONFIG,
     deps = SRC_DEPS,
+)
+
+ts_project(
+    name = "dist-esm",
+    srcs = [":srcs"],
+    declaration = True,
+    declaration_transpiler = oxc_transpiler,
+    resolve_json_module = True,
+    transpiler = oxc_transpiler,
+    tsconfig = BASE_TSCONFIG,
+    deps = SRC_DEPS + ["//:node_modules/oxc-transform"],
+)
+
+js_library(
+    name = "dist",
+    srcs = [
+        "package.json",
+        ":dist-esm",
+    ],
 )
 
 vitest(

--- a/packages/intl-durationformat/BUILD.bazel
+++ b/packages/intl-durationformat/BUILD.bazel
@@ -1,8 +1,13 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file")
+load("//tools:oxc_transpiler.bzl", "oxc_transpiler")
+load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -31,10 +36,34 @@ SRC_DEPS = [
     ":node_modules/@formatjs/intl-localematcher",
 ]
 
-ts_compile(
-    name = "dist",
+ts_project(
+    name = "dist-esm-typecheck",
     srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = BASE_TSCONFIG,
     deps = SRC_DEPS,
+)
+
+ts_project(
+    name = "dist-esm",
+    srcs = [":srcs"],
+    declaration = True,
+    declaration_transpiler = oxc_transpiler,
+    resolve_json_module = True,
+    transpiler = oxc_transpiler,
+    tsconfig = BASE_TSCONFIG,
+    deps = SRC_DEPS + ["//:node_modules/oxc-transform"],
+)
+
+js_library(
+    name = "dist",
+    srcs = [
+        "package.json",
+        ":dist-esm",
+    ],
 )
 
 vitest(

--- a/packages/intl-durationformat/BUILD.bazel
+++ b/packages/intl-durationformat/BUILD.bazel
@@ -37,6 +37,7 @@ SRC_DEPS = [
 ]
 
 ts_project(
+    # Type-check only (tsgo, no emit)
     name = "dist-esm-typecheck",
     srcs = [":srcs"],
     declaration = True,
@@ -48,6 +49,7 @@ ts_project(
 )
 
 ts_project(
+    # Transpile to JS + .d.ts (oxc-transform)
     name = "dist-esm",
     srcs = [":srcs"],
     declaration = True,

--- a/packages/intl-getcanonicallocales/BUILD.bazel
+++ b/packages/intl-getcanonicallocales/BUILD.bazel
@@ -52,6 +52,7 @@ SRC_DEPS = [
 TEST_DEPS = SRC_DEPS
 
 ts_project(
+    # Type-check only (tsgo, no emit)
     name = "dist-esm-typecheck",
     srcs = [":srcs"],
     declaration = True,
@@ -63,6 +64,7 @@ ts_project(
 )
 
 ts_project(
+    # Transpile to JS + .d.ts (oxc-transform)
     name = "dist-esm",
     srcs = [":srcs"],
     declaration = True,

--- a/packages/intl-getcanonicallocales/BUILD.bazel
+++ b/packages/intl-getcanonicallocales/BUILD.bazel
@@ -1,8 +1,13 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file")
+load("//tools:oxc_transpiler.bzl", "oxc_transpiler")
+load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -46,10 +51,34 @@ SRC_DEPS = [
 
 TEST_DEPS = SRC_DEPS
 
-ts_compile(
-    name = "dist",
+ts_project(
+    name = "dist-esm-typecheck",
     srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = BASE_TSCONFIG,
     deps = SRC_DEPS,
+)
+
+ts_project(
+    name = "dist-esm",
+    srcs = [":srcs"],
+    declaration = True,
+    declaration_transpiler = oxc_transpiler,
+    resolve_json_module = True,
+    transpiler = oxc_transpiler,
+    tsconfig = BASE_TSCONFIG,
+    deps = SRC_DEPS + ["//:node_modules/oxc-transform"],
+)
+
+js_library(
+    name = "dist",
+    srcs = [
+        "package.json",
+        ":dist-esm",
+    ],
 )
 
 vitest(

--- a/packages/intl-listformat/BUILD.bazel
+++ b/packages/intl-listformat/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile", "ts_run_binary")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_run_binary")
+load("//tools:oxc_transpiler.bzl", "oxc_transpiler")
+load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -58,10 +63,34 @@ TEST_DEPS = SRC_DEPS + [
     "//:node_modules/@types/node",
 ]
 
-ts_compile(
-    name = "dist",
+ts_project(
+    name = "dist-esm-typecheck",
     srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = BASE_TSCONFIG,
     deps = SRC_DEPS,
+)
+
+ts_project(
+    name = "dist-esm",
+    srcs = [":srcs"],
+    declaration = True,
+    declaration_transpiler = oxc_transpiler,
+    resolve_json_module = True,
+    transpiler = oxc_transpiler,
+    tsconfig = BASE_TSCONFIG,
+    deps = SRC_DEPS + ["//:node_modules/oxc-transform"],
+)
+
+js_library(
+    name = "dist",
+    srcs = [
+        "package.json",
+        ":dist-esm",
+    ],
 )
 
 vitest(

--- a/packages/intl-listformat/BUILD.bazel
+++ b/packages/intl-listformat/BUILD.bazel
@@ -64,6 +64,7 @@ TEST_DEPS = SRC_DEPS + [
 ]
 
 ts_project(
+    # Type-check only (tsgo, no emit)
     name = "dist-esm-typecheck",
     srcs = [":srcs"],
     declaration = True,
@@ -75,6 +76,7 @@ ts_project(
 )
 
 ts_project(
+    # Transpile to JS + .d.ts (oxc-transform)
     name = "dist-esm",
     srcs = [":srcs"],
     declaration = True,

--- a/packages/intl-locale/BUILD.bazel
+++ b/packages/intl-locale/BUILD.bazel
@@ -41,6 +41,7 @@ SRC_DEPS = [
 ]
 
 ts_project(
+    # Type-check only (tsgo, no emit)
     name = "dist-esm-typecheck",
     srcs = [":srcs"],
     declaration = True,
@@ -52,6 +53,7 @@ ts_project(
 )
 
 ts_project(
+    # Transpile to JS + .d.ts (oxc-transform)
     name = "dist-esm",
     srcs = [":srcs"],
     declaration = True,

--- a/packages/intl-locale/BUILD.bazel
+++ b/packages/intl-locale/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file")
+load("//tools:oxc_transpiler.bzl", "oxc_transpiler")
+load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -35,10 +40,34 @@ SRC_DEPS = [
     "//:node_modules/cldr-bcp47",
 ]
 
-ts_compile(
-    name = "dist",
+ts_project(
+    name = "dist-esm-typecheck",
     srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = BASE_TSCONFIG,
     deps = SRC_DEPS,
+)
+
+ts_project(
+    name = "dist-esm",
+    srcs = [":srcs"],
+    declaration = True,
+    declaration_transpiler = oxc_transpiler,
+    resolve_json_module = True,
+    transpiler = oxc_transpiler,
+    tsconfig = BASE_TSCONFIG,
+    deps = SRC_DEPS + ["//:node_modules/oxc-transform"],
+)
+
+js_library(
+    name = "dist",
+    srcs = [
+        "package.json",
+        ":dist-esm",
+    ],
 )
 
 vitest(

--- a/packages/intl-localematcher/BUILD.bazel
+++ b/packages/intl-localematcher/BUILD.bazel
@@ -36,6 +36,7 @@ SRC_DEPS = [
 ]
 
 ts_project(
+    # Type-check only (tsgo, no emit)
     name = "dist-esm-typecheck",
     srcs = [":srcs"],
     declaration = True,
@@ -47,6 +48,7 @@ ts_project(
 )
 
 ts_project(
+    # Transpile to JS + .d.ts (oxc-transform)
     name = "dist-esm",
     srcs = [":srcs"],
     declaration = True,

--- a/packages/intl-localematcher/BUILD.bazel
+++ b/packages/intl-localematcher/BUILD.bazel
@@ -1,8 +1,13 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file")
+load("//tools:oxc_transpiler.bzl", "oxc_transpiler")
+load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -30,11 +35,35 @@ SRC_DEPS = [
     ":node_modules/@formatjs/fast-memoize",
 ]
 
-ts_compile(
-    name = "dist",
+ts_project(
+    name = "dist-esm-typecheck",
     srcs = [":srcs"],
-    visibility = ["//packages/intl-localematcher/benchmark:__pkg__"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = BASE_TSCONFIG,
     deps = SRC_DEPS,
+)
+
+ts_project(
+    name = "dist-esm",
+    srcs = [":srcs"],
+    declaration = True,
+    declaration_transpiler = oxc_transpiler,
+    resolve_json_module = True,
+    transpiler = oxc_transpiler,
+    tsconfig = BASE_TSCONFIG,
+    deps = SRC_DEPS + ["//:node_modules/oxc-transform"],
+)
+
+js_library(
+    name = "dist",
+    srcs = [
+        "package.json",
+        ":dist-esm",
+    ],
+    visibility = ["//packages/intl-localematcher/benchmark:__pkg__"],
 )
 
 vitest(

--- a/packages/intl-messageformat/BUILD.bazel
+++ b/packages/intl-messageformat/BUILD.bazel
@@ -1,9 +1,13 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
-load("@aspect_rules_js//js:defs.bzl", "js_binary")
+load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json")
+load("//tools:oxc_transpiler.bzl", "oxc_transpiler")
+load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -41,10 +45,34 @@ TESTS = glob([
 
 TEST_DEPS = SRC_DEPS
 
-ts_compile(
-    name = "dist",
+ts_project(
+    name = "dist-esm-typecheck",
     srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = BASE_TSCONFIG,
     deps = SRC_DEPS,
+)
+
+ts_project(
+    name = "dist-esm",
+    srcs = [":srcs"],
+    declaration = True,
+    declaration_transpiler = oxc_transpiler,
+    resolve_json_module = True,
+    transpiler = oxc_transpiler,
+    tsconfig = BASE_TSCONFIG,
+    deps = SRC_DEPS + ["//:node_modules/oxc-transform"],
+)
+
+js_library(
+    name = "dist",
+    srcs = [
+        "package.json",
+        ":dist-esm",
+    ],
 )
 
 vitest(

--- a/packages/intl-messageformat/BUILD.bazel
+++ b/packages/intl-messageformat/BUILD.bazel
@@ -46,6 +46,7 @@ TESTS = glob([
 TEST_DEPS = SRC_DEPS
 
 ts_project(
+    # Type-check only (tsgo, no emit)
     name = "dist-esm-typecheck",
     srcs = [":srcs"],
     declaration = True,
@@ -57,6 +58,7 @@ ts_project(
 )
 
 ts_project(
+    # Transpile to JS + .d.ts (oxc-transform)
     name = "dist-esm",
     srcs = [":srcs"],
     declaration = True,

--- a/packages/intl-numberformat/BUILD.bazel
+++ b/packages/intl-numberformat/BUILD.bazel
@@ -110,6 +110,7 @@ TEST_DEPS = SRC_DEPS + [
 ]
 
 ts_project(
+    # Type-check only (tsgo, no emit)
     name = "dist-esm-typecheck",
     srcs = [":srcs"],
     declaration = True,
@@ -121,6 +122,7 @@ ts_project(
 )
 
 ts_project(
+    # Transpile to JS + .d.ts (oxc-transform)
     name = "dist-esm",
     srcs = [":srcs"],
     declaration = True,

--- a/packages/intl-numberformat/BUILD.bazel
+++ b/packages/intl-numberformat/BUILD.bazel
@@ -1,13 +1,17 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
-load("@aspect_rules_js//js:defs.bzl", "js_binary")
+load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
 load("@rules_multirun//:defs.bzl", "multirun")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile", "ts_run_binary")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_run_binary")
+load("//tools:oxc_transpiler.bzl", "oxc_transpiler")
+load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -105,10 +109,34 @@ TEST_DEPS = SRC_DEPS + [
     "//:node_modules/@types/node",
 ]
 
-ts_compile(
-    name = "dist",
+ts_project(
+    name = "dist-esm-typecheck",
     srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = BASE_TSCONFIG,
     deps = SRC_DEPS,
+)
+
+ts_project(
+    name = "dist-esm",
+    srcs = [":srcs"],
+    declaration = True,
+    declaration_transpiler = oxc_transpiler,
+    resolve_json_module = True,
+    transpiler = oxc_transpiler,
+    tsconfig = BASE_TSCONFIG,
+    deps = SRC_DEPS + ["//:node_modules/oxc-transform"],
+)
+
+js_library(
+    name = "dist",
+    srcs = [
+        "package.json",
+        ":dist-esm",
+    ],
 )
 
 UNIT_TEST_LOCALES = [

--- a/packages/intl-pluralrules/BUILD.bazel
+++ b/packages/intl-pluralrules/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile", "ts_run_binary")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_run_binary")
+load("//tools:oxc_transpiler.bzl", "oxc_transpiler")
+load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -270,10 +275,34 @@ SRC_DEPS = [
     ":node_modules/@formatjs/bigdecimal",
 ]
 
-ts_compile(
-    name = "dist",
+ts_project(
+    name = "dist-esm-typecheck",
     srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = BASE_TSCONFIG,
     deps = SRC_DEPS,
+)
+
+ts_project(
+    name = "dist-esm",
+    srcs = [":srcs"],
+    declaration = True,
+    declaration_transpiler = oxc_transpiler,
+    resolve_json_module = True,
+    transpiler = oxc_transpiler,
+    tsconfig = BASE_TSCONFIG,
+    deps = SRC_DEPS + ["//:node_modules/oxc-transform"],
+)
+
+js_library(
+    name = "dist",
+    srcs = [
+        "package.json",
+        ":dist-esm",
+    ],
 )
 
 vitest(

--- a/packages/intl-pluralrules/BUILD.bazel
+++ b/packages/intl-pluralrules/BUILD.bazel
@@ -276,6 +276,7 @@ SRC_DEPS = [
 ]
 
 ts_project(
+    # Type-check only (tsgo, no emit)
     name = "dist-esm-typecheck",
     srcs = [":srcs"],
     declaration = True,
@@ -287,6 +288,7 @@ ts_project(
 )
 
 ts_project(
+    # Transpile to JS + .d.ts (oxc-transform)
     name = "dist-esm",
     srcs = [":srcs"],
     declaration = True,

--- a/packages/intl-relativetimeformat/BUILD.bazel
+++ b/packages/intl-relativetimeformat/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile", "ts_run_binary")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_run_binary")
+load("//tools:oxc_transpiler.bzl", "oxc_transpiler")
+load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -53,10 +58,34 @@ SRC_DEPS = [
     ":node_modules/@formatjs/intl-localematcher",
 ]
 
-ts_compile(
-    name = "dist",
+ts_project(
+    name = "dist-esm-typecheck",
     srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = BASE_TSCONFIG,
     deps = SRC_DEPS,
+)
+
+ts_project(
+    name = "dist-esm",
+    srcs = [":srcs"],
+    declaration = True,
+    declaration_transpiler = oxc_transpiler,
+    resolve_json_module = True,
+    transpiler = oxc_transpiler,
+    tsconfig = BASE_TSCONFIG,
+    deps = SRC_DEPS + ["//:node_modules/oxc-transform"],
+)
+
+js_library(
+    name = "dist",
+    srcs = [
+        "package.json",
+        ":dist-esm",
+    ],
 )
 
 vitest(

--- a/packages/intl-relativetimeformat/BUILD.bazel
+++ b/packages/intl-relativetimeformat/BUILD.bazel
@@ -59,6 +59,7 @@ SRC_DEPS = [
 ]
 
 ts_project(
+    # Type-check only (tsgo, no emit)
     name = "dist-esm-typecheck",
     srcs = [":srcs"],
     declaration = True,
@@ -70,6 +71,7 @@ ts_project(
 )
 
 ts_project(
+    # Transpile to JS + .d.ts (oxc-transform)
     name = "dist-esm",
     srcs = [":srcs"],
     declaration = True,

--- a/packages/intl-segmenter/BUILD.bazel
+++ b/packages/intl-segmenter/BUILD.bazel
@@ -66,6 +66,7 @@ TESTS = glob([
 ])
 
 ts_project(
+    # Type-check only (tsgo, no emit)
     name = "dist-esm-typecheck",
     srcs = [":srcs"],
     declaration = True,
@@ -77,6 +78,7 @@ ts_project(
 )
 
 ts_project(
+    # Transpile to JS + .d.ts (oxc-transform)
     name = "dist-esm",
     srcs = [":srcs"],
     declaration = True,

--- a/packages/intl-segmenter/BUILD.bazel
+++ b/packages/intl-segmenter/BUILD.bazel
@@ -2,10 +2,15 @@ load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file")
+load("//tools:oxc_transpiler.bzl", "oxc_transpiler")
+load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
 load("//tools:vitest.bzl", "vitest")
 load(":index.bzl", "unicode_file_name")
 
@@ -60,10 +65,34 @@ TESTS = glob([
     "tests/*.test.ts",
 ])
 
-ts_compile(
-    name = "dist",
+ts_project(
+    name = "dist-esm-typecheck",
     srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = BASE_TSCONFIG,
     deps = SRC_DEPS,
+)
+
+ts_project(
+    name = "dist-esm",
+    srcs = [":srcs"],
+    declaration = True,
+    declaration_transpiler = oxc_transpiler,
+    resolve_json_module = True,
+    transpiler = oxc_transpiler,
+    tsconfig = BASE_TSCONFIG,
+    deps = SRC_DEPS + ["//:node_modules/oxc-transform"],
+)
+
+js_library(
+    name = "dist",
+    srcs = [
+        "package.json",
+        ":dist-esm",
+    ],
 )
 
 vitest(

--- a/packages/intl-supportedvaluesof/BUILD.bazel
+++ b/packages/intl-supportedvaluesof/BUILD.bazel
@@ -45,6 +45,7 @@ TESTS = glob([
 ])
 
 ts_project(
+    # Type-check only (tsgo, no emit)
     name = "dist-esm-typecheck",
     srcs = [":srcs"],
     declaration = True,
@@ -56,6 +57,7 @@ ts_project(
 )
 
 ts_project(
+    # Transpile to JS + .d.ts (oxc-transform)
     name = "dist-esm",
     srcs = [":srcs"],
     declaration = True,

--- a/packages/intl-supportedvaluesof/BUILD.bazel
+++ b/packages/intl-supportedvaluesof/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//packages/intl-datetimeformat:defs.bzl", "ZONES")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file")
+load("//tools:oxc_transpiler.bzl", "oxc_transpiler")
+load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -39,10 +44,34 @@ TESTS = glob([
     "tests/*.test.ts",
 ])
 
-ts_compile(
-    name = "dist",
+ts_project(
+    name = "dist-esm-typecheck",
     srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = BASE_TSCONFIG,
     deps = SRC_DEPS,
+)
+
+ts_project(
+    name = "dist-esm",
+    srcs = [":srcs"],
+    declaration = True,
+    declaration_transpiler = oxc_transpiler,
+    resolve_json_module = True,
+    transpiler = oxc_transpiler,
+    tsconfig = BASE_TSCONFIG,
+    deps = SRC_DEPS + ["//:node_modules/oxc-transform"],
+)
+
+js_library(
+    name = "dist",
+    srcs = [
+        "package.json",
+        ":dist-esm",
+    ],
 )
 
 vitest(

--- a/packages/intl/BUILD.bazel
+++ b/packages/intl/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:tsd/package_json.bzl", tsd_bin = "bin")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json")
+load("//tools:oxc_transpiler.bzl", "oxc_transpiler")
+load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -41,10 +46,34 @@ TESTS = glob(
     ],
 )
 
-ts_compile(
-    name = "dist",
+ts_project(
+    name = "dist-esm-typecheck",
     srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = BASE_TSCONFIG,
     deps = SRC_DEPS,
+)
+
+ts_project(
+    name = "dist-esm",
+    srcs = [":srcs"],
+    declaration = True,
+    declaration_transpiler = oxc_transpiler,
+    resolve_json_module = True,
+    transpiler = oxc_transpiler,
+    tsconfig = BASE_TSCONFIG,
+    deps = SRC_DEPS + ["//:node_modules/oxc-transform"],
+)
+
+js_library(
+    name = "dist",
+    srcs = [
+        "package.json",
+        ":dist-esm",
+    ],
 )
 
 vitest(

--- a/packages/intl/BUILD.bazel
+++ b/packages/intl/BUILD.bazel
@@ -47,6 +47,7 @@ TESTS = glob(
 )
 
 ts_project(
+    # Type-check only (tsgo, no emit)
     name = "dist-esm-typecheck",
     srcs = [":srcs"],
     declaration = True,
@@ -58,6 +59,7 @@ ts_project(
 )
 
 ts_project(
+    # Transpile to JS + .d.ts (oxc-transform)
     name = "dist-esm",
     srcs = [":srcs"],
     declaration = True,

--- a/packages/react-intl/BUILD.bazel
+++ b/packages/react-intl/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:tsd/package_json.bzl", tsd_bin = "bin")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json")
+load("//tools:oxc_transpiler.bzl", "oxc_transpiler")
+load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -55,10 +60,34 @@ TEST_DEPS = SRC_DEPS + [
     "//:node_modules/typescript",
 ]
 
-ts_compile(
-    name = "dist",
+ts_project(
+    name = "dist-esm-typecheck",
     srcs = SRCS,
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = BASE_TSCONFIG,
     deps = SRC_DEPS,
+)
+
+ts_project(
+    name = "dist-esm",
+    srcs = SRCS,
+    declaration = True,
+    declaration_transpiler = oxc_transpiler,
+    resolve_json_module = True,
+    transpiler = oxc_transpiler,
+    tsconfig = BASE_TSCONFIG,
+    deps = SRC_DEPS + ["//:node_modules/oxc-transform"],
+)
+
+js_library(
+    name = "dist",
+    srcs = [
+        "package.json",
+        ":dist-esm",
+    ],
 )
 
 esbuild(

--- a/packages/react-intl/BUILD.bazel
+++ b/packages/react-intl/BUILD.bazel
@@ -61,6 +61,7 @@ TEST_DEPS = SRC_DEPS + [
 ]
 
 ts_project(
+    # Type-check only (tsgo, no emit)
     name = "dist-esm-typecheck",
     srcs = SRCS,
     declaration = True,
@@ -72,6 +73,7 @@ ts_project(
 )
 
 ts_project(
+    # Transpile to JS + .d.ts (oxc-transform)
     name = "dist-esm",
     srcs = SRCS,
     declaration = True,

--- a/packages/svelte-intl/BUILD.bazel
+++ b/packages/svelte-intl/BUILD.bazel
@@ -1,7 +1,11 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "ts_compile_node")
+load("//tools:oxc_transpiler.bzl", "oxc_transpiler")
+load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -28,10 +32,34 @@ SRC_DEPS = [
     ":node_modules/@formatjs/icu-messageformat-parser",
 ]
 
-ts_compile_node(
-    name = "dist",
+ts_project(
+    name = "dist-esm-esnext-typecheck",
     srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = ESNEXT_TSCONFIG,
     deps = SRC_DEPS,
+)
+
+ts_project(
+    name = "dist-esm-esnext",
+    srcs = [":srcs"],
+    declaration = True,
+    declaration_transpiler = oxc_transpiler,
+    resolve_json_module = True,
+    transpiler = oxc_transpiler,
+    tsconfig = ESNEXT_TSCONFIG,
+    deps = SRC_DEPS + ["//:node_modules/oxc-transform"],
+)
+
+js_library(
+    name = "dist",
+    srcs = [
+        "package.json",
+        ":dist-esm-esnext",
+    ],
 )
 
 vitest(

--- a/packages/svelte-intl/BUILD.bazel
+++ b/packages/svelte-intl/BUILD.bazel
@@ -33,6 +33,7 @@ SRC_DEPS = [
 ]
 
 ts_project(
+    # Type-check only (tsgo, no emit)
     name = "dist-esm-esnext-typecheck",
     srcs = [":srcs"],
     declaration = True,
@@ -44,6 +45,7 @@ ts_project(
 )
 
 ts_project(
+    # Transpile to JS + .d.ts (oxc-transform)
     name = "dist-esm-esnext",
     srcs = [":srcs"],
     declaration = True,

--- a/packages/ts-transformer/BUILD.bazel
+++ b/packages/ts-transformer/BUILD.bazel
@@ -55,6 +55,7 @@ SRC_DEPS = [
 ]
 
 ts_project(
+    # Type-check only (tsgo, no emit)
     name = "dist-esm-esnext-typecheck",
     srcs = [":srcs"],
     declaration = True,
@@ -66,6 +67,7 @@ ts_project(
 )
 
 ts_project(
+    # Transpile to JS + .d.ts (oxc-transform)
     name = "dist-esm-esnext",
     srcs = [":srcs"],
     declaration = True,

--- a/packages/ts-transformer/BUILD.bazel
+++ b/packages/ts-transformer/BUILD.bazel
@@ -1,8 +1,13 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "ts_compile_node")
+load("//tools:index.bzl", "generate_ide_tsconfig_json")
+load("//tools:oxc_transpiler.bzl", "oxc_transpiler")
+load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -49,10 +54,34 @@ SRC_DEPS = [
     "//:node_modules/typescript",
 ]
 
-ts_compile_node(
-    name = "dist",
+ts_project(
+    name = "dist-esm-esnext-typecheck",
     srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = ESNEXT_TSCONFIG,
     deps = SRC_DEPS,
+)
+
+ts_project(
+    name = "dist-esm-esnext",
+    srcs = [":srcs"],
+    declaration = True,
+    declaration_transpiler = oxc_transpiler,
+    resolve_json_module = True,
+    transpiler = oxc_transpiler,
+    tsconfig = ESNEXT_TSCONFIG,
+    deps = SRC_DEPS + ["//:node_modules/oxc-transform"],
+)
+
+js_library(
+    name = "dist",
+    srcs = [
+        "package.json",
+        ":dist-esm-esnext",
+    ],
 )
 
 vitest(

--- a/packages/unplugin/BUILD.bazel
+++ b/packages/unplugin/BUILD.bazel
@@ -43,9 +43,9 @@ SRC_DEPS = [
     "//:node_modules/vite",
 ]
 
-# Type check only with tsgo (fast, parallel)
 # Uses skipLibCheck because unplugin's .d.ts imports types from many optional peer deps
 ts_project(
+    # Type-check only (tsgo, no emit)
     name = "dist-esm-esnext-typecheck",
     srcs = [":srcs"],
     declaration = True,
@@ -56,8 +56,8 @@ ts_project(
     deps = SRC_DEPS,
 )
 
-# Transpile with oxc-transform (fast JS and .d.ts generation)
 ts_project(
+    # Transpile to JS + .d.ts (oxc-transform)
     name = "dist-esm-esnext",
     srcs = [":srcs"],
     declaration = True,

--- a/packages/utils/BUILD.bazel
+++ b/packages/utils/BUILD.bazel
@@ -44,6 +44,7 @@ SRC_DEPS = [
 ]
 
 ts_project(
+    # Type-check only (tsgo, no emit)
     name = "dist-esm-typecheck",
     srcs = [":srcs"],
     declaration = True,
@@ -55,6 +56,7 @@ ts_project(
 )
 
 ts_project(
+    # Transpile to JS + .d.ts (oxc-transform)
     name = "dist-esm",
     srcs = [":srcs"],
     declaration = True,

--- a/packages/utils/BUILD.bazel
+++ b/packages/utils/BUILD.bazel
@@ -1,9 +1,14 @@
 load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file")
+load("//tools:oxc_transpiler.bzl", "oxc_transpiler")
+load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -38,10 +43,34 @@ SRC_DEPS = [
     ":node_modules/@formatjs/fast-memoize",
 ]
 
-ts_compile(
-    name = "dist",
+ts_project(
+    name = "dist-esm-typecheck",
     srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = BASE_TSCONFIG,
     deps = SRC_DEPS,
+)
+
+ts_project(
+    name = "dist-esm",
+    srcs = [":srcs"],
+    declaration = True,
+    declaration_transpiler = oxc_transpiler,
+    resolve_json_module = True,
+    transpiler = oxc_transpiler,
+    tsconfig = BASE_TSCONFIG,
+    deps = SRC_DEPS + ["//:node_modules/oxc-transform"],
+)
+
+js_library(
+    name = "dist",
+    srcs = [
+        "package.json",
+        ":dist-esm",
+    ],
 )
 
 # Generate tsconfig.json with correct extends path

--- a/packages/vue-intl/BUILD.bazel
+++ b/packages/vue-intl/BUILD.bazel
@@ -1,7 +1,11 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "ts_compile_node")
+load("//tools:oxc_transpiler.bzl", "oxc_transpiler")
+load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -28,10 +32,34 @@ SRC_DEPS = [
     ":node_modules/@formatjs/icu-messageformat-parser",
 ]
 
-ts_compile_node(
-    name = "dist",
+ts_project(
+    name = "dist-esm-esnext-typecheck",
     srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = ESNEXT_TSCONFIG,
     deps = SRC_DEPS,
+)
+
+ts_project(
+    name = "dist-esm-esnext",
+    srcs = [":srcs"],
+    declaration = True,
+    declaration_transpiler = oxc_transpiler,
+    resolve_json_module = True,
+    transpiler = oxc_transpiler,
+    tsconfig = ESNEXT_TSCONFIG,
+    deps = SRC_DEPS + ["//:node_modules/oxc-transform"],
+)
+
+js_library(
+    name = "dist",
+    srcs = [
+        "package.json",
+        ":dist-esm-esnext",
+    ],
 )
 
 vitest(

--- a/packages/vue-intl/BUILD.bazel
+++ b/packages/vue-intl/BUILD.bazel
@@ -33,6 +33,7 @@ SRC_DEPS = [
 ]
 
 ts_project(
+    # Type-check only (tsgo, no emit)
     name = "dist-esm-esnext-typecheck",
     srcs = [":srcs"],
     declaration = True,
@@ -44,6 +45,7 @@ ts_project(
 )
 
 ts_project(
+    # Transpile to JS + .d.ts (oxc-transform)
     name = "dist-esm-esnext",
     srcs = [":srcs"],
     declaration = True,


### PR DESCRIPTION
## Summary

Gazelle migration phases 2 and 3: decompose all custom macros (`ts_compile`, `ts_compile_node`, `vitest`) into explicit `ts_project` + `js_library` / `vitest_runner` targets. This makes all `ts_project` targets visible at the BUILD file level — the prerequisite for gazelle to manage `deps` by reading TypeScript imports.

### Phase 2: Decompose `ts_compile` / `ts_compile_node`

Each macro call expanded to 3 explicit targets:

```python
ts_project(
    # Type-check only (tsgo, no emit)
    name = "dist-esm-typecheck", ...
)
ts_project(
    # Transpile to JS + .d.ts (oxc-transform)
    name = "dist-esm", ...
)
js_library(name = "dist", srcs = [":dist-esm", "package.json"])
```

- 21 `ts_compile` packages (BASE_TSCONFIG) + 1 custom (BASE_NODE_TSCONFIG)
- 7 `ts_compile_node` packages (ESNEXT_TSCONFIG)
- **29 BUILD.bazel files** modified

### Phase 3: Decompose `vitest`

Created `vitest_runner` macro in `tools/vitest.bzl` (test runner + snapshots only, no ts_project). Inlined `ts_project` typecheck into BUILD files:

```python
ts_project(
    # Type-check only (tsgo, no emit)
    name = "unit_test_typecheck",
    deps = SRC_DEPS + VITEST_DEPS, ...
)
vitest_runner(name = "unit_test", srcs = ..., deps = ...)
```

- Exported `TEST_TSCONFIG`, `VITEST_DEPS`, `VITEST_DOM_DEPS` from `vitest.bzl`
- **40 vitest calls** across **34 BUILD.bazel files** migrated
- Old `vitest` macro kept as deprecated wrapper for backwards compatibility

### What's NOT changed (Phase 4)

- `npm_package`, `esbuild`, `generate_src_file`, `generate_ide_tsconfig_json` — packaging/codegen stays manual
- `tools/index.bzl` — old macros remain for reference

## Test plan
- [x] `pnpm t` — all 495 tests pass
- [x] All lefthook hooks pass (buildifier, gazelle 0 files updated)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)