### PR TITLE
refactor(deps): add formatjs_compile macro

### DIFF
--- a/packages/fast-memoize/BUILD.bazel
+++ b/packages/fast-memoize/BUILD.bazel
@@ -1,12 +1,8 @@
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
-load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
-load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
+load("//tools:compile.bzl", "formatjs_compile")
 load("//tools:index.bzl", "generate_ide_tsconfig_json", "no_internal_imports_test", "package_exports_test", "package_json_test")
-load("//tools:rolldown.bzl", "rolldown_bundle")
-load("//tools:tsconfig.bzl", "packages_tsconfig")
 
 npm_link_all_packages()
 
@@ -20,24 +16,15 @@ SRCS = glob([
     "*.ts",
 ])
 
-SRC_DEPS = [
-]
-
 ENTRY_POINTS = [
     "index.ts",
 ]
 
-[rolldown_bundle(
-    name = "%s-bundle" % entry.replace(".ts", ""),
-    srcs = [":srcs"],
-    dts = True,
-    entry_point = entry,
-    external = [],
-    format = "esm",
-    output = "%s.js" % entry.replace(".ts", ""),
-    target = "es2020",
-    deps = SRC_DEPS,
-) for entry in ENTRY_POINTS]
+formatjs_compile(
+    name = "dist",
+    srcs = SRCS,
+    entry_points = ENTRY_POINTS,
+)
 
 BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
 
@@ -69,28 +56,11 @@ no_internal_imports_test(
     data = BUNDLES,
 )
 
-ts_project(
-    name = "typecheck",
-    srcs = [":srcs"],
-    declaration = True,
-    no_emit = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
-    tsconfig = packages_tsconfig(),
-    deps = SRC_DEPS,
-)
-
 # Generate tsconfig.json with correct extends path
 generate_ide_tsconfig_json()
 
 package_json_test(
     name = "package_json_test",
-    deps = SRC_DEPS,
-)
-
-copy_to_bin(
-    name = "srcs",
-    srcs = SRCS,
 )
 
 package_exports_test(

--- a/packages/intl-localematcher/BUILD.bazel
+++ b/packages/intl-localematcher/BUILD.bazel
@@ -1,13 +1,9 @@
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
-load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
-load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
+load("//tools:compile.bzl", "formatjs_compile")
 load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "no_internal_imports_test", "package_exports_test", "package_json_test")
