### PR TITLE
fix(@formatjs/cli-lib): add missing EOF newline in compile-folder output

### DIFF
--- a/packages/cli-lib/src/compile_folder.ts
+++ b/packages/cli-lib/src/compile_folder.ts
@@ -10,6 +10,6 @@ export default async function compileFolder(
   const outFiles = files.map(f => join(outFolder, basename(f)))
 
   return Promise.all(
-    outFiles.map((outFile, i) => outputFile(outFile, results[i]))
+    outFiles.map((outFile, i) => outputFile(outFile, results[i] + '\n'))
   )
 }


### PR DESCRIPTION
## Summary

Fixes #6225

Add trailing `\n` to `compile-folder` output files, matching the existing behavior of `compile` (#4539) and `extract` (#2803) commands.

The Rust implementation already handles this correctly since it delegates to `compile()` which adds the newline.

## Test plan
- [x] Verified the one-line change matches the pattern in `compile.ts` (line 166) and `extract.ts` (line 338)