### PR TITLE
chore(@formatjs/intl-segmenter): use #packages direct imports for ecma402-abstract

### DIFF
--- a/packages/intl-segmenter/BUILD.bazel
+++ b/packages/intl-segmenter/BUILD.bazel
@@ -16,10 +16,19 @@ load(":index.bzl", "unicode_file_name")
 
 npm_link_all_packages()
 
+# tsconfig with #packages/* path alias for tsc resolution
+TSCONFIG = BASE_TSCONFIG | {
+    "compilerOptions": BASE_TSCONFIG["compilerOptions"] | {
+        "paths": {
+            "#packages/*": ["../*"],
+        },
+    },
+}
+
 PACKAGE_NAME = "intl-segmenter"
 
 SRC_DEPS = [
-    ":node_modules/@formatjs/ecma402-abstract",
+    "//packages/ecma402-abstract",
     ":node_modules/@formatjs/intl-localematcher",
 ]
 
@@ -114,7 +123,7 @@ ts_project(
     no_emit = True,
     resolve_json_module = True,
     transpiler = tsgo_bin.tsgo,
-    tsconfig = BASE_TSCONFIG,
+    tsconfig = TSCONFIG,
     deps = SRC_DEPS,
 )
 
@@ -126,7 +135,7 @@ ts_project(
     emit_declaration_only = True,
     resolve_json_module = True,
     transpiler = tsgo_bin.tsgo,
-    tsconfig = BASE_TSCONFIG,
+    tsconfig = TSCONFIG,
     visibility = ["//visibility:public"],
     deps = SRC_DEPS,
 )
@@ -134,11 +143,16 @@ ts_project(
 vitest(
     name = "unit_test",
     srcs = SRCS + TESTS + ["tests/test-utils.ts"],
+    data = [
+        "//:package.json",
+    ],
     no_copy_to_bin = [
+        "//:package.json",
         "@GraphemeBreakTest//file",
         "@WordBreakTest//file",
         "@SentenceBreakTest//file",
     ],
+    tsconfig = TSCONFIG,
     deps = TEST_DEPS,
 )
 

--- a/packages/intl-segmenter/src/segmenter.ts
+++ b/packages/intl-segmenter/src/segmenter.ts
@@ -1,12 +1,12 @@
+import {CanonicalizeLocaleList} from '#packages/ecma402-abstract/CanonicalizeLocaleList.js'
+import {GetOption} from '#packages/ecma402-abstract/GetOption.js'
+import {GetOptionsObject} from '#packages/ecma402-abstract/GetOptionsObject.js'
+import {SupportedLocales} from '#packages/ecma402-abstract/SupportedLocales.js'
 import {
-  CanonicalizeLocaleList,
-  GetOption,
-  GetOptionsObject,
-  SupportedLocales,
   getInternalSlot,
   getMultiInternalSlots,
   setInternalSlot,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/utils.js'
 import {ResolveLocale} from '@formatjs/intl-localematcher'
 import {SegmentationRules} from './cldr-segmentation-rules.generated.js'
 import {isSurrogate, replaceVariables} from './segmentation-utils.js'


### PR DESCRIPTION
## Summary
Replace barrel import from `@formatjs/ecma402-abstract` with direct file imports via `#packages` path alias. Each symbol now imports from its specific source file (de-barreled):

- `CanonicalizeLocaleList` → `#packages/ecma402-abstract/CanonicalizeLocaleList.js`
- `GetOption` → `#packages/ecma402-abstract/GetOption.js`
- `GetOptionsObject` → `#packages/ecma402-abstract/GetOptionsObject.js`
- `SupportedLocales` → `#packages/ecma402-abstract/SupportedLocales.js`
- `getInternalSlot`, `getMultiInternalSlots`, `setInternalSlot` → `#packages/ecma402-abstract/utils.js`

## Test plan
- [x] All 497 tests pass (`pnpm -w run test`)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)