### PR TITLE
chore: add esbuild bundling to remaining 7 packages

### DIFF
--- a/packages/icu-messageformat-parser/BUILD.bazel
+++ b/packages/icu-messageformat-parser/BUILD.bazel
@@ -1,7 +1,13 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
+load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_compile")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test")
+load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -12,18 +18,6 @@ exports_files([
 
 PACKAGE_NAME = "icu-messageformat-parser"
 
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-        ":dist",
-    ],
-    package = "@formatjs/%s" % PACKAGE_NAME,
-    visibility = ["//visibility:public"],
-)
-
 SRCS = glob(["*.ts"])
 
 SRC_DEPS = [
@@ -31,9 +25,79 @@ SRC_DEPS = [
     ":node_modules/@formatjs/icu-skeleton-parser",
 ]
 
-ts_compile(
-    name = "dist",
+EXTERNAL_PACKAGES = [
+    dep.split("node_modules/")[1]
+    for dep in SRC_DEPS
+    if "node_modules/" in dep and "ecma402-abstract" not in dep
+]
+
+ENTRY_POINTS = [
+    "index.ts",
+    "no-parser.ts",
+    "printer.ts",
+    "manipulator.ts",
+]
+
+[esbuild(
+    name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
+    config = "//tools:esbuild-packages-resolve",
+    entry_point = entry,
+    external = EXTERNAL_PACKAGES,
+    format = "esm",
+    output = "%s.js" % entry.replace(".ts", ""),
+    target = "es2020",
+    deps = SRC_DEPS,
+) for entry in ENTRY_POINTS]
+
+BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
+
+js_library(
+    name = PACKAGE_NAME,
+    srcs = BUNDLES + [
+        "package.json",
+        ":types",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+npm_package(
+    name = "pkg",
+    srcs = [
+        "LICENSE.md",
+        "README.md",
+        "package.json",
+    ] + BUNDLES + [":types"],
+    package = "@formatjs/%s" % PACKAGE_NAME,
+    visibility = ["//visibility:public"],
+)
+
+sh_test(
+    name = "no_internal_imports_test",
+    srcs = ["//tools:check_no_internal_imports.sh"],
+    data = BUNDLES,
+)
+
+ts_project(
+    name = "typecheck",
+    srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = packages_tsconfig(),
+    deps = SRC_DEPS,
+)
+
+ts_project(
+    name = "types",
+    srcs = [":srcs"],
+    declaration = True,
+    emit_declaration_only = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = packages_tsconfig(),
+    visibility = ["//visibility:public"],
     deps = SRC_DEPS,
 )
 

--- a/packages/icu-skeleton-parser/BUILD.bazel
+++ b/packages/icu-skeleton-parser/BUILD.bazel
@@ -1,25 +1,19 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
+load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_compile")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test")
+load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
 
 PACKAGE_NAME = "icu-skeleton-parser"
-
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-        ":dist",
-    ],
-    package = "@formatjs/%s" % PACKAGE_NAME,
-    visibility = ["//visibility:public"],
-)
 
 SRCS = glob(["*.ts"])
 
@@ -27,9 +21,76 @@ SRC_DEPS = [
     ":node_modules/@formatjs/ecma402-abstract",
 ]
 
-ts_compile(
-    name = "dist",
+EXTERNAL_PACKAGES = [
+    dep.split("node_modules/")[1]
+    for dep in SRC_DEPS
+    if "node_modules/" in dep and "ecma402-abstract" not in dep
+]
+
+ENTRY_POINTS = [
+    "index.ts",
+]
+
+[esbuild(
+    name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
+    config = "//tools:esbuild-packages-resolve",
+    entry_point = entry,
+    external = EXTERNAL_PACKAGES,
+    format = "esm",
+    output = "%s.js" % entry.replace(".ts", ""),
+    target = "es2020",
+    deps = SRC_DEPS,
+) for entry in ENTRY_POINTS]
+
+BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
+
+js_library(
+    name = PACKAGE_NAME,
+    srcs = BUNDLES + [
+        "package.json",
+        ":types",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+npm_package(
+    name = "pkg",
+    srcs = [
+        "LICENSE.md",
+        "README.md",
+        "package.json",
+    ] + BUNDLES + [":types"],
+    package = "@formatjs/%s" % PACKAGE_NAME,
+    visibility = ["//visibility:public"],
+)
+
+sh_test(
+    name = "no_internal_imports_test",
+    srcs = ["//tools:check_no_internal_imports.sh"],
+    data = BUNDLES,
+)
+
+ts_project(
+    name = "typecheck",
+    srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = packages_tsconfig(),
+    deps = SRC_DEPS,
+)
+
+ts_project(
+    name = "types",
+    srcs = [":srcs"],
+    declaration = True,
+    emit_declaration_only = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = packages_tsconfig(),
+    visibility = ["//visibility:public"],
     deps = SRC_DEPS,
 )
 

--- a/packages/intl-durationformat/BUILD.bazel
+++ b/packages/intl-durationformat/BUILD.bazel
@@ -1,25 +1,19 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
+load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file")
+load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
 
 PACKAGE_NAME = "intl-durationformat"
-
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-        ":dist",
-    ],
-    package = "@formatjs/%s" % PACKAGE_NAME,
-    visibility = ["//visibility:public"],
-)
 
 SRCS = glob([
     "*.ts",
@@ -31,9 +25,79 @@ SRC_DEPS = [
     ":node_modules/@formatjs/intl-localematcher",
 ]
 
-ts_compile(
-    name = "dist",
+EXTERNAL_PACKAGES = [
+    dep.split("node_modules/")[1]
+    for dep in SRC_DEPS
+    if "node_modules/" in dep and "ecma402-abstract" not in dep
+]
+
+ENTRY_POINTS = [
+    "index.ts",
+    "polyfill.ts",
+    "polyfill-force.ts",
+    "should-polyfill.ts",
+]
+
+[esbuild(
+    name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
+    config = "//tools:esbuild-packages-resolve",
+    entry_point = entry,
+    external = EXTERNAL_PACKAGES,
+    format = "esm",
+    output = "%s.js" % entry.replace(".ts", ""),
+    target = "es2020",
+    deps = SRC_DEPS,
+) for entry in ENTRY_POINTS]
+
+BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
+
+js_library(
+    name = PACKAGE_NAME,
+    srcs = BUNDLES + [
+        "package.json",
+        ":types",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+npm_package(
+    name = "pkg",
+    srcs = [
+        "LICENSE.md",
+        "README.md",
+        "package.json",
+    ] + BUNDLES + [":types"],
+    package = "@formatjs/%s" % PACKAGE_NAME,
+    visibility = ["//visibility:public"],
+)
+
+sh_test(
+    name = "no_internal_imports_test",
+    srcs = ["//tools:check_no_internal_imports.sh"],
+    data = BUNDLES,
+)
+
+ts_project(
+    name = "typecheck",
+    srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = packages_tsconfig(),
+    deps = SRC_DEPS,
+)
+
+ts_project(
+    name = "types",
+    srcs = [":srcs"],
+    declaration = True,
+    emit_declaration_only = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = packages_tsconfig(),
+    visibility = ["//visibility:public"],
     deps = SRC_DEPS,
 )
 

--- a/packages/intl-messageformat/BUILD.bazel
+++ b/packages/intl-messageformat/BUILD.bazel
@@ -1,9 +1,13 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
-load("@aspect_rules_js//js:defs.bzl", "js_binary")
+load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "package_json_test", "ts_compile")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "package_json_test")
+load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -14,19 +18,6 @@ exports_files([
 
 PACKAGE_NAME = "intl-messageformat"
 
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-        "%s.iife.js" % PACKAGE_NAME,
-        ":dist",
-    ],
-    package = PACKAGE_NAME,
-    visibility = ["//visibility:public"],
-)
-
 SRCS = glob(["src/*.ts"]) + ["index.ts"]
 
 SRC_DEPS = [
@@ -35,15 +26,83 @@ SRC_DEPS = [
     ":node_modules/@formatjs/ecma402-abstract",
 ]
 
+EXTERNAL_PACKAGES = [
+    dep.split("node_modules/")[1]
+    for dep in SRC_DEPS
+    if "node_modules/" in dep and "ecma402-abstract" not in dep
+]
+
 TESTS = glob([
     "tests/*.test.ts",
 ])
 
 TEST_DEPS = SRC_DEPS
 
-ts_compile(
-    name = "dist",
+ENTRY_POINTS = [
+    "index.ts",
+]
+
+[esbuild(
+    name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
+    config = "//tools:esbuild-packages-resolve",
+    entry_point = entry,
+    external = EXTERNAL_PACKAGES,
+    format = "esm",
+    output = "%s.js" % entry.replace(".ts", ""),
+    target = "es2020",
+    deps = SRC_DEPS,
+) for entry in ENTRY_POINTS]
+
+BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
+
+js_library(
+    name = PACKAGE_NAME,
+    srcs = BUNDLES + [
+        "package.json",
+        ":types",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+npm_package(
+    name = "pkg",
+    srcs = [
+        "LICENSE.md",
+        "README.md",
+        "package.json",
+        "%s.iife.js" % PACKAGE_NAME,
+    ] + BUNDLES + [":types"],
+    package = PACKAGE_NAME,
+    visibility = ["//visibility:public"],
+)
+
+sh_test(
+    name = "no_internal_imports_test",
+    srcs = ["//tools:check_no_internal_imports.sh"],
+    data = BUNDLES,
+)
+
+ts_project(
+    name = "typecheck",
+    srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = packages_tsconfig(),
+    deps = SRC_DEPS,
+)
+
+ts_project(
+    name = "types",
+    srcs = [":srcs"],
+    declaration = True,
+    emit_declaration_only = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = packages_tsconfig(),
+    visibility = ["//visibility:public"],
     deps = SRC_DEPS,
 )
 

--- a/packages/intl-supportedvaluesof/BUILD.bazel
+++ b/packages/intl-supportedvaluesof/BUILD.bazel
@@ -1,29 +1,20 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//packages/intl-datetimeformat:defs.bzl", "ZONES")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file")
+load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
 
 PACKAGE_NAME = "intl-supportedvaluesof"
-
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-        ":dist",
-        # polyfill-library uses this
-        "polyfill.iife.js",
-    ],
-    package = "@formatjs/%s" % PACKAGE_NAME,
-    visibility = ["//visibility:public"],
-)
 
 SRCS = glob([
     "src/**/*.ts",
@@ -35,13 +26,86 @@ SRC_DEPS = [
     ":node_modules/@formatjs/fast-memoize",
 ]
 
+EXTERNAL_PACKAGES = [
+    dep.split("node_modules/")[1]
+    for dep in SRC_DEPS
+    if "node_modules/" in dep and "ecma402-abstract" not in dep
+]
+
 TESTS = glob([
     "tests/*.test.ts",
 ])
 
-ts_compile(
-    name = "dist",
+ENTRY_POINTS = [
+    "index.ts",
+    "polyfill.ts",
+    "polyfill-force.ts",
+    "should-polyfill.ts",
+]
+
+[esbuild(
+    name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
+    config = "//tools:esbuild-packages-resolve",
+    entry_point = entry,
+    external = EXTERNAL_PACKAGES,
+    format = "esm",
+    output = "%s.js" % entry.replace(".ts", ""),
+    target = "es2020",
+    deps = SRC_DEPS,
+) for entry in ENTRY_POINTS]
+
+BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
+
+js_library(
+    name = PACKAGE_NAME,
+    srcs = BUNDLES + [
+        "package.json",
+        ":types",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+npm_package(
+    name = "pkg",
+    srcs = [
+        "LICENSE.md",
+        "README.md",
+        "package.json",
+    ] + BUNDLES + [":types"] + [
+        # polyfill-library uses this
+        "polyfill.iife.js",
+    ],
+    package = "@formatjs/%s" % PACKAGE_NAME,
+    visibility = ["//visibility:public"],
+)
+
+sh_test(
+    name = "no_internal_imports_test",
+    srcs = ["//tools:check_no_internal_imports.sh"],
+    data = BUNDLES,
+)
+
+ts_project(
+    name = "typecheck",
+    srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = packages_tsconfig(),
+    deps = SRC_DEPS,
+)
+
+ts_project(
+    name = "types",
+    srcs = [":srcs"],
+    declaration = True,
+    emit_declaration_only = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = packages_tsconfig(),
+    visibility = ["//visibility:public"],
     deps = SRC_DEPS,
 )
 
@@ -123,6 +187,7 @@ generate_src_file(
 esbuild(
     name = "polyfill.iife",
     srcs = [":srcs"],
+    config = "//tools:esbuild-packages-resolve",
     entry_point = "polyfill.ts",
     target = "es2020",
     deps = [

--- a/packages/intl/BUILD.bazel
+++ b/packages/intl/BUILD.bazel
@@ -1,27 +1,21 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
+load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:tsd/package_json.bzl", tsd_bin = "bin")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "package_json_test", "ts_compile")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "package_json_test")
+load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
 
 PACKAGE_NAME = "intl"
-
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-        ":dist",
-    ],
-    package = "@formatjs/%s" % PACKAGE_NAME,
-    visibility = ["//visibility:public"],
-)
 
 SRCS = glob(["src/**/*.ts*"]) + ["index.ts"]
 
@@ -30,6 +24,12 @@ SRC_DEPS = [
     ":node_modules/@formatjs/fast-memoize",
     ":node_modules/@formatjs/icu-messageformat-parser",
     ":node_modules/intl-messageformat",
+]
+
+EXTERNAL_PACKAGES = [
+    dep.split("node_modules/")[1]
+    for dep in SRC_DEPS
+    if "node_modules/" in dep and "ecma402-abstract" not in dep
 ]
 
 TESTS = glob(
@@ -41,9 +41,70 @@ TESTS = glob(
     ],
 )
 
-ts_compile(
-    name = "dist",
+ENTRY_POINTS = [
+    "index.ts",
+]
+
+[esbuild(
+    name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
+    config = "//tools:esbuild-packages-resolve",
+    entry_point = entry,
+    external = EXTERNAL_PACKAGES,
+    format = "esm",
+    output = "%s.js" % entry.replace(".ts", ""),
+    target = "es2020",
+    deps = SRC_DEPS,
+) for entry in ENTRY_POINTS]
+
+BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
+
+js_library(
+    name = PACKAGE_NAME,
+    srcs = BUNDLES + [
+        "package.json",
+        ":types",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+npm_package(
+    name = "pkg",
+    srcs = [
+        "LICENSE.md",
+        "README.md",
+        "package.json",
+    ] + BUNDLES + [":types"],
+    package = "@formatjs/%s" % PACKAGE_NAME,
+    visibility = ["//visibility:public"],
+)
+
+sh_test(
+    name = "no_internal_imports_test",
+    srcs = ["//tools:check_no_internal_imports.sh"],
+    data = BUNDLES,
+)
+
+ts_project(
+    name = "typecheck",
+    srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = packages_tsconfig(),
+    deps = SRC_DEPS,
+)
+
+ts_project(
+    name = "types",
+    srcs = [":srcs"],
+    declaration = True,
+    emit_declaration_only = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = packages_tsconfig(),
+    visibility = ["//visibility:public"],
     deps = SRC_DEPS,
 )
 

--- a/packages/react-intl/BUILD.bazel
+++ b/packages/react-intl/BUILD.bazel
@@ -1,29 +1,20 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:tsd/package_json.bzl", tsd_bin = "bin")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "package_json_test", "ts_compile")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "package_json_test")
+load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
 
 PACKAGE_NAME = "react-intl"
-
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-        "%s.iife.js" % PACKAGE_NAME,
-        ":dist",
-        ":dist-esm",
-    ],
-    package = PACKAGE_NAME,
-    visibility = ["//visibility:public"],
-)
 
 SRCS = glob(["src/**/*.ts*"]) + [
     "index.ts",
@@ -37,6 +28,12 @@ SRC_DEPS = [
     ":node_modules/intl-messageformat",
     "//:node_modules/@types/react",
     "//:node_modules/react",
+]
+
+EXTERNAL_PACKAGES = [
+    dep.split("node_modules/")[1]
+    for dep in SRC_DEPS
+    if "node_modules/" in dep and "ecma402-abstract" not in dep
 ]
 
 TESTS = glob(
@@ -55,9 +52,72 @@ TEST_DEPS = SRC_DEPS + [
     "//:node_modules/typescript",
 ]
 
-ts_compile(
-    name = "dist",
-    srcs = SRCS,
+ENTRY_POINTS = [
+    "index.ts",
+    "server.ts",
+]
+
+[esbuild(
+    name = "%s-bundle" % entry.replace(".ts", ""),
+    srcs = [":srcs"],
+    config = "//tools:esbuild-packages-resolve",
+    entry_point = entry,
+    external = EXTERNAL_PACKAGES,
+    format = "esm",
+    output = "%s.js" % entry.replace(".ts", ""),
+    target = "es2020",
+    deps = SRC_DEPS,
+) for entry in ENTRY_POINTS]
+
+BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
+
+js_library(
+    name = PACKAGE_NAME,
+    srcs = BUNDLES + [
+        "package.json",
+        ":types",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+npm_package(
+    name = "pkg",
+    srcs = [
+        "LICENSE.md",
+        "README.md",
+        "package.json",
+        "%s.iife.js" % PACKAGE_NAME,
+    ] + BUNDLES + [":types"],
+    package = PACKAGE_NAME,
+    visibility = ["//visibility:public"],
+)
+
+sh_test(
+    name = "no_internal_imports_test",
+    srcs = ["//tools:check_no_internal_imports.sh"],
+    data = BUNDLES,
+)
+
+ts_project(
+    name = "typecheck",
+    srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = packages_tsconfig(),
+    deps = SRC_DEPS,
+)
+
+ts_project(
+    name = "types",
+    srcs = [":srcs"],
+    declaration = True,
+    emit_declaration_only = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = packages_tsconfig(),
+    visibility = ["//visibility:public"],
     deps = SRC_DEPS,
 )
 


### PR DESCRIPTION
## Summary
Add esbuild bundling to the remaining 7 packages that still used `ts_compile`:
- icu-messageformat-parser, icu-skeleton-parser, intl, intl-durationformat, intl-messageformat, intl-supportedvaluesof, react-intl

Same pattern as #6214. Each package now:
- Bundles entry points with esbuild (with workspace-resolve plugin)
- Uses `js_library` as default target (served via npm_link)
- Type checks with `ts_project(no_emit=True)`
- Generates `.d.ts` with `emit_declaration_only`
- Has `no_internal_imports_test` to verify no `#packages/*` leaks

## Test plan
- [x] All 494 tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)