### PR TITLE
refactor(deps): add #packages/ imports field to all package.json files

### DIFF
--- a/packages/babel-plugin-formatjs/package.json
+++ b/packages/babel-plugin-formatjs/package.json
@@ -9,6 +9,9 @@
   "exports": {
     ".": "./index.js"
   },
+  "imports": {
+    "#packages/*": "../../packages/*"
+  },
   "dependencies": {
     "@babel/core": "^7.28.5",
     "@babel/helper-plugin-utils": "^7.27.1",

--- a/packages/bigdecimal/package.json
+++ b/packages/bigdecimal/package.json
@@ -10,6 +10,9 @@
   "exports": {
     ".": "./index.js"
   },
+  "imports": {
+    "#packages/*": "../../packages/*"
+  },
   "dependencies": {},
   "bugs": "https://github.com/formatjs/formatjs/issues",
   "homepage": "https://github.com/formatjs/formatjs#readme",

--- a/packages/cli-lib/package.json
+++ b/packages/cli-lib/package.json
@@ -9,6 +9,9 @@
   "exports": {
     ".": "./index.js"
   },
+  "imports": {
+    "#packages/*": "../../packages/*"
+  },
   "engines": {
     "node": ">= 20.12.0"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,6 +4,9 @@
   "version": "6.14.1",
   "license": "MIT",
   "author": "Linjie Ding <linjie@airtable.com>",
+  "imports": {
+    "#packages/*": "../../packages/*"
+  },
   "engines": {
     "node": ">= 20.12.0"
   },

--- a/packages/ecma376/package.json
+++ b/packages/ecma376/package.json
@@ -9,6 +9,9 @@
   "exports": {
     ".": "./index.js"
   },
+  "imports": {
+    "#packages/*": "../../packages/*"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -39,5 +39,8 @@
   },
   "bugs": {
     "url": "https://github.com/formatjs/formatjs/issues"
+  },
+  "imports": {
+    "#packages/*": "../../packages/*"
   }
 }

--- a/packages/eslint-plugin-formatjs/package.json
+++ b/packages/eslint-plugin-formatjs/package.json
@@ -10,6 +10,9 @@
     ".": "./index.js",
     "./util": "./util.js"
   },
+  "imports": {
+    "#packages/*": "../../packages/*"
+  },
   "dependencies": {
     "@formatjs/icu-messageformat-parser": "workspace:*",
     "@formatjs/ts-transformer": "workspace:*",

--- a/packages/fast-memoize/package.json
+++ b/packages/fast-memoize/package.json
@@ -10,6 +10,9 @@
   "exports": {
     ".": "./index.js"
   },
+  "imports": {
+    "#packages/*": "../../packages/*"
+  },
   "dependencies": {},
   "bugs": "https://github.com/formatjs/formatjs/issues",
   "homepage": "https://github.com/formatjs/formatjs#readme",

--- a/packages/icu-messageformat-parser/package.json
+++ b/packages/icu-messageformat-parser/package.json
@@ -10,6 +10,9 @@
     "./printer.js": "./printer.js",
     "./manipulator.js": "./manipulator.js"
   },
+  "imports": {
+    "#packages/*": "../../packages/*"
+  },
   "dependencies": {
     "@formatjs/icu-skeleton-parser": "workspace:*"
   },

--- a/packages/icu-skeleton-parser/package.json
+++ b/packages/icu-skeleton-parser/package.json
@@ -7,8 +7,10 @@
   "exports": {
     ".": "./index.js"
   },
-  "dependencies": {
+  "imports": {
+    "#packages/*": "../../packages/*"
   },
+  "dependencies": {},
   "repository": {
     "type": "git",
     "url": "https://github.com/formatjs/formatjs.git",

--- a/packages/intl-datetimeformat/package.json
+++ b/packages/intl-datetimeformat/package.json
@@ -16,6 +16,9 @@
     "./locale-data/*": "./locale-data/*",
     "./locale-data": "./locale-data"
   },
+  "imports": {
+    "#packages/*": "../../packages/*"
+  },
   "dependencies": {
     "@formatjs/bigdecimal": "workspace:*",
     "@formatjs/intl-localematcher": "workspace:*"

--- a/packages/intl-displaynames/package.json
+++ b/packages/intl-displaynames/package.json
@@ -14,6 +14,9 @@
     "./locale-data/*": "./locale-data/*",
     "./locale-data": "./locale-data"
   },
+  "imports": {
+    "#packages/*": "../../packages/*"
+  },
   "dependencies": {
     "@formatjs/intl-localematcher": "workspace:*"
   },

--- a/packages/intl-durationformat/package.json
+++ b/packages/intl-durationformat/package.json
@@ -12,6 +12,9 @@
     "./polyfill-force.js": "./polyfill-force.js",
     "./should-polyfill.js": "./should-polyfill.js"
   },
