### PR TITLE
ci(deps): combine rust-cli-test into test job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,52 +46,19 @@ jobs:
             bazel test //...
           fi
 
-  rust-cli-test:
-    name: Rust CLI - Build & Test (${{ matrix.os }})
-    runs-on: ${{ matrix.runner }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: macOS
-            runner: macos-latest
-            config: ci-darwin
-          - os: Linux
-            runner: ubuntu-latest
-            config: ci
-
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v6
-
-      - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@0.18.0
-        with:
-          bazelisk-cache: true
-          disk-cache: ${{ github.workflow }}-${{ matrix.os }}
-          repository-cache: true
-
-      - name: Build Rust CLI
-        if: matrix.runner != 'macos-latest' || github.event_name != 'pull_request'
+      - name: Rust CLI Smoke Test
+        if: matrix.os != 'macos-latest' || github.event_name != 'pull_request'
         run: |
           if [ -n "${{ secrets.BUILDBUDDY_ORG_API_KEY }}" ]; then
-            echo "Building with BuildBuddy config: ${{ matrix.config }}"
             bazel build \
-              --config=${{ matrix.config }} \
+              --config=${{ matrix.bazel-config }} \
               --compilation_mode=opt \
               --remote_download_outputs=all \
               --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
               //crates/formatjs_cli
           else
-            echo "Building without BuildBuddy (no API key)"
             bazel build --compilation_mode=opt //crates/formatjs_cli
           fi
-
-      - name: Smoke Test Binary
-        if: matrix.runner != 'macos-latest' || github.event_name != 'pull_request'
-        run: |
           BINARY_PATH=bazel-bin/crates/formatjs_cli/formatjs_cli
-          echo "Testing binary at: $BINARY_PATH"
           $BINARY_PATH --version
           $BINARY_PATH --help


### PR DESCRIPTION
## Summary
- Merge the separate `rust-cli-test` job into the main `test` job as a "Rust CLI Smoke Test" step
- Eliminates 2 redundant CI runners (the separate job duplicated checkout + Bazel setup)
- Still builds the CLI in release mode (`-c opt`) and runs `--version`/`--help` smoke test
- Runs on both Ubuntu and macOS (same matrix as the test job)

## Test plan
- [x] Smoke test step runs after `bazel test //...` completes
- [x] Release-mode binary build catches optimization-specific issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)