### PR TITLE
chore: bundle .d.ts files with rolldown-plugin-dts

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -402,7 +402,7 @@
         "recordedInputs": [
           "REPO_MAPPING:aspect_rules_ts+,aspect_rules_ts aspect_rules_ts+",
           "REPO_MAPPING:aspect_rules_ts+,bazel_tools bazel_tools",
-          "FILE:@@//package.json dc875ae33b93591ef417d520a6c962d9180fd27ef260f0e88897c579789fbab9"
+          "FILE:@@//package.json 6d059f6d76321748c11475b0bdacd1fa6016c82ad9677a965f16956a76244b17"
         ],
         "generatedRepoSpecs": {
           "npm_typescript": {

--- a/knowledge-base/001-repo-layout-and-toolchain.md
+++ b/knowledge-base/001-repo-layout-and-toolchain.md
@@ -47,14 +47,16 @@ BuildBuddy provides remote caching for all CI builds and remote execution for Li
 
 ### Custom Bazel Macros (tools/)
 
-| Macro               | File                 | Expands To                                                              |
-| ------------------- | -------------------- | ----------------------------------------------------------------------- |
-| `ts_compile`        | `index.bzl`          | ts_project (typecheck, tsgo) + ts_project (transpile, oxc) + js_library |
-| `ts_compile_node`   | `index.bzl`          | Same as ts_compile with ESNEXT_TSCONFIG                                 |
-| `vitest`            | `vitest.bzl`         | ts_project (typecheck) + vitest_test + snapshot targets                 |
-| `ts_binary`         | `index.bzl`          | js_binary with `--experimental-transform-types`                         |
-| `generate_src_file` | `index.bzl`          | ts_run_binary + oxfmt + write_source_files                              |
-| `oxc_transpiler`    | `oxc_transpiler.bzl` | Custom rule: .ts -> .js + .d.ts via oxc-transform                       |
+| Macro                  | File                 | Expands To                                                                         |
+| ---------------------- | -------------------- | ---------------------------------------------------------------------------------- |
+| `ts_compile`           | `index.bzl`          | ts_project (typecheck, tsgo) + ts_project (transpile, oxc) + js_library            |
+| `ts_compile_node`      | `index.bzl`          | Same as ts_compile with ESNEXT_TSCONFIG                                            |
+| `rolldown_bundle`      | `rolldown.bzl`       | js_run_binary (rolldown bundler); `dts=True` bundles .d.ts via rolldown-plugin-dts |
+| `package_exports_test` | `index.bzl`          | js_test validating package.json exports/types exist in npm_package                 |
+| `vitest`               | `vitest.bzl`         | ts_project (typecheck) + vitest_test + snapshot targets                            |
+| `ts_binary`            | `index.bzl`          | js_binary with `--experimental-transform-types`                                    |
+| `generate_src_file`    | `index.bzl`          | ts_run_binary + oxfmt + write_source_files                                         |
+| `oxc_transpiler`       | `oxc_transpiler.bzl` | Custom rule: .ts -> .js + .d.ts via oxc-transform                                  |
 
 ## Package Management: pnpm
 
@@ -68,10 +70,19 @@ BuildBuddy provides remote caching for all CI builds and remote execution for Li
 
 **TypeScript:** 6.0.2
 
-The build uses a dual typecheck + transpile pattern for speed:
+The build uses two patterns depending on the package type:
+
+### Rolldown-bundled packages (15 packages: polyfills, parsers, intl, react-intl)
 
 1. **Typecheck:** `@typescript/native-preview` (tsgo) — fast parallel type checking, no emit
-2. **Transpile:** `oxc-transform` 0.120.0 — generates .js + .d.ts files
+2. **Bundle:** `rolldown` with `rolldown-plugin-dts` — single pass producing bundled `.js`, `.js.map`, and `.d.ts` per entry point
+3. The `dts` plugin uses oxc for fast `isolatedDeclarations` generation and oxc-resolver for `#packages/*` path resolution (via a temp tsconfig)
+4. Each npm package gets one flat `.d.ts` file per export instead of a tree of individual declaration files
+
+### ts_compile packages (10 packages: utilities, Node tooling, framework integrations)
+
+1. **Typecheck:** `@typescript/native-preview` (tsgo) — fast parallel type checking, no emit
+2. **Transpile:** `oxc-transform` — generates .js + .d.ts files (individual, not bundled)
 
 TypeScript configs are defined as Starlark dicts in `tools/tsconfig.bzl`:
 

--- a/knowledge-base/007-package-intl-polyfills.md
+++ b/knowledge-base/007-package-intl-polyfills.md
@@ -14,6 +14,15 @@ All 11 polyfill packages share a common architecture. See individual docs (007a-
 - Only imported locales are bundled — critical for mobile where bundle size matters
 - All packages use ES modules with `"type": "module"`
 
+## Build Output
+
+Each polyfill uses `rolldown_bundle` with `dts = True` to produce bundled output:
+
+- Each entry point (index, polyfill, polyfill-force, should-polyfill) produces a single `.js`, `.js.map`, and `.d.ts` file
+- Declaration files are bundled into one `.d.ts` per entry point via `rolldown-plugin-dts` (not scattered `src/*.d.ts` trees)
+- The `no_internal_imports_test` validates that neither `.js` nor `.d.ts` files contain leaked `#packages/` path aliases
+- The `package_exports_test` validates that all files referenced in `package.json` exports exist and have corresponding `.d.ts` files
+
 ## Two Data Loading Patterns
 
 ### Dynamic per-locale (numberformat, datetimeformat, pluralrules, displaynames, listformat, relativetimeformat)

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "remark-frontmatter": "^5.0.0",
     "remark-gfm": "^4.0.1",
     "rolldown": "1.0.0-rc.13",
+    "rolldown-plugin-dts": "^0.23.2",
     "rollup": "^4.40.0",
     "serialize-javascript": "^7.0.2",
     "svelte": "^5.0.0",

--- a/packages/icu-messageformat-parser/BUILD.bazel
+++ b/packages/icu-messageformat-parser/BUILD.bazel
@@ -41,6 +41,7 @@ ENTRY_POINTS = [
 [rolldown_bundle(
     name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
+    dts = True,
     entry_point = entry,
     external = EXTERNAL_PACKAGES,
     format = "esm",
@@ -55,7 +56,6 @@ js_library(
     name = PACKAGE_NAME,
     srcs = BUNDLES + [
         "package.json",
-        ":types",
     ],
     visibility = ["//visibility:public"],
 )
@@ -66,8 +66,12 @@ npm_package(
         "LICENSE.md",
         "README.md",
         "package.json",
-    ] + BUNDLES + [":types"],
+    ] + BUNDLES,
     package = "@formatjs/%s" % PACKAGE_NAME,
+    replace_prefixes = {
+        "%s-bundle/" % entry.replace(".ts", ""): ""
+        for entry in ENTRY_POINTS
+    },
     visibility = ["//visibility:public"],
 )
 

--- a/packages/icu-skeleton-parser/BUILD.bazel
+++ b/packages/icu-skeleton-parser/BUILD.bazel
@@ -34,6 +34,7 @@ ENTRY_POINTS = [
 [rolldown_bundle(
     name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
+    dts = True,
     entry_point = entry,
     external = EXTERNAL_PACKAGES,
     format = "esm",
@@ -48,7 +49,6 @@ js_library(
     name = PACKAGE_NAME,
     srcs = BUNDLES + [
         "package.json",
-        ":types",
     ],
     visibility = ["//visibility:public"],
 )
@@ -59,8 +59,12 @@ npm_package(
         "LICENSE.md",
         "README.md",
         "package.json",
-    ] + BUNDLES + [":types"],
+    ] + BUNDLES,
     package = "@formatjs/%s" % PACKAGE_NAME,
+    replace_prefixes = {
+        "%s-bundle/" % entry.replace(".ts", ""): ""
+        for entry in ENTRY_POINTS
+    },
     visibility = ["//visibility:public"],
 )
 

--- a/packages/intl-datetimeformat/BUILD.bazel
+++ b/packages/intl-datetimeformat/BUILD.bazel
@@ -77,6 +77,7 @@ ENTRY_POINTS = [
 [rolldown_bundle(
     name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
+    dts = True,
     entry_point = entry,
     external = EXTERNAL_PACKAGES,
     format = "esm",
@@ -91,7 +92,6 @@ js_library(
     name = PACKAGE_NAME,
     srcs = BUNDLES + [
         "package.json",
-        ":types",
     ],
     visibility = ["//visibility:public"],
 )
@@ -106,12 +106,16 @@ npm_package(
         "add-golden-tz.d.ts",
         "add-golden-tz.js",
         "package.json",
-    ] + BUNDLES + [":types"] + [
+    ] + BUNDLES + [
         ":locale-data",
         # polyfill-library uses this
         "polyfill.iife.js",
     ],
     package = "@formatjs/%s" % PACKAGE_NAME,
+    replace_prefixes = {
+        "%s-bundle/" % entry.replace(".ts", ""): ""
+        for entry in ENTRY_POINTS
+    },
     visibility = ["//visibility:public"],
 )
 

--- a/packages/intl-displaynames/BUILD.bazel
+++ b/packages/intl-displaynames/BUILD.bazel
@@ -61,6 +61,7 @@ ENTRY_POINTS = [
 [rolldown_bundle(
     name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
+    dts = True,
     entry_point = entry,
     external = EXTERNAL_PACKAGES,
     format = "esm",
@@ -75,7 +76,6 @@ js_library(
     name = PACKAGE_NAME,
     srcs = BUNDLES + [
         "package.json",
-        ":types",
     ],
     visibility = ["//visibility:public"],
 )
@@ -86,12 +86,16 @@ npm_package(
         "LICENSE.md",
         "README.md",
         "package.json",
-    ] + BUNDLES + [":types"] + [
+    ] + BUNDLES + [
         ":locale-data",
         # polyfill-library uses this
         "polyfill.iife.js",
     ],
     package = "@formatjs/%s" % PACKAGE_NAME,
+    replace_prefixes = {
+        "%s-bundle/" % entry.replace(".ts", ""): ""
+        for entry in ENTRY_POINTS
+    },
     visibility = ["//visibility:public"],
 )
 

--- a/packages/intl-durationformat/BUILD.bazel
+++ b/packages/intl-durationformat/BUILD.bazel
@@ -41,6 +41,7 @@ ENTRY_POINTS = [
 [rolldown_bundle(
     name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
+    dts = True,
     entry_point = entry,
     external = EXTERNAL_PACKAGES,
     format = "esm",
@@ -55,7 +56,6 @@ js_library(
     name = PACKAGE_NAME,
     srcs = BUNDLES + [
         "package.json",
-        ":types",
     ],
     visibility = ["//visibility:public"],
 )
@@ -66,8 +66,12 @@ npm_package(
         "LICENSE.md",
         "README.md",
         "package.json",
-    ] + BUNDLES + [":types"],
+    ] + BUNDLES,
     package = "@formatjs/%s" % PACKAGE_NAME,
+    replace_prefixes = {
+        "%s-bundle/" % entry.replace(".ts", ""): ""
+        for entry in ENTRY_POINTS
+    },
     visibility = ["//visibility:public"],
 )
 

--- a/packages/intl-listformat/BUILD.bazel
+++ b/packages/intl-listformat/BUILD.bazel
@@ -64,6 +64,7 @@ ENTRY_POINTS = [
 [rolldown_bundle(
     name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
+    dts = True,
     entry_point = entry,
     external = EXTERNAL_PACKAGES,
     format = "esm",
@@ -78,7 +79,6 @@ js_library(
     name = PACKAGE_NAME,
     srcs = BUNDLES + [
         "package.json",
-        ":types",
     ],
     visibility = ["//visibility:public"],
 )
@@ -89,12 +89,16 @@ npm_package(
         "LICENSE.md",
         "README.md",
         "package.json",
-    ] + BUNDLES + [":types"] + [
+    ] + BUNDLES + [
         ":locale-data",
         # polyfill-library uses this
         "polyfill.iife.js",
     ],
     package = "@formatjs/%s" % PACKAGE_NAME,
+    replace_prefixes = {
+        "%s-bundle/" % entry.replace(".ts", ""): ""
+        for entry in ENTRY_POINTS
+    },
     visibility = ["//visibility:public"],
 )
 

--- a/packages/intl-locale/BUILD.bazel
+++ b/packages/intl-locale/BUILD.bazel
@@ -58,6 +58,7 @@ EXTERNAL_PACKAGES = [
 [rolldown_bundle(
     name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
+    dts = True,
     entry_point = entry,
     external = EXTERNAL_PACKAGES,
     format = "esm",
@@ -116,10 +117,19 @@ npm_package(
         "LICENSE.md",
         "README.md",
         "package.json",
-    ] + BUNDLES + [":types"] + [
+    ] + BUNDLES + [
         "polyfill.iife.js",
     ],
     package = "@formatjs/%s" % PACKAGE_NAME,
+    replace_prefixes = {
+        "%s-bundle/" % entry.replace(".ts", ""): ""
+        for entry in [
+            "index.ts",
+            "polyfill.ts",
+            "polyfill-force.ts",
+            "should-polyfill.ts",
+        ]
+    },
     visibility = ["//visibility:public"],
 )
 

--- a/packages/intl-messageformat/BUILD.bazel
+++ b/packages/intl-messageformat/BUILD.bazel
@@ -45,6 +45,7 @@ ENTRY_POINTS = [
 [rolldown_bundle(
     name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
+    dts = True,
     entry_point = entry,
     external = EXTERNAL_PACKAGES,
     format = "esm",
@@ -59,7 +60,6 @@ js_library(
     name = PACKAGE_NAME,
     srcs = BUNDLES + [
         "package.json",
-        ":types",
     ],
     visibility = ["//visibility:public"],
 )
@@ -71,8 +71,12 @@ npm_package(
         "README.md",
         "package.json",
         "%s.iife.js" % PACKAGE_NAME,
-    ] + BUNDLES + [":types"],
+    ] + BUNDLES,
     package = PACKAGE_NAME,
+    replace_prefixes = {
+        "%s-bundle/" % entry.replace(".ts", ""): ""
+        for entry in ENTRY_POINTS
+    },
     visibility = ["//visibility:public"],
 )
 

--- a/packages/intl-numberformat/BUILD.bazel
+++ b/packages/intl-numberformat/BUILD.bazel
@@ -100,6 +100,7 @@ ENTRY_POINTS = [
 [rolldown_bundle(
     name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
+    dts = True,
     entry_point = entry,
     external = EXTERNAL_PACKAGES,
     format = "esm",
@@ -114,7 +115,6 @@ js_library(
     name = PACKAGE_NAME,
     srcs = BUNDLES + [
         "package.json",
-        ":types",
     ],
     visibility = ["//visibility:public"],
 )
@@ -125,12 +125,16 @@ npm_package(
         "LICENSE.md",
         "README.md",
         "package.json",
-    ] + BUNDLES + [":types"] + [
+    ] + BUNDLES + [
         ":locale-data",
         # polyfill-library uses this
         "polyfill.iife.js",
     ],
     package = "@formatjs/%s" % PACKAGE_NAME,
+    replace_prefixes = {
+        "%s-bundle/" % entry.replace(".ts", ""): ""
+        for entry in ENTRY_POINTS
+    },
     visibility = ["//visibility:public"],
 )
 

--- a/packages/intl-pluralrules/BUILD.bazel
+++ b/packages/intl-pluralrules/BUILD.bazel
@@ -276,6 +276,7 @@ ENTRY_POINTS = [
 [rolldown_bundle(
     name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
+    dts = True,
     entry_point = entry,
     external = EXTERNAL_PACKAGES,
     format = "esm",
@@ -290,7 +291,6 @@ js_library(
     name = PACKAGE_NAME,
     srcs = BUNDLES + [
         "package.json",
-        ":types",
     ],
     visibility = ["//visibility:public"],
 )
@@ -301,12 +301,16 @@ npm_package(
         "LICENSE.md",
         "README.md",
         "package.json",
-    ] + BUNDLES + [":types"] + [
+    ] + BUNDLES + [
         ":locale-data",
         # polyfill-library uses this
         "polyfill.iife.js",
     ],
     package = "@formatjs/%s" % PACKAGE_NAME,
+    replace_prefixes = {
+        "%s-bundle/" % entry.replace(".ts", ""): ""
+        for entry in ENTRY_POINTS
+    },
     visibility = ["//visibility:public"],
 )
 

--- a/packages/intl-relativetimeformat/BUILD.bazel
+++ b/packages/intl-relativetimeformat/BUILD.bazel
@@ -59,6 +59,7 @@ ENTRY_POINTS = [
 [rolldown_bundle(
     name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
+    dts = True,
     entry_point = entry,
     external = EXTERNAL_PACKAGES,
     format = "esm",
@@ -73,7 +74,6 @@ js_library(
     name = PACKAGE_NAME,
     srcs = BUNDLES + [
         "package.json",
-        ":types",
     ],
     visibility = ["//visibility:public"],
 )
@@ -84,12 +84,16 @@ npm_package(
         "LICENSE.md",
         "README.md",
         "package.json",
-    ] + BUNDLES + [":types"] + [
+    ] + BUNDLES + [
         ":locale-data",
         # polyfill-library uses this
         "polyfill.iife.js",
     ],
     package = "@formatjs/%s" % PACKAGE_NAME,
+    replace_prefixes = {
+        "%s-bundle/" % entry.replace(".ts", ""): ""
+        for entry in ENTRY_POINTS
+    },
     visibility = ["//visibility:public"],
 )
 

--- a/packages/intl-segmenter/BUILD.bazel
+++ b/packages/intl-segmenter/BUILD.bazel
@@ -75,6 +75,7 @@ ENTRY_POINTS = [
 [rolldown_bundle(
     name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
+    dts = True,
     entry_point = entry,
     external = EXTERNAL_PACKAGES,
     format = "esm",
@@ -89,7 +90,6 @@ js_library(
     name = PACKAGE_NAME,
     srcs = BUNDLES + [
         "package.json",
-        ":types",
     ],
     visibility = ["//visibility:public"],
 )
@@ -100,11 +100,15 @@ npm_package(
         "LICENSE.md",
         "README.md",
         "package.json",
-    ] + BUNDLES + [":types"] + [
+    ] + BUNDLES + [
         # polyfill-library uses this
         "polyfill.iife.js",
     ],
     package = "@formatjs/%s" % PACKAGE_NAME,
+    replace_prefixes = {
+        "%s-bundle/" % entry.replace(".ts", ""): ""
+        for entry in ENTRY_POINTS
+    },
     visibility = ["//visibility:public"],
 )
 

--- a/packages/intl-supportedvaluesof/BUILD.bazel
+++ b/packages/intl-supportedvaluesof/BUILD.bazel
@@ -46,6 +46,7 @@ ENTRY_POINTS = [
 [rolldown_bundle(
     name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
+    dts = True,
     entry_point = entry,
     external = EXTERNAL_PACKAGES,
     format = "esm",
@@ -60,7 +61,6 @@ js_library(
     name = PACKAGE_NAME,
     srcs = BUNDLES + [
         "package.json",
-        ":types",
     ],
     visibility = ["//visibility:public"],
 )
@@ -71,11 +71,15 @@ npm_package(
         "LICENSE.md",
         "README.md",
         "package.json",
-    ] + BUNDLES + [":types"] + [
+    ] + BUNDLES + [
         # polyfill-library uses this
         "polyfill.iife.js",
     ],
     package = "@formatjs/%s" % PACKAGE_NAME,
+    replace_prefixes = {
+        "%s-bundle/" % entry.replace(".ts", ""): ""
+        for entry in ENTRY_POINTS
+    },
     visibility = ["//visibility:public"],
 )
 

--- a/packages/intl/BUILD.bazel
+++ b/packages/intl/BUILD.bazel
@@ -48,6 +48,7 @@ ENTRY_POINTS = [
 [rolldown_bundle(
     name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
+    dts = True,
     entry_point = entry,
     external = EXTERNAL_PACKAGES,
     format = "esm",
@@ -62,7 +63,6 @@ js_library(
     name = PACKAGE_NAME,
     srcs = BUNDLES + [
         "package.json",
-        ":types",
     ],
     visibility = ["//visibility:public"],
 )
@@ -74,7 +74,12 @@ npm_package(
         "README.md",
         "package.json",
     ] + BUNDLES + [":types"],
+    allow_overwrites = True,
     package = "@formatjs/%s" % PACKAGE_NAME,
+    replace_prefixes = {
+        "%s-bundle/" % entry.replace(".ts", ""): ""
+        for entry in ENTRY_POINTS
+    },
     visibility = ["//visibility:public"],
 )
 

--- a/packages/react-intl/BUILD.bazel
+++ b/packages/react-intl/BUILD.bazel
@@ -60,6 +60,7 @@ ENTRY_POINTS = [
 [rolldown_bundle(
     name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
+    dts = True,
     entry_point = entry,
     external = EXTERNAL_PACKAGES,
     format = "esm",
@@ -74,7 +75,6 @@ js_library(
     name = PACKAGE_NAME,
     srcs = BUNDLES + [
         "package.json",
-        ":types",
     ],
     visibility = ["//visibility:public"],
 )
@@ -86,8 +86,12 @@ npm_package(
         "README.md",
         "package.json",
         "%s.iife.js" % PACKAGE_NAME,
-    ] + BUNDLES + [":types"],
+    ] + BUNDLES,
     package = PACKAGE_NAME,
+    replace_prefixes = {
+        "%s-bundle/" % entry.replace(".ts", ""): ""
+        for entry in ENTRY_POINTS
+    },
     visibility = ["//visibility:public"],
 )
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -420,6 +420,9 @@ importers:
       rolldown:
         specifier: 1.0.0-rc.13
         version: 1.0.0-rc.13
+      rolldown-plugin-dts:
+        specifier: ^0.23.2
+        version: 0.23.2(@typescript/native-preview@7.0.0-dev.20260326.1)(rolldown@1.0.0-rc.13)(typescript@6.0.2)
       rollup:
         specifier: ^4.40.0
         version: 4.59.0
@@ -1109,6 +1112,10 @@ packages:
     resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/generator@8.0.0-rc.3':
+    resolution: {integrity: sha512-em37/13/nR320G4jab/nIIHZgc2Wz2y/D39lxnTyxB4/D/omPQncl/lSdlnJY1OhQcRGugTSIF2l/69o31C9dA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
   '@babel/helper-annotate-as-pure@7.27.3':
     resolution: {integrity: sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==}
     engines: {node: '>=6.9.0'}
@@ -1180,9 +1187,17 @@ packages:
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@8.0.0-rc.3':
+    resolution: {integrity: sha512-AmwWFx1m8G/a5cXkxLxTiWl+YEoWuoFLUCwqMlNuWO1tqAYITQAbCRPUkyBHv1VOFgfjVOqEj6L3u15J5ZCzTA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@8.0.0-rc.3':
+    resolution: {integrity: sha512-8AWCJ2VJJyDFlGBep5GpaaQ9AAaE/FjAcrqI7jyssYhtL7WGV0DOKpJsQqM037xDbpRLHXsY8TwU7zDma7coOw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
 
   '@babel/helper-validator-option@7.27.1':
     resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
@@ -1209,6 +1224,11 @@ packages:
   '@babel/parser@7.29.2':
     resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@8.0.0-rc.3':
+    resolution: {integrity: sha512-B20dvP3MfNc/XS5KKCHy/oyWl5IA6Cn9YjXRdDlCjNmUFrjvLXMNUfQq/QUy9fnG2gYkKKcrto2YaF9B32ToOQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5':
@@ -1716,6 +1736,10 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/types@8.0.0-rc.3':
+    resolution: {integrity: sha512-mOm5ZrYmphGfqVWoH5YYMTITb3cDXsFgmvFlvkvWDMsR9X8RFnt7a0Wb6yNIdoFsiMO9WjYLq+U/FMtqIYAF8Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
 
   '@bazel/bazelisk@1.28.1':
     resolution: {integrity: sha512-K21x83NXOtd0yb2qzjMES3UV4xEWZ1q1vnXFhADA1u7IoiMVQkJAVQRK3oZ5txpnrGafY15HS+YYr2nmsEP4Tg==}
@@ -4304,6 +4328,9 @@ packages:
   '@types/istanbul-reports@3.0.4':
     resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
 
+  '@types/jsesc@2.5.1':
+    resolution: {integrity: sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -4805,6 +4832,10 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  ast-kit@3.0.0-beta.1:
+    resolution: {integrity: sha512-trmleAnZ2PxN/loHWVhhx1qeOHSRXq4TDsBBxq3GqeJitfk3+jTQ+v/C1km/KYq9M7wKqCewMh+/NAvVH7m+bw==}
+    engines: {node: '>=20.19.0'}
+
   ast-types@0.12.4:
     resolution: {integrity: sha512-ky/YVYCbtVAS8TdMIaTiPFHwEpRB5z1hctepJplTr3UW5q8TDrpIMCILyk8pmLxGtn2KCtC/lSn7zOsaI7nzDw==}
     engines: {node: '>=4'}
@@ -4915,6 +4946,9 @@ packages:
 
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
+
+  birpc@4.0.0:
+    resolution: {integrity: sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==}
 
   blob@0.0.5:
     resolution: {integrity: sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==}
@@ -5392,6 +5426,15 @@ packages:
     resolution: {integrity: sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==}
     engines: {node: '>=12'}
 
+  dts-resolver@2.1.3:
+    resolution: {integrity: sha512-bihc7jPC90VrosXNzK0LTE2cuLP6jr0Ro8jk+kMugHReJVLIpHz/xadeq3MhuwyO4TD4OA3L1Q8pBBFRc08Tsw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      oxc-resolver: '>=11.0.0'
+    peerDependenciesMeta:
+      oxc-resolver:
+        optional: true
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -5839,6 +5882,9 @@ packages:
 
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
+
+  get-tsconfig@4.13.7:
+    resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
 
   git-raw-commits@5.0.1:
     resolution: {integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==}
@@ -7403,6 +7449,10 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
@@ -7702,6 +7752,25 @@ packages:
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rolldown-plugin-dts@0.23.2:
+    resolution: {integrity: sha512-PbSqLawLgZBGcOGT3yqWBGn4cX+wh2nt5FuBGdcMHyOhoukmjbhYAl8NT9sE4U38Cm9tqLOIQeOrvzeayM0DLQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@ts-macro/tsc': ^0.3.6
+      '@typescript/native-preview': '>=7.0.0-dev.20260325.1'
+      rolldown: ^1.0.0-rc.12
+      typescript: ^5.0.0 || ^6.0.0
+      vue-tsc: ~3.2.0
+    peerDependenciesMeta:
+      '@ts-macro/tsc':
+        optional: true
+      '@typescript/native-preview':
+        optional: true
+      typescript:
+        optional: true
+      vue-tsc:
+        optional: true
 
   rolldown@1.0.0-rc.13:
     resolution: {integrity: sha512-bvVj8YJmf0rq4pSFmH7laLa6pYrhghv3PRzrCdRAr23g66zOKVJ4wkvFtgohtPLWmthgg8/rkaqRHrpUEh0Zbw==}
@@ -8946,6 +9015,15 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
+  '@babel/generator@8.0.0-rc.3':
+    dependencies:
+      '@babel/parser': 8.0.0-rc.3
+      '@babel/types': 8.0.0-rc.3
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/jsesc': 2.5.1
+      jsesc: 3.1.0
+
   '@babel/helper-annotate-as-pure@7.27.3':
     dependencies:
       '@babel/types': 7.29.0
@@ -9047,7 +9125,11 @@ snapshots:
 
   '@babel/helper-string-parser@7.27.1': {}
 
+  '@babel/helper-string-parser@8.0.0-rc.3': {}
+
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-identifier@8.0.0-rc.3': {}
 
   '@babel/helper-validator-option@7.27.1': {}
 
@@ -9075,6 +9157,10 @@ snapshots:
   '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@babel/parser@8.0.0-rc.3':
+    dependencies:
+      '@babel/types': 8.0.0-rc.3
 
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.29.0)':
     dependencies:
@@ -9694,6 +9780,11 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@babel/types@8.0.0-rc.3':
+    dependencies:
+      '@babel/helper-string-parser': 8.0.0-rc.3
+      '@babel/helper-validator-identifier': 8.0.0-rc.3
 
   '@bazel/bazelisk@1.28.1': {}
 
@@ -12005,6 +12096,8 @@ snapshots:
     dependencies:
       '@types/istanbul-lib-report': 3.0.3
 
+  '@types/jsesc@2.5.1': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/jsonfile@6.1.4':
@@ -12588,6 +12681,12 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  ast-kit@3.0.0-beta.1:
+    dependencies:
+      '@babel/parser': 8.0.0-rc.3
+      estree-walker: 3.0.3
+      pathe: 2.0.3
+
   ast-types@0.12.4: {}
 
   astring@1.9.0: {}
@@ -12719,6 +12818,8 @@ snapshots:
       safe-buffer: 5.1.2
 
   before-after-hook@4.0.0: {}
+
+  birpc@4.0.0: {}
 
   blob@0.0.5: {}
 
@@ -13157,6 +13258,8 @@ snapshots:
       is-obj: 2.0.0
 
   dotenv@17.3.1: {}
+
+  dts-resolver@2.1.3: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -13744,6 +13847,10 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
     optional: true
+
+  get-tsconfig@4.13.7:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   git-raw-commits@5.0.1(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.3.0):
     dependencies:
@@ -15864,6 +15971,8 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  picomatch@4.0.4: {}
+
   pirates@4.0.7: {}
 
   pkg-dir@4.2.0:
@@ -16227,8 +16336,7 @@ snapshots:
 
   resolve-from@5.0.0: {}
 
-  resolve-pkg-maps@1.0.0:
-    optional: true
+  resolve-pkg-maps@1.0.0: {}
 
   resolve.exports@2.0.3: {}
 
@@ -16244,6 +16352,25 @@ snapshots:
     optional: true
 
   reusify@1.1.0: {}
+
+  rolldown-plugin-dts@0.23.2(@typescript/native-preview@7.0.0-dev.20260326.1)(rolldown@1.0.0-rc.13)(typescript@6.0.2):
+    dependencies:
+      '@babel/generator': 8.0.0-rc.3
+      '@babel/helper-validator-identifier': 8.0.0-rc.3
+      '@babel/parser': 8.0.0-rc.3
+      '@babel/types': 8.0.0-rc.3
+      ast-kit: 3.0.0-beta.1
+      birpc: 4.0.0
+      dts-resolver: 2.1.3
+      get-tsconfig: 4.13.7
+      obug: 2.1.1
+      picomatch: 4.0.4
+      rolldown: 1.0.0-rc.13
+    optionalDependencies:
+      '@typescript/native-preview': 7.0.0-dev.20260326.1
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - oxc-resolver
 
   rolldown@1.0.0-rc.13:
     dependencies:

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -45,6 +45,7 @@ ts_binary(
     data = [
         "//:node_modules/minimist",
         "//:node_modules/rolldown",
+        "//:node_modules/rolldown-plugin-dts",
     ],
     entry_point = "rolldown-bundle.ts",
     visibility = ["//visibility:public"],

--- a/tools/check_no_internal_imports.sh
+++ b/tools/check_no_internal_imports.sh
@@ -1,27 +1,35 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Ensure no internal path aliases (e.g. #packages/) leak into bundled JS output.
-# This runs against esbuild bundle output to catch misconfigured externals.
+# Ensure no internal path aliases (e.g. #packages/) leak into bundled output.
+# Checks both .js and .d.ts files. Handles both file and directory arguments.
 
 found=0
-for f in "$@"; do
+
+check_file() {
+  local f="$1"
   if grep -qE '#packages/' "$f" 2>/dev/null; then
     echo "FAIL: internal import '#packages/' found in $f"
     grep -n '#packages/' "$f"
     found=1
   fi
+}
+
+for arg in "$@"; do
+  if [ -d "$arg" ]; then
+    while IFS= read -r -d '' f; do
+      check_file "$f"
+    done < <(find "$arg" \( -name '*.js' -o -name '*.d.ts' \) -print0)
+  elif [ -f "$arg" ]; then
+    check_file "$arg"
+  fi
 done
 
-# If no args given, check all .js files in runfiles
+# If no args given, check all .js and .d.ts files in runfiles
 if [ $# -eq 0 ]; then
   while IFS= read -r -d '' f; do
-    if grep -qE '#packages/' "$f" 2>/dev/null; then
-      echo "FAIL: internal import '#packages/' found in $f"
-      grep -n '#packages/' "$f"
-      found=1
-    fi
-  done < <(find . -name '*.js' -print0)
+    check_file "$f"
+  done < <(find . \( -name '*.js' -o -name '*.d.ts' \) -print0)
 fi
 
 if [ "$found" -eq 1 ]; then

--- a/tools/rolldown-bundle.ts
+++ b/tools/rolldown-bundle.ts
@@ -7,7 +7,10 @@
  *        [--globalName Name] [--platform browser|node]
  */
 import {rolldown} from 'rolldown'
+import {dts} from 'rolldown-plugin-dts'
 import path from 'node:path'
+import {writeFileSync} from 'node:fs'
+import {tmpdir} from 'node:os'
 import minimist from 'minimist'
 
 interface Args extends minimist.ParsedArgs {
@@ -20,6 +23,7 @@ interface Args extends minimist.ParsedArgs {
   globalName?: string
   platform?: string
   define?: string | string[]
+  dts?: boolean
 }
 
 function getWorkspaceRoot(): string {
@@ -69,6 +73,28 @@ async function main(args: Args) {
   const bundle = await rolldown({
     input,
     external: externalPatterns,
+    plugins: args.dts
+      ? (() => {
+          // Write a temp tsconfig so the oxc resolver can resolve #packages/* paths
+          const tsconfigPath = path.join(
+            tmpdir(),
+            `rolldown-dts-tsconfig-${process.pid}.json`
+          )
+          writeFileSync(
+            tsconfigPath,
+            JSON.stringify({
+              compilerOptions: {
+                isolatedDeclarations: true,
+                baseUrl: workspaceRoot,
+                paths: {
+                  '#packages/*': ['packages/*'],
+                },
+              },
+            })
+          )
+          return dts({tsconfig: tsconfigPath})
+        })()
+      : [],
     platform:
       platform === 'node'
         ? 'node'
@@ -92,13 +118,25 @@ async function main(args: Args) {
       target,
     })
   } else if (output) {
-    await bundle.write({
-      file: output,
-      format,
-      sourcemap: true,
-      name: globalName,
-      target,
-    })
+    if (args.dts) {
+      // dts plugin generates multiple chunks, requiring dir mode
+      const dir = path.dirname(output)
+      await bundle.write({
+        dir: dir || '.',
+        format,
+        sourcemap: true,
+        name: globalName,
+        target,
+      })
+    } else {
+      await bundle.write({
+        file: output,
+        format,
+        sourcemap: true,
+        name: globalName,
+        target,
+      })
+    }
   }
 }
 

--- a/tools/rolldown.bzl
+++ b/tools/rolldown.bzl
@@ -2,7 +2,7 @@
 
 load("@aspect_rules_js//js:defs.bzl", "js_run_binary")
 
-def rolldown_bundle(name, entry_point, srcs = [], output = None, deps = [], external = [], format = "esm", target = "es2020", global_name = None, config = None, platform = None, define = None, code_splitting = False, visibility = None, **kwargs):
+def rolldown_bundle(name, entry_point, srcs = [], output = None, deps = [], external = [], format = "esm", target = "es2020", global_name = None, config = None, platform = None, define = None, code_splitting = False, dts = False, visibility = None, **kwargs):
     """Bundle JS/TS with rolldown.
 
     Drop-in replacement for the esbuild() macro. Bundles an entry point into
@@ -19,6 +19,7 @@ def rolldown_bundle(name, entry_point, srcs = [], output = None, deps = [], exte
         target: JS target (es2020, esnext, etc.)
         global_name: global variable name for iife format
         config: unused, kept for esbuild() API compatibility
+        dts: if True, generate bundled .d.ts alongside .js using rolldown-plugin-dts
         visibility: target visibility
         **kwargs: additional args (ignored, for esbuild compat)
     """
@@ -49,19 +50,30 @@ def rolldown_bundle(name, entry_point, srcs = [], output = None, deps = [], exte
         for k, v in define.items():
             args += ["--define", "%s=%s" % (k, v)]
 
-    # Use out_dirs when code splitting is expected (dynamic imports with externals)
-    if code_splitting:
-        # Build args without --output, add --outDir instead
+    if dts:
+        args += ["--dts"]
+
+    dts_deps = ["//:node_modules/rolldown-plugin-dts"] if dts else []
+
+    # Use out_dirs when code splitting or dts is expected (both produce multiple chunks)
+    if code_splitting or dts:
+        # Build args with --output (script derives dir from it when --dts) or --outDir
         dir_args = [
             "--input",
             native.package_name() + "/" + entry_point,
-            "--outDir",
-            native.package_name() + "/" + name,
             "--format",
             format,
             "--target",
             target,
         ]
+
+        if dts:
+            # Use --output so the script can derive the output dir
+            dir_args += ["--output", native.package_name() + "/" + name + "/" + effective_output]
+            dir_args += ["--dts"]
+        else:
+            dir_args += ["--outDir", native.package_name() + "/" + name]
+
         for ext in external:
             dir_args += ["--external", ext]
         if global_name:
@@ -78,7 +90,7 @@ def rolldown_bundle(name, entry_point, srcs = [], output = None, deps = [], exte
             srcs = srcs + deps + [
                 "//:node_modules/rolldown",
                 "//:node_modules/minimist",
-            ],
+            ] + dts_deps,
             out_dirs = [name],
             args = dir_args,
             visibility = visibility,


### PR DESCRIPTION
## Summary
- Adds `rolldown-plugin-dts` to generate bundled `.d.ts` files alongside `.js` bundles in a single rolldown build pass
- Replaces separate `ts_project :types` targets for 15 rolldown-based packages
- Each exported `.js` file now has a single corresponding `.d.ts` instead of a tree of individual declaration files mirroring the source structure
- Uses `isolatedDeclarations` with Oxc backend for fast declaration generation

## Changes
- `tools/rolldown-bundle.ts`: Added `--dts` flag that enables `rolldown-plugin-dts`
- `tools/rolldown.bzl`: Added `dts` parameter; when enabled, uses `out_dirs` mode to emit `.js`, `.js.map`, and `.d.ts` together
- `tools/BUILD.bazel`: Added `rolldown-plugin-dts` to bundler tool deps
- 15 package BUILD files: Enabled `dts = True`, removed `:types` from `npm_package`, added `replace_prefixes` to flatten bundle output directories
- `packages/intl`: Keeps `:types` alongside bundled dts (with `allow_overwrites`) for `global_type_overrides_test` which imports from internal `src/` paths

## Test plan
- [x] `pnpm t` — all 536 tests pass
- [x] `package_exports_test` validates all `.js` exports have corresponding `.d.ts` files
- [x] `global_type_overrides_test` passes for both `intl` and `react-intl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)