+  "imports": {
+    "#packages/*": "../../packages/*"
+  },
   "dependencies": {
     "@formatjs/intl-localematcher": "workspace:*"
   },

--- a/packages/intl-getcanonicallocales/package.json
+++ b/packages/intl-getcanonicallocales/package.json
@@ -12,6 +12,9 @@
     "./polyfill-force.js": "./polyfill-force.js",
     "./should-polyfill.js": "./should-polyfill.js"
   },
+  "imports": {
+    "#packages/*": "../../packages/*"
+  },
   "dependencies": {},
   "bugs": "https://github.com/formatjs/formatjs/issues",
   "homepage": "https://github.com/formatjs/formatjs#readme",

--- a/packages/intl-listformat/package.json
+++ b/packages/intl-listformat/package.json
@@ -14,6 +14,9 @@
     "./locale-data/*": "./locale-data/*",
     "./locale-data": "./locale-data"
   },
+  "imports": {
+    "#packages/*": "../../packages/*"
+  },
   "dependencies": {
     "@formatjs/intl-localematcher": "workspace:*"
   },

--- a/packages/intl-locale/package.json
+++ b/packages/intl-locale/package.json
@@ -12,6 +12,9 @@
     "./polyfill-force.js": "./polyfill-force.js",
     "./should-polyfill.js": "./should-polyfill.js"
   },
+  "imports": {
+    "#packages/*": "../../packages/*"
+  },
   "dependencies": {
     "@formatjs/intl-getcanonicallocales": "workspace:*",
     "@formatjs/intl-supportedvaluesof": "workspace:*"

--- a/packages/intl-localematcher/package.json
+++ b/packages/intl-localematcher/package.json
@@ -10,6 +10,9 @@
   "exports": {
     ".": "./index.js"
   },
+  "imports": {
+    "#packages/*": "../../packages/*"
+  },
   "dependencies": {
     "@formatjs/fast-memoize": "workspace:*"
   },

--- a/packages/intl-messageformat/package.json
+++ b/packages/intl-messageformat/package.json
@@ -10,6 +10,9 @@
   "exports": {
     ".": "./index.js"
   },
+  "imports": {
+    "#packages/*": "../../packages/*"
+  },
   "dependencies": {
     "@formatjs/fast-memoize": "workspace:*",
     "@formatjs/icu-messageformat-parser": "workspace:*"

--- a/packages/intl-numberformat/package.json
+++ b/packages/intl-numberformat/package.json
@@ -13,6 +13,9 @@
     "./locale-data/*": "./locale-data/*",
     "./locale-data": "./locale-data"
   },
+  "imports": {
+    "#packages/*": "../../packages/*"
+  },
   "dependencies": {
     "@formatjs/bigdecimal": "workspace:*",
     "@formatjs/intl-localematcher": "workspace:*"

--- a/packages/intl-pluralrules/package.json
+++ b/packages/intl-pluralrules/package.json
@@ -14,6 +14,9 @@
     "./locale-data/*": "./locale-data/*",
     "./locale-data": "./locale-data"
   },
+  "imports": {
+    "#packages/*": "../../packages/*"
+  },
   "dependencies": {
     "@formatjs/bigdecimal": "workspace:*",
     "@formatjs/intl-localematcher": "workspace:*"

--- a/packages/intl-relativetimeformat/package.json
+++ b/packages/intl-relativetimeformat/package.json
@@ -14,6 +14,9 @@
     "./locale-data/*": "./locale-data/*",
     "./locale-data": "./locale-data"
   },
+  "imports": {
+    "#packages/*": "../../packages/*"
+  },
   "dependencies": {
     "@formatjs/intl-localematcher": "workspace:*"
   },

--- a/packages/intl-segmenter/package.json
+++ b/packages/intl-segmenter/package.json
@@ -11,6 +11,9 @@
     "./polyfill-force.js": "./polyfill-force.js",
     "./should-polyfill.js": "./should-polyfill.js"
   },
+  "imports": {
+    "#packages/*": "../../packages/*"
+  },
   "dependencies": {
     "@formatjs/intl-localematcher": "workspace:*"
   },

