### PR TITLE
chore(deps): regenerate MODULE.bazel.lock

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -402,7 +402,7 @@
         "recordedInputs": [
           "REPO_MAPPING:aspect_rules_ts+,aspect_rules_ts aspect_rules_ts+",
           "REPO_MAPPING:aspect_rules_ts+,bazel_tools bazel_tools",
-          "FILE:@@//package.json fdd42f440853c650c018fd5e83266474b815ebac28de3fc7e820c5668ebb7a54"
+          "FILE:@@//package.json 7f67761ee3f35bbae0af139d287213809bbf63ea2d46589e1e5668a8ddf79ce2"
         ],
         "generatedRepoSpecs": {
           "npm_typescript": {


### PR DESCRIPTION
## Summary
- Regenerate MODULE.bazel.lock after recent dependency updates

## Test plan
- [x] `bazel mod deps` completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)