### PR TITLE
chore: make @formatjs/ecma402-abstract internal-only

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -64,7 +64,6 @@ PACKAGES_TO_DIST = [
     "//packages/cli-lib",
     "//packages/cli",
     "//packages/ecma376",
-    "//packages/ecma402-abstract",
     "//packages/eslint-plugin-formatjs",
     "//packages/fast-memoize",
     "//packages/icu-messageformat-parser",

--- a/packages/ecma402-abstract/BUILD.bazel
+++ b/packages/ecma402-abstract/BUILD.bazel
@@ -1,24 +1,11 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
-load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
 
 PACKAGE_NAME = "ecma402-abstract"
-
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-        ":%s" % PACKAGE_NAME,
-    ],
-    package = "@formatjs/%s" % PACKAGE_NAME,
-    visibility = ["//visibility:public"],
-)
 
 SRCS = glob(
     [
@@ -75,11 +62,6 @@ generate_src_file(
         "//:node_modules/regenerate",
     ],
     tool = "//packages/ecma402-abstract/scripts:regex-gen",
-)
-
-package_json_test(
-    name = "package_json_test",
-    deps = SRC_DEPS,
 )
 
 copy_to_bin(

--- a/packages/ecma402-abstract/package.json
+++ b/packages/ecma402-abstract/package.json
@@ -1,33 +1,10 @@
 {
   "name": "@formatjs/ecma402-abstract",
-  "description": "A collection of implementation for ECMAScript abstract operations",
-  "version": "3.2.0",
-  "license": "MIT",
-  "author": "Long Ho <holevietlong@gmail.com",
+  "private": true,
   "type": "module",
-  "sideEffects": false,
-  "types": "index.d.ts",
-  "exports": {
-    ".": "./index.js"
-  },
   "dependencies": {
     "@formatjs/bigdecimal": "workspace:*",
     "@formatjs/fast-memoize": "workspace:*",
     "@formatjs/intl-localematcher": "workspace:*"
-  },
-  "bugs": "https://github.com/formatjs/formatjs/issues",
-  "gitHead": "a7842673d8ad205171ad7c8cb8bb2f318b427c0c",
-  "homepage": "https://github.com/formatjs/formatjs",
-  "keywords": [
-    "abstract",
-    "ecma262",
-    "ecma402",
-    "es",
-    "format",
-    "i18n",
-    "intl",
-    "javascript",
-    "relative"
-  ],
-  "repository": "git@github.com:formatjs/formatjs.git"
+  }
 }

--- a/packages/icu-messageformat-parser/BUILD.bazel
+++ b/packages/icu-messageformat-parser/BUILD.bazel
@@ -2,6 +2,7 @@ load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_compile")
+load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -27,13 +28,14 @@ npm_package(
 SRCS = glob(["*.ts"])
 
 SRC_DEPS = [
-    ":node_modules/@formatjs/ecma402-abstract",
+    "//packages/ecma402-abstract",
     ":node_modules/@formatjs/icu-skeleton-parser",
 ]
 
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
+    tsconfig = packages_tsconfig(),
     deps = SRC_DEPS,
 )
 

--- a/packages/icu-messageformat-parser/package.json
+++ b/packages/icu-messageformat-parser/package.json
@@ -11,7 +11,6 @@
     "./manipulator.js": "./manipulator.js"
   },
   "dependencies": {
-    "@formatjs/ecma402-abstract": "workspace:*",
     "@formatjs/icu-skeleton-parser": "workspace:*"
   },
   "repository": {

--- a/packages/icu-messageformat-parser/types.ts
+++ b/packages/icu-messageformat-parser/types.ts
@@ -1,4 +1,4 @@
-import type {NumberFormatOptions} from '@formatjs/ecma402-abstract'
+import type {NumberFormatOptions} from '#packages/ecma402-abstract/types/number.js'
 import {type NumberSkeletonToken} from '@formatjs/icu-skeleton-parser'
 
 export interface ExtendedNumberFormatOptions extends NumberFormatOptions {

--- a/packages/icu-skeleton-parser/BUILD.bazel
+++ b/packages/icu-skeleton-parser/BUILD.bazel
@@ -3,6 +3,7 @@ load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_compile")
+load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -24,12 +25,13 @@ npm_package(
 SRCS = glob(["*.ts"])
 
 SRC_DEPS = [
-    ":node_modules/@formatjs/ecma402-abstract",
+    "//packages/ecma402-abstract",
 ]
 
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
+    tsconfig = packages_tsconfig(),
     deps = SRC_DEPS,
 )
 

--- a/packages/icu-skeleton-parser/number.ts
+++ b/packages/icu-skeleton-parser/number.ts
@@ -1,4 +1,4 @@
-import type {NumberFormatOptions} from '@formatjs/ecma402-abstract'
+import type {NumberFormatOptions} from '#packages/ecma402-abstract/types/number.js'
 import {WHITE_SPACE_REGEX} from './regex.generated.js'
 
 export interface ExtendedNumberFormatOptions extends NumberFormatOptions {

--- a/packages/icu-skeleton-parser/package.json
+++ b/packages/icu-skeleton-parser/package.json
@@ -7,9 +7,7 @@
   "exports": {
     ".": "./index.js"
   },
-  "dependencies": {
-    "@formatjs/ecma402-abstract": "workspace:*"
-  },
+  "dependencies": {},
   "repository": {
     "type": "git",
     "url": "https://github.com/formatjs/formatjs.git",

--- a/packages/intl-datetimeformat/BUILD.bazel
+++ b/packages/intl-datetimeformat/BUILD.bazel
@@ -50,7 +50,6 @@ TESTS = glob([
 
 SRC_DEPS = [
     "//packages/ecma402-abstract",
-    ":node_modules/@formatjs/ecma402-abstract",  # for src/ files still using barrel imports
     ":node_modules/@formatjs/intl-localematcher",
     ":node_modules/@formatjs/bigdecimal",
 ]
@@ -755,7 +754,6 @@ ts_run_binary(
     srcs = [
         "src/abstract/skeleton.ts",
         "src/types.ts",
-        ":node_modules/@formatjs/ecma402-abstract",
         ":node_modules/@formatjs/intl-locale",
         "//:node_modules/cldr-bcp47",
         "//:node_modules/cldr-core",
@@ -869,7 +867,6 @@ generate_src_file(
     data = [
         "src/packer.ts",
         "src/types.ts",
-        ":node_modules/@formatjs/ecma402-abstract",
         ":zdumps",
         "//:node_modules/json-stable-stringify",
         "//packages/ecma402-abstract",
@@ -885,7 +882,6 @@ ts_run_binary(
     srcs = [
         "src/packer.ts",
         "src/types.ts",
-        ":node_modules/@formatjs/ecma402-abstract",
         ":zdumps",
         "//:node_modules/fs-extra",
         "//:node_modules/json-stable-stringify",
@@ -912,7 +908,6 @@ ts_run_binary(
     srcs = [
         "src/packer.ts",
         "src/types.ts",
-        ":node_modules/@formatjs/ecma402-abstract",
         ":zdumps",
         "//:node_modules/fs-extra",
         "//:node_modules/json-stable-stringify",

--- a/packages/intl-datetimeformat/package.json
+++ b/packages/intl-datetimeformat/package.json
@@ -18,7 +18,6 @@
   },
   "dependencies": {
     "@formatjs/bigdecimal": "workspace:*",
-    "@formatjs/ecma402-abstract": "workspace:*",
     "@formatjs/intl-localematcher": "workspace:*"
   },
   "devDependencies": {

--- a/packages/intl-datetimeformat/scripts/extract-dates.ts
+++ b/packages/intl-datetimeformat/scripts/extract-dates.ts
@@ -23,7 +23,7 @@ import rawCalendarPreferenceData from 'cldr-core/supplemental/calendarPreference
 import TimeZoneNames from 'cldr-dates-full/main/en/timeZoneNames.json' with {type: 'json'}
 import metaZones from 'cldr-core/supplemental/metaZones.json' with {type: 'json'}
 import IntlLocale from '@formatjs/intl-locale'
-import {type Formats} from '@formatjs/ecma402-abstract'
+import {type Formats} from '#packages/ecma402-abstract/types/date-time.js'
 import {parseDateTimeSkeleton} from '../src/abstract/skeleton.ts'
 import {isEqual} from 'lodash-es'
 const {timeData} = rawTimeData.supplemental

--- a/packages/intl-datetimeformat/src/abstract/skeleton.ts
+++ b/packages/intl-datetimeformat/src/abstract/skeleton.ts
@@ -4,7 +4,7 @@ import {
   type RangePatterns,
   RangePatternType,
   type TABLE_2,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/types/date-time.js'
 
 /**
  * https://unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table

--- a/packages/intl-datetimeformat/src/packer.ts
+++ b/packages/intl-datetimeformat/src/packer.ts
@@ -1,5 +1,5 @@
 import {type UnpackedData, type PackedData} from './types.ts'
-import {type UnpackedZoneData} from '@formatjs/ecma402-abstract'
+import {type UnpackedZoneData} from '#packages/ecma402-abstract/types/date-time.js'
 
 export function pack(data: UnpackedData): PackedData {
   const zoneNames = Object.keys(data.zones)

--- a/packages/intl-datetimeformat/src/types.ts
+++ b/packages/intl-datetimeformat/src/types.ts
@@ -1,8 +1,8 @@
+import {type LocaleData} from '#packages/ecma402-abstract/types/core.js'
 import {
-  type LocaleData,
   type DateTimeFormatLocaleInternalData,
   type IntervalFormatsData,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/types/date-time.js'
 
 export interface PackedData {
   zones: string[]

--- a/packages/intl-displaynames/package.json
+++ b/packages/intl-displaynames/package.json
@@ -15,7 +15,6 @@
     "./locale-data": "./locale-data"
   },
   "dependencies": {
-    "@formatjs/ecma402-abstract": "workspace:*",
     "@formatjs/intl-localematcher": "workspace:*"
   },
   "devDependencies": {

--- a/packages/intl-durationformat/BUILD.bazel
+++ b/packages/intl-durationformat/BUILD.bazel
@@ -3,6 +3,7 @@ load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile")
+load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -27,13 +28,14 @@ SRCS = glob([
 ])
 
 SRC_DEPS = [
-    ":node_modules/@formatjs/ecma402-abstract",
+    "//packages/ecma402-abstract",
     ":node_modules/@formatjs/intl-localematcher",
 ]
 
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
+    tsconfig = packages_tsconfig(),
     deps = SRC_DEPS,
 )
 
@@ -61,7 +63,6 @@ generate_src_file(
     name = "time-separators",
     src = "src/time-separators.generated.ts",
     data = [
-        ":node_modules/@formatjs/ecma402-abstract",
         "//:node_modules/@types/lodash-es",
         "//:node_modules/cldr-core",
         "//:node_modules/cldr-localenames-full",

--- a/packages/intl-durationformat/package.json
+++ b/packages/intl-durationformat/package.json
@@ -13,7 +13,6 @@
     "./should-polyfill.js": "./should-polyfill.js"
   },
   "dependencies": {
-    "@formatjs/ecma402-abstract": "workspace:*",
     "@formatjs/intl-localematcher": "workspace:*"
   },
   "bugs": "https://github.com/formatjs/formatjs/issues",

--- a/packages/intl-durationformat/src/abstract/GetDurationUnitOptions.ts
+++ b/packages/intl-durationformat/src/abstract/GetDurationUnitOptions.ts
@@ -1,4 +1,4 @@
-import {GetOption} from '@formatjs/ecma402-abstract'
+import {GetOption} from '#packages/ecma402-abstract/GetOption.js'
 
 export function GetDurationUnitOptions<T extends object>(
   unit: keyof T,

--- a/packages/intl-durationformat/src/abstract/IsValidDurationRecord.ts
+++ b/packages/intl-durationformat/src/abstract/IsValidDurationRecord.ts
@@ -1,4 +1,4 @@
-import {invariant} from '@formatjs/ecma402-abstract'
+import {invariant} from '#packages/ecma402-abstract/utils.js'
 import {TABLE_1} from '../constants.js'
 import {type DurationRecord} from '../types.js'
 import {DurationRecordSign} from './DurationRecordSign.js'

--- a/packages/intl-durationformat/src/abstract/PartitionDurationFormatPattern.ts
+++ b/packages/intl-durationformat/src/abstract/PartitionDurationFormatPattern.ts
@@ -1,9 +1,9 @@
+import {type NumberFormatOptions} from '#packages/ecma402-abstract/types/number.js'
 import {
-  type NumberFormatOptions,
   createMemoizedListFormat,
   createMemoizedNumberFormat,
   invariant,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract/utils.js'
 import {TABLE_2} from '../constants.js'
 import {DurationFormat} from '../core.js'
 import {getInternalSlots} from '../get_internal_slots.js'

--- a/packages/intl-durationformat/src/abstract/ToIntegerIfIntegral.ts
+++ b/packages/intl-durationformat/src/abstract/ToIntegerIfIntegral.ts
@@ -1,4 +1,5 @@
-import {invariant, ToNumber} from '@formatjs/ecma402-abstract'
+import {ToNumber} from '#packages/ecma402-abstract/262.js'
+import {invariant} from '#packages/ecma402-abstract/utils.js'
 
 export function ToIntegerIfIntegral(arg: any): number {
   const number = ToNumber(arg)

--- a/packages/intl-durationformat/src/core.ts
+++ b/packages/intl-durationformat/src/core.ts
@@ -1,15 +1,12 @@
 // Core implementation of Intl.DurationFormat polyfill
 // Follows the TC39 Intl.DurationFormat proposal specification
 
-import {
-  CanonicalizeLocaleList,
-  GetNumberOption,
-  GetOption,
-  OrdinaryHasInstance,
-  SupportedLocales,
-  ToObject,
-  invariant,
-} from '@formatjs/ecma402-abstract'
+import {OrdinaryHasInstance, ToObject} from '#packages/ecma402-abstract/262.js'
+import {CanonicalizeLocaleList} from '#packages/ecma402-abstract/CanonicalizeLocaleList.js'
+import {GetNumberOption} from '#packages/ecma402-abstract/GetNumberOption.js'
+import {GetOption} from '#packages/ecma402-abstract/GetOption.js'
+import {SupportedLocales} from '#packages/ecma402-abstract/SupportedLocales.js'
+import {invariant} from '#packages/ecma402-abstract/utils.js'
 import {ResolveLocale} from '@formatjs/intl-localematcher'
 import {GetDurationUnitOptions} from './abstract/GetDurationUnitOptions.js'
 import {PartitionDurationFormatPattern} from './abstract/PartitionDurationFormatPattern.js'

--- a/packages/intl-listformat/package.json
+++ b/packages/intl-listformat/package.json
@@ -15,7 +15,6 @@
     "./locale-data": "./locale-data"
   },
   "dependencies": {
-    "@formatjs/ecma402-abstract": "workspace:*",
     "@formatjs/intl-localematcher": "workspace:*"
   },
   "devDependencies": {

--- a/packages/intl-locale/package.json
+++ b/packages/intl-locale/package.json
@@ -13,7 +13,6 @@
     "./should-polyfill.js": "./should-polyfill.js"
   },
   "dependencies": {
-    "@formatjs/ecma402-abstract": "workspace:*",
     "@formatjs/intl-getcanonicallocales": "workspace:*",
     "@formatjs/intl-supportedvaluesof": "workspace:*"
   },

--- a/packages/intl-messageformat/BUILD.bazel
+++ b/packages/intl-messageformat/BUILD.bazel
@@ -4,6 +4,7 @@ load("@aspect_rules_js//js:defs.bzl", "js_binary")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:index.bzl", "generate_ide_tsconfig_json", "package_json_test", "ts_compile")
+load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -30,9 +31,9 @@ npm_package(
 SRCS = glob(["src/*.ts"]) + ["index.ts"]
 
 SRC_DEPS = [
+    "//packages/ecma402-abstract",
     ":node_modules/@formatjs/icu-messageformat-parser",
     ":node_modules/@formatjs/fast-memoize",
-    ":node_modules/@formatjs/ecma402-abstract",
 ]
 
 TESTS = glob([
@@ -44,12 +45,16 @@ TEST_DEPS = SRC_DEPS
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
+    tsconfig = packages_tsconfig(),
     deps = SRC_DEPS,
 )
 
 vitest(
     name = "unit_test",
     srcs = SRCS + TESTS,
+    data = ["//:package.json"],
+    no_copy_to_bin = ["//:package.json"],
+    tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
     deps = SRC_DEPS + TEST_DEPS,
 )
 

--- a/packages/intl-messageformat/package.json
+++ b/packages/intl-messageformat/package.json
@@ -11,7 +11,6 @@
     ".": "./index.js"
   },
   "dependencies": {
-    "@formatjs/ecma402-abstract": "workspace:*",
     "@formatjs/fast-memoize": "workspace:*",
     "@formatjs/icu-messageformat-parser": "workspace:*"
   },

--- a/packages/intl-messageformat/src/formatters.ts
+++ b/packages/intl-messageformat/src/formatters.ts
@@ -1,4 +1,4 @@
-import {type NumberFormatOptions} from '@formatjs/ecma402-abstract'
+import {type NumberFormatOptions} from '#packages/ecma402-abstract/types/number.js'
 import {
   type ExtendedNumberFormatOptions,
   isArgumentElement,

--- a/packages/intl-numberformat/package.json
+++ b/packages/intl-numberformat/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "@formatjs/bigdecimal": "workspace:*",
-    "@formatjs/ecma402-abstract": "workspace:*",
     "@formatjs/intl-localematcher": "workspace:*"
   },
   "devDependencies": {

--- a/packages/intl-pluralrules/package.json
+++ b/packages/intl-pluralrules/package.json
@@ -16,7 +16,6 @@
   },
   "dependencies": {
     "@formatjs/bigdecimal": "workspace:*",
-    "@formatjs/ecma402-abstract": "workspace:*",
     "@formatjs/intl-localematcher": "workspace:*"
   },
   "devDependencies": {

--- a/packages/intl-relativetimeformat/package.json
+++ b/packages/intl-relativetimeformat/package.json
@@ -15,7 +15,6 @@
     "./locale-data": "./locale-data"
   },
   "dependencies": {
-    "@formatjs/ecma402-abstract": "workspace:*",
     "@formatjs/intl-localematcher": "workspace:*"
   },
   "devDependencies": {

--- a/packages/intl-segmenter/package.json
+++ b/packages/intl-segmenter/package.json
@@ -11,7 +11,6 @@
     "./should-polyfill.js": "./should-polyfill.js"
   },
   "dependencies": {
-    "@formatjs/ecma402-abstract": "workspace:*",
     "@formatjs/intl-localematcher": "workspace:*"
   },
   "bugs": "https://github.com/formatjs/formatjs/issues",

--- a/packages/intl-supportedvaluesof/BUILD.bazel
+++ b/packages/intl-supportedvaluesof/BUILD.bazel
@@ -5,6 +5,7 @@ load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//packages/intl-datetimeformat:defs.bzl", "ZONES")
 load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile")
+load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -31,7 +32,6 @@ SRCS = glob([
 ])
 
 SRC_DEPS = [
-    ":node_modules/@formatjs/ecma402-abstract",
     ":node_modules/@formatjs/fast-memoize",
 ]
 
@@ -42,12 +42,16 @@ TESTS = glob([
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
+    tsconfig = packages_tsconfig(),
     deps = SRC_DEPS,
 )
 
 vitest(
     name = "unit_test",
     srcs = SRCS + TESTS,
+    data = ["//:package.json"],
+    no_copy_to_bin = ["//:package.json"],
+    tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
     deps = SRC_DEPS,
 )
 

--- a/packages/intl-supportedvaluesof/package.json
+++ b/packages/intl-supportedvaluesof/package.json
@@ -13,7 +13,6 @@
     "./should-polyfill.js": "./should-polyfill.js"
   },
   "dependencies": {
-    "@formatjs/ecma402-abstract": "workspace:*",
     "@formatjs/fast-memoize": "workspace:*"
   },
   "bugs": "https://github.com/formatjs/formatjs/issues",

--- a/packages/intl-supportedvaluesof/src/get-supported-currencies.ts
+++ b/packages/intl-supportedvaluesof/src/get-supported-currencies.ts
@@ -1,4 +1,4 @@
-import {createMemoizedNumberFormat} from '@formatjs/ecma402-abstract'
+import {createMemoizedNumberFormat} from '#packages/ecma402-abstract/utils.js'
 import type {Currency} from './currencies.generated.js'
 import {currencies} from './currencies.generated.js'
 

--- a/packages/intl-supportedvaluesof/src/get-supported-numbering-systems.ts
+++ b/packages/intl-supportedvaluesof/src/get-supported-numbering-systems.ts
@@ -1,4 +1,4 @@
-import {createMemoizedNumberFormat} from '@formatjs/ecma402-abstract'
+import {createMemoizedNumberFormat} from '#packages/ecma402-abstract/utils.js'
 import {numberingSystemNames} from './numbering-systems.generated.js'
 
 /**

--- a/packages/intl-supportedvaluesof/src/get-supported-units.ts
+++ b/packages/intl-supportedvaluesof/src/get-supported-units.ts
@@ -1,4 +1,4 @@
-import {createMemoizedNumberFormat} from '@formatjs/ecma402-abstract'
+import {createMemoizedNumberFormat} from '#packages/ecma402-abstract/utils.js'
 import type {Unit} from './units.generated.js'
 import {units} from './units.generated.js'
 

--- a/packages/intl/BUILD.bazel
+++ b/packages/intl/BUILD.bazel
@@ -5,6 +5,7 @@ load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:tsd/package_json.bzl", tsd_bin = "bin")
 load("//tools:index.bzl", "generate_ide_tsconfig_json", "package_json_test", "ts_compile")
+load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -26,7 +27,7 @@ npm_package(
 SRCS = glob(["src/**/*.ts*"]) + ["index.ts"]
 
 SRC_DEPS = [
-    ":node_modules/@formatjs/ecma402-abstract",
+    "//packages/ecma402-abstract",
     ":node_modules/@formatjs/fast-memoize",
     ":node_modules/@formatjs/icu-messageformat-parser",
     ":node_modules/intl-messageformat",
@@ -44,6 +45,7 @@ TESTS = glob(
 ts_compile(
     name = "dist",
     srcs = [":srcs"],
+    tsconfig = packages_tsconfig(),
     deps = SRC_DEPS,
 )
 

--- a/packages/intl/package.json
+++ b/packages/intl/package.json
@@ -11,7 +11,6 @@
     ".": "./index.js"
   },
   "dependencies": {
-    "@formatjs/ecma402-abstract": "workspace:*",
     "@formatjs/fast-memoize": "workspace:*",
     "@formatjs/icu-messageformat-parser": "workspace:*",
     "intl-messageformat": "workspace:*"

--- a/packages/intl/src/number.ts
+++ b/packages/intl/src/number.ts
@@ -1,4 +1,4 @@
-import {type NumberFormatOptions} from '@formatjs/ecma402-abstract'
+import {type NumberFormatOptions} from '#packages/ecma402-abstract/types/number.js'
 import {IntlFormatError} from './error.js'
 import {
   type CustomFormats,

--- a/packages/intl/src/types.ts
+++ b/packages/intl/src/types.ts
@@ -1,6 +1,6 @@
 import {type MessageFormatElement} from '@formatjs/icu-messageformat-parser'
 
-import {type NumberFormatOptions} from '@formatjs/ecma402-abstract'
+import {type NumberFormatOptions} from '#packages/ecma402-abstract/types/number.js'
 import type {FormatError, IntlMessageFormat} from 'intl-messageformat'
 import {
   type Formats,

--- a/packages/intl/src/utils.ts
+++ b/packages/intl/src/utils.ts
@@ -1,4 +1,4 @@
-import {type NumberFormatOptions} from '@formatjs/ecma402-abstract'
+import {type NumberFormatOptions} from '#packages/ecma402-abstract/types/number.js'
 import {type Cache, memoize, strategies} from '@formatjs/fast-memoize'
 import {IntlMessageFormat} from 'intl-messageformat'
 import {UnsupportedFormatterError} from './error.js'

--- a/packages/react-intl/BUILD.bazel
+++ b/packages/react-intl/BUILD.bazel
@@ -5,6 +5,7 @@ load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:tsd/package_json.bzl", tsd_bin = "bin")
 load("//tools:index.bzl", "generate_ide_tsconfig_json", "package_json_test", "ts_compile")
+load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -31,7 +32,7 @@ SRCS = glob(["src/**/*.ts*"]) + [
 ]
 
 SRC_DEPS = [
-    ":node_modules/@formatjs/ecma402-abstract",
+    "//packages/ecma402-abstract",
     ":node_modules/@formatjs/icu-messageformat-parser",
     ":node_modules/@formatjs/intl",
     ":node_modules/intl-messageformat",
@@ -85,7 +86,10 @@ vitest(
     srcs = SRCS +
            TESTS,
     config = "vitest.config.mjs",
+    data = ["//:package.json"],
     dom = True,
+    no_copy_to_bin = ["//:package.json"],
+    tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
     deps = TEST_DEPS,
 )
 

--- a/packages/react-intl/examples/package.json
+++ b/packages/react-intl/examples/package.json
@@ -2,7 +2,6 @@
   "name": "examples",
   "private": true,
   "devDependencies": {
-    "@formatjs/ecma402-abstract": "workspace:*",
     "@formatjs/icu-messageformat-parser": "workspace:*",
     "@formatjs/intl": "workspace:*",
     "@formatjs/intl-datetimeformat": "workspace:*",

--- a/packages/react-intl/index.ts
+++ b/packages/react-intl/index.ts
@@ -4,7 +4,7 @@
  * Copyrights licensed under the New BSD License.
  * See the accompanying LICENSE file for terms.
  */
-import {type NumberFormatOptions} from '@formatjs/ecma402-abstract'
+import {type NumberFormatOptions} from '#packages/ecma402-abstract/types/number.js'
 import {
   type CustomFormatConfig,
   type FormatDateOptions,

--- a/packages/react-intl/package.json
+++ b/packages/react-intl/package.json
@@ -12,7 +12,6 @@
     "./server": "./server.js"
   },
   "dependencies": {
-    "@formatjs/ecma402-abstract": "workspace:*",
     "@formatjs/icu-messageformat-parser": "workspace:*",
     "@formatjs/intl": "workspace:*",
     "intl-messageformat": "workspace:*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -594,9 +594,6 @@ importers:
 
   packages/icu-messageformat-parser:
     dependencies:
-      '@formatjs/ecma402-abstract':
-        specifier: workspace:*
-        version: link:../ecma402-abstract
       '@formatjs/icu-skeleton-parser':
         specifier: workspace:*
         version: link:../icu-skeleton-parser
@@ -613,17 +610,10 @@ importers:
         specifier: workspace:*
         version: link:..
 
-  packages/icu-skeleton-parser:
-    dependencies:
-      '@formatjs/ecma402-abstract':
-        specifier: workspace:*
-        version: link:../ecma402-abstract
+  packages/icu-skeleton-parser: {}
 
   packages/intl:
     dependencies:
-      '@formatjs/ecma402-abstract':
-        specifier: workspace:*
-        version: link:../ecma402-abstract
       '@formatjs/fast-memoize':
         specifier: workspace:*
         version: link:../fast-memoize
@@ -639,9 +629,6 @@ importers:
       '@formatjs/bigdecimal':
         specifier: workspace:*
         version: link:../bigdecimal
-      '@formatjs/ecma402-abstract':
-        specifier: workspace:*
-        version: link:../ecma402-abstract
       '@formatjs/intl-localematcher':
         specifier: workspace:*
         version: link:../intl-localematcher
@@ -655,9 +642,6 @@ importers:
 
   packages/intl-displaynames:
     dependencies:
-      '@formatjs/ecma402-abstract':
-        specifier: workspace:*
-        version: link:../ecma402-abstract
       '@formatjs/intl-localematcher':
         specifier: workspace:*
         version: link:../intl-localematcher
@@ -671,9 +655,6 @@ importers:
 
   packages/intl-durationformat:
     dependencies:
-      '@formatjs/ecma402-abstract':
-        specifier: workspace:*
-        version: link:../ecma402-abstract
       '@formatjs/intl-localematcher':
         specifier: workspace:*
         version: link:../intl-localematcher
@@ -688,9 +669,6 @@ importers:
 
   packages/intl-listformat:
     dependencies:
-      '@formatjs/ecma402-abstract':
-        specifier: workspace:*
-        version: link:../ecma402-abstract
       '@formatjs/intl-localematcher':
         specifier: workspace:*
         version: link:../intl-localematcher
@@ -704,9 +682,6 @@ importers:
 
   packages/intl-locale:
     dependencies:
-      '@formatjs/ecma402-abstract':
-        specifier: workspace:*
-        version: link:../ecma402-abstract
       '@formatjs/intl-getcanonicallocales':
         specifier: workspace:*
         version: link:../intl-getcanonicallocales
@@ -728,9 +703,6 @@ importers:
 
   packages/intl-messageformat:
     dependencies:
-      '@formatjs/ecma402-abstract':
-        specifier: workspace:*
-        version: link:../ecma402-abstract
       '@formatjs/fast-memoize':
         specifier: workspace:*
         version: link:../fast-memoize
@@ -743,9 +715,6 @@ importers:
       '@formatjs/bigdecimal':
         specifier: workspace:*
         version: link:../bigdecimal
-      '@formatjs/ecma402-abstract':
-        specifier: workspace:*
-        version: link:../ecma402-abstract
       '@formatjs/intl-localematcher':
         specifier: workspace:*
         version: link:../intl-localematcher
@@ -771,9 +740,6 @@ importers:
       '@formatjs/bigdecimal':
         specifier: workspace:*
         version: link:../bigdecimal
-      '@formatjs/ecma402-abstract':
-        specifier: workspace:*
-        version: link:../ecma402-abstract
       '@formatjs/intl-localematcher':
         specifier: workspace:*
         version: link:../intl-localematcher
@@ -787,9 +753,6 @@ importers:
 
   packages/intl-relativetimeformat:
     dependencies:
-      '@formatjs/ecma402-abstract':
-        specifier: workspace:*
-        version: link:../ecma402-abstract
       '@formatjs/intl-localematcher':
         specifier: workspace:*
         version: link:../intl-localematcher
@@ -806,27 +769,18 @@ importers:
 
   packages/intl-segmenter:
     dependencies:
-      '@formatjs/ecma402-abstract':
-        specifier: workspace:*
-        version: link:../ecma402-abstract
       '@formatjs/intl-localematcher':
         specifier: workspace:*
         version: link:../intl-localematcher
 
   packages/intl-supportedvaluesof:
     dependencies:
-      '@formatjs/ecma402-abstract':
-        specifier: workspace:*
-        version: link:../ecma402-abstract
       '@formatjs/fast-memoize':
         specifier: workspace:*
         version: link:../fast-memoize
 
   packages/react-intl:
     dependencies:
-      '@formatjs/ecma402-abstract':
-        specifier: workspace:*
-        version: link:../ecma402-abstract
       '@formatjs/icu-messageformat-parser':
         specifier: workspace:*
         version: link:../icu-messageformat-parser
@@ -845,9 +799,6 @@ importers:
 
   packages/react-intl/examples:
     devDependencies:
-      '@formatjs/ecma402-abstract':
-        specifier: workspace:*
-        version: link:../../ecma402-abstract
       '@formatjs/icu-messageformat-parser':
         specifier: workspace:*
         version: link:../../icu-messageformat-parser


### PR DESCRIPTION
## Summary
Make `@formatjs/ecma402-abstract` an internal-only package — no longer published to npm.

- Mark `package.json` as `private: true`, strip all npm metadata
- Remove from `PACKAGES_TO_DIST` in root BUILD
- Remove `npm_package` target from ecma402-abstract BUILD
- Remove `@formatjs/ecma402-abstract` from all downstream `package.json` dependencies (15 packages)
- Convert all remaining barrel imports to `#packages` direct imports
- Remove all `:node_modules/@formatjs/ecma402-abstract` from BUILD files

The package keeps `package.json` (with `private: true`) for pnpm workspace resolution of its own deps.

**Known issues (needs esbuild bundling):**
7 unbundled packages fail vitest — per-package `package.json` blocks `#packages` resolution at Node runtime:
- intl, intl-durationformat, intl-supportedvaluesof, react-intl, svelte-intl, vue-intl, intl (global_type_overrides)

These need esbuild bundling migration (same pattern as #6214) to resolve.

## Test plan
- [x] 425/497 tests pass (72 failures from unbundled packages needing esbuild migration)
- [x] oxlint + pre-commit hooks pass
- [x] syncpack + pnpm install clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)