### PR TITLE
chore: migrate from esbuild to rolldown for JS bundling

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -402,7 +402,7 @@
         "recordedInputs": [
           "REPO_MAPPING:aspect_rules_ts+,aspect_rules_ts aspect_rules_ts+",
           "REPO_MAPPING:aspect_rules_ts+,bazel_tools bazel_tools",
-          "FILE:@@//package.json 6c62b98360d0ba6e905033b3e910d443e04aeb6290685e8610cf4b4ac295b9f6"
+          "FILE:@@//package.json dc875ae33b93591ef417d520a6c962d9180fd27ef260f0e88897c579789fbab9"
         ],
         "generatedRepoSpecs": {
           "npm_typescript": {

--- a/knowledge-base/010-script-conventions.md
+++ b/knowledge-base/010-script-conventions.md
@@ -1,0 +1,54 @@
+# Script Conventions
+
+## CLI Script Pattern
+
+All TypeScript CLI scripts in `tools/` and `packages/*/scripts/` follow a consistent pattern:
+
+### 1. Typed Args Interface
+
+Define an `Args` interface extending `minimist.ParsedArgs` with typed fields for all CLI arguments:
+
+```typescript
+import minimist from 'minimist'
+
+interface Args extends minimist.ParsedArgs {
+  out: string
+  format?: string
+  external?: string | string[] // use union for --flag that can repeat
+}
+```
+
+### 2. Main Function
+
+Extract logic into a `main(args: Args)` function:
+
+```typescript
+function main(args: Args) {
+  const {out, format} = args
+  // ...
+}
+```
+
+Use `async function main(args: Args)` if the script uses `await`.
+
+### 3. Entry Point Guard
+
+Use `import.meta.filename` to guard the entry point:
+
+```typescript
+if (import.meta.filename === process.argv[1]) {
+  main(minimist<Args>(process.argv.slice(2)))
+}
+```
+
+### 4. Array Arguments
+
+For CLI flags that can repeat (e.g., `--external foo --external bar`), use `[].concat(args.flag || [])` to normalize:
+
+```typescript
+const externals: string[] = [].concat(args.external || [])
+```
+
+### Example
+
+See `tools/generate-supported-locales.ts` for the canonical minimal example, or `tools/rolldown-bundle.ts` for a more complex one.

--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
     "rehype-slug": "^6.0.0",
     "remark-frontmatter": "^5.0.0",
     "remark-gfm": "^4.0.1",
+    "rolldown": "1.0.0-rc.13",
     "rollup": "^4.40.0",
     "serialize-javascript": "^7.0.2",
     "svelte": "^5.0.0",
@@ -179,9 +180,6 @@
   },
   "packageManager": "pnpm@10.32.1",
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild"
-    ],
     "overrides": {
       "@tailwindcss/vite>vite": "$vite"
     },
@@ -229,7 +227,10 @@
       "unicode-match-property-value-ecmascript@2.2.1": "patches/unicode-match-property-value-ecmascript@2.2.1.patch",
       "unicode-match-property-ecmascript@2.0.0": "patches/unicode-match-property-ecmascript@2.0.0.patch",
       "oxlint@1.48.0": "patches/oxlint@1.48.0.patch"
-    }
+    },
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ]
   },
   "repository": "formatjs/formatjs"
 }

--- a/packages/icu-messageformat-parser/BUILD.bazel
+++ b/packages/icu-messageformat-parser/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
-load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
@@ -7,6 +6,7 @@ load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test")
+load("//tools:rolldown.bzl", "rolldown_bundle")
 load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
@@ -38,10 +38,9 @@ ENTRY_POINTS = [
     "manipulator.ts",
 ]
 
