### PR TITLE
chore: convert scripts to use #packages imports for ecma402-abstract

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -19,6 +19,18 @@ exports_files(
     visibility = ["//visibility:public"],
 )
 
+# Root package.json for Node subpath import resolution (#packages/*).
+copy_to_bin(
+    name = "root_package_json",
+    srcs = ["package.json"],
+    visibility = ["//visibility:public"],
+)
+
+exports_files(
+    ["package.json"],
+    visibility = ["//visibility:public"],
+)
+
 gazelle(
     name = "gazelle",
     env = {

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -23,7 +23,7 @@ copy_to_bin(
 ts_project(
     name = "typecheck",
     srcs = [":srcs"],
-    declaration = True,
+    declaration = False,
     no_emit = True,
     resolve_json_module = True,
     transpiler = tsgo_bin.tsgo,

--- a/packages/intl-datetimeformat/BUILD.bazel
+++ b/packages/intl-datetimeformat/BUILD.bazel
@@ -10,7 +10,7 @@ load("@rules_multirun//:defs.bzl", "multirun")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_run_binary")
-load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
+load("//tools:tsconfig.bzl", "BASE_TSCONFIG", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 load(":defs.bzl", "ZONES")
 load(":index.bzl", "generate_dockerfile")
@@ -49,6 +49,7 @@ TESTS = glob([
 ])
 
 SRC_DEPS = [
+    "//packages/ecma402-abstract",
     ":node_modules/@formatjs/ecma402-abstract",
     ":node_modules/@formatjs/intl-localematcher",
     ":node_modules/@formatjs/bigdecimal",
@@ -63,7 +64,7 @@ TEST_DEPS = SRC_DEPS + [
 EXTERNAL_PACKAGES = [
     dep.split("node_modules/")[1]
     for dep in SRC_DEPS
-    if "node_modules/" in dep
+    if "node_modules/" in dep and "ecma402-abstract" not in dep
 ]
 
 ENTRY_POINTS = [
@@ -129,7 +130,7 @@ ts_project(
     no_emit = True,
     resolve_json_module = True,
     transpiler = tsgo_bin.tsgo,
-    tsconfig = BASE_TSCONFIG,
+    tsconfig = packages_tsconfig(),
     deps = SRC_DEPS,
 )
 
@@ -141,7 +142,7 @@ ts_project(
     emit_declaration_only = True,
     resolve_json_module = True,
     transpiler = tsgo_bin.tsgo,
-    tsconfig = BASE_TSCONFIG,
+    tsconfig = packages_tsconfig(),
     visibility = ["//visibility:public"],
     deps = SRC_DEPS,
 )
@@ -149,6 +150,9 @@ ts_project(
 vitest(
     name = "unit_test",
     srcs = SRCS + TESTS + TEST_LOCALE_DATA,
+    data = ["//:package.json"],
+    no_copy_to_bin = ["//:package.json"],
+    tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
     deps = TEST_DEPS,
 )
 
@@ -762,6 +766,7 @@ ts_run_binary(
         "//:node_modules/json-stable-stringify",
         "//:node_modules/lodash-es",
         "//:node_modules/minimist",
+        "//packages/ecma402-abstract",
     ],
     outs = CLDR_RAW_FILES,
     args = [
@@ -867,6 +872,7 @@ generate_src_file(
         ":node_modules/@formatjs/ecma402-abstract",
         ":zdumps",
         "//:node_modules/json-stable-stringify",
+        "//packages/ecma402-abstract",
     ],
     tags = ["cldr"],
     tool = "//packages/intl-datetimeformat/scripts:process-zdump",
@@ -884,6 +890,7 @@ ts_run_binary(
         "//:node_modules/fs-extra",
         "//:node_modules/json-stable-stringify",
         "//:node_modules/minimist",
+        "//packages/ecma402-abstract",
     ],
     outs = ["add-all-tz.js"],
     args = [
@@ -910,6 +917,7 @@ ts_run_binary(
         "//:node_modules/fs-extra",
         "//:node_modules/json-stable-stringify",
         "//:node_modules/minimist",
+        "//packages/ecma402-abstract",
     ],
     outs = ["add-golden-tz.js"],
     args = [

--- a/packages/intl-datetimeformat/polyfill-force.ts
+++ b/packages/intl-datetimeformat/polyfill-force.ts
@@ -1,4 +1,4 @@
-import {defineProperty} from '@formatjs/ecma402-abstract'
+import {defineProperty} from '#packages/ecma402-abstract/utils.js'
 import {DateTimeFormat} from './index.js'
 import {
   toLocaleDateString as _toLocaleDateString,

--- a/packages/intl-datetimeformat/polyfill.ts
+++ b/packages/intl-datetimeformat/polyfill.ts
@@ -1,5 +1,5 @@
 import {DateTimeFormat} from './index.js'
-import {defineProperty} from '@formatjs/ecma402-abstract'
+import {defineProperty} from '#packages/ecma402-abstract/utils.js'
 import {shouldPolyfill} from './should-polyfill.js'
 import {
   toLocaleString as _toLocaleString,

--- a/packages/intl-datetimeformat/src/abstract/BasicFormatMatcher.ts
+++ b/packages/intl-datetimeformat/src/abstract/BasicFormatMatcher.ts
@@ -1,4 +1,5 @@
-import {type Formats, invariant} from '@formatjs/ecma402-abstract'
+import {type Formats} from '#packages/ecma402-abstract/types/date-time.js'
+import {invariant} from '#packages/ecma402-abstract/utils.js'
 import {
   DATE_TIME_PROPS,
   additionPenalty,

--- a/packages/intl-datetimeformat/src/abstract/BestFitFormatMatcher.ts
+++ b/packages/intl-datetimeformat/src/abstract/BestFitFormatMatcher.ts
@@ -1,4 +1,8 @@
-import {type Formats, type TABLE_6, invariant} from '@formatjs/ecma402-abstract'
+import {
+  type Formats,
+  type TABLE_6,
+} from '#packages/ecma402-abstract/types/date-time.js'
+import {invariant} from '#packages/ecma402-abstract/utils.js'
 import {processDateTimePattern} from './skeleton.js'
 import {
   DATE_TIME_PROPS,

--- a/packages/intl-datetimeformat/src/abstract/DateTimeStyleFormat.ts
+++ b/packages/intl-datetimeformat/src/abstract/DateTimeStyleFormat.ts
@@ -1,8 +1,8 @@
 import {
   type DateTimeFormatLocaleInternalData,
   type Formats,
-  invariant,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/types/date-time.js'
+import {invariant} from '#packages/ecma402-abstract/utils.js'
 
 export function DateTimeStyleFormat(
   dateStyle: Intl.DateTimeFormatOptions['dateStyle'],

--- a/packages/intl-datetimeformat/src/abstract/FormatDateTime.ts
+++ b/packages/intl-datetimeformat/src/abstract/FormatDateTime.ts
@@ -1,4 +1,4 @@
-import {type DateTimeFormat} from '@formatjs/ecma402-abstract'
+import {type DateTimeFormat} from '#packages/ecma402-abstract/types/date-time.js'
 import type Decimal from '@formatjs/bigdecimal'
 import {PartitionDateTimePattern} from './PartitionDateTimePattern.js'
 

--- a/packages/intl-datetimeformat/src/abstract/FormatDateTimePattern.ts
+++ b/packages/intl-datetimeformat/src/abstract/FormatDateTimePattern.ts
@@ -1,11 +1,11 @@
+import {TimeClip} from '#packages/ecma402-abstract/262.js'
 import {
   type DateTimeFormat,
   type DateTimeFormatLocaleInternalData,
   type IntlDateTimeFormatInternal,
   type IntlDateTimeFormatPart,
-  TimeClip,
-  createMemoizedNumberFormat,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/types/date-time.js'
+import {createMemoizedNumberFormat} from '#packages/ecma402-abstract/utils.js'
 
 import Decimal from '@formatjs/bigdecimal'
 import {ToLocalTime, type ToLocalTimeImplDetails} from './ToLocalTime.js'

--- a/packages/intl-datetimeformat/src/abstract/FormatDateTimeRangeToParts.ts
+++ b/packages/intl-datetimeformat/src/abstract/FormatDateTimeRangeToParts.ts
@@ -1,4 +1,4 @@
-import {type IntlDateTimeFormatPart} from '@formatjs/ecma402-abstract'
+import {type IntlDateTimeFormatPart} from '#packages/ecma402-abstract/types/date-time.js'
 import type {Decimal} from '@formatjs/bigdecimal'
 import {type FormatDateTimePatternImplDetails} from './FormatDateTimePattern.js'
 import {PartitionDateTimeRangePattern} from './PartitionDateTimeRangePattern.js'

--- a/packages/intl-datetimeformat/src/abstract/FormatDateTimeToParts.ts
+++ b/packages/intl-datetimeformat/src/abstract/FormatDateTimeToParts.ts
@@ -1,7 +1,5 @@
-import {
-  ArrayCreate,
-  type IntlDateTimeFormatPart,
-} from '@formatjs/ecma402-abstract'
+import {ArrayCreate} from '#packages/ecma402-abstract/262.js'
+import {type IntlDateTimeFormatPart} from '#packages/ecma402-abstract/types/date-time.js'
 import type Decimal from '@formatjs/bigdecimal'
 import {PartitionDateTimePattern} from './PartitionDateTimePattern.js'
 

--- a/packages/intl-datetimeformat/src/abstract/InitializeDateTimeFormat.ts
+++ b/packages/intl-datetimeformat/src/abstract/InitializeDateTimeFormat.ts
@@ -1,15 +1,15 @@
+import {CanonicalizeLocaleList} from '#packages/ecma402-abstract/CanonicalizeLocaleList.js'
+import {CanonicalizeTimeZoneName} from '#packages/ecma402-abstract/CanonicalizeTimeZoneName.js'
+import {GetNumberOption} from '#packages/ecma402-abstract/GetNumberOption.js'
+import {GetOption} from '#packages/ecma402-abstract/GetOption.js'
+import {IsValidTimeZoneName} from '#packages/ecma402-abstract/IsValidTimeZoneName.js'
 import {
-  CanonicalizeLocaleList,
-  CanonicalizeTimeZoneName,
   type DateTimeFormat,
   type DateTimeFormatLocaleInternalData,
   type Formats,
-  GetNumberOption,
-  GetOption,
   type IntlDateTimeFormatInternal,
-  IsValidTimeZoneName,
-  invariant,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/types/date-time.js'
+import {invariant} from '#packages/ecma402-abstract/utils.js'
 import {ResolveLocale} from '@formatjs/intl-localematcher'
 import {BasicFormatMatcher} from './BasicFormatMatcher.js'
 import {BestFitFormatMatcher} from './BestFitFormatMatcher.js'

--- a/packages/intl-datetimeformat/src/abstract/PartitionDateTimePattern.ts
+++ b/packages/intl-datetimeformat/src/abstract/PartitionDateTimePattern.ts
@@ -1,11 +1,11 @@
+import {TimeClip} from '#packages/ecma402-abstract/262.js'
+import {PartitionPattern} from '#packages/ecma402-abstract/PartitionPattern.js'
 import {
   type DateTimeFormat,
   type IntlDateTimeFormatPart,
   type IntlDateTimeFormatPartType,
-  invariant,
-  PartitionPattern,
-  TimeClip,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/types/date-time.js'
+import {invariant} from '#packages/ecma402-abstract/utils.js'
 import type Decimal from '@formatjs/bigdecimal'
 import {
   FormatDateTimePattern,

--- a/packages/intl-datetimeformat/src/abstract/PartitionDateTimeRangePattern.ts
+++ b/packages/intl-datetimeformat/src/abstract/PartitionDateTimeRangePattern.ts
@@ -1,12 +1,11 @@
+import {SameValue, TimeClip} from '#packages/ecma402-abstract/262.js'
+import {PartitionPattern} from '#packages/ecma402-abstract/PartitionPattern.js'
 import {
   type IntlDateTimeFormatPart,
   type IntlDateTimeFormatPartType,
-  PartitionPattern,
   RangePatternType,
-  SameValue,
   type TABLE_2,
-  TimeClip,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/types/date-time.js'
 import type Decimal from '@formatjs/bigdecimal'
 import {
   FormatDateTimePattern,

--- a/packages/intl-datetimeformat/src/abstract/ToDateTimeOptions.ts
+++ b/packages/intl-datetimeformat/src/abstract/ToDateTimeOptions.ts
@@ -1,4 +1,4 @@
-import {ToObject} from '@formatjs/ecma402-abstract'
+import {ToObject} from '#packages/ecma402-abstract/262.js'
 
 /**
  * https://tc39.es/ecma402/#sec-todatetimeoptions

--- a/packages/intl-datetimeformat/src/abstract/ToLocalTime.ts
+++ b/packages/intl-datetimeformat/src/abstract/ToLocalTime.ts
@@ -4,12 +4,12 @@ import {
   MinFromTime,
   MonthFromTime,
   SecFromTime,
-  type UnpackedZoneData,
   WeekDay,
   YearFromTime,
-  invariant,
   msFromTime,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/262.js'
+import {type UnpackedZoneData} from '#packages/ecma402-abstract/types/date-time.js'
+import {invariant} from '#packages/ecma402-abstract/utils.js'
 import type Decimal from '@formatjs/bigdecimal'
 
 // Cached regex patterns for performance

--- a/packages/intl-datetimeformat/src/abstract/utils.ts
+++ b/packages/intl-datetimeformat/src/abstract/utils.ts
@@ -1,7 +1,7 @@
 import {
   type IntlDateTimeFormatInternal,
   type TABLE_6,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/types/date-time.js'
 
 export const DATE_TIME_PROPS: Array<
   keyof Pick<IntlDateTimeFormatInternal, TABLE_6>

--- a/packages/intl-datetimeformat/src/core.ts
+++ b/packages/intl-datetimeformat/src/core.ts
@@ -1,18 +1,16 @@
+import {OrdinaryHasInstance, ToNumber} from '#packages/ecma402-abstract/262.js'
+import {CanonicalizeLocaleList} from '#packages/ecma402-abstract/CanonicalizeLocaleList.js'
+import {CanonicalizeTimeZoneName} from '#packages/ecma402-abstract/CanonicalizeTimeZoneName.js'
+import {IsValidTimeZoneName} from '#packages/ecma402-abstract/IsValidTimeZoneName.js'
+import {SupportedLocales} from '#packages/ecma402-abstract/SupportedLocales.js'
 import {
-  CanonicalizeLocaleList,
-  CanonicalizeTimeZoneName,
   type DateTimeFormatLocaleInternalData,
   type DateTimeFormat as IDateTimeFormat,
   type IntlDateTimeFormatInternal,
-  IsValidTimeZoneName,
-  OrdinaryHasInstance,
-  SupportedLocales,
   type TABLE_6,
-  ToNumber,
   type UnpackedZoneData,
-  defineProperty,
-  invariant,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/types/date-time.js'
+import {defineProperty, invariant} from '#packages/ecma402-abstract/utils.js'
 import Decimal from '@formatjs/bigdecimal'
 import {FormatDateTime} from './abstract/FormatDateTime.js'
 import {FormatDateTimeRange} from './abstract/FormatDateTimeRange.js'

--- a/packages/intl-datetimeformat/src/get_internal_slots.ts
+++ b/packages/intl-datetimeformat/src/get_internal_slots.ts
@@ -4,7 +4,7 @@
 import {
   type DateTimeFormat,
   type IntlDateTimeFormatInternal,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/types/date-time.js'
 
 const internalSlotMap = new WeakMap<
   DateTimeFormat,

--- a/packages/intl-datetimeformat/tests/ftp-main.test.ts
+++ b/packages/intl-datetimeformat/tests/ftp-main.test.ts
@@ -4,7 +4,7 @@ import de from './locale-data/de.json' with {type: 'json'}
 import ar from './locale-data/ar.json' with {type: 'json'}
 import allData from '../src/data/all-tz.generated'
 import {DateTimeFormat} from '../src/core'
-import {type IntlDateTimeFormatPart} from '@formatjs/ecma402-abstract'
+import {type IntlDateTimeFormatPart} from '#packages/ecma402-abstract/types/date-time.js'
 import {describe, expect, it} from 'vitest'
 // @ts-ignore
 DateTimeFormat.__addLocaleData(en, pl, de, ar)

--- a/packages/intl-displaynames/BUILD.bazel
+++ b/packages/intl-displaynames/BUILD.bazel
@@ -9,7 +9,7 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_run_binary")
-load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
+load("//tools:tsconfig.bzl", "BASE_TSCONFIG", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -36,6 +36,7 @@ TESTS = glob([
 ])
 
 SRC_DEPS = [
+    "//packages/ecma402-abstract",
     ":node_modules/@formatjs/ecma402-abstract",
     ":node_modules/@formatjs/intl-localematcher",
 ]
@@ -48,7 +49,7 @@ TEST_DEPS = SRC_DEPS + [
 EXTERNAL_PACKAGES = [
     dep.split("node_modules/")[1]
     for dep in SRC_DEPS
-    if "node_modules/" in dep
+    if "node_modules/" in dep and "ecma402-abstract" not in dep
 ]
 
 ENTRY_POINTS = [
@@ -110,7 +111,7 @@ ts_project(
     no_emit = True,
     resolve_json_module = True,
     transpiler = tsgo_bin.tsgo,
-    tsconfig = BASE_TSCONFIG,
+    tsconfig = packages_tsconfig(),
     deps = SRC_DEPS,
 )
 
@@ -122,7 +123,7 @@ ts_project(
     emit_declaration_only = True,
     resolve_json_module = True,
     transpiler = tsgo_bin.tsgo,
-    tsconfig = BASE_TSCONFIG,
+    tsconfig = packages_tsconfig(),
     visibility = ["//visibility:public"],
     deps = SRC_DEPS,
 )
@@ -130,6 +131,9 @@ ts_project(
 vitest(
     name = "unit_test",
     srcs = SRCS + TESTS + TEST_LOCALE_DATA,
+    data = ["//:package.json"],
+    no_copy_to_bin = ["//:package.json"],
+    tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
     deps = TEST_DEPS,
 )
 
@@ -713,7 +717,6 @@ CLDR_RAW_FILES = ["cldr-raw/%s.json" % locale for locale in ALL_LOCALES]
 ts_run_binary(
     name = "cldr-raw",
     srcs = [
-        ":node_modules/@formatjs/ecma402-abstract",
         "//:node_modules/cldr-core",
         "//:node_modules/cldr-dates-full",
         "//:node_modules/cldr-localenames-full",
@@ -722,6 +725,7 @@ ts_run_binary(
         "//:node_modules/fs-extra",
         "//:node_modules/json-stable-stringify",
         "//:node_modules/minimist",
+        "//packages/ecma402-abstract",
     ],
     outs = CLDR_RAW_FILES,
     args = [

--- a/packages/intl-displaynames/abstract/CanonicalCodeForDisplayNames.ts
+++ b/packages/intl-displaynames/abstract/CanonicalCodeForDisplayNames.ts
@@ -1,8 +1,6 @@
-import {
-  CanonicalizeLocaleList,
-  invariant,
-  IsWellFormedCurrencyCode,
-} from '@formatjs/ecma402-abstract'
+import {CanonicalizeLocaleList} from '#packages/ecma402-abstract/CanonicalizeLocaleList.js'
+import {IsWellFormedCurrencyCode} from '#packages/ecma402-abstract/IsWellFormedCurrencyCode.js'
+import {invariant} from '#packages/ecma402-abstract/utils.js'
 
 import {IsValidDateTimeFieldCode} from './IsValidDateTimeFieldCode.js'
 

--- a/packages/intl-displaynames/index.ts
+++ b/packages/intl-displaynames/index.ts
@@ -1,17 +1,19 @@
+import {ToString} from '#packages/ecma402-abstract/262.js'
+import {CanonicalizeLocaleList} from '#packages/ecma402-abstract/CanonicalizeLocaleList.js'
+import {GetOption} from '#packages/ecma402-abstract/GetOption.js'
+import {GetOptionsObject} from '#packages/ecma402-abstract/GetOptionsObject.js'
+import {IsWellFormedCurrencyCode} from '#packages/ecma402-abstract/IsWellFormedCurrencyCode.js'
+import {SupportedLocales} from '#packages/ecma402-abstract/SupportedLocales.js'
 import {
-  CanonicalizeLocaleList,
   type DisplayNamesData,
   type DisplayNamesLocaleData,
-  GetOption,
-  GetOptionsObject,
-  IsWellFormedCurrencyCode,
-  SupportedLocales,
-  ToString,
+} from '#packages/ecma402-abstract/types/displaynames.js'
+import {
   getInternalSlot,
   getMultiInternalSlots,
   invariant,
   setInternalSlot,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/utils.js'
 import {CanonicalCodeForDisplayNames} from './abstract/CanonicalCodeForDisplayNames.js'
 import {IsValidDateTimeFieldCode} from './abstract/IsValidDateTimeFieldCode.js'
 

--- a/packages/intl-displaynames/scripts/BUILD.bazel
+++ b/packages/intl-displaynames/scripts/BUILD.bazel
@@ -4,6 +4,7 @@ ts_binary(
     name = "cldr-raw",
     data = [
         "extract-displaynames.ts",
+        "//:root_package_json",
     ],
     entry_point = "cldr-raw.ts",
     visibility = ["//packages/intl-displaynames:__pkg__"],
@@ -11,12 +12,14 @@ ts_binary(
 
 ts_binary(
     name = "cldr",
+    data = ["//:root_package_json"],
     entry_point = "cldr.ts",
     visibility = ["//packages/intl-displaynames:__pkg__"],
 )
 
 ts_binary(
     name = "test262-main-gen",
+    data = ["//:root_package_json"],
     entry_point = "test262-main-gen.ts",
     visibility = ["//packages/intl-displaynames:__pkg__"],
 )

--- a/packages/intl-displaynames/scripts/extract-displaynames.ts
+++ b/packages/intl-displaynames/scripts/extract-displaynames.ts
@@ -1,4 +1,4 @@
-import {type DisplayNamesData} from '@formatjs/ecma402-abstract'
+import {type DisplayNamesData} from '#packages/ecma402-abstract/types/displaynames.js'
 import AVAILABLE_LOCALES from 'cldr-core/availableLocales.json' with {type: 'json'}
 import glob from 'fast-glob'
 import {dirname, resolve} from 'path'

--- a/packages/intl-listformat/BUILD.bazel
+++ b/packages/intl-listformat/BUILD.bazel
@@ -9,7 +9,7 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_run_binary")
-load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
+load("//tools:tsconfig.bzl", "BASE_TSCONFIG", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -38,6 +38,7 @@ TESTS = glob([
 ])
 
 SRC_DEPS = [
+    "//packages/ecma402-abstract",
     ":node_modules/@formatjs/ecma402-abstract",
     ":node_modules/@formatjs/intl-localematcher",
 ]
@@ -51,7 +52,7 @@ TEST_DEPS = SRC_DEPS + [
 EXTERNAL_PACKAGES = [
     dep.split("node_modules/")[1]
     for dep in SRC_DEPS
-    if "node_modules/" in dep
+    if "node_modules/" in dep and "ecma402-abstract" not in dep
 ]
 
 ENTRY_POINTS = [
@@ -113,7 +114,7 @@ ts_project(
     no_emit = True,
     resolve_json_module = True,
     transpiler = tsgo_bin.tsgo,
-    tsconfig = BASE_TSCONFIG,
+    tsconfig = packages_tsconfig(),
     deps = SRC_DEPS,
 )
 
@@ -125,7 +126,7 @@ ts_project(
     emit_declaration_only = True,
     resolve_json_module = True,
     transpiler = tsgo_bin.tsgo,
-    tsconfig = BASE_TSCONFIG,
+    tsconfig = packages_tsconfig(),
     visibility = ["//visibility:public"],
     deps = SRC_DEPS,
 )
@@ -133,6 +134,9 @@ ts_project(
 vitest(
     name = "unit_test",
     srcs = SRCS + TESTS + TEST_LOCALE_DATA,
+    data = ["//:package.json"],
+    no_copy_to_bin = ["//:package.json"],
+    tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
     deps = TEST_DEPS,
 )
 
@@ -716,7 +720,6 @@ CLDR_RAW_FILES = ["cldr-raw/%s.json" % locale for locale in ALL_LOCALES]
 ts_run_binary(
     name = "cldr-raw",
     srcs = [
-        ":node_modules/@formatjs/ecma402-abstract",
         "//:node_modules/@types/lodash-es",
         "//:node_modules/cldr-core",
         "//:node_modules/cldr-misc-full",
@@ -725,6 +728,7 @@ ts_run_binary(
         "//:node_modules/json-stable-stringify",
         "//:node_modules/lodash-es",
         "//:node_modules/minimist",
+        "//packages/ecma402-abstract",
     ],
     outs = CLDR_RAW_FILES,
     args = [

--- a/packages/intl-listformat/index.ts
+++ b/packages/intl-listformat/index.ts
@@ -1,18 +1,20 @@
+import {CanonicalizeLocaleList} from '#packages/ecma402-abstract/CanonicalizeLocaleList.js'
+import {GetOption} from '#packages/ecma402-abstract/GetOption.js'
+import {GetOptionsObject} from '#packages/ecma402-abstract/GetOptionsObject.js'
+import {PartitionPattern} from '#packages/ecma402-abstract/PartitionPattern.js'
+import {SupportedLocales} from '#packages/ecma402-abstract/SupportedLocales.js'
 import {
-  CanonicalizeLocaleList,
-  getInternalSlot,
-  GetOption,
-  GetOptionsObject,
-  invariant,
-  isLiteralPart,
   type ListPatternData,
   type ListPatternFieldsData,
   type ListPatternLocaleData,
+} from '#packages/ecma402-abstract/types/list.js'
+import {
   type LiteralPart,
-  PartitionPattern,
+  getInternalSlot,
+  invariant,
+  isLiteralPart,
   setInternalSlot,
-  SupportedLocales,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/utils.js'
 import {ResolveLocale} from '@formatjs/intl-localematcher'
 
 export interface IntlListFormatOptions {

--- a/packages/intl-listformat/scripts/BUILD.bazel
+++ b/packages/intl-listformat/scripts/BUILD.bazel
@@ -4,6 +4,7 @@ ts_binary(
     name = "cldr-raw",
     data = [
         "extract-list.ts",
+        "//:root_package_json",
     ],
     entry_point = "cldr-raw.ts",
     visibility = ["//packages/intl-listformat:__pkg__"],
@@ -11,12 +12,14 @@ ts_binary(
 
 ts_binary(
     name = "cldr",
+    data = ["//:root_package_json"],
     entry_point = "cldr.ts",
     visibility = ["//packages/intl-listformat:__pkg__"],
 )
 
 ts_binary(
     name = "test262-main-gen",
+    data = ["//:root_package_json"],
     entry_point = "test262-main-gen.ts",
     visibility = ["//packages/intl-listformat:__pkg__"],
 )

--- a/packages/intl-listformat/scripts/extract-list.ts
+++ b/packages/intl-listformat/scripts/extract-list.ts
@@ -13,7 +13,7 @@ const require = createRequire(import.meta.url)
 import {
   type ListPatternFieldsData,
   type ListPattern,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/types/list.js'
 
 export type ListTypes = (typeof ListPatterns)['main']['en']['listPatterns']
 

--- a/packages/intl-numberformat/BUILD.bazel
+++ b/packages/intl-numberformat/BUILD.bazel
@@ -11,7 +11,7 @@ load("@rules_multirun//:defs.bzl", "multirun")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_run_binary")
-load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
+load("//tools:tsconfig.bzl", "BASE_TSCONFIG", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -72,6 +72,7 @@ SRCS = glob(
 )
 
 SRC_DEPS = [
+    "//packages/ecma402-abstract",
     ":node_modules/@formatjs/ecma402-abstract",
     ":node_modules/@formatjs/intl-localematcher",
     ":node_modules/@formatjs/bigdecimal",
@@ -87,7 +88,7 @@ TEST_DEPS = SRC_DEPS + [
 EXTERNAL_PACKAGES = [
     dep.split("node_modules/")[1]
     for dep in SRC_DEPS
-    if "node_modules/" in dep
+    if "node_modules/" in dep and "ecma402-abstract" not in dep
 ]
 
 ENTRY_POINTS = [
@@ -149,7 +150,7 @@ ts_project(
     no_emit = True,
     resolve_json_module = True,
     transpiler = tsgo_bin.tsgo,
-    tsconfig = BASE_TSCONFIG,
+    tsconfig = packages_tsconfig(),
     deps = SRC_DEPS,
 )
 
@@ -161,7 +162,7 @@ ts_project(
     emit_declaration_only = True,
     resolve_json_module = True,
     transpiler = tsgo_bin.tsgo,
-    tsconfig = BASE_TSCONFIG,
+    tsconfig = packages_tsconfig(),
     visibility = ["//visibility:public"],
     deps = SRC_DEPS,
 )
@@ -250,6 +251,9 @@ vitest(
                "tests/*.test.ts",
            ]) + [":srcs"] +
            TEST_LOCALE_DATA,
+    data = ["//:package.json"],
+    no_copy_to_bin = ["//:package.json"],
+    tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
     deps = TEST_DEPS,
 )
 
@@ -264,6 +268,9 @@ vitest(
             ":srcs",
             "tests/%s/%sTest.ts" % (type, type),
         ] + TEST_LOCALE_DATA,
+        data = ["//:package.json"],
+        no_copy_to_bin = ["//:package.json"],
+        tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
         deps = TEST_DEPS,
     )
     for type in LOCALE_TEST_TYPES
@@ -849,7 +856,6 @@ CLDR_RAW_FILES = ["cldr-raw/%s.json" % locale for locale in ALL_LOCALES]
 ts_run_binary(
     name = "cldr-raw",
     srcs = [
-        ":node_modules/@formatjs/ecma402-abstract",
         "//:node_modules/@types/lodash-es",
         "//:node_modules/cldr-core",
         "//:node_modules/cldr-numbers-full",
@@ -859,6 +865,7 @@ ts_run_binary(
         "//:node_modules/json-stable-stringify",
         "//:node_modules/lodash-es",
         "//:node_modules/minimist",
+        "//packages/ecma402-abstract",
     ],
     outs = CLDR_RAW_FILES,
     args = [
@@ -943,13 +950,13 @@ generate_src_file(
     name = "currency-digits",
     src = "src/currency-digits.generated.ts",
     data = [
-        ":node_modules/@formatjs/ecma402-abstract",
         "//:node_modules/@types/lodash-es",
         "//:node_modules/cldr-core",
         "//:node_modules/cldr-numbers-full",
         "//:node_modules/fast-glob",
         "//:node_modules/json-stable-stringify",
         "//:node_modules/lodash-es",
+        "//packages/ecma402-abstract",
     ],
     tags = ["cldr"],
     tool = "//packages/intl-numberformat/scripts:currency-digits",
@@ -960,11 +967,11 @@ generate_src_file(
     name = "numbering-systems",
     src = "src/numbering-systems.generated.ts",
     data = [
-        ":node_modules/@formatjs/ecma402-abstract",
         "//:node_modules/@types/lodash-es",
         "//:node_modules/cldr-core",
         "//:node_modules/cldr-numbers-full",
         "//:node_modules/lodash-es",
+        "//packages/ecma402-abstract",
     ],
     tags = ["cldr"],
     tool = "//packages/intl-numberformat/scripts:numbering-systems",

--- a/packages/intl-numberformat/polyfill-force.ts
+++ b/packages/intl-numberformat/polyfill-force.ts
@@ -1,9 +1,7 @@
 import {NumberFormat} from './src/core.js'
 import {toLocaleString as _toLocaleString} from './src/to_locale_string.js'
-import {
-  defineProperty,
-  type NumberFormatOptions,
-} from '@formatjs/ecma402-abstract'
+import {type NumberFormatOptions} from '#packages/ecma402-abstract/types/number.js'
+import {defineProperty} from '#packages/ecma402-abstract/utils.js'
 
 defineProperty(Intl, 'NumberFormat', {value: NumberFormat})
 defineProperty(Number.prototype, 'toLocaleString', {

--- a/packages/intl-numberformat/polyfill.ts
+++ b/packages/intl-numberformat/polyfill.ts
@@ -1,9 +1,7 @@
 import {NumberFormat} from './src/core.js'
 import {toLocaleString as _toLocaleString} from './src/to_locale_string.js'
-import {
-  defineProperty,
-  type NumberFormatOptions,
-} from '@formatjs/ecma402-abstract'
+import {type NumberFormatOptions} from '#packages/ecma402-abstract/types/number.js'
+import {defineProperty} from '#packages/ecma402-abstract/utils.js'
 import {shouldPolyfill} from './should-polyfill.js'
 
 if (shouldPolyfill()) {

--- a/packages/intl-numberformat/scripts/BUILD.bazel
+++ b/packages/intl-numberformat/scripts/BUILD.bazel
@@ -7,6 +7,7 @@ ts_binary(
     data = [
         "//:node_modules/fs-extra",
         "//:node_modules/minimist",
+        "//:root_package_json",
     ],
     entry_point = "generate-locale-test.ts",
     visibility = ["//packages/intl-numberformat:__pkg__"],
@@ -19,6 +20,7 @@ ts_binary(
         "extract-numbers.ts",
         "extract-units.ts",
         "utils.ts",
+        "//:root_package_json",
     ],
     entry_point = "cldr-raw.ts",
     visibility = ["//packages/intl-numberformat:__pkg__"],
@@ -26,12 +28,14 @@ ts_binary(
 
 ts_binary(
     name = "cldr",
+    data = ["//:root_package_json"],
     entry_point = "cldr.ts",
     visibility = ["//packages/intl-numberformat:__pkg__"],
 )
 
 ts_binary(
     name = "test262-main-gen",
+    data = ["//:root_package_json"],
     entry_point = "test262-main-gen.ts",
     visibility = ["//packages/intl-numberformat:__pkg__"],
 )
@@ -41,6 +45,7 @@ ts_binary(
     data = [
         "extract-currencies.ts",
         "utils.ts",
+        "//:root_package_json",
     ],
     entry_point = "currency-digits.ts",
     visibility = ["//packages/intl-numberformat:__pkg__"],
@@ -51,6 +56,7 @@ ts_binary(
     data = [
         "extract-numbers.ts",
         "utils.ts",
+        "//:root_package_json",
     ],
     entry_point = "numbering-systems.ts",
     visibility = ["//packages/intl-numberformat:__pkg__"],

--- a/packages/intl-numberformat/scripts/extract-currencies.ts
+++ b/packages/intl-numberformat/scripts/extract-currencies.ts
@@ -15,7 +15,7 @@ const require = createRequire(import.meta.url)
 import {
   type CurrencyData,
   type LDMLPluralRuleMap,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/types/number.js'
 import AVAILABLE_LOCALES from 'cldr-core/availableLocales.json' with {type: 'json'}
 import {collapseSingleValuePluralRule, PLURAL_RULES} from './utils.ts'
 

--- a/packages/intl-numberformat/scripts/extract-numbers.ts
+++ b/packages/intl-numberformat/scripts/extract-numbers.ts
@@ -11,8 +11,8 @@ import {
   type LDMLPluralRuleMap,
   type DecimalFormatNum,
   type RawCurrencyData,
-  invariant,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/types/number.js'
+import {invariant} from '#packages/ecma402-abstract/utils.js'
 import AVAILABLE_LOCALES from 'cldr-core/availableLocales.json' with {type: 'json'}
 import {collapseSingleValuePluralRule, PLURAL_RULES} from './utils.ts'
 

--- a/packages/intl-numberformat/scripts/extract-units.ts
+++ b/packages/intl-numberformat/scripts/extract-units.ts
@@ -4,14 +4,14 @@
  * See the accompanying LICENSE file for terms.
  */
 import {fromPairs} from 'lodash-es'
+import {removeUnitNamespace} from '#packages/ecma402-abstract/IsSanctionedSimpleUnitIdentifier.js'
+import {IsWellFormedUnitIdentifier} from '#packages/ecma402-abstract/IsWellFormedUnitIdentifier.js'
 import {
-  invariant,
   type LDMLPluralRuleMap,
   type UnitDataTable,
-  removeUnitNamespace,
-  IsWellFormedUnitIdentifier,
   type UnitData,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/types/number.js'
+import {invariant} from '#packages/ecma402-abstract/utils.js'
 import UnitsData from 'cldr-units-full/main/en/units.json' with {type: 'json'}
 import AVAILABLE_LOCALES from 'cldr-core/availableLocales.json' with {type: 'json'}
 import {collapseSingleValuePluralRule, PLURAL_RULES} from './utils.ts'

--- a/packages/intl-numberformat/scripts/units-constants.ts
+++ b/packages/intl-numberformat/scripts/units-constants.ts
@@ -1,5 +1,5 @@
 import minimist from 'minimist'
-import {SIMPLE_UNITS} from '@formatjs/ecma402-abstract'
+import {SIMPLE_UNITS} from '#packages/ecma402-abstract/IsSanctionedSimpleUnitIdentifier.js'
 import {outputFileSync} from 'fs-extra/esm'
 
 function main(args: minimist.ParsedArgs) {

--- a/packages/intl-numberformat/scripts/utils.ts
+++ b/packages/intl-numberformat/scripts/utils.ts
@@ -1,7 +1,5 @@
-import {
-  type LDMLPluralRuleMap,
-  type LDMLPluralRule,
-} from '@formatjs/ecma402-abstract'
+import {type LDMLPluralRuleMap} from '#packages/ecma402-abstract/types/number.js'
+import {type LDMLPluralRule} from '#packages/ecma402-abstract/types/plural-rules.js'
 import {isEqual} from 'lodash-es'
 export function collapseSingleValuePluralRule<T>(
   rules: LDMLPluralRuleMap<T>

--- a/packages/intl-numberformat/src/core.ts
+++ b/packages/intl-numberformat/src/core.ts
@@ -1,19 +1,21 @@
+import {OrdinaryHasInstance} from '#packages/ecma402-abstract/262.js'
+import {CanonicalizeLocaleList} from '#packages/ecma402-abstract/CanonicalizeLocaleList.js'
+import {FormatNumeric} from '#packages/ecma402-abstract/NumberFormat/FormatNumeric.js'
+import {FormatNumericRange} from '#packages/ecma402-abstract/NumberFormat/FormatNumericRange.js'
+import {FormatNumericRangeToParts} from '#packages/ecma402-abstract/NumberFormat/FormatNumericRangeToParts.js'
+import {FormatNumericToParts} from '#packages/ecma402-abstract/NumberFormat/FormatNumericToParts.js'
+import {InitializeNumberFormat} from '#packages/ecma402-abstract/NumberFormat/InitializeNumberFormat.js'
+import {SupportedLocales} from '#packages/ecma402-abstract/SupportedLocales.js'
+import {ToIntlMathematicalValue} from '#packages/ecma402-abstract/ToIntlMathematicalValue.js'
 import {
-  CanonicalizeLocaleList,
-  FormatNumeric,
-  FormatNumericRange,
-  FormatNumericRangeToParts,
-  FormatNumericToParts,
-  InitializeNumberFormat,
   type NumberFormatOptions,
-  OrdinaryHasInstance,
   type RawNumberLocaleData,
-  SupportedLocales,
-  ToIntlMathematicalValue,
+} from '#packages/ecma402-abstract/types/number.js'
+import {
   createMemoizedPluralRules,
   defineProperty,
   invariant,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/utils.js'
 import {currencyDigitsData} from './currency-digits.generated.js'
 import {numberingSystemNames} from './numbering-systems.generated.js'
 // eslint-disable-next-line import/no-cycle

--- a/packages/intl-numberformat/src/get_internal_slots.ts
+++ b/packages/intl-numberformat/src/get_internal_slots.ts
@@ -1,6 +1,6 @@
 // Type-only circular import
 
-import {type NumberFormatInternal} from '@formatjs/ecma402-abstract'
+import {type NumberFormatInternal} from '#packages/ecma402-abstract/types/number.js'
 
 const internalSlotMap = new WeakMap<Intl.NumberFormat, NumberFormatInternal>()
 

--- a/packages/intl-numberformat/src/to_locale_string.ts
+++ b/packages/intl-numberformat/src/to_locale_string.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line import/no-cycle
 import {NumberFormat} from './core.js'
-import {type NumberFormatOptions} from '@formatjs/ecma402-abstract'
+import {type NumberFormatOptions} from '#packages/ecma402-abstract/types/number.js'
 
 /**
  * Number.prototype.toLocaleString ponyfill

--- a/packages/intl-numberformat/src/types.ts
+++ b/packages/intl-numberformat/src/types.ts
@@ -5,7 +5,7 @@ import {
   type NumberRangeToParts,
   type RawNumberLocaleData,
   type ResolvedNumberFormatOptions,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/types/number.js'
 import type Decimal from '@formatjs/bigdecimal'
 
 // Public --------------------------------------------------------------------------------------------------------------

--- a/packages/intl-numberformat/tests/currency/currencyTest.ts
+++ b/packages/intl-numberformat/tests/currency/currencyTest.ts
@@ -1,5 +1,5 @@
 import {describe, it, beforeAll, expect} from 'vitest'
-import {type NumberFormatOptions} from '@formatjs/ecma402-abstract'
+import {type NumberFormatOptions} from '#packages/ecma402-abstract/types/number.js'
 import '@formatjs/intl-pluralrules/polyfill.js'
 import {NumberFormat} from '../../src/core'
 

--- a/packages/intl-numberformat/tests/decimal/decimalTest.ts
+++ b/packages/intl-numberformat/tests/decimal/decimalTest.ts
@@ -1,5 +1,5 @@
 import {describe, it, beforeAll, expect} from 'vitest'
-import {type NumberFormatOptions} from '@formatjs/ecma402-abstract'
+import {type NumberFormatOptions} from '#packages/ecma402-abstract/types/number.js'
 import '@formatjs/intl-pluralrules/polyfill.js'
 import {NumberFormat} from '../../src/core'
 

--- a/packages/intl-numberformat/tests/format_to_parts.test.ts
+++ b/packages/intl-numberformat/tests/format_to_parts.test.ts
@@ -1,5 +1,5 @@
 import {it, expect} from 'vitest'
-import {_formatToParts} from '@formatjs/ecma402-abstract'
+import _formatToParts from '#packages/ecma402-abstract/NumberFormat/format_to_parts.js'
 import Decimal from '@formatjs/bigdecimal'
 
 function format(...args: Parameters<typeof _formatToParts>): string {

--- a/packages/intl-numberformat/tests/notation-compact-ko-KR.test.ts
+++ b/packages/intl-numberformat/tests/notation-compact-ko-KR.test.ts
@@ -1,5 +1,5 @@
 import {describe, it, expect} from 'vitest'
-import {type NumberFormatPart} from '@formatjs/ecma402-abstract'
+import {type NumberFormatPart} from '#packages/ecma402-abstract/types/number.js'
 import '@formatjs/intl-pluralrules/locale-data/ko'
 import '@formatjs/intl-pluralrules/polyfill.js'
 import {NumberFormat} from '../src/core'

--- a/packages/intl-numberformat/tests/percent/percentTest.ts
+++ b/packages/intl-numberformat/tests/percent/percentTest.ts
@@ -1,5 +1,5 @@
 import {describe, it, beforeAll, expect} from 'vitest'
-import {type NumberFormatOptions} from '@formatjs/ecma402-abstract'
+import {type NumberFormatOptions} from '#packages/ecma402-abstract/types/number.js'
 import '@formatjs/intl-pluralrules/polyfill.js'
 import {NumberFormat} from '../../src/core'
 

--- a/packages/intl-numberformat/tests/unit/unitTest.ts
+++ b/packages/intl-numberformat/tests/unit/unitTest.ts
@@ -1,5 +1,5 @@
 import {describe, it, beforeAll, expect} from 'vitest'
-import {type NumberFormatOptions} from '@formatjs/ecma402-abstract'
+import {type NumberFormatOptions} from '#packages/ecma402-abstract/types/number.js'
 import '@formatjs/intl-pluralrules/polyfill.js'
 import {NumberFormat} from '../../src/core'
 

--- a/packages/intl-pluralrules/BUILD.bazel
+++ b/packages/intl-pluralrules/BUILD.bazel
@@ -9,7 +9,7 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_run_binary")
-load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
+load("//tools:tsconfig.bzl", "BASE_TSCONFIG", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -255,6 +255,7 @@ TESTS = glob([
 ])
 
 SRC_DEPS = [
+    "//packages/ecma402-abstract",
     ":node_modules/@formatjs/ecma402-abstract",
     ":node_modules/@formatjs/intl-localematcher",
     ":node_modules/@formatjs/bigdecimal",
@@ -263,7 +264,7 @@ SRC_DEPS = [
 EXTERNAL_PACKAGES = [
     dep.split("node_modules/")[1]
     for dep in SRC_DEPS
-    if "node_modules/" in dep
+    if "node_modules/" in dep and "ecma402-abstract" not in dep
 ]
 
 ENTRY_POINTS = [
@@ -325,7 +326,7 @@ ts_project(
     no_emit = True,
     resolve_json_module = True,
     transpiler = tsgo_bin.tsgo,
-    tsconfig = BASE_TSCONFIG,
+    tsconfig = packages_tsconfig(),
     deps = SRC_DEPS,
 )
 
@@ -337,7 +338,7 @@ ts_project(
     emit_declaration_only = True,
     resolve_json_module = True,
     transpiler = tsgo_bin.tsgo,
-    tsconfig = BASE_TSCONFIG,
+    tsconfig = packages_tsconfig(),
     visibility = ["//visibility:public"],
     deps = SRC_DEPS,
 )
@@ -345,6 +346,9 @@ ts_project(
 vitest(
     name = "unit_test",
     srcs = SRCS + TESTS + TEST_LOCALE_DATA,
+    data = ["//:package.json"],
+    no_copy_to_bin = ["//:package.json"],
+    tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
     deps = SRC_DEPS + [
         ":node_modules/@formatjs/intl-getcanonicallocales",
         ":node_modules/@formatjs/intl-locale",
@@ -357,7 +361,6 @@ CLDR_RAW_FILES = ["cldr-raw/%s.js" % locale for locale in ALL_LOCALES]
 ts_run_binary(
     name = "cldr-raw",
     srcs = [
-        ":node_modules/@formatjs/ecma402-abstract",
         "//:node_modules/@types/serialize-javascript",
         "//:node_modules/cldr-core",
         "//:node_modules/fs-extra",
@@ -365,6 +368,7 @@ ts_run_binary(
         "//:node_modules/minimist",
         "//:node_modules/serialize-javascript",
         "//:node_modules/typescript",
+        "//packages/ecma402-abstract",
     ],
     outs = CLDR_RAW_FILES,
     args = [

--- a/packages/intl-pluralrules/abstract/GetOperands.ts
+++ b/packages/intl-pluralrules/abstract/GetOperands.ts
@@ -1,4 +1,6 @@
-import {invariant, ToNumber, ZERO} from '@formatjs/ecma402-abstract'
+import {ToNumber} from '#packages/ecma402-abstract/262.js'
+import {ZERO} from '#packages/ecma402-abstract/constants.js'
+import {invariant} from '#packages/ecma402-abstract/utils.js'
 import type Decimal from '@formatjs/bigdecimal'
 
 /**

--- a/packages/intl-pluralrules/abstract/InitializePluralRules.ts
+++ b/packages/intl-pluralrules/abstract/InitializePluralRules.ts
@@ -1,11 +1,11 @@
+import {CanonicalizeLocaleList} from '#packages/ecma402-abstract/CanonicalizeLocaleList.js'
+import {CoerceOptionsToObject} from '#packages/ecma402-abstract/CoerceOptionsToObject.js'
+import {GetOption} from '#packages/ecma402-abstract/GetOption.js'
+import {SetNumberFormatDigitOptions} from '#packages/ecma402-abstract/NumberFormat/SetNumberFormatDigitOptions.js'
 import {
-  CanonicalizeLocaleList,
-  CoerceOptionsToObject,
-  GetOption,
   type PluralRulesData,
   type PluralRulesInternal,
-  SetNumberFormatDigitOptions,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/types/plural-rules.js'
 import {ResolveLocale} from '@formatjs/intl-localematcher'
 
 export function InitializePluralRules(

--- a/packages/intl-pluralrules/abstract/ResolvePlural.ts
+++ b/packages/intl-pluralrules/abstract/ResolvePlural.ts
@@ -1,11 +1,11 @@
+import {Type} from '#packages/ecma402-abstract/262.js'
+import {ComputeExponentForMagnitude} from '#packages/ecma402-abstract/NumberFormat/ComputeExponentForMagnitude.js'
+import {FormatNumericToString} from '#packages/ecma402-abstract/NumberFormat/FormatNumericToString.js'
 import {
-  ComputeExponentForMagnitude,
-  FormatNumericToString,
-  invariant,
   type LDMLPluralRule,
   type PluralRulesInternal,
-  Type,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/types/plural-rules.js'
+import {invariant} from '#packages/ecma402-abstract/utils.js'
 import Decimal from '@formatjs/bigdecimal'
 import {GetOperands, type OperandsRecord} from './GetOperands.js'
 

--- a/packages/intl-pluralrules/abstract/ResolvePluralRange.ts
+++ b/packages/intl-pluralrules/abstract/ResolvePluralRange.ts
@@ -1,9 +1,9 @@
+import {Type} from '#packages/ecma402-abstract/262.js'
 import {
-  invariant,
   type LDMLPluralRule,
   type PluralRulesInternal,
-  Type,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/types/plural-rules.js'
+import {invariant} from '#packages/ecma402-abstract/utils.js'
 import type Decimal from '@formatjs/bigdecimal'
 import {type OperandsRecord} from './GetOperands.js'
 import {ResolvePluralInternal} from './ResolvePlural.js'

--- a/packages/intl-pluralrules/index.ts
+++ b/packages/intl-pluralrules/index.ts
@@ -1,12 +1,12 @@
+import {CanonicalizeLocaleList} from '#packages/ecma402-abstract/CanonicalizeLocaleList.js'
+import {SupportedLocales} from '#packages/ecma402-abstract/SupportedLocales.js'
+import {ToIntlMathematicalValue} from '#packages/ecma402-abstract/ToIntlMathematicalValue.js'
+import {type NumberFormatDigitInternalSlots} from '#packages/ecma402-abstract/types/number.js'
 import {
-  CanonicalizeLocaleList,
   type LDMLPluralRule,
-  type NumberFormatDigitInternalSlots,
   type PluralRulesData,
   type PluralRulesLocaleData,
-  SupportedLocales,
-  ToIntlMathematicalValue,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/types/plural-rules.js'
 import type Decimal from '@formatjs/bigdecimal'
 import {type OperandsRecord} from './abstract/GetOperands.js'
 import {InitializePluralRules} from './abstract/InitializePluralRules.js'

--- a/packages/intl-pluralrules/scripts/BUILD.bazel
+++ b/packages/intl-pluralrules/scripts/BUILD.bazel
@@ -4,6 +4,7 @@ ts_binary(
     name = "cldr-raw",
     data = [
         "plural-rules-compiler.ts",
+        "//:root_package_json",
     ],
     entry_point = "cldr-raw.ts",
     visibility = ["//packages/intl-pluralrules:__pkg__"],
@@ -11,12 +12,14 @@ ts_binary(
 
 ts_binary(
     name = "cldr",
+    data = ["//:root_package_json"],
     entry_point = "cldr.ts",
     visibility = ["//packages/intl-pluralrules:__pkg__"],
 )
 
 ts_binary(
     name = "test262-main-gen",
+    data = ["//:root_package_json"],
     entry_point = "test262-main-gen.ts",
     visibility = ["//packages/intl-pluralrules:__pkg__"],
 )

--- a/packages/intl-pluralrules/scripts/cldr-raw.ts
+++ b/packages/intl-pluralrules/scripts/cldr-raw.ts
@@ -1,7 +1,7 @@
 import {join} from 'path'
 import {outputFileSync} from 'fs-extra/esm'
 import serialize from 'serialize-javascript'
-import {type LDMLPluralRule} from '@formatjs/ecma402-abstract'
+import {type LDMLPluralRule} from '#packages/ecma402-abstract/types/plural-rules.js'
 import plurals from 'cldr-core/supplemental/plurals.json' with {type: 'json'}
 import ordinals from 'cldr-core/supplemental/ordinals.json' with {type: 'json'}
 import pluralRanges from 'cldr-core/supplemental/pluralRanges.json' with {type: 'json'}

--- a/packages/intl-relativetimeformat/BUILD.bazel
+++ b/packages/intl-relativetimeformat/BUILD.bazel
@@ -9,7 +9,7 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_run_binary")
-load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
+load("//tools:tsconfig.bzl", "BASE_TSCONFIG", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -39,6 +39,7 @@ TESTS = glob([
 ])
 
 SRC_DEPS = [
+    "//packages/ecma402-abstract",
     ":node_modules/@formatjs/ecma402-abstract",
     ":node_modules/@formatjs/intl-localematcher",
 ]
@@ -46,7 +47,7 @@ SRC_DEPS = [
 EXTERNAL_PACKAGES = [
     dep.split("node_modules/")[1]
     for dep in SRC_DEPS
-    if "node_modules/" in dep
+    if "node_modules/" in dep and "ecma402-abstract" not in dep
 ]
 
 ENTRY_POINTS = [
@@ -108,7 +109,7 @@ ts_project(
     no_emit = True,
     resolve_json_module = True,
     transpiler = tsgo_bin.tsgo,
-    tsconfig = BASE_TSCONFIG,
+    tsconfig = packages_tsconfig(),
     deps = SRC_DEPS,
 )
 
@@ -120,7 +121,7 @@ ts_project(
     emit_declaration_only = True,
     resolve_json_module = True,
     transpiler = tsgo_bin.tsgo,
-    tsconfig = BASE_TSCONFIG,
+    tsconfig = packages_tsconfig(),
     visibility = ["//visibility:public"],
     deps = SRC_DEPS,
 )
@@ -128,6 +129,9 @@ ts_project(
 vitest(
     name = "unit_test",
     srcs = SRCS + TESTS + TEST_LOCALE_DATA,
+    data = ["//:package.json"],
+    no_copy_to_bin = ["//:package.json"],
+    tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
     deps = SRC_DEPS + [
         ":node_modules/@formatjs/intl-getcanonicallocales",
         ":node_modules/@formatjs/intl-locale",
@@ -715,7 +719,6 @@ CLDR_RAW_FILES = ["cldr-raw/%s.json" % locale for locale in ALL_LOCALES]
 ts_run_binary(
     name = "cldr-raw",
     srcs = [
-        ":node_modules/@formatjs/ecma402-abstract",
         "//:node_modules/cldr-core",
         "//:node_modules/cldr-dates-full",
         "//:node_modules/cldr-numbers-full",
@@ -723,6 +726,7 @@ ts_run_binary(
         "//:node_modules/fs-extra",
         "//:node_modules/json-stable-stringify",
         "//:node_modules/minimist",
+        "//packages/ecma402-abstract",
     ],
     outs = CLDR_RAW_FILES,
     args = [

--- a/packages/intl-relativetimeformat/abstract/FormatRelativeTime.ts
+++ b/packages/intl-relativetimeformat/abstract/FormatRelativeTime.ts
@@ -1,4 +1,4 @@
-import {type RelativeTimeFormatInternal} from '@formatjs/ecma402-abstract'
+import {type RelativeTimeFormatInternal} from '#packages/ecma402-abstract/types/relative-time.js'
 import {PartitionRelativeTimePattern} from './PartitionRelativeTimePattern.js'
 
 export function FormatRelativeTime(

--- a/packages/intl-relativetimeformat/abstract/FormatRelativeTimeToParts.ts
+++ b/packages/intl-relativetimeformat/abstract/FormatRelativeTimeToParts.ts
@@ -1,4 +1,4 @@
-import {type RelativeTimeFormatInternal} from '@formatjs/ecma402-abstract'
+import {type RelativeTimeFormatInternal} from '#packages/ecma402-abstract/types/relative-time.js'
 import {PartitionRelativeTimePattern} from './PartitionRelativeTimePattern.js'
 
 export function FormatRelativeTimeToParts(

--- a/packages/intl-relativetimeformat/abstract/InitializeRelativeTimeFormat.ts
+++ b/packages/intl-relativetimeformat/abstract/InitializeRelativeTimeFormat.ts
@@ -1,13 +1,15 @@
+import {CanonicalizeLocaleList} from '#packages/ecma402-abstract/CanonicalizeLocaleList.js'
+import {CoerceOptionsToObject} from '#packages/ecma402-abstract/CoerceOptionsToObject.js'
+import {GetOption} from '#packages/ecma402-abstract/GetOption.js'
 import {
-  CanonicalizeLocaleList,
-  CoerceOptionsToObject,
-  createMemoizedNumberFormat,
-  createMemoizedPluralRules,
-  GetOption,
-  invariant,
   type LocaleFieldsData,
   type RelativeTimeFormatInternal,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/types/relative-time.js'
+import {
+  createMemoizedNumberFormat,
+  createMemoizedPluralRules,
+  invariant,
+} from '#packages/ecma402-abstract/utils.js'
 import {ResolveLocale} from '@formatjs/intl-localematcher'
 
 const NUMBERING_SYSTEM_REGEX = /^[a-z0-9]{3,8}(-[a-z0-9]{3,8})*$/i

--- a/packages/intl-relativetimeformat/abstract/MakePartsList.ts
+++ b/packages/intl-relativetimeformat/abstract/MakePartsList.ts
@@ -1,4 +1,5 @@
-import {invariant, PartitionPattern} from '@formatjs/ecma402-abstract'
+import {PartitionPattern} from '#packages/ecma402-abstract/PartitionPattern.js'
+import {invariant} from '#packages/ecma402-abstract/utils.js'
 
 export function MakePartsList(
   pattern: string,

--- a/packages/intl-relativetimeformat/abstract/PartitionRelativeTimePattern.ts
+++ b/packages/intl-relativetimeformat/abstract/PartitionRelativeTimePattern.ts
@@ -1,13 +1,11 @@
+import {SameValue, ToString, Type} from '#packages/ecma402-abstract/262.js'
+import {type LDMLPluralRule} from '#packages/ecma402-abstract/types/plural-rules.js'
 import {
   type FieldData,
-  invariant,
-  type LDMLPluralRule,
   type RelativeTimeField,
   type RelativeTimeFormatInternal,
-  SameValue,
-  ToString,
-  Type,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/types/relative-time.js'
+import {invariant} from '#packages/ecma402-abstract/utils.js'
 import {SingularRelativeTimeUnit} from './SingularRelativeTimeUnit.js'
 import {MakePartsList} from './MakePartsList.js'
 

--- a/packages/intl-relativetimeformat/abstract/SingularRelativeTimeUnit.ts
+++ b/packages/intl-relativetimeformat/abstract/SingularRelativeTimeUnit.ts
@@ -1,8 +1,6 @@
-import {
-  invariant,
-  type RelativeTimeFormatSingularUnit,
-  Type,
-} from '@formatjs/ecma402-abstract'
+import {Type} from '#packages/ecma402-abstract/262.js'
+import {type RelativeTimeFormatSingularUnit} from '#packages/ecma402-abstract/types/relative-time.js'
+import {invariant} from '#packages/ecma402-abstract/utils.js'
 
 /**
  * https://tc39.es/proposal-intl-relative-time/#sec-singularrelativetimeunit

--- a/packages/intl-relativetimeformat/get_internal_slots.ts
+++ b/packages/intl-relativetimeformat/get_internal_slots.ts
@@ -1,7 +1,7 @@
 // Type-only circular import
 // eslint-disable-next-line import/no-cycle
 
-import {type RelativeTimeFormatInternal} from '@formatjs/ecma402-abstract'
+import {type RelativeTimeFormatInternal} from '#packages/ecma402-abstract/types/relative-time.js'
 
 const internalSlotMap = new WeakMap<
   Intl.RelativeTimeFormat,

--- a/packages/intl-relativetimeformat/index.ts
+++ b/packages/intl-relativetimeformat/index.ts
@@ -1,10 +1,10 @@
+import {ToString} from '#packages/ecma402-abstract/262.js'
+import {CanonicalizeLocaleList} from '#packages/ecma402-abstract/CanonicalizeLocaleList.js'
+import {SupportedLocales} from '#packages/ecma402-abstract/SupportedLocales.js'
 import {
-  CanonicalizeLocaleList,
   type LocaleFieldsData,
   type RelativeTimeLocaleData,
-  SupportedLocales,
-  ToString,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/types/relative-time.js'
 import {InitializeRelativeTimeFormat} from './abstract/InitializeRelativeTimeFormat.js'
 import {PartitionRelativeTimePattern} from './abstract/PartitionRelativeTimePattern.js'
 import getInternalSlots from './get_internal_slots.js'

--- a/packages/intl-relativetimeformat/scripts/BUILD.bazel
+++ b/packages/intl-relativetimeformat/scripts/BUILD.bazel
@@ -4,6 +4,7 @@ ts_binary(
     name = "cldr-raw",
     data = [
         "extract-relative.ts",
+        "//:root_package_json",
     ],
     entry_point = "cldr-raw.ts",
     visibility = ["//packages/intl-relativetimeformat:__pkg__"],
@@ -11,12 +12,14 @@ ts_binary(
 
 ts_binary(
     name = "cldr",
+    data = ["//:root_package_json"],
     entry_point = "cldr.ts",
     visibility = ["//packages/intl-relativetimeformat:__pkg__"],
 )
 
 ts_binary(
     name = "test262-main-gen",
+    data = ["//:root_package_json"],
     entry_point = "test262-main-gen.ts",
     visibility = ["//packages/intl-relativetimeformat:__pkg__"],
 )

--- a/packages/intl-relativetimeformat/scripts/extract-relative.ts
+++ b/packages/intl-relativetimeformat/scripts/extract-relative.ts
@@ -12,7 +12,10 @@ import {resolve, dirname} from 'path'
 import {createRequire} from 'node:module'
 
 const require = createRequire(import.meta.url)
-import {type FieldData, type LocaleFieldsData} from '@formatjs/ecma402-abstract'
+import {
+  type FieldData,
+  type LocaleFieldsData,
+} from '#packages/ecma402-abstract/types/relative-time.js'
 import AVAILABLE_LOCALES from 'cldr-core/availableLocales.json' with {type: 'json'}
 
 // The set of CLDR date field names that are used in FormatJS.

--- a/packages/intl-supportedvaluesof/BUILD.bazel
+++ b/packages/intl-supportedvaluesof/BUILD.bazel
@@ -113,8 +113,8 @@ generate_src_file(
     name = "units",
     src = "src/units.generated.ts",
     data = [
-        ":node_modules/@formatjs/ecma402-abstract",
         "//:node_modules/cldr-bcp47",
+        "//packages/ecma402-abstract",
     ],
     tags = ["cldr"],
     tool = "//packages/intl-supportedvaluesof/scripts:units",

--- a/packages/intl-supportedvaluesof/scripts/BUILD.bazel
+++ b/packages/intl-supportedvaluesof/scripts/BUILD.bazel
@@ -26,6 +26,7 @@ ts_binary(
 
 ts_binary(
     name = "units",
+    data = ["//:root_package_json"],
     entry_point = "units.ts",
     visibility = ["//packages/intl-supportedvaluesof:__pkg__"],
 )

--- a/packages/intl-supportedvaluesof/scripts/units.ts
+++ b/packages/intl-supportedvaluesof/scripts/units.ts
@@ -1,6 +1,6 @@
 import minimist from 'minimist'
 import {outputFileSync} from 'fs-extra/esm'
-import {SIMPLE_UNITS} from '@formatjs/ecma402-abstract'
+import {SIMPLE_UNITS} from '#packages/ecma402-abstract/IsSanctionedSimpleUnitIdentifier.js'
 
 interface Args extends minimist.ParsedArgs {
   zone: string[]

--- a/tools/tsconfig.bzl
+++ b/tools/tsconfig.bzl
@@ -72,6 +72,27 @@ DOCS_TSCONFIG = BASE_TSCONFIG | {
     },
 }
 
+def packages_tsconfig(base = None):
+    """Return a tsconfig with #packages/* path alias based on current package depth.
+
+    Args:
+        base: base tsconfig dict to extend (defaults to BASE_TSCONFIG)
+
+    Returns:
+        tsconfig dict with paths mapping #packages/* to the packages/ directory
+    """
+    base = base or BASE_TSCONFIG
+    package = native.package_name()
+    depth = len(package.split("/")) if package else 0
+    relative_to_root = "/".join([".."] * depth) if depth else "."
+    return base | {
+        "compilerOptions": base["compilerOptions"] | {
+            "paths": {
+                "#packages/*": [relative_to_root + "/packages/*"],
+            },
+        },
+    }
+
 # ESNext + skipLibCheck configuration - for packages with deps that have unresolvable type imports
 ESNEXT_SKIP_LIB_CHECK_TSCONFIG = ESNEXT_TSCONFIG | {
     "compilerOptions": ESNEXT_TSCONFIG["compilerOptions"] | {


### PR DESCRIPTION
## Summary
Convert all remaining `@formatjs/ecma402-abstract` barrel imports in scripts to de-barreled `#packages` direct imports.

The key insight: scripts run from `packages/X/scripts/` which has NO `package.json`. By ensuring `ts_run_binary` srcs don't include per-package `:node_modules/` deps (which would drag in `packages/X/package.json`), Node walks up to root `package.json` and resolves `#packages/*` correctly.

Changes:
- Convert 11 script files across 6 packages to `#packages` imports
- Convert 3 `intl-datetimeformat/src/` files that were kept on barrel imports
- Replace `:node_modules/@formatjs/ecma402-abstract` with `//packages/ecma402-abstract` in `ts_run_binary`/`generate_src_file` data
- Add `//:root_package_json` to script tool data for Node subpath import resolution

## Test plan
- [x] All 497 tests pass
- [x] oxlint + pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)