### PR TITLE
chore: add esbuild bundling to all polyfill packages

### DIFF
--- a/packages/intl-datetimeformat/BUILD.bazel
+++ b/packages/intl-datetimeformat/BUILD.bazel
@@ -1,12 +1,16 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
-load("@aspect_rules_js//js:defs.bzl", "js_binary")
+load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@rules_multirun//:defs.bzl", "multirun")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_compile", "ts_run_binary")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_run_binary")
+load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
 load("//tools:vitest.bzl", "vitest")
 load(":defs.bzl", "ZONES")
 load(":index.bzl", "generate_dockerfile")
@@ -33,25 +37,6 @@ TEST_LOCALES = [
 
 TEST_LOCALE_DATA = ["tests/locale-data/%s.json" % locale for locale in TEST_LOCALES]
 
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-        "add-all-tz.js",
-        "add-all-tz.d.ts",
-        "add-golden-tz.js",
-        "add-golden-tz.d.ts",
-        ":dist",
-        ":locale-data",
-        # polyfill-library uses this
-        "polyfill.iife.js",
-    ],
-    package = "@formatjs/%s" % PACKAGE_NAME,
-    visibility = ["//visibility:public"],
-)
-
 SRCS = glob(
     [
         "*.ts",
@@ -75,9 +60,89 @@ TEST_DEPS = SRC_DEPS + [
     "//:node_modules/@types/node",
 ]
 
-ts_compile(
-    name = "dist",
+EXTERNAL_PACKAGES = [
+    dep.split("node_modules/")[1]
+    for dep in SRC_DEPS
+    if "node_modules/" in dep
+]
+
+ENTRY_POINTS = [
+    "index.ts",
+    "polyfill.ts",
+    "polyfill-force.ts",
+    "should-polyfill.ts",
+]
+
+[esbuild(
+    name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
+    config = "//tools:esbuild-packages-resolve",
+    entry_point = entry,
+    external = EXTERNAL_PACKAGES,
+    format = "esm",
+    output = "%s.js" % entry.replace(".ts", ""),
+    target = "es2020",
+    deps = SRC_DEPS,
+) for entry in ENTRY_POINTS]
+
+BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
+
+js_library(
+    name = PACKAGE_NAME,
+    srcs = BUNDLES + [
+        "package.json",
+        ":types",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+npm_package(
+    name = "pkg",
+    srcs = [
+        "LICENSE.md",
+        "README.md",
+        "add-all-tz.d.ts",
+        "add-all-tz.js",
+        "add-golden-tz.d.ts",
+        "add-golden-tz.js",
+        "package.json",
+    ] + BUNDLES + [":types"] + [
+        ":locale-data",
+        # polyfill-library uses this
+        "polyfill.iife.js",
+    ],
+    package = "@formatjs/%s" % PACKAGE_NAME,
+    visibility = ["//visibility:public"],
+)
+
+# Ensure no internal path aliases leak into published JS
+sh_test(
+    name = "no_internal_imports_test",
+    srcs = ["//tools:check_no_internal_imports.sh"],
+    data = BUNDLES,
+)
+
+ts_project(
+    name = "typecheck",
+    srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = BASE_TSCONFIG,
+    deps = SRC_DEPS,
+)
+
+# --- Generate .d.ts declarations ---
+ts_project(
+    name = "types",
+    srcs = [":srcs"],
+    declaration = True,
+    emit_declaration_only = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = BASE_TSCONFIG,
+    visibility = ["//visibility:public"],
     deps = SRC_DEPS,
 )
 
@@ -895,6 +960,7 @@ write_source_files(
 esbuild(
     name = "polyfill.iife",
     srcs = [":srcs"],
+    config = "//tools:esbuild-packages-resolve",
     entry_point = "polyfill.ts",
     target = "es2020",
     deps = [

--- a/packages/intl-displaynames/BUILD.bazel
+++ b/packages/intl-displaynames/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_compile", "ts_run_binary")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_run_binary")
+load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -17,21 +22,6 @@ TEST_LOCALES = [
 ]
 
 TEST_LOCALE_DATA = ["tests/locale-data/%s.json" % locale for locale in TEST_LOCALES]
-
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-        ":dist",
-        ":locale-data",
-        # polyfill-library uses this
-        "polyfill.iife.js",
-    ],
-    package = "@formatjs/%s" % PACKAGE_NAME,
-    visibility = ["//visibility:public"],
-)
 
 SRCS = glob(
     [
@@ -55,9 +45,85 @@ TEST_DEPS = SRC_DEPS + [
     ":node_modules/@formatjs/intl-locale",
 ]
 
-ts_compile(
-    name = "dist",
+EXTERNAL_PACKAGES = [
+    dep.split("node_modules/")[1]
+    for dep in SRC_DEPS
+    if "node_modules/" in dep
+]
+
+ENTRY_POINTS = [
+    "index.ts",
+    "polyfill.ts",
+    "polyfill-force.ts",
+    "should-polyfill.ts",
+]
+
+[esbuild(
+    name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
+    config = "//tools:esbuild-packages-resolve",
+    entry_point = entry,
+    external = EXTERNAL_PACKAGES,
+    format = "esm",
+    output = "%s.js" % entry.replace(".ts", ""),
+    target = "es2020",
+    deps = SRC_DEPS,
+) for entry in ENTRY_POINTS]
+
+BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
+
+js_library(
+    name = PACKAGE_NAME,
+    srcs = BUNDLES + [
+        "package.json",
+        ":types",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+npm_package(
+    name = "pkg",
+    srcs = [
+        "LICENSE.md",
+        "README.md",
+        "package.json",
+    ] + BUNDLES + [":types"] + [
+        ":locale-data",
+        # polyfill-library uses this
+        "polyfill.iife.js",
+    ],
+    package = "@formatjs/%s" % PACKAGE_NAME,
+    visibility = ["//visibility:public"],
+)
+
+# Ensure no internal path aliases leak into published JS
+sh_test(
+    name = "no_internal_imports_test",
+    srcs = ["//tools:check_no_internal_imports.sh"],
+    data = BUNDLES,
+)
+
+ts_project(
+    name = "typecheck",
+    srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = BASE_TSCONFIG,
+    deps = SRC_DEPS,
+)
+
+# --- Generate .d.ts declarations ---
+ts_project(
+    name = "types",
+    srcs = [":srcs"],
+    declaration = True,
+    emit_declaration_only = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = BASE_TSCONFIG,
+    visibility = ["//visibility:public"],
     deps = SRC_DEPS,
 )
 
@@ -735,6 +801,7 @@ generate_src_file(
 esbuild(
     name = "test262-polyfill",
     srcs = [":srcs"],
+    config = "//tools:esbuild-packages-resolve",
     entry_point = "test262-main.ts",
     target = "es2020",
     deps = SRC_DEPS,
@@ -778,6 +845,7 @@ write_source_files(
 esbuild(
     name = "polyfill.iife",
     srcs = [":srcs"],
+    config = "//tools:esbuild-packages-resolve",
     entry_point = "polyfill.ts",
     target = "es2020",
     deps = [

--- a/packages/intl-listformat/BUILD.bazel
+++ b/packages/intl-listformat/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_compile", "ts_run_binary")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_run_binary")
+load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -20,21 +25,6 @@ TEST_LOCALES = [
 ]
 
 TEST_LOCALE_DATA = ["tests/locale-data/%s.json" % locale for locale in TEST_LOCALES]
-
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-        ":dist",
-        ":locale-data",
-        # polyfill-library uses this
-        "polyfill.iife.js",
-    ],
-    package = "@formatjs/%s" % PACKAGE_NAME,
-    visibility = ["//visibility:public"],
-)
 
 SRCS = glob(
     [
@@ -58,9 +48,85 @@ TEST_DEPS = SRC_DEPS + [
     "//:node_modules/@types/node",
 ]
 
-ts_compile(
-    name = "dist",
+EXTERNAL_PACKAGES = [
+    dep.split("node_modules/")[1]
+    for dep in SRC_DEPS
+    if "node_modules/" in dep
+]
+
+ENTRY_POINTS = [
+    "index.ts",
+    "polyfill.ts",
+    "polyfill-force.ts",
+    "should-polyfill.ts",
+]
+
+[esbuild(
+    name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
+    config = "//tools:esbuild-packages-resolve",
+    entry_point = entry,
+    external = EXTERNAL_PACKAGES,
+    format = "esm",
+    output = "%s.js" % entry.replace(".ts", ""),
+    target = "es2020",
+    deps = SRC_DEPS,
+) for entry in ENTRY_POINTS]
+
+BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
+
+js_library(
+    name = PACKAGE_NAME,
+    srcs = BUNDLES + [
+        "package.json",
+        ":types",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+npm_package(
+    name = "pkg",
+    srcs = [
+        "LICENSE.md",
+        "README.md",
+        "package.json",
+    ] + BUNDLES + [":types"] + [
+        ":locale-data",
+        # polyfill-library uses this
+        "polyfill.iife.js",
+    ],
+    package = "@formatjs/%s" % PACKAGE_NAME,
+    visibility = ["//visibility:public"],
+)
+
+# Ensure no internal path aliases leak into published JS
+sh_test(
+    name = "no_internal_imports_test",
+    srcs = ["//tools:check_no_internal_imports.sh"],
+    data = BUNDLES,
+)
+
+ts_project(
+    name = "typecheck",
+    srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = BASE_TSCONFIG,
+    deps = SRC_DEPS,
+)
+
+# --- Generate .d.ts declarations ---
+ts_project(
+    name = "types",
+    srcs = [":srcs"],
+    declaration = True,
+    emit_declaration_only = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = BASE_TSCONFIG,
+    visibility = ["//visibility:public"],
     deps = SRC_DEPS,
 )
 
@@ -726,6 +792,7 @@ generate_src_file(
 esbuild(
     name = "test262-polyfill",
     srcs = [":srcs"],
+    config = "//tools:esbuild-packages-resolve",
     entry_point = "polyfill-force.ts",
     target = "es2020",
     deps = SRC_DEPS,
@@ -766,6 +833,7 @@ write_source_files(
 esbuild(
     name = "polyfill.iife",
     srcs = [":srcs"],
+    config = "//tools:esbuild-packages-resolve",
     entry_point = "polyfill.ts",
     target = "es2020",
     deps = [

--- a/packages/intl-numberformat/BUILD.bazel
+++ b/packages/intl-numberformat/BUILD.bazel
@@ -1,12 +1,17 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
 load("@rules_multirun//:defs.bzl", "multirun")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_compile", "ts_run_binary")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_run_binary")
+load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -58,21 +63,6 @@ TEST_LOCALES = [
 
 TEST_LOCALE_DATA = ["tests/locale-data/%s.json" % locale for locale in TEST_LOCALES]
 
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-        ":dist",
-        ":locale-data",
-        # polyfill-library uses this
-        "polyfill.iife.js",
-    ],
-    package = "@formatjs/%s" % PACKAGE_NAME,
-    visibility = ["//visibility:public"],
-)
-
 SRCS = glob(
     [
         "*.ts",
@@ -94,9 +84,85 @@ TEST_DEPS = SRC_DEPS + [
     "//:node_modules/@types/node",
 ]
 
-ts_compile(
-    name = "dist",
+EXTERNAL_PACKAGES = [
+    dep.split("node_modules/")[1]
+    for dep in SRC_DEPS
+    if "node_modules/" in dep
+]
+
+ENTRY_POINTS = [
+    "index.ts",
+    "polyfill.ts",
+    "polyfill-force.ts",
+    "should-polyfill.ts",
+]
+
+[esbuild(
+    name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
+    config = "//tools:esbuild-packages-resolve",
+    entry_point = entry,
+    external = EXTERNAL_PACKAGES,
+    format = "esm",
+    output = "%s.js" % entry.replace(".ts", ""),
+    target = "es2020",
+    deps = SRC_DEPS,
+) for entry in ENTRY_POINTS]
+
+BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
+
+js_library(
+    name = PACKAGE_NAME,
+    srcs = BUNDLES + [
+        "package.json",
+        ":types",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+npm_package(
+    name = "pkg",
+    srcs = [
+        "LICENSE.md",
+        "README.md",
+        "package.json",
+    ] + BUNDLES + [":types"] + [
+        ":locale-data",
+        # polyfill-library uses this
+        "polyfill.iife.js",
+    ],
+    package = "@formatjs/%s" % PACKAGE_NAME,
+    visibility = ["//visibility:public"],
+)
+
+# Ensure no internal path aliases leak into published JS
+sh_test(
+    name = "no_internal_imports_test",
+    srcs = ["//tools:check_no_internal_imports.sh"],
+    data = BUNDLES,
+)
+
+ts_project(
+    name = "typecheck",
+    srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = BASE_TSCONFIG,
+    deps = SRC_DEPS,
+)
+
+# --- Generate .d.ts declarations ---
+ts_project(
+    name = "types",
+    srcs = [":srcs"],
+    declaration = True,
+    emit_declaration_only = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = BASE_TSCONFIG,
+    visibility = ["//visibility:public"],
     deps = SRC_DEPS,
 )
 
@@ -919,6 +985,7 @@ generate_src_file(
 esbuild(
     name = "test262-polyfill",
     srcs = [":srcs"],
+    config = "//tools:esbuild-packages-resolve",
     entry_point = "test262-main.ts",
     target = "es2020",
     deps = [
@@ -959,6 +1026,7 @@ write_source_files(
 esbuild(
     name = "polyfill.iife",
     srcs = [":srcs"],
+    config = "//tools:esbuild-packages-resolve",
     entry_point = "polyfill.ts",
     target = "es2020",
     deps = [

--- a/packages/intl-pluralrules/BUILD.bazel
+++ b/packages/intl-pluralrules/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_compile", "ts_run_binary")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_run_binary")
+load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -237,21 +242,6 @@ TEST_LOCALES = [
 
 TEST_LOCALE_DATA = ["tests/locale-data/%s.ts" % locale for locale in TEST_LOCALES]
 
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-        ":dist",
-        ":locale-data",
-        # polyfill-library uses this
-        "polyfill.iife.js",
-    ],
-    package = "@formatjs/%s" % PACKAGE_NAME,
-    visibility = ["//visibility:public"],
-)
-
 SRCS = glob(
     [
         "*.ts",
@@ -270,9 +260,85 @@ SRC_DEPS = [
     ":node_modules/@formatjs/bigdecimal",
 ]
 
-ts_compile(
-    name = "dist",
+EXTERNAL_PACKAGES = [
+    dep.split("node_modules/")[1]
+    for dep in SRC_DEPS
+    if "node_modules/" in dep
+]
+
+ENTRY_POINTS = [
+    "index.ts",
+    "polyfill.ts",
+    "polyfill-force.ts",
+    "should-polyfill.ts",
+]
+
+[esbuild(
+    name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
+    config = "//tools:esbuild-packages-resolve",
+    entry_point = entry,
+    external = EXTERNAL_PACKAGES,
+    format = "esm",
+    output = "%s.js" % entry.replace(".ts", ""),
+    target = "es2020",
+    deps = SRC_DEPS,
+) for entry in ENTRY_POINTS]
+
+BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
+
+js_library(
+    name = PACKAGE_NAME,
+    srcs = BUNDLES + [
+        "package.json",
+        ":types",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+npm_package(
+    name = "pkg",
+    srcs = [
+        "LICENSE.md",
+        "README.md",
+        "package.json",
+    ] + BUNDLES + [":types"] + [
+        ":locale-data",
+        # polyfill-library uses this
+        "polyfill.iife.js",
+    ],
+    package = "@formatjs/%s" % PACKAGE_NAME,
+    visibility = ["//visibility:public"],
+)
+
+# Ensure no internal path aliases leak into published JS
+sh_test(
+    name = "no_internal_imports_test",
+    srcs = ["//tools:check_no_internal_imports.sh"],
+    data = BUNDLES,
+)
+
+ts_project(
+    name = "typecheck",
+    srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = BASE_TSCONFIG,
+    deps = SRC_DEPS,
+)
+
+# --- Generate .d.ts declarations ---
+ts_project(
+    name = "types",
+    srcs = [":srcs"],
+    declaration = True,
+    emit_declaration_only = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = BASE_TSCONFIG,
+    visibility = ["//visibility:public"],
     deps = SRC_DEPS,
 )
 
@@ -373,6 +439,7 @@ generate_src_file(
 esbuild(
     name = "test262-polyfill",
     srcs = [":srcs"],
+    config = "//tools:esbuild-packages-resolve",
     entry_point = "test262-main.ts",
     target = "es2020",
     deps = SRC_DEPS,
@@ -412,6 +479,7 @@ write_source_files(
 esbuild(
     name = "polyfill.iife",
     srcs = [":srcs"],
+    config = "//tools:esbuild-packages-resolve",
     entry_point = "polyfill.ts",
     target = "es2020",
     # TODO: fix this and set it back to es5

--- a/packages/intl-relativetimeformat/BUILD.bazel
+++ b/packages/intl-relativetimeformat/BUILD.bazel
@@ -1,10 +1,15 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_compile", "ts_run_binary")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_run_binary")
+load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -20,21 +25,6 @@ TEST_LOCALES = [
 ]
 
 TEST_LOCALE_DATA = ["tests/locale-data/%s.json" % locale for locale in TEST_LOCALES]
-
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-        ":dist",
-        ":locale-data",
-        # polyfill-library uses this
-        "polyfill.iife.js",
-    ],
-    package = "@formatjs/%s" % PACKAGE_NAME,
-    visibility = ["//visibility:public"],
-)
 
 SRCS = glob(
     [
@@ -53,9 +43,85 @@ SRC_DEPS = [
     ":node_modules/@formatjs/intl-localematcher",
 ]
 
-ts_compile(
-    name = "dist",
+EXTERNAL_PACKAGES = [
+    dep.split("node_modules/")[1]
+    for dep in SRC_DEPS
+    if "node_modules/" in dep
+]
+
+ENTRY_POINTS = [
+    "index.ts",
+    "polyfill.ts",
+    "polyfill-force.ts",
+    "should-polyfill.ts",
+]
+
+[esbuild(
+    name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
+    config = "//tools:esbuild-packages-resolve",
+    entry_point = entry,
+    external = EXTERNAL_PACKAGES,
+    format = "esm",
+    output = "%s.js" % entry.replace(".ts", ""),
+    target = "es2020",
+    deps = SRC_DEPS,
+) for entry in ENTRY_POINTS]
+
+BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
+
+js_library(
+    name = PACKAGE_NAME,
+    srcs = BUNDLES + [
+        "package.json",
+        ":types",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+npm_package(
+    name = "pkg",
+    srcs = [
+        "LICENSE.md",
+        "README.md",
+        "package.json",
+    ] + BUNDLES + [":types"] + [
+        ":locale-data",
+        # polyfill-library uses this
+        "polyfill.iife.js",
+    ],
+    package = "@formatjs/%s" % PACKAGE_NAME,
+    visibility = ["//visibility:public"],
+)
+
+# Ensure no internal path aliases leak into published JS
+sh_test(
+    name = "no_internal_imports_test",
+    srcs = ["//tools:check_no_internal_imports.sh"],
+    data = BUNDLES,
+)
+
+ts_project(
+    name = "typecheck",
+    srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = BASE_TSCONFIG,
+    deps = SRC_DEPS,
+)
+
+# --- Generate .d.ts declarations ---
+ts_project(
+    name = "types",
+    srcs = [":srcs"],
+    declaration = True,
+    emit_declaration_only = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = BASE_TSCONFIG,
+    visibility = ["//visibility:public"],
     deps = SRC_DEPS,
 )
 
@@ -724,6 +790,7 @@ generate_src_file(
 esbuild(
     name = "test262-polyfill",
     srcs = [":srcs"],
+    config = "//tools:esbuild-packages-resolve",
     entry_point = "test262-main.ts",
     target = "es2020",
     deps = SRC_DEPS,
@@ -763,6 +830,7 @@ write_source_files(
 esbuild(
     name = "polyfill.iife",
     srcs = [":srcs"],
+    config = "//tools:esbuild-packages-resolve",
     entry_point = "polyfill.ts",
     target = "es2020",
     deps = [

--- a/packages/intl-segmenter/BUILD.bazel
+++ b/packages/intl-segmenter/BUILD.bazel
@@ -2,30 +2,21 @@ load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file")
+load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
 load("//tools:vitest.bzl", "vitest")
 load(":index.bzl", "unicode_file_name")
 
 npm_link_all_packages()
 
 PACKAGE_NAME = "intl-segmenter"
-
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-        ":dist",
-        # polyfill-library uses this
-        "polyfill.iife.js",
-    ],
-    package = "@formatjs/%s" % PACKAGE_NAME,
-    visibility = ["//visibility:public"],
-)
 
 SRC_DEPS = [
     ":node_modules/@formatjs/ecma402-abstract",
@@ -60,9 +51,83 @@ TESTS = glob([
     "tests/*.test.ts",
 ])
 
-ts_compile(
-    name = "dist",
+EXTERNAL_PACKAGES = [
+    dep.split("node_modules/")[1]
+    for dep in SRC_DEPS
+    if "node_modules/" in dep
+]
+
+ENTRY_POINTS = [
+    "polyfill.ts",
+    "polyfill-force.ts",
+    "should-polyfill.ts",
+]
+
+[esbuild(
+    name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
+    config = "//tools:esbuild-packages-resolve",
+    entry_point = entry,
+    external = EXTERNAL_PACKAGES,
+    format = "esm",
+    output = "%s.js" % entry.replace(".ts", ""),
+    target = "es2020",
+    deps = SRC_DEPS,
+) for entry in ENTRY_POINTS]
+
+BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
+
+js_library(
+    name = PACKAGE_NAME,
+    srcs = BUNDLES + [
+        "package.json",
+        ":types",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+npm_package(
+    name = "pkg",
+    srcs = [
+        "LICENSE.md",
+        "README.md",
+        "package.json",
+    ] + BUNDLES + [":types"] + [
+        # polyfill-library uses this
+        "polyfill.iife.js",
+    ],
+    package = "@formatjs/%s" % PACKAGE_NAME,
+    visibility = ["//visibility:public"],
+)
+
+# Ensure no internal path aliases leak into published JS
+sh_test(
+    name = "no_internal_imports_test",
+    srcs = ["//tools:check_no_internal_imports.sh"],
+    data = BUNDLES,
+)
+
+ts_project(
+    name = "typecheck",
+    srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = BASE_TSCONFIG,
+    deps = SRC_DEPS,
+)
+
+# --- Generate .d.ts declarations ---
+ts_project(
+    name = "types",
+    srcs = [":srcs"],
+    declaration = True,
+    emit_declaration_only = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = BASE_TSCONFIG,
+    visibility = ["//visibility:public"],
     deps = SRC_DEPS,
 )
 
@@ -91,6 +156,7 @@ generate_src_file(
 esbuild(
     name = "test262-polyfill",
     srcs = [":srcs"],
+    config = "//tools:esbuild-packages-resolve",
     entry_point = "test262-main.ts",
     target = "es2020",
     deps = SRC_DEPS,
@@ -127,6 +193,7 @@ write_source_files(
 esbuild(
     name = "polyfill.iife",
     srcs = [":srcs"],
+    config = "//tools:esbuild-packages-resolve",
     entry_point = "polyfill.ts",
     target = "es2020",
     deps = [


### PR DESCRIPTION
## Summary
Set up esbuild bundling for all 9 remaining polyfill packages, matching the intl-locale pattern from #6210.

Each package now:
- Bundles entry points with esbuild (with workspace-resolve plugin for `#packages/*`)
- Uses `js_library` as default target (what `npm_link_all_packages` serves)
- Type checks with `ts_project(no_emit=True)` instead of `ts_compile`
- Has `no_internal_imports_test` to verify no `#packages/*` leaks in bundle output
- All esbuild targets use the workspace-resolve plugin

Packages transformed:
- intl-datetimeformat, intl-displaynames, intl-getcanonicallocales
- intl-listformat, intl-numberformat, intl-pluralrules
- intl-relativetimeformat, intl-segmenter, intl-supportedvaluesof

## Test plan
- [x] 493 tests pass (2 pre-existing intl-locale typecheck failures from #6210)
- [x] Pre-commit hooks pass (buildifier, gazelle, commitlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)