-[esbuild(
+[rolldown_bundle(
     name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
-    config = "//tools:esbuild-packages-resolve",
     entry_point = entry,
     external = EXTERNAL_PACKAGES,
     format = "esm",

--- a/packages/icu-skeleton-parser/BUILD.bazel
+++ b/packages/icu-skeleton-parser/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
-load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
@@ -8,6 +7,7 @@ load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test")
+load("//tools:rolldown.bzl", "rolldown_bundle")
 load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
@@ -31,10 +31,9 @@ ENTRY_POINTS = [
     "index.ts",
 ]
 
-[esbuild(
+[rolldown_bundle(
     name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
-    config = "//tools:esbuild-packages-resolve",
     entry_point = entry,
     external = EXTERNAL_PACKAGES,
     format = "esm",

--- a/packages/intl-datetimeformat/BUILD.bazel
+++ b/packages/intl-datetimeformat/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
-load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
@@ -10,6 +9,7 @@ load("@rules_multirun//:defs.bzl", "multirun")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_run_binary")
+load("//tools:rolldown.bzl", "rolldown_bundle")
 load("//tools:tsconfig.bzl", "BASE_TSCONFIG", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 load(":defs.bzl", "ZONES")
@@ -74,10 +74,9 @@ ENTRY_POINTS = [
     "should-polyfill.ts",
 ]
 
-[esbuild(
+[rolldown_bundle(
     name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
-    config = "//tools:esbuild-packages-resolve",
     entry_point = entry,
     external = EXTERNAL_PACKAGES,
     format = "esm",
@@ -965,10 +964,9 @@ write_source_files(
     visibility = ["//:__pkg__"],
 )
 
-esbuild(
+rolldown_bundle(
     name = "polyfill.iife",
     srcs = [":srcs"],
-    config = "//tools:esbuild-packages-resolve",
     entry_point = "polyfill.ts",
     target = "es2020",
     deps = [

--- a/packages/intl-displaynames/BUILD.bazel
+++ b/packages/intl-displaynames/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
-load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
@@ -9,6 +8,7 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_run_binary")
+load("//tools:rolldown.bzl", "rolldown_bundle")
 load("//tools:tsconfig.bzl", "BASE_TSCONFIG", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
@@ -58,10 +58,9 @@ ENTRY_POINTS = [
     "should-polyfill.ts",
 ]
 
-[esbuild(
+[rolldown_bundle(
     name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
-    config = "//tools:esbuild-packages-resolve",
     entry_point = entry,
     external = EXTERNAL_PACKAGES,
     format = "esm",
@@ -801,10 +800,12 @@ generate_src_file(
 )
 
 # Test262
-esbuild(
+rolldown_bundle(
     name = "test262-polyfill",
-    srcs = [":srcs"],
-    config = "//tools:esbuild-packages-resolve",
+    srcs = [
+        "test262-main.ts",
+        ":srcs",
+    ],
     entry_point = "test262-main.ts",
     target = "es2020",
     deps = SRC_DEPS,
@@ -845,10 +846,9 @@ write_source_files(
     visibility = ["//:__pkg__"],
 )
 
-esbuild(
+rolldown_bundle(
     name = "polyfill.iife",
     srcs = [":srcs"],
-    config = "//tools:esbuild-packages-resolve",
     entry_point = "polyfill.ts",
     target = "es2020",
     deps = [

--- a/packages/intl-durationformat/BUILD.bazel
+++ b/packages/intl-durationformat/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
-load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
@@ -8,6 +7,7 @@ load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file")
+load("//tools:rolldown.bzl", "rolldown_bundle")
 load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
@@ -38,10 +38,9 @@ ENTRY_POINTS = [
     "should-polyfill.ts",
 ]
 
-[esbuild(
+[rolldown_bundle(
     name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
-    config = "//tools:esbuild-packages-resolve",
     entry_point = entry,
     external = EXTERNAL_PACKAGES,
     format = "esm",

--- a/packages/intl-getcanonicallocales/BUILD.bazel
+++ b/packages/intl-getcanonicallocales/BUILD.bazel
@@ -1,8 +1,8 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
-load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_compile")
+load("//tools:rolldown.bzl", "rolldown_bundle")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -86,7 +86,7 @@ generate_src_file(
 # Generate tsconfig.json with correct extends path
 generate_ide_tsconfig_json()
 
-esbuild(
+rolldown_bundle(
     name = "polyfill.iife",
     srcs = [":srcs"],
     entry_point = "polyfill.ts",

--- a/packages/intl-listformat/BUILD.bazel
+++ b/packages/intl-listformat/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
-load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
@@ -9,6 +8,7 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_run_binary")
+load("//tools:rolldown.bzl", "rolldown_bundle")
 load("//tools:tsconfig.bzl", "BASE_TSCONFIG", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
@@ -61,10 +61,9 @@ ENTRY_POINTS = [
     "should-polyfill.ts",
 ]
 
-[esbuild(
+[rolldown_bundle(
     name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
-    config = "//tools:esbuild-packages-resolve",
     entry_point = entry,
     external = EXTERNAL_PACKAGES,
     format = "esm",
@@ -792,10 +791,9 @@ generate_src_file(
 )
 
 # Test262
-esbuild(
+rolldown_bundle(
     name = "test262-polyfill",
     srcs = [":srcs"],
-    config = "//tools:esbuild-packages-resolve",
     entry_point = "polyfill-force.ts",
     target = "es2020",
     deps = SRC_DEPS,
@@ -833,10 +831,9 @@ write_source_files(
     visibility = ["//:__pkg__"],
 )
 
-esbuild(
+rolldown_bundle(
     name = "polyfill.iife",
     srcs = [":srcs"],
-    config = "//tools:esbuild-packages-resolve",
     entry_point = "polyfill.ts",
     target = "es2020",
     deps = [

--- a/packages/intl-locale/BUILD.bazel
+++ b/packages/intl-locale/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
-load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
@@ -9,6 +8,7 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test")
+load("//tools:rolldown.bzl", "rolldown_bundle")
 load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
 load("//tools:vitest.bzl", "vitest")
 
@@ -38,7 +38,7 @@ TYPECHECK_DEPS = [
     "//packages/ecma402-abstract",
 ]
 
-# Deps for esbuild — ecma402-abstract comes via #packages, not node_modules
+# Deps for bundling — ecma402-abstract comes via #packages, not node_modules
 BUNDLE_DEPS = [
     "//:node_modules/@formatjs/intl-supportedvaluesof",
     "//:node_modules/@formatjs/intl-getcanonicallocales",
@@ -54,11 +54,10 @@ EXTERNAL_PACKAGES = [
     if "node_modules/" in dep
 ]
 
-# --- Bundle each entry point with esbuild (resolves #packages/* imports) ---
-[esbuild(
+# --- Bundle each entry point with rolldown (resolves #packages/* imports) ---
+[rolldown_bundle(
     name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
-    config = "//tools:esbuild-packages-resolve",
     entry_point = entry,
     external = EXTERNAL_PACKAGES,
     format = "esm",
@@ -135,10 +134,9 @@ vitest(
 )
 
 # Test262
-esbuild(
+rolldown_bundle(
     name = "test262-polyfill",
     srcs = [":srcs"],
-    config = "//tools:esbuild-packages-resolve",
     entry_point = "polyfill-force.ts",
     target = "es2020",
     deps = BUNDLE_DEPS,
@@ -174,10 +172,9 @@ generate_ide_tsconfig_json(
     ],
 )
 
-esbuild(
+rolldown_bundle(
     name = "polyfill.iife",
     srcs = [":srcs"],
-    config = "//tools:esbuild-packages-resolve",
     entry_point = "polyfill.ts",
     target = "es2020",
     deps = BUNDLE_DEPS,

--- a/packages/intl-messageformat/BUILD.bazel
+++ b/packages/intl-messageformat/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
-load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
@@ -7,6 +6,7 @@ load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//tools:index.bzl", "generate_ide_tsconfig_json", "package_json_test")
+load("//tools:rolldown.bzl", "rolldown_bundle")
 load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
@@ -42,10 +42,9 @@ ENTRY_POINTS = [
     "index.ts",
 ]
 
-[esbuild(
+[rolldown_bundle(
     name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
-    config = "//tools:esbuild-packages-resolve",
     entry_point = entry,
     external = EXTERNAL_PACKAGES,
     format = "esm",
@@ -112,25 +111,21 @@ vitest(
     deps = SRC_DEPS + TEST_DEPS,
 )
 
-esbuild(
+rolldown_bundle(
     name = "%s.iife" % PACKAGE_NAME,
     srcs = [":srcs"],
-    config = {
-        "globalName": "IntlMessageFormat",
-    },
     entry_point = "index.ts",
+    global_name = "IntlMessageFormat",
     target = "es2020",
     deps = SRC_DEPS,
 )
 
-esbuild(
+rolldown_bundle(
     name = "%s.esm" % PACKAGE_NAME,
     srcs = [":srcs"],
-    config = {
-        "globalName": "IntlMessageFormat",
-    },
     entry_point = "index.ts",
     format = "esm",
+    global_name = "IntlMessageFormat",
     target = "esnext",
     deps = SRC_DEPS,
 )

--- a/packages/intl-numberformat/BUILD.bazel
+++ b/packages/intl-numberformat/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
-load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
@@ -11,6 +10,7 @@ load("@rules_multirun//:defs.bzl", "multirun")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_run_binary")
+load("//tools:rolldown.bzl", "rolldown_bundle")
 load("//tools:tsconfig.bzl", "BASE_TSCONFIG", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
@@ -97,10 +97,9 @@ ENTRY_POINTS = [
     "should-polyfill.ts",
 ]
 
-[esbuild(
+[rolldown_bundle(
     name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
-    config = "//tools:esbuild-packages-resolve",
     entry_point = entry,
     external = EXTERNAL_PACKAGES,
     format = "esm",
@@ -988,10 +987,12 @@ generate_src_file(
 # )
 
 # Test262
-esbuild(
+rolldown_bundle(
     name = "test262-polyfill",
-    srcs = [":srcs"],
-    config = "//tools:esbuild-packages-resolve",
+    srcs = [
+        "test262-main.ts",
+        ":srcs",
+    ],
     entry_point = "test262-main.ts",
     target = "es2020",
     deps = [
@@ -1029,10 +1030,9 @@ write_source_files(
     visibility = ["//:__pkg__"],
 )
 
-esbuild(
+rolldown_bundle(
     name = "polyfill.iife",
     srcs = [":srcs"],
-    config = "//tools:esbuild-packages-resolve",
     entry_point = "polyfill.ts",
     target = "es2020",
     deps = [

--- a/packages/intl-pluralrules/BUILD.bazel
+++ b/packages/intl-pluralrules/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
-load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
@@ -9,6 +8,7 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_run_binary")
+load("//tools:rolldown.bzl", "rolldown_bundle")
 load("//tools:tsconfig.bzl", "BASE_TSCONFIG", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
@@ -273,10 +273,9 @@ ENTRY_POINTS = [
     "should-polyfill.ts",
 ]
 
-[esbuild(
+[rolldown_bundle(
     name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
-    config = "//tools:esbuild-packages-resolve",
     entry_point = entry,
     external = EXTERNAL_PACKAGES,
     format = "esm",
@@ -439,10 +438,12 @@ generate_src_file(
 )
 
 # Test262
-esbuild(
+rolldown_bundle(
     name = "test262-polyfill",
-    srcs = [":srcs"],
-    config = "//tools:esbuild-packages-resolve",
+    srcs = [
+        "test262-main.ts",
+        ":srcs",
+    ],
     entry_point = "test262-main.ts",
     target = "es2020",
     deps = SRC_DEPS,
@@ -479,10 +480,9 @@ write_source_files(
     visibility = ["//:__pkg__"],
 )
 
-esbuild(
+rolldown_bundle(
     name = "polyfill.iife",
     srcs = [":srcs"],
-    config = "//tools:esbuild-packages-resolve",
     entry_point = "polyfill.ts",
     target = "es2020",
     # TODO: fix this and set it back to es5

--- a/packages/intl-relativetimeformat/BUILD.bazel
+++ b/packages/intl-relativetimeformat/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
-load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
@@ -9,6 +8,7 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_json_test", "ts_run_binary")
+load("//tools:rolldown.bzl", "rolldown_bundle")
 load("//tools:tsconfig.bzl", "BASE_TSCONFIG", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
@@ -56,10 +56,9 @@ ENTRY_POINTS = [
     "should-polyfill.ts",
 ]
 
-[esbuild(
+[rolldown_bundle(
     name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
-    config = "//tools:esbuild-packages-resolve",
     entry_point = entry,
     external = EXTERNAL_PACKAGES,
     format = "esm",
@@ -790,10 +789,12 @@ generate_src_file(
 )
 
 # Test262
-esbuild(
+rolldown_bundle(
     name = "test262-polyfill",
-    srcs = [":srcs"],
-    config = "//tools:esbuild-packages-resolve",
+    srcs = [
+        "test262-main.ts",
+        ":srcs",
+    ],
     entry_point = "test262-main.ts",
     target = "es2020",
     deps = SRC_DEPS,
@@ -830,10 +831,9 @@ write_source_files(
     visibility = ["//:__pkg__"],
 )
 
-esbuild(
+rolldown_bundle(
     name = "polyfill.iife",
     srcs = [":srcs"],
-    config = "//tools:esbuild-packages-resolve",
     entry_point = "polyfill.ts",
     target = "es2020",
     deps = [

--- a/packages/intl-segmenter/BUILD.bazel
+++ b/packages/intl-segmenter/BUILD.bazel
@@ -1,7 +1,6 @@
 load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
-load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
@@ -10,6 +9,7 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file")
+load("//tools:rolldown.bzl", "rolldown_bundle")
 load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
 load("//tools:vitest.bzl", "vitest")
 load(":index.bzl", "unicode_file_name")
@@ -72,10 +72,9 @@ ENTRY_POINTS = [
     "should-polyfill.ts",
 ]
 
-[esbuild(
+[rolldown_bundle(
     name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
-    config = "//tools:esbuild-packages-resolve",
     entry_point = entry,
     external = EXTERNAL_PACKAGES,
     format = "esm",
@@ -167,10 +166,12 @@ generate_src_file(
 )
 
 # Test262
-esbuild(
+rolldown_bundle(
     name = "test262-polyfill",
-    srcs = [":srcs"],
-    config = "//tools:esbuild-packages-resolve",
+    srcs = [
+        "test262-main.ts",
+        ":srcs",
+    ],
     entry_point = "test262-main.ts",
     target = "es2020",
     deps = SRC_DEPS,
@@ -204,10 +205,9 @@ write_source_files(
     visibility = ["//:__pkg__"],
 )
 
-esbuild(
+rolldown_bundle(
     name = "polyfill.iife",
     srcs = [":srcs"],
-    config = "//tools:esbuild-packages-resolve",
     entry_point = "polyfill.ts",
     target = "es2020",
     deps = [

--- a/packages/intl-supportedvaluesof/BUILD.bazel
+++ b/packages/intl-supportedvaluesof/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
-load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
@@ -9,6 +8,7 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//packages/intl-datetimeformat:defs.bzl", "ZONES")
 load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file")
+load("//tools:rolldown.bzl", "rolldown_bundle")
 load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
@@ -43,10 +43,9 @@ ENTRY_POINTS = [
     "should-polyfill.ts",
 ]
 
-[esbuild(
+[rolldown_bundle(
     name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
-    config = "//tools:esbuild-packages-resolve",
     entry_point = entry,
     external = EXTERNAL_PACKAGES,
     format = "esm",
@@ -184,10 +183,9 @@ generate_src_file(
     tool = "//packages/intl-supportedvaluesof/scripts:units",
 )
 
-esbuild(
+rolldown_bundle(
     name = "polyfill.iife",
     srcs = [":srcs"],
-    config = "//tools:esbuild-packages-resolve",
     entry_point = "polyfill.ts",
     target = "es2020",
     deps = [

--- a/packages/intl/BUILD.bazel
+++ b/packages/intl/BUILD.bazel
@@ -1,7 +1,6 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
-load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
@@ -10,6 +9,7 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:tsd/package_json.bzl", tsd_bin = "bin")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//tools:index.bzl", "generate_ide_tsconfig_json", "package_json_test")
+load("//tools:rolldown.bzl", "rolldown_bundle")
 load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
@@ -45,10 +45,9 @@ ENTRY_POINTS = [
     "index.ts",
 ]
 
-[esbuild(
+[rolldown_bundle(
     name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
-    config = "//tools:esbuild-packages-resolve",
     entry_point = entry,
     external = EXTERNAL_PACKAGES,
     format = "esm",

--- a/packages/react-intl/BUILD.bazel
+++ b/packages/react-intl/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
-load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
@@ -9,6 +8,7 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:tsd/package_json.bzl", tsd_bin = "bin")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//tools:index.bzl", "generate_ide_tsconfig_json", "package_json_test")
+load("//tools:rolldown.bzl", "rolldown_bundle")
 load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
@@ -57,10 +57,9 @@ ENTRY_POINTS = [
     "server.ts",
 ]
 
-[esbuild(
+[rolldown_bundle(
     name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
-    config = "//tools:esbuild-packages-resolve",
     entry_point = entry,
     external = EXTERNAL_PACKAGES,
     format = "esm",
@@ -121,14 +120,12 @@ ts_project(
     deps = SRC_DEPS,
 )
 
-esbuild(
+rolldown_bundle(
     name = "%s.esbuild.iife" % PACKAGE_NAME,
     srcs = [":srcs"],
-    config = {
-        "globalName": "ReactIntl",
-    },
     entry_point = "index.ts",
     external = ["react"],
+    global_name = "ReactIntl",
     target = "es2020",
     deps = SRC_DEPS,
 )

--- a/packages/react-intl/examples/BUILD.bazel
+++ b/packages/react-intl/examples/BUILD.bazel
@@ -1,8 +1,8 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
-load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:http-server/package_json.bzl", "bin")
+load("//tools:rolldown.bzl", "rolldown_bundle")
 load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
 
 npm_link_all_packages()
@@ -39,7 +39,7 @@ ts_project(
     deps = EXAMPLES_SRC_DEPS,
 )
 
-esbuild(
+rolldown_bundle(
     name = "main",
     define = {
         "process.env.NODE_ENV": '"development"',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -417,6 +417,9 @@ importers:
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
+      rolldown:
+        specifier: 1.0.0-rc.13
+        version: 1.0.0-rc.13
       rollup:
         specifier: ^4.40.0
         version: 4.59.0
@@ -1831,11 +1834,17 @@ packages:
   '@emnapi/core@1.9.0':
     resolution: {integrity: sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==}
 
+  '@emnapi/core@1.9.1':
+    resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
+
   '@emnapi/runtime@1.8.1':
     resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
 
   '@emnapi/runtime@1.9.0':
     resolution: {integrity: sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==}
+
+  '@emnapi/runtime@1.9.1':
+    resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
 
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
@@ -2372,6 +2381,12 @@ packages:
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
 
+  '@napi-rs/wasm-runtime@1.1.2':
+    resolution: {integrity: sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -2615,6 +2630,9 @@ packages:
 
   '@oxc-project/types@0.120.0':
     resolution: {integrity: sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg==}
+
+  '@oxc-project/types@0.123.0':
+    resolution: {integrity: sha512-YtECP/y8Mj1lSHiUWGSRzy/C6teUKlS87dEfuVKT09LgQbUsBW1rNg+MiJ4buGu3yuADV60gbIvo9/HplA56Ew==}
 
   '@oxc-transform/binding-android-arm-eabi@0.120.0':
     resolution: {integrity: sha512-NRSGsDmnVYWMnYq4LlxakKbZUFhV+A9cVIwQu/Iy/eZcADxT3eSRJ8ItLbAryMjuuWJiCQFdlGNMFzuMtHogzw==}
@@ -3413,16 +3431,34 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.13':
+    resolution: {integrity: sha512-5ZiiecKH2DXAVJTNN13gNMUcCDg4Jy8ZjbXEsPnqa248wgOVeYRX0iqXXD5Jz4bI9BFHgKsI2qmyJynstbmr+g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
   '@rolldown/binding-android-arm64@1.0.0-rc.9':
     resolution: {integrity: sha512-lcJL0bN5hpgJfSIz/8PIf02irmyL43P+j1pTCfbD1DbLkmGRuFIA4DD3B3ZOvGqG0XiVvRznbKtN0COQVaKUTg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.13':
+    resolution: {integrity: sha512-tz/v/8G77seu8zAB3A5sK3UFoOl06zcshEzhUO62sAEtrEuW/H1CcyoupOrD+NbQJytYgA4CppXPzlrmp4JZKA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rolldown/binding-darwin-arm64@1.0.0-rc.9':
     resolution: {integrity: sha512-J7Zk3kLYFsLtuH6U+F4pS2sYVzac0qkjcO5QxHS7OS7yZu2LRs+IXo+uvJ/mvpyUljDJ3LROZPoQfgBIpCMhdQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.13':
+    resolution: {integrity: sha512-8DakphqOz8JrMYWTJmWA+vDJxut6LijZ8Xcdc4flOlAhU7PNVwo2MaWBF9iXjJAPo5rC/IxEFZDhJ3GC7NHvug==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
     os: [darwin]
 
   '@rolldown/binding-darwin-x64@1.0.0-rc.9':
@@ -3431,17 +3467,36 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.13':
+    resolution: {integrity: sha512-4wBQFfjDuXYN/SVI8inBF3Aa+isq40rc6VMFbk5jcpolUBTe5cYnMsHZ51nFWsx3PVyyNN3vgoESki0Hmr/4BA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
   '@rolldown/binding-freebsd-x64@1.0.0-rc.9':
     resolution: {integrity: sha512-DLFYI78SCiZr5VvdEplsVC2Vx53lnA4/Ga5C65iyldMVaErr86aiqCoNBLl92PXPfDtUYjUh+xFFor40ueNs4Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.13':
+    resolution: {integrity: sha512-JW/e4yPIXLms+jmnbwwy5LA/LxVwZUWLN8xug+V200wzaVi5TEGIWQlh8o91gWYFxW609euI98OCCemmWGuPrw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.9':
     resolution: {integrity: sha512-CsjTmTwd0Hri6iTw/DRMK7kOZ7FwAkrO4h8YWKoX/kcj833e4coqo2wzIFywtch/8Eb5enQ/lwLM7w6JX1W5RQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.13':
+    resolution: {integrity: sha512-ZfKWpXiUymDnavepCaM6KG/uGydJ4l2nBmMxg60Ci4CbeefpqjPWpfaZM7PThOhk2dssqBAcwLc6rAyr0uTdXg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.9':
     resolution: {integrity: sha512-2x9O2JbSPxpxMDhP9Z74mahAStibTlrBMW0520+epJH5sac7/LwZW5Bmg/E6CXuEF53JJFW509uP+lSedaUNxg==}
@@ -3450,6 +3505,13 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.13':
+    resolution: {integrity: sha512-bmRg3O6Z0gq9yodKKWCIpnlH051sEfdVwt+6m5UDffAQMUUqU0xjnQqqAUm+Gu7ofAAly9DqiQDtKu2nPDEABA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.9':
     resolution: {integrity: sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -3457,10 +3519,24 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.13':
+    resolution: {integrity: sha512-8Wtnbw4k7pMYN9B/mOEAsQ8HOiq7AZ31Ig4M9BKn2So4xRaFEhtCSa4ZJaOutOWq50zpgR4N5+L/opnlaCx8wQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.9':
     resolution: {integrity: sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.13':
+    resolution: {integrity: sha512-D/0Nlo8mQuxSMohNJUF2lDXWRsFDsHldfRRgD9bRgktj+EndGPj4DOV37LqDKPYS+osdyhZEH7fTakTAEcW7qg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
@@ -3471,12 +3547,26 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.13':
+    resolution: {integrity: sha512-eRrPvat2YaVQcwwKi/JzOP6MKf1WRnOCr+VaI3cTWz3ZoLcP/654z90lVCJ4dAuMEpPdke0n+qyAqXDZdIC4rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.9':
     resolution: {integrity: sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.13':
+    resolution: {integrity: sha512-PsdONiFRp8hR8KgVjTWjZ9s7uA3uueWL0t74/cKHfM4dR5zXYv4AjB8BvA+QDToqxAFg4ZkcVEqeu5F7inoz5w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.9':
     resolution: {integrity: sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==}
@@ -3485,16 +3575,33 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.13':
+    resolution: {integrity: sha512-hCNXgC5dI3TVOLrPT++PKFNZ+1EtS0mLQwfXXXSUD/+rGlB65gZDwN/IDuxLpQP4x8RYYHqGomlUXzpO8aVI2w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.9':
     resolution: {integrity: sha512-+6zoiF+RRyf5cdlFQP7nm58mq7+/2PFaY2DNQeD4B87N36JzfF/l9mdBkkmTvSYcYPE8tMh/o3cRlsx1ldLfog==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.13':
+    resolution: {integrity: sha512-viLS5C5et8NFtLWw9Sw3M/w4vvnVkbWkO7wSNh3C+7G1+uCkGpr6PcjNDSFcNtmXY/4trjPBqUfcOL+P3sWy/g==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.9':
     resolution: {integrity: sha512-rgFN6sA/dyebil3YTlL2evvi/M+ivhfnyxec7AccTpRPccno/rPoNlqybEZQBkcbZu8Hy+eqNJCqfBR8P7Pg8g==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.13':
+    resolution: {integrity: sha512-Fqa3Tlt1xL4wzmAYxGNFV36Hb+VfPc9PYU+E25DAnswXv3ODDu/yyWjQDbXMo5AGWkQVjLgQExuVu8I/UaZhPQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
 
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.9':
     resolution: {integrity: sha512-lHVNUG/8nlF1IQk1C0Ci574qKYyty2goMiPlRqkC5R+3LkXDkL5Dhx8ytbxq35m+pkHVIvIxviD+TWLdfeuadA==}
@@ -3502,11 +3609,20 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.13':
+    resolution: {integrity: sha512-/pLI5kPkGEi44TDlnbio3St/5gUFeN51YWNAk/Gnv6mEQBOahRBh52qVFVBpmrnU01n2yysvBML9Ynu7K4kGAQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.9':
     resolution: {integrity: sha512-G0oA4+w1iY5AGi5HcDTxWsoxF509hrFIPB2rduV5aDqS9FtDg1CAfa7V34qImbjfhIcA8C+RekocJZA96EarwQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.13':
+    resolution: {integrity: sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==}
 
   '@rolldown/pluginutils@1.0.0-rc.7':
     resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
@@ -7587,6 +7703,11 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rolldown@1.0.0-rc.13:
+    resolution: {integrity: sha512-bvVj8YJmf0rq4pSFmH7laLa6pYrhghv3PRzrCdRAr23g66zOKVJ4wkvFtgohtPLWmthgg8/rkaqRHrpUEh0Zbw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   rolldown@1.0.0-rc.9:
     resolution: {integrity: sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -9729,12 +9850,23 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/core@1.9.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.0
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.8.1':
     dependencies:
       tslib: 2.8.1
     optional: true
 
   '@emnapi/runtime@1.9.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.9.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -10451,6 +10583,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.2(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)':
+    dependencies:
+      '@emnapi/core': 1.9.1
+      '@emnapi/runtime': 1.9.1
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -10660,6 +10799,8 @@ snapshots:
   '@oxc-project/types@0.115.0': {}
 
   '@oxc-project/types@0.120.0': {}
+
+  '@oxc-project/types@0.123.0': {}
 
   '@oxc-transform/binding-android-arm-eabi@0.120.0':
     optional: true
@@ -11256,40 +11397,83 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.13':
+    optional: true
+
   '@rolldown/binding-android-arm64@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.13':
     optional: true
 
   '@rolldown/binding-darwin-arm64@1.0.0-rc.9':
     optional: true
 
+  '@rolldown/binding-darwin-x64@1.0.0-rc.13':
+    optional: true
+
   '@rolldown/binding-darwin-x64@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.13':
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.0.0-rc.9':
     optional: true
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.13':
+    optional: true
+
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.13':
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.9':
     optional: true
 
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.13':
+    optional: true
+
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.13':
     optional: true
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.9':
     optional: true
 
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.13':
+    optional: true
+
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.13':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.9':
     optional: true
 
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.13':
+    optional: true
+
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.9':
     optional: true
 
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.13':
+    optional: true
+
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.13':
+    dependencies:
+      '@emnapi/core': 1.9.1
+      '@emnapi/runtime': 1.9.1
+      '@napi-rs/wasm-runtime': 1.1.2(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.9':
@@ -11297,11 +11481,19 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.1
     optional: true
 
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.13':
+    optional: true
+
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.13':
     optional: true
 
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.9':
     optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.13': {}
 
   '@rolldown/pluginutils@1.0.0-rc.7': {}
 
@@ -16052,6 +16244,27 @@ snapshots:
     optional: true
 
   reusify@1.1.0: {}
+
+  rolldown@1.0.0-rc.13:
+    dependencies:
+      '@oxc-project/types': 0.123.0
+      '@rolldown/pluginutils': 1.0.0-rc.13
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.13
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.13
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.13
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.13
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.13
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.13
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.13
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.13
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.13
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.13
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.13
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.13
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.13
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.13
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.13
 
   rolldown@1.0.0-rc.9:
     dependencies:

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -25,6 +25,16 @@ copy_to_bin(
 )
 
 ts_binary(
+    name = "rolldown-bundle-bin",
+    data = [
+        "//:node_modules/minimist",
+        "//:node_modules/rolldown",
+    ],
+    entry_point = "rolldown-bundle.ts",
+    visibility = ["//visibility:public"],
+)
+
+ts_binary(
     name = "generate-supported-locales",
     data = [
         "//:node_modules/fs-extra",

--- a/tools/rolldown-bundle.ts
+++ b/tools/rolldown-bundle.ts
@@ -1,0 +1,107 @@
+/**
+ * Rolldown bundler script for Bazel.
+ * Replaces esbuild for JS bundling with #packages/* workspace resolution.
+ *
+ * Usage: rolldown-bundle --input <entry.ts> --output <out.js> --format esm
+ *        [--external pkg1 --external pkg2] [--target es2020]
+ *        [--globalName Name] [--platform browser|node]
+ */
+import {rolldown} from 'rolldown'
+import path from 'node:path'
+import minimist from 'minimist'
+
+interface Args extends minimist.ParsedArgs {
+  input: string
+  output?: string
+  outDir?: string
+  format?: string
+  external?: string | string[]
+  target?: string
+  globalName?: string
+  platform?: string
+  define?: string | string[]
+}
+
+function getWorkspaceRoot(): string {
+  if (process.env.BUILD_WORKSPACE_DIRECTORY)
+    return process.env.BUILD_WORKSPACE_DIRECTORY
+  if (process.env.JS_BINARY__EXECROOT && process.env.BAZEL_BINDIR)
+    return path.join(process.env.JS_BINARY__EXECROOT, process.env.BAZEL_BINDIR)
+  if (process.env.JS_BINARY__RUNFILES && process.env.JS_BINARY__WORKSPACE)
+    return path.join(
+      process.env.JS_BINARY__RUNFILES,
+      process.env.JS_BINARY__WORKSPACE
+    )
+  return process.cwd()
+}
+
+async function main(args: Args) {
+  const {input, output, outDir, globalName, platform} = args
+  const format: 'es' | 'cjs' | 'iife' =
+    args.format === 'esm'
+      ? 'es'
+      : (args.format as 'es' | 'cjs' | 'iife') || 'es'
+  const externals: string[] = [].concat(args.external || [])
+  const target: string = args.target || 'es2020'
+  const defines: string[] = [].concat(args.define || [])
+
+  if (!input || (!output && !outDir)) {
+    throw new Error(
+      'Usage: rolldown-bundle --input <entry> --output <out>|--outDir <dir> [--format esm] [--external pkg]'
+    )
+  }
+
+  const workspaceRoot = getWorkspaceRoot()
+
+  // Parse --define key=value pairs
+  const defineMap: Record<string, string> = {}
+  for (const d of defines) {
+    const eq = d.indexOf('=')
+    if (eq > 0) defineMap[d.slice(0, eq)] = d.slice(eq + 1)
+  }
+
+  // Convert externals to regex patterns that match subpath imports
+  const externalPatterns: Array<string | RegExp> = externals.map(ext => {
+    const escaped = ext.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    return new RegExp(`^${escaped}(\\/.*)?$`)
+  })
+
+  const bundle = await rolldown({
+    input,
+    external: externalPatterns,
+    platform:
+      platform === 'node'
+        ? 'node'
+        : platform === 'browser'
+          ? 'browser'
+          : undefined,
+    define: Object.keys(defineMap).length > 0 ? defineMap : undefined,
+    resolve: {
+      alias: {
+        '#packages': path.join(workspaceRoot, 'packages'),
+      },
+    },
+  })
+
+  if (outDir) {
+    await bundle.write({
+      dir: outDir,
+      format,
+      sourcemap: true,
+      name: globalName,
+      target,
+    })
+  } else if (output) {
+    await bundle.write({
+      file: output,
+      format,
+      sourcemap: true,
+      name: globalName,
+      target,
+    })
+  }
+}
+
+if (import.meta.filename === process.argv[1]) {
+  main(minimist<Args>(process.argv.slice(2)))
+}

--- a/tools/rolldown.bzl
+++ b/tools/rolldown.bzl
@@ -1,0 +1,97 @@
+"Bazel macro for bundling JS with rolldown."
+
+load("@aspect_rules_js//js:defs.bzl", "js_run_binary")
+
+def rolldown_bundle(name, entry_point, srcs = [], output = None, deps = [], external = [], format = "esm", target = "es2020", global_name = None, config = None, platform = None, define = None, code_splitting = False, visibility = None, **kwargs):
+    """Bundle JS/TS with rolldown.
+
+    Drop-in replacement for the esbuild() macro. Bundles an entry point into
+    a single output file, resolving #packages/* workspace imports.
+
+    Args:
+        name: target name
+        srcs: source files
+        entry_point: entry .ts file
+        output: output .js file name
+        deps: dependencies
+        external: list of external package names
+        format: output format (esm, cjs, iife)
+        target: JS target (es2020, esnext, etc.)
+        global_name: global variable name for iife format
+        config: unused, kept for esbuild() API compatibility
+        visibility: target visibility
+        **kwargs: additional args (ignored, for esbuild compat)
+    """
+
+    effective_output = output or (name + ".js")
+
+    args = [
+        "--input",
+        native.package_name() + "/" + entry_point,
+        "--output",
+        "$(rootpath %s)" % effective_output,
+        "--format",
+        format,
+        "--target",
+        target,
+    ]
+
+    for ext in external:
+        args += ["--external", ext]
+
+    if global_name:
+        args += ["--globalName", global_name]
+
+    if platform:
+        args += ["--platform", platform]
+
+    if define:
+        for k, v in define.items():
+            args += ["--define", "%s=%s" % (k, v)]
+
+    # Use out_dirs when code splitting is expected (dynamic imports with externals)
+    if code_splitting:
+        # Build args without --output, add --outDir instead
+        dir_args = [
+            "--input",
+            native.package_name() + "/" + entry_point,
+            "--outDir",
+            native.package_name() + "/" + name,
+            "--format",
+            format,
+            "--target",
+            target,
+        ]
+        for ext in external:
+            dir_args += ["--external", ext]
+        if global_name:
+            dir_args += ["--globalName", global_name]
+        if platform:
+            dir_args += ["--platform", platform]
+        if define:
+            for k, v in define.items():
+                dir_args += ["--define", "%s=%s" % (k, v)]
+
+        js_run_binary(
+            name = name,
+            tool = "//tools:rolldown-bundle-bin",
+            srcs = srcs + deps + [
+                "//:node_modules/rolldown",
+                "//:node_modules/minimist",
+            ],
+            out_dirs = [name],
+            args = dir_args,
+            visibility = visibility,
+        )
+    else:
+        js_run_binary(
+            name = name,
+            tool = "//tools:rolldown-bundle-bin",
+            srcs = srcs + deps + [
+                "//:node_modules/rolldown",
+                "//:node_modules/minimist",
+            ],
+            outs = [effective_output, effective_output + ".map"],
+            args = args,
+            visibility = visibility,
+        )


### PR DESCRIPTION
## Summary
- Replace esbuild with rolldown for JS bundling across 17 packages
- Create `rolldown_bundle` Bazel macro as drop-in `esbuild()` replacement
- Create `tools/rolldown-bundle.ts` with `#packages/*` resolve plugin and `resolve.alias`
- External package matching uses regex to handle subpath imports (e.g. `react/jsx-runtime`)
- cli-lib stays on esbuild due to rolldown converting dynamic `import()` to `require()` for external modules

## Why rolldown?
- Rust-based bundler, faster than esbuild for large bundles
- Rollup-compatible plugin API enables future .d.ts bundling via rolldown-plugin-dts
- Better TypeScript support via oxc

## Test plan
- [x] All 504 tests pass via `pnpm t`
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)