### PR TITLE
chore(formatjs-repo): add ast-grep with no-barrel-export rule

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -40,6 +40,9 @@ pre-commit:
       glob: '**/*.{js,mjs,cjs,jsx,ts,mts,cts,tsx,vue,astro,svelte}'
       run: pnpm oxlint --config .oxlintrc.json --fix {staged_files}
       stage_fixed: true
+    lint-ast-grep:
+      glob: '**/*.{ts,tsx}'
+      run: pnpm ast-grep scan {staged_files}
     gazelle:
       glob:
         - "**/*.{ts,tsx,js,jsx,mjs,cjs}"

--- a/package.json
+++ b/package.json
@@ -13,10 +13,11 @@
     "format": "lefthook run pre-commit --all-files",
     "prepare": "lefthook install",
     "prerelease": "LEFTHOOK=0 lerna version --yes --no-private",
-    "test": "syncpack lint && oxlint --config .oxlintrc.json && bazel test //...",
+    "test": "syncpack lint && oxlint --config .oxlintrc.json && ast-grep scan && bazel test //...",
     "website": "ibazel run //docs:serve"
   },
   "devDependencies": {
+    "@ast-grep/cli": "^0.38.0",
     "@babel/core": "^7.28.5",
     "@babel/helper-plugin-utils": "^7.27.1",
     "@babel/plugin-syntax-jsx": "^7.27.1",
@@ -230,6 +231,7 @@
       "oxlint@1.48.0": "patches/oxlint@1.48.0.patch"
     },
     "onlyBuiltDependencies": [
+      "@ast-grep/cli",
       "esbuild"
     ]
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
 
   .:
     devDependencies:
+      '@ast-grep/cli':
+        specifier: ^0.38.0
+        version: 0.38.7
       '@babel/core':
         specifier: ^7.28.5
         version: 7.29.0
