### PR TITLE
fix(@formatjs/ecma402-abstract): migrate remaining imports to #packages subpath

### DIFF
--- a/packages/icu-messageformat-parser/BUILD.bazel
+++ b/packages/icu-messageformat-parser/BUILD.bazel
@@ -20,7 +20,7 @@ PACKAGE_NAME = "icu-messageformat-parser"
 SRCS = glob(["*.ts"])
 
 SRC_DEPS = [
-    "//:node_modules/@formatjs/ecma402-abstract",
+    "//packages/ecma402-abstract",
     "//:node_modules/@formatjs/icu-skeleton-parser",
 ]
 

--- a/packages/icu-messageformat-parser/types.ts
+++ b/packages/icu-messageformat-parser/types.ts
@@ -1,4 +1,4 @@
-import type {NumberFormatOptions} from '@formatjs/ecma402-abstract'
+import type {NumberFormatOptions} from '#packages/ecma402-abstract'
 import {type NumberSkeletonToken} from '@formatjs/icu-skeleton-parser'
 
 export interface ExtendedNumberFormatOptions extends NumberFormatOptions {

--- a/packages/icu-skeleton-parser/BUILD.bazel
+++ b/packages/icu-skeleton-parser/BUILD.bazel
@@ -17,7 +17,7 @@ PACKAGE_NAME = "icu-skeleton-parser"
 SRCS = glob(["*.ts"])
 
 SRC_DEPS = [
-    "//:node_modules/@formatjs/ecma402-abstract",
+    "//packages/ecma402-abstract",
 ]
 
 EXTERNAL_PACKAGES = [

--- a/packages/icu-skeleton-parser/number.ts
+++ b/packages/icu-skeleton-parser/number.ts
@@ -1,4 +1,4 @@
-import type {NumberFormatOptions} from '@formatjs/ecma402-abstract'
+import type {NumberFormatOptions} from '#packages/ecma402-abstract'
 import {WHITE_SPACE_REGEX} from './regex.generated.js'
 
 export interface ExtendedNumberFormatOptions extends NumberFormatOptions {

--- a/packages/intl-datetimeformat/BUILD.bazel
+++ b/packages/intl-datetimeformat/BUILD.bazel
@@ -49,7 +49,6 @@ TESTS = glob([
 
 SRC_DEPS = [
     "//packages/ecma402-abstract",
-    "//:node_modules/@formatjs/ecma402-abstract",  # for src/ files still using barrel imports
     "//:node_modules/@formatjs/intl-localematcher",
     "//:node_modules/@formatjs/bigdecimal",
 ]
@@ -756,7 +755,6 @@ ts_run_binary(
     srcs = [
         "src/abstract/skeleton.ts",
         "src/types.ts",
-        "//:node_modules/@formatjs/ecma402-abstract",
         "//:node_modules/@formatjs/intl-locale",
         "//:node_modules/cldr-bcp47",
         "//:node_modules/cldr-core",
@@ -871,7 +869,6 @@ generate_src_file(
         "src/packer.ts",
         "src/types.ts",
         ":zdumps",
-        "//:node_modules/@formatjs/ecma402-abstract",
         "//:node_modules/json-stable-stringify",
         "//packages/ecma402-abstract",
     ],
@@ -887,7 +884,6 @@ ts_run_binary(
         "src/packer.ts",
         "src/types.ts",
         ":zdumps",
-        "//:node_modules/@formatjs/ecma402-abstract",
         "//:node_modules/fs-extra",
         "//:node_modules/json-stable-stringify",
         "//:node_modules/minimist",
@@ -914,7 +910,6 @@ ts_run_binary(
         "src/packer.ts",
         "src/types.ts",
         ":zdumps",
-        "//:node_modules/@formatjs/ecma402-abstract",
         "//:node_modules/fs-extra",
         "//:node_modules/json-stable-stringify",
         "//:node_modules/minimist",

--- a/packages/intl-datetimeformat/scripts/extract-dates.ts
+++ b/packages/intl-datetimeformat/scripts/extract-dates.ts
@@ -23,7 +23,7 @@ import rawCalendarPreferenceData from 'cldr-core/supplemental/calendarPreference
 import TimeZoneNames from 'cldr-dates-full/main/en/timeZoneNames.json' with {type: 'json'}
 import metaZones from 'cldr-core/supplemental/metaZones.json' with {type: 'json'}
 import IntlLocale from '@formatjs/intl-locale'
-import {type Formats} from '@formatjs/ecma402-abstract'
+import {type Formats} from '#packages/ecma402-abstract'
 import {parseDateTimeSkeleton} from '../src/abstract/skeleton.ts'
 import {isEqual} from 'lodash-es'
 const {timeData} = rawTimeData.supplemental

--- a/packages/intl-datetimeformat/src/abstract/skeleton.ts
+++ b/packages/intl-datetimeformat/src/abstract/skeleton.ts
@@ -4,7 +4,7 @@ import {
   type RangePatterns,
   RangePatternType,
   type TABLE_2,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract'
 
 /**
  * https://unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table

--- a/packages/intl-datetimeformat/src/packer.ts
+++ b/packages/intl-datetimeformat/src/packer.ts
@@ -1,5 +1,5 @@
 import {type UnpackedData, type PackedData} from './types.ts'
-import {type UnpackedZoneData} from '@formatjs/ecma402-abstract'
+import {type UnpackedZoneData} from '#packages/ecma402-abstract'
 
 export function pack(data: UnpackedData): PackedData {
   const zoneNames = Object.keys(data.zones)

--- a/packages/intl-datetimeformat/src/types.ts
+++ b/packages/intl-datetimeformat/src/types.ts
@@ -2,7 +2,7 @@ import {
   type LocaleData,
   type DateTimeFormatLocaleInternalData,
   type IntervalFormatsData,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract'
 
 export interface PackedData {
   zones: string[]

--- a/packages/intl-durationformat/BUILD.bazel
+++ b/packages/intl-durationformat/BUILD.bazel
@@ -20,7 +20,7 @@ SRCS = glob([
 ])
 
 SRC_DEPS = [
-    "//:node_modules/@formatjs/ecma402-abstract",
+    "//packages/ecma402-abstract",
     "//:node_modules/@formatjs/intl-localematcher",
 ]
 
@@ -126,7 +126,6 @@ generate_src_file(
     name = "time-separators",
     src = "src/time-separators.generated.ts",
     data = [
-        "//:node_modules/@formatjs/ecma402-abstract",
         "//:node_modules/@types/lodash-es",
         "//:node_modules/cldr-core",
         "//:node_modules/cldr-localenames-full",
@@ -134,6 +133,7 @@ generate_src_file(
         "//:node_modules/fast-glob",
         "//:node_modules/json-stable-stringify",
         "//:node_modules/lodash-es",
+        "//packages/ecma402-abstract",
     ],
     tags = ["cldr"],
     tool = "//packages/intl-durationformat/scripts:time-separators",

--- a/packages/intl-durationformat/src/abstract/GetDurationUnitOptions.ts
+++ b/packages/intl-durationformat/src/abstract/GetDurationUnitOptions.ts
@@ -1,4 +1,4 @@
-import {GetOption} from '@formatjs/ecma402-abstract'
+import {GetOption} from '#packages/ecma402-abstract'
 
 export function GetDurationUnitOptions<T extends object>(
   unit: keyof T,

--- a/packages/intl-durationformat/src/abstract/IsValidDurationRecord.ts
+++ b/packages/intl-durationformat/src/abstract/IsValidDurationRecord.ts
@@ -1,4 +1,4 @@
-import {invariant} from '@formatjs/ecma402-abstract'
+import {invariant} from '#packages/ecma402-abstract'
 import {TABLE_1} from '../constants.js'
 import {type DurationRecord} from '../types.js'
 import {DurationRecordSign} from './DurationRecordSign.js'

--- a/packages/intl-durationformat/src/abstract/PartitionDurationFormatPattern.ts
+++ b/packages/intl-durationformat/src/abstract/PartitionDurationFormatPattern.ts
@@ -3,7 +3,7 @@ import {
   createMemoizedListFormat,
   createMemoizedNumberFormat,
   invariant,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract'
 import {TABLE_2} from '../constants.js'
 import {DurationFormat} from '../core.js'
 import {getInternalSlots} from '../get_internal_slots.js'

--- a/packages/intl-durationformat/src/abstract/ToIntegerIfIntegral.ts
+++ b/packages/intl-durationformat/src/abstract/ToIntegerIfIntegral.ts
@@ -1,4 +1,4 @@
-import {invariant, ToNumber} from '@formatjs/ecma402-abstract'
+import {invariant, ToNumber} from '#packages/ecma402-abstract'
 
 export function ToIntegerIfIntegral(arg: any): number {
   const number = ToNumber(arg)

--- a/packages/intl-durationformat/src/core.ts
+++ b/packages/intl-durationformat/src/core.ts
@@ -9,7 +9,7 @@ import {
   SupportedLocales,
   ToObject,
   invariant,
-} from '@formatjs/ecma402-abstract'
+} from '#packages/ecma402-abstract'
 import {ResolveLocale} from '@formatjs/intl-localematcher'
 import {GetDurationUnitOptions} from './abstract/GetDurationUnitOptions.js'
 import {PartitionDurationFormatPattern} from './abstract/PartitionDurationFormatPattern.js'

--- a/packages/intl-messageformat/BUILD.bazel
+++ b/packages/intl-messageformat/BUILD.bazel
@@ -22,7 +22,7 @@ SRCS = glob(["src/*.ts"]) + ["index.ts"]
 SRC_DEPS = [
     "//:node_modules/@formatjs/icu-messageformat-parser",
     "//:node_modules/@formatjs/fast-memoize",
-    "//:node_modules/@formatjs/ecma402-abstract",
+    "//packages/ecma402-abstract",
 ]
 
 EXTERNAL_PACKAGES = [

--- a/packages/intl-messageformat/src/formatters.ts
+++ b/packages/intl-messageformat/src/formatters.ts
@@ -1,4 +1,4 @@
-import {type NumberFormatOptions} from '@formatjs/ecma402-abstract'
+import {type NumberFormatOptions} from '#packages/ecma402-abstract'
 import {
   type ExtendedNumberFormatOptions,
   isArgumentElement,

--- a/packages/intl-supportedvaluesof/BUILD.bazel
+++ b/packages/intl-supportedvaluesof/BUILD.bazel
@@ -21,7 +21,7 @@ SRCS = glob([
 ])
 
 SRC_DEPS = [
-    "//:node_modules/@formatjs/ecma402-abstract",
+    "//packages/ecma402-abstract",
     "//:node_modules/@formatjs/fast-memoize",
 ]
 

--- a/packages/intl-supportedvaluesof/src/get-supported-currencies.ts
+++ b/packages/intl-supportedvaluesof/src/get-supported-currencies.ts
@@ -1,4 +1,4 @@
-import {createMemoizedNumberFormat} from '@formatjs/ecma402-abstract'
+import {createMemoizedNumberFormat} from '#packages/ecma402-abstract'
 import type {Currency} from './currencies.generated.js'
 import {currencies} from './currencies.generated.js'
 

--- a/packages/intl-supportedvaluesof/src/get-supported-numbering-systems.ts
+++ b/packages/intl-supportedvaluesof/src/get-supported-numbering-systems.ts
@@ -1,4 +1,4 @@
-import {createMemoizedNumberFormat} from '@formatjs/ecma402-abstract'
+import {createMemoizedNumberFormat} from '#packages/ecma402-abstract'
 import {numberingSystemNames} from './numbering-systems.generated.js'
 
 /**

--- a/packages/intl-supportedvaluesof/src/get-supported-units.ts
+++ b/packages/intl-supportedvaluesof/src/get-supported-units.ts
@@ -1,4 +1,4 @@
-import {createMemoizedNumberFormat} from '@formatjs/ecma402-abstract'
+import {createMemoizedNumberFormat} from '#packages/ecma402-abstract'
 import type {Unit} from './units.generated.js'
 import {units} from './units.generated.js'
 

--- a/packages/intl/BUILD.bazel
+++ b/packages/intl/BUILD.bazel
@@ -19,7 +19,7 @@ PACKAGE_NAME = "intl"
 SRCS = glob(["src/**/*.ts*"]) + ["index.ts"]
 
 SRC_DEPS = [
-    "//:node_modules/@formatjs/ecma402-abstract",
+    "//packages/ecma402-abstract",
     "//:node_modules/@formatjs/fast-memoize",
     "//:node_modules/@formatjs/icu-messageformat-parser",
     "//:node_modules/intl-messageformat",

--- a/packages/intl/src/number.ts
+++ b/packages/intl/src/number.ts
@@ -1,4 +1,4 @@
-import {type NumberFormatOptions} from '@formatjs/ecma402-abstract'
+import {type NumberFormatOptions} from '#packages/ecma402-abstract'
 import {IntlFormatError} from './error.js'
 import {
   type CustomFormats,

--- a/packages/intl/src/types.ts
+++ b/packages/intl/src/types.ts
@@ -1,6 +1,6 @@
 import {type MessageFormatElement} from '@formatjs/icu-messageformat-parser'
 
-import {type NumberFormatOptions} from '@formatjs/ecma402-abstract'
+import {type NumberFormatOptions} from '#packages/ecma402-abstract'
 import type {FormatError, IntlMessageFormat} from 'intl-messageformat'
 import {
   type Formats,

--- a/packages/intl/src/utils.ts
+++ b/packages/intl/src/utils.ts
@@ -1,4 +1,4 @@
-import {type NumberFormatOptions} from '@formatjs/ecma402-abstract'
+import {type NumberFormatOptions} from '#packages/ecma402-abstract'
 import {type Cache, memoize, strategies} from '@formatjs/fast-memoize'
 import {IntlMessageFormat} from 'intl-messageformat'
 import {UnsupportedFormatterError} from './error.js'

--- a/packages/react-intl/BUILD.bazel
+++ b/packages/react-intl/BUILD.bazel
@@ -21,7 +21,7 @@ SRCS = glob(["src/**/*.ts*"]) + [
 ]
 
 SRC_DEPS = [
-    "//:node_modules/@formatjs/ecma402-abstract",
+    "//packages/ecma402-abstract",
     "//:node_modules/@formatjs/icu-messageformat-parser",
     "//:node_modules/@formatjs/intl",
     "//:node_modules/intl-messageformat",

--- a/packages/react-intl/examples/BUILD.bazel
+++ b/packages/react-intl/examples/BUILD.bazel
@@ -8,7 +8,7 @@ load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
 npm_link_all_packages()
 
 EXAMPLES_SRC_DEPS = [
-    "//:node_modules/@formatjs/ecma402-abstract",
+    "//packages/ecma402-abstract",
     "//:node_modules/@formatjs/intl-datetimeformat",
     "//:node_modules/@formatjs/intl-getcanonicallocales",
     "//:node_modules/@formatjs/intl-locale",

--- a/packages/react-intl/index.ts
+++ b/packages/react-intl/index.ts
@@ -4,7 +4,7 @@
  * Copyrights licensed under the New BSD License.
  * See the accompanying LICENSE file for terms.
  */
-import {type NumberFormatOptions} from '@formatjs/ecma402-abstract'
+import {type NumberFormatOptions} from '#packages/ecma402-abstract'
 import {
   type CustomFormatConfig,
   type FormatDateOptions,


### PR DESCRIPTION
## Summary
- Convert 19 source files from `@formatjs/ecma402-abstract` to `#packages/ecma402-abstract` Node.js subpath imports
- Update 9 BUILD.bazel files to use `//packages/ecma402-abstract` direct source targets instead of `//:node_modules/@formatjs/ecma402-abstract`
- Remove duplicate node_modules references in `intl-datetimeformat/BUILD.bazel` that were alongside direct source deps

This is a prerequisite for removing the `@formatjs/ecma402-abstract` package.json entirely.

## Test plan
- [ ] `bazel test //...` passes
- [ ] Verify no remaining `@formatjs/ecma402-abstract` imports in source files (only in ecma402-abstract's own package)

🤖 Generated with [Claude Code](https://claude.com/claude-code)