### PR TITLE
refactor(deps): add formatjs_package macro

### DIFF
--- a/packages/fast-memoize/BUILD.bazel
+++ b/packages/fast-memoize/BUILD.bazel
@@ -1,8 +1,6 @@
-load("@aspect_rules_js//js:defs.bzl", "js_library")
-load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:compile.bzl", "formatjs_compile")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "no_internal_imports_test", "package_exports_test", "package_json_test")
+load("//tools:package.bzl", "formatjs_package")
 
 npm_link_all_packages()
 
@@ -10,60 +8,15 @@ exports_files([
     "package.json",
 ])
 
-PACKAGE_NAME = "fast-memoize"
-
 SRCS = glob([
     "*.ts",
 ])
 
-ENTRY_POINTS = [
-    "index.ts",
-]
-
 formatjs_compile(
     name = "dist",
     srcs = SRCS,
-    entry_points = ENTRY_POINTS,
 )
 
-BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
-
-js_library(
-    name = PACKAGE_NAME,
-    srcs = BUNDLES + [
-        "package.json",
-    ],
-    visibility = ["//visibility:public"],
-)
-
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-    ] + BUNDLES,
-    package = "@formatjs/%s" % PACKAGE_NAME,
-    replace_prefixes = {
-        "%s-bundle/" % entry.replace(".ts", ""): ""
-        for entry in ENTRY_POINTS
-    },
-    visibility = ["//visibility:public"],
-)
-
-no_internal_imports_test(
-    name = "no_internal_imports_test",
-    data = BUNDLES,
-)
-
-# Generate tsconfig.json with correct extends path
-generate_ide_tsconfig_json()
-
-package_json_test(
-    name = "package_json_test",
-)
-
-package_exports_test(
-    name = "package_exports_test",
-    pkg = ":pkg",
+formatjs_package(
+    name = "fast-memoize",
 )

--- a/packages/intl-localematcher/BUILD.bazel
+++ b/packages/intl-localematcher/BUILD.bazel
@@ -1,14 +1,10 @@
-load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
-load("@aspect_rules_js//js:defs.bzl", "js_library")
-load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:compile.bzl", "formatjs_compile")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "no_internal_imports_test", "package_exports_test", "package_json_test")
+load("//tools:index.bzl", "generate_src_file")
+load("//tools:package.bzl", "formatjs_package")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
-
-PACKAGE_NAME = "intl-localematcher"
 
 SRCS = glob(
     ["abstract/*"],
@@ -19,58 +15,21 @@ SRC_DEPS = [
     "//:node_modules/@formatjs/fast-memoize",
 ]
 
-ENTRY_POINTS = [
-    "index.ts",
-]
-
 formatjs_compile(
     name = "dist",
     srcs = SRCS,
-    entry_points = ENTRY_POINTS,
     deps = SRC_DEPS,
 )
 
-BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
-
-js_library(
-    name = PACKAGE_NAME,
-    srcs = BUNDLES + [
-        "package.json",
-    ],
-    visibility = ["//visibility:public"],
-)
-
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-    ] + BUNDLES,
-    package = "@formatjs/%s" % PACKAGE_NAME,
-    replace_prefixes = {
-        "%s-bundle/" % entry.replace(".ts", ""): ""
-        for entry in ENTRY_POINTS
-    },
-    visibility = ["//visibility:public"],
-)
-
-no_internal_imports_test(
-    name = "no_internal_imports_test",
-    data = BUNDLES,
+formatjs_package(
+    name = "intl-localematcher",
+    deps = SRC_DEPS,
 )
 
 vitest(
     name = "unit_test",
     srcs = SRCS + glob(["tests/**/*.ts"]),
     deps = SRC_DEPS,
-)
-
-# Generate tsconfig.json with correct extends path
-generate_ide_tsconfig_json()
-
-package_json_test(
-    name = "package_json_test",
 )
 
 generate_src_file(
@@ -81,9 +40,4 @@ generate_src_file(
         "//:node_modules/json-stable-stringify",
     ],
     tool = "//packages/intl-localematcher/scripts:regions-gen",
-)
-
-package_exports_test(
-    name = "package_exports_test",
-    pkg = ":pkg",
 )

--- a/tools/package.bzl
+++ b/tools/package.bzl
@@ -1,0 +1,81 @@
+"Macro for npm packaging + validation tests."
+
+load("@aspect_rules_js//js:defs.bzl", "js_library")
+load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "no_internal_imports_test", "package_exports_test", "package_json_test")
+
+def formatjs_package(
+        name,
+        entry_points = ["index.ts"],
+        deps = [],
+        npm_package_name = None,
+        extra_npm_srcs = [],
+        allow_overwrites = False):
+    """npm packaging + validation tests.
+
+    Generates:
+    - js_library(name = {name}) with bundles + package.json
+    - npm_package(name = "pkg")
+    - no_internal_imports_test
+    - package_json_test
+    - package_exports_test
+    - generate_ide_tsconfig_json()
+
+    Expects formatjs_compile to have been called first, producing
+    "{entry}-bundle" targets for each entry point.
+
+    Args:
+        name: package name (e.g. "fast-memoize"), used as js_library target name
+        entry_points: list of .ts entry points (must match formatjs_compile's entry_points)
+        deps: all dependencies (for package_json_test)
+        npm_package_name: npm package name for publishing (default "@formatjs/{name}")
+        extra_npm_srcs: additional files for npm_package (iife bundles, locale-data, etc.)
+        allow_overwrites: passed to npm_package (default False)
+    """
+    effective_npm_name = npm_package_name or ("@formatjs/%s" % name)
+
+    bundles = [":%s-bundle" % entry.replace(".ts", "") for entry in entry_points]
+    replace_prefixes = {
+        "%s-bundle/" % entry.replace(".ts", ""): ""
+        for entry in entry_points
+    }
+
+    js_library(
+        name = name,
+        srcs = bundles + ["package.json"],
+        visibility = ["//visibility:public"],
+    )
+
+    npm_pkg_kwargs = {}
+    if allow_overwrites:
+        npm_pkg_kwargs["allow_overwrites"] = True
+
+    npm_package(
+        name = "pkg",
+        srcs = [
+            "LICENSE.md",
+            "README.md",
+            "package.json",
+        ] + bundles + extra_npm_srcs,
+        package = effective_npm_name,
+        replace_prefixes = replace_prefixes,
+        visibility = ["//visibility:public"],
+        **npm_pkg_kwargs
+    )
+
+    no_internal_imports_test(
+        name = "no_internal_imports_test",
+        data = bundles,
+    )
+
+    package_json_test(
+        name = "package_json_test",
+        deps = deps,
+    )
+
+    package_exports_test(
+        name = "package_exports_test",
+        pkg = ":pkg",
+    )
+
+    generate_ide_tsconfig_json()


### PR DESCRIPTION
## Summary
- Add `tools/package.bzl` with `formatjs_package` macro encapsulating: `js_library`, `npm_package`, `no_internal_imports_test`, `package_json_test`, `package_exports_test`, `generate_ide_tsconfig_json()`
- Combined with `formatjs_compile` from PR 1: fast-memoize 100→21 lines, intl-localematcher 121→39 lines

**Stack:** PR 2 of 6 (stacked on #6299)

## Test plan
- [x] `bazel test //packages/fast-memoize:all //packages/intl-localematcher:all` — all 11 tests pass
- [x] `bazel build //packages/fast-memoize:pkg //packages/intl-localematcher:pkg` — npm packages build

🤖 Generated with [Claude Code](https://claude.com/claude-code)