### PR TITLE
fix(icu-messageformat-parser): use Map.has() instead of in operator in collectVariables

### DIFF
--- a/packages/icu-messageformat-parser/manipulator.ts
+++ b/packages/icu-messageformat-parser/manipulator.ts
@@ -172,6 +172,9 @@ function collectVariables(
       isTimeElement(el) ||
       isNumberElement(el)
     ) {
+      if (vars.has(el.value) && vars.get(el.value) !== el.type) {
+        throw new Error(`Variable ${el.value} has conflicting types`)
+      }
       vars.set(el.value, el.type)
     }
 

--- a/packages/icu-messageformat-parser/manipulator.ts
+++ b/packages/icu-messageformat-parser/manipulator.ts
@@ -172,9 +172,6 @@ function collectVariables(
       isTimeElement(el) ||
       isNumberElement(el)
     ) {
-      if (el.value in vars && vars.get(el.value) !== el.type) {
-        throw new Error(`Variable ${el.value} has conflicting types`)
-      }
       vars.set(el.value, el.type)
     }
 

--- a/packages/icu-messageformat-parser/tests/manipulator.test.ts
+++ b/packages/icu-messageformat-parser/tests/manipulator.test.ts
@@ -112,6 +112,34 @@ test('structurally same literal', function () {
   )
 })
 
+// https://github.com/formatjs/formatjs/issues/6212
+test('GH #6212: variable names matching Map prototype properties should not conflict', function () {
+  // 'size' and 'entries' are properties on Map.prototype.
+  // Using `in` operator instead of `Map.has()` caused false positives.
+  expect(
+    isStructurallySame(parse('{size} m²'), parse('{date} · {size}'))
+  ).toEqual({
+    success: false,
+    error: new Error(
+      'Different number of variables: [size] vs [date, size]'
+    ),
+  })
+
+  // Same variables — should succeed without "conflicting types" error
+  expect(
+    isStructurallySame(parse('{size} m²'), parse('{size} sq ft'))
+  ).toEqual({
+    success: true,
+  })
+
+  // 'entries' is also a Map prototype property
+  expect(
+    isStructurallySame(parse('{entries} items'), parse('{entries} records'))
+  ).toEqual({
+    success: true,
+  })
+})
+
 // https://github.com/formatjs/formatjs/issues/4202
 test('GH #4202: multiple plurals with hash placeholders', function () {
   const input =


### PR DESCRIPTION
### What

Fixes #6212

### Problem

In `collectVariables()`, the check `el.value in vars` uses the `in` operator on a `Map` object. The `in` operator checks the **entire prototype chain**, so ICU variable names like `size`, `entries`, `get`, `set`, `has`, `delete`, `clear`, `forEach`, and `keys` falsely match `Map.prototype` properties. This causes a spurious `Variable {name} has conflicting types` error even when no conflict exists.

### Root Cause

```ts
// Before (buggy): 'in' checks prototype chain
if (el.value in vars && vars.get(el.value) !== el.type) {
```

For example, `'size' in new Map()` returns `true` because `Map.prototype.size` exists as a getter.

### Fix

```ts
// After: .has() only checks the Map's own entries
if (vars.has(el.value) && vars.get(el.value) !== el.type) {
```

Also added a regression test covering variable names that collide with `Map` prototype properties.