### PR TITLE
fix(deps): use tsconfig-based resolution in rolldown bundler

### DIFF
--- a/tools/rolldown-bundle.ts
+++ b/tools/rolldown-bundle.ts
@@ -70,31 +70,29 @@ async function main(args: Args) {
     return new RegExp(`^${escaped}(\\/.*)?$`)
   })
 
+  // Write a temp tsconfig so the oxc resolver can resolve #packages/* paths
+  // with proper TypeScript extension mapping (.js -> .ts/.tsx)
+  const tsconfigPath = path.join(
+    tmpdir(),
+    `rolldown-tsconfig-${process.pid}.json`
+  )
+  writeFileSync(
+    tsconfigPath,
+    JSON.stringify({
+      compilerOptions: {
+        baseUrl: workspaceRoot,
+        paths: {
+          '#packages/*': ['packages/*'],
+        },
+        ...(args.dts ? {isolatedDeclarations: true} : {}),
+      },
+    })
+  )
+
   const bundle = await rolldown({
     input,
     external: externalPatterns,
-    plugins: args.dts
-      ? (() => {
-          // Write a temp tsconfig so the oxc resolver can resolve #packages/* paths
-          const tsconfigPath = path.join(
-            tmpdir(),
-            `rolldown-dts-tsconfig-${process.pid}.json`
-          )
-          writeFileSync(
-            tsconfigPath,
-            JSON.stringify({
-              compilerOptions: {
-                isolatedDeclarations: true,
-                baseUrl: workspaceRoot,
-                paths: {
-                  '#packages/*': ['packages/*'],
-                },
-              },
-            })
-          )
-          return dts({tsconfig: tsconfigPath})
-        })()
-      : [],
+    plugins: args.dts ? dts({tsconfig: tsconfigPath}) : [],
     platform:
       platform === 'node'
         ? 'node'
@@ -103,9 +101,7 @@ async function main(args: Args) {
           : undefined,
     define: Object.keys(defineMap).length > 0 ? defineMap : undefined,
     resolve: {
-      alias: {
-        '#packages': path.join(workspaceRoot, 'packages'),
-      },
+      tsconfigFilename: tsconfigPath,
     },
   })
 


### PR DESCRIPTION
## Summary
- Replace `resolve.alias` with `resolve.tsconfigFilename` for `#packages/*` path resolution in the rolldown bundler script
- Fixes CI failure on `main` where `//packages/react-intl/examples:main` rolldown bundle failed with `RESOLVE_ERROR` on macOS (and locally)

**Root cause:** After #6285 converted `react-intl/index.ts` to `#packages/` imports, the examples' rolldown bundle would resolve bare `react-intl` imports through the parent `packages/react-intl/package.json` (in the Bazel execroot) instead of `node_modules/`. That `package.json` points to `./index.js` which doesn't exist (only `index.ts` source and `index-bundle/index.js` bundle exist), so rolldown fell back to `index.ts` — which has `#packages/` imports that `resolve.alias` couldn't fully resolve (no `.js` → `.ts`/`.tsx` extension mapping).

**Fix:** Using `resolve.tsconfigFilename` delegates to oxc-resolver's TypeScript-aware resolution, which properly handles extension mapping and `#packages/*` path resolution via tsconfig `paths`.

## Test plan
- [x] `bazel build //packages/react-intl/examples:main` — passes (was failing)
- [x] `bazel test //...` — 562 tests pass, build completes successfully
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)