### PR TITLE
fix(@formatjs/intl-segmenter): add default index export

### DIFF
--- a/packages/intl-segmenter/BUILD.bazel
+++ b/packages/intl-segmenter/BUILD.bazel
@@ -66,6 +66,7 @@ EXTERNAL_PACKAGES = [
 ]
 
 ENTRY_POINTS = [
+    "index.ts",
     "polyfill.ts",
     "polyfill-force.ts",
     "should-polyfill.ts",

--- a/packages/intl-segmenter/index.ts
+++ b/packages/intl-segmenter/index.ts
@@ -1,0 +1,1 @@
+export * from './src/segmenter.js'

--- a/packages/intl-segmenter/package.json
+++ b/packages/intl-segmenter/package.json
@@ -6,6 +6,7 @@
   "author": "Matija Gaspar <matijagaspar@gmail.com>",
   "type": "module",
   "exports": {
+    ".": "./index.js",
     "./polyfill.js": "./polyfill.js",
     "./polyfill-force.js": "./polyfill-force.js",
     "./should-polyfill.js": "./should-polyfill.js"


### PR DESCRIPTION
## Summary

Fixes #6211

- Add `"."` entry to `package.json` exports pointing to `./index.js`
- Create `index.ts` that re-exports from `src/segmenter.ts`
- Add `index.ts` to `ENTRY_POINTS` in BUILD.bazel so it gets bundled

This matches the pattern used by other polyfill packages (`intl-numberformat`, `intl-datetimeformat`, `intl-pluralrules`, etc.) and allows users to `import { Segmenter } from "@formatjs/intl-segmenter"`.

## Test plan
- [x] `bazel build //packages/intl-segmenter:index-bundle` — builds successfully
- [x] `bazel test //packages/intl-segmenter:unit_test` — passes
- [x] `bazel test //packages/intl-segmenter:no_internal_imports_test` — passes