### PR TITLE
refactor(deps): ban relative imports in internal packages

### DIFF
--- a/packages/ecma262-abstract/TimeClip.ts
+++ b/packages/ecma262-abstract/TimeClip.ts
@@ -1,6 +1,6 @@
 import {Decimal} from '@formatjs/bigdecimal'
 const ZERO = new Decimal(0)
-import {ToNumber} from './ToNumber.js'
+import {ToNumber} from '#packages/ecma262-abstract/ToNumber.js'
 
 function ToInteger(n: any): Decimal {
   const number = ToNumber(n)

--- a/packages/ecma262-abstract/ToNumber.ts
+++ b/packages/ecma262-abstract/ToNumber.ts
@@ -1,5 +1,5 @@
 import {Decimal} from '@formatjs/bigdecimal'
-import {ToPrimitive} from './ToPrimitive.js'
+import {ToPrimitive} from '#packages/ecma262-abstract/ToPrimitive.js'
 
 const ZERO = new Decimal(0)
 

--- a/packages/ecma402-abstract/DateTimeFormat/BasicFormatMatcher.ts
+++ b/packages/ecma402-abstract/DateTimeFormat/BasicFormatMatcher.ts
@@ -9,7 +9,7 @@ import {
   shortLessPenalty,
   longLessPenalty,
   offsetPenalty,
-} from './utils.js'
+} from '#packages/ecma402-abstract/DateTimeFormat/utils.js'
 
 /**
  * https://tc39.es/ecma402/#sec-basicformatmatcher

--- a/packages/ecma402-abstract/DateTimeFormat/BestFitFormatMatcher.ts
+++ b/packages/ecma402-abstract/DateTimeFormat/BestFitFormatMatcher.ts
@@ -3,7 +3,7 @@ import {
   type TABLE_6,
 } from '#packages/ecma402-abstract/types/date-time.js'
 import {invariant} from '#packages/ecma402-abstract/utils.js'
-import {processDateTimePattern} from './skeleton.js'
+import {processDateTimePattern} from '#packages/ecma402-abstract/DateTimeFormat/skeleton.js'
 import {
   DATE_TIME_PROPS,
   additionPenalty,
@@ -13,7 +13,7 @@ import {
   removalPenalty,
   shortLessPenalty,
   shortMorePenalty,
-} from './utils.js'
+} from '#packages/ecma402-abstract/DateTimeFormat/utils.js'
 
 function isNumericType(
   t: 'numeric' | '2-digit' | 'narrow' | 'short' | 'long'

--- a/packages/ecma402-abstract/DateTimeFormat/FormatDateTime.ts
+++ b/packages/ecma402-abstract/DateTimeFormat/FormatDateTime.ts
@@ -1,6 +1,6 @@
 import {type DateTimeFormat} from '#packages/ecma402-abstract/types/date-time.js'
 import type Decimal from '@formatjs/bigdecimal'
-import {PartitionDateTimePattern} from './PartitionDateTimePattern.js'
+import {PartitionDateTimePattern} from '#packages/ecma402-abstract/DateTimeFormat/PartitionDateTimePattern.js'
 
 /**
  * https://tc39.es/ecma402/#sec-formatdatetime

--- a/packages/ecma402-abstract/DateTimeFormat/FormatDateTimePattern.ts
+++ b/packages/ecma402-abstract/DateTimeFormat/FormatDateTimePattern.ts
@@ -8,8 +8,11 @@ import {
 import {createMemoizedNumberFormat} from '#packages/ecma402-abstract/utils.js'
 
 import Decimal from '@formatjs/bigdecimal'
-import {ToLocalTime, type ToLocalTimeImplDetails} from './ToLocalTime.js'
-import {DATE_TIME_PROPS} from './utils.js'
+import {
+  ToLocalTime,
+  type ToLocalTimeImplDetails,
+} from '#packages/ecma402-abstract/DateTimeFormat/ToLocalTime.js'
+import {DATE_TIME_PROPS} from '#packages/ecma402-abstract/DateTimeFormat/utils.js'
 
 function pad(n: number): string {
   if (n < 10) {

--- a/packages/ecma402-abstract/DateTimeFormat/FormatDateTimeRange.ts
+++ b/packages/ecma402-abstract/DateTimeFormat/FormatDateTimeRange.ts
@@ -1,7 +1,7 @@
 import type Decimal from '@formatjs/bigdecimal'
-import {type FormatDateTimePatternImplDetails} from './FormatDateTimePattern.js'
-import {PartitionDateTimeRangePattern} from './PartitionDateTimeRangePattern.js'
-import {type ToLocalTimeImplDetails} from './ToLocalTime.js'
+import {type FormatDateTimePatternImplDetails} from '#packages/ecma402-abstract/DateTimeFormat/FormatDateTimePattern.js'
+import {PartitionDateTimeRangePattern} from '#packages/ecma402-abstract/DateTimeFormat/PartitionDateTimeRangePattern.js'
+import {type ToLocalTimeImplDetails} from '#packages/ecma402-abstract/DateTimeFormat/ToLocalTime.js'
 
 export function FormatDateTimeRange(
   dtf: Intl.DateTimeFormat,

--- a/packages/ecma402-abstract/DateTimeFormat/FormatDateTimeRangeToParts.ts
+++ b/packages/ecma402-abstract/DateTimeFormat/FormatDateTimeRangeToParts.ts
@@ -1,8 +1,8 @@
 import {type IntlDateTimeFormatPart} from '#packages/ecma402-abstract/types/date-time.js'
 import type {Decimal} from '@formatjs/bigdecimal'
-import {type FormatDateTimePatternImplDetails} from './FormatDateTimePattern.js'
-import {PartitionDateTimeRangePattern} from './PartitionDateTimeRangePattern.js'
-import {type ToLocalTimeImplDetails} from './ToLocalTime.js'
+import {type FormatDateTimePatternImplDetails} from '#packages/ecma402-abstract/DateTimeFormat/FormatDateTimePattern.js'
+import {PartitionDateTimeRangePattern} from '#packages/ecma402-abstract/DateTimeFormat/PartitionDateTimeRangePattern.js'
+import {type ToLocalTimeImplDetails} from '#packages/ecma402-abstract/DateTimeFormat/ToLocalTime.js'
 
 export function FormatDateTimeRangeToParts(
   dtf: Intl.DateTimeFormat,

--- a/packages/ecma402-abstract/DateTimeFormat/FormatDateTimeToParts.ts
+++ b/packages/ecma402-abstract/DateTimeFormat/FormatDateTimeToParts.ts
@@ -1,7 +1,7 @@
 import {ArrayCreate} from '#packages/ecma262-abstract/ArrayCreate.js'
 import {type IntlDateTimeFormatPart} from '#packages/ecma402-abstract/types/date-time.js'
 import type Decimal from '@formatjs/bigdecimal'
-import {PartitionDateTimePattern} from './PartitionDateTimePattern.js'
+import {PartitionDateTimePattern} from '#packages/ecma402-abstract/DateTimeFormat/PartitionDateTimePattern.js'
 
 /**
  * https://tc39.es/ecma402/#sec-formatdatetimetoparts

--- a/packages/ecma402-abstract/DateTimeFormat/InitializeDateTimeFormat.ts
+++ b/packages/ecma402-abstract/DateTimeFormat/InitializeDateTimeFormat.ts
@@ -11,11 +11,11 @@ import {
 } from '#packages/ecma402-abstract/types/date-time.js'
 import {invariant} from '#packages/ecma402-abstract/utils.js'
 import {ResolveLocale} from '@formatjs/intl-localematcher'
-import {BasicFormatMatcher} from './BasicFormatMatcher.js'
-import {BestFitFormatMatcher} from './BestFitFormatMatcher.js'
-import {DateTimeStyleFormat} from './DateTimeStyleFormat.js'
-import {ToDateTimeOptions} from './ToDateTimeOptions.js'
-import {DATE_TIME_PROPS} from './utils.js'
+import {BasicFormatMatcher} from '#packages/ecma402-abstract/DateTimeFormat/BasicFormatMatcher.js'
+import {BestFitFormatMatcher} from '#packages/ecma402-abstract/DateTimeFormat/BestFitFormatMatcher.js'
+import {DateTimeStyleFormat} from '#packages/ecma402-abstract/DateTimeFormat/DateTimeStyleFormat.js'
+import {ToDateTimeOptions} from '#packages/ecma402-abstract/DateTimeFormat/ToDateTimeOptions.js'
+import {DATE_TIME_PROPS} from '#packages/ecma402-abstract/DateTimeFormat/utils.js'
 
 function isTimeRelated(opt: Opt) {
   for (const prop of ['hour', 'minute', 'second'] as Array<

--- a/packages/ecma402-abstract/DateTimeFormat/PartitionDateTimePattern.ts
+++ b/packages/ecma402-abstract/DateTimeFormat/PartitionDateTimePattern.ts
@@ -10,8 +10,8 @@ import type Decimal from '@formatjs/bigdecimal'
 import {
   FormatDateTimePattern,
   type FormatDateTimePatternImplDetails,
-} from './FormatDateTimePattern.js'
-import {type ToLocalTimeImplDetails} from './ToLocalTime.js'
+} from '#packages/ecma402-abstract/DateTimeFormat/FormatDateTimePattern.js'
+import {type ToLocalTimeImplDetails} from '#packages/ecma402-abstract/DateTimeFormat/ToLocalTime.js'
 
 /**
  * https://tc39.es/ecma402/#sec-partitiondatetimepattern

--- a/packages/ecma402-abstract/DateTimeFormat/PartitionDateTimeRangePattern.ts
+++ b/packages/ecma402-abstract/DateTimeFormat/PartitionDateTimeRangePattern.ts
@@ -11,8 +11,11 @@ import type Decimal from '@formatjs/bigdecimal'
 import {
   FormatDateTimePattern,
   type FormatDateTimePatternImplDetails,
-} from './FormatDateTimePattern.js'
-import {ToLocalTime, type ToLocalTimeImplDetails} from './ToLocalTime.js'
+} from '#packages/ecma402-abstract/DateTimeFormat/FormatDateTimePattern.js'
+import {
+  ToLocalTime,
+  type ToLocalTimeImplDetails,
+} from '#packages/ecma402-abstract/DateTimeFormat/ToLocalTime.js'
 
 const TABLE_2_FIELDS: Array<TABLE_2> = [
   'era',

--- a/packages/ecma402-abstract/DisplayNames/CanonicalCodeForDisplayNames.ts
+++ b/packages/ecma402-abstract/DisplayNames/CanonicalCodeForDisplayNames.ts
@@ -2,7 +2,7 @@ import {CanonicalizeLocaleList} from '#packages/ecma402-abstract/CanonicalizeLoc
 import {IsWellFormedCurrencyCode} from '#packages/ecma402-abstract/IsWellFormedCurrencyCode.js'
 import {invariant} from '#packages/ecma402-abstract/utils.js'
 
-import {IsValidDateTimeFieldCode} from './IsValidDateTimeFieldCode.js'
+import {IsValidDateTimeFieldCode} from '#packages/ecma402-abstract/DisplayNames/IsValidDateTimeFieldCode.js'
 
 const UNICODE_REGION_SUBTAG_REGEX = /^([a-z]{2}|[0-9]{3})$/i
 const ALPHA_4 = /^[a-z]{4}$/i

--- a/packages/ecma402-abstract/DurationFormat/DurationRecordSign.ts
+++ b/packages/ecma402-abstract/DurationFormat/DurationRecordSign.ts
@@ -1,4 +1,4 @@
-import {TABLE_1} from './constants.js'
+import {TABLE_1} from '#packages/ecma402-abstract/DurationFormat/constants.js'
 import {type DurationRecord} from '#packages/ecma402-abstract/types/duration.js'
 
 export function DurationRecordSign(record: DurationRecord): -1 | 0 | 1 {

--- a/packages/ecma402-abstract/DurationFormat/IsValidDurationRecord.ts
+++ b/packages/ecma402-abstract/DurationFormat/IsValidDurationRecord.ts
@@ -1,7 +1,7 @@
 import {invariant} from '#packages/ecma402-abstract/utils.js'
-import {TABLE_1} from './constants.js'
+import {TABLE_1} from '#packages/ecma402-abstract/DurationFormat/constants.js'
 import {type DurationRecord} from '#packages/ecma402-abstract/types/duration.js'
-import {DurationRecordSign} from './DurationRecordSign.js'
+import {DurationRecordSign} from '#packages/ecma402-abstract/DurationFormat/DurationRecordSign.js'
 
 export function IsValidDurationRecord(record: DurationRecord): boolean {
   const sign = DurationRecordSign(record)

--- a/packages/ecma402-abstract/DurationFormat/ToDurationRecord.ts
+++ b/packages/ecma402-abstract/DurationFormat/ToDurationRecord.ts
@@ -2,8 +2,8 @@ import {
   type DurationInput,
   type DurationRecord,
 } from '#packages/ecma402-abstract/types/duration.js'
-import {IsValidDurationRecord} from './IsValidDurationRecord.js'
-import {ToIntegerIfIntegral} from './ToIntegerIfIntegral.js'
+import {IsValidDurationRecord} from '#packages/ecma402-abstract/DurationFormat/IsValidDurationRecord.js'
+import {ToIntegerIfIntegral} from '#packages/ecma402-abstract/DurationFormat/ToIntegerIfIntegral.js'
 
 export function ToDurationRecord(input: DurationInput): DurationRecord {
   if (typeof input !== 'object') {

--- a/packages/ecma402-abstract/GetNumberOption.ts
+++ b/packages/ecma402-abstract/GetNumberOption.ts
@@ -7,7 +7,7 @@
  * @param fallback
  */
 
