### PR TITLE
chore(@formatjs/intl-listformat): use #packages direct imports for ecma402-abstract

### DIFF
--- a/packages/ecma402-abstract/BUILD.bazel
+++ b/packages/ecma402-abstract/BUILD.bazel
@@ -85,4 +85,5 @@ package_json_test(
 copy_to_bin(
     name = "srcs",
     srcs = SRCS,
+    visibility = ["//visibility:public"],
 )

--- a/packages/intl-listformat/BUILD.bazel
+++ b/packages/intl-listformat/BUILD.bazel
@@ -14,6 +14,14 @@ load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
 
+TSCONFIG = BASE_TSCONFIG | {
+    "compilerOptions": BASE_TSCONFIG["compilerOptions"] | {
+        "paths": {
+            "#packages/*": ["../*"],
+        },
+    },
+}
+
 PACKAGE_NAME = "intl-listformat"
 
 TEST_LOCALES = [
@@ -38,7 +46,7 @@ TESTS = glob([
 ])
 
 SRC_DEPS = [
-    ":node_modules/@formatjs/ecma402-abstract",
+    "//packages/ecma402-abstract",
     ":node_modules/@formatjs/intl-localematcher",
 ]
 
@@ -113,7 +121,7 @@ ts_project(
     no_emit = True,
     resolve_json_module = True,
     transpiler = tsgo_bin.tsgo,
-    tsconfig = BASE_TSCONFIG,
+    tsconfig = TSCONFIG,
     deps = SRC_DEPS,
 )
 
@@ -125,7 +133,7 @@ ts_project(
     emit_declaration_only = True,
     resolve_json_module = True,
     transpiler = tsgo_bin.tsgo,
-    tsconfig = BASE_TSCONFIG,
+    tsconfig = TSCONFIG,
     visibility = ["//visibility:public"],
     deps = SRC_DEPS,
 )
@@ -133,6 +141,9 @@ ts_project(
 vitest(
     name = "unit_test",
     srcs = SRCS + TESTS + TEST_LOCALE_DATA,
+    data = ["//:package.json"],
+    no_copy_to_bin = ["//:package.json"],
+    tsconfig = TSCONFIG,
     deps = TEST_DEPS,
 )
 

--- a/packages/intl-listformat/index.ts
+++ b/packages/intl-listformat/index.ts
@@ -1,18 +1,20 @@
+import {CanonicalizeLocaleList} from '#packages/ecma402-abstract/CanonicalizeLocaleList.js'
+import {GetOption} from '#packages/ecma402-abstract/GetOption.js'
+import {GetOptionsObject} from '#packages/ecma402-abstract/GetOptionsObject.js'
+import {PartitionPattern} from '#packages/ecma402-abstract/PartitionPattern.js'
+import {SupportedLocales} from '#packages/ecma402-abstract/SupportedLocales.js'
 import {
-  CanonicalizeLocaleList,
-  getInternalSlot,
-  GetOption,
-  GetOptionsObject,
-  invariant,
-  isLiteralPart,
   type ListPatternData,
   type ListPatternFieldsData,
   type ListPatternLocaleData,
+} from '#packages/ecma402-abstract/types/list.js'
+import {
   type LiteralPart,
-  PartitionPattern,
+  getInternalSlot,
+  invariant,
+  isLiteralPart,
   setInternalSlot,
-  SupportedLocales,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/utils.js'
 import {ResolveLocale} from '@formatjs/intl-localematcher'
 
 export interface IntlListFormatOptions {

--- a/packages/intl-listformat/scripts/BUILD.bazel
+++ b/packages/intl-listformat/scripts/BUILD.bazel
@@ -4,6 +4,7 @@ ts_binary(
     name = "cldr-raw",
     data = [
         "extract-list.ts",
+        "//:package.json",
     ],
     entry_point = "cldr-raw.ts",
     visibility = ["//packages/intl-listformat:__pkg__"],

--- a/packages/intl-listformat/scripts/extract-list.ts
+++ b/packages/intl-listformat/scripts/extract-list.ts
@@ -13,7 +13,7 @@ const require = createRequire(import.meta.url)
 import {
   type ListPatternFieldsData,
   type ListPattern,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/types/list.js'
 
 export type ListTypes = (typeof ListPatterns)['main']['en']['listPatterns']
 

--- a/packages/intl-numberformat/BUILD.bazel
+++ b/packages/intl-numberformat/BUILD.bazel
@@ -11,10 +11,16 @@ load("@rules_multirun//:defs.bzl", "multirun")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_run_binary")
-load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
+load("//tools:tsconfig.bzl", "BASE_TSCONFIG", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
+
+PACKAGES_PATHS = {
+    "paths": {
+        "#packages/*": ["../*"],
+    },
+}
 
 exports_files(
     [
@@ -72,7 +78,7 @@ SRCS = glob(
 )
 
 SRC_DEPS = [
-    ":node_modules/@formatjs/ecma402-abstract",
+    "//packages/ecma402-abstract",
     ":node_modules/@formatjs/intl-localematcher",
     ":node_modules/@formatjs/bigdecimal",
 ]
@@ -149,7 +155,7 @@ ts_project(
     no_emit = True,
     resolve_json_module = True,
     transpiler = tsgo_bin.tsgo,
-    tsconfig = BASE_TSCONFIG,
+    tsconfig = packages_tsconfig(),
     deps = SRC_DEPS,
 )
 
@@ -161,7 +167,7 @@ ts_project(
     emit_declaration_only = True,
     resolve_json_module = True,
     transpiler = tsgo_bin.tsgo,
-    tsconfig = BASE_TSCONFIG,
+    tsconfig = packages_tsconfig(),
     visibility = ["//visibility:public"],
     deps = SRC_DEPS,
 )
@@ -250,6 +256,9 @@ vitest(
                "tests/*.test.ts",
            ]) + [":srcs"] +
            TEST_LOCALE_DATA,
+    data = ["//:package.json"],
+    no_copy_to_bin = ["//:package.json"],
+    tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
     deps = TEST_DEPS,
 )
 
@@ -264,6 +273,9 @@ vitest(
             ":srcs",
             "tests/%s/%sTest.ts" % (type, type),
         ] + TEST_LOCALE_DATA,
+        data = ["//:package.json"],
+        no_copy_to_bin = ["//:package.json"],
+        tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
         deps = TEST_DEPS,
     )
     for type in LOCALE_TEST_TYPES

--- a/packages/intl-numberformat/polyfill-force.ts
+++ b/packages/intl-numberformat/polyfill-force.ts
@@ -1,9 +1,7 @@
 import {NumberFormat} from './src/core.js'
 import {toLocaleString as _toLocaleString} from './src/to_locale_string.js'
-import {
-  defineProperty,
-  type NumberFormatOptions,
-} from '@formatjs/ecma402-abstract'
+import {type NumberFormatOptions} from '#packages/ecma402-abstract/types/number.js'
+import {defineProperty} from '#packages/ecma402-abstract/utils.js'
 
 defineProperty(Intl, 'NumberFormat', {value: NumberFormat})
 defineProperty(Number.prototype, 'toLocaleString', {

--- a/packages/intl-numberformat/polyfill.ts
+++ b/packages/intl-numberformat/polyfill.ts
@@ -1,9 +1,7 @@
 import {NumberFormat} from './src/core.js'
 import {toLocaleString as _toLocaleString} from './src/to_locale_string.js'
-import {
-  defineProperty,
-  type NumberFormatOptions,
-} from '@formatjs/ecma402-abstract'
+import {type NumberFormatOptions} from '#packages/ecma402-abstract/types/number.js'
+import {defineProperty} from '#packages/ecma402-abstract/utils.js'
 import {shouldPolyfill} from './should-polyfill.js'
 
 if (shouldPolyfill()) {

--- a/packages/intl-numberformat/scripts/BUILD.bazel
+++ b/packages/intl-numberformat/scripts/BUILD.bazel
@@ -19,6 +19,7 @@ ts_binary(
         "extract-numbers.ts",
         "extract-units.ts",
         "utils.ts",
+        "//:package.json",
     ],
     entry_point = "cldr-raw.ts",
     visibility = ["//packages/intl-numberformat:__pkg__"],
@@ -41,6 +42,7 @@ ts_binary(
     data = [
         "extract-currencies.ts",
         "utils.ts",
+        "//:package.json",
     ],
     entry_point = "currency-digits.ts",
     visibility = ["//packages/intl-numberformat:__pkg__"],
@@ -51,6 +53,7 @@ ts_binary(
     data = [
         "extract-numbers.ts",
         "utils.ts",
+        "//:package.json",
     ],
     entry_point = "numbering-systems.ts",
     visibility = ["//packages/intl-numberformat:__pkg__"],

--- a/packages/intl-numberformat/scripts/extract-currencies.ts
+++ b/packages/intl-numberformat/scripts/extract-currencies.ts
@@ -15,7 +15,7 @@ const require = createRequire(import.meta.url)
 import {
   type CurrencyData,
   type LDMLPluralRuleMap,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/types/number.js'
 import AVAILABLE_LOCALES from 'cldr-core/availableLocales.json' with {type: 'json'}
 import {collapseSingleValuePluralRule, PLURAL_RULES} from './utils.ts'
 

--- a/packages/intl-numberformat/scripts/extract-numbers.ts
+++ b/packages/intl-numberformat/scripts/extract-numbers.ts
@@ -11,8 +11,8 @@ import {
   type LDMLPluralRuleMap,
   type DecimalFormatNum,
   type RawCurrencyData,
-  invariant,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/types/number.js'
+import {invariant} from '#packages/ecma402-abstract/utils.js'
 import AVAILABLE_LOCALES from 'cldr-core/availableLocales.json' with {type: 'json'}
 import {collapseSingleValuePluralRule, PLURAL_RULES} from './utils.ts'
 

--- a/packages/intl-numberformat/scripts/extract-units.ts
+++ b/packages/intl-numberformat/scripts/extract-units.ts
@@ -4,14 +4,14 @@
  * See the accompanying LICENSE file for terms.
  */
 import {fromPairs} from 'lodash-es'
+import {removeUnitNamespace} from '#packages/ecma402-abstract/IsSanctionedSimpleUnitIdentifier.js'
+import {IsWellFormedUnitIdentifier} from '#packages/ecma402-abstract/IsWellFormedUnitIdentifier.js'
 import {
-  invariant,
   type LDMLPluralRuleMap,
   type UnitDataTable,
-  removeUnitNamespace,
-  IsWellFormedUnitIdentifier,
   type UnitData,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/types/number.js'
+import {invariant} from '#packages/ecma402-abstract/utils.js'
 import UnitsData from 'cldr-units-full/main/en/units.json' with {type: 'json'}
 import AVAILABLE_LOCALES from 'cldr-core/availableLocales.json' with {type: 'json'}
 import {collapseSingleValuePluralRule, PLURAL_RULES} from './utils.ts'

--- a/packages/intl-numberformat/scripts/units-constants.ts
+++ b/packages/intl-numberformat/scripts/units-constants.ts
@@ -1,5 +1,5 @@
 import minimist from 'minimist'
-import {SIMPLE_UNITS} from '@formatjs/ecma402-abstract'
+import {SIMPLE_UNITS} from '#packages/ecma402-abstract/IsSanctionedSimpleUnitIdentifier.js'
 import {outputFileSync} from 'fs-extra/esm'
 
 function main(args: minimist.ParsedArgs) {

--- a/packages/intl-numberformat/scripts/utils.ts
+++ b/packages/intl-numberformat/scripts/utils.ts
@@ -1,7 +1,5 @@
-import {
-  type LDMLPluralRuleMap,
-  type LDMLPluralRule,
-} from '@formatjs/ecma402-abstract'
+import {type LDMLPluralRuleMap} from '#packages/ecma402-abstract/types/number.js'
+import {type LDMLPluralRule} from '#packages/ecma402-abstract/types/plural-rules.js'
 import {isEqual} from 'lodash-es'
 export function collapseSingleValuePluralRule<T>(
   rules: LDMLPluralRuleMap<T>

--- a/packages/intl-numberformat/src/core.ts
+++ b/packages/intl-numberformat/src/core.ts
@@ -1,19 +1,21 @@
+import {OrdinaryHasInstance} from '#packages/ecma402-abstract/262.js'
+import {CanonicalizeLocaleList} from '#packages/ecma402-abstract/CanonicalizeLocaleList.js'
+import {FormatNumeric} from '#packages/ecma402-abstract/NumberFormat/FormatNumeric.js'
+import {FormatNumericRange} from '#packages/ecma402-abstract/NumberFormat/FormatNumericRange.js'
+import {FormatNumericRangeToParts} from '#packages/ecma402-abstract/NumberFormat/FormatNumericRangeToParts.js'
+import {FormatNumericToParts} from '#packages/ecma402-abstract/NumberFormat/FormatNumericToParts.js'
+import {InitializeNumberFormat} from '#packages/ecma402-abstract/NumberFormat/InitializeNumberFormat.js'
+import {SupportedLocales} from '#packages/ecma402-abstract/SupportedLocales.js'
+import {ToIntlMathematicalValue} from '#packages/ecma402-abstract/ToIntlMathematicalValue.js'
 import {
-  CanonicalizeLocaleList,
-  FormatNumeric,
-  FormatNumericRange,
-  FormatNumericRangeToParts,
-  FormatNumericToParts,
-  InitializeNumberFormat,
   type NumberFormatOptions,
-  OrdinaryHasInstance,
   type RawNumberLocaleData,
-  SupportedLocales,
-  ToIntlMathematicalValue,
+} from '#packages/ecma402-abstract/types/number.js'
+import {
   createMemoizedPluralRules,
   defineProperty,
   invariant,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/utils.js'
 import {currencyDigitsData} from './currency-digits.generated.js'
 import {numberingSystemNames} from './numbering-systems.generated.js'
 // eslint-disable-next-line import/no-cycle

--- a/packages/intl-numberformat/src/get_internal_slots.ts
+++ b/packages/intl-numberformat/src/get_internal_slots.ts
@@ -1,6 +1,6 @@
 // Type-only circular import
 
-import {type NumberFormatInternal} from '@formatjs/ecma402-abstract'
+import {type NumberFormatInternal} from '#packages/ecma402-abstract/types/number.js'
 
 const internalSlotMap = new WeakMap<Intl.NumberFormat, NumberFormatInternal>()
 

--- a/packages/intl-numberformat/src/to_locale_string.ts
+++ b/packages/intl-numberformat/src/to_locale_string.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line import/no-cycle
 import {NumberFormat} from './core.js'
-import {type NumberFormatOptions} from '@formatjs/ecma402-abstract'
+import {type NumberFormatOptions} from '#packages/ecma402-abstract/types/number.js'
 
 /**
  * Number.prototype.toLocaleString ponyfill

--- a/packages/intl-numberformat/src/types.ts
+++ b/packages/intl-numberformat/src/types.ts
@@ -5,7 +5,7 @@ import {
   type NumberRangeToParts,
   type RawNumberLocaleData,
   type ResolvedNumberFormatOptions,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/types/number.js'
 import type Decimal from '@formatjs/bigdecimal'
 
 // Public --------------------------------------------------------------------------------------------------------------

--- a/packages/intl-numberformat/tests/currency/currencyTest.ts
+++ b/packages/intl-numberformat/tests/currency/currencyTest.ts
@@ -1,5 +1,5 @@
 import {describe, it, beforeAll, expect} from 'vitest'
-import {type NumberFormatOptions} from '@formatjs/ecma402-abstract'
+import {type NumberFormatOptions} from '#packages/ecma402-abstract/types/number.js'
 import '@formatjs/intl-pluralrules/polyfill.js'
 import {NumberFormat} from '../../src/core'
 

--- a/packages/intl-numberformat/tests/decimal/decimalTest.ts
+++ b/packages/intl-numberformat/tests/decimal/decimalTest.ts
@@ -1,5 +1,5 @@
 import {describe, it, beforeAll, expect} from 'vitest'
-import {type NumberFormatOptions} from '@formatjs/ecma402-abstract'
+import {type NumberFormatOptions} from '#packages/ecma402-abstract/types/number.js'
 import '@formatjs/intl-pluralrules/polyfill.js'
 import {NumberFormat} from '../../src/core'
 

--- a/packages/intl-numberformat/tests/format_to_parts.test.ts
+++ b/packages/intl-numberformat/tests/format_to_parts.test.ts
@@ -1,5 +1,5 @@
 import {it, expect} from 'vitest'
-import {_formatToParts} from '@formatjs/ecma402-abstract'
+import _formatToParts from '#packages/ecma402-abstract/NumberFormat/format_to_parts.js'
 import Decimal from '@formatjs/bigdecimal'
 
 function format(...args: Parameters<typeof _formatToParts>): string {

--- a/packages/intl-numberformat/tests/notation-compact-ko-KR.test.ts
+++ b/packages/intl-numberformat/tests/notation-compact-ko-KR.test.ts
@@ -1,5 +1,5 @@
 import {describe, it, expect} from 'vitest'
-import {type NumberFormatPart} from '@formatjs/ecma402-abstract'
+import {type NumberFormatPart} from '#packages/ecma402-abstract/types/number.js'
 import '@formatjs/intl-pluralrules/locale-data/ko'
 import '@formatjs/intl-pluralrules/polyfill.js'
 import {NumberFormat} from '../src/core'

--- a/packages/intl-numberformat/tests/percent/percentTest.ts
+++ b/packages/intl-numberformat/tests/percent/percentTest.ts
@@ -1,5 +1,5 @@
 import {describe, it, beforeAll, expect} from 'vitest'
-import {type NumberFormatOptions} from '@formatjs/ecma402-abstract'
+import {type NumberFormatOptions} from '#packages/ecma402-abstract/types/number.js'
 import '@formatjs/intl-pluralrules/polyfill.js'
 import {NumberFormat} from '../../src/core'
 

--- a/packages/intl-numberformat/tests/unit/unitTest.ts
+++ b/packages/intl-numberformat/tests/unit/unitTest.ts
@@ -1,5 +1,5 @@
 import {describe, it, beforeAll, expect} from 'vitest'
-import {type NumberFormatOptions} from '@formatjs/ecma402-abstract'
+import {type NumberFormatOptions} from '#packages/ecma402-abstract/types/number.js'
 import '@formatjs/intl-pluralrules/polyfill.js'
 import {NumberFormat} from '../../src/core'
 

--- a/packages/intl-pluralrules/BUILD.bazel
+++ b/packages/intl-pluralrules/BUILD.bazel
@@ -9,10 +9,24 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_run_binary")
-load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
+load("//tools:tsconfig.bzl", "BASE_TSCONFIG", "ESNEXT_TSCONFIG")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
+
+PACKAGES_PATHS = {
+    "paths": {
+        "#packages/*": ["../*"],
+    },
+}
+
+TSCONFIG = BASE_TSCONFIG | {
+    "compilerOptions": BASE_TSCONFIG["compilerOptions"] | PACKAGES_PATHS,
+}
+
+VITEST_TSCONFIG = ESNEXT_TSCONFIG | {
+    "compilerOptions": ESNEXT_TSCONFIG["compilerOptions"] | PACKAGES_PATHS,
+}
 
 ALL_LOCALES = [
     "af",
@@ -255,7 +269,7 @@ TESTS = glob([
 ])
 
 SRC_DEPS = [
-    ":node_modules/@formatjs/ecma402-abstract",
+    "//packages/ecma402-abstract",
     ":node_modules/@formatjs/intl-localematcher",
     ":node_modules/@formatjs/bigdecimal",
 ]
@@ -325,7 +339,7 @@ ts_project(
     no_emit = True,
     resolve_json_module = True,
     transpiler = tsgo_bin.tsgo,
-    tsconfig = BASE_TSCONFIG,
+    tsconfig = TSCONFIG,
     deps = SRC_DEPS,
 )
 
@@ -337,7 +351,7 @@ ts_project(
     emit_declaration_only = True,
     resolve_json_module = True,
     transpiler = tsgo_bin.tsgo,
-    tsconfig = BASE_TSCONFIG,
+    tsconfig = TSCONFIG,
     visibility = ["//visibility:public"],
     deps = SRC_DEPS,
 )
@@ -345,6 +359,9 @@ ts_project(
 vitest(
     name = "unit_test",
     srcs = SRCS + TESTS + TEST_LOCALE_DATA,
+    data = ["//:package.json"],
+    no_copy_to_bin = ["//:package.json"],
+    tsconfig = VITEST_TSCONFIG,
     deps = SRC_DEPS + [
         ":node_modules/@formatjs/intl-getcanonicallocales",
         ":node_modules/@formatjs/intl-locale",

--- a/packages/intl-pluralrules/abstract/GetOperands.ts
+++ b/packages/intl-pluralrules/abstract/GetOperands.ts
@@ -1,4 +1,6 @@
-import {invariant, ToNumber, ZERO} from '@formatjs/ecma402-abstract'
+import {ToNumber} from '#packages/ecma402-abstract/262.js'
+import {ZERO} from '#packages/ecma402-abstract/constants.js'
+import {invariant} from '#packages/ecma402-abstract/utils.js'
 import type Decimal from '@formatjs/bigdecimal'
 
 /**

--- a/packages/intl-pluralrules/abstract/InitializePluralRules.ts
+++ b/packages/intl-pluralrules/abstract/InitializePluralRules.ts
@@ -1,11 +1,11 @@
+import {CanonicalizeLocaleList} from '#packages/ecma402-abstract/CanonicalizeLocaleList.js'
+import {CoerceOptionsToObject} from '#packages/ecma402-abstract/CoerceOptionsToObject.js'
+import {GetOption} from '#packages/ecma402-abstract/GetOption.js'
+import {SetNumberFormatDigitOptions} from '#packages/ecma402-abstract/NumberFormat/SetNumberFormatDigitOptions.js'
 import {
-  CanonicalizeLocaleList,
-  CoerceOptionsToObject,
-  GetOption,
   type PluralRulesData,
   type PluralRulesInternal,
-  SetNumberFormatDigitOptions,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/types/plural-rules.js'
 import {ResolveLocale} from '@formatjs/intl-localematcher'
 
 export function InitializePluralRules(

--- a/packages/intl-pluralrules/abstract/ResolvePlural.ts
+++ b/packages/intl-pluralrules/abstract/ResolvePlural.ts
@@ -1,11 +1,11 @@
+import {Type} from '#packages/ecma402-abstract/262.js'
+import {ComputeExponentForMagnitude} from '#packages/ecma402-abstract/NumberFormat/ComputeExponentForMagnitude.js'
+import {FormatNumericToString} from '#packages/ecma402-abstract/NumberFormat/FormatNumericToString.js'
 import {
-  ComputeExponentForMagnitude,
-  FormatNumericToString,
-  invariant,
   type LDMLPluralRule,
   type PluralRulesInternal,
-  Type,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/types/plural-rules.js'
+import {invariant} from '#packages/ecma402-abstract/utils.js'
 import Decimal from '@formatjs/bigdecimal'
 import {GetOperands, type OperandsRecord} from './GetOperands.js'
 

--- a/packages/intl-pluralrules/abstract/ResolvePluralRange.ts
+++ b/packages/intl-pluralrules/abstract/ResolvePluralRange.ts
@@ -1,9 +1,9 @@
+import {Type} from '#packages/ecma402-abstract/262.js'
 import {
-  invariant,
   type LDMLPluralRule,
   type PluralRulesInternal,
-  Type,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/types/plural-rules.js'
+import {invariant} from '#packages/ecma402-abstract/utils.js'
 import type Decimal from '@formatjs/bigdecimal'
 import {type OperandsRecord} from './GetOperands.js'
 import {ResolvePluralInternal} from './ResolvePlural.js'

--- a/packages/intl-pluralrules/index.ts
+++ b/packages/intl-pluralrules/index.ts
@@ -1,12 +1,12 @@
+import {CanonicalizeLocaleList} from '#packages/ecma402-abstract/CanonicalizeLocaleList.js'
+import {SupportedLocales} from '#packages/ecma402-abstract/SupportedLocales.js'
+import {ToIntlMathematicalValue} from '#packages/ecma402-abstract/ToIntlMathematicalValue.js'
+import {type NumberFormatDigitInternalSlots} from '#packages/ecma402-abstract/types/number.js'
 import {
-  CanonicalizeLocaleList,
   type LDMLPluralRule,
-  type NumberFormatDigitInternalSlots,
   type PluralRulesData,
   type PluralRulesLocaleData,
-  SupportedLocales,
-  ToIntlMathematicalValue,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/types/plural-rules.js'
 import type Decimal from '@formatjs/bigdecimal'
 import {type OperandsRecord} from './abstract/GetOperands.js'
 import {InitializePluralRules} from './abstract/InitializePluralRules.js'

--- a/packages/intl-pluralrules/scripts/BUILD.bazel
+++ b/packages/intl-pluralrules/scripts/BUILD.bazel
@@ -4,6 +4,7 @@ ts_binary(
     name = "cldr-raw",
     data = [
         "plural-rules-compiler.ts",
+        "//:package.json",
     ],
     entry_point = "cldr-raw.ts",
     visibility = ["//packages/intl-pluralrules:__pkg__"],

--- a/packages/intl-pluralrules/scripts/cldr-raw.ts
+++ b/packages/intl-pluralrules/scripts/cldr-raw.ts
@@ -1,7 +1,7 @@
 import {join} from 'path'
 import {outputFileSync} from 'fs-extra/esm'
 import serialize from 'serialize-javascript'
-import {type LDMLPluralRule} from '@formatjs/ecma402-abstract'
+import {type LDMLPluralRule} from '#packages/ecma402-abstract/types/plural-rules.js'
 import plurals from 'cldr-core/supplemental/plurals.json' with {type: 'json'}
 import ordinals from 'cldr-core/supplemental/ordinals.json' with {type: 'json'}
 import pluralRanges from 'cldr-core/supplemental/pluralRanges.json' with {type: 'json'}

--- a/packages/intl-relativetimeformat/BUILD.bazel
+++ b/packages/intl-relativetimeformat/BUILD.bazel
@@ -9,10 +9,24 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_run_binary")
-load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
+load("//tools:tsconfig.bzl", "BASE_TSCONFIG", "ESNEXT_TSCONFIG")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
+
+PACKAGES_PATHS = {
+    "paths": {
+        "#packages/*": ["../*"],
+    },
+}
+
+TSCONFIG = BASE_TSCONFIG | {
+    "compilerOptions": BASE_TSCONFIG["compilerOptions"] | PACKAGES_PATHS,
+}
+
+VITEST_TSCONFIG = ESNEXT_TSCONFIG | {
+    "compilerOptions": ESNEXT_TSCONFIG["compilerOptions"] | PACKAGES_PATHS,
+}
 
 PACKAGE_NAME = "intl-relativetimeformat"
 
@@ -39,7 +53,7 @@ TESTS = glob([
 ])
 
 SRC_DEPS = [
-    ":node_modules/@formatjs/ecma402-abstract",
+    "//packages/ecma402-abstract",
     ":node_modules/@formatjs/intl-localematcher",
 ]
 
@@ -108,7 +122,7 @@ ts_project(
     no_emit = True,
     resolve_json_module = True,
     transpiler = tsgo_bin.tsgo,
-    tsconfig = BASE_TSCONFIG,
+    tsconfig = TSCONFIG,
     deps = SRC_DEPS,
 )
 
@@ -120,7 +134,7 @@ ts_project(
     emit_declaration_only = True,
     resolve_json_module = True,
     transpiler = tsgo_bin.tsgo,
-    tsconfig = BASE_TSCONFIG,
+    tsconfig = TSCONFIG,
     visibility = ["//visibility:public"],
     deps = SRC_DEPS,
 )
@@ -128,6 +142,9 @@ ts_project(
 vitest(
     name = "unit_test",
     srcs = SRCS + TESTS + TEST_LOCALE_DATA,
+    data = ["//:package.json"],
+    no_copy_to_bin = ["//:package.json"],
+    tsconfig = VITEST_TSCONFIG,
     deps = SRC_DEPS + [
         ":node_modules/@formatjs/intl-getcanonicallocales",
         ":node_modules/@formatjs/intl-locale",

--- a/packages/intl-relativetimeformat/abstract/FormatRelativeTime.ts
+++ b/packages/intl-relativetimeformat/abstract/FormatRelativeTime.ts
@@ -1,4 +1,4 @@
-import {type RelativeTimeFormatInternal} from '@formatjs/ecma402-abstract'
+import {type RelativeTimeFormatInternal} from '#packages/ecma402-abstract/types/relative-time.js'
 import {PartitionRelativeTimePattern} from './PartitionRelativeTimePattern.js'
 
 export function FormatRelativeTime(

--- a/packages/intl-relativetimeformat/abstract/FormatRelativeTimeToParts.ts
+++ b/packages/intl-relativetimeformat/abstract/FormatRelativeTimeToParts.ts
@@ -1,4 +1,4 @@
-import {type RelativeTimeFormatInternal} from '@formatjs/ecma402-abstract'
+import {type RelativeTimeFormatInternal} from '#packages/ecma402-abstract/types/relative-time.js'
 import {PartitionRelativeTimePattern} from './PartitionRelativeTimePattern.js'
 
 export function FormatRelativeTimeToParts(

--- a/packages/intl-relativetimeformat/abstract/InitializeRelativeTimeFormat.ts
+++ b/packages/intl-relativetimeformat/abstract/InitializeRelativeTimeFormat.ts
@@ -1,13 +1,15 @@
+import {CanonicalizeLocaleList} from '#packages/ecma402-abstract/CanonicalizeLocaleList.js'
+import {CoerceOptionsToObject} from '#packages/ecma402-abstract/CoerceOptionsToObject.js'
+import {GetOption} from '#packages/ecma402-abstract/GetOption.js'
 import {
-  CanonicalizeLocaleList,
-  CoerceOptionsToObject,
-  createMemoizedNumberFormat,
-  createMemoizedPluralRules,
-  GetOption,
-  invariant,
   type LocaleFieldsData,
   type RelativeTimeFormatInternal,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/types/relative-time.js'
+import {
+  createMemoizedNumberFormat,
+  createMemoizedPluralRules,
+  invariant,
+} from '#packages/ecma402-abstract/utils.js'
 import {ResolveLocale} from '@formatjs/intl-localematcher'
 
 const NUMBERING_SYSTEM_REGEX = /^[a-z0-9]{3,8}(-[a-z0-9]{3,8})*$/i

--- a/packages/intl-relativetimeformat/abstract/MakePartsList.ts
+++ b/packages/intl-relativetimeformat/abstract/MakePartsList.ts
@@ -1,4 +1,5 @@
-import {invariant, PartitionPattern} from '@formatjs/ecma402-abstract'
+import {PartitionPattern} from '#packages/ecma402-abstract/PartitionPattern.js'
+import {invariant} from '#packages/ecma402-abstract/utils.js'
 
 export function MakePartsList(
   pattern: string,

--- a/packages/intl-relativetimeformat/abstract/PartitionRelativeTimePattern.ts
+++ b/packages/intl-relativetimeformat/abstract/PartitionRelativeTimePattern.ts
@@ -1,13 +1,11 @@
+import {SameValue, ToString, Type} from '#packages/ecma402-abstract/262.js'
+import {type LDMLPluralRule} from '#packages/ecma402-abstract/types/plural-rules.js'
 import {
   type FieldData,
-  invariant,
-  type LDMLPluralRule,
   type RelativeTimeField,
   type RelativeTimeFormatInternal,
-  SameValue,
-  ToString,
-  Type,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/types/relative-time.js'
+import {invariant} from '#packages/ecma402-abstract/utils.js'
 import {SingularRelativeTimeUnit} from './SingularRelativeTimeUnit.js'
 import {MakePartsList} from './MakePartsList.js'
 

--- a/packages/intl-relativetimeformat/abstract/SingularRelativeTimeUnit.ts
+++ b/packages/intl-relativetimeformat/abstract/SingularRelativeTimeUnit.ts
@@ -1,8 +1,6 @@
-import {
-  invariant,
-  type RelativeTimeFormatSingularUnit,
-  Type,
-} from '@formatjs/ecma402-abstract'
+import {Type} from '#packages/ecma402-abstract/262.js'
+import {type RelativeTimeFormatSingularUnit} from '#packages/ecma402-abstract/types/relative-time.js'
+import {invariant} from '#packages/ecma402-abstract/utils.js'
 
 /**
  * https://tc39.es/proposal-intl-relative-time/#sec-singularrelativetimeunit

--- a/packages/intl-relativetimeformat/get_internal_slots.ts
+++ b/packages/intl-relativetimeformat/get_internal_slots.ts
@@ -1,7 +1,7 @@
 // Type-only circular import
 // eslint-disable-next-line import/no-cycle
 
-import {type RelativeTimeFormatInternal} from '@formatjs/ecma402-abstract'
+import {type RelativeTimeFormatInternal} from '#packages/ecma402-abstract/types/relative-time.js'
 
 const internalSlotMap = new WeakMap<
   Intl.RelativeTimeFormat,

--- a/packages/intl-relativetimeformat/index.ts
+++ b/packages/intl-relativetimeformat/index.ts
@@ -1,10 +1,10 @@
+import {ToString} from '#packages/ecma402-abstract/262.js'
+import {CanonicalizeLocaleList} from '#packages/ecma402-abstract/CanonicalizeLocaleList.js'
+import {SupportedLocales} from '#packages/ecma402-abstract/SupportedLocales.js'
 import {
-  CanonicalizeLocaleList,
   type LocaleFieldsData,
   type RelativeTimeLocaleData,
-  SupportedLocales,
-  ToString,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/types/relative-time.js'
 import {InitializeRelativeTimeFormat} from './abstract/InitializeRelativeTimeFormat.js'
 import {PartitionRelativeTimePattern} from './abstract/PartitionRelativeTimePattern.js'
 import getInternalSlots from './get_internal_slots.js'

--- a/packages/intl-relativetimeformat/scripts/BUILD.bazel
+++ b/packages/intl-relativetimeformat/scripts/BUILD.bazel
@@ -4,6 +4,7 @@ ts_binary(
     name = "cldr-raw",
     data = [
         "extract-relative.ts",
+        "//:package.json",
     ],
     entry_point = "cldr-raw.ts",
     visibility = ["//packages/intl-relativetimeformat:__pkg__"],

--- a/packages/intl-relativetimeformat/scripts/extract-relative.ts
+++ b/packages/intl-relativetimeformat/scripts/extract-relative.ts
@@ -12,7 +12,10 @@ import {resolve, dirname} from 'path'
 import {createRequire} from 'node:module'
 
 const require = createRequire(import.meta.url)
-import {type FieldData, type LocaleFieldsData} from '@formatjs/ecma402-abstract'
+import {
+  type FieldData,
+  type LocaleFieldsData,
+} from '#packages/ecma402-abstract/types/relative-time.js'
 import AVAILABLE_LOCALES from 'cldr-core/availableLocales.json' with {type: 'json'}
 
 // The set of CLDR date field names that are used in FormatJS.


### PR DESCRIPTION
## Summary
Replace barrel imports from `@formatjs/ecma402-abstract` with direct file imports via `#packages` path alias (de-barreled) in intl-listformat.

Stacked on #6219.

## Test plan
- [x] All 488 tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)