### PR TITLE
build: migrate remaining packages from ts_compile to rolldown

### DIFF
--- a/packages/babel-plugin-formatjs/BUILD.bazel
+++ b/packages/babel-plugin-formatjs/BUILD.bazel
@@ -1,24 +1,17 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "package_exports_test", "package_json_test", "ts_compile_node")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "no_internal_imports_test", "package_exports_test", "package_json_test")
+load("//tools:rolldown.bzl", "rolldown_bundle")
+load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
 
 PACKAGE_NAME = "babel-plugin-formatjs"
-
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-        ":dist",
-    ],
-    package = PACKAGE_NAME,
-    visibility = ["//visibility:public"],
-)
 
 SRCS = glob(
     ["**/*.ts"],
@@ -38,9 +31,66 @@ SRC_DEPS = [
     "//:node_modules/@types/babel__traverse",
 ]
 
-ts_compile_node(
-    name = "dist",
+EXTERNAL_PACKAGES = [
+    dep.split("node_modules/")[1]
+    for dep in SRC_DEPS
+    if "node_modules/" in dep
+]
+
+ENTRY_POINTS = [
+    "index.ts",
+]
+
+[rolldown_bundle(
+    name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
+    dts = True,
+    entry_point = entry,
+    external = EXTERNAL_PACKAGES,
+    format = "esm",
+    output = "%s.js" % entry.replace(".ts", ""),
+    target = "es2020",
+    deps = SRC_DEPS,
+) for entry in ENTRY_POINTS]
+
+BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
+
+js_library(
+    name = PACKAGE_NAME,
+    srcs = BUNDLES + [
+        "package.json",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+npm_package(
+    name = "pkg",
+    srcs = [
+        "LICENSE.md",
+        "README.md",
+        "package.json",
+    ] + BUNDLES,
+    package = PACKAGE_NAME,
+    replace_prefixes = {
+        "%s-bundle/" % entry.replace(".ts", ""): ""
+        for entry in ENTRY_POINTS
+    },
+    visibility = ["//visibility:public"],
+)
+
+no_internal_imports_test(
+    name = "no_internal_imports_test",
+    data = BUNDLES,
+)
+
+ts_project(
+    name = "typecheck",
+    srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
     deps = SRC_DEPS,
 )
 

--- a/packages/bigdecimal/BUILD.bazel
+++ b/packages/bigdecimal/BUILD.bazel
@@ -1,7 +1,12 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "package_exports_test", "package_json_test", "ts_compile_node")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "no_internal_imports_test", "package_exports_test", "package_json_test")
+load("//tools:rolldown.bzl", "rolldown_bundle")
+load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -12,18 +17,6 @@ exports_files([
 
 PACKAGE_NAME = "bigdecimal"
 
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-        ":dist",
-    ],
-    package = "@formatjs/%s" % PACKAGE_NAME,
-    visibility = ["//visibility:public"],
-)
-
 SRCS = glob([
     "*.ts",
 ])
@@ -31,22 +24,71 @@ SRCS = glob([
 SRC_DEPS = [
 ]
 
+ENTRY_POINTS = [
+    "index.ts",
+]
+
+[rolldown_bundle(
+    name = "%s-bundle" % entry.replace(".ts", ""),
+    srcs = [":srcs"],
+    dts = True,
+    entry_point = entry,
+    external = [],
+    format = "esm",
+    output = "%s.js" % entry.replace(".ts", ""),
+    target = "es2020",
+    deps = SRC_DEPS,
+) for entry in ENTRY_POINTS]
+
+BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
+
+js_library(
+    name = PACKAGE_NAME,
+    srcs = BUNDLES + [
+        "package.json",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+npm_package(
+    name = "pkg",
+    srcs = [
+        "LICENSE.md",
+        "README.md",
+        "package.json",
+    ] + BUNDLES,
+    package = "@formatjs/%s" % PACKAGE_NAME,
+    replace_prefixes = {
+        "%s-bundle/" % entry.replace(".ts", ""): ""
+        for entry in ENTRY_POINTS
+    },
+    visibility = ["//visibility:public"],
+)
+
+no_internal_imports_test(
+    name = "no_internal_imports_test",
+    data = BUNDLES,
+)
+
+ts_project(
+    name = "typecheck",
+    srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
+    deps = SRC_DEPS,
+)
+
 TESTS = glob([
     "tests/*.test.ts",
 ])
 
-TEST_DEPS = SRC_DEPS
-
-ts_compile_node(
-    name = "dist",
-    srcs = [":srcs"],
-    deps = SRC_DEPS,
-)
-
 vitest(
     name = "unit_test",
     srcs = SRCS + TESTS,
-    deps = TEST_DEPS,
+    deps = SRC_DEPS,
 )
 
 generate_ide_tsconfig_json()

--- a/packages/ecma376/BUILD.bazel
+++ b/packages/ecma376/BUILD.bazel
@@ -1,6 +1,11 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "package_exports_test", "package_json_test", "ts_compile")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "no_internal_imports_test", "package_exports_test", "package_json_test")
+load("//tools:rolldown.bzl", "rolldown_bundle")
+load("//tools:tsconfig.bzl", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
 exports_files([
@@ -9,18 +14,6 @@ exports_files([
 
 PACKAGE_NAME = "ecma376"
 
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-        ":dist",
-    ],
-    package = "@formatjs/%s" % PACKAGE_NAME,
-    visibility = ["//visibility:public"],
-)
-
 SRCS = glob([
     "*.ts",
 ])
@@ -28,13 +21,64 @@ SRCS = glob([
 SRC_DEPS = [
 ]
 
-TESTS = glob(["tests/*"])
+ENTRY_POINTS = [
+    "index.ts",
+]
 
-ts_compile(
-    name = "dist",
+[rolldown_bundle(
+    name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
+    dts = True,
+    entry_point = entry,
+    external = [],
+    format = "esm",
+    output = "%s.js" % entry.replace(".ts", ""),
+    target = "es2020",
+    deps = SRC_DEPS,
+) for entry in ENTRY_POINTS]
+
+BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
+
+js_library(
+    name = PACKAGE_NAME,
+    srcs = BUNDLES + [
+        "package.json",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+npm_package(
+    name = "pkg",
+    srcs = [
+        "LICENSE.md",
+        "README.md",
+        "package.json",
+    ] + BUNDLES,
+    package = "@formatjs/%s" % PACKAGE_NAME,
+    replace_prefixes = {
+        "%s-bundle/" % entry.replace(".ts", ""): ""
+        for entry in ENTRY_POINTS
+    },
+    visibility = ["//visibility:public"],
+)
+
+no_internal_imports_test(
+    name = "no_internal_imports_test",
+    data = BUNDLES,
+)
+
+ts_project(
+    name = "typecheck",
+    srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = packages_tsconfig(),
     deps = SRC_DEPS,
 )
+
+TESTS = glob(["tests/*"])
 
 # Generate tsconfig.json with correct extends path
 generate_ide_tsconfig_json()

--- a/packages/eslint-plugin-formatjs/BUILD.bazel
+++ b/packages/eslint-plugin-formatjs/BUILD.bazel
@@ -1,8 +1,13 @@
 load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_exports_test", "package_json_test", "ts_compile_node")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "no_internal_imports_test", "package_exports_test", "package_json_test")
+load("//tools:rolldown.bzl", "rolldown_bundle")
+load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -30,18 +35,6 @@ generate_src_file(
     tool = "//packages/eslint-plugin-formatjs/scripts:generate-emoji-data",
 )
 
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-        ":dist",
-    ],
-    package = PACKAGE_NAME,
-    visibility = ["//visibility:public"],
-)
-
 SRCS = glob(["rules/*.ts"]) + [
     "index.ts",
     "util.ts",
@@ -64,9 +57,67 @@ SRC_DEPS = [
     "//:node_modules/typescript",
 ]
 
-ts_compile_node(
-    name = "dist",
+EXTERNAL_PACKAGES = [
+    dep.split("node_modules/")[1]
+    for dep in SRC_DEPS
+    if "node_modules/" in dep
+]
+
+ENTRY_POINTS = [
+    "index.ts",
+    "util.ts",
+]
+
+[rolldown_bundle(
+    name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
+    dts = True,
+    entry_point = entry,
+    external = EXTERNAL_PACKAGES,
+    format = "esm",
+    output = "%s.js" % entry.replace(".ts", ""),
+    target = "es2020",
+    deps = SRC_DEPS,
+) for entry in ENTRY_POINTS]
+
+BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
+
+js_library(
+    name = PACKAGE_NAME,
+    srcs = BUNDLES + [
+        "package.json",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+npm_package(
+    name = "pkg",
+    srcs = [
+        "LICENSE.md",
+        "README.md",
+        "package.json",
+    ] + BUNDLES,
+    package = PACKAGE_NAME,
+    replace_prefixes = {
+        "%s-bundle/" % entry.replace(".ts", ""): ""
+        for entry in ENTRY_POINTS
+    },
+    visibility = ["//visibility:public"],
+)
+
+no_internal_imports_test(
+    name = "no_internal_imports_test",
+    data = BUNDLES,
+)
+
+ts_project(
+    name = "typecheck",
+    srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
     deps = SRC_DEPS,
 )
 

--- a/packages/fast-memoize/BUILD.bazel
+++ b/packages/fast-memoize/BUILD.bazel
@@ -1,7 +1,12 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "package_exports_test", "package_json_test", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "no_internal_imports_test", "package_exports_test", "package_json_test")
+load("//tools:rolldown.bzl", "rolldown_bundle")
+load("//tools:tsconfig.bzl", "packages_tsconfig")
 
 npm_link_all_packages()
 
@@ -11,18 +16,6 @@ exports_files([
 
 PACKAGE_NAME = "fast-memoize"
 
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-        ":dist",
-    ],
-    package = "@formatjs/%s" % PACKAGE_NAME,
-    visibility = ["//visibility:public"],
-)
-
 SRCS = glob([
     "*.ts",
 ])
@@ -30,9 +23,60 @@ SRCS = glob([
 SRC_DEPS = [
 ]
 
-ts_compile(
-    name = "dist",
+ENTRY_POINTS = [
+    "index.ts",
+]
+
+[rolldown_bundle(
+    name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
+    dts = True,
+    entry_point = entry,
+    external = [],
+    format = "esm",
+    output = "%s.js" % entry.replace(".ts", ""),
+    target = "es2020",
+    deps = SRC_DEPS,
+) for entry in ENTRY_POINTS]
+
+BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
+
+js_library(
+    name = PACKAGE_NAME,
+    srcs = BUNDLES + [
+        "package.json",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+npm_package(
+    name = "pkg",
+    srcs = [
+        "LICENSE.md",
+        "README.md",
+        "package.json",
+    ] + BUNDLES,
+    package = "@formatjs/%s" % PACKAGE_NAME,
+    replace_prefixes = {
+        "%s-bundle/" % entry.replace(".ts", ""): ""
+        for entry in ENTRY_POINTS
+    },
+    visibility = ["//visibility:public"],
+)
+
+no_internal_imports_test(
+    name = "no_internal_imports_test",
+    data = BUNDLES,
+)
+
+ts_project(
+    name = "typecheck",
+    srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = packages_tsconfig(),
     deps = SRC_DEPS,
 )
 

--- a/packages/intl-localematcher/BUILD.bazel
+++ b/packages/intl-localematcher/BUILD.bazel
@@ -1,25 +1,18 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_exports_test", "package_json_test", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "no_internal_imports_test", "package_exports_test", "package_json_test")
+load("//tools:rolldown.bzl", "rolldown_bundle")
+load("//tools:tsconfig.bzl", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
 
 PACKAGE_NAME = "intl-localematcher"
-
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-        ":dist",
-    ],
-    package = "@formatjs/%s" % PACKAGE_NAME,
-    visibility = ["//visibility:public"],
-)
 
 SRCS = glob(
     ["abstract/*"],
@@ -30,10 +23,66 @@ SRC_DEPS = [
     "//:node_modules/@formatjs/fast-memoize",
 ]
 
-ts_compile(
-    name = "dist",
+EXTERNAL_PACKAGES = [
+    dep.split("node_modules/")[1]
+    for dep in SRC_DEPS
+    if "node_modules/" in dep
+]
+
+ENTRY_POINTS = [
+    "index.ts",
+]
+
+[rolldown_bundle(
+    name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
-    visibility = ["//packages/intl-localematcher/benchmark:__pkg__"],
+    dts = True,
+    entry_point = entry,
+    external = EXTERNAL_PACKAGES,
+    format = "esm",
+    output = "%s.js" % entry.replace(".ts", ""),
+    target = "es2020",
+    deps = SRC_DEPS,
+) for entry in ENTRY_POINTS]
+
+BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
+
+js_library(
+    name = PACKAGE_NAME,
+    srcs = BUNDLES + [
+        "package.json",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+npm_package(
+    name = "pkg",
+    srcs = [
+        "LICENSE.md",
+        "README.md",
+        "package.json",
+    ] + BUNDLES,
+    package = "@formatjs/%s" % PACKAGE_NAME,
+    replace_prefixes = {
+        "%s-bundle/" % entry.replace(".ts", ""): ""
+        for entry in ENTRY_POINTS
+    },
+    visibility = ["//visibility:public"],
+)
+
+no_internal_imports_test(
+    name = "no_internal_imports_test",
+    data = BUNDLES,
+)
+
+ts_project(
+    name = "typecheck",
+    srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = packages_tsconfig(),
     deps = SRC_DEPS,
 )
 

--- a/packages/intl-localematcher/benchmark/BUILD.bazel
+++ b/packages/intl-localematcher/benchmark/BUILD.bazel
@@ -7,7 +7,7 @@ ts_binary(
     name = "benchmark",
     data = [
         "//:node_modules/tinybench",
-        "//packages/intl-localematcher:dist",
+        "//packages/intl-localematcher",
     ],
     entry_point = "benchmark.ts",
 )
@@ -25,7 +25,7 @@ ts_binary(
 ts_binary(
     name = "profile",
     data = [
-        "//packages/intl-localematcher:dist",
+        "//packages/intl-localematcher",
     ],
     entry_point = "profile.ts",
 )
@@ -33,7 +33,7 @@ ts_binary(
 ts_binary(
     name = "profile_cpu",
     data = [
-        "//packages/intl-localematcher:dist",
+        "//packages/intl-localematcher",
     ],
     entry_point = "profile.ts",
     node_options = [

--- a/packages/svelte-intl/BUILD.bazel
+++ b/packages/svelte-intl/BUILD.bazel
@@ -1,21 +1,15 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "package_exports_test", "package_json_test", "ts_compile_node")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "no_internal_imports_test", "package_exports_test", "package_json_test")
+load("//tools:rolldown.bzl", "rolldown_bundle")
+load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
-
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-        ":dist",
-    ],
-    visibility = ["//visibility:public"],
-)
 
 SRCS = glob([
     "*.ts",
@@ -28,9 +22,65 @@ SRC_DEPS = [
     "//:node_modules/@formatjs/icu-messageformat-parser",
 ]
 
-ts_compile_node(
-    name = "dist",
+EXTERNAL_PACKAGES = [
+    dep.split("node_modules/")[1]
+    for dep in SRC_DEPS
+    if "node_modules/" in dep
+]
+
+ENTRY_POINTS = [
+    "index.ts",
+]
+
+[rolldown_bundle(
+    name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
+    dts = True,
+    entry_point = entry,
+    external = EXTERNAL_PACKAGES,
+    format = "esm",
+    output = "%s.js" % entry.replace(".ts", ""),
+    target = "es2020",
+    deps = SRC_DEPS,
+) for entry in ENTRY_POINTS]
+
+BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
+
+js_library(
+    name = "svelte-intl",
+    srcs = BUNDLES + [
+        "package.json",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+npm_package(
+    name = "pkg",
+    srcs = [
+        "LICENSE.md",
+        "README.md",
+        "package.json",
+    ] + BUNDLES,
+    replace_prefixes = {
+        "%s-bundle/" % entry.replace(".ts", ""): ""
+        for entry in ENTRY_POINTS
+    },
+    visibility = ["//visibility:public"],
+)
+
+no_internal_imports_test(
+    name = "no_internal_imports_test",
+    data = BUNDLES,
+)
+
+ts_project(
+    name = "typecheck",
+    srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
     deps = SRC_DEPS,
 )
 
@@ -41,6 +91,8 @@ vitest(
     ]),
     deps = SRC_DEPS,
 )
+
+generate_ide_tsconfig_json()
 
 package_json_test(
     name = "package_json_test",

--- a/packages/ts-transformer/BUILD.bazel
+++ b/packages/ts-transformer/BUILD.bazel
@@ -1,8 +1,13 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "package_exports_test", "package_json_test", "ts_compile_node")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "no_internal_imports_test", "package_exports_test", "package_json_test")
+load("//tools:rolldown.bzl", "rolldown_bundle")
+load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -22,18 +27,6 @@ filegroup(
 
 PACKAGE_NAME = "ts-transformer"
 
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-        ":dist",
-    ],
-    package = "@formatjs/%s" % PACKAGE_NAME,
-    visibility = ["//visibility:public"],
-)
-
 SRCS = glob([
     "src/*.ts",
     "*.ts",
@@ -49,9 +42,66 @@ SRC_DEPS = [
     "//:node_modules/typescript",
 ]
 
-ts_compile_node(
-    name = "dist",
+EXTERNAL_PACKAGES = [
+    dep.split("node_modules/")[1]
+    for dep in SRC_DEPS
+    if "node_modules/" in dep
+]
+
+ENTRY_POINTS = [
+    "index.ts",
+]
+
+[rolldown_bundle(
+    name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
+    dts = True,
+    entry_point = entry,
+    external = EXTERNAL_PACKAGES,
+    format = "esm",
+    output = "%s.js" % entry.replace(".ts", ""),
+    target = "es2020",
+    deps = SRC_DEPS,
+) for entry in ENTRY_POINTS]
+
+BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
+
+js_library(
+    name = PACKAGE_NAME,
+    srcs = BUNDLES + [
+        "package.json",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+npm_package(
+    name = "pkg",
+    srcs = [
+        "LICENSE.md",
+        "README.md",
+        "package.json",
+    ] + BUNDLES,
+    package = "@formatjs/%s" % PACKAGE_NAME,
+    replace_prefixes = {
+        "%s-bundle/" % entry.replace(".ts", ""): ""
+        for entry in ENTRY_POINTS
+    },
+    visibility = ["//visibility:public"],
+)
+
+no_internal_imports_test(
+    name = "no_internal_imports_test",
+    data = BUNDLES,
+)
+
+ts_project(
+    name = "typecheck",
+    srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
     deps = SRC_DEPS,
 )
 

--- a/packages/unplugin/BUILD.bazel
+++ b/packages/unplugin/BUILD.bazel
@@ -5,8 +5,8 @@ load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "package_exports_test", "package_json_test")
-load("//tools:oxc_transpiler.bzl", "oxc_transpiler")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "no_internal_imports_test", "package_exports_test", "package_json_test")
+load("//tools:rolldown.bzl", "rolldown_bundle")
 load("//tools:tsconfig.bzl", "ESNEXT_SKIP_LIB_CHECK_TSCONFIG")
 load("//tools:vitest.bzl", "vitest")
 
@@ -43,10 +43,67 @@ SRC_DEPS = [
     "//:node_modules/vite",
 ]
 
+EXTERNAL_PACKAGES = [
+    dep.split("node_modules/")[1]
+    for dep in SRC_DEPS
+    if "node_modules/" in dep
+]
+
+ENTRY_POINTS = [
+    "index.ts",
+    "vite.ts",
+    "webpack.ts",
+    "rollup.ts",
+    "esbuild.ts",
+    "rspack.ts",
+    "transform.ts",
+]
+
+[rolldown_bundle(
+    name = "%s-bundle" % entry.replace(".ts", ""),
+    srcs = [":srcs"],
+    dts = True,
+    entry_point = entry,
+    external = EXTERNAL_PACKAGES,
+    format = "esm",
+    output = "%s.js" % entry.replace(".ts", ""),
+    target = "es2020",
+    deps = SRC_DEPS,
+) for entry in ENTRY_POINTS]
+
+BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
+
+js_library(
+    name = "dist",
+    srcs = BUNDLES + [
+        "package.json",
+    ],
+)
+
+npm_package(
+    name = "pkg",
+    srcs = [
+        "LICENSE.md",
+        "README.md",
+        "package.json",
+    ] + BUNDLES,
+    package = PACKAGE_NAME,
+    replace_prefixes = {
+        "%s-bundle/" % entry.replace(".ts", ""): ""
+        for entry in ENTRY_POINTS
+    },
+    visibility = ["//visibility:public"],
+)
+
+no_internal_imports_test(
+    name = "no_internal_imports_test",
+    data = BUNDLES,
+)
+
 # Type check only with tsgo (fast, parallel)
 # Uses skipLibCheck because unplugin's .d.ts imports types from many optional peer deps
 ts_project(
-    name = "dist-esm-esnext-typecheck",
+    name = "typecheck",
     srcs = [":srcs"],
     declaration = True,
     no_emit = True,
@@ -54,26 +111,6 @@ ts_project(
     transpiler = tsgo_bin.tsgo,
     tsconfig = ESNEXT_SKIP_LIB_CHECK_TSCONFIG,
     deps = SRC_DEPS,
-)
-
-# Transpile with oxc-transform (fast JS and .d.ts generation)
-ts_project(
-    name = "dist-esm-esnext",
-    srcs = [":srcs"],
-    declaration = True,
-    declaration_transpiler = oxc_transpiler,
-    resolve_json_module = True,
-    transpiler = oxc_transpiler,
-    tsconfig = ESNEXT_SKIP_LIB_CHECK_TSCONFIG,
-    deps = SRC_DEPS + ["//:node_modules/oxc-transform"],
-)
-
-js_library(
-    name = "dist",
-    srcs = [
-        "package.json",
-        ":dist-esm-esnext",
-    ],
 )
 
 vitest(
@@ -93,18 +130,6 @@ vitest(
     deps = SRC_DEPS + [
         "//:node_modules/@bazel/runfiles",
     ],
-)
-
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-        ":dist",
-    ],
-    package = PACKAGE_NAME,
-    visibility = ["//visibility:public"],
 )
 
 copy_to_bin(

--- a/packages/utils/BUILD.bazel
+++ b/packages/utils/BUILD.bazel
@@ -1,9 +1,14 @@
 load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_exports_test", "package_json_test", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "no_internal_imports_test", "package_exports_test", "package_json_test")
+load("//tools:rolldown.bzl", "rolldown_bundle")
+load("//tools:tsconfig.bzl", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -17,18 +22,6 @@ exports_files([
 
 PACKAGE_NAME = "utils"
 
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-        ":dist",
-    ],
-    package = "@formatjs/%s" % PACKAGE_NAME,
-    visibility = ["//visibility:public"],
-)
-
 SRCS = glob([
     "src/**/*",
     "*.ts",
@@ -38,9 +31,66 @@ SRC_DEPS = [
     "//:node_modules/@formatjs/fast-memoize",
 ]
 
-ts_compile(
-    name = "dist",
+EXTERNAL_PACKAGES = [
+    dep.split("node_modules/")[1]
+    for dep in SRC_DEPS
+    if "node_modules/" in dep
+]
+
+ENTRY_POINTS = [
+    "index.ts",
+]
+
+[rolldown_bundle(
+    name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
+    dts = True,
+    entry_point = entry,
+    external = EXTERNAL_PACKAGES,
+    format = "esm",
+    output = "%s.js" % entry.replace(".ts", ""),
+    target = "es2020",
+    deps = SRC_DEPS,
+) for entry in ENTRY_POINTS]
+
+BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
+
+js_library(
+    name = PACKAGE_NAME,
+    srcs = BUNDLES + [
+        "package.json",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+npm_package(
+    name = "pkg",
+    srcs = [
+        "LICENSE.md",
+        "README.md",
+        "package.json",
+    ] + BUNDLES,
+    package = "@formatjs/%s" % PACKAGE_NAME,
+    replace_prefixes = {
+        "%s-bundle/" % entry.replace(".ts", ""): ""
+        for entry in ENTRY_POINTS
+    },
+    visibility = ["//visibility:public"],
+)
+
+no_internal_imports_test(
+    name = "no_internal_imports_test",
+    data = BUNDLES,
+)
+
+ts_project(
+    name = "typecheck",
+    srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = packages_tsconfig(),
     deps = SRC_DEPS,
 )
 

--- a/packages/vue-intl/BUILD.bazel
+++ b/packages/vue-intl/BUILD.bazel
@@ -1,21 +1,15 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "package_exports_test", "package_json_test", "ts_compile_node")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "no_internal_imports_test", "package_exports_test", "package_json_test")
+load("//tools:rolldown.bzl", "rolldown_bundle")
+load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
-
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-        ":dist",
-    ],
-    visibility = ["//visibility:public"],
-)
 
 SRCS = glob([
     "*.ts",
@@ -28,9 +22,65 @@ SRC_DEPS = [
     "//:node_modules/@formatjs/icu-messageformat-parser",
 ]
 
-ts_compile_node(
-    name = "dist",
+EXTERNAL_PACKAGES = [
+    dep.split("node_modules/")[1]
+    for dep in SRC_DEPS
+    if "node_modules/" in dep
+]
+
+ENTRY_POINTS = [
+    "index.ts",
+]
+
+[rolldown_bundle(
+    name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
+    dts = True,
+    entry_point = entry,
+    external = EXTERNAL_PACKAGES,
+    format = "esm",
+    output = "%s.js" % entry.replace(".ts", ""),
+    target = "es2020",
+    deps = SRC_DEPS,
+) for entry in ENTRY_POINTS]
+
+BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
+
+js_library(
+    name = "vue-intl",
+    srcs = BUNDLES + [
+        "package.json",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+npm_package(
+    name = "pkg",
+    srcs = [
+        "LICENSE.md",
+        "README.md",
+        "package.json",
+    ] + BUNDLES,
+    replace_prefixes = {
+        "%s-bundle/" % entry.replace(".ts", ""): ""
+        for entry in ENTRY_POINTS
+    },
+    visibility = ["//visibility:public"],
+)
+
+no_internal_imports_test(
+    name = "no_internal_imports_test",
+    data = BUNDLES,
+)
+
+ts_project(
+    name = "typecheck",
+    srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
     deps = SRC_DEPS,
 )
 
@@ -46,6 +96,8 @@ vitest(
         "//:node_modules/@vue/test-utils",
     ],
 )
+
+generate_ide_tsconfig_json()
 
 package_json_test(
     name = "package_json_test",


### PR DESCRIPTION
## Summary
- Migrate 11 packages from `ts_compile`/`ts_compile_node` to `rolldown_bundle` for their dist targets
- Packages: `babel-plugin-formatjs`, `bigdecimal`, `ecma376`, `eslint-plugin-formatjs`, `fast-memoize`, `intl-localematcher`, `svelte-intl`, `ts-transformer`, `unplugin`, `utils`, `vue-intl`
- This ensures all published packages bundle their output through rolldown, which resolves `#packages/` imports at build time — prerequisite for banning relative imports repo-wide

## Test plan
- [x] `bazel test //...` — all 562 tests pass
- [x] All pre-commit hooks pass (buildifier, gazelle, commitlint)
- [x] `no_internal_imports_test` added to all migrated packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)