@@ -1095,6 +1098,55 @@ packages:
 
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
+  '@ast-grep/cli-darwin-arm64@0.38.7':
+    resolution: {integrity: sha512-Ma6PczwSFArKnWZTiYoxZHc0plUpdg2i8u9uqOHQbwARgNkktFvGgdImrny64m9NueoIbWNHWfhOHPFWljyY1Q==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@ast-grep/cli-darwin-x64@0.38.7':
+    resolution: {integrity: sha512-+G2q4lcQNA9QBb/HK5fxoa9Vaai6fLhl9QLixMUrVFWTmZAGmaAhjbF1XDHFPpJGgKqm9BJE+eGepEdsATlbHg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@ast-grep/cli-linux-arm64-gnu@0.38.7':
+    resolution: {integrity: sha512-5/Q/Jm0XMNU+gQBTPBmC6IAct7GEx69OBcpl6UkuHMUfXwFab+PjEeNo//f6a3X2Xv/uSV4yQv0thu18nzvXTw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@ast-grep/cli-linux-x64-gnu@0.38.7':
+    resolution: {integrity: sha512-Ua2eODoazCMRJ1RDCmMATOp2oJmZn9rsgOw8YZHxDJRDVZIkgwAbTYLoPWQxwAm2OZlWqkQDR1niywZZzyTMNg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@ast-grep/cli-win32-arm64-msvc@0.38.7':
+    resolution: {integrity: sha512-v2aIAsJd/VEP+otPGKTv6pI5nR2ow5iYw5iubqFg+sIJcRwIz6AVy3D1Ewx0y0PUfY5L9WkSEhOd1lsHEvAxKw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@ast-grep/cli-win32-ia32-msvc@0.38.7':
+    resolution: {integrity: sha512-7BQ14iESfGCHJP+w84psPaLfsXaGJb9TuOpuTH4gBe/XBE7dju6vWLqq+x/u3Fk+1nk8sj/asEEgAHKF3CUCYA==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@ast-grep/cli-win32-x64-msvc@0.38.7':
+    resolution: {integrity: sha512-49Z4xOFgoUYFQubzoZ9IotA3MYuuIGmKiBa58QrMX6DIGqkshnHKzVKEyrETv/WNU4pbfEpDNCAaHi6XR9LKJg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@ast-grep/cli@0.38.7':
+    resolution: {integrity: sha512-gpAd9xt4/DDJaYXJlJZG2v0hZwhL/M4YvT61AHZevvsqWXJr49wO1UxjqrRV+2DiqscVWyeeBqWGz63XLKf3ng==}
+    engines: {node: '>= 12.0.0'}
+    hasBin: true
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -5378,6 +5430,10 @@ packages:
     resolution: {integrity: sha512-y+8xyqdGLL+6sh0tVeHcfP/QDd8gUgbasolJJpY7NgeQGSZ739bDtSiaiDgtoicy+mtYB81dKLxO9xRhCyIB3A==}
     engines: {node: '>=12.20'}
 
+  detect-libc@2.0.4:
+    resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
+    engines: {node: '>=8'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -5879,9 +5935,6 @@ packages:
   get-stream@9.0.1:
     resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
     engines: {node: '>=18'}
-
-  get-tsconfig@4.13.6:
-    resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
 
   get-tsconfig@4.13.7:
     resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
@@ -8978,6 +9031,39 @@ packages:
 snapshots:
 
   '@adobe/css-tools@4.4.4': {}
+
+  '@ast-grep/cli-darwin-arm64@0.38.7':
+    optional: true
+
+  '@ast-grep/cli-darwin-x64@0.38.7':
+    optional: true
+
+  '@ast-grep/cli-linux-arm64-gnu@0.38.7':
+    optional: true
+
+  '@ast-grep/cli-linux-x64-gnu@0.38.7':
+    optional: true
+
+  '@ast-grep/cli-win32-arm64-msvc@0.38.7':
+    optional: true
+
+  '@ast-grep/cli-win32-ia32-msvc@0.38.7':
+    optional: true
+
+  '@ast-grep/cli-win32-x64-msvc@0.38.7':
+    optional: true
+
+  '@ast-grep/cli@0.38.7':
+    dependencies:
+      detect-libc: 2.0.4
+    optionalDependencies:
+      '@ast-grep/cli-darwin-arm64': 0.38.7
+      '@ast-grep/cli-darwin-x64': 0.38.7
+      '@ast-grep/cli-linux-arm64-gnu': 0.38.7
+      '@ast-grep/cli-linux-x64-gnu': 0.38.7
+      '@ast-grep/cli-win32-arm64-msvc': 0.38.7
+      '@ast-grep/cli-win32-ia32-msvc': 0.38.7
+      '@ast-grep/cli-win32-x64-msvc': 0.38.7
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -13224,6 +13310,8 @@ snapshots:
 
   detect-indent@7.0.2: {}
 
+  detect-libc@2.0.4: {}
+
   detect-libc@2.1.2: {}
 
   detect-newline@3.1.0: {}
@@ -13842,11 +13930,6 @@ snapshots:
     dependencies:
       '@sec-ant/readable-stream': 0.4.1
       is-stream: 4.0.1
-
-  get-tsconfig@4.13.6:
-    dependencies:
-      resolve-pkg-maps: 1.0.0
-    optional: true
 
   get-tsconfig@4.13.7:
     dependencies:
@@ -17102,7 +17185,7 @@ snapshots:
   tsx@4.21.0:
     dependencies:
       esbuild: 0.27.4
-      get-tsconfig: 4.13.6
+      get-tsconfig: 4.13.7
     optionalDependencies:
       fsevents: 2.3.3
     optional: true

--- a/sg-rules/no-barrel-export.yml
+++ b/sg-rules/no-barrel-export.yml
@@ -1,0 +1,8 @@
+id: no-barrel-export
+language: typescript
+message: "Barrel exports (export * from) are banned in private packages. Use deep imports instead."
+severity: error
+rule:
+  pattern: "export * from '$PATH'"
+files:
+  - "packages/ecma402-abstract/**"

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -1,0 +1,2 @@
+ruleDirs:
+  - sg-rules


### PR DESCRIPTION
## Summary
- Add `@ast-grep/cli` for structural code linting
- Add `no-barrel-export` rule banning `export * from` in `packages/ecma402-abstract/`
- Add `lint-ast-grep` to lefthook pre-commit hooks
- Add `ast-grep scan` to the `test` script
- Add `@ast-grep/cli` to `onlyBuiltDependencies` for postinstall

## Test plan
- [x] `pnpm t` passes (536/536 tests)
- [x] `pnpm ast-grep scan` runs cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)