--- a/packages/intl-supportedvaluesof/package.json
+++ b/packages/intl-supportedvaluesof/package.json
@@ -12,6 +12,9 @@
     "./polyfill-force.js": "./polyfill-force.js",
     "./should-polyfill.js": "./should-polyfill.js"
   },
+  "imports": {
+    "#packages/*": "../../packages/*"
+  },
   "dependencies": {
     "@formatjs/fast-memoize": "workspace:*"
   },

--- a/packages/intl/package.json
+++ b/packages/intl/package.json
@@ -10,6 +10,9 @@
   "exports": {
     ".": "./index.js"
   },
+  "imports": {
+    "#packages/*": "../../packages/*"
+  },
   "dependencies": {
     "@formatjs/fast-memoize": "workspace:*",
     "@formatjs/icu-messageformat-parser": "workspace:*",

--- a/packages/react-intl/package.json
+++ b/packages/react-intl/package.json
@@ -11,6 +11,9 @@
     ".": "./index.js",
     "./server": "./server.js"
   },
+  "imports": {
+    "#packages/*": "../../packages/*"
+  },
   "dependencies": {
     "@formatjs/icu-messageformat-parser": "workspace:*",
     "@formatjs/intl": "workspace:*",

--- a/packages/svelte-intl/package.json
+++ b/packages/svelte-intl/package.json
@@ -9,6 +9,9 @@
   "exports": {
     ".": "./index.js"
   },
+  "imports": {
+    "#packages/*": "../../packages/*"
+  },
   "dependencies": {
     "@formatjs/icu-messageformat-parser": "workspace:*",
     "@formatjs/intl": "workspace:*"

--- a/packages/ts-transformer/package.json
+++ b/packages/ts-transformer/package.json
@@ -9,6 +9,9 @@
   "exports": {
     ".": "./index.js"
   },
+  "imports": {
+    "#packages/*": "../../packages/*"
+  },
   "engines": {
     "node": ">= 20.12.0"
   },

--- a/packages/unplugin/package.json
+++ b/packages/unplugin/package.json
@@ -15,6 +15,9 @@
     "./rspack": "./rspack.js",
     "./transform": "./transform.js"
   },
+  "imports": {
+    "#packages/*": "../../packages/*"
+  },
   "dependencies": {
     "@formatjs/icu-messageformat-parser": "workspace:*",
     "@formatjs/ts-transformer": "workspace:*",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -9,6 +9,9 @@
   "exports": {
     ".": "./index.js"
   },
+  "imports": {
+    "#packages/*": "../../packages/*"
+  },
   "dependencies": {
     "@formatjs/fast-memoize": "workspace:*"
   },

--- a/packages/vue-intl/package.json
+++ b/packages/vue-intl/package.json
@@ -9,6 +9,9 @@
   "exports": {
     ".": "./index.js"
   },
+  "imports": {
+    "#packages/*": "../../packages/*"
+  },
   "dependencies": {
     "@babel/types": "^7.29.0",
     "@formatjs/icu-messageformat-parser": "workspace:*",

--- a/tools/check_no_internal_imports.ts
+++ b/tools/check_no_internal_imports.ts
@@ -7,13 +7,15 @@ interface Args extends minimist.ParsedArgs {
 }
 
 const PATTERN = /#packages\//
+// Skip lines that are just the package.json imports field definition (inlined by bundler)
+const IMPORTS_FIELD_PATTERN = /["']#packages\/\*["']\s*:\s*["']\.\.\/\.\.\//
 
 export function checkFile(filePath: string): string[] {
   const content = readFileSync(filePath, 'utf8')
   const errors: string[] = []
   const lines = content.split('\n')
   for (let i = 0; i < lines.length; i++) {
-    if (PATTERN.test(lines[i])) {
+    if (PATTERN.test(lines[i]) && !IMPORTS_FIELD_PATTERN.test(lines[i])) {
       errors.push(`${filePath}:${i + 1}: ${lines[i].trim()}`)
     }
   }


### PR DESCRIPTION
## Summary
- Add `"imports": {"#packages/*": "../../packages/*"}` to all 30 package.json files
- Update `check_no_internal_imports.ts` to allow the imports field pattern in bundled output

This enables Node.js subpath import resolution for `#packages/*` from within each package's directory — prerequisite for migrating relative imports to absolute `#packages/` imports.

## Test plan
- [x] `bazel test //...` — all 562 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)