-load("//tools:rolldown.bzl", "rolldown_bundle")
-load("//tools:tsconfig.bzl", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -23,27 +19,16 @@ SRC_DEPS = [
     "//:node_modules/@formatjs/fast-memoize",
 ]
 
-EXTERNAL_PACKAGES = [
-    dep.split("node_modules/")[1]
-    for dep in SRC_DEPS
-    if "node_modules/" in dep
-]
-
 ENTRY_POINTS = [
     "index.ts",
 ]
 
-[rolldown_bundle(
-    name = "%s-bundle" % entry.replace(".ts", ""),
-    srcs = [":srcs"],
-    dts = True,
-    entry_point = entry,
-    external = EXTERNAL_PACKAGES,
-    format = "esm",
-    output = "%s.js" % entry.replace(".ts", ""),
-    target = "es2020",
+formatjs_compile(
+    name = "dist",
+    srcs = SRCS,
+    entry_points = ENTRY_POINTS,
     deps = SRC_DEPS,
-) for entry in ENTRY_POINTS]
+)
 
 BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
 
@@ -75,17 +60,6 @@ no_internal_imports_test(
     data = BUNDLES,
 )
 
-ts_project(
-    name = "typecheck",
-    srcs = [":srcs"],
-    declaration = True,
-    no_emit = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
-    tsconfig = packages_tsconfig(),
-    deps = SRC_DEPS,
-)
-
 vitest(
     name = "unit_test",
     srcs = SRCS + glob(["tests/**/*.ts"]),
@@ -107,11 +81,6 @@ generate_src_file(
         "//:node_modules/json-stable-stringify",
     ],
     tool = "//packages/intl-localematcher/scripts:regions-gen",
-)
-
-copy_to_bin(
-    name = "srcs",
-    srcs = SRCS,
 )
 
 package_exports_test(

--- a/tools/compile.bzl
+++ b/tools/compile.bzl
@@ -1,0 +1,81 @@
+"Macro for TypeScript compilation + rolldown bundling."
+
+load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
+load("//tools:rolldown.bzl", "rolldown_bundle")
+load("//tools:tsconfig.bzl", "packages_tsconfig")
+
+def formatjs_compile(
+        name,
+        srcs,
+        deps = [],
+        project_references = [],
+        entry_points = ["index.ts"],
+        types = False):
+    """TypeScript compilation + rolldown bundling.
+
+    Generates:
+    - copy_to_bin(name = "srcs") for sandbox compatibility
+    - ts_project(name = "typecheck") for type checking (tsgo, no emit)
+    - rolldown_bundle per entry point (dts=True, esm, es2020)
+    - Optionally ts_project(name = "types") with emit_declaration_only
+
+    Args:
+        name: target name (e.g. "dist")
+        srcs: source files (already globbed)
+        deps: external npm dependencies (e.g. //:node_modules/react)
+        project_references: internal package dependencies (e.g. //packages/ecma402-abstract)
+        entry_points: list of .ts entry points to bundle
+        types: if True, generate a "types" ts_project with emit_declaration_only
+    """
+    all_deps = deps + project_references
+
+    # Compute external packages for rolldown (only node_modules deps are externalized)
+    external_packages = [
+        dep.split("node_modules/")[1]
+        for dep in deps
+        if "node_modules/" in dep
+    ]
+
+    copy_to_bin(
+        name = "srcs",
+        srcs = srcs,
+    )
+
+    ts_project(
+        name = "typecheck",
+        srcs = [":srcs"],
+        declaration = True,
+        no_emit = True,
+        resolve_json_module = True,
+        transpiler = tsgo_bin.tsgo,
+        tsconfig = packages_tsconfig(),
+        deps = all_deps,
+    )
+
+    for entry in entry_points:
+        rolldown_bundle(
+            name = "%s-bundle" % entry.replace(".ts", ""),
+            srcs = [":srcs"],
+            dts = True,
+            entry_point = entry,
+            external = external_packages,
+            format = "esm",
+            output = "%s.js" % entry.replace(".ts", ""),
+            target = "es2020",
+            deps = all_deps,
+        )
+
+    if types:
+        ts_project(
+            name = "types",
+            srcs = [":srcs"],
+            declaration = True,
+            emit_declaration_only = True,
+            resolve_json_module = True,
+            transpiler = tsgo_bin.tsgo,
+            tsconfig = packages_tsconfig(),
+            visibility = ["//visibility:public"],
+            deps = all_deps,
+        )


### PR DESCRIPTION
## Summary
- Add `tools/compile.bzl` with `formatjs_compile` macro encapsulating: `copy_to_bin(srcs)`, `ts_project(typecheck)`, `rolldown_bundle` per entry point, optional `ts_project(types)`
- Separates `deps` (external npm) from `project_references` (internal `//packages/*`) to prepare for custom gazelle plugin
- Migrate `fast-memoize` and `intl-localematcher` as proof of concept

**Stack:** PR 1 of 6 — compile macro → package macro → test macro → batch migrate → gazelle plugin → enable gazelle

## Test plan
- [x] `bazel test //packages/fast-memoize:all` — all tests pass
- [x] `bazel test //packages/intl-localematcher:all` — all tests pass
- [x] `bazel build //packages/fast-memoize:pkg //packages/intl-localematcher:pkg` — npm packages build

🤖 Generated with [Claude Code](https://claude.com/claude-code)