### PR TITLE
refactor(deps): add formatjs_test macro

### DIFF
--- a/packages/intl-localematcher/BUILD.bazel
+++ b/packages/intl-localematcher/BUILD.bazel
@@ -2,7 +2,7 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:compile.bzl", "formatjs_compile")
 load("//tools:index.bzl", "generate_src_file")
 load("//tools:package.bzl", "formatjs_package")
-load("//tools:vitest.bzl", "vitest")
+load("//tools:test.bzl", "formatjs_test")
 
 npm_link_all_packages()
 
@@ -26,7 +26,7 @@ formatjs_package(
     deps = SRC_DEPS,
 )
 
-vitest(
+formatjs_test(
     name = "unit_test",
     srcs = SRCS + glob(["tests/**/*.ts"]),
     deps = SRC_DEPS,

--- a/tools/test.bzl
+++ b/tools/test.bzl
@@ -1,0 +1,39 @@
+"Macro for formatjs test targets with separated dep tracking."
+
+load("//tools:vitest.bzl", "vitest")
+
+def formatjs_test(
+        name,
+        srcs = [],
+        deps = [],
+        project_references = [],
+        test_deps = [],
+        test_project_references = [],
+        **kwargs):
+    """Vitest wrapper with separated dependency tracking.
+
+    Separates deps into 4 categories for gazelle:
+    - deps: external npm deps from source files
+    - project_references: internal //packages/* deps from source files
+    - test_deps: external npm deps only in test files
+    - test_project_references: internal deps only in test files
+
+    All categories are merged and passed to vitest.
+
+    Args:
+        name: target name (e.g. "unit_test")
+        srcs: source + test files
+        deps: external npm dependencies from source files (gazelle-managed)
+        project_references: internal package deps from source files (gazelle-managed)
+        test_deps: external npm deps only in test files (gazelle-managed)
+        test_project_references: internal deps only in test files (gazelle-managed)
+        **kwargs: passed through to vitest (dom, config, size, tsconfig, data, etc.)
+    """
+    all_deps = deps + project_references + test_deps + test_project_references
+
+    vitest(
+        name = name,
+        srcs = srcs,
+        deps = all_deps,
+        **kwargs
+    )


### PR DESCRIPTION
## Summary
- Add `tools/test.bzl` with `formatjs_test` macro wrapping vitest with 4 gazelle-managed dep categories: `deps`, `project_references`, `test_deps`, `test_project_references`
- Migrate `intl-localematcher` tests to use it

**Stack:** PR 3 of 6 (stacked on #6300)

## Test plan
- [x] `bazel test //packages/intl-localematcher:all` — all 7 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)