### PR TITLE
fix(deps): revert example-sandboxes to relative imports, fix examples BUILD

### DIFF
--- a/packages/react-intl/example-sandboxes/rescripts/src/App.tsx
+++ b/packages/react-intl/example-sandboxes/rescripts/src/App.tsx
@@ -1,4 +1,4 @@
-import '#packages/react-intl/example-sandboxes/rescripts/src/styles.css'
+import './styles.css'
 import {IntlProvider, FormattedMessage} from 'react-intl'
 export default function App() {
   return (

--- a/packages/react-intl/example-sandboxes/rescripts/src/index.tsx
+++ b/packages/react-intl/example-sandboxes/rescripts/src/index.tsx
@@ -1,5 +1,5 @@
 import {render} from 'react-dom'
-import App from '#packages/react-intl/example-sandboxes/rescripts/src/App'
+import App from './App'
 
 const rootElement = document.getElementById('root')
 render(<App />, rootElement)

--- a/packages/react-intl/example-sandboxes/strict-locale-type/src/App.tsx
+++ b/packages/react-intl/example-sandboxes/strict-locale-type/src/App.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import '#packages/react-intl/example-sandboxes/strict-locale-type/src/styles.css'
+import './styles.css'
 import {IntlProvider, FormattedMessage, useIntl} from 'react-intl'
 
 const messages = {

--- a/packages/react-intl/example-sandboxes/strict-locale-type/src/index.tsx
+++ b/packages/react-intl/example-sandboxes/strict-locale-type/src/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import ReactDOM from 'react-dom'
 
-import App from '#packages/react-intl/example-sandboxes/strict-locale-type/src/App'
+import App from './App'
 
 const rootElement = document.getElementById('root')
 ReactDOM.render(<App />, rootElement)

--- a/packages/react-intl/example-sandboxes/strict-message-types/src/App.tsx
+++ b/packages/react-intl/example-sandboxes/strict-message-types/src/App.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import '#packages/react-intl/example-sandboxes/strict-message-types/src/styles.css'
+import './styles.css'
 import {IntlProvider, FormattedMessage} from 'react-intl'
 
 const messages = {

--- a/packages/react-intl/example-sandboxes/strict-message-types/src/index.tsx
+++ b/packages/react-intl/example-sandboxes/strict-message-types/src/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import ReactDOM from 'react-dom'
 
-import App from '#packages/react-intl/example-sandboxes/strict-message-types/src/App'
+import App from './App'
 
 const rootElement = document.getElementById('root')
 ReactDOM.render(<App />, rootElement)

--- a/packages/react-intl/examples/BUILD.bazel
+++ b/packages/react-intl/examples/BUILD.bazel
@@ -3,7 +3,7 @@ load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:http-server/package_json.bzl", "bin")
 load("//tools:rolldown.bzl", "rolldown_bundle")
-load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
+load("//tools:tsconfig.bzl", "packages_tsconfig")
 
 npm_link_all_packages()
 
@@ -35,7 +35,7 @@ ts_project(
     declaration = True,
     out_dir = "examples-lib",
     resolve_json_module = True,
-    tsconfig = BASE_TSCONFIG,
+    tsconfig = packages_tsconfig(),
     deps = EXAMPLES_SRC_DEPS,
 )
 


### PR DESCRIPTION
## Summary
- Revert `react-intl/example-sandboxes` back to relative imports (standalone CodeSandbox projects, not part of Bazel build)
- Update `react-intl/examples/BUILD.bazel` to use `packages_tsconfig()` for `#packages/` path mapping

Fixes CI failure on macOS from #6285 where the examples rolldown bundle couldn't resolve `#packages/` imports.

## Test plan
- [x] `bazel test //...` — all 562 tests pass
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)