### PR TITLE
chore: add #packages/* path alias to generated tsconfigs

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -69,7 +69,7 @@ bazel_dep(name = "aspect_rules_ts", version = "3.8.7")
 
 rules_ts_ext = use_extension("@aspect_rules_ts//ts:extensions.bzl", "ext", dev_dependency = True)
 rules_ts_ext.deps(
-    ts_integrity = "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+    ts_integrity = "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
     ts_version_from = "//:package.json",
 )
 use_repo(rules_ts_ext, "npm_typescript")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -398,11 +398,11 @@
     "@@aspect_rules_ts+//ts:extensions.bzl%ext": {
       "general": {
         "bzlTransitiveDigest": "mgipZzBrc3b7BdA8UsakMd4W6/9h6+GDAUZpx2grCJ4=",
-        "usagesDigest": "Poc6aR0RvidJ/IlCHO+XuhdTUb8PcIKz/zhczsNKsEc=",
+        "usagesDigest": "HMmnOypE3Tj+GItyJdCrFcUM7+x2KPyeTv0JzIFDnwY=",
         "recordedInputs": [
           "REPO_MAPPING:aspect_rules_ts+,aspect_rules_ts aspect_rules_ts+",
           "REPO_MAPPING:aspect_rules_ts+,bazel_tools bazel_tools",
-          "FILE:@@//package.json 33f628fd1af26e9cf29b160090917c3914cbcbb66af8447b1d3d430749a7a016"
+          "FILE:@@//package.json edc6abdb7665dc09cd62fd097c7c9c065f79500ce7265ddfe152b82061b1e28c"
         ],
         "generatedRepoSpecs": {
           "npm_typescript": {
@@ -1065,7 +1065,7 @@
           "FILE:@@//Cargo.lock b25f6e198c91b5282f93a5c62a3a799917ec7c2f6a03b0488948c4328d6c1c93",
           "FILE:@@//Cargo.toml 4e0e0629ddbf521db0ad31e9ad8cd8805f29b141f7edaaa560af34e5f325f882",
           "FILE:@@rules_rust++rust_host_tools+rust_host_tools//rust_host_tools ENOENT",
-          "FILE:@@//MODULE.bazel b3c52aebfef9abc70f79ec1e3d9c6cb314c360814024c8db82e000c79a4b6e32",
+          "FILE:@@//MODULE.bazel 3f46a8196391cf91ceb155ae04c234b0240c160845b570e125dd740ee1154034",
           "FILE:@@//crates/icu_skeleton_parser/Cargo.toml eac4ca44b47b0fde5ae7f4afcdb6e7d4951eac75eb44db7349b2ba912a9840da",
           "FILE:@@//crates/icu_messageformat_parser/Cargo.toml 1c2096e9a8853568596e65ebbb56af73feef324883c36b9fec7fa2ab7a7621ed",
           "FILE:@@//crates/formatjs_cli/Cargo.toml aec7493b4f9b37ec1d2ee32c7a60814c0e8c0823b0a5596bd69f8400c857b033",

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,5 +1,8 @@
-// @generated
 {
-  // This is purely for IDE, not for compilation
+  "compilerOptions": {
+    "paths": {
+      "#packages/*": ["../packages/*"]
+    }
+  },
   "extends": "../tsconfig.json"
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "version": "1.0.0",
   "author": "Long Ho <holevietlong@gmail.com>",
   "private": true,
+  "imports": {
+    "#packages/*": "./packages/*"
+  },
   "scripts": {
     "build": "bazel build //...",
     "examples": "bazel run //packages/react-intl/examples",

--- a/packages/babel-plugin-formatjs/tsconfig.json
+++ b/packages/babel-plugin-formatjs/tsconfig.json
@@ -1,5 +1,8 @@
-// @generated
 {
-  // This is purely for IDE, not for compilation
+  "compilerOptions": {
+    "paths": {
+      "#packages/*": ["../../packages/*"]
+    }
+  },
   "extends": "../../tsconfig.json"
 }

--- a/packages/bigdecimal/tsconfig.json
+++ b/packages/bigdecimal/tsconfig.json
@@ -1,5 +1,8 @@
-// @generated
 {
-  // This is purely for IDE, not for compilation
+  "compilerOptions": {
+    "paths": {
+      "#packages/*": ["../../packages/*"]
+    }
+  },
   "extends": "../../tsconfig.json"
 }

--- a/packages/cli-lib/tsconfig.json
+++ b/packages/cli-lib/tsconfig.json
@@ -1,5 +1,8 @@
-// @generated
 {
-  // This is purely for IDE, not for compilation
+  "compilerOptions": {
+    "paths": {
+      "#packages/*": ["../../packages/*"]
+    }
+  },
   "extends": "../../tsconfig.json"
 }

--- a/packages/ecma376/tsconfig.json
+++ b/packages/ecma376/tsconfig.json
@@ -1,5 +1,8 @@
-// @generated
 {
-  // This is purely for IDE, not for compilation
+  "compilerOptions": {
+    "paths": {
+      "#packages/*": ["../../packages/*"]
+    }
+  },
   "extends": "../../tsconfig.json"
 }

--- a/packages/ecma402-abstract/tsconfig.json
+++ b/packages/ecma402-abstract/tsconfig.json
@@ -1,5 +1,8 @@
-// @generated
 {
-  // This is purely for IDE, not for compilation
+  "compilerOptions": {
+    "paths": {
+      "#packages/*": ["../../packages/*"]
+    }
+  },
   "extends": "../../tsconfig.json"
 }

--- a/packages/editor/tsconfig.json
+++ b/packages/editor/tsconfig.json
@@ -1,5 +1,8 @@
-// @generated
 {
-  // This is purely for IDE, not for compilation
+  "compilerOptions": {
+    "paths": {
+      "#packages/*": ["../../packages/*"]
+    }
+  },
   "extends": "../../tsconfig.json"
 }

--- a/packages/eslint-plugin-formatjs/tsconfig.json
+++ b/packages/eslint-plugin-formatjs/tsconfig.json
@@ -1,5 +1,8 @@
-// @generated
 {
-  // This is purely for IDE, not for compilation
+  "compilerOptions": {
+    "paths": {
+      "#packages/*": ["../../packages/*"]
+    }
+  },
   "extends": "../../tsconfig.json"
 }

--- a/packages/fast-memoize/tsconfig.json
+++ b/packages/fast-memoize/tsconfig.json
@@ -1,5 +1,8 @@
-// @generated
 {
-  // This is purely for IDE, not for compilation
+  "compilerOptions": {
+    "paths": {
+      "#packages/*": ["../../packages/*"]
+    }
+  },
   "extends": "../../tsconfig.json"
 }

--- a/packages/icu-messageformat-parser-wasm/tsconfig.json
+++ b/packages/icu-messageformat-parser-wasm/tsconfig.json
@@ -1,5 +1,8 @@
-// @generated
 {
-  // This is purely for IDE, not for compilation
+  "compilerOptions": {
+    "paths": {
+      "#packages/*": ["../../packages/*"]
+    }
+  },
   "extends": "../../tsconfig.json"
 }

--- a/packages/icu-messageformat-parser/tsconfig.json
+++ b/packages/icu-messageformat-parser/tsconfig.json
@@ -1,5 +1,8 @@
-// @generated
 {
-  // This is purely for IDE, not for compilation
+  "compilerOptions": {
+    "paths": {
+      "#packages/*": ["../../packages/*"]
+    }
+  },
   "extends": "../../tsconfig.json"
 }

--- a/packages/icu-skeleton-parser/tsconfig.json
+++ b/packages/icu-skeleton-parser/tsconfig.json
@@ -1,5 +1,8 @@
-// @generated
 {
-  // This is purely for IDE, not for compilation
+  "compilerOptions": {
+    "paths": {
+      "#packages/*": ["../../packages/*"]
+    }
+  },
   "extends": "../../tsconfig.json"
 }

--- a/packages/intl-datetimeformat/tsconfig.json
+++ b/packages/intl-datetimeformat/tsconfig.json
@@ -1,5 +1,8 @@
-// @generated
 {
-  // This is purely for IDE, not for compilation
+  "compilerOptions": {
+    "paths": {
+      "#packages/*": ["../../packages/*"]
+    }
+  },
   "extends": "../../tsconfig.json"
 }

--- a/packages/intl-displaynames/tsconfig.json
+++ b/packages/intl-displaynames/tsconfig.json
@@ -1,5 +1,8 @@
-// @generated
 {
-  // This is purely for IDE, not for compilation
+  "compilerOptions": {
+    "paths": {
+      "#packages/*": ["../../packages/*"]
+    }
+  },
   "extends": "../../tsconfig.json"
 }

--- a/packages/intl-durationformat/tsconfig.json
+++ b/packages/intl-durationformat/tsconfig.json
@@ -1,5 +1,8 @@
-// @generated
 {
-  // This is purely for IDE, not for compilation
+  "compilerOptions": {
+    "paths": {
+      "#packages/*": ["../../packages/*"]
+    }
+  },
   "extends": "../../tsconfig.json"
 }

--- a/packages/intl-getcanonicallocales/tsconfig.json
+++ b/packages/intl-getcanonicallocales/tsconfig.json
@@ -1,5 +1,8 @@
-// @generated
 {
-  // This is purely for IDE, not for compilation
+  "compilerOptions": {
+    "paths": {
+      "#packages/*": ["../../packages/*"]
+    }
+  },
   "extends": "../../tsconfig.json"
 }

--- a/packages/intl-listformat/tsconfig.json
+++ b/packages/intl-listformat/tsconfig.json
@@ -1,5 +1,8 @@
-// @generated
 {
-  // This is purely for IDE, not for compilation
+  "compilerOptions": {
+    "paths": {
+      "#packages/*": ["../../packages/*"]
+    }
+  },
   "extends": "../../tsconfig.json"
 }

--- a/packages/intl-locale/tsconfig.json
+++ b/packages/intl-locale/tsconfig.json
@@ -1,5 +1,8 @@
-// @generated
 {
-  // This is purely for IDE, not for compilation
+  "compilerOptions": {
+    "paths": {
+      "#packages/*": ["../../packages/*"]
+    }
+  },
   "extends": "../../tsconfig.json"
 }

--- a/packages/intl-localematcher/tsconfig.json
+++ b/packages/intl-localematcher/tsconfig.json
@@ -1,5 +1,8 @@
-// @generated
 {
-  // This is purely for IDE, not for compilation
+  "compilerOptions": {
+    "paths": {
+      "#packages/*": ["../../packages/*"]
+    }
+  },
   "extends": "../../tsconfig.json"
 }

--- a/packages/intl-messageformat/tsconfig.json
+++ b/packages/intl-messageformat/tsconfig.json
@@ -1,5 +1,8 @@
-// @generated
 {
-  // This is purely for IDE, not for compilation
+  "compilerOptions": {
+    "paths": {
+      "#packages/*": ["../../packages/*"]
+    }
+  },
   "extends": "../../tsconfig.json"
 }

--- a/packages/intl-numberformat/tsconfig.json
+++ b/packages/intl-numberformat/tsconfig.json
@@ -1,5 +1,8 @@
-// @generated
 {
-  // This is purely for IDE, not for compilation
+  "compilerOptions": {
+    "paths": {
+      "#packages/*": ["../../packages/*"]
+    }
+  },
   "extends": "../../tsconfig.json"
 }

--- a/packages/intl-pluralrules/tsconfig.json
+++ b/packages/intl-pluralrules/tsconfig.json
@@ -1,5 +1,8 @@
-// @generated
 {
-  // This is purely for IDE, not for compilation
+  "compilerOptions": {
+    "paths": {
+      "#packages/*": ["../../packages/*"]
+    }
+  },
   "extends": "../../tsconfig.json"
 }

--- a/packages/intl-relativetimeformat/tsconfig.json
+++ b/packages/intl-relativetimeformat/tsconfig.json
@@ -1,5 +1,8 @@
-// @generated
 {
-  // This is purely for IDE, not for compilation
+  "compilerOptions": {
+    "paths": {
+      "#packages/*": ["../../packages/*"]
+    }
+  },
   "extends": "../../tsconfig.json"
 }

--- a/packages/intl-segmenter/tsconfig.json
+++ b/packages/intl-segmenter/tsconfig.json
@@ -1,5 +1,8 @@
-// @generated
 {
-  // This is purely for IDE, not for compilation
+  "compilerOptions": {
+    "paths": {
+      "#packages/*": ["../../packages/*"]
+    }
+  },
   "extends": "../../tsconfig.json"
 }

--- a/packages/intl-supportedvaluesof/tsconfig.json
+++ b/packages/intl-supportedvaluesof/tsconfig.json
@@ -1,5 +1,8 @@
-// @generated
 {
-  // This is purely for IDE, not for compilation
+  "compilerOptions": {
+    "paths": {
+      "#packages/*": ["../../packages/*"]
+    }
+  },
   "extends": "../../tsconfig.json"
 }

--- a/packages/intl/tsconfig.json
+++ b/packages/intl/tsconfig.json
@@ -1,5 +1,8 @@
-// @generated
 {
-  // This is purely for IDE, not for compilation
+  "compilerOptions": {
+    "paths": {
+      "#packages/*": ["../../packages/*"]
+    }
+  },
   "extends": "../../tsconfig.json"
 }

--- a/packages/react-intl/tsconfig.json
+++ b/packages/react-intl/tsconfig.json
@@ -1,5 +1,8 @@
-// @generated
 {
-  // This is purely for IDE, not for compilation
+  "compilerOptions": {
+    "paths": {
+      "#packages/*": ["../../packages/*"]
+    }
+  },
   "extends": "../../tsconfig.json"
 }

--- a/packages/svelte-intl/tsconfig.json
+++ b/packages/svelte-intl/tsconfig.json
@@ -1,6 +1,8 @@
 {
-  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "lib": ["dom", "ES2020", "ESNext.Intl"]
-  }
+    "paths": {
+      "#packages/*": ["../../packages/*"]
+    }
+  },
+  "extends": "../../tsconfig.json"
 }

--- a/packages/ts-transformer/tsconfig.json
+++ b/packages/ts-transformer/tsconfig.json
@@ -1,5 +1,8 @@
-// @generated
 {
-  // This is purely for IDE, not for compilation
+  "compilerOptions": {
+    "paths": {
+      "#packages/*": ["../../packages/*"]
+    }
+  },
   "extends": "../../tsconfig.json"
 }

--- a/packages/unplugin/tsconfig.json
+++ b/packages/unplugin/tsconfig.json
@@ -1,5 +1,8 @@
-// @generated
 {
-  // This is purely for IDE, not for compilation
+  "compilerOptions": {
+    "paths": {
+      "#packages/*": ["../../packages/*"]
+    }
+  },
   "extends": "../../tsconfig.json"
 }

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -1,5 +1,8 @@
-// @generated
 {
-  // This is purely for IDE, not for compilation
+  "compilerOptions": {
+    "paths": {
+      "#packages/*": ["../../packages/*"]
+    }
+  },
   "extends": "../../tsconfig.json"
 }

--- a/packages/vue-intl/tsconfig.json
+++ b/packages/vue-intl/tsconfig.json
@@ -1,6 +1,8 @@
 {
-  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "lib": ["dom", "ES2020", "ESNext.Intl"]
-  }
+    "paths": {
+      "#packages/*": ["../../packages/*"]
+    }
+  },
+  "extends": "../../tsconfig.json"
 }

--- a/tools/index.bzl
+++ b/tools/index.bzl
@@ -239,7 +239,8 @@ def generate_ide_tsconfig_json(name = "tsconfig_json"):
     """Generate a tsconfig.json file with the correct extends path based on package depth.
 
     This macro calculates the correct relative path to the root tsconfig.json
-    based on the package's location in the repository.
+    based on the package's location in the repository. It also generates
+    path aliases so that #packages/* imports resolve correctly at any depth.
 
     Args:
         name: target name (default: "tsconfig_json")
@@ -250,26 +251,39 @@ def generate_ide_tsconfig_json(name = "tsconfig_json"):
     # Empty string (root) = 0, "docs" = 1, "packages/foo" = 2
     depth = len(package.split("/")) if package else 0
 
-    # Generate the extends path: one "../" per level to reach root
-    # For packages/foo (depth=2): ../../tsconfig.json
-    # For docs (depth=1): ../tsconfig.json
-    extends_path = ("../" * depth) + "tsconfig.json"
+    # Generate the relative path to repo root: one "../" per level
+    # For packages/foo (depth=2): ../..
+    # For packages/foo/scripts (depth=3): ../../..
+    relative_to_root = "/".join([".."] * depth) if depth else "."
 
-    # Create tsconfig as a dict
+    extends_path = relative_to_root + "/tsconfig.json"
+
+    # Build tsconfig with paths for #packages/* alias
+    # Maps #packages/* to the packages/ directory relative to this tsconfig
     tsconfig = {
         "extends": extends_path,
+        "compilerOptions": {
+            "paths": {
+                "#packages/*": [relative_to_root + "/packages/*"],
+            },
+        },
     }
 
-    # Encode to JSON
-    json_content = json.encode_indent(tsconfig, indent = "  ")
+    content = json.encode_indent(tsconfig, indent = "  ")
 
-    # Add comment header
-    content = "// @generated\n{\n  // This is purely for IDE, not for compilation\n  \"extends\": \"%s\"\n}\n" % extends_path
+    tmp_name = name + "_unformatted"
+    native.genrule(
+        name = tmp_name,
+        outs = [tmp_name + ".json"],
+        cmd = "cat > $@ << 'EOF'\n%s\nEOF" % content,
+    )
 
     native.genrule(
         name = name + "_generated",
+        srcs = [tmp_name + ".json"],
         outs = [name + ".generated.json"],
-        cmd = "printf '%s' > $@" % content,
+        cmd = "$(location //:oxfmt) --stdin-filepath=$< < $< > $@",
+        tools = ["//:oxfmt"],
     )
 
     write_source_files(


### PR DESCRIPTION
## Summary
- Updated `generate_ide_tsconfig_json` macro to emit `compilerOptions.paths` mapping `#packages/*` to `packages/` relative to each tsconfig's depth
- Added `"imports": { "#packages/*": "./packages/*" }` to root `package.json` for Node runtime resolution
- Generated output is piped through oxfmt to match checked-in formatting
- Regenerated all tsconfig.json files

Enables absolute imports like:
```ts
import { type Formats } from '#packages/ecma402-abstract/src/types.ts'
```
instead of fragile relative paths like `../src/types.ts`. The depth calculation ensures correct resolution at any nesting level.

## Test plan
- [x] All Bazel tests pass
- [x] `tsconfig_json_test` targets pass (generated matches checked-in)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)