### PR TITLE
chore: add composite project support to tsconfig generation

### DIFF
--- a/packages/ecma402-abstract/BUILD.bazel
+++ b/packages/ecma402-abstract/BUILD.bazel
@@ -51,7 +51,9 @@ vitest(
 )
 
 # Generate tsconfig.json with correct extends path
-generate_ide_tsconfig_json()
+generate_ide_tsconfig_json(
+    composite = True,
+)
 
 # digit-mapping
 generate_src_file(

--- a/packages/ecma402-abstract/tsconfig.json
+++ b/packages/ecma402-abstract/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "composite": true,
     "paths": {
       "#packages/*": ["../../packages/*"]
     }

--- a/packages/intl-locale/BUILD.bazel
+++ b/packages/intl-locale/BUILD.bazel
@@ -82,7 +82,11 @@ test262_harness_bin.test262_harness_test(
 )
 
 # Generate tsconfig.json with correct extends path
-generate_ide_tsconfig_json()
+generate_ide_tsconfig_json(
+    project_references = [
+        "//packages/ecma402-abstract",
+    ],
+)
 
 esbuild(
     name = "polyfill.iife",

--- a/packages/intl-locale/tsconfig.json
+++ b/packages/intl-locale/tsconfig.json
@@ -4,5 +4,10 @@
       "#packages/*": ["../../packages/*"]
     }
   },
-  "extends": "../../tsconfig.json"
+  "extends": "../../tsconfig.json",
+  "references": [
+    {
+      "path": "../ecma402-abstract/tsconfig.json"
+    }
+  ]
 }

--- a/tools/index.bzl
+++ b/tools/index.bzl
@@ -235,7 +235,33 @@ def generate_src_file(name, src, entry_point = None, tool = None, chdir = None, 
         tags = tags + ["codegen"],
     )
 
-def generate_ide_tsconfig_json(name = "tsconfig_json"):
+def _relative_path(target, start):
+    """Compute the relative path from start directory to target directory.
+
+    Args:
+        target: target directory path (e.g. "packages/ecma402-abstract")
+        start: start directory path (e.g. "packages/intl-locale")
+
+    Returns:
+        Relative path string (e.g. "../ecma402-abstract")
+    """
+    t_pieces = target.split("/")
+    s_pieces = start.split("/")
+    common_len = 0
+
+    for tp, sp in zip(t_pieces, s_pieces):
+        if tp == sp:
+            common_len += 1
+        else:
+            break
+
+    result = [".."] * (len(s_pieces) - common_len) + t_pieces[common_len:]
+    path = "/".join(result) if result else "."
+    if not path.startswith("."):
+        path = "./" + path
+    return path
+
+def generate_ide_tsconfig_json(name = "tsconfig_json", composite = False, project_references = []):
     """Generate a tsconfig.json file with the correct extends path based on package depth.
 
     This macro calculates the correct relative path to the root tsconfig.json
@@ -244,6 +270,8 @@ def generate_ide_tsconfig_json(name = "tsconfig_json"):
 
     Args:
         name: target name (default: "tsconfig_json")
+        composite: whether to enable TypeScript composite projects (default: False)
+        project_references: list of Bazel package labels to reference (e.g. ["//packages/ecma402-abstract"])
     """
     package = native.package_name()
 
@@ -258,16 +286,29 @@ def generate_ide_tsconfig_json(name = "tsconfig_json"):
 
     extends_path = relative_to_root + "/tsconfig.json"
 
-    # Build tsconfig with paths for #packages/* alias
-    # Maps #packages/* to the packages/ directory relative to this tsconfig
-    tsconfig = {
-        "extends": extends_path,
-        "compilerOptions": {
-            "paths": {
-                "#packages/*": [relative_to_root + "/packages/*"],
-            },
+    compiler_options = {
+        "paths": {
+            "#packages/*": [relative_to_root + "/packages/*"],
         },
     }
+
+    if composite:
+        compiler_options["composite"] = True
+
+    # Build tsconfig
+    tsconfig = {
+        "extends": extends_path,
+        "compilerOptions": compiler_options,
+    }
+
+    # Convert project_references (Bazel labels) to relative tsconfig paths
+    if project_references:
+        refs = []
+        for ref in project_references:
+            ref_path = ref.lstrip("/")
+            relative = _relative_path(ref_path, package)
+            refs.append({"path": relative + "/tsconfig.json"})
+        tsconfig["references"] = refs
 
     content = json.encode_indent(tsconfig, indent = "  ")
 


### PR DESCRIPTION
## Summary
- Add `composite` and `project_references` params to `generate_ide_tsconfig_json` macro
- Add `_relative_path()` helper to convert Bazel labels to relative tsconfig paths
- `ecma402-abstract`: `composite = True` (referenced by other packages)
- `intl-locale`: `project_references = ["//packages/ecma402-abstract"]` (leaf node, no composite needed)

This enables intl-locale to import from ecma402-abstract via `#packages/ecma402-abstract/...` with full IDE type checking across project boundaries. Other packages can be migrated incrementally.

## Test plan
- [x] All 495 Bazel tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)