### PR TITLE
docs(react-intl): remove references to injectIntl HOC removed in v10

### DIFF
--- a/docs/src/docs/getting-started/message-extraction.mdx
+++ b/docs/src/docs/getting-started/message-extraction.mdx
@@ -91,30 +91,26 @@ values={[
 <TabItem value="react">
 
 ```tsx
-class PasswordChangeWithIntl extends React.Component {
-  render() {
-    const {intl} = this.props
-    return (
-      <li>
-        <input
-          placeholder={intl.formatMessage({
-            defaultMessage: 'New Password',
-            description: 'placeholder text',
-          })}
-        />
-        <input
-          placeholder={intl.formatMessage({
-            id: 'explicit-id',
-            defaultMessage: 'Confirm Password',
-            description: 'placeholder text',
-          })}
-        />
-      </li>
-    )
-  }
+function PasswordChange() {
+  const intl = useIntl()
+  return (
+    <li>
+      <input
+        placeholder={intl.formatMessage({
+          defaultMessage: 'New Password',
+          description: 'placeholder text',
+        })}
+      />
+      <input
+        placeholder={intl.formatMessage({
+          id: 'explicit-id',
+          defaultMessage: 'Confirm Password',
+          description: 'placeholder text',
+        })}
+      />
+    </li>
+  )
 }
-
-const PasswordChange = injectIntl(PasswordChangeWithIntl)
 
 export function List(props) {
   const intl = useIntl()

--- a/docs/src/docs/guides/testing-with-react-intl.mdx
+++ b/docs/src/docs/guides/testing-with-react-intl.mdx
@@ -24,7 +24,7 @@ You can either load the polyfill in the browser from `node_modules` or use the [
 
 ## Shallow Rendering
 
-React's `react-addons-test-utils` package contains a [shallow rendering](http://facebook.github.io/react/docs/test-utils.html#shallow-rendering) feature which you might use to test your app's React components. If a component you're trying to test using `ReactShallowRenderer` uses React Intl — specifically `injectIntl()` — you'll need to do extra setup work because React Intl components expect to be nested inside an `<IntlProvider>`.
+React's `react-addons-test-utils` package contains a [shallow rendering](http://facebook.github.io/react/docs/test-utils.html#shallow-rendering) feature which you might use to test your app's React components. If a component you're trying to test using `ReactShallowRenderer` uses React Intl — specifically `useIntl()` or `<Formatted*>` components — you'll need to do extra setup work because React Intl components expect to be nested inside an `<IntlProvider>`.
 
 ### Testing Example Components That Use React Intl
 
@@ -75,62 +75,7 @@ let element = ReactTestUtils.renderIntoDocument(
 )
 ```
 
-However this means that the `element` reference is now pointing to the `IntlProvider` instead of your component. To retrieve a reference to your wrapped component, you can use "refs" with these changes to the code:
-
-In your component, remember to add `{forwardRef: true}` when calling `injectIntl()`:
-
-```tsx
-class MyComponent extends React.Component {
-  ...
-  myClassFn() { ... }
-}
-export default injectIntl(MyComponent, {forwardRef: true});
-```
-
-In your test, add a "ref" to extract the reference to your tested component:
-
-```tsx
-const element = React.createRef()
-ReactTestUtils.renderIntoDocument(
-  <IntlProvider>
-    <MyComponent ref={element} />
-  </IntlProvider>
-)
-```
-
-You can now access the wrapped component instance from `element` like this:
-
-```tsx
-element.current.myClassFn()
-```
-
-### Helper function
-
-Since you will have to do this in all your unit tests, you should probably wrap that setup in a `render` function like this:
-
-```tsx
-function renderWithIntl(element) {
-  let instance
-
-  ReactTestUtils.renderIntoDocument(
-    <IntlProvider>
-      {React.cloneElement(element, {
-        ref: instance,
-      })}
-    </IntlProvider>
-  )
-
-  return instance
-}
-```
-
-You can now use this in your tests like this:
-
-```tsx
-const element = React.createRef();
-renderWithIntl(<MyElement ref={element}>);
-element.current.myClassFn();
-```
+However this means that the `element` reference is now pointing to the `IntlProvider` instead of your component. We recommend using `@testing-library/react` as shown below for a simpler testing experience.
 
 ## @testing-library/react
 

--- a/docs/src/docs/react-intl.mdx
+++ b/docs/src/docs/react-intl.mdx
@@ -97,7 +97,7 @@ We've made React Intl work well with module bundlers like: Browserify, Webpack, 
 
 Whether you use the ES6, CommonJS, or UMD version of React Intl, they all provide the same named exports:
 
-- [`injectIntl`](/docs/react-intl/api#injectintl)
+- [`useIntl`](/docs/react-intl/api#useintl)
 - [`defineMessages`](/docs/react-intl/api#definemessages)
 - [`IntlProvider`](/docs/react-intl/components#intlprovider)
 - [`FormattedDate`](/docs/react-intl/components#formatteddate)
@@ -138,7 +138,7 @@ ReactDOM.render(
 
 React Intl has two ways to format data, through [React components](/docs/react-intl/components) and its [API](/docs/react-intl/api). The components provide an idiomatic-React way of integrating internationalization into a React app, and the `<Formatted*>` components have [benefits](/docs/react-intl/components#why-components) over always using the imperative API directly. The API should be used when your React component needs to format data to a string value where a React element is not suitable; e.g., a `title` or `aria` attribute, or for side-effect in `componentDidMount`.
 
-React Intl's imperative API is accessed via [**`injectIntl`**](/docs/react-intl/api#injectintl), a High-Order Component (HOC) factory. It will wrap the passed-in React component with another React component which provides the imperative formatting API into the wrapped component via its `props`. (This is similar to the connect-to-stores pattern found in many Flux implementations.)
+React Intl's imperative API is accessed via the [**`useIntl`**](/docs/react-intl/api#useintl) hook, which provides the `intl` object with all formatting methods.
 
 Here's an example using `<IntlProvider>`, `<Formatted*>` components, and the imperative API to setup an i18n context and format data:
 

--- a/docs/src/docs/react-intl/api.mdx
+++ b/docs/src/docs/react-intl/api.mdx
@@ -18,8 +18,7 @@ The core of `react-intl` is the `intl` object (of type [`IntlShape`](#intlshape)
 
 There are a few ways to get access to the `intl` object:
 
-- `useIntl` hook: Once you've declared your `IntlProvider`, you can get access to the `intl` object via calling this hook in your functional React component
-- `injectIntl` HOC: In `class`-based React components, you can wrap them with the `injectIntl` HOC and `intl` should be available as a `prop`.
+- `useIntl` hook: Once you've declared your `IntlProvider`, you can get access to the `intl` object via calling this hook in your functional React component.
 - `createIntl`: In a non-React environment (Node, vue, angular, testing... you name it), you can directly create a `intl` object by calling this function with the same configuration as the `IntlProvider`.
 
 ## useIntl hook
@@ -40,52 +39,6 @@ export default FunctionComponent
 ```
 
 To keep the API surface clean and simple, we only provide `useIntl` hook in the package. If preferable, user can wrap this built-in hook to make customized hook like `useFormatMessage` easily. Please visit React's official website for more general [introduction on React hooks](https://reactjs.org/docs/hooks-intro.html).
-
-## injectIntl HOC
-
-```ts
-type WrappedComponentProps<IntlPropName extends string = 'intl'> = {
-  [k in IntlPropName]: IntlShape
-}
-
-type WithIntlProps<P> = Omit<P, keyof WrappedComponentProps> & {
-  forwardedRef?: React.Ref<any>
-}
-
-function injectIntl<
-  IntlPropName extends string = 'intl',
-  P extends WrappedComponentProps<IntlPropName> = WrappedComponentProps<any>,
->(
-  WrappedComponent: React.ComponentType<P>,
-  options?: Opts<IntlPropName>
-): React.ComponentType<WithIntlProps<P>> & {
-  WrappedComponent: typeof WrappedComponent
-}
-```
-
-This function is exported by the `react-intl` package and is a High-Order Component (HOC) factory. It will wrap the passed-in React component with another React component which provides the imperative formatting API into the wrapped component via its `props`. (This is similar to the connect-to-stores pattern found in many Flux implementations.)
-
-By default, the formatting API will be provided to the wrapped component via `props.intl`, but this can be overridden when specifying `options.intlPropName`. The value of the prop will be of type [`IntlShape`](#Intlshape), defined in the next section.
-
-```tsx
-interface Props {
-  date: Date | number
-}
-
-const FunctionalComponent: React.FC<Props> = props => {
-  const {
-    date,
-    intl, // Injected by `injectIntl`
-  } = props
-  return (
-    <span title={intl.formatDate(date)}>
-      <FormattedDate value={date} />
-    </span>
-  )
-}
-
-export default injectIntl(FunctionalComponent)
-```
 
 ## createIntl
 
@@ -179,9 +132,9 @@ interface IntlFormatters {
 type IntlShape = IntlConfig & IntlFormatters
 ```
 
-This interface is exported by the `react-intl` package that can be used in conjunction with the [`injectIntl`](#injectintl) HOC factory function.
+This interface is exported by the `react-intl` package and represents the `intl` object returned by the [`useIntl`](#useintl) hook or [`createIntl`](#createintl).
 
-The definition above shows what the `props.intl` object will look like that's injected to your component via `injectIntl`. It's made up of two parts:
+It's made up of two parts:
 
 - **`IntlConfig`:** The intl metadata passed as props into the parent `<IntlProvider>`.
 - **`IntlFormatters`:** The imperative formatting API described below.


### PR DESCRIPTION
Fixes #6216

## Summary
- Remove `injectIntl` HOC section from API docs (`api.mdx`)
- Replace `injectIntl` references with `useIntl` hook in main react-intl overview (`react-intl.mdx`)
- Update `IntlShape` docs to reference `useIntl`/`createIntl` instead of `injectIntl`
- Replace class component + `injectIntl` example with function component + `useIntl` in message extraction guide
- Remove outdated `injectIntl` + `forwardRef` DOM testing section, point to `@testing-library/react` instead
- Upgrade guides (2.x, 3.x, 10.x) are kept as-is since they're historical migration docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)