### PR TITLE
fix(@formatjs/icu-messageformat-parser): use Map.has() instead of in operator in collectVariables

### DIFF
--- a/crates/icu_messageformat_parser/manipulator.rs
+++ b/crates/icu_messageformat_parser/manipulator.rs
@@ -834,4 +834,93 @@ mod tests {
             result.err()
         );
     }
+
+    // https://github.com/formatjs/formatjs/issues/6212
+    // Variable names that happen to match Map prototype properties (e.g., "size",
+    // "entries", "get") should work correctly. The TypeScript implementation had a
+    // bug where `in` operator on a Map checked the prototype chain instead of Map
+    // entries. The Rust implementation uses Vec so it's not affected, but these
+    // tests ensure parity with the TypeScript fix.
+    #[test]
+    fn test_map_prototype_variable_names_no_false_conflict() {
+        use crate::parser::{Parser, ParserOptions};
+        let opts = ParserOptions::default();
+
+        // "size" and "entries" are Map.prototype properties in JS
+        let a = Parser::new("{size} m²", opts.clone())
+            .parse()
+            .expect("parse a");
+        let b = Parser::new("{size} sq ft", opts.clone())
+            .parse()
+            .expect("parse b");
+        assert!(
+            is_structurally_same(&a, &b, "test.size".to_string()).is_ok(),
+            "Same variable 'size' should be structurally equal"
+        );
+
+        let a = Parser::new("{entries} items", opts.clone())
+            .parse()
+            .expect("parse a");
+        let b = Parser::new("{entries} records", opts.clone())
+            .parse()
+            .expect("parse b");
+        assert!(
+            is_structurally_same(&a, &b, "test.entries".to_string()).is_ok(),
+            "Same variable 'entries' should be structurally equal"
+        );
+
+        // Different variable counts should still fail
+        let a = Parser::new("{size} m²", opts.clone())
+            .parse()
+            .expect("parse a");
+        let b = Parser::new("{date} · {size}", opts.clone())
+            .parse()
+            .expect("parse b");
+        let result = is_structurally_same(&a, &b, "test.size_mismatch".to_string());
+        assert!(result.is_err(), "Different variable counts should fail");
+    }
+
+    #[test]
+    fn test_plural_with_inner_number_element() {
+        use crate::parser::{Parser, ParserOptions};
+        let opts = ParserOptions::default();
+
+        // {count, plural, one {{count, number} cat} other {{count, number} cats}}
+        // 'count' appears as both Plural and Number — this is valid ICU usage
+        let a = Parser::new(
+            "{count, plural, one {{count, number} cat} other {{count, number} cats}}",
+            opts.clone(),
+        )
+        .parse()
+        .expect("parse a");
+        let b = Parser::new(
+            "{count, plural, one {{count, number} foo} few{# cats} other {{count, number} bax}}",
+            opts.clone(),
+        )
+        .parse()
+        .expect("parse b");
+        assert!(
+            is_structurally_same(&a, &b, "test.plural_number".to_string()).is_ok(),
+            "Plural with inner number for same variable should be structurally equal"
+        );
+
+        // Mismatch: different outer variable name
+        let a = Parser::new(
+            "some static string {count, plural, one {{count, number} cat} other {{count, number} cats}}",
+            opts.clone(),
+        )
+        .parse()
+        .expect("parse a");
+        let b = Parser::new(
+            "{count2, plural, one {{count, number} foo} other {{count, number} bax}}",
+            opts.clone(),
+        )
+        .parse()
+        .expect("parse b");
+        let result = is_structurally_same(&a, &b, "test.plural_mismatch".to_string());
+        assert!(
+            result.is_err(),
+            "Different plural variable names should fail"
+        );
+    }
 }

--- a/packages/icu-messageformat-parser/manipulator.ts
+++ b/packages/icu-messageformat-parser/manipulator.ts
@@ -172,10 +172,20 @@ function collectVariables(
       isTimeElement(el) ||
       isNumberElement(el)
     ) {
-      if (el.value in vars && vars.get(el.value) !== el.type) {
-        throw new Error(`Variable ${el.value} has conflicting types`)
+      // If the variable was already registered as a plural/select, it's normal
+      // for it to also appear inside as number/date/time/argument — not a conflict.
+      if (vars.has(el.value)) {
+        const existingType = vars.get(el.value)!
+        if (
+          existingType !== el.type &&
+          existingType !== TYPE.plural &&
+          existingType !== TYPE.select
+        ) {
+          throw new Error(`Variable ${el.value} has conflicting types`)
+        }
+      } else {
+        vars.set(el.value, el.type)
       }
-      vars.set(el.value, el.type)
     }
 
     if (isPluralElement(el) || isSelectElement(el)) {

--- a/packages/icu-messageformat-parser/tests/manipulator.test.ts
+++ b/packages/icu-messageformat-parser/tests/manipulator.test.ts
@@ -112,6 +112,32 @@ test('structurally same literal', function () {
   )
 })
 
+// https://github.com/formatjs/formatjs/issues/6212
+test('GH #6212: variable names matching Map prototype properties should not conflict', function () {
+  // 'size' and 'entries' are properties on Map.prototype.
+  // Using `in` operator instead of `Map.has()` caused false positives.
+  expect(
+    isStructurallySame(parse('{size} m²'), parse('{date} · {size}'))
+  ).toEqual({
+    success: false,
+    error: new Error('Different number of variables: [size] vs [date, size]'),
+  })
+
+  // Same variables — should succeed without "conflicting types" error
+  expect(isStructurallySame(parse('{size} m²'), parse('{size} sq ft'))).toEqual(
+    {
+      success: true,
+    }
+  )
+
+  // 'entries' is also a Map prototype property
+  expect(
+    isStructurallySame(parse('{entries} items'), parse('{entries} records'))
+  ).toEqual({
+    success: true,
+  })
+})
+
 // https://github.com/formatjs/formatjs/issues/4202
 test('GH #4202: multiple plurals with hash placeholders', function () {
   const input =


### PR DESCRIPTION
## Summary

Fixes #6212. Based on #6213.

- Replace `el.value in vars` with `vars.has(el.value)` in `collectVariables()`. The `in` operator checks the prototype chain, so variable names like `size`, `entries`, `get`, etc. that match `Map.prototype` properties caused false positive "conflicting types" errors.
- Fix conflict detection to allow variables used as plural/select selectors to also appear as number/date/time/argument inside their options (normal ICU usage like `{count, plural, one {{count, number} cat} ...}`).
- Add regression test for variable names matching Map prototype properties.

## Test plan
- [x] `bazel test //packages/icu-messageformat-parser:unit_test` — all 15 tests pass