### PR TITLE
build(deps): migrate intl-getcanonicallocales and cli-lib to rolldown

### DIFF
--- a/packages/cli-lib/BUILD.bazel
+++ b/packages/cli-lib/BUILD.bazel
@@ -1,8 +1,12 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "package_exports_test", "package_json_test", "ts_compile_node")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "no_internal_imports_test", "package_exports_test", "package_json_test")
 load("//tools:rolldown.bzl", "rolldown_bundle")
+load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -11,22 +15,9 @@ PACKAGE_NAME = "cli-lib"
 
 exports_files(["package.json"])
 
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-        ":dist",
-    ],
-    package = "@formatjs/%s" % PACKAGE_NAME,
-    visibility = ["//visibility:public"],
-)
-
 SRCS = glob(["src/**/*.ts"]) + [
     "index.ts",
     "main.ts",
-    # "package.json",
 ]
 
 VUE_DEPS = [
@@ -59,9 +50,66 @@ SRC_DEPS = [
     "//:node_modules/typescript",
 ] + VUE_DEPS + SVELTE_DEPS + GLIMMER_HBS_DEPS
 
-ts_compile_node(
-    name = "dist",
+EXTERNAL_PACKAGES = [
+    dep.split("node_modules/")[1]
+    for dep in SRC_DEPS
+    if "node_modules/" in dep
+]
+
+ENTRY_POINTS = [
+    "index.ts",
+]
+
+[rolldown_bundle(
+    name = "%s-bundle" % entry.replace(".ts", ""),
     srcs = [":srcs"],
+    dts = True,
+    entry_point = entry,
+    external = EXTERNAL_PACKAGES,
+    format = "esm",
+    output = "%s.js" % entry.replace(".ts", ""),
+    target = "es2020",
+    deps = SRC_DEPS,
+) for entry in ENTRY_POINTS]
+
+BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
+
+js_library(
+    name = PACKAGE_NAME,
+    srcs = BUNDLES + [
+        "package.json",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+npm_package(
+    name = "pkg",
+    srcs = [
+        "LICENSE.md",
+        "README.md",
+        "package.json",
+    ] + BUNDLES,
+    package = "@formatjs/%s" % PACKAGE_NAME,
+    replace_prefixes = {
+        "%s-bundle/" % entry.replace(".ts", ""): ""
+        for entry in ENTRY_POINTS
+    },
+    visibility = ["//visibility:public"],
+)
+
+no_internal_imports_test(
+    name = "no_internal_imports_test",
+    data = BUNDLES,
+)
+
+ts_project(
+    name = "typecheck",
+    srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
     deps = SRC_DEPS,
 )
 

--- a/packages/intl-getcanonicallocales/BUILD.bazel
+++ b/packages/intl-getcanonicallocales/BUILD.bazel
@@ -1,8 +1,12 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "package_exports_test", "package_json_test", "ts_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "no_internal_imports_test", "package_exports_test", "package_json_test")
 load("//tools:rolldown.bzl", "rolldown_bundle")
+load("//tools:tsconfig.bzl", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -13,24 +17,75 @@ exports_files([
 
 PACKAGE_NAME = "intl-getcanonicallocales"
 
+SRCS = glob([
+    "src/**/*.ts",
+    "*.ts",
+])
+
+SRC_DEPS = [
+]
+
+ENTRY_POINTS = [
+    "index.ts",
+    "polyfill.ts",
+    "polyfill-force.ts",
+    "should-polyfill.ts",
+]
+
+[rolldown_bundle(
+    name = "%s-bundle" % entry.replace(".ts", ""),
+    srcs = [":srcs"],
+    dts = True,
+    entry_point = entry,
+    external = [],
+    format = "esm",
+    output = "%s.js" % entry.replace(".ts", ""),
+    target = "es2020",
+    deps = SRC_DEPS,
+) for entry in ENTRY_POINTS]
+
+BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
+
+js_library(
+    name = PACKAGE_NAME,
+    srcs = BUNDLES + [
+        "package.json",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 npm_package(
     name = "pkg",
     srcs = [
         "LICENSE.md",
         "README.md",
         "package.json",
-        ":dist",
         # polyfill-library uses this
         "polyfill.iife.js",
-    ],
+    ] + BUNDLES,
     package = "@formatjs/%s" % PACKAGE_NAME,
+    replace_prefixes = {
+        "%s-bundle/" % entry.replace(".ts", ""): ""
+        for entry in ENTRY_POINTS
+    },
     visibility = ["//visibility:public"],
 )
 
-SRCS = glob([
-    "src/**/*.ts",
-    "*.ts",
-])
+no_internal_imports_test(
+    name = "no_internal_imports_test",
+    data = BUNDLES,
+)
+
+ts_project(
+    name = "typecheck",
+    srcs = [":srcs"],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = packages_tsconfig(),
+    deps = SRC_DEPS,
+)
 
 TESTS = glob([
     "tests/*.test.ts",
@@ -41,16 +96,7 @@ copy_to_bin(
     srcs = TESTS,
 )
 
-SRC_DEPS = [
-]
-
 TEST_DEPS = SRC_DEPS
-
-ts_compile(
-    name = "dist",
-    srcs = [":srcs"],
-    deps = SRC_DEPS,
-)
 
 vitest(
     name = "unit_test",
@@ -91,8 +137,7 @@ rolldown_bundle(
     srcs = [":srcs"],
     entry_point = "polyfill.ts",
     target = "es6",
-    deps = [
-    ] + SRC_DEPS,
+    deps = SRC_DEPS,
 )
 
 package_json_test(


### PR DESCRIPTION
## Summary
- Migrate `intl-getcanonicallocales` and `cli-lib` from `ts_compile`/`ts_compile_node` to `rolldown_bundle` for their dist targets
- These were the last 2 packages still using ts_compile for dist

## Test plan
- [x] `bazel test //...` — all 562 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)