-import {DefaultNumberOption} from './DefaultNumberOption.js'
+import {DefaultNumberOption} from '#packages/ecma402-abstract/DefaultNumberOption.js'
 
 export function GetNumberOption<
   T extends object,

--- a/packages/ecma402-abstract/IsWellFormedUnitIdentifier.ts
+++ b/packages/ecma402-abstract/IsWellFormedUnitIdentifier.ts
@@ -1,4 +1,4 @@
-import {IsSanctionedSimpleUnitIdentifier} from './IsSanctionedSimpleUnitIdentifier.js'
+import {IsSanctionedSimpleUnitIdentifier} from '#packages/ecma402-abstract/IsSanctionedSimpleUnitIdentifier.js'
 
 /**
  * This follows https://tc39.es/ecma402/#sec-case-sensitivity-and-case-mapping

--- a/packages/ecma402-abstract/NumberFormat/ApplyUnsignedRoundingMode.ts
+++ b/packages/ecma402-abstract/NumberFormat/ApplyUnsignedRoundingMode.ts
@@ -1,6 +1,6 @@
 import type {Decimal} from '@formatjs/bigdecimal'
-import {type UnsignedRoundingModeType} from '../types/number.js'
-import {invariant} from '../utils.js'
+import {type UnsignedRoundingModeType} from '#packages/ecma402-abstract/types/number.js'
+import {invariant} from '#packages/ecma402-abstract/utils.js'
 
 export function ApplyUnsignedRoundingMode(
   x: Decimal,

--- a/packages/ecma402-abstract/NumberFormat/CollapseNumberRange.ts
+++ b/packages/ecma402-abstract/NumberFormat/CollapseNumberRange.ts
@@ -2,7 +2,7 @@ import {
   type NumberFormatInternal,
   type NumberFormatPart,
   type NumberFormatPartTypes,
-} from '../types/number.js'
+} from '#packages/ecma402-abstract/types/number.js'
 
 const PART_TYPES_TO_COLLAPSE = new Set<NumberFormatPartTypes>([
   'unit',

--- a/packages/ecma402-abstract/NumberFormat/ComputeExponent.ts
+++ b/packages/ecma402-abstract/NumberFormat/ComputeExponent.ts
@@ -1,8 +1,8 @@
 import {Decimal} from '@formatjs/bigdecimal'
-import {type NumberFormatInternal} from '../types/number.js'
-import {ComputeExponentForMagnitude} from './ComputeExponentForMagnitude.js'
-import {FormatNumericToString} from './FormatNumericToString.js'
-import {getPowerOf10} from './decimal-cache.js'
+import {type NumberFormatInternal} from '#packages/ecma402-abstract/types/number.js'
+import {ComputeExponentForMagnitude} from '#packages/ecma402-abstract/NumberFormat/ComputeExponentForMagnitude.js'
+import {FormatNumericToString} from '#packages/ecma402-abstract/NumberFormat/FormatNumericToString.js'
+import {getPowerOf10} from '#packages/ecma402-abstract/NumberFormat/decimal-cache.js'
 
 /**
  * The abstract operation ComputeExponent computes an exponent (power of ten) by which to scale x

--- a/packages/ecma402-abstract/NumberFormat/ComputeExponentForMagnitude.ts
+++ b/packages/ecma402-abstract/NumberFormat/ComputeExponentForMagnitude.ts
@@ -2,9 +2,9 @@ import type {Decimal} from '@formatjs/bigdecimal'
 import {
   type DecimalFormatNum,
   type NumberFormatInternal,
-} from '../types/number.js'
-import {invariant} from '../utils.js'
-import {getPowerOf10} from './decimal-cache.js'
+} from '#packages/ecma402-abstract/types/number.js'
+import {invariant} from '#packages/ecma402-abstract/utils.js'
+import {getPowerOf10} from '#packages/ecma402-abstract/NumberFormat/decimal-cache.js'
 /**
  * The abstract operation ComputeExponentForMagnitude computes an exponent by which to scale a
  * number of the given magnitude (power of ten of the most significant digit) according to the

--- a/packages/ecma402-abstract/NumberFormat/FormatApproximately.ts
+++ b/packages/ecma402-abstract/NumberFormat/FormatApproximately.ts
@@ -1,7 +1,7 @@
 import {
   type NumberFormatInternal,
   type NumberFormatPart,
-} from '../types/number.js'
+} from '#packages/ecma402-abstract/types/number.js'
 
 /**
  * https://tc39.es/ecma402/#sec-formatapproximately

--- a/packages/ecma402-abstract/NumberFormat/FormatNumeric.ts
+++ b/packages/ecma402-abstract/NumberFormat/FormatNumeric.ts
@@ -1,6 +1,6 @@
 import type {Decimal} from '@formatjs/bigdecimal'
-import {type NumberFormatInternal} from '../types/number.js'
-import {PartitionNumberPattern} from './PartitionNumberPattern.js'
+import {type NumberFormatInternal} from '#packages/ecma402-abstract/types/number.js'
+import {PartitionNumberPattern} from '#packages/ecma402-abstract/NumberFormat/PartitionNumberPattern.js'
 
 export function FormatNumeric(
   internalSlots: NumberFormatInternal,

--- a/packages/ecma402-abstract/NumberFormat/FormatNumericRange.ts
+++ b/packages/ecma402-abstract/NumberFormat/FormatNumericRange.ts
@@ -1,6 +1,6 @@
 import type {Decimal} from '@formatjs/bigdecimal'
-import {type NumberFormatInternal} from '../types/number.js'
-import {PartitionNumberRangePattern} from './PartitionNumberRangePattern.js'
+import {type NumberFormatInternal} from '#packages/ecma402-abstract/types/number.js'
+import {PartitionNumberRangePattern} from '#packages/ecma402-abstract/NumberFormat/PartitionNumberRangePattern.js'
 
 /**
  * https://tc39.es/ecma402/#sec-formatnumericrange

--- a/packages/ecma402-abstract/NumberFormat/FormatNumericRangeToParts.ts
+++ b/packages/ecma402-abstract/NumberFormat/FormatNumericRangeToParts.ts
@@ -2,8 +2,8 @@ import type {Decimal} from '@formatjs/bigdecimal'
 import {
   type NumberFormatInternal,
   type NumberRangeToParts,
-} from '../types/number.js'
-import {PartitionNumberRangePattern} from './PartitionNumberRangePattern.js'
+} from '#packages/ecma402-abstract/types/number.js'
+import {PartitionNumberRangePattern} from '#packages/ecma402-abstract/NumberFormat/PartitionNumberRangePattern.js'
 
 /**
  * https://tc39.es/ecma402/#sec-formatnumericrangetoparts

--- a/packages/ecma402-abstract/NumberFormat/FormatNumericToParts.ts
+++ b/packages/ecma402-abstract/NumberFormat/FormatNumericToParts.ts
@@ -3,8 +3,8 @@ import {ArrayCreate} from '#packages/ecma262-abstract/ArrayCreate.js'
 import {
   type NumberFormatInternal,
   type NumberFormatPart,
-} from '../types/number.js'
-import {PartitionNumberPattern} from './PartitionNumberPattern.js'
+} from '#packages/ecma402-abstract/types/number.js'
+import {PartitionNumberPattern} from '#packages/ecma402-abstract/NumberFormat/PartitionNumberPattern.js'
 
 export function FormatNumericToParts(
   nf: Intl.NumberFormat,

--- a/packages/ecma402-abstract/NumberFormat/FormatNumericToString.ts
+++ b/packages/ecma402-abstract/NumberFormat/FormatNumericToString.ts
@@ -1,13 +1,13 @@
 import type {Decimal} from '@formatjs/bigdecimal'
-import {NEGATIVE_ZERO, ZERO} from '../constants.js'
+import {NEGATIVE_ZERO, ZERO} from '#packages/ecma402-abstract/constants.js'
 import {
   type NumberFormatDigitInternalSlots,
   type RawNumberFormatResult,
-} from '../types/number.js'
-import {invariant, repeat} from '../utils.js'
-import {GetUnsignedRoundingMode} from './GetUnsignedRoundingMode.js'
-import {ToRawFixed} from './ToRawFixed.js'
-import {ToRawPrecision} from './ToRawPrecision.js'
+} from '#packages/ecma402-abstract/types/number.js'
+import {invariant, repeat} from '#packages/ecma402-abstract/utils.js'
+import {GetUnsignedRoundingMode} from '#packages/ecma402-abstract/NumberFormat/GetUnsignedRoundingMode.js'
+import {ToRawFixed} from '#packages/ecma402-abstract/NumberFormat/ToRawFixed.js'
+import {ToRawPrecision} from '#packages/ecma402-abstract/NumberFormat/ToRawPrecision.js'
 
 /**
  * https://tc39.es/ecma402/#sec-formatnumberstring

--- a/packages/ecma402-abstract/NumberFormat/GetUnsignedRoundingMode.ts
+++ b/packages/ecma402-abstract/NumberFormat/GetUnsignedRoundingMode.ts
@@ -1,7 +1,7 @@
 import {
   type RoundingModeType,
   type UnsignedRoundingModeType,
-} from '../types/number.js'
+} from '#packages/ecma402-abstract/types/number.js'
 
 const negativeMapping: Record<RoundingModeType, UnsignedRoundingModeType> = {
   ceil: 'zero',

--- a/packages/ecma402-abstract/NumberFormat/InitializeNumberFormat.ts
+++ b/packages/ecma402-abstract/NumberFormat/InitializeNumberFormat.ts
@@ -1,18 +1,18 @@
 import {ResolveLocale} from '@formatjs/intl-localematcher'
-import {CanonicalizeLocaleList} from '../CanonicalizeLocaleList.js'
-import {CoerceOptionsToObject} from '../CoerceOptionsToObject.js'
-import {GetOption} from '../GetOption.js'
-import {GetStringOrBooleanOption} from '../GetStringOrBooleanOption.js'
+import {CanonicalizeLocaleList} from '#packages/ecma402-abstract/CanonicalizeLocaleList.js'
+import {CoerceOptionsToObject} from '#packages/ecma402-abstract/CoerceOptionsToObject.js'
+import {GetOption} from '#packages/ecma402-abstract/GetOption.js'
+import {GetStringOrBooleanOption} from '#packages/ecma402-abstract/GetStringOrBooleanOption.js'
 import {
   type NumberFormatInternal,
   type NumberFormatLocaleInternalData,
   type NumberFormatOptions,
   type UseGroupingType,
-} from '../types/number.js'
-import {invariant} from '../utils.js'
-import {CurrencyDigits} from './CurrencyDigits.js'
-import {SetNumberFormatDigitOptions} from './SetNumberFormatDigitOptions.js'
-import {SetNumberFormatUnitOptions} from './SetNumberFormatUnitOptions.js'
+} from '#packages/ecma402-abstract/types/number.js'
+import {invariant} from '#packages/ecma402-abstract/utils.js'
+import {CurrencyDigits} from '#packages/ecma402-abstract/NumberFormat/CurrencyDigits.js'
+import {SetNumberFormatDigitOptions} from '#packages/ecma402-abstract/NumberFormat/SetNumberFormatDigitOptions.js'
+import {SetNumberFormatUnitOptions} from '#packages/ecma402-abstract/NumberFormat/SetNumberFormatUnitOptions.js'
 
 /**
  * https://tc39.es/ecma402/#sec-initializenumberformat

--- a/packages/ecma402-abstract/NumberFormat/PartitionNumberPattern.ts
+++ b/packages/ecma402-abstract/NumberFormat/PartitionNumberPattern.ts
@@ -2,12 +2,12 @@ import type {Decimal} from '@formatjs/bigdecimal'
 import {
   type NumberFormatInternal,
   type NumberFormatPart,
-} from '../types/number.js'
-import {invariant} from '../utils.js'
-import {ComputeExponent} from './ComputeExponent.js'
-import formatToParts from './format_to_parts.js'
-import {FormatNumericToString} from './FormatNumericToString.js'
-import {getPowerOf10} from './decimal-cache.js'
+} from '#packages/ecma402-abstract/types/number.js'
+import {invariant} from '#packages/ecma402-abstract/utils.js'
+import {ComputeExponent} from '#packages/ecma402-abstract/NumberFormat/ComputeExponent.js'
+import formatToParts from '#packages/ecma402-abstract/NumberFormat/format_to_parts.js'
+import {FormatNumericToString} from '#packages/ecma402-abstract/NumberFormat/FormatNumericToString.js'
+import {getPowerOf10} from '#packages/ecma402-abstract/NumberFormat/decimal-cache.js'
 
 /**
  * https://tc39.es/ecma402/#sec-partitionnumberpattern

--- a/packages/ecma402-abstract/NumberFormat/PartitionNumberRangePattern.ts
+++ b/packages/ecma402-abstract/NumberFormat/PartitionNumberRangePattern.ts
@@ -2,12 +2,12 @@ import type {Decimal} from '@formatjs/bigdecimal'
 import {
   type NumberFormatInternal,
   type NumberFormatPart,
-} from '../types/number.js'
-import {invariant} from '../utils.js'
-import {CollapseNumberRange} from './CollapseNumberRange.js'
-import {FormatApproximately} from './FormatApproximately.js'
-import {FormatNumeric} from './FormatNumeric.js'
-import {PartitionNumberPattern} from './PartitionNumberPattern.js'
+} from '#packages/ecma402-abstract/types/number.js'
+import {invariant} from '#packages/ecma402-abstract/utils.js'
+import {CollapseNumberRange} from '#packages/ecma402-abstract/NumberFormat/CollapseNumberRange.js'
+import {FormatApproximately} from '#packages/ecma402-abstract/NumberFormat/FormatApproximately.js'
+import {FormatNumeric} from '#packages/ecma402-abstract/NumberFormat/FormatNumeric.js'
+import {PartitionNumberPattern} from '#packages/ecma402-abstract/NumberFormat/PartitionNumberPattern.js'
 
 /**
  * https://tc39.es/ecma402/#sec-partitionnumberrangepattern

--- a/packages/ecma402-abstract/NumberFormat/SetNumberFormatDigitOptions.ts
+++ b/packages/ecma402-abstract/NumberFormat/SetNumberFormatDigitOptions.ts
@@ -1,12 +1,12 @@
-import {DefaultNumberOption} from '../DefaultNumberOption.js'
-import {GetNumberOption} from '../GetNumberOption.js'
-import {GetOption} from '../GetOption.js'
+import {DefaultNumberOption} from '#packages/ecma402-abstract/DefaultNumberOption.js'
+import {GetNumberOption} from '#packages/ecma402-abstract/GetNumberOption.js'
+import {GetOption} from '#packages/ecma402-abstract/GetOption.js'
 import {
   type NumberFormatDigitInternalSlots,
   type NumberFormatDigitOptions,
   type NumberFormatNotation,
-} from '../types/number.js'
-import {invariant} from '../utils.js'
+} from '#packages/ecma402-abstract/types/number.js'
+import {invariant} from '#packages/ecma402-abstract/utils.js'
 
 //IMPL: Valid rounding increments as per implementation
 const VALID_ROUNDING_INCREMENTS = new Set([

--- a/packages/ecma402-abstract/NumberFormat/SetNumberFormatUnitOptions.ts
+++ b/packages/ecma402-abstract/NumberFormat/SetNumberFormatUnitOptions.ts
@@ -1,11 +1,11 @@
-import {GetOption} from '../GetOption.js'
-import {IsWellFormedCurrencyCode} from '../IsWellFormedCurrencyCode.js'
-import {IsWellFormedUnitIdentifier} from '../IsWellFormedUnitIdentifier.js'
+import {GetOption} from '#packages/ecma402-abstract/GetOption.js'
+import {IsWellFormedCurrencyCode} from '#packages/ecma402-abstract/IsWellFormedCurrencyCode.js'
+import {IsWellFormedUnitIdentifier} from '#packages/ecma402-abstract/IsWellFormedUnitIdentifier.js'
 import {
   type NumberFormatInternal,
   type NumberFormatOptions,
-} from '../types/number.js'
-import {invariant} from '../utils.js'
+} from '#packages/ecma402-abstract/types/number.js'
+import {invariant} from '#packages/ecma402-abstract/utils.js'
 
 /**
  * https://tc39.es/ecma402/#sec-setnumberformatunitoptions

--- a/packages/ecma402-abstract/NumberFormat/ToRawFixed.ts
+++ b/packages/ecma402-abstract/NumberFormat/ToRawFixed.ts
@@ -2,10 +2,10 @@ import type {Decimal} from '@formatjs/bigdecimal'
 import {
   type RawNumberFormatResult,
   type UnsignedRoundingModeType,
-} from '../types/number.js'
-import {repeat} from '../utils.js'
-import {ApplyUnsignedRoundingMode} from './ApplyUnsignedRoundingMode.js'
-import {getPowerOf10} from './decimal-cache.js'
+} from '#packages/ecma402-abstract/types/number.js'
+import {repeat} from '#packages/ecma402-abstract/utils.js'
+import {ApplyUnsignedRoundingMode} from '#packages/ecma402-abstract/NumberFormat/ApplyUnsignedRoundingMode.js'
+import {getPowerOf10} from '#packages/ecma402-abstract/NumberFormat/decimal-cache.js'
 
 //IMPL: Helper function to calculate raw fixed value
 function ToRawFixedFn(n: Decimal, f: number) {

--- a/packages/ecma402-abstract/NumberFormat/ToRawPrecision.ts
+++ b/packages/ecma402-abstract/NumberFormat/ToRawPrecision.ts
@@ -1,12 +1,12 @@
 import type {Decimal} from '@formatjs/bigdecimal'
-import {ZERO} from '../constants.js'
+import {ZERO} from '#packages/ecma402-abstract/constants.js'
 import {
   type RawNumberFormatResult,
   type UnsignedRoundingModeType,
-} from '../types/number.js'
-import {invariant, repeat} from '../utils.js'
-import {ApplyUnsignedRoundingMode} from './ApplyUnsignedRoundingMode.js'
-import {getPowerOf10} from './decimal-cache.js'
+} from '#packages/ecma402-abstract/types/number.js'
+import {invariant, repeat} from '#packages/ecma402-abstract/utils.js'
+import {ApplyUnsignedRoundingMode} from '#packages/ecma402-abstract/NumberFormat/ApplyUnsignedRoundingMode.js'
+import {getPowerOf10} from '#packages/ecma402-abstract/NumberFormat/decimal-cache.js'
 
 //IMPL: Helper function to find n1, e1, and r1 using direct calculation
 function findN1E1R1(x: Decimal, p: number) {

--- a/packages/ecma402-abstract/NumberFormat/format_to_parts.ts
+++ b/packages/ecma402-abstract/NumberFormat/format_to_parts.ts
@@ -1,5 +1,5 @@
 import {Decimal} from '@formatjs/bigdecimal'
-import {S_UNICODE_REGEX} from '../regex.generated.js'
+import {S_UNICODE_REGEX} from '#packages/ecma402-abstract/regex.generated.js'
 import {
   type DecimalFormatNum,
   type LDMLPluralRuleMap,
@@ -17,12 +17,12 @@ import {
   type UnitData,
   type UnsignedRoundingModeType,
   type UseGroupingType,
-} from '../types/number.js'
-import {getPowerOf10} from './decimal-cache.js'
-import {type LDMLPluralRule} from '../types/plural-rules.js'
-import {digitMapping} from './digit-mapping.generated.js'
-import {GetUnsignedRoundingMode} from './GetUnsignedRoundingMode.js'
-import {ToRawFixed} from './ToRawFixed.js'
+} from '#packages/ecma402-abstract/types/number.js'
+import {getPowerOf10} from '#packages/ecma402-abstract/NumberFormat/decimal-cache.js'
+import {type LDMLPluralRule} from '#packages/ecma402-abstract/types/plural-rules.js'
+import {digitMapping} from '#packages/ecma402-abstract/NumberFormat/digit-mapping.generated.js'
+import {GetUnsignedRoundingMode} from '#packages/ecma402-abstract/NumberFormat/GetUnsignedRoundingMode.js'
+import {ToRawFixed} from '#packages/ecma402-abstract/NumberFormat/ToRawFixed.js'
 
 // This is from: unicode-12.1.0/General_Category/Symbol/regex.js
 // IE11 does not support unicode flag, otherwise this is just /\p{S}/u.

--- a/packages/ecma402-abstract/PartitionPattern.ts
+++ b/packages/ecma402-abstract/PartitionPattern.ts
@@ -1,4 +1,4 @@
-import {invariant} from './utils.js'
+import {invariant} from '#packages/ecma402-abstract/utils.js'
 
 /**
  * Partition a pattern into a list of literals and placeholders

--- a/packages/ecma402-abstract/PluralRules/ResolvePlural.ts
+++ b/packages/ecma402-abstract/PluralRules/ResolvePlural.ts
@@ -7,7 +7,10 @@ import {
 } from '#packages/ecma402-abstract/types/plural-rules.js'
 import {invariant} from '#packages/ecma402-abstract/utils.js'
 import Decimal from '@formatjs/bigdecimal'
-import {GetOperands, type OperandsRecord} from './GetOperands.js'
+import {
+  GetOperands,
+  type OperandsRecord,
+} from '#packages/ecma402-abstract/PluralRules/GetOperands.js'
 
 /**
  * Result of ResolvePluralInternal containing both the formatted string and plural category.

--- a/packages/ecma402-abstract/PluralRules/ResolvePluralRange.ts
+++ b/packages/ecma402-abstract/PluralRules/ResolvePluralRange.ts
@@ -5,8 +5,8 @@ import {
 } from '#packages/ecma402-abstract/types/plural-rules.js'
 import {invariant} from '#packages/ecma402-abstract/utils.js'
 import type Decimal from '@formatjs/bigdecimal'
-import {type OperandsRecord} from './GetOperands.js'
-import {ResolvePluralInternal} from './ResolvePlural.js'
+import {type OperandsRecord} from '#packages/ecma402-abstract/PluralRules/GetOperands.js'
+import {ResolvePluralInternal} from '#packages/ecma402-abstract/PluralRules/ResolvePlural.js'
 
 /**
  * ResolvePluralRange ( pluralRules, x, y )

--- a/packages/ecma402-abstract/RelativeTimeFormat/FormatRelativeTime.ts
+++ b/packages/ecma402-abstract/RelativeTimeFormat/FormatRelativeTime.ts
@@ -1,5 +1,5 @@
 import {type RelativeTimeFormatInternal} from '#packages/ecma402-abstract/types/relative-time.js'
-import {PartitionRelativeTimePattern} from './PartitionRelativeTimePattern.js'
+import {PartitionRelativeTimePattern} from '#packages/ecma402-abstract/RelativeTimeFormat/PartitionRelativeTimePattern.js'
 
 export function FormatRelativeTime(
   rtf: Intl.RelativeTimeFormat,

--- a/packages/ecma402-abstract/RelativeTimeFormat/FormatRelativeTimeToParts.ts
+++ b/packages/ecma402-abstract/RelativeTimeFormat/FormatRelativeTimeToParts.ts
@@ -1,5 +1,5 @@
 import {type RelativeTimeFormatInternal} from '#packages/ecma402-abstract/types/relative-time.js'
-import {PartitionRelativeTimePattern} from './PartitionRelativeTimePattern.js'
+import {PartitionRelativeTimePattern} from '#packages/ecma402-abstract/RelativeTimeFormat/PartitionRelativeTimePattern.js'
 
 export function FormatRelativeTimeToParts(
   rtf: Intl.RelativeTimeFormat,

--- a/packages/ecma402-abstract/RelativeTimeFormat/PartitionRelativeTimePattern.ts
+++ b/packages/ecma402-abstract/RelativeTimeFormat/PartitionRelativeTimePattern.ts
@@ -8,8 +8,8 @@ import {
   type RelativeTimeFormatInternal,
 } from '#packages/ecma402-abstract/types/relative-time.js'
 import {invariant} from '#packages/ecma402-abstract/utils.js'
-import {SingularRelativeTimeUnit} from './SingularRelativeTimeUnit.js'
-import {MakePartsList} from './MakePartsList.js'
+import {SingularRelativeTimeUnit} from '#packages/ecma402-abstract/RelativeTimeFormat/SingularRelativeTimeUnit.js'
+import {MakePartsList} from '#packages/ecma402-abstract/RelativeTimeFormat/MakePartsList.js'
 
 export function PartitionRelativeTimePattern(
   rtf: Intl.RelativeTimeFormat,

--- a/packages/ecma402-abstract/SupportedLocales.ts
+++ b/packages/ecma402-abstract/SupportedLocales.ts
@@ -1,6 +1,6 @@
 import {LookupSupportedLocales} from '@formatjs/intl-localematcher'
 import {ToObject} from '#packages/ecma262-abstract/ToObject.js'
-import {GetOption} from './GetOption.js'
+import {GetOption} from '#packages/ecma402-abstract/GetOption.js'
 
 /**
  * https://tc39.es/ecma402/#sec-supportedlocales

--- a/packages/ecma402-abstract/tests/ApplyUnsignedRoundingMode.test.ts
+++ b/packages/ecma402-abstract/tests/ApplyUnsignedRoundingMode.test.ts
@@ -1,5 +1,5 @@
 import Decimal from '@formatjs/bigdecimal'
-import {ApplyUnsignedRoundingMode} from '../NumberFormat/ApplyUnsignedRoundingMode.js'
+import {ApplyUnsignedRoundingMode} from '#packages/ecma402-abstract/NumberFormat/ApplyUnsignedRoundingMode.js'
 import {describe, expect, it} from 'vitest'
 describe('ApplyUnsignedRoundingMode', () => {
   it('return r1 for x = r1', () => {

--- a/packages/ecma402-abstract/tests/CanonicalizeTimeZoneName.test.ts
+++ b/packages/ecma402-abstract/tests/CanonicalizeTimeZoneName.test.ts
@@ -1,4 +1,4 @@
-import {CanonicalizeTimeZoneName} from '../CanonicalizeTimeZoneName.js'
+import {CanonicalizeTimeZoneName} from '#packages/ecma402-abstract/CanonicalizeTimeZoneName.js'
 import {expect, test, describe} from 'vitest'
 
 describe('CanonicalizeTimeZoneName', () => {

--- a/packages/ecma402-abstract/tests/CollapseNumberRange.test.ts
+++ b/packages/ecma402-abstract/tests/CollapseNumberRange.test.ts
@@ -1,5 +1,5 @@
-import {CollapseNumberRange} from '../NumberFormat/CollapseNumberRange.js'
-import {getInternalSlots} from './utils.js'
+import {CollapseNumberRange} from '#packages/ecma402-abstract/NumberFormat/CollapseNumberRange.js'
+import {getInternalSlots} from '#packages/ecma402-abstract/tests/utils.js'
 import {describe, expect, test} from 'vitest'
 const numberFormat: Intl.NumberFormat = new Intl.NumberFormat('it')
 

--- a/packages/ecma402-abstract/tests/FormatApproximately.test.ts
+++ b/packages/ecma402-abstract/tests/FormatApproximately.test.ts
@@ -1,6 +1,6 @@
-import {FormatApproximately} from '../NumberFormat/FormatApproximately.js'
-import {type NumberFormatPart} from '../types/number.js'
-import {getInternalSlots} from './utils.js'
+import {FormatApproximately} from '#packages/ecma402-abstract/NumberFormat/FormatApproximately.js'
+import {type NumberFormatPart} from '#packages/ecma402-abstract/types/number.js'
+import {getInternalSlots} from '#packages/ecma402-abstract/tests/utils.js'
 import {describe, expect, it} from 'vitest'
 describe('FormatApproximately', () => {
   const numberFormat: Intl.NumberFormat = new Intl.NumberFormat('it')

--- a/packages/ecma402-abstract/tests/FormatNumericRange.test.ts
+++ b/packages/ecma402-abstract/tests/FormatNumericRange.test.ts
@@ -1,6 +1,6 @@
 import Decimal from '@formatjs/bigdecimal'
-import {FormatNumericRange} from '../NumberFormat/FormatNumericRange.js'
-import {getInternalSlots} from './utils.js'
+import {FormatNumericRange} from '#packages/ecma402-abstract/NumberFormat/FormatNumericRange.js'
+import {getInternalSlots} from '#packages/ecma402-abstract/tests/utils.js'
 import {describe, expect, it} from 'vitest'
 describe('FormatNumericRange', () => {
   const numberFormat: Intl.NumberFormat = new Intl.NumberFormat('it')

--- a/packages/ecma402-abstract/tests/FormatNumericRangeToParts.test.ts
+++ b/packages/ecma402-abstract/tests/FormatNumericRangeToParts.test.ts
@@ -1,6 +1,6 @@
 import Decimal from '@formatjs/bigdecimal'
-import {FormatNumericRangeToParts} from '../NumberFormat/FormatNumericRangeToParts.js'
-import {getInternalSlots} from './utils.js'
+import {FormatNumericRangeToParts} from '#packages/ecma402-abstract/NumberFormat/FormatNumericRangeToParts.js'
+import {getInternalSlots} from '#packages/ecma402-abstract/tests/utils.js'
 import {describe, expect, it} from 'vitest'
 describe('FormatNumericRangeToParts', () => {
   const numberFormat: Intl.NumberFormat = new Intl.NumberFormat('it')

--- a/packages/ecma402-abstract/tests/GetStringOrBooleanOption.test.ts
+++ b/packages/ecma402-abstract/tests/GetStringOrBooleanOption.test.ts
@@ -1,4 +1,4 @@
-import {GetStringOrBooleanOption} from '../GetStringOrBooleanOption.js'
+import {GetStringOrBooleanOption} from '#packages/ecma402-abstract/GetStringOrBooleanOption.js'
 import {describe, expect, test} from 'vitest'
 describe('GetStringOrBooleanOption', () => {
   test('returns fallback for undefined options', () => {

--- a/packages/ecma402-abstract/tests/GetUnsignedRoundingMode.test.ts
+++ b/packages/ecma402-abstract/tests/GetUnsignedRoundingMode.test.ts
@@ -1,8 +1,8 @@
-import {GetUnsignedRoundingMode} from '../NumberFormat/GetUnsignedRoundingMode.js'
+import {GetUnsignedRoundingMode} from '#packages/ecma402-abstract/NumberFormat/GetUnsignedRoundingMode.js'
 import {
   type RoundingModeType,
   type UnsignedRoundingModeType,
-} from '../types/number.js'
+} from '#packages/ecma402-abstract/types/number.js'
 import {describe, expect, it} from 'vitest'
 describe('GetUnsignedRoundingMod', () => {
   const negativeMapping: Record<RoundingModeType, UnsignedRoundingModeType> = {

--- a/packages/ecma402-abstract/tests/IsValidTimeZoneName.test.ts
+++ b/packages/ecma402-abstract/tests/IsValidTimeZoneName.test.ts
@@ -1,4 +1,4 @@
-import {IsValidTimeZoneName} from '../IsValidTimeZoneName.js'
+import {IsValidTimeZoneName} from '#packages/ecma402-abstract/IsValidTimeZoneName.js'
 import {expect, test, describe} from 'vitest'
 
 describe('IsValidTimeZoneName', () => {

--- a/packages/ecma402-abstract/tests/PartitionNumberPattern.test.ts
+++ b/packages/ecma402-abstract/tests/PartitionNumberPattern.test.ts
@@ -1,6 +1,6 @@
 import Decimal from '@formatjs/bigdecimal'
-import {PartitionNumberPattern} from '../NumberFormat/PartitionNumberPattern.js'
-import {getInternalSlots} from './utils.js'
+import {PartitionNumberPattern} from '#packages/ecma402-abstract/NumberFormat/PartitionNumberPattern.js'
+import {getInternalSlots} from '#packages/ecma402-abstract/tests/utils.js'
 import {describe, expect, test, it} from 'vitest'
 describe('PartitionNumberPattern', () => {
   const decimalNumberFormat: Intl.NumberFormat = new Intl.NumberFormat('it', {

--- a/packages/ecma402-abstract/tests/PartitionNumberRangePattern.test.ts
+++ b/packages/ecma402-abstract/tests/PartitionNumberRangePattern.test.ts
@@ -1,6 +1,6 @@
 import Decimal from '@formatjs/bigdecimal'
-import {PartitionNumberRangePattern} from '../NumberFormat/PartitionNumberRangePattern.js'
-import {getInternalSlots} from './utils.js'
+import {PartitionNumberRangePattern} from '#packages/ecma402-abstract/NumberFormat/PartitionNumberRangePattern.js'
+import {getInternalSlots} from '#packages/ecma402-abstract/tests/utils.js'
 import {describe, expect, test} from 'vitest'
 describe('PartitionNumberRangePattern', () => {
   const numberFormat: Intl.NumberFormat = new Intl.NumberFormat('it')

--- a/packages/ecma402-abstract/tests/PartitionPattern.test.ts
+++ b/packages/ecma402-abstract/tests/PartitionPattern.test.ts
@@ -1,4 +1,4 @@
-import {PartitionPattern} from '../PartitionPattern.js'
+import {PartitionPattern} from '#packages/ecma402-abstract/PartitionPattern.js'
 import {expect, test} from 'vitest'
 test('PartitionPattern should partition pattern correctly', function () {
   expect(PartitionPattern('AA{0}BB')).toEqual([

--- a/packages/ecma402-abstract/tests/SetNumberFormatDigitOptions.test.ts
+++ b/packages/ecma402-abstract/tests/SetNumberFormatDigitOptions.test.ts
@@ -1,8 +1,8 @@
-import {SetNumberFormatDigitOptions} from '../NumberFormat/SetNumberFormatDigitOptions.js'
+import {SetNumberFormatDigitOptions} from '#packages/ecma402-abstract/NumberFormat/SetNumberFormatDigitOptions.js'
 import {
   type NumberFormatDigitInternalSlots,
   type NumberFormatDigitOptions,
-} from '../types/number.js'
+} from '#packages/ecma402-abstract/types/number.js'
 import {describe, expect, it, beforeEach} from 'vitest'
 describe('SetNumberFormatDigitOptions', () => {
   let internalSlots: NumberFormatDigitInternalSlots

--- a/packages/ecma402-abstract/tests/ToRawFixed.test.tsx
+++ b/packages/ecma402-abstract/tests/ToRawFixed.test.tsx
@@ -1,5 +1,5 @@
 import Decimal from '@formatjs/bigdecimal'
-import {ToRawFixed} from '../NumberFormat/ToRawFixed'
+import {ToRawFixed} from '#packages/ecma402-abstract/NumberFormat/ToRawFixed'
 import {expect, it, test} from 'vitest'
 test('ToRawFixed(9.99, 0, 1)', () => {
   expect(ToRawFixed(new Decimal(9.99), 0, 1, 1, 'half-infinity')).toEqual({

--- a/packages/ecma402-abstract/tests/ToRawPrecision.test.tsx
+++ b/packages/ecma402-abstract/tests/ToRawPrecision.test.tsx
@@ -1,5 +1,5 @@
 import Decimal from '@formatjs/bigdecimal'
-import {ToRawPrecision} from '../NumberFormat/ToRawPrecision'
+import {ToRawPrecision} from '#packages/ecma402-abstract/NumberFormat/ToRawPrecision'
 import {describe, expect, it} from 'vitest'
 
 describe('ToRawPrecision', () => {

--- a/packages/ecma402-abstract/tests/utils.ts
+++ b/packages/ecma402-abstract/tests/utils.ts
@@ -1,5 +1,5 @@
-import {SetNumberFormatDigitOptions} from '../NumberFormat/SetNumberFormatDigitOptions.js'
-import {type NumberFormatInternal} from '../types/number.js'
+import {SetNumberFormatDigitOptions} from '#packages/ecma402-abstract/NumberFormat/SetNumberFormatDigitOptions.js'
+import {type NumberFormatInternal} from '#packages/ecma402-abstract/types/number.js'
 
 const internalSlotMap = new WeakMap<Intl.NumberFormat, NumberFormatInternal>()
 

--- a/packages/ecma402-abstract/types/displaynames.ts
+++ b/packages/ecma402-abstract/types/displaynames.ts
@@ -1,4 +1,4 @@
-import {type LocaleData} from './core.js'
+import {type LocaleData} from '#packages/ecma402-abstract/types/core.js'
 
 type LanguageTag = string
 type RegionCode = string

--- a/packages/ecma402-abstract/types/list.ts
+++ b/packages/ecma402-abstract/types/list.ts
@@ -1,4 +1,4 @@
-import {type LocaleData} from './core.js'
+import {type LocaleData} from '#packages/ecma402-abstract/types/core.js'
 
 export type ListPatternLocaleData = LocaleData<ListPatternFieldsData>
 

--- a/packages/ecma402-abstract/types/number.ts
+++ b/packages/ecma402-abstract/types/number.ts
@@ -1,6 +1,6 @@
 import type {Decimal} from '@formatjs/bigdecimal'
-import {type LocaleData} from './core.js'
-import {type LDMLPluralRule} from './plural-rules.js'
+import {type LocaleData} from '#packages/ecma402-abstract/types/core.js'
+import {type LDMLPluralRule} from '#packages/ecma402-abstract/types/plural-rules.js'
 
 export type NumberFormatNotation =
   | 'standard'

--- a/packages/ecma402-abstract/types/plural-rules.ts
+++ b/packages/ecma402-abstract/types/plural-rules.ts
@@ -1,5 +1,5 @@
-import {type LocaleData} from './core.js'
-import {type NumberFormatDigitInternalSlots} from './number.js'
+import {type LocaleData} from '#packages/ecma402-abstract/types/core.js'
+import {type NumberFormatDigitInternalSlots} from '#packages/ecma402-abstract/types/number.js'
 export type LDMLPluralRule = 'zero' | 'one' | 'two' | 'few' | 'many' | 'other'
 
 export interface PluralRangesData {

--- a/packages/ecma402-abstract/types/relative-time.ts
+++ b/packages/ecma402-abstract/types/relative-time.ts
@@ -1,5 +1,5 @@
-import {type LocaleData} from './core.js'
-import {type LDMLPluralRule} from './plural-rules.js'
+import {type LocaleData} from '#packages/ecma402-abstract/types/core.js'
+import {type LDMLPluralRule} from '#packages/ecma402-abstract/types/plural-rules.js'
 
 export interface FieldData {
   '0'?: string

--- a/sg-rules/no-relative-import.yml
+++ b/sg-rules/no-relative-import.yml
@@ -1,0 +1,17 @@
+id: no-relative-import
+language: typescript
+message: "Relative imports are banned in internal packages. Use absolute '#packages/' imports instead."
+severity: error
+rule:
+  any:
+    - pattern: "import $$$ARGS from '$PATH'"
+    - pattern: "import type $$$ARGS from '$PATH'"
+    - pattern: "export * from '$PATH'"
+    - pattern: "export { $$$ARGS } from '$PATH'"
+    - pattern: "export type { $$$ARGS } from '$PATH'"
+constraints:
+  PATH:
+    regex: ^\.\.?/
+files:
+  - 'packages/ecma402-abstract/**/*.ts'
+  - 'packages/ecma262-abstract/**/*.ts'


### PR DESCRIPTION
## Summary
- Migrate 148 remaining relative imports in `ecma402-abstract` and `ecma262-abstract` to absolute `#packages/` imports
- Add `sg-rules/no-relative-import.yml` ast-grep rule to enforce no relative imports in internal packages going forward

## Test plan
- [x] `bazel test //...` — all 560 tests pass
- [x] `ast-grep scan` — zero violations
- [x] All pre-commit hooks pass (oxfmt, gazelle, ast-grep, oxlint, commitlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)