### PR TITLE
fix(deps): fix broken GitHub URLs in changelogs

### DIFF
--- a/package.json
+++ b/package.json
@@ -234,5 +234,5 @@
       "esbuild"
     ]
   },
-  "repository": "formatjs/formatjs"
+  "repository": "https://github.com/formatjs/formatjs"
 }

--- a/packages/ecma402-abstract/CHANGELOG.md
+++ b/packages/ecma402-abstract/CHANGELOG.md
@@ -3,76 +3,76 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [3.2.0](github.com/formatjs/formatjs/compare/@formatjs/ecma402-abstract@3.1.2...@formatjs/ecma402-abstract@3.2.0) (2026-03-17)
+# [3.2.0](https://github.com/formatjs/formatjs/compare/@formatjs/ecma402-abstract@3.1.2...@formatjs/ecma402-abstract@3.2.0) (2026-03-17)
 
 ### Features
 
-* **@formatjs/ecma402-abstract:** migrate from decimal.js to @formatjs/bigdecimal ([#6148](/github.com/formatjs/formatjs/issues/6148)) ([93744d4](github.com/formatjs/formatjs/commits/93744d4732ab2dfdc93e7ddb2a73e80a6e461534)) - by @longlho
+* **@formatjs/ecma402-abstract:** migrate from decimal.js to @formatjs/bigdecimal ([#6148](https://github.com/formatjs/formatjs/issues/6148)) ([93744d4](https://github.com/formatjs/formatjs/commits/93744d4732ab2dfdc93e7ddb2a73e80a6e461534)) - by @longlho
 
-## [3.1.2](github.com/formatjs/formatjs/compare/@formatjs/ecma402-abstract@3.1.1...@formatjs/ecma402-abstract@3.1.2) (2026-03-16)
-
-**Note:** Version bump only for package @formatjs/ecma402-abstract
-
-## [3.1.1](github.com/formatjs/formatjs/compare/@formatjs/ecma402-abstract@3.1.0...@formatjs/ecma402-abstract@3.1.1) (2026-02-01)
+## [3.1.2](https://github.com/formatjs/formatjs/compare/@formatjs/ecma402-abstract@3.1.1...@formatjs/ecma402-abstract@3.1.2) (2026-03-16)
 
 **Note:** Version bump only for package @formatjs/ecma402-abstract
 
-# [3.1.0](github.com/formatjs/formatjs/compare/@formatjs/ecma402-abstract@3.0.8...@formatjs/ecma402-abstract@3.1.0) (2026-01-15)
+## [3.1.1](https://github.com/formatjs/formatjs/compare/@formatjs/ecma402-abstract@3.1.0...@formatjs/ecma402-abstract@3.1.1) (2026-02-01)
+
+**Note:** Version bump only for package @formatjs/ecma402-abstract
+
+# [3.1.0](https://github.com/formatjs/formatjs/compare/@formatjs/ecma402-abstract@3.0.8...@formatjs/ecma402-abstract@3.1.0) (2026-01-15)
 
 ### Features
 
-* **@formatjs/ecma402-abstract:** upgrade Unicode from 13.0.0 to 17.0.0 ([#5866](/github.com/formatjs/formatjs/issues/5866)) ([00343fe](github.com/formatjs/formatjs/commits/00343fe97e34f8f494d8b9a8b99bca50af6b48b2)) - by @longlho
-* **@formatjs/intl-pluralrules:** replace make-plural-compiler with native implementation and add BigInt support ([#5910](/github.com/formatjs/formatjs/issues/5910)) ([bed7271](github.com/formatjs/formatjs/commits/bed7271893174309c320bb308c6c62756873977e)) - by @longlho
-* **@formatjs/intl-pluralrules:** support notation/compactDisplay (c/e operands) ([#5914](/github.com/formatjs/formatjs/issues/5914)) ([c13e633](github.com/formatjs/formatjs/commits/c13e6331c09725e80993c8a44913d04be6ebae24)) - by @longlho
-* **@formatjs/intl-pluralrules:** support selectRange ([#5913](/github.com/formatjs/formatjs/issues/5913)) ([3240e62](github.com/formatjs/formatjs/commits/3240e629c639d4c91a5c0db0b209bcacda93a505)) - by @longlho
-* **@formatjs/intl-segmenter:** improve Unicode 17.0 Format/Extend transparency and upgrade deps ([#5862](/github.com/formatjs/formatjs/issues/5862)) ([effeb9c](github.com/formatjs/formatjs/commits/effeb9cd9d26f8c43c1e3df64a84c42dc7b12043)), closes [#29](github.com/formatjs/formatjs/issues/29) - by @longlho
-* **@formatjs/intl-supportedvaluesof:** update to latest spec ([#5918](/github.com/formatjs/formatjs/issues/5918)) ([f6ed7eb](github.com/formatjs/formatjs/commits/f6ed7eb6cf075e893488960acb8320e1cb99ea05)) - by @longlho
+* **@formatjs/ecma402-abstract:** upgrade Unicode from 13.0.0 to 17.0.0 ([#5866](https://github.com/formatjs/formatjs/issues/5866)) ([00343fe](https://github.com/formatjs/formatjs/commits/00343fe97e34f8f494d8b9a8b99bca50af6b48b2)) - by @longlho
+* **@formatjs/intl-pluralrules:** replace make-plural-compiler with native implementation and add BigInt support ([#5910](https://github.com/formatjs/formatjs/issues/5910)) ([bed7271](https://github.com/formatjs/formatjs/commits/bed7271893174309c320bb308c6c62756873977e)) - by @longlho
+* **@formatjs/intl-pluralrules:** support notation/compactDisplay (c/e operands) ([#5914](https://github.com/formatjs/formatjs/issues/5914)) ([c13e633](https://github.com/formatjs/formatjs/commits/c13e6331c09725e80993c8a44913d04be6ebae24)) - by @longlho
+* **@formatjs/intl-pluralrules:** support selectRange ([#5913](https://github.com/formatjs/formatjs/issues/5913)) ([3240e62](https://github.com/formatjs/formatjs/commits/3240e629c639d4c91a5c0db0b209bcacda93a505)) - by @longlho
+* **@formatjs/intl-segmenter:** improve Unicode 17.0 Format/Extend transparency and upgrade deps ([#5862](https://github.com/formatjs/formatjs/issues/5862)) ([effeb9c](https://github.com/formatjs/formatjs/commits/effeb9cd9d26f8c43c1e3df64a84c42dc7b12043)), closes [#29](https://github.com/formatjs/formatjs/issues/29) - by @longlho
+* **@formatjs/intl-supportedvaluesof:** update to latest spec ([#5918](https://github.com/formatjs/formatjs/issues/5918)) ([f6ed7eb](https://github.com/formatjs/formatjs/commits/f6ed7eb6cf075e893488960acb8320e1cb99ea05)) - by @longlho
 
-## [3.0.8](github.com/formatjs/formatjs/compare/@formatjs/ecma402-abstract@3.0.7...@formatjs/ecma402-abstract@3.0.8) (2026-01-06)
-
-**Note:** Version bump only for package @formatjs/ecma402-abstract
-
-## [3.0.7](github.com/formatjs/formatjs/compare/@formatjs/ecma402-abstract@3.0.6...@formatjs/ecma402-abstract@3.0.7) (2026-01-02)
-
-### Bug Fixes
-
-* **@formatjs/intl-datetimeformat:** add support for offset tz, fix [#4804](/github.com/formatjs/formatjs/issues/4804) ([#5735](/github.com/formatjs/formatjs/issues/5735)) ([0e835b0](github.com/formatjs/formatjs/commits/0e835b016068e1d3ffd22070be0ad9493eab5323)) - by @longlho
-* **@formatjs/intl-numberformat:** handle massive numbers, fix [#4236](/github.com/formatjs/formatjs/issues/4236) ([#5782](/github.com/formatjs/formatjs/issues/5782)) ([3464284](github.com/formatjs/formatjs/commits/3464284d983070b9b0f307f5f1d1709be829f14c)) - by @longlho
-
-## [3.0.6](github.com/formatjs/formatjs/compare/@formatjs/ecma402-abstract@3.0.5...@formatjs/ecma402-abstract@3.0.6) (2025-12-26)
-
-### Bug Fixes
-
-* **@formatjs/intl-datetimeformat:** handle interval format fallback, fix [#4168](/github.com/formatjs/formatjs/issues/4168) ([#5685](/github.com/formatjs/formatjs/issues/5685)) ([55cb0f6](github.com/formatjs/formatjs/commits/55cb0f61a85f7bf6cddd1949cb9ce0c049b43817)) - by @longlho
-
-## [3.0.5](github.com/formatjs/formatjs/compare/@formatjs/ecma402-abstract@3.0.4...@formatjs/ecma402-abstract@3.0.5) (2025-12-23)
+## [3.0.8](https://github.com/formatjs/formatjs/compare/@formatjs/ecma402-abstract@3.0.7...@formatjs/ecma402-abstract@3.0.8) (2026-01-06)
 
 **Note:** Version bump only for package @formatjs/ecma402-abstract
 
-## [3.0.4](github.com/formatjs/formatjs/compare/@formatjs/ecma402-abstract@3.0.3...@formatjs/ecma402-abstract@3.0.4) (2025-12-23)
+## [3.0.7](https://github.com/formatjs/formatjs/compare/@formatjs/ecma402-abstract@3.0.6...@formatjs/ecma402-abstract@3.0.7) (2026-01-02)
 
 ### Bug Fixes
 
-* **@formatjs/ecma402-abstract:** optimize ToRawPrecision ([#5663](/github.com/formatjs/formatjs/issues/5663)) ([99fc228](github.com/formatjs/formatjs/commits/99fc228fa43b6b7fc5a488b39cbc5269c3231738)), closes [#5023](github.com/formatjs/formatjs/issues/5023) [#5023](github.com/formatjs/formatjs/issues/5023) - by @longlho
-* **@formatjs/intl-numberformat:** optimize decimal, perf 10x, fix [#5023](/github.com/formatjs/formatjs/issues/5023) ([51fcd21](github.com/formatjs/formatjs/commits/51fcd21fbe084b8bdb3fe54a23c9bd6f37b3f5e0)) - by @longlho
+* **@formatjs/intl-datetimeformat:** add support for offset tz, fix [#4804](https://github.com/formatjs/formatjs/issues/4804) ([#5735](https://github.com/formatjs/formatjs/issues/5735)) ([0e835b0](https://github.com/formatjs/formatjs/commits/0e835b016068e1d3ffd22070be0ad9493eab5323)) - by @longlho
+* **@formatjs/intl-numberformat:** handle massive numbers, fix [#4236](https://github.com/formatjs/formatjs/issues/4236) ([#5782](https://github.com/formatjs/formatjs/issues/5782)) ([3464284](https://github.com/formatjs/formatjs/commits/3464284d983070b9b0f307f5f1d1709be829f14c)) - by @longlho
 
-## [3.0.3](github.com/formatjs/formatjs/compare/@formatjs/ecma402-abstract@3.0.2...@formatjs/ecma402-abstract@3.0.3) (2025-12-18)
-
-### Bug Fixes
-
-* **@formatjs/intl-datetimeformat:** support standalone months, fix [#5134](/github.com/formatjs/formatjs/issues/5134) ([#5583](/github.com/formatjs/formatjs/issues/5583)) ([3c7dd24](github.com/formatjs/formatjs/commits/3c7dd24854c42a3ff9034ef511fa2aff8efde78f)) - by @longlho
-
-## [3.0.2](github.com/formatjs/formatjs/compare/@formatjs/ecma402-abstract@3.0.1...@formatjs/ecma402-abstract@3.0.2) (2025-12-17)
+## [3.0.6](https://github.com/formatjs/formatjs/compare/@formatjs/ecma402-abstract@3.0.5...@formatjs/ecma402-abstract@3.0.6) (2025-12-26)
 
 ### Bug Fixes
 
-* **@formatjs/cli-lib:** fix fs-extra imports, fix [#5569](/github.com/formatjs/formatjs/issues/5569) ([76c8793](github.com/formatjs/formatjs/commits/76c8793bf8a0744ad9a7c64ab3adbe5c1434898f)) - by @longlho
+* **@formatjs/intl-datetimeformat:** handle interval format fallback, fix [#4168](https://github.com/formatjs/formatjs/issues/4168) ([#5685](https://github.com/formatjs/formatjs/issues/5685)) ([55cb0f6](https://github.com/formatjs/formatjs/commits/55cb0f61a85f7bf6cddd1949cb9ce0c049b43817)) - by @longlho
 
-## [3.0.1](github.com/formatjs/formatjs/compare/@formatjs/ecma402-abstract@3.0.0...@formatjs/ecma402-abstract@3.0.1) (2025-12-15)
+## [3.0.5](https://github.com/formatjs/formatjs/compare/@formatjs/ecma402-abstract@3.0.4...@formatjs/ecma402-abstract@3.0.5) (2025-12-23)
 
 **Note:** Version bump only for package @formatjs/ecma402-abstract
 
-## [3.0.0](/github.com/formatjs/formatjs/compare/@formatjs/ecma402-abstract@2.3.6...@formatjs/ecma402-abstract@3.0.0) (2025-12-15)
+## [3.0.4](https://github.com/formatjs/formatjs/compare/@formatjs/ecma402-abstract@3.0.3...@formatjs/ecma402-abstract@3.0.4) (2025-12-23)
+
+### Bug Fixes
+
+* **@formatjs/ecma402-abstract:** optimize ToRawPrecision ([#5663](https://github.com/formatjs/formatjs/issues/5663)) ([99fc228](https://github.com/formatjs/formatjs/commits/99fc228fa43b6b7fc5a488b39cbc5269c3231738)), closes [#5023](https://github.com/formatjs/formatjs/issues/5023) [#5023](https://github.com/formatjs/formatjs/issues/5023) - by @longlho
+* **@formatjs/intl-numberformat:** optimize decimal, perf 10x, fix [#5023](https://github.com/formatjs/formatjs/issues/5023) ([51fcd21](https://github.com/formatjs/formatjs/commits/51fcd21fbe084b8bdb3fe54a23c9bd6f37b3f5e0)) - by @longlho
+
+## [3.0.3](https://github.com/formatjs/formatjs/compare/@formatjs/ecma402-abstract@3.0.2...@formatjs/ecma402-abstract@3.0.3) (2025-12-18)
+
+### Bug Fixes
+
+* **@formatjs/intl-datetimeformat:** support standalone months, fix [#5134](https://github.com/formatjs/formatjs/issues/5134) ([#5583](https://github.com/formatjs/formatjs/issues/5583)) ([3c7dd24](https://github.com/formatjs/formatjs/commits/3c7dd24854c42a3ff9034ef511fa2aff8efde78f)) - by @longlho
+
+## [3.0.2](https://github.com/formatjs/formatjs/compare/@formatjs/ecma402-abstract@3.0.1...@formatjs/ecma402-abstract@3.0.2) (2025-12-17)
+
+### Bug Fixes
+
+* **@formatjs/cli-lib:** fix fs-extra imports, fix [#5569](https://github.com/formatjs/formatjs/issues/5569) ([76c8793](https://github.com/formatjs/formatjs/commits/76c8793bf8a0744ad9a7c64ab3adbe5c1434898f)) - by @longlho
+
+## [3.0.1](https://github.com/formatjs/formatjs/compare/@formatjs/ecma402-abstract@3.0.0...@formatjs/ecma402-abstract@3.0.1) (2025-12-15)
+
+**Note:** Version bump only for package @formatjs/ecma402-abstract
+
+## [3.0.0](https://github.com/formatjs/formatjs/compare/@formatjs/ecma402-abstract@2.3.6...@formatjs/ecma402-abstract@3.0.0) (2025-12-15)
 
 ### ⚠ BREAKING CHANGES
 
@@ -80,19 +80,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* **@formatjs/ecma402-abstract:** convert to esm ([#5466](/github.com/formatjs/formatjs/issues/5466)) ([0911508](/github.com/formatjs/formatjs/commit/0911508aeabd9331ded8e75cd03182d814849bbe)) - by @longlho
+* **@formatjs/ecma402-abstract:** convert to esm ([#5466](https://github.com/formatjs/formatjs/issues/5466)) ([0911508](https://github.com/formatjs/formatjs/commit/0911508aeabd9331ded8e75cd03182d814849bbe)) - by @longlho
 
-## [2.3.6](github.com/formatjs/formatjs/compare/@formatjs/ecma402-abstract@2.3.5...@formatjs/ecma402-abstract@2.3.6) (2025-10-09)
-
-### Bug Fixes
-
-* add a comment just to bump patch version ([fe0dd85](github.com/formatjs/formatjs/commits/fe0dd851574d1413fd8820d28f18cbd660a81776)) - by @longlho
-
-## [2.3.5](github.com/formatjs/formatjs/compare/@formatjs/ecma402-abstract@2.3.4...@formatjs/ecma402-abstract@2.3.5) (2025-10-03)
+## [2.3.6](https://github.com/formatjs/formatjs/compare/@formatjs/ecma402-abstract@2.3.5...@formatjs/ecma402-abstract@2.3.6) (2025-10-09)
 
 ### Bug Fixes
 
-* **ecma402:** DayFromYear handling for years below 100 AD ([#5039](/github.com/formatjs/formatjs/issues/5039)) ([aef53fb](github.com/formatjs/formatjs/commits/aef53fbc55240cb116c02d0ac57b5e4be41609e4)), closes [#5038](github.com/formatjs/formatjs/issues/5038) - by @korri123
+* add a comment just to bump patch version ([fe0dd85](https://github.com/formatjs/formatjs/commits/fe0dd851574d1413fd8820d28f18cbd660a81776)) - by @longlho
+
+## [2.3.5](https://github.com/formatjs/formatjs/compare/@formatjs/ecma402-abstract@2.3.4...@formatjs/ecma402-abstract@2.3.5) (2025-10-03)
+
+### Bug Fixes
+
+* **ecma402:** DayFromYear handling for years below 100 AD ([#5039](https://github.com/formatjs/formatjs/issues/5039)) ([aef53fb](https://github.com/formatjs/formatjs/commits/aef53fbc55240cb116c02d0ac57b5e4be41609e4)), closes [#5038](https://github.com/formatjs/formatjs/issues/5038) - by @korri123
 
 ## [2.3.4](https://github.com/formatjs/formatjs/compare/@formatjs/ecma402-abstract@2.3.3...@formatjs/ecma402-abstract@2.3.4) (2025-03-23)
 

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -3,87 +3,87 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [3.0.20](github.com/formatjs/formatjs/compare/@formatjs/editor@3.0.19...@formatjs/editor@3.0.20) (2026-03-27)
+## [3.0.20](https://github.com/formatjs/formatjs/compare/@formatjs/editor@3.0.19...@formatjs/editor@3.0.20) (2026-03-27)
 
 **Note:** Version bump only for package @formatjs/editor
 
-## [3.0.19](github.com/formatjs/formatjs/compare/@formatjs/editor@3.0.18...@formatjs/editor@3.0.19) (2026-03-17)
+## [3.0.19](https://github.com/formatjs/formatjs/compare/@formatjs/editor@3.0.18...@formatjs/editor@3.0.19) (2026-03-17)
 
 **Note:** Version bump only for package @formatjs/editor
 
-## [3.0.18](github.com/formatjs/formatjs/compare/@formatjs/editor@3.0.17...@formatjs/editor@3.0.18) (2026-03-16)
+## [3.0.18](https://github.com/formatjs/formatjs/compare/@formatjs/editor@3.0.17...@formatjs/editor@3.0.18) (2026-03-16)
 
 **Note:** Version bump only for package @formatjs/editor
 
-## [3.0.17](github.com/formatjs/formatjs/compare/@formatjs/editor@3.0.16...@formatjs/editor@3.0.17) (2026-03-16)
+## [3.0.17](https://github.com/formatjs/formatjs/compare/@formatjs/editor@3.0.16...@formatjs/editor@3.0.17) (2026-03-16)
 
 **Note:** Version bump only for package @formatjs/editor
 
-## [3.0.16](github.com/formatjs/formatjs/compare/@formatjs/editor@3.0.15...@formatjs/editor@3.0.16) (2026-03-15)
+## [3.0.16](https://github.com/formatjs/formatjs/compare/@formatjs/editor@3.0.15...@formatjs/editor@3.0.16) (2026-03-15)
 
 **Note:** Version bump only for package @formatjs/editor
 
-## [3.0.15](github.com/formatjs/formatjs/compare/@formatjs/editor@3.0.14...@formatjs/editor@3.0.15) (2026-02-03)
+## [3.0.15](https://github.com/formatjs/formatjs/compare/@formatjs/editor@3.0.14...@formatjs/editor@3.0.15) (2026-02-03)
 
 **Note:** Version bump only for package @formatjs/editor
 
-## [3.0.14](github.com/formatjs/formatjs/compare/@formatjs/editor@3.0.13...@formatjs/editor@3.0.14) (2026-02-01)
+## [3.0.14](https://github.com/formatjs/formatjs/compare/@formatjs/editor@3.0.13...@formatjs/editor@3.0.14) (2026-02-01)
 
 **Note:** Version bump only for package @formatjs/editor
 
-## [3.0.13](github.com/formatjs/formatjs/compare/@formatjs/editor@3.0.12...@formatjs/editor@3.0.13) (2026-01-19)
+## [3.0.13](https://github.com/formatjs/formatjs/compare/@formatjs/editor@3.0.12...@formatjs/editor@3.0.13) (2026-01-19)
 
 **Note:** Version bump only for package @formatjs/editor
 
-## [3.0.12](github.com/formatjs/formatjs/compare/@formatjs/editor@3.0.11...@formatjs/editor@3.0.12) (2026-01-15)
+## [3.0.12](https://github.com/formatjs/formatjs/compare/@formatjs/editor@3.0.11...@formatjs/editor@3.0.12) (2026-01-15)
 
 **Note:** Version bump only for package @formatjs/editor
 
-## [3.0.11](github.com/formatjs/formatjs/compare/@formatjs/editor@3.0.10...@formatjs/editor@3.0.11) (2026-01-06)
+## [3.0.11](https://github.com/formatjs/formatjs/compare/@formatjs/editor@3.0.10...@formatjs/editor@3.0.11) (2026-01-06)
 
 **Note:** Version bump only for package @formatjs/editor
 
-## [3.0.10](github.com/formatjs/formatjs/compare/@formatjs/editor@3.0.9...@formatjs/editor@3.0.10) (2026-01-02)
+## [3.0.10](https://github.com/formatjs/formatjs/compare/@formatjs/editor@3.0.9...@formatjs/editor@3.0.10) (2026-01-02)
 
 **Note:** Version bump only for package @formatjs/editor
 
-## [3.0.9](github.com/formatjs/formatjs/compare/@formatjs/editor@3.0.8...@formatjs/editor@3.0.9) (2025-12-26)
+## [3.0.9](https://github.com/formatjs/formatjs/compare/@formatjs/editor@3.0.8...@formatjs/editor@3.0.9) (2025-12-26)
 
 **Note:** Version bump only for package @formatjs/editor
 
-## [3.0.8](github.com/formatjs/formatjs/compare/@formatjs/editor@3.0.7...@formatjs/editor@3.0.8) (2025-12-23)
+## [3.0.8](https://github.com/formatjs/formatjs/compare/@formatjs/editor@3.0.7...@formatjs/editor@3.0.8) (2025-12-23)
 
 **Note:** Version bump only for package @formatjs/editor
 
-## [3.0.7](github.com/formatjs/formatjs/compare/@formatjs/editor@3.0.6...@formatjs/editor@3.0.7) (2025-12-23)
+## [3.0.7](https://github.com/formatjs/formatjs/compare/@formatjs/editor@3.0.6...@formatjs/editor@3.0.7) (2025-12-23)
 
 **Note:** Version bump only for package @formatjs/editor
 
-## [3.0.6](github.com/formatjs/formatjs/compare/@formatjs/editor@3.0.5...@formatjs/editor@3.0.6) (2025-12-19)
+## [3.0.6](https://github.com/formatjs/formatjs/compare/@formatjs/editor@3.0.5...@formatjs/editor@3.0.6) (2025-12-19)
 
 **Note:** Version bump only for package @formatjs/editor
 
-## [3.0.5](github.com/formatjs/formatjs/compare/@formatjs/editor@3.0.4...@formatjs/editor@3.0.5) (2025-12-18)
+## [3.0.5](https://github.com/formatjs/formatjs/compare/@formatjs/editor@3.0.4...@formatjs/editor@3.0.5) (2025-12-18)
 
 **Note:** Version bump only for package @formatjs/editor
 
-## [3.0.4](github.com/formatjs/formatjs/compare/@formatjs/editor@3.0.3...@formatjs/editor@3.0.4) (2025-12-17)
+## [3.0.4](https://github.com/formatjs/formatjs/compare/@formatjs/editor@3.0.3...@formatjs/editor@3.0.4) (2025-12-17)
 
 **Note:** Version bump only for package @formatjs/editor
 
-## [3.0.3](github.com/formatjs/formatjs/compare/@formatjs/editor@3.0.2...@formatjs/editor@3.0.3) (2025-12-16)
+## [3.0.3](https://github.com/formatjs/formatjs/compare/@formatjs/editor@3.0.2...@formatjs/editor@3.0.3) (2025-12-16)
 
 **Note:** Version bump only for package @formatjs/editor
 
-## [3.0.2](github.com/formatjs/formatjs/compare/@formatjs/editor@3.0.1...@formatjs/editor@3.0.2) (2025-12-16)
+## [3.0.2](https://github.com/formatjs/formatjs/compare/@formatjs/editor@3.0.1...@formatjs/editor@3.0.2) (2025-12-16)
 
 **Note:** Version bump only for package @formatjs/editor
 
-## [3.0.1](github.com/formatjs/formatjs/compare/@formatjs/editor@3.0.0...@formatjs/editor@3.0.1) (2025-12-15)
+## [3.0.1](https://github.com/formatjs/formatjs/compare/@formatjs/editor@3.0.0...@formatjs/editor@3.0.1) (2025-12-15)
 
 **Note:** Version bump only for package @formatjs/editor
 
-## [3.0.0](/github.com/formatjs/formatjs/compare/@formatjs/editor@2.0.80...@formatjs/editor@3.0.0) (2025-12-15)
+## [3.0.0](https://github.com/formatjs/formatjs/compare/@formatjs/editor@2.0.80...@formatjs/editor@3.0.0) (2025-12-15)
 
 ### ⚠ BREAKING CHANGES
 
@@ -92,18 +92,18 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* **@formatjs/editor:** convert to ESM ([#5455](/github.com/formatjs/formatjs/issues/5455)) ([5d6928e](/github.com/formatjs/formatjs/commit/5d6928e1ee25a052c3e4b4d79c36bc4983b4db9b)) - by @longlho
-* **react-intl:** drop support for React 18 and below ([#5485](/github.com/formatjs/formatjs/issues/5485)) ([2ea4b7e](/github.com/formatjs/formatjs/commit/2ea4b7e4ffa7df0974632fdbeb632da6dc9c0f6c)) - by @longlho
+* **@formatjs/editor:** convert to ESM ([#5455](https://github.com/formatjs/formatjs/issues/5455)) ([5d6928e](https://github.com/formatjs/formatjs/commit/5d6928e1ee25a052c3e4b4d79c36bc4983b4db9b)) - by @longlho
+* **react-intl:** drop support for React 18 and below ([#5485](https://github.com/formatjs/formatjs/issues/5485)) ([2ea4b7e](https://github.com/formatjs/formatjs/commit/2ea4b7e4ffa7df0974632fdbeb632da6dc9c0f6c)) - by @longlho
 
-## [2.0.80](github.com/formatjs/formatjs/compare/@formatjs/editor@2.0.79...@formatjs/editor@2.0.80) (2025-10-09)
-
-**Note:** Version bump only for package @formatjs/editor
-
-## [2.0.79](github.com/formatjs/formatjs/compare/@formatjs/editor@2.0.78...@formatjs/editor@2.0.79) (2025-10-06)
+## [2.0.80](https://github.com/formatjs/formatjs/compare/@formatjs/editor@2.0.79...@formatjs/editor@2.0.80) (2025-10-09)
 
 **Note:** Version bump only for package @formatjs/editor
 
-## [2.0.78](github.com/formatjs/formatjs/compare/@formatjs/editor@2.0.77...@formatjs/editor@2.0.78) (2025-10-03)
+## [2.0.79](https://github.com/formatjs/formatjs/compare/@formatjs/editor@2.0.78...@formatjs/editor@2.0.79) (2025-10-06)
+
+**Note:** Version bump only for package @formatjs/editor
+
+## [2.0.78](https://github.com/formatjs/formatjs/compare/@formatjs/editor@2.0.77...@formatjs/editor@2.0.78) (2025-10-03)
 
 **Note:** Version bump only for package @formatjs/editor
 

--- a/packages/intl-listformat/CHANGELOG.md
+++ b/packages/intl-listformat/CHANGELOG.md
@@ -3,82 +3,82 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [8.3.1](github.com/formatjs/formatjs/compare/@formatjs/intl-listformat@8.3.0...@formatjs/intl-listformat@8.3.1) (2026-03-19)
+## [8.3.1](https://github.com/formatjs/formatjs/compare/@formatjs/intl-listformat@8.3.0...@formatjs/intl-listformat@8.3.1) (2026-03-19)
 
 ### Bug Fixes
 
-* **deps:** update .bazeliskrc to Bazel 9.0.1 ([#6151](/github.com/formatjs/formatjs/issues/6151)) ([92f9803](github.com/formatjs/formatjs/commits/92f9803232789835d97d97d336ddbbdefb753c6c)), closes [#6135](github.com/formatjs/formatjs/issues/6135) - by @longlho
+* **deps:** update .bazeliskrc to Bazel 9.0.1 ([#6151](https://github.com/formatjs/formatjs/issues/6151)) ([92f9803](https://github.com/formatjs/formatjs/commits/92f9803232789835d97d97d336ddbbdefb753c6c)), closes [#6135](https://github.com/formatjs/formatjs/issues/6135) - by @longlho
 
-# [8.3.0](github.com/formatjs/formatjs/compare/@formatjs/intl-listformat@8.2.3...@formatjs/intl-listformat@8.3.0) (2026-03-17)
+# [8.3.0](https://github.com/formatjs/formatjs/compare/@formatjs/intl-listformat@8.2.3...@formatjs/intl-listformat@8.3.0) (2026-03-17)
 
 ### Features
 
-* **@formatjs/ecma402-abstract:** migrate from decimal.js to @formatjs/bigdecimal ([#6148](/github.com/formatjs/formatjs/issues/6148)) ([93744d4](github.com/formatjs/formatjs/commits/93744d4732ab2dfdc93e7ddb2a73e80a6e461534)) - by @longlho
-* buffer locale data for parallel polyfill + data loading ([#6145](/github.com/formatjs/formatjs/issues/6145)) ([1b28e30](github.com/formatjs/formatjs/commits/1b28e30c26c264a039e1326a45c4fecb649e5d45)), closes [#4457](github.com/formatjs/formatjs/issues/4457) - by @longlho
+* **@formatjs/ecma402-abstract:** migrate from decimal.js to @formatjs/bigdecimal ([#6148](https://github.com/formatjs/formatjs/issues/6148)) ([93744d4](https://github.com/formatjs/formatjs/commits/93744d4732ab2dfdc93e7ddb2a73e80a6e461534)) - by @longlho
+* buffer locale data for parallel polyfill + data loading ([#6145](https://github.com/formatjs/formatjs/issues/6145)) ([1b28e30](https://github.com/formatjs/formatjs/commits/1b28e30c26c264a039e1326a45c4fecb649e5d45)), closes [#4457](https://github.com/formatjs/formatjs/issues/4457) - by @longlho
 
-## [8.2.3](github.com/formatjs/formatjs/compare/@formatjs/intl-listformat@8.2.2...@formatjs/intl-listformat@8.2.3) (2026-03-16)
+## [8.2.3](https://github.com/formatjs/formatjs/compare/@formatjs/intl-listformat@8.2.2...@formatjs/intl-listformat@8.2.3) (2026-03-16)
 
 **Note:** Version bump only for package @formatjs/intl-listformat
 
-## [8.2.2](github.com/formatjs/formatjs/compare/@formatjs/intl-listformat@8.2.1...@formatjs/intl-listformat@8.2.2) (2026-03-09)
+## [8.2.2](https://github.com/formatjs/formatjs/compare/@formatjs/intl-listformat@8.2.1...@formatjs/intl-listformat@8.2.2) (2026-03-09)
 
 ### Bug Fixes
 
-* add locale-data directory export for variable dynamic imports ([#6063](/github.com/formatjs/formatjs/issues/6063)) ([0492f8b](github.com/formatjs/formatjs/commits/0492f8bf5c7cefb561b2bc7b9f7363d218bd0641)), closes [#6060](github.com/formatjs/formatjs/issues/6060) - by @longlho
+* add locale-data directory export for variable dynamic imports ([#6063](https://github.com/formatjs/formatjs/issues/6063)) ([0492f8b](https://github.com/formatjs/formatjs/commits/0492f8bf5c7cefb561b2bc7b9f7363d218bd0641)), closes [#6060](https://github.com/formatjs/formatjs/issues/6060) - by @longlho
 
-## [8.2.1](github.com/formatjs/formatjs/compare/@formatjs/intl-listformat@8.2.0...@formatjs/intl-listformat@8.2.1) (2026-02-01)
+## [8.2.1](https://github.com/formatjs/formatjs/compare/@formatjs/intl-listformat@8.2.0...@formatjs/intl-listformat@8.2.1) (2026-02-01)
 
 **Note:** Version bump only for package @formatjs/intl-listformat
 
-# [8.2.0](github.com/formatjs/formatjs/compare/@formatjs/intl-listformat@8.1.2...@formatjs/intl-listformat@8.2.0) (2026-01-15)
+# [8.2.0](https://github.com/formatjs/formatjs/compare/@formatjs/intl-listformat@8.1.2...@formatjs/intl-listformat@8.2.0) (2026-01-15)
 
 ### Features
 
-* **@formatjs/intl-segmenter:** improve Unicode 17.0 Format/Extend transparency and upgrade deps ([#5862](/github.com/formatjs/formatjs/issues/5862)) ([effeb9c](github.com/formatjs/formatjs/commits/effeb9cd9d26f8c43c1e3df64a84c42dc7b12043)), closes [#29](github.com/formatjs/formatjs/issues/29) - by @longlho
+* **@formatjs/intl-segmenter:** improve Unicode 17.0 Format/Extend transparency and upgrade deps ([#5862](https://github.com/formatjs/formatjs/issues/5862)) ([effeb9c](https://github.com/formatjs/formatjs/commits/effeb9cd9d26f8c43c1e3df64a84c42dc7b12043)), closes [#29](https://github.com/formatjs/formatjs/issues/29) - by @longlho
 
-## [8.1.2](github.com/formatjs/formatjs/compare/@formatjs/intl-listformat@8.1.1...@formatjs/intl-listformat@8.1.2) (2026-01-06)
-
-**Note:** Version bump only for package @formatjs/intl-listformat
-
-## [8.1.1](github.com/formatjs/formatjs/compare/@formatjs/intl-listformat@8.1.0...@formatjs/intl-listformat@8.1.1) (2026-01-02)
+## [8.1.2](https://github.com/formatjs/formatjs/compare/@formatjs/intl-listformat@8.1.1...@formatjs/intl-listformat@8.1.2) (2026-01-06)
 
 **Note:** Version bump only for package @formatjs/intl-listformat
 
-# [8.1.0](github.com/formatjs/formatjs/compare/@formatjs/intl-listformat@8.0.6...@formatjs/intl-listformat@8.1.0) (2025-12-26)
+## [8.1.1](https://github.com/formatjs/formatjs/compare/@formatjs/intl-listformat@8.1.0...@formatjs/intl-listformat@8.1.1) (2026-01-02)
+
+**Note:** Version bump only for package @formatjs/intl-listformat
+
+# [8.1.0](https://github.com/formatjs/formatjs/compare/@formatjs/intl-listformat@8.0.6...@formatjs/intl-listformat@8.1.0) (2025-12-26)
 
 ### Features
 
-* upgrade cldr to v48 ([#5678](/github.com/formatjs/formatjs/issues/5678)) ([54ef319](github.com/formatjs/formatjs/commits/54ef31940172467889be64907e9fbbf567ea3f4b)) - by @longlho
+* upgrade cldr to v48 ([#5678](https://github.com/formatjs/formatjs/issues/5678)) ([54ef319](https://github.com/formatjs/formatjs/commits/54ef31940172467889be64907e9fbbf567ea3f4b)) - by @longlho
 
-## [8.0.6](github.com/formatjs/formatjs/compare/@formatjs/intl-listformat@8.0.5...@formatjs/intl-listformat@8.0.6) (2025-12-23)
-
-**Note:** Version bump only for package @formatjs/intl-listformat
-
-## [8.0.5](github.com/formatjs/formatjs/compare/@formatjs/intl-listformat@8.0.4...@formatjs/intl-listformat@8.0.5) (2025-12-23)
+## [8.0.6](https://github.com/formatjs/formatjs/compare/@formatjs/intl-listformat@8.0.5...@formatjs/intl-listformat@8.0.6) (2025-12-23)
 
 **Note:** Version bump only for package @formatjs/intl-listformat
 
-## [8.0.4](github.com/formatjs/formatjs/compare/@formatjs/intl-listformat@8.0.3...@formatjs/intl-listformat@8.0.4) (2025-12-19)
+## [8.0.5](https://github.com/formatjs/formatjs/compare/@formatjs/intl-listformat@8.0.4...@formatjs/intl-listformat@8.0.5) (2025-12-23)
+
+**Note:** Version bump only for package @formatjs/intl-listformat
+
+## [8.0.4](https://github.com/formatjs/formatjs/compare/@formatjs/intl-listformat@8.0.3...@formatjs/intl-listformat@8.0.4) (2025-12-19)
 
 ### Bug Fixes
 
-* **@formatjs/utils:** fix json ESM import ([#5594](/github.com/formatjs/formatjs/issues/5594)) ([dfd79a2](github.com/formatjs/formatjs/commits/dfd79a2d9935e0b7d06c08555ff6625d3f1c884f)) - by @longlho
+* **@formatjs/utils:** fix json ESM import ([#5594](https://github.com/formatjs/formatjs/issues/5594)) ([dfd79a2](https://github.com/formatjs/formatjs/commits/dfd79a2d9935e0b7d06c08555ff6625d3f1c884f)) - by @longlho
 
-## [8.0.3](github.com/formatjs/formatjs/compare/@formatjs/intl-listformat@8.0.2...@formatjs/intl-listformat@8.0.3) (2025-12-18)
+## [8.0.3](https://github.com/formatjs/formatjs/compare/@formatjs/intl-listformat@8.0.2...@formatjs/intl-listformat@8.0.3) (2025-12-18)
 
 **Note:** Version bump only for package @formatjs/intl-listformat
 
-## [8.0.2](github.com/formatjs/formatjs/compare/@formatjs/intl-listformat@8.0.1...@formatjs/intl-listformat@8.0.2) (2025-12-17)
+## [8.0.2](https://github.com/formatjs/formatjs/compare/@formatjs/intl-listformat@8.0.1...@formatjs/intl-listformat@8.0.2) (2025-12-17)
 
 ### Bug Fixes
 
-* **@formatjs/cli-lib:** fix fs-extra imports, fix [#5569](/github.com/formatjs/formatjs/issues/5569) ([76c8793](github.com/formatjs/formatjs/commits/76c8793bf8a0744ad9a7c64ab3adbe5c1434898f)) - by @longlho
+* **@formatjs/cli-lib:** fix fs-extra imports, fix [#5569](https://github.com/formatjs/formatjs/issues/5569) ([76c8793](https://github.com/formatjs/formatjs/commits/76c8793bf8a0744ad9a7c64ab3adbe5c1434898f)) - by @longlho
 
-## [8.0.1](github.com/formatjs/formatjs/compare/@formatjs/intl-listformat@8.0.0...@formatjs/intl-listformat@8.0.1) (2025-12-15)
+## [8.0.1](https://github.com/formatjs/formatjs/compare/@formatjs/intl-listformat@8.0.0...@formatjs/intl-listformat@8.0.1) (2025-12-15)
 
 **Note:** Version bump only for package @formatjs/intl-listformat
 
-## [8.0.0](/github.com/formatjs/formatjs/compare/@formatjs/intl-listformat@7.7.13...@formatjs/intl-listformat@8.0.0) (2025-12-15)
+## [8.0.0](https://github.com/formatjs/formatjs/compare/@formatjs/intl-listformat@7.7.13...@formatjs/intl-listformat@8.0.0) (2025-12-15)
 
 ### ⚠ BREAKING CHANGES
 
@@ -88,23 +88,23 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* **@formatjs/intl-getcanonicallocales:** convert to esm ([#5457](/github.com/formatjs/formatjs/issues/5457)) ([e1a6d19](/github.com/formatjs/formatjs/commit/e1a6d196404a25c67eba3bc149b9d5162715f0db)) - by @longlho
-* **@formatjs/intl-listformat:** convert to ESM ([bef4a10](/github.com/formatjs/formatjs/commit/bef4a1030ccda93c863af47790b9618e5316cf40)) - by @longlho
-* **@formatjs/intl-locale:** convert to esm ([#5435](/github.com/formatjs/formatjs/issues/5435)) ([fc9ae8e](/github.com/formatjs/formatjs/commit/fc9ae8e20b556108b1b800fb930d70ffc5545041)) - by @longlho
+* **@formatjs/intl-getcanonicallocales:** convert to esm ([#5457](https://github.com/formatjs/formatjs/issues/5457)) ([e1a6d19](https://github.com/formatjs/formatjs/commit/e1a6d196404a25c67eba3bc149b9d5162715f0db)) - by @longlho
+* **@formatjs/intl-listformat:** convert to ESM ([bef4a10](https://github.com/formatjs/formatjs/commit/bef4a1030ccda93c863af47790b9618e5316cf40)) - by @longlho
+* **@formatjs/intl-locale:** convert to esm ([#5435](https://github.com/formatjs/formatjs/issues/5435)) ([fc9ae8e](https://github.com/formatjs/formatjs/commit/fc9ae8e20b556108b1b800fb930d70ffc5545041)) - by @longlho
 
 ### Bug Fixes
 
-* fix exports ([#5430](/github.com/formatjs/formatjs/issues/5430)) ([b7a9b4c](/github.com/formatjs/formatjs/commit/b7a9b4cd7a0566c6aaa33305a9f700d639f30ddd)) - by @longlho
+* fix exports ([#5430](https://github.com/formatjs/formatjs/issues/5430)) ([b7a9b4c](https://github.com/formatjs/formatjs/commit/b7a9b4cd7a0566c6aaa33305a9f700d639f30ddd)) - by @longlho
 
-## [7.7.13](github.com/formatjs/formatjs/compare/@formatjs/intl-listformat@7.7.12...@formatjs/intl-listformat@7.7.13) (2025-10-09)
+## [7.7.13](https://github.com/formatjs/formatjs/compare/@formatjs/intl-listformat@7.7.12...@formatjs/intl-listformat@7.7.13) (2025-10-09)
 
 **Note:** Version bump only for package @formatjs/intl-listformat
 
-## [7.7.12](github.com/formatjs/formatjs/compare/@formatjs/intl-listformat@7.7.11...@formatjs/intl-listformat@7.7.12) (2025-10-03)
+## [7.7.12](https://github.com/formatjs/formatjs/compare/@formatjs/intl-listformat@7.7.11...@formatjs/intl-listformat@7.7.12) (2025-10-03)
 
 ### Bug Fixes
 
-* string list from iterable ([#5046](/github.com/formatjs/formatjs/issues/5046)) ([19a4c05](github.com/formatjs/formatjs/commits/19a4c051238aa48c6cab5eadf3a46ca7783a987c)) - by @septs
+* string list from iterable ([#5046](https://github.com/formatjs/formatjs/issues/5046)) ([19a4c05](https://github.com/formatjs/formatjs/commits/19a4c051238aa48c6cab5eadf3a46ca7783a987c)) - by @septs
 
 ## [7.7.11](https://github.com/formatjs/formatjs/compare/@formatjs/intl-listformat@7.7.10...@formatjs/intl-listformat@7.7.11) (2025-03-23)
 

--- a/packages/intl-messageformat/CHANGELOG.md
+++ b/packages/intl-messageformat/CHANGELOG.md
@@ -3,70 +3,70 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [11.2.0](github.com/formatjs/formatjs/compare/intl-messageformat@11.1.3...intl-messageformat@11.2.0) (2026-03-17)
+# [11.2.0](https://github.com/formatjs/formatjs/compare/intl-messageformat@11.1.3...intl-messageformat@11.2.0) (2026-03-17)
 
 ### Features
 
-* **@formatjs/ecma402-abstract:** migrate from decimal.js to @formatjs/bigdecimal ([#6148](/github.com/formatjs/formatjs/issues/6148)) ([93744d4](github.com/formatjs/formatjs/commits/93744d4732ab2dfdc93e7ddb2a73e80a6e461534)) - by @longlho
+* **@formatjs/ecma402-abstract:** migrate from decimal.js to @formatjs/bigdecimal ([#6148](https://github.com/formatjs/formatjs/issues/6148)) ([93744d4](https://github.com/formatjs/formatjs/commits/93744d4732ab2dfdc93e7ddb2a73e80a6e461534)) - by @longlho
 
-## [11.1.3](github.com/formatjs/formatjs/compare/intl-messageformat@11.1.2...intl-messageformat@11.1.3) (2026-03-16)
-
-**Note:** Version bump only for package intl-messageformat
-
-## [11.1.2](github.com/formatjs/formatjs/compare/intl-messageformat@11.1.1...intl-messageformat@11.1.2) (2026-02-01)
+## [11.1.3](https://github.com/formatjs/formatjs/compare/intl-messageformat@11.1.2...intl-messageformat@11.1.3) (2026-03-16)
 
 **Note:** Version bump only for package intl-messageformat
 
-## [11.1.1](github.com/formatjs/formatjs/compare/intl-messageformat@11.1.0...intl-messageformat@11.1.1) (2026-01-19)
+## [11.1.2](https://github.com/formatjs/formatjs/compare/intl-messageformat@11.1.1...intl-messageformat@11.1.2) (2026-02-01)
 
 **Note:** Version bump only for package intl-messageformat
 
-# [11.1.0](github.com/formatjs/formatjs/compare/intl-messageformat@11.0.9...intl-messageformat@11.1.0) (2026-01-15)
+## [11.1.1](https://github.com/formatjs/formatjs/compare/intl-messageformat@11.1.0...intl-messageformat@11.1.1) (2026-01-19)
+
+**Note:** Version bump only for package intl-messageformat
+
+# [11.1.0](https://github.com/formatjs/formatjs/compare/intl-messageformat@11.0.9...intl-messageformat@11.1.0) (2026-01-15)
 
 ### Features
 
-* **@formatjs/intl-segmenter:** improve Unicode 17.0 Format/Extend transparency and upgrade deps ([#5862](/github.com/formatjs/formatjs/issues/5862)) ([effeb9c](github.com/formatjs/formatjs/commits/effeb9cd9d26f8c43c1e3df64a84c42dc7b12043)), closes [#29](github.com/formatjs/formatjs/issues/29) - by @longlho
+* **@formatjs/intl-segmenter:** improve Unicode 17.0 Format/Extend transparency and upgrade deps ([#5862](https://github.com/formatjs/formatjs/issues/5862)) ([effeb9c](https://github.com/formatjs/formatjs/commits/effeb9cd9d26f8c43c1e3df64a84c42dc7b12043)), closes [#29](https://github.com/formatjs/formatjs/issues/29) - by @longlho
 
-## [11.0.9](github.com/formatjs/formatjs/compare/intl-messageformat@11.0.8...intl-messageformat@11.0.9) (2026-01-06)
+## [11.0.9](https://github.com/formatjs/formatjs/compare/intl-messageformat@11.0.8...intl-messageformat@11.0.9) (2026-01-06)
 
 **Note:** Version bump only for package intl-messageformat
 
-## [11.0.8](github.com/formatjs/formatjs/compare/intl-messageformat@11.0.7...intl-messageformat@11.0.8) (2026-01-02)
+## [11.0.8](https://github.com/formatjs/formatjs/compare/intl-messageformat@11.0.7...intl-messageformat@11.0.8) (2026-01-02)
 
 ### Bug Fixes
 
-* **intl-messageformat:** fix value having special key like constructor, fix #[#4490](/github.com/formatjs/formatjs/issues/4490) ([#5751](/github.com/formatjs/formatjs/issues/5751)) ([83d24fe](github.com/formatjs/formatjs/commits/83d24fe00c3eedac8d8a298abb1d1d93509fef80)) - by @longlho
-* **intl-messageformat:** handle bigint, fix [#5081](/github.com/formatjs/formatjs/issues/5081) ([#5743](/github.com/formatjs/formatjs/issues/5743)) ([aa40318](github.com/formatjs/formatjs/commits/aa4031838aa136db882d1f6ba6101480094014ff)) - by @longlho
+* **intl-messageformat:** fix value having special key like constructor, fix #[#4490](https://github.com/formatjs/formatjs/issues/4490) ([#5751](https://github.com/formatjs/formatjs/issues/5751)) ([83d24fe](https://github.com/formatjs/formatjs/commits/83d24fe00c3eedac8d8a298abb1d1d93509fef80)) - by @longlho
+* **intl-messageformat:** handle bigint, fix [#5081](https://github.com/formatjs/formatjs/issues/5081) ([#5743](https://github.com/formatjs/formatjs/issues/5743)) ([aa40318](https://github.com/formatjs/formatjs/commits/aa4031838aa136db882d1f6ba6101480094014ff)) - by @longlho
 
-## [11.0.7](github.com/formatjs/formatjs/compare/intl-messageformat@11.0.6...intl-messageformat@11.0.7) (2025-12-26)
-
-**Note:** Version bump only for package intl-messageformat
-
-## [11.0.6](github.com/formatjs/formatjs/compare/intl-messageformat@11.0.5...intl-messageformat@11.0.6) (2025-12-23)
+## [11.0.7](https://github.com/formatjs/formatjs/compare/intl-messageformat@11.0.6...intl-messageformat@11.0.7) (2025-12-26)
 
 **Note:** Version bump only for package intl-messageformat
 
-## [11.0.5](github.com/formatjs/formatjs/compare/intl-messageformat@11.0.4...intl-messageformat@11.0.5) (2025-12-23)
+## [11.0.6](https://github.com/formatjs/formatjs/compare/intl-messageformat@11.0.5...intl-messageformat@11.0.6) (2025-12-23)
 
 **Note:** Version bump only for package intl-messageformat
 
-## [11.0.4](github.com/formatjs/formatjs/compare/intl-messageformat@11.0.3...intl-messageformat@11.0.4) (2025-12-19)
+## [11.0.5](https://github.com/formatjs/formatjs/compare/intl-messageformat@11.0.4...intl-messageformat@11.0.5) (2025-12-23)
 
 **Note:** Version bump only for package intl-messageformat
 
-## [11.0.3](github.com/formatjs/formatjs/compare/intl-messageformat@11.0.2...intl-messageformat@11.0.3) (2025-12-18)
+## [11.0.4](https://github.com/formatjs/formatjs/compare/intl-messageformat@11.0.3...intl-messageformat@11.0.4) (2025-12-19)
 
 **Note:** Version bump only for package intl-messageformat
 
-## [11.0.2](github.com/formatjs/formatjs/compare/intl-messageformat@11.0.1...intl-messageformat@11.0.2) (2025-12-17)
+## [11.0.3](https://github.com/formatjs/formatjs/compare/intl-messageformat@11.0.2...intl-messageformat@11.0.3) (2025-12-18)
 
 **Note:** Version bump only for package intl-messageformat
 
-## [11.0.1](github.com/formatjs/formatjs/compare/intl-messageformat@11.0.0...intl-messageformat@11.0.1) (2025-12-15)
+## [11.0.2](https://github.com/formatjs/formatjs/compare/intl-messageformat@11.0.1...intl-messageformat@11.0.2) (2025-12-17)
 
 **Note:** Version bump only for package intl-messageformat
 
-## [11.0.0](/github.com/formatjs/formatjs/compare/intl-messageformat@10.7.18...intl-messageformat@11.0.0) (2025-12-15)
+## [11.0.1](https://github.com/formatjs/formatjs/compare/intl-messageformat@11.0.0...intl-messageformat@11.0.1) (2025-12-15)
+
+**Note:** Version bump only for package intl-messageformat
+
+## [11.0.0](https://github.com/formatjs/formatjs/compare/intl-messageformat@10.7.18...intl-messageformat@11.0.0) (2025-12-15)
 
 ### ⚠ BREAKING CHANGES
 
@@ -75,14 +75,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* **@formatjs/intl-pluralrules:** convert to esm ([#5436](/github.com/formatjs/formatjs/issues/5436)) ([0ed2ff9](/github.com/formatjs/formatjs/commit/0ed2ff979aa24088265f953d205a1d0c0029a433)) - by @longlho
-* **intl-messageformat:** convert to esm ([#5456](/github.com/formatjs/formatjs/issues/5456)) ([e6459ea](/github.com/formatjs/formatjs/commit/e6459ea4563c4ea942ae0991317f8407ba8e1154)) - by @longlho
+* **@formatjs/intl-pluralrules:** convert to esm ([#5436](https://github.com/formatjs/formatjs/issues/5436)) ([0ed2ff9](https://github.com/formatjs/formatjs/commit/0ed2ff979aa24088265f953d205a1d0c0029a433)) - by @longlho
+* **intl-messageformat:** convert to esm ([#5456](https://github.com/formatjs/formatjs/issues/5456)) ([e6459ea](https://github.com/formatjs/formatjs/commit/e6459ea4563c4ea942ae0991317f8407ba8e1154)) - by @longlho
 
-## [10.7.18](github.com/formatjs/formatjs/compare/intl-messageformat@10.7.17...intl-messageformat@10.7.18) (2025-10-09)
+## [10.7.18](https://github.com/formatjs/formatjs/compare/intl-messageformat@10.7.17...intl-messageformat@10.7.18) (2025-10-09)
 
 **Note:** Version bump only for package intl-messageformat
 
-## [10.7.17](github.com/formatjs/formatjs/compare/intl-messageformat@10.7.16...intl-messageformat@10.7.17) (2025-10-03)
+## [10.7.17](https://github.com/formatjs/formatjs/compare/intl-messageformat@10.7.16...intl-messageformat@10.7.17) (2025-10-03)
 
 **Note:** Version bump only for package intl-messageformat
 

--- a/packages/intl-relativetimeformat/CHANGELOG.md
+++ b/packages/intl-relativetimeformat/CHANGELOG.md
@@ -3,92 +3,92 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [12.3.1](github.com/formatjs/formatjs/compare/@formatjs/intl-relativetimeformat@12.3.0...@formatjs/intl-relativetimeformat@12.3.1) (2026-03-19)
+## [12.3.1](https://github.com/formatjs/formatjs/compare/@formatjs/intl-relativetimeformat@12.3.0...@formatjs/intl-relativetimeformat@12.3.1) (2026-03-19)
 
 ### Bug Fixes
 
-* **deps:** update .bazeliskrc to Bazel 9.0.1 ([#6151](/github.com/formatjs/formatjs/issues/6151)) ([92f9803](github.com/formatjs/formatjs/commits/92f9803232789835d97d97d336ddbbdefb753c6c)), closes [#6135](github.com/formatjs/formatjs/issues/6135) - by @longlho
+* **deps:** update .bazeliskrc to Bazel 9.0.1 ([#6151](https://github.com/formatjs/formatjs/issues/6151)) ([92f9803](https://github.com/formatjs/formatjs/commits/92f9803232789835d97d97d336ddbbdefb753c6c)), closes [#6135](https://github.com/formatjs/formatjs/issues/6135) - by @longlho
 
-# [12.3.0](github.com/formatjs/formatjs/compare/@formatjs/intl-relativetimeformat@12.2.4...@formatjs/intl-relativetimeformat@12.3.0) (2026-03-17)
+# [12.3.0](https://github.com/formatjs/formatjs/compare/@formatjs/intl-relativetimeformat@12.2.4...@formatjs/intl-relativetimeformat@12.3.0) (2026-03-17)
 
 ### Features
 
-* **@formatjs/ecma402-abstract:** migrate from decimal.js to @formatjs/bigdecimal ([#6148](/github.com/formatjs/formatjs/issues/6148)) ([93744d4](github.com/formatjs/formatjs/commits/93744d4732ab2dfdc93e7ddb2a73e80a6e461534)) - by @longlho
-* buffer locale data for parallel polyfill + data loading ([#6145](/github.com/formatjs/formatjs/issues/6145)) ([1b28e30](github.com/formatjs/formatjs/commits/1b28e30c26c264a039e1326a45c4fecb649e5d45)), closes [#4457](github.com/formatjs/formatjs/issues/4457) - by @longlho
+* **@formatjs/ecma402-abstract:** migrate from decimal.js to @formatjs/bigdecimal ([#6148](https://github.com/formatjs/formatjs/issues/6148)) ([93744d4](https://github.com/formatjs/formatjs/commits/93744d4732ab2dfdc93e7ddb2a73e80a6e461534)) - by @longlho
+* buffer locale data for parallel polyfill + data loading ([#6145](https://github.com/formatjs/formatjs/issues/6145)) ([1b28e30](https://github.com/formatjs/formatjs/commits/1b28e30c26c264a039e1326a45c4fecb649e5d45)), closes [#4457](https://github.com/formatjs/formatjs/issues/4457) - by @longlho
 
-## [12.2.4](github.com/formatjs/formatjs/compare/@formatjs/intl-relativetimeformat@12.2.3...@formatjs/intl-relativetimeformat@12.2.4) (2026-03-16)
+## [12.2.4](https://github.com/formatjs/formatjs/compare/@formatjs/intl-relativetimeformat@12.2.3...@formatjs/intl-relativetimeformat@12.2.4) (2026-03-16)
 
 **Note:** Version bump only for package @formatjs/intl-relativetimeformat
 
-## [12.2.3](github.com/formatjs/formatjs/compare/@formatjs/intl-relativetimeformat@12.2.2...@formatjs/intl-relativetimeformat@12.2.3) (2026-03-09)
+## [12.2.3](https://github.com/formatjs/formatjs/compare/@formatjs/intl-relativetimeformat@12.2.2...@formatjs/intl-relativetimeformat@12.2.3) (2026-03-09)
 
 ### Bug Fixes
 
-* add locale-data directory export for variable dynamic imports ([#6063](/github.com/formatjs/formatjs/issues/6063)) ([0492f8b](github.com/formatjs/formatjs/commits/0492f8bf5c7cefb561b2bc7b9f7363d218bd0641)), closes [#6060](github.com/formatjs/formatjs/issues/6060) - by @longlho
+* add locale-data directory export for variable dynamic imports ([#6063](https://github.com/formatjs/formatjs/issues/6063)) ([0492f8b](https://github.com/formatjs/formatjs/commits/0492f8bf5c7cefb561b2bc7b9f7363d218bd0641)), closes [#6060](https://github.com/formatjs/formatjs/issues/6060) - by @longlho
 
-## [12.2.2](github.com/formatjs/formatjs/compare/@formatjs/intl-relativetimeformat@12.2.1...@formatjs/intl-relativetimeformat@12.2.2) (2026-02-01)
-
-**Note:** Version bump only for package @formatjs/intl-relativetimeformat
-
-## [12.2.1](github.com/formatjs/formatjs/compare/@formatjs/intl-relativetimeformat@12.2.0...@formatjs/intl-relativetimeformat@12.2.1) (2026-01-19)
+## [12.2.2](https://github.com/formatjs/formatjs/compare/@formatjs/intl-relativetimeformat@12.2.1...@formatjs/intl-relativetimeformat@12.2.2) (2026-02-01)
 
 **Note:** Version bump only for package @formatjs/intl-relativetimeformat
 
-# [12.2.0](github.com/formatjs/formatjs/compare/@formatjs/intl-relativetimeformat@12.1.2...@formatjs/intl-relativetimeformat@12.2.0) (2026-01-15)
+## [12.2.1](https://github.com/formatjs/formatjs/compare/@formatjs/intl-relativetimeformat@12.2.0...@formatjs/intl-relativetimeformat@12.2.1) (2026-01-19)
+
+**Note:** Version bump only for package @formatjs/intl-relativetimeformat
+
+# [12.2.0](https://github.com/formatjs/formatjs/compare/@formatjs/intl-relativetimeformat@12.1.2...@formatjs/intl-relativetimeformat@12.2.0) (2026-01-15)
 
 ### Features
 
-* **@formatjs/intl-segmenter:** improve Unicode 17.0 Format/Extend transparency and upgrade deps ([#5862](/github.com/formatjs/formatjs/issues/5862)) ([effeb9c](github.com/formatjs/formatjs/commits/effeb9cd9d26f8c43c1e3df64a84c42dc7b12043)), closes [#29](github.com/formatjs/formatjs/issues/29) - by @longlho
+* **@formatjs/intl-segmenter:** improve Unicode 17.0 Format/Extend transparency and upgrade deps ([#5862](https://github.com/formatjs/formatjs/issues/5862)) ([effeb9c](https://github.com/formatjs/formatjs/commits/effeb9cd9d26f8c43c1e3df64a84c42dc7b12043)), closes [#29](https://github.com/formatjs/formatjs/issues/29) - by @longlho
 
-## [12.1.2](github.com/formatjs/formatjs/compare/@formatjs/intl-relativetimeformat@12.1.1...@formatjs/intl-relativetimeformat@12.1.2) (2026-01-06)
-
-**Note:** Version bump only for package @formatjs/intl-relativetimeformat
-
-## [12.1.1](github.com/formatjs/formatjs/compare/@formatjs/intl-relativetimeformat@12.1.0...@formatjs/intl-relativetimeformat@12.1.1) (2026-01-02)
+## [12.1.2](https://github.com/formatjs/formatjs/compare/@formatjs/intl-relativetimeformat@12.1.1...@formatjs/intl-relativetimeformat@12.1.2) (2026-01-06)
 
 **Note:** Version bump only for package @formatjs/intl-relativetimeformat
 
-# [12.1.0](github.com/formatjs/formatjs/compare/@formatjs/intl-relativetimeformat@12.0.7...@formatjs/intl-relativetimeformat@12.1.0) (2025-12-26)
+## [12.1.1](https://github.com/formatjs/formatjs/compare/@formatjs/intl-relativetimeformat@12.1.0...@formatjs/intl-relativetimeformat@12.1.1) (2026-01-02)
+
+**Note:** Version bump only for package @formatjs/intl-relativetimeformat
+
+# [12.1.0](https://github.com/formatjs/formatjs/compare/@formatjs/intl-relativetimeformat@12.0.7...@formatjs/intl-relativetimeformat@12.1.0) (2025-12-26)
 
 ### Features
 
-* upgrade cldr to v48 ([#5678](/github.com/formatjs/formatjs/issues/5678)) ([54ef319](github.com/formatjs/formatjs/commits/54ef31940172467889be64907e9fbbf567ea3f4b)) - by @longlho
+* upgrade cldr to v48 ([#5678](https://github.com/formatjs/formatjs/issues/5678)) ([54ef319](https://github.com/formatjs/formatjs/commits/54ef31940172467889be64907e9fbbf567ea3f4b)) - by @longlho
 
-## [12.0.7](github.com/formatjs/formatjs/compare/@formatjs/intl-relativetimeformat@12.0.6...@formatjs/intl-relativetimeformat@12.0.7) (2025-12-23)
-
-**Note:** Version bump only for package @formatjs/intl-relativetimeformat
-
-## [12.0.6](github.com/formatjs/formatjs/compare/@formatjs/intl-relativetimeformat@12.0.5...@formatjs/intl-relativetimeformat@12.0.6) (2025-12-23)
+## [12.0.7](https://github.com/formatjs/formatjs/compare/@formatjs/intl-relativetimeformat@12.0.6...@formatjs/intl-relativetimeformat@12.0.7) (2025-12-23)
 
 **Note:** Version bump only for package @formatjs/intl-relativetimeformat
 
-## [12.0.5](github.com/formatjs/formatjs/compare/@formatjs/intl-relativetimeformat@12.0.4...@formatjs/intl-relativetimeformat@12.0.5) (2025-12-19)
+## [12.0.6](https://github.com/formatjs/formatjs/compare/@formatjs/intl-relativetimeformat@12.0.5...@formatjs/intl-relativetimeformat@12.0.6) (2025-12-23)
+
+**Note:** Version bump only for package @formatjs/intl-relativetimeformat
+
+## [12.0.5](https://github.com/formatjs/formatjs/compare/@formatjs/intl-relativetimeformat@12.0.4...@formatjs/intl-relativetimeformat@12.0.5) (2025-12-19)
 
 ### Bug Fixes
 
-* **@formatjs/utils:** fix json ESM import ([#5594](/github.com/formatjs/formatjs/issues/5594)) ([dfd79a2](github.com/formatjs/formatjs/commits/dfd79a2d9935e0b7d06c08555ff6625d3f1c884f)) - by @longlho
+* **@formatjs/utils:** fix json ESM import ([#5594](https://github.com/formatjs/formatjs/issues/5594)) ([dfd79a2](https://github.com/formatjs/formatjs/commits/dfd79a2d9935e0b7d06c08555ff6625d3f1c884f)) - by @longlho
 
-## [12.0.4](github.com/formatjs/formatjs/compare/@formatjs/intl-relativetimeformat@12.0.3...@formatjs/intl-relativetimeformat@12.0.4) (2025-12-18)
-
-**Note:** Version bump only for package @formatjs/intl-relativetimeformat
-
-## [12.0.3](github.com/formatjs/formatjs/compare/@formatjs/intl-relativetimeformat@12.0.2...@formatjs/intl-relativetimeformat@12.0.3) (2025-12-17)
-
-### Bug Fixes
-
-* **@formatjs/cli-lib:** fix fs-extra imports, fix [#5569](/github.com/formatjs/formatjs/issues/5569) ([76c8793](github.com/formatjs/formatjs/commits/76c8793bf8a0744ad9a7c64ab3adbe5c1434898f)) - by @longlho
-
-## [12.0.2](github.com/formatjs/formatjs/compare/@formatjs/intl-relativetimeformat@12.0.1...@formatjs/intl-relativetimeformat@12.0.2) (2025-12-16)
-
-### Bug Fixes
-
-* **@formatjs/intl-relativetimeformat:** add locale-data exports ([7c0490c](github.com/formatjs/formatjs/commits/7c0490c5ced3a87e2221d7558f3ecd5c061a1ca9)) - by @longlho
-
-## [12.0.1](github.com/formatjs/formatjs/compare/@formatjs/intl-relativetimeformat@12.0.0...@formatjs/intl-relativetimeformat@12.0.1) (2025-12-15)
+## [12.0.4](https://github.com/formatjs/formatjs/compare/@formatjs/intl-relativetimeformat@12.0.3...@formatjs/intl-relativetimeformat@12.0.4) (2025-12-18)
 
 **Note:** Version bump only for package @formatjs/intl-relativetimeformat
 
-## [12.0.0](/github.com/formatjs/formatjs/compare/@formatjs/intl-relativetimeformat@11.4.13...@formatjs/intl-relativetimeformat@12.0.0) (2025-12-15)
+## [12.0.3](https://github.com/formatjs/formatjs/compare/@formatjs/intl-relativetimeformat@12.0.2...@formatjs/intl-relativetimeformat@12.0.3) (2025-12-17)
+
+### Bug Fixes
+
+* **@formatjs/cli-lib:** fix fs-extra imports, fix [#5569](https://github.com/formatjs/formatjs/issues/5569) ([76c8793](https://github.com/formatjs/formatjs/commits/76c8793bf8a0744ad9a7c64ab3adbe5c1434898f)) - by @longlho
+
+## [12.0.2](https://github.com/formatjs/formatjs/compare/@formatjs/intl-relativetimeformat@12.0.1...@formatjs/intl-relativetimeformat@12.0.2) (2025-12-16)
+
+### Bug Fixes
+
+* **@formatjs/intl-relativetimeformat:** add locale-data exports ([7c0490c](https://github.com/formatjs/formatjs/commits/7c0490c5ced3a87e2221d7558f3ecd5c061a1ca9)) - by @longlho
+
+## [12.0.1](https://github.com/formatjs/formatjs/compare/@formatjs/intl-relativetimeformat@12.0.0...@formatjs/intl-relativetimeformat@12.0.1) (2025-12-15)
+
+**Note:** Version bump only for package @formatjs/intl-relativetimeformat
+
+## [12.0.0](https://github.com/formatjs/formatjs/compare/@formatjs/intl-relativetimeformat@11.4.13...@formatjs/intl-relativetimeformat@12.0.0) (2025-12-15)
 
 ### ⚠ BREAKING CHANGES
 
@@ -99,20 +99,20 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* **@formatjs/intl-getcanonicallocales:** convert to esm ([#5457](/github.com/formatjs/formatjs/issues/5457)) ([e1a6d19](/github.com/formatjs/formatjs/commit/e1a6d196404a25c67eba3bc149b9d5162715f0db)) - by @longlho
-* **@formatjs/intl-locale:** convert to esm ([#5435](/github.com/formatjs/formatjs/issues/5435)) ([fc9ae8e](/github.com/formatjs/formatjs/commit/fc9ae8e20b556108b1b800fb930d70ffc5545041)) - by @longlho
-* **@formatjs/intl-pluralrules:** convert to esm ([#5436](/github.com/formatjs/formatjs/issues/5436)) ([0ed2ff9](/github.com/formatjs/formatjs/commit/0ed2ff979aa24088265f953d205a1d0c0029a433)) - by @longlho
-* **@formatjs/intl-relativetimeformat:** convert to ESM ([3f42e70](/github.com/formatjs/formatjs/commit/3f42e70ebd4c6e3f185cee7661fe325d7739baf2)) - by @longlho
+* **@formatjs/intl-getcanonicallocales:** convert to esm ([#5457](https://github.com/formatjs/formatjs/issues/5457)) ([e1a6d19](https://github.com/formatjs/formatjs/commit/e1a6d196404a25c67eba3bc149b9d5162715f0db)) - by @longlho
+* **@formatjs/intl-locale:** convert to esm ([#5435](https://github.com/formatjs/formatjs/issues/5435)) ([fc9ae8e](https://github.com/formatjs/formatjs/commit/fc9ae8e20b556108b1b800fb930d70ffc5545041)) - by @longlho
+* **@formatjs/intl-pluralrules:** convert to esm ([#5436](https://github.com/formatjs/formatjs/issues/5436)) ([0ed2ff9](https://github.com/formatjs/formatjs/commit/0ed2ff979aa24088265f953d205a1d0c0029a433)) - by @longlho
+* **@formatjs/intl-relativetimeformat:** convert to ESM ([3f42e70](https://github.com/formatjs/formatjs/commit/3f42e70ebd4c6e3f185cee7661fe325d7739baf2)) - by @longlho
 
 ### Bug Fixes
 
-* **@formatjs/intl-relativetimeformat:** fix exports ([6c0a0f7](/github.com/formatjs/formatjs/commit/6c0a0f766436cd30e3c4c93ee1e45e4dc72c3214)) - by @longlho
+* **@formatjs/intl-relativetimeformat:** fix exports ([6c0a0f7](https://github.com/formatjs/formatjs/commit/6c0a0f766436cd30e3c4c93ee1e45e4dc72c3214)) - by @longlho
 
-## [11.4.13](github.com/formatjs/formatjs/compare/@formatjs/intl-relativetimeformat@11.4.12...@formatjs/intl-relativetimeformat@11.4.13) (2025-10-09)
+## [11.4.13](https://github.com/formatjs/formatjs/compare/@formatjs/intl-relativetimeformat@11.4.12...@formatjs/intl-relativetimeformat@11.4.13) (2025-10-09)
 
 **Note:** Version bump only for package @formatjs/intl-relativetimeformat
 
-## [11.4.12](github.com/formatjs/formatjs/compare/@formatjs/intl-relativetimeformat@11.4.11...@formatjs/intl-relativetimeformat@11.4.12) (2025-10-03)
+## [11.4.12](https://github.com/formatjs/formatjs/compare/@formatjs/intl-relativetimeformat@11.4.11...@formatjs/intl-relativetimeformat@11.4.12) (2025-10-03)
 
 **Note:** Version bump only for package @formatjs/intl-relativetimeformat
 

--- a/packages/intl-segmenter/CHANGELOG.md
+++ b/packages/intl-segmenter/CHANGELOG.md
@@ -3,71 +3,71 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [12.2.1](github.com/formatjs/formatjs/compare/@formatjs/intl-segmenter@12.2.0...@formatjs/intl-segmenter@12.2.1) (2026-03-19)
+## [12.2.1](https://github.com/formatjs/formatjs/compare/@formatjs/intl-segmenter@12.2.0...@formatjs/intl-segmenter@12.2.1) (2026-03-19)
 
 ### Bug Fixes
 
-* **deps:** update .bazeliskrc to Bazel 9.0.1 ([#6151](/github.com/formatjs/formatjs/issues/6151)) ([92f9803](github.com/formatjs/formatjs/commits/92f9803232789835d97d97d336ddbbdefb753c6c)), closes [#6135](github.com/formatjs/formatjs/issues/6135) - by @longlho
+* **deps:** update .bazeliskrc to Bazel 9.0.1 ([#6151](https://github.com/formatjs/formatjs/issues/6151)) ([92f9803](https://github.com/formatjs/formatjs/commits/92f9803232789835d97d97d336ddbbdefb753c6c)), closes [#6135](https://github.com/formatjs/formatjs/issues/6135) - by @longlho
 
-# [12.2.0](github.com/formatjs/formatjs/compare/@formatjs/intl-segmenter@12.1.2...@formatjs/intl-segmenter@12.2.0) (2026-03-17)
+# [12.2.0](https://github.com/formatjs/formatjs/compare/@formatjs/intl-segmenter@12.1.2...@formatjs/intl-segmenter@12.2.0) (2026-03-17)
 
 ### Features
 
-* **@formatjs/ecma402-abstract:** migrate from decimal.js to @formatjs/bigdecimal ([#6148](/github.com/formatjs/formatjs/issues/6148)) ([93744d4](github.com/formatjs/formatjs/commits/93744d4732ab2dfdc93e7ddb2a73e80a6e461534)) - by @longlho
+* **@formatjs/ecma402-abstract:** migrate from decimal.js to @formatjs/bigdecimal ([#6148](https://github.com/formatjs/formatjs/issues/6148)) ([93744d4](https://github.com/formatjs/formatjs/commits/93744d4732ab2dfdc93e7ddb2a73e80a6e461534)) - by @longlho
 
-## [12.1.2](github.com/formatjs/formatjs/compare/@formatjs/intl-segmenter@12.1.1...@formatjs/intl-segmenter@12.1.2) (2026-03-16)
+## [12.1.2](https://github.com/formatjs/formatjs/compare/@formatjs/intl-segmenter@12.1.1...@formatjs/intl-segmenter@12.1.2) (2026-03-16)
 
 ### Bug Fixes
 
-* **eslint-plugin-formatjs:** rm typescript-eslint dep ([#6028](/github.com/formatjs/formatjs/issues/6028)) ([db3a76b](github.com/formatjs/formatjs/commits/db3a76bb67865716067deffbbb3f3f683382029c)) - by @
+* **eslint-plugin-formatjs:** rm typescript-eslint dep ([#6028](https://github.com/formatjs/formatjs/issues/6028)) ([db3a76b](https://github.com/formatjs/formatjs/commits/db3a76bb67865716067deffbbb3f3f683382029c)) - by @
 
-## [12.1.1](github.com/formatjs/formatjs/compare/@formatjs/intl-segmenter@12.1.0...@formatjs/intl-segmenter@12.1.1) (2026-02-01)
+## [12.1.1](https://github.com/formatjs/formatjs/compare/@formatjs/intl-segmenter@12.1.0...@formatjs/intl-segmenter@12.1.1) (2026-02-01)
 
 **Note:** Version bump only for package @formatjs/intl-segmenter
 
-# [12.1.0](github.com/formatjs/formatjs/compare/@formatjs/intl-segmenter@12.0.8...@formatjs/intl-segmenter@12.1.0) (2026-01-15)
+# [12.1.0](https://github.com/formatjs/formatjs/compare/@formatjs/intl-segmenter@12.0.8...@formatjs/intl-segmenter@12.1.0) (2026-01-15)
 
 ### Features
 
-* **@formatjs/intl-segmenter:** improve Unicode 17.0 Format/Extend transparency and upgrade deps ([#5862](/github.com/formatjs/formatjs/issues/5862)) ([effeb9c](github.com/formatjs/formatjs/commits/effeb9cd9d26f8c43c1e3df64a84c42dc7b12043)), closes [#29](github.com/formatjs/formatjs/issues/29) - by @longlho
+* **@formatjs/intl-segmenter:** improve Unicode 17.0 Format/Extend transparency and upgrade deps ([#5862](https://github.com/formatjs/formatjs/issues/5862)) ([effeb9c](https://github.com/formatjs/formatjs/commits/effeb9cd9d26f8c43c1e3df64a84c42dc7b12043)), closes [#29](https://github.com/formatjs/formatjs/issues/29) - by @longlho
 
-## [12.0.8](github.com/formatjs/formatjs/compare/@formatjs/intl-segmenter@12.0.7...@formatjs/intl-segmenter@12.0.8) (2026-01-06)
+## [12.0.8](https://github.com/formatjs/formatjs/compare/@formatjs/intl-segmenter@12.0.7...@formatjs/intl-segmenter@12.0.8) (2026-01-06)
 
 **Note:** Version bump only for package @formatjs/intl-segmenter
 
-## [12.0.7](github.com/formatjs/formatjs/compare/@formatjs/intl-segmenter@12.0.6...@formatjs/intl-segmenter@12.0.7) (2026-01-02)
+## [12.0.7](https://github.com/formatjs/formatjs/compare/@formatjs/intl-segmenter@12.0.6...@formatjs/intl-segmenter@12.0.7) (2026-01-02)
 
 ### Bug Fixes
 
-* **@formatjs/intl-segmenter:** fix isWordLike, fix [#4370](/github.com/formatjs/formatjs/issues/4370) ([#5737](/github.com/formatjs/formatjs/issues/5737)) ([2a06016](github.com/formatjs/formatjs/commits/2a06016a3f2ada063bf22ad174186d61f5632372)), closes [#29](github.com/formatjs/formatjs/issues/29) - by @longlho
+* **@formatjs/intl-segmenter:** fix isWordLike, fix [#4370](https://github.com/formatjs/formatjs/issues/4370) ([#5737](https://github.com/formatjs/formatjs/issues/5737)) ([2a06016](https://github.com/formatjs/formatjs/commits/2a06016a3f2ada063bf22ad174186d61f5632372)), closes [#29](https://github.com/formatjs/formatjs/issues/29) - by @longlho
 
-## [12.0.6](github.com/formatjs/formatjs/compare/@formatjs/intl-segmenter@12.0.5...@formatjs/intl-segmenter@12.0.6) (2025-12-26)
-
-**Note:** Version bump only for package @formatjs/intl-segmenter
-
-## [12.0.5](github.com/formatjs/formatjs/compare/@formatjs/intl-segmenter@12.0.4...@formatjs/intl-segmenter@12.0.5) (2025-12-23)
+## [12.0.6](https://github.com/formatjs/formatjs/compare/@formatjs/intl-segmenter@12.0.5...@formatjs/intl-segmenter@12.0.6) (2025-12-26)
 
 **Note:** Version bump only for package @formatjs/intl-segmenter
 
-## [12.0.4](github.com/formatjs/formatjs/compare/@formatjs/intl-segmenter@12.0.3...@formatjs/intl-segmenter@12.0.4) (2025-12-23)
+## [12.0.5](https://github.com/formatjs/formatjs/compare/@formatjs/intl-segmenter@12.0.4...@formatjs/intl-segmenter@12.0.5) (2025-12-23)
 
 **Note:** Version bump only for package @formatjs/intl-segmenter
 
-## [12.0.3](github.com/formatjs/formatjs/compare/@formatjs/intl-segmenter@12.0.2...@formatjs/intl-segmenter@12.0.3) (2025-12-18)
+## [12.0.4](https://github.com/formatjs/formatjs/compare/@formatjs/intl-segmenter@12.0.3...@formatjs/intl-segmenter@12.0.4) (2025-12-23)
 
 **Note:** Version bump only for package @formatjs/intl-segmenter
 
-## [12.0.2](github.com/formatjs/formatjs/compare/@formatjs/intl-segmenter@12.0.1...@formatjs/intl-segmenter@12.0.2) (2025-12-17)
+## [12.0.3](https://github.com/formatjs/formatjs/compare/@formatjs/intl-segmenter@12.0.2...@formatjs/intl-segmenter@12.0.3) (2025-12-18)
+
+**Note:** Version bump only for package @formatjs/intl-segmenter
+
+## [12.0.2](https://github.com/formatjs/formatjs/compare/@formatjs/intl-segmenter@12.0.1...@formatjs/intl-segmenter@12.0.2) (2025-12-17)
 
 ### Bug Fixes
 
-* **@formatjs/cli-lib:** fix fs-extra imports, fix [#5569](/github.com/formatjs/formatjs/issues/5569) ([76c8793](github.com/formatjs/formatjs/commits/76c8793bf8a0744ad9a7c64ab3adbe5c1434898f)) - by @longlho
+* **@formatjs/cli-lib:** fix fs-extra imports, fix [#5569](https://github.com/formatjs/formatjs/issues/5569) ([76c8793](https://github.com/formatjs/formatjs/commits/76c8793bf8a0744ad9a7c64ab3adbe5c1434898f)) - by @longlho
 
-## [12.0.1](github.com/formatjs/formatjs/compare/@formatjs/intl-segmenter@12.0.0...@formatjs/intl-segmenter@12.0.1) (2025-12-15)
+## [12.0.1](https://github.com/formatjs/formatjs/compare/@formatjs/intl-segmenter@12.0.0...@formatjs/intl-segmenter@12.0.1) (2025-12-15)
 
 **Note:** Version bump only for package @formatjs/intl-segmenter
 
-## [12.0.0](/github.com/formatjs/formatjs/compare/@formatjs/intl-segmenter@11.7.12...@formatjs/intl-segmenter@12.0.0) (2025-12-15)
+## [12.0.0](https://github.com/formatjs/formatjs/compare/@formatjs/intl-segmenter@11.7.12...@formatjs/intl-segmenter@12.0.0) (2025-12-15)
 
 ### ⚠ BREAKING CHANGES
 
@@ -75,17 +75,17 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* **@formatjs/intl-segmenter:** convert to ESM only ([73b80a7](/github.com/formatjs/formatjs/commit/73b80a7ef45ed0e972ba3d61c4d8554f6816e99b)) - by @longlho
+* **@formatjs/intl-segmenter:** convert to ESM only ([73b80a7](https://github.com/formatjs/formatjs/commit/73b80a7ef45ed0e972ba3d61c4d8554f6816e99b)) - by @longlho
 
 ### Bug Fixes
 
-* **@formatjs/intl-segmenter:** fix exports ([07f700d](/github.com/formatjs/formatjs/commit/07f700d44e22becc2f20526bcb10c8f5bd60a47d)) - by @longlho
+* **@formatjs/intl-segmenter:** fix exports ([07f700d](https://github.com/formatjs/formatjs/commit/07f700d44e22becc2f20526bcb10c8f5bd60a47d)) - by @longlho
 
-## [11.7.12](github.com/formatjs/formatjs/compare/@formatjs/intl-segmenter@11.7.11...@formatjs/intl-segmenter@11.7.12) (2025-10-09)
+## [11.7.12](https://github.com/formatjs/formatjs/compare/@formatjs/intl-segmenter@11.7.11...@formatjs/intl-segmenter@11.7.12) (2025-10-09)
 
 **Note:** Version bump only for package @formatjs/intl-segmenter
 
-## [11.7.11](github.com/formatjs/formatjs/compare/@formatjs/intl-segmenter@11.7.10...@formatjs/intl-segmenter@11.7.11) (2025-10-03)
+## [11.7.11](https://github.com/formatjs/formatjs/compare/@formatjs/intl-segmenter@11.7.10...@formatjs/intl-segmenter@11.7.11) (2025-10-03)
 
 **Note:** Version bump only for package @formatjs/intl-segmenter
 

--- a/packages/intl/CHANGELOG.md
+++ b/packages/intl/CHANGELOG.md
@@ -3,73 +3,73 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [4.1.5](github.com/formatjs/formatjs/compare/@formatjs/intl@4.1.4...@formatjs/intl@4.1.5) (2026-03-27)
+## [4.1.5](https://github.com/formatjs/formatjs/compare/@formatjs/intl@4.1.4...@formatjs/intl@4.1.5) (2026-03-27)
 
 ### Bug Fixes
 
-* **deps:** remove typescript peer dependencies ([#6180](/github.com/formatjs/formatjs/issues/6180)) ([b4dba3d](github.com/formatjs/formatjs/commits/b4dba3dfde138c2ea872a6372c01d8ad89216ee4)), closes [#6179](github.com/formatjs/formatjs/issues/6179) - by @camsteffen
+* **deps:** remove typescript peer dependencies ([#6180](https://github.com/formatjs/formatjs/issues/6180)) ([b4dba3d](https://github.com/formatjs/formatjs/commits/b4dba3dfde138c2ea872a6372c01d8ad89216ee4)), closes [#6179](https://github.com/formatjs/formatjs/issues/6179) - by @camsteffen
 
-## [4.1.4](github.com/formatjs/formatjs/compare/@formatjs/intl@4.1.3...@formatjs/intl@4.1.4) (2026-03-17)
-
-**Note:** Version bump only for package @formatjs/intl
-
-## [4.1.3](github.com/formatjs/formatjs/compare/@formatjs/intl@4.1.2...@formatjs/intl@4.1.3) (2026-03-16)
+## [4.1.4](https://github.com/formatjs/formatjs/compare/@formatjs/intl@4.1.3...@formatjs/intl@4.1.4) (2026-03-17)
 
 **Note:** Version bump only for package @formatjs/intl
 
-## [4.1.2](github.com/formatjs/formatjs/compare/@formatjs/intl@4.1.1...@formatjs/intl@4.1.2) (2026-02-01)
+## [4.1.3](https://github.com/formatjs/formatjs/compare/@formatjs/intl@4.1.2...@formatjs/intl@4.1.3) (2026-03-16)
 
 **Note:** Version bump only for package @formatjs/intl
 
-## [4.1.1](github.com/formatjs/formatjs/compare/@formatjs/intl@4.1.0...@formatjs/intl@4.1.1) (2026-01-19)
+## [4.1.2](https://github.com/formatjs/formatjs/compare/@formatjs/intl@4.1.1...@formatjs/intl@4.1.2) (2026-02-01)
+
+**Note:** Version bump only for package @formatjs/intl
+
+## [4.1.1](https://github.com/formatjs/formatjs/compare/@formatjs/intl@4.1.0...@formatjs/intl@4.1.1) (2026-01-19)
 
 ### Bug Fixes
 
-* **@formatjs/intl:** remove hot path optimization to fix escaped character handling, fix [#4973](/github.com/formatjs/formatjs/issues/4973) ([309f579](github.com/formatjs/formatjs/commits/309f5792a1871488a4287fafdc0467f65bc9530c)) - by @longlho
+* **@formatjs/intl:** remove hot path optimization to fix escaped character handling, fix [#4973](https://github.com/formatjs/formatjs/issues/4973) ([309f579](https://github.com/formatjs/formatjs/commits/309f5792a1871488a4287fafdc0467f65bc9530c)) - by @longlho
 
-# [4.1.0](github.com/formatjs/formatjs/compare/@formatjs/intl@4.0.9...@formatjs/intl@4.1.0) (2026-01-15)
+# [4.1.0](https://github.com/formatjs/formatjs/compare/@formatjs/intl@4.0.9...@formatjs/intl@4.1.0) (2026-01-15)
 
 ### Features
 
-* **@formatjs/intl-segmenter:** improve Unicode 17.0 Format/Extend transparency and upgrade deps ([#5862](/github.com/formatjs/formatjs/issues/5862)) ([effeb9c](github.com/formatjs/formatjs/commits/effeb9cd9d26f8c43c1e3df64a84c42dc7b12043)), closes [#29](github.com/formatjs/formatjs/issues/29) - by @longlho
+* **@formatjs/intl-segmenter:** improve Unicode 17.0 Format/Extend transparency and upgrade deps ([#5862](https://github.com/formatjs/formatjs/issues/5862)) ([effeb9c](https://github.com/formatjs/formatjs/commits/effeb9cd9d26f8c43c1e3df64a84c42dc7b12043)), closes [#29](https://github.com/formatjs/formatjs/issues/29) - by @longlho
 
-## [4.0.9](github.com/formatjs/formatjs/compare/@formatjs/intl@4.0.8...@formatjs/intl@4.0.9) (2026-01-06)
-
-**Note:** Version bump only for package @formatjs/intl
-
-## [4.0.8](github.com/formatjs/formatjs/compare/@formatjs/intl@4.0.7...@formatjs/intl@4.0.8) (2026-01-02)
+## [4.0.9](https://github.com/formatjs/formatjs/compare/@formatjs/intl@4.0.8...@formatjs/intl@4.0.9) (2026-01-06)
 
 **Note:** Version bump only for package @formatjs/intl
 
-## [4.0.7](github.com/formatjs/formatjs/compare/@formatjs/intl@4.0.6...@formatjs/intl@4.0.7) (2025-12-26)
+## [4.0.8](https://github.com/formatjs/formatjs/compare/@formatjs/intl@4.0.7...@formatjs/intl@4.0.8) (2026-01-02)
 
 **Note:** Version bump only for package @formatjs/intl
 
-## [4.0.6](github.com/formatjs/formatjs/compare/@formatjs/intl@4.0.5...@formatjs/intl@4.0.6) (2025-12-23)
+## [4.0.7](https://github.com/formatjs/formatjs/compare/@formatjs/intl@4.0.6...@formatjs/intl@4.0.7) (2025-12-26)
 
 **Note:** Version bump only for package @formatjs/intl
 
-## [4.0.5](github.com/formatjs/formatjs/compare/@formatjs/intl@4.0.4...@formatjs/intl@4.0.5) (2025-12-23)
+## [4.0.6](https://github.com/formatjs/formatjs/compare/@formatjs/intl@4.0.5...@formatjs/intl@4.0.6) (2025-12-23)
 
 **Note:** Version bump only for package @formatjs/intl
 
-## [4.0.4](github.com/formatjs/formatjs/compare/@formatjs/intl@4.0.3...@formatjs/intl@4.0.4) (2025-12-19)
+## [4.0.5](https://github.com/formatjs/formatjs/compare/@formatjs/intl@4.0.4...@formatjs/intl@4.0.5) (2025-12-23)
 
 **Note:** Version bump only for package @formatjs/intl
 
-## [4.0.3](github.com/formatjs/formatjs/compare/@formatjs/intl@4.0.2...@formatjs/intl@4.0.3) (2025-12-18)
+## [4.0.4](https://github.com/formatjs/formatjs/compare/@formatjs/intl@4.0.3...@formatjs/intl@4.0.4) (2025-12-19)
 
 **Note:** Version bump only for package @formatjs/intl
 
-## [4.0.2](github.com/formatjs/formatjs/compare/@formatjs/intl@4.0.1...@formatjs/intl@4.0.2) (2025-12-17)
+## [4.0.3](https://github.com/formatjs/formatjs/compare/@formatjs/intl@4.0.2...@formatjs/intl@4.0.3) (2025-12-18)
 
 **Note:** Version bump only for package @formatjs/intl
 
-## [4.0.1](github.com/formatjs/formatjs/compare/@formatjs/intl@4.0.0...@formatjs/intl@4.0.1) (2025-12-15)
+## [4.0.2](https://github.com/formatjs/formatjs/compare/@formatjs/intl@4.0.1...@formatjs/intl@4.0.2) (2025-12-17)
 
 **Note:** Version bump only for package @formatjs/intl
 
-## [4.0.0](/github.com/formatjs/formatjs/compare/@formatjs/intl@3.1.8...@formatjs/intl@4.0.0) (2025-12-15)
+## [4.0.1](https://github.com/formatjs/formatjs/compare/@formatjs/intl@4.0.0...@formatjs/intl@4.0.1) (2025-12-15)
+
+**Note:** Version bump only for package @formatjs/intl
+
+## [4.0.0](https://github.com/formatjs/formatjs/compare/@formatjs/intl@3.1.8...@formatjs/intl@4.0.0) (2025-12-15)
 
 ### ⚠ BREAKING CHANGES
 
@@ -77,22 +77,22 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* **@formatjs/intl:** convert to ESM ([#5434](/github.com/formatjs/formatjs/issues/5434)) ([47e75d7](/github.com/formatjs/formatjs/commit/47e75d7f5ca6fcf1fcb64088b8a5dd8a00fddadc)) - by @longlho
+* **@formatjs/intl:** convert to ESM ([#5434](https://github.com/formatjs/formatjs/issues/5434)) ([47e75d7](https://github.com/formatjs/formatjs/commit/47e75d7f5ca6fcf1fcb64088b8a5dd8a00fddadc)) - by @longlho
 
 ### Bug Fixes
 
-* use global 'time' Formats override with formatTime/FormattedTimeParts 'format' config instead of 'date' Formats, add strict 'format' overrides typing to FormattedDate and FormattedTime ([#5151](/github.com/formatjs/formatjs/issues/5151)) ([3fe4b50](/github.com/formatjs/formatjs/commit/3fe4b50d4b14e04717072217adf8514c580b55b7)) - by @seanmadi
+* use global 'time' Formats override with formatTime/FormattedTimeParts 'format' config instead of 'date' Formats, add strict 'format' overrides typing to FormattedDate and FormattedTime ([#5151](https://github.com/formatjs/formatjs/issues/5151)) ([3fe4b50](https://github.com/formatjs/formatjs/commit/3fe4b50d4b14e04717072217adf8514c580b55b7)) - by @seanmadi
 
-## [3.1.8](github.com/formatjs/formatjs/compare/@formatjs/intl@3.1.7...@formatjs/intl@3.1.8) (2025-10-09)
+## [3.1.8](https://github.com/formatjs/formatjs/compare/@formatjs/intl@3.1.7...@formatjs/intl@3.1.8) (2025-10-09)
 
 **Note:** Version bump only for package @formatjs/intl
 
-## [3.1.7](github.com/formatjs/formatjs/compare/@formatjs/intl@3.1.6...@formatjs/intl@3.1.7) (2025-10-03)
+## [3.1.7](https://github.com/formatjs/formatjs/compare/@formatjs/intl@3.1.6...@formatjs/intl@3.1.7) (2025-10-03)
 
 ### Bug Fixes
 
-* formatList null value replaced to placeholder value ([f629131](github.com/formatjs/formatjs/commits/f629131bad27b5ef8fbc1d7fd60ef4d2aa33f9e5)) - by @septs
-* string list from iterable ([#5046](/github.com/formatjs/formatjs/issues/5046)) ([19a4c05](github.com/formatjs/formatjs/commits/19a4c051238aa48c6cab5eadf3a46ca7783a987c)) - by @septs
+* formatList null value replaced to placeholder value ([f629131](https://github.com/formatjs/formatjs/commits/f629131bad27b5ef8fbc1d7fd60ef4d2aa33f9e5)) - by @septs
+* string list from iterable ([#5046](https://github.com/formatjs/formatjs/issues/5046)) ([19a4c05](https://github.com/formatjs/formatjs/commits/19a4c051238aa48c6cab5eadf3a46ca7783a987c)) - by @septs
 
 ## [3.1.6](https://github.com/formatjs/formatjs/compare/@formatjs/intl@3.1.5...@formatjs/intl@3.1.6) (2025-03-26)
 

--- a/packages/react-intl/CHANGELOG.md
+++ b/packages/react-intl/CHANGELOG.md
@@ -3,23 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [10.1.1](github.com/formatjs/formatjs/compare/react-intl@10.1.0...react-intl@10.1.1) (2026-03-27)
+## [10.1.1](https://github.com/formatjs/formatjs/compare/react-intl@10.1.0...react-intl@10.1.1) (2026-03-27)
 
 ### Bug Fixes
 
-* **deps:** remove typescript peer dependencies ([#6180](/github.com/formatjs/formatjs/issues/6180)) ([b4dba3d](github.com/formatjs/formatjs/commits/b4dba3dfde138c2ea872a6372c01d8ad89216ee4)), closes [#6179](github.com/formatjs/formatjs/issues/6179) - by @camsteffen
+* **deps:** remove typescript peer dependencies ([#6180](https://github.com/formatjs/formatjs/issues/6180)) ([b4dba3d](https://github.com/formatjs/formatjs/commits/b4dba3dfde138c2ea872a6372c01d8ad89216ee4)), closes [#6179](https://github.com/formatjs/formatjs/issues/6179) - by @camsteffen
 
-# [10.1.0](github.com/formatjs/formatjs/compare/react-intl@10.0.0...react-intl@10.1.0) (2026-03-17)
-
-### Features
-
-* **@formatjs/ecma402-abstract:** migrate from decimal.js to @formatjs/bigdecimal ([#6148](/github.com/formatjs/formatjs/issues/6148)) ([93744d4](github.com/formatjs/formatjs/commits/93744d4732ab2dfdc93e7ddb2a73e80a6e461534)) - by @longlho
-
-# [10.0.0](github.com/formatjs/formatjs/compare/react-intl@8.2.0...react-intl@10.0.0) (2026-03-16)
+# [10.1.0](https://github.com/formatjs/formatjs/compare/react-intl@10.0.0...react-intl@10.1.0) (2026-03-17)
 
 ### Features
 
-* **react-intl:** bump to v9.0.0 ([#6112](/github.com/formatjs/formatjs/issues/6112)) ([8de45c7](github.com/formatjs/formatjs/commits/8de45c7f4bca0852b3844775a234f54fec3e2739)) - by @longlho
+* **@formatjs/ecma402-abstract:** migrate from decimal.js to @formatjs/bigdecimal ([#6148](https://github.com/formatjs/formatjs/issues/6148)) ([93744d4](https://github.com/formatjs/formatjs/commits/93744d4732ab2dfdc93e7ddb2a73e80a6e461534)) - by @longlho
+
+# [10.0.0](https://github.com/formatjs/formatjs/compare/react-intl@8.2.0...react-intl@10.0.0) (2026-03-16)
+
+### Features
+
+* **react-intl:** bump to v9.0.0 ([#6112](https://github.com/formatjs/formatjs/issues/6112)) ([8de45c7](https://github.com/formatjs/formatjs/commits/8de45c7f4bca0852b3844775a234f54fec3e2739)) - by @longlho
 
 ### BREAKING CHANGES
 
@@ -31,89 +31,89 @@ migration instructions.
 
 Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
 
-# [8.2.0](github.com/formatjs/formatjs/compare/react-intl@8.1.4...react-intl@8.2.0) (2026-03-16)
+# [8.2.0](https://github.com/formatjs/formatjs/compare/react-intl@8.1.4...react-intl@8.2.0) (2026-03-16)
 
 ### Bug Fixes
 
-* **react-intl:** fix vitest DOM tests failing in Bazel sandbox ([#6099](/github.com/formatjs/formatjs/issues/6099)) ([d364a33](github.com/formatjs/formatjs/commits/d364a3393615bd5837b1678351b53178f0c697cf)) - by @longlho
+* **react-intl:** fix vitest DOM tests failing in Bazel sandbox ([#6099](https://github.com/formatjs/formatjs/issues/6099)) ([d364a33](https://github.com/formatjs/formatjs/commits/d364a3393615bd5837b1678351b53178f0c697cf)) - by @longlho
 
 ### Features
 
-* **react-intl:** modernize for React 19 and RSC support ([#6083](/github.com/formatjs/formatjs/issues/6083)) ([4ecc046](github.com/formatjs/formatjs/commits/4ecc0468350681a9f33e9a1488a5bea99dc50783)) - by @longlho
+* **react-intl:** modernize for React 19 and RSC support ([#6083](https://github.com/formatjs/formatjs/issues/6083)) ([4ecc046](https://github.com/formatjs/formatjs/commits/4ecc0468350681a9f33e9a1488a5bea99dc50783)) - by @longlho
 
-## [8.1.4](github.com/formatjs/formatjs/compare/react-intl@8.1.3...react-intl@8.1.4) (2026-03-15)
+## [8.1.4](https://github.com/formatjs/formatjs/compare/react-intl@8.1.3...react-intl@8.1.4) (2026-03-15)
 
 **Note:** Version bump only for package react-intl
 
-## [8.1.3](github.com/formatjs/formatjs/compare/react-intl@8.1.2...react-intl@8.1.3) (2026-02-03)
+## [8.1.3](https://github.com/formatjs/formatjs/compare/react-intl@8.1.2...react-intl@8.1.3) (2026-02-03)
 
 ### Bug Fixes
 
-* **react-intl:** update react/react-dom dep versions to 19 ([#6015](/github.com/formatjs/formatjs/issues/6015)) ([70e7ad3](github.com/formatjs/formatjs/commits/70e7ad3a3d81a071411a1a7f30fced08b2797c80)), closes [#6014](github.com/formatjs/formatjs/issues/6014) - by @longlho
+* **react-intl:** update react/react-dom dep versions to 19 ([#6015](https://github.com/formatjs/formatjs/issues/6015)) ([70e7ad3](https://github.com/formatjs/formatjs/commits/70e7ad3a3d81a071411a1a7f30fced08b2797c80)), closes [#6014](https://github.com/formatjs/formatjs/issues/6014) - by @longlho
 
-## [8.1.2](github.com/formatjs/formatjs/compare/react-intl@8.1.1...react-intl@8.1.2) (2026-02-01)
-
-**Note:** Version bump only for package react-intl
-
-## [8.1.1](github.com/formatjs/formatjs/compare/react-intl@8.1.0...react-intl@8.1.1) (2026-01-19)
+## [8.1.2](https://github.com/formatjs/formatjs/compare/react-intl@8.1.1...react-intl@8.1.2) (2026-02-01)
 
 **Note:** Version bump only for package react-intl
 
-# [8.1.0](github.com/formatjs/formatjs/compare/react-intl@8.0.11...react-intl@8.1.0) (2026-01-15)
+## [8.1.1](https://github.com/formatjs/formatjs/compare/react-intl@8.1.0...react-intl@8.1.1) (2026-01-19)
+
+**Note:** Version bump only for package react-intl
+
+# [8.1.0](https://github.com/formatjs/formatjs/compare/react-intl@8.0.11...react-intl@8.1.0) (2026-01-15)
 
 ### Features
 
-* **@formatjs/intl-segmenter:** improve Unicode 17.0 Format/Extend transparency and upgrade deps ([#5862](/github.com/formatjs/formatjs/issues/5862)) ([effeb9c](github.com/formatjs/formatjs/commits/effeb9cd9d26f8c43c1e3df64a84c42dc7b12043)), closes [#29](github.com/formatjs/formatjs/issues/29) - by @longlho
+* **@formatjs/intl-segmenter:** improve Unicode 17.0 Format/Extend transparency and upgrade deps ([#5862](https://github.com/formatjs/formatjs/issues/5862)) ([effeb9c](https://github.com/formatjs/formatjs/commits/effeb9cd9d26f8c43c1e3df64a84c42dc7b12043)), closes [#29](https://github.com/formatjs/formatjs/issues/29) - by @longlho
 
-## [8.0.11](github.com/formatjs/formatjs/compare/react-intl@8.0.10...react-intl@8.0.11) (2026-01-06)
-
-**Note:** Version bump only for package react-intl
-
-## [8.0.10](github.com/formatjs/formatjs/compare/react-intl@8.0.9...react-intl@8.0.10) (2026-01-02)
+## [8.0.11](https://github.com/formatjs/formatjs/compare/react-intl@8.0.10...react-intl@8.0.11) (2026-01-06)
 
 **Note:** Version bump only for package react-intl
 
-## [8.0.9](github.com/formatjs/formatjs/compare/react-intl@8.0.8...react-intl@8.0.9) (2025-12-26)
+## [8.0.10](https://github.com/formatjs/formatjs/compare/react-intl@8.0.9...react-intl@8.0.10) (2026-01-02)
 
 **Note:** Version bump only for package react-intl
 
-## [8.0.8](github.com/formatjs/formatjs/compare/react-intl@8.0.7...react-intl@8.0.8) (2025-12-23)
+## [8.0.9](https://github.com/formatjs/formatjs/compare/react-intl@8.0.8...react-intl@8.0.9) (2025-12-26)
 
 **Note:** Version bump only for package react-intl
 
-## [8.0.7](github.com/formatjs/formatjs/compare/react-intl@8.0.6...react-intl@8.0.7) (2025-12-23)
+## [8.0.8](https://github.com/formatjs/formatjs/compare/react-intl@8.0.7...react-intl@8.0.8) (2025-12-23)
 
 **Note:** Version bump only for package react-intl
 
-## [8.0.6](github.com/formatjs/formatjs/compare/react-intl@8.0.5...react-intl@8.0.6) (2025-12-19)
+## [8.0.7](https://github.com/formatjs/formatjs/compare/react-intl@8.0.6...react-intl@8.0.7) (2025-12-23)
+
+**Note:** Version bump only for package react-intl
+
+## [8.0.6](https://github.com/formatjs/formatjs/compare/react-intl@8.0.5...react-intl@8.0.6) (2025-12-19)
 
 ### Bug Fixes
 
-* **@formatjs/utils:** fix json ESM import ([#5594](/github.com/formatjs/formatjs/issues/5594)) ([dfd79a2](github.com/formatjs/formatjs/commits/dfd79a2d9935e0b7d06c08555ff6625d3f1c884f)) - by @longlho
+* **@formatjs/utils:** fix json ESM import ([#5594](https://github.com/formatjs/formatjs/issues/5594)) ([dfd79a2](https://github.com/formatjs/formatjs/commits/dfd79a2d9935e0b7d06c08555ff6625d3f1c884f)) - by @longlho
 
-## [8.0.5](github.com/formatjs/formatjs/compare/react-intl@8.0.4...react-intl@8.0.5) (2025-12-18)
-
-**Note:** Version bump only for package react-intl
-
-## [8.0.4](github.com/formatjs/formatjs/compare/react-intl@8.0.3...react-intl@8.0.4) (2025-12-17)
+## [8.0.5](https://github.com/formatjs/formatjs/compare/react-intl@8.0.4...react-intl@8.0.5) (2025-12-18)
 
 **Note:** Version bump only for package react-intl
 
-## [8.0.3](github.com/formatjs/formatjs/compare/react-intl@8.0.2...react-intl@8.0.3) (2025-12-16)
+## [8.0.4](https://github.com/formatjs/formatjs/compare/react-intl@8.0.3...react-intl@8.0.4) (2025-12-17)
+
+**Note:** Version bump only for package react-intl
+
+## [8.0.3](https://github.com/formatjs/formatjs/compare/react-intl@8.0.2...react-intl@8.0.3) (2025-12-16)
 
 ### Bug Fixes
 
-* **react-intl:** jiggle package.json to republish ([b93b961](github.com/formatjs/formatjs/commits/b93b961de2412cdf67b5f7ba72872f0ecb59ecf7)) - by @longlho
+* **react-intl:** jiggle package.json to republish ([b93b961](https://github.com/formatjs/formatjs/commits/b93b961de2412cdf67b5f7ba72872f0ecb59ecf7)) - by @longlho
 
-## [8.0.2](github.com/formatjs/formatjs/compare/react-intl@8.0.1...react-intl@8.0.2) (2025-12-16)
-
-**Note:** Version bump only for package react-intl
-
-## [8.0.1](github.com/formatjs/formatjs/compare/react-intl@8.0.0...react-intl@8.0.1) (2025-12-15)
+## [8.0.2](https://github.com/formatjs/formatjs/compare/react-intl@8.0.1...react-intl@8.0.2) (2025-12-16)
 
 **Note:** Version bump only for package react-intl
 
-## [8.0.0](/github.com/formatjs/formatjs/compare/react-intl@7.1.14...react-intl@8.0.0) (2025-12-15)
+## [8.0.1](https://github.com/formatjs/formatjs/compare/react-intl@8.0.0...react-intl@8.0.1) (2025-12-15)
+
+**Note:** Version bump only for package react-intl
+
+## [8.0.0](https://github.com/formatjs/formatjs/compare/react-intl@7.1.14...react-intl@8.0.0) (2025-12-15)
 
 ### ⚠ BREAKING CHANGES
 
@@ -128,34 +128,34 @@ Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
 
 ### Features
 
-* **@formatjs/intl-datetimeformat:** convert to ESM ([#5429](/github.com/formatjs/formatjs/issues/5429)) ([c717c1a](/github.com/formatjs/formatjs/commit/c717c1adee58ad9d7604c74a4bafca2628e2a0a8)) - by @longlho
-* **@formatjs/intl-getcanonicallocales:** convert to esm ([#5457](/github.com/formatjs/formatjs/issues/5457)) ([e1a6d19](/github.com/formatjs/formatjs/commit/e1a6d196404a25c67eba3bc149b9d5162715f0db)) - by @longlho
-* **@formatjs/intl-locale:** convert to esm ([#5435](/github.com/formatjs/formatjs/issues/5435)) ([fc9ae8e](/github.com/formatjs/formatjs/commit/fc9ae8e20b556108b1b800fb930d70ffc5545041)) - by @longlho
-* **@formatjs/intl-pluralrules:** convert to esm ([#5436](/github.com/formatjs/formatjs/issues/5436)) ([0ed2ff9](/github.com/formatjs/formatjs/commit/0ed2ff979aa24088265f953d205a1d0c0029a433)) - by @longlho
-* **react-intl:** convert to ESM ([cb93e7d](/github.com/formatjs/formatjs/commit/cb93e7dc7fd1ba0b2eb697f84a8f00ae4d7f536d)) - by @longlho
-* **react-intl:** drop support for React 18 and below ([#5485](/github.com/formatjs/formatjs/issues/5485)) ([2ea4b7e](/github.com/formatjs/formatjs/commit/2ea4b7e4ffa7df0974632fdbeb632da6dc9c0f6c)) - by @longlho
+* **@formatjs/intl-datetimeformat:** convert to ESM ([#5429](https://github.com/formatjs/formatjs/issues/5429)) ([c717c1a](https://github.com/formatjs/formatjs/commit/c717c1adee58ad9d7604c74a4bafca2628e2a0a8)) - by @longlho
+* **@formatjs/intl-getcanonicallocales:** convert to esm ([#5457](https://github.com/formatjs/formatjs/issues/5457)) ([e1a6d19](https://github.com/formatjs/formatjs/commit/e1a6d196404a25c67eba3bc149b9d5162715f0db)) - by @longlho
+* **@formatjs/intl-locale:** convert to esm ([#5435](https://github.com/formatjs/formatjs/issues/5435)) ([fc9ae8e](https://github.com/formatjs/formatjs/commit/fc9ae8e20b556108b1b800fb930d70ffc5545041)) - by @longlho
+* **@formatjs/intl-pluralrules:** convert to esm ([#5436](https://github.com/formatjs/formatjs/issues/5436)) ([0ed2ff9](https://github.com/formatjs/formatjs/commit/0ed2ff979aa24088265f953d205a1d0c0029a433)) - by @longlho
+* **react-intl:** convert to ESM ([cb93e7d](https://github.com/formatjs/formatjs/commit/cb93e7dc7fd1ba0b2eb697f84a8f00ae4d7f536d)) - by @longlho
+* **react-intl:** drop support for React 18 and below ([#5485](https://github.com/formatjs/formatjs/issues/5485)) ([2ea4b7e](https://github.com/formatjs/formatjs/commit/2ea4b7e4ffa7df0974632fdbeb632da6dc9c0f6c)) - by @longlho
 
 ### Bug Fixes
 
-* **@formatjs/intl-numberformat:** convert to ESM ([#5431](/github.com/formatjs/formatjs/issues/5431)) ([793ae5c](/github.com/formatjs/formatjs/commit/793ae5c586cfa89e19d1a591f0c3d3c86d59ca23)) - by @longlho
-* **react-intl:** move @types/react to peerDep ([eea10ff](/github.com/formatjs/formatjs/commit/eea10ffd62f51d828b941809d31a1b39481cf362)) - by @longlho
-* **react-intl:** wrap rich text with Fragment instead of clone, fix [#5135](/github.com/formatjs/formatjs/issues/5135) ([#5507](/github.com/formatjs/formatjs/issues/5507)) ([27365e8](/github.com/formatjs/formatjs/commit/27365e847ab08828d8f0777a6c4a027b80e76c95)) - by @longlho
-* use global 'time' Formats override with formatTime/FormattedTimeParts 'format' config instead of 'date' Formats, add strict 'format' overrides typing to FormattedDate and FormattedTime ([#5151](/github.com/formatjs/formatjs/issues/5151)) ([3fe4b50](/github.com/formatjs/formatjs/commit/3fe4b50d4b14e04717072217adf8514c580b55b7)) - by @seanmadi
+* **@formatjs/intl-numberformat:** convert to ESM ([#5431](https://github.com/formatjs/formatjs/issues/5431)) ([793ae5c](https://github.com/formatjs/formatjs/commit/793ae5c586cfa89e19d1a591f0c3d3c86d59ca23)) - by @longlho
+* **react-intl:** move @types/react to peerDep ([eea10ff](https://github.com/formatjs/formatjs/commit/eea10ffd62f51d828b941809d31a1b39481cf362)) - by @longlho
+* **react-intl:** wrap rich text with Fragment instead of clone, fix [#5135](https://github.com/formatjs/formatjs/issues/5135) ([#5507](https://github.com/formatjs/formatjs/issues/5507)) ([27365e8](https://github.com/formatjs/formatjs/commit/27365e847ab08828d8f0777a6c4a027b80e76c95)) - by @longlho
+* use global 'time' Formats override with formatTime/FormattedTimeParts 'format' config instead of 'date' Formats, add strict 'format' overrides typing to FormattedDate and FormattedTime ([#5151](https://github.com/formatjs/formatjs/issues/5151)) ([3fe4b50](https://github.com/formatjs/formatjs/commit/3fe4b50d4b14e04717072217adf8514c580b55b7)) - by @seanmadi
 
-## [7.1.14](github.com/formatjs/formatjs/compare/react-intl@7.1.13...react-intl@7.1.14) (2025-10-09)
-
-**Note:** Version bump only for package react-intl
-
-## [7.1.13](github.com/formatjs/formatjs/compare/react-intl@7.1.12...react-intl@7.1.13) (2025-10-06)
+## [7.1.14](https://github.com/formatjs/formatjs/compare/react-intl@7.1.13...react-intl@7.1.14) (2025-10-09)
 
 **Note:** Version bump only for package react-intl
 
-## [7.1.12](github.com/formatjs/formatjs/compare/react-intl@7.1.11...react-intl@7.1.12) (2025-10-03)
+## [7.1.13](https://github.com/formatjs/formatjs/compare/react-intl@7.1.12...react-intl@7.1.13) (2025-10-06)
+
+**Note:** Version bump only for package react-intl
+
+## [7.1.12](https://github.com/formatjs/formatjs/compare/react-intl@7.1.11...react-intl@7.1.12) (2025-10-03)
 
 ### Bug Fixes
 
-* keyed react node ([#5050](/github.com/formatjs/formatjs/issues/5050)) ([8ef2c8b](github.com/formatjs/formatjs/commits/8ef2c8ba5a4959b58eeb53b8eeb0fe4e3067a27f)) - by @septs
-* **react-intl:** add keys on nested rich text elements ([#5032](/github.com/formatjs/formatjs/issues/5032)) ([7ebf80e](github.com/formatjs/formatjs/commits/7ebf80efb8c82cd197d1f2f22f07d55e1c04fd67)) - by @zyzo
+* keyed react node ([#5050](https://github.com/formatjs/formatjs/issues/5050)) ([8ef2c8b](https://github.com/formatjs/formatjs/commits/8ef2c8ba5a4959b58eeb53b8eeb0fe4e3067a27f)) - by @septs
+* **react-intl:** add keys on nested rich text elements ([#5032](https://github.com/formatjs/formatjs/issues/5032)) ([7ebf80e](https://github.com/formatjs/formatjs/commits/7ebf80efb8c82cd197d1f2f22f07d55e1c04fd67)) - by @zyzo
 
 ## [7.1.11](https://github.com/formatjs/formatjs/compare/react-intl@7.1.10...react-intl@7.1.11) (2025-04-19)
 


### PR DESCRIPTION
## Summary
- Fix root `package.json` repository field from `"formatjs/formatjs"` to `"https://github.com/formatjs/formatjs"` so future changelogs generate correct URLs
- Fix all existing broken URLs in 8 CHANGELOG.md files (240 links fixed)

Fixes #6248

## Test plan
- [x] Verified all `github.com/formatjs/` links now have `https://` prefix
- [x] No broken link patterns remain in any CHANGELOG.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)