### PR TITLE
chore: remove :node_modules/@formatjs/ecma402-abstract from bundled polyfill packages

### DIFF
--- a/packages/intl-datetimeformat/BUILD.bazel
+++ b/packages/intl-datetimeformat/BUILD.bazel
@@ -50,7 +50,7 @@ TESTS = glob([
 
 SRC_DEPS = [
     "//packages/ecma402-abstract",
-    ":node_modules/@formatjs/ecma402-abstract",
+    ":node_modules/@formatjs/ecma402-abstract",  # for src/ files still using barrel imports
     ":node_modules/@formatjs/intl-localematcher",
     ":node_modules/@formatjs/bigdecimal",
 ]

--- a/packages/intl-displaynames/BUILD.bazel
+++ b/packages/intl-displaynames/BUILD.bazel
@@ -37,7 +37,6 @@ TESTS = glob([
 
 SRC_DEPS = [
     "//packages/ecma402-abstract",
-    ":node_modules/@formatjs/ecma402-abstract",
     ":node_modules/@formatjs/intl-localematcher",
 ]
 

--- a/packages/intl-listformat/BUILD.bazel
+++ b/packages/intl-listformat/BUILD.bazel
@@ -39,7 +39,6 @@ TESTS = glob([
 
 SRC_DEPS = [
     "//packages/ecma402-abstract",
-    ":node_modules/@formatjs/ecma402-abstract",
     ":node_modules/@formatjs/intl-localematcher",
 ]
 

--- a/packages/intl-locale/BUILD.bazel
+++ b/packages/intl-locale/BUILD.bazel
@@ -30,7 +30,6 @@ SRCS = glob(["*.ts"])
 
 # Node_modules deps for type checking and downstream consumers
 TYPECHECK_DEPS = [
-    ":node_modules/@formatjs/ecma402-abstract",
     ":node_modules/@formatjs/intl-supportedvaluesof",
     ":node_modules/@formatjs/intl-getcanonicallocales",
     "//:node_modules/cldr-core",

--- a/packages/intl-numberformat/BUILD.bazel
+++ b/packages/intl-numberformat/BUILD.bazel
@@ -73,7 +73,6 @@ SRCS = glob(
 
 SRC_DEPS = [
     "//packages/ecma402-abstract",
-    ":node_modules/@formatjs/ecma402-abstract",
     ":node_modules/@formatjs/intl-localematcher",
     ":node_modules/@formatjs/bigdecimal",
 ]
@@ -982,7 +981,7 @@ generate_src_file(
 #     name = "units-constants",
 #     src = "src/units-constants.generated.ts",
 #     data = [
-#         ":node_modules/@formatjs/ecma402-abstract",
+#
 #
 #     ],
 #     tool = "//packages/intl-numberformat/scripts:units-constants",

--- a/packages/intl-pluralrules/BUILD.bazel
+++ b/packages/intl-pluralrules/BUILD.bazel
@@ -256,7 +256,6 @@ TESTS = glob([
 
 SRC_DEPS = [
     "//packages/ecma402-abstract",
-    ":node_modules/@formatjs/ecma402-abstract",
     ":node_modules/@formatjs/intl-localematcher",
     ":node_modules/@formatjs/bigdecimal",
 ]

--- a/packages/intl-relativetimeformat/BUILD.bazel
+++ b/packages/intl-relativetimeformat/BUILD.bazel
@@ -40,7 +40,6 @@ TESTS = glob([
 
 SRC_DEPS = [
     "//packages/ecma402-abstract",
-    ":node_modules/@formatjs/ecma402-abstract",
     ":node_modules/@formatjs/intl-localematcher",
 ]
 


### PR DESCRIPTION
## Summary
Remove `:node_modules/@formatjs/ecma402-abstract` from SRC_DEPS in all esbuild-bundled polyfill packages. Only `//packages/ecma402-abstract` (the compiled project dep) is needed since all imports use `#packages` path alias.

Also converts the intl-datetimeformat `scripts/extract-dates.ts` to `#packages` import.

**Note:** intl-datetimeformat's `src/{types,packer,abstract/skeleton}.ts` still use `@formatjs/ecma402-abstract` barrel imports because they're imported transitively by `generate_src_file` targets that include source files from the parent package (where `package.json` blocks `#packages` resolution).

## Test plan
- [x] All 483 tests pass
- [x] oxlint + pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)