### PR TITLE
refactor(deps): migrate all 28 packages to formatjs macros

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,4 @@ docs/typesense-index.jsonl
 # Environment files
 docs/.env
 .env
-.env.local
+.env.local.trunk/

--- a/packages/babel-plugin-formatjs/BUILD.bazel
+++ b/packages/babel-plugin-formatjs/BUILD.bazel
@@ -1,17 +1,9 @@
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
-load("@aspect_rules_js//js:defs.bzl", "js_library")
-load("@aspect_rules_js//npm:defs.bzl", "npm_package")
-load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
-load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "no_internal_imports_test", "package_exports_test", "package_json_test")
-load("//tools:rolldown.bzl", "rolldown_bundle")
-load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
-load("//tools:vitest.bzl", "vitest")
+load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:package.bzl", "formatjs_package")
+load("//tools:test.bzl", "formatjs_test")
 
 npm_link_all_packages()
-
-PACKAGE_NAME = "babel-plugin-formatjs"
 
 SRCS = glob(
     ["**/*.ts"],
@@ -31,70 +23,19 @@ SRC_DEPS = [
     "//:node_modules/@types/babel__traverse",
 ]
 
-EXTERNAL_PACKAGES = [
-    dep.split("node_modules/")[1]
-    for dep in SRC_DEPS
-    if "node_modules/" in dep
-]
-
-ENTRY_POINTS = [
-    "index.ts",
-]
-
-[rolldown_bundle(
-    name = "%s-bundle" % entry.replace(".ts", ""),
-    srcs = [":srcs"],
-    dts = True,
-    entry_point = entry,
-    external = EXTERNAL_PACKAGES,
-    format = "esm",
-    output = "%s.js" % entry.replace(".ts", ""),
-    target = "es2020",
-    deps = SRC_DEPS,
-) for entry in ENTRY_POINTS]
-
-BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
-
-js_library(
-    name = PACKAGE_NAME,
-    srcs = BUNDLES + [
-        "package.json",
-    ],
-    visibility = ["//visibility:public"],
-)
-
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-    ] + BUNDLES,
-    package = PACKAGE_NAME,
-    replace_prefixes = {
-        "%s-bundle/" % entry.replace(".ts", ""): ""
-        for entry in ENTRY_POINTS
-    },
-    visibility = ["//visibility:public"],
-)
-
-no_internal_imports_test(
-    name = "no_internal_imports_test",
-    data = BUNDLES,
-)
-
-ts_project(
-    name = "typecheck",
-    srcs = [":srcs"],
-    declaration = True,
-    no_emit = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
-    tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
+formatjs_compile(
+    name = "dist",
+    srcs = SRCS,
     deps = SRC_DEPS,
 )
 
-vitest(
+formatjs_package(
+    name = "babel-plugin-formatjs",
+    npm_package_name = "babel-plugin-formatjs",
+    deps = SRC_DEPS,
+)
+
+formatjs_test(
     name = "unit_test",
     srcs = SRCS + glob(
         [
@@ -102,27 +43,10 @@ vitest(
         ],
         exclude = ["tests/vue/**/*"],
     ),
-    deps = SRC_DEPS + [
+    test_deps = [
         "//:node_modules/@babel/preset-env",
         "//:node_modules/@babel/preset-react",
         "//packages/babel-plugin-formatjs/tests/fixtures",
     ],
-)
-
-package_json_test(
-    name = "package_json_test",
     deps = SRC_DEPS,
-)
-
-# Generate tsconfig.json with correct extends path
-generate_ide_tsconfig_json()
-
-copy_to_bin(
-    name = "srcs",
-    srcs = SRCS,
-)
-
-package_exports_test(
-    name = "package_exports_test",
-    pkg = ":pkg",
 )

--- a/packages/bigdecimal/BUILD.bazel
+++ b/packages/bigdecimal/BUILD.bazel
@@ -1,21 +1,14 @@
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
-load("@aspect_rules_js//js:defs.bzl", "js_library")
-load("@aspect_rules_js//npm:defs.bzl", "npm_package")
-load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
-load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "no_internal_imports_test", "package_exports_test", "package_json_test")
-load("//tools:rolldown.bzl", "rolldown_bundle")
+load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:package.bzl", "formatjs_package")
+load("//tools:test.bzl", "formatjs_test")
 load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
-load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
 
 exports_files([
     "package.json",
 ])
-
-PACKAGE_NAME = "bigdecimal"
 
 SRCS = glob([
     "*.ts",
@@ -24,86 +17,19 @@ SRCS = glob([
 SRC_DEPS = [
 ]
 
-ENTRY_POINTS = [
-    "index.ts",
-]
-
-[rolldown_bundle(
-    name = "%s-bundle" % entry.replace(".ts", ""),
-    srcs = [":srcs"],
-    dts = True,
-    entry_point = entry,
-    external = [],
-    format = "esm",
-    output = "%s.js" % entry.replace(".ts", ""),
-    target = "es2020",
-    deps = SRC_DEPS,
-) for entry in ENTRY_POINTS]
-
-BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
-
-js_library(
-    name = PACKAGE_NAME,
-    srcs = BUNDLES + [
-        "package.json",
-    ],
-    visibility = ["//visibility:public"],
-)
-
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-    ] + BUNDLES,
-    package = "@formatjs/%s" % PACKAGE_NAME,
-    replace_prefixes = {
-        "%s-bundle/" % entry.replace(".ts", ""): ""
-        for entry in ENTRY_POINTS
-    },
-    visibility = ["//visibility:public"],
-)
-
-no_internal_imports_test(
-    name = "no_internal_imports_test",
-    data = BUNDLES,
-)
-
-ts_project(
-    name = "typecheck",
-    srcs = [":srcs"],
-    declaration = True,
-    no_emit = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
-    tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
-    deps = SRC_DEPS,
-)
-
-TESTS = glob([
-    "tests/*.test.ts",
-])
-
-vitest(
-    name = "unit_test",
-    srcs = SRCS + TESTS,
-    deps = SRC_DEPS,
-)
-
-generate_ide_tsconfig_json()
-
-package_json_test(
-    name = "package_json_test",
-    deps = SRC_DEPS,
-)
-
-copy_to_bin(
-    name = "srcs",
+formatjs_compile(
+    name = "dist",
     srcs = SRCS,
+    tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
 )
 
-package_exports_test(
-    name = "package_exports_test",
-    pkg = ":pkg",
+formatjs_package(
+    name = "bigdecimal",
+)
+
+formatjs_test(
+    name = "unit_test",
+    srcs = SRCS + glob([
+        "tests/*.test.ts",
+    ]),
 )

--- a/packages/cli-lib/BUILD.bazel
+++ b/packages/cli-lib/BUILD.bazel
@@ -1,19 +1,14 @@
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
-load("@aspect_rules_js//js:defs.bzl", "js_library")
-load("@aspect_rules_js//npm:defs.bzl", "npm_package")
-load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
-load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "no_internal_imports_test", "package_exports_test", "package_json_test")
+load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:package.bzl", "formatjs_package")
 load("//tools:rolldown.bzl", "rolldown_bundle")
-load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
-load("//tools:vitest.bzl", "vitest")
+load("//tools:test.bzl", "formatjs_test")
 
 npm_link_all_packages()
 
-PACKAGE_NAME = "cli-lib"
-
 exports_files(["package.json"])
+
+PACKAGE_NAME = "cli-lib"
 
 SRCS = glob(
     ["**/*.ts"],
@@ -53,70 +48,18 @@ SRC_DEPS = [
     "//:node_modules/typescript",
 ] + VUE_DEPS + SVELTE_DEPS + GLIMMER_HBS_DEPS
 
-EXTERNAL_PACKAGES = [
-    dep.split("node_modules/")[1]
-    for dep in SRC_DEPS
-    if "node_modules/" in dep
-]
-
-ENTRY_POINTS = [
-    "index.ts",
-]
-
-[rolldown_bundle(
-    name = "%s-bundle" % entry.replace(".ts", ""),
-    srcs = [":srcs"],
-    dts = True,
-    entry_point = entry,
-    external = EXTERNAL_PACKAGES,
-    format = "esm",
-    output = "%s.js" % entry.replace(".ts", ""),
-    target = "es2020",
+formatjs_compile(
+    name = "dist",
+    srcs = SRCS,
     deps = SRC_DEPS,
-) for entry in ENTRY_POINTS]
+)
 
-BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
-
-js_library(
+formatjs_package(
     name = PACKAGE_NAME,
-    srcs = BUNDLES + [
-        "package.json",
-    ],
-    visibility = ["//visibility:public"],
-)
-
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-    ] + BUNDLES,
-    package = "@formatjs/%s" % PACKAGE_NAME,
-    replace_prefixes = {
-        "%s-bundle/" % entry.replace(".ts", ""): ""
-        for entry in ENTRY_POINTS
-    },
-    visibility = ["//visibility:public"],
-)
-
-no_internal_imports_test(
-    name = "no_internal_imports_test",
-    data = BUNDLES,
-)
-
-ts_project(
-    name = "typecheck",
-    srcs = [":srcs"],
-    declaration = True,
-    no_emit = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
-    tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
     deps = SRC_DEPS,
 )
 
-vitest(
+formatjs_test(
     name = "unit_test",
     srcs = [":srcs"] + glob(
         ["tests/unit/**/*.test.ts"],
@@ -126,9 +69,6 @@ vitest(
     ),
     deps = SRC_DEPS,
 )
-
-# Generate tsconfig.json with correct extends path
-generate_ide_tsconfig_json()
 
 genrule(
     name = "bin",
@@ -158,19 +98,4 @@ rolldown_bundle(
     target = "node20",
     visibility = ["//packages/cli:__pkg__"],
     deps = SRC_DEPS,
-)
-
-package_json_test(
-    name = "package_json_test",
-    deps = SRC_DEPS,
-)
-
-copy_to_bin(
-    name = "srcs",
-    srcs = SRCS,
-)
-
-package_exports_test(
-    name = "package_exports_test",
-    pkg = ":pkg",
 )

--- a/packages/ecma376/BUILD.bazel
+++ b/packages/ecma376/BUILD.bazel
@@ -1,18 +1,10 @@
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
-load("@aspect_rules_js//js:defs.bzl", "js_library")
-load("@aspect_rules_js//npm:defs.bzl", "npm_package")
-load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
-load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "no_internal_imports_test", "package_exports_test", "package_json_test")
-load("//tools:rolldown.bzl", "rolldown_bundle")
-load("//tools:tsconfig.bzl", "packages_tsconfig")
-load("//tools:vitest.bzl", "vitest")
+load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:package.bzl", "formatjs_package")
+load("//tools:test.bzl", "formatjs_test")
 
 exports_files([
     "package.json",
 ])
-
-PACKAGE_NAME = "ecma376"
 
 SRCS = glob([
     "*.ts",
@@ -21,85 +13,16 @@ SRCS = glob([
 SRC_DEPS = [
 ]
 
-ENTRY_POINTS = [
-    "index.ts",
-]
-
-[rolldown_bundle(
-    name = "%s-bundle" % entry.replace(".ts", ""),
-    srcs = [":srcs"],
-    dts = True,
-    entry_point = entry,
-    external = [],
-    format = "esm",
-    output = "%s.js" % entry.replace(".ts", ""),
-    target = "es2020",
-    deps = SRC_DEPS,
-) for entry in ENTRY_POINTS]
-
-BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
-
-js_library(
-    name = PACKAGE_NAME,
-    srcs = BUNDLES + [
-        "package.json",
-    ],
-    visibility = ["//visibility:public"],
-)
-
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-    ] + BUNDLES,
-    package = "@formatjs/%s" % PACKAGE_NAME,
-    replace_prefixes = {
-        "%s-bundle/" % entry.replace(".ts", ""): ""
-        for entry in ENTRY_POINTS
-    },
-    visibility = ["//visibility:public"],
-)
-
-no_internal_imports_test(
-    name = "no_internal_imports_test",
-    data = BUNDLES,
-)
-
-ts_project(
-    name = "typecheck",
-    srcs = [":srcs"],
-    declaration = True,
-    no_emit = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
-    tsconfig = packages_tsconfig(),
-    deps = SRC_DEPS,
-)
-
-TESTS = glob(["tests/*"])
-
-# Generate tsconfig.json with correct extends path
-generate_ide_tsconfig_json()
-
-vitest(
-    name = "unit_test",
-    srcs = SRCS + TESTS,
-    deps = SRC_DEPS,
-)
-
-package_json_test(
-    name = "package_json_test",
-    deps = SRC_DEPS,
-)
-
-copy_to_bin(
-    name = "srcs",
+formatjs_compile(
+    name = "dist",
     srcs = SRCS,
 )
 
-package_exports_test(
-    name = "package_exports_test",
-    pkg = ":pkg",
+formatjs_package(
+    name = "ecma376",
+)
+
+formatjs_test(
+    name = "unit_test",
+    srcs = SRCS + glob(["tests/*"]),
 )

--- a/packages/eslint-plugin-formatjs/BUILD.bazel
+++ b/packages/eslint-plugin-formatjs/BUILD.bazel
@@ -1,10 +1,14 @@
 load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
+load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
+load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:compile.bzl", "formatjs_compile")
-load("//tools:index.bzl", "generate_src_file")
-load("//tools:package.bzl", "formatjs_package")
-load("//tools:test.bzl", "formatjs_test")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "no_internal_imports_test", "package_exports_test", "package_json_test")
+load("//tools:rolldown.bzl", "rolldown_bundle")
 load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
+load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
 
@@ -52,23 +56,73 @@ SRC_DEPS = [
     "//:node_modules/typescript",
 ]
 
+EXTERNAL_PACKAGES = [
+    dep.split("node_modules/")[1]
+    for dep in SRC_DEPS
+    if "node_modules/" in dep
+]
+
 ENTRY_POINTS = [
     "index.ts",
     "util.ts",
 ]
 
-formatjs_compile(
-    name = "dist",
-    srcs = SRCS,
-    entry_points = ENTRY_POINTS,
-    tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
+[rolldown_bundle(
+    name = "%s-bundle" % entry.replace(".ts", ""),
+    srcs = [
+        "package.json",
+        ":srcs",
+    ],
+    dts = True,
+    entry_point = entry,
+    external = EXTERNAL_PACKAGES,
+    format = "esm",
+    output = "%s.js" % entry.replace(".ts", ""),
+    target = "es2020",
     deps = SRC_DEPS,
+) for entry in ENTRY_POINTS]
+
+BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
+
+js_library(
+    name = PACKAGE_NAME,
+    srcs = BUNDLES + [
+        "package.json",
+    ],
+    visibility = ["//visibility:public"],
 )
 
-formatjs_package(
-    name = PACKAGE_NAME,
-    entry_points = ENTRY_POINTS,
-    npm_package_name = PACKAGE_NAME,
+npm_package(
+    name = "pkg",
+    srcs = [
+        "LICENSE.md",
+        "README.md",
+        "package.json",
+    ] + BUNDLES,
+    package = PACKAGE_NAME,
+    replace_prefixes = {
+        "%s-bundle/" % entry.replace(".ts", ""): ""
+        for entry in ENTRY_POINTS
+    },
+    visibility = ["//visibility:public"],
+)
+
+no_internal_imports_test(
+    name = "no_internal_imports_test",
+    data = BUNDLES,
+)
+
+ts_project(
+    name = "typecheck",
+    srcs = [
+        "package.json",
+        ":srcs",
+    ],
+    declaration = True,
+    no_emit = True,
+    resolve_json_module = True,
+    transpiler = tsgo_bin.tsgo,
+    tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
     deps = SRC_DEPS,
 )
 
@@ -83,13 +137,30 @@ TEST_FILES = glob([
     "tests/*.test.ts",
 ])
 
-formatjs_test(
+vitest(
     name = "unit_test",
     srcs = TESTS_BASE_SRCS + TEST_FILES,
-    test_deps = [
+    deps = SRC_DEPS + [
         "//:node_modules/@typescript-eslint/utils",
         "//:node_modules/oxlint",
         "//:node_modules/vue-eslint-parser",
     ],
+)
+
+# Generate tsconfig.json with correct extends path
+generate_ide_tsconfig_json()
+
+package_json_test(
+    name = "package_json_test",
     deps = SRC_DEPS,
+)
+
+copy_to_bin(
+    name = "srcs",
+    srcs = SRCS,
+)
+
+package_exports_test(
+    name = "package_exports_test",
+    pkg = ":pkg",
 )

--- a/packages/eslint-plugin-formatjs/BUILD.bazel
+++ b/packages/eslint-plugin-formatjs/BUILD.bazel
@@ -1,14 +1,10 @@
 load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
-load("@aspect_rules_js//js:defs.bzl", "js_library")
-load("@aspect_rules_js//npm:defs.bzl", "npm_package")
-load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
-load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "no_internal_imports_test", "package_exports_test", "package_json_test")
-load("//tools:rolldown.bzl", "rolldown_bundle")
+load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:index.bzl", "generate_src_file")
+load("//tools:package.bzl", "formatjs_package")
+load("//tools:test.bzl", "formatjs_test")
 load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
-load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
 
@@ -56,73 +52,23 @@ SRC_DEPS = [
     "//:node_modules/typescript",
 ]
 
-EXTERNAL_PACKAGES = [
-    dep.split("node_modules/")[1]
-    for dep in SRC_DEPS
-    if "node_modules/" in dep
-]
-
 ENTRY_POINTS = [
     "index.ts",
     "util.ts",
 ]
 
-[rolldown_bundle(
-    name = "%s-bundle" % entry.replace(".ts", ""),
-    srcs = [
-        "package.json",
-        ":srcs",
-    ],
-    dts = True,
-    entry_point = entry,
-    external = EXTERNAL_PACKAGES,
-    format = "esm",
-    output = "%s.js" % entry.replace(".ts", ""),
-    target = "es2020",
-    deps = SRC_DEPS,
-) for entry in ENTRY_POINTS]
-
-BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
-
-js_library(
-    name = PACKAGE_NAME,
-    srcs = BUNDLES + [
-        "package.json",
-    ],
-    visibility = ["//visibility:public"],
-)
-
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-    ] + BUNDLES,
-    package = PACKAGE_NAME,
-    replace_prefixes = {
-        "%s-bundle/" % entry.replace(".ts", ""): ""
-        for entry in ENTRY_POINTS
-    },
-    visibility = ["//visibility:public"],
-)
-
-no_internal_imports_test(
-    name = "no_internal_imports_test",
-    data = BUNDLES,
-)
-
-ts_project(
-    name = "typecheck",
-    srcs = [
-        "package.json",
-        ":srcs",
-    ],
-    declaration = True,
-    no_emit = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
+formatjs_compile(
+    name = "dist",
+    srcs = SRCS,
+    entry_points = ENTRY_POINTS,
     tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
+    deps = SRC_DEPS,
+)
+
+formatjs_package(
+    name = PACKAGE_NAME,
+    entry_points = ENTRY_POINTS,
+    npm_package_name = PACKAGE_NAME,
     deps = SRC_DEPS,
 )
 
@@ -137,30 +83,13 @@ TEST_FILES = glob([
     "tests/*.test.ts",
 ])
 
-vitest(
+formatjs_test(
     name = "unit_test",
     srcs = TESTS_BASE_SRCS + TEST_FILES,
-    deps = SRC_DEPS + [
+    test_deps = [
         "//:node_modules/@typescript-eslint/utils",
         "//:node_modules/oxlint",
         "//:node_modules/vue-eslint-parser",
     ],
-)
-
-# Generate tsconfig.json with correct extends path
-generate_ide_tsconfig_json()
-
-package_json_test(
-    name = "package_json_test",
     deps = SRC_DEPS,
-)
-
-copy_to_bin(
-    name = "srcs",
-    srcs = SRCS,
-)
-
-package_exports_test(
-    name = "package_exports_test",
-    pkg = ":pkg",
 )

--- a/packages/icu-messageformat-parser/BUILD.bazel
+++ b/packages/icu-messageformat-parser/BUILD.bazel
@@ -1,21 +1,15 @@
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
-load("@aspect_rules_js//js:defs.bzl", "js_library")
-load("@aspect_rules_js//npm:defs.bzl", "npm_package")
-load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
-load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "no_internal_imports_test", "package_exports_test", "package_json_test")
-load("//tools:rolldown.bzl", "rolldown_bundle")
+load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:index.bzl", "generate_src_file")
+load("//tools:package.bzl", "formatjs_package")
+load("//tools:test.bzl", "formatjs_test")
 load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
-load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
 
 exports_files([
     "package.json",
 ])
-
-PACKAGE_NAME = "icu-messageformat-parser"
 
 SRCS = glob(["*.ts"])
 
@@ -25,12 +19,6 @@ SRC_DEPS = [
     "//:node_modules/@formatjs/icu-skeleton-parser",
 ]
 
-EXTERNAL_PACKAGES = [
-    dep.split("node_modules/")[1]
-    for dep in SRC_DEPS
-    if "node_modules/" in dep and "ecma402-abstract" not in dep
-]
-
 ENTRY_POINTS = [
     "index.ts",
     "no-parser.ts",
@@ -38,88 +26,47 @@ ENTRY_POINTS = [
     "manipulator.ts",
 ]
 
-[rolldown_bundle(
-    name = "%s-bundle" % entry.replace(".ts", ""),
-    srcs = [":srcs"],
-    dts = True,
-    entry_point = entry,
-    external = EXTERNAL_PACKAGES,
-    format = "esm",
-    output = "%s.js" % entry.replace(".ts", ""),
-    target = "es2020",
-    deps = SRC_DEPS,
-) for entry in ENTRY_POINTS]
-
-BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
-
-js_library(
-    name = PACKAGE_NAME,
-    srcs = BUNDLES + [
-        "package.json",
+formatjs_compile(
+    name = "dist",
+    srcs = SRCS,
+    entry_points = ENTRY_POINTS,
+    project_references = [
+        "//packages/ecma402-abstract",
+        "//packages/ecma402-abstract/types",
     ],
-    visibility = ["//visibility:public"],
+    types = True,
+    deps = [
+        "//:node_modules/@formatjs/icu-skeleton-parser",
+    ],
 )
 
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-    ] + BUNDLES,
-    package = "@formatjs/%s" % PACKAGE_NAME,
-    replace_prefixes = {
-        "%s-bundle/" % entry.replace(".ts", ""): ""
-        for entry in ENTRY_POINTS
-    },
-    visibility = ["//visibility:public"],
-)
-
-no_internal_imports_test(
-    name = "no_internal_imports_test",
-    data = BUNDLES,
-)
-
-ts_project(
-    name = "typecheck",
-    srcs = [":srcs"],
-    declaration = True,
-    no_emit = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
-    tsconfig = packages_tsconfig(),
+formatjs_package(
+    name = "icu-messageformat-parser",
+    entry_points = ENTRY_POINTS,
     deps = SRC_DEPS,
 )
 
-ts_project(
-    name = "types",
-    srcs = [":srcs"],
-    declaration = True,
-    emit_declaration_only = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
-    tsconfig = packages_tsconfig(),
-    visibility = ["//visibility:public"],
-    deps = SRC_DEPS,
-)
-
-vitest(
+formatjs_test(
     name = "unit_test",
     srcs = SRCS + glob([
         "tests/**/*.ts",
     ]),
     data = ["//:package.json"],
     no_copy_to_bin = ["//:package.json"],
-    tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
-    deps = SRC_DEPS + [
+    project_references = [
+        "//packages/ecma402-abstract",
+        "//packages/ecma402-abstract/types",
+    ],
+    test_deps = [
         "//:node_modules/@types/lodash-es",
         "//:node_modules/fast-glob",
         "//:node_modules/lodash-es",
     ],
+    tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
+    deps = [
+        "//:node_modules/@formatjs/icu-skeleton-parser",
+    ],
 )
-
-# Generate tsconfig.json with correct extends path
-generate_ide_tsconfig_json()
 
 generate_src_file(
     name = "regex",
@@ -132,19 +79,4 @@ generate_src_file(
     src = "time-data.generated.ts",
     tags = ["cldr"],
     tool = "//packages/icu-messageformat-parser/tools:time_data_gen",
-)
-
-package_json_test(
-    name = "package_json_test",
-    deps = SRC_DEPS,
-)
-
-copy_to_bin(
-    name = "srcs",
-    srcs = SRCS,
-)
-
-package_exports_test(
-    name = "package_exports_test",
-    pkg = ":pkg",
 )

--- a/packages/icu-skeleton-parser/BUILD.bazel
+++ b/packages/icu-skeleton-parser/BUILD.bazel
@@ -1,18 +1,11 @@
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
-load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
-load("@aspect_rules_js//js:defs.bzl", "js_library")
-load("@aspect_rules_js//npm:defs.bzl", "npm_package")
-load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
-load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "no_internal_imports_test", "package_exports_test", "package_json_test")
-load("//tools:rolldown.bzl", "rolldown_bundle")
+load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:index.bzl", "generate_src_file")
+load("//tools:package.bzl", "formatjs_package")
+load("//tools:test.bzl", "formatjs_test")
 load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
-load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
-
-PACKAGE_NAME = "icu-skeleton-parser"
 
 SRCS = glob(["*.ts"])
 
@@ -21,92 +14,26 @@ SRC_DEPS = [
     "//packages/ecma402-abstract/types",
 ]
 
-EXTERNAL_PACKAGES = [
-    dep.split("node_modules/")[1]
-    for dep in SRC_DEPS
-    if "node_modules/" in dep and "ecma402-abstract" not in dep
-]
-
-ENTRY_POINTS = [
-    "index.ts",
-]
-
-[rolldown_bundle(
-    name = "%s-bundle" % entry.replace(".ts", ""),
-    srcs = [":srcs"],
-    dts = True,
-    entry_point = entry,
-    external = EXTERNAL_PACKAGES,
-    format = "esm",
-    output = "%s.js" % entry.replace(".ts", ""),
-    target = "es2020",
-    deps = SRC_DEPS,
-) for entry in ENTRY_POINTS]
-
-BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
-
-js_library(
-    name = PACKAGE_NAME,
-    srcs = BUNDLES + [
-        "package.json",
-    ],
-    visibility = ["//visibility:public"],
+formatjs_compile(
+    name = "dist",
+    srcs = SRCS,
+    project_references = SRC_DEPS,
+    types = True,
 )
 
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-    ] + BUNDLES,
-    package = "@formatjs/%s" % PACKAGE_NAME,
-    replace_prefixes = {
-        "%s-bundle/" % entry.replace(".ts", ""): ""
-        for entry in ENTRY_POINTS
-    },
-    visibility = ["//visibility:public"],
-)
-
-no_internal_imports_test(
-    name = "no_internal_imports_test",
-    data = BUNDLES,
-)
-
-ts_project(
-    name = "typecheck",
-    srcs = [":srcs"],
-    declaration = True,
-    no_emit = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
-    tsconfig = packages_tsconfig(),
+formatjs_package(
+    name = "icu-skeleton-parser",
     deps = SRC_DEPS,
 )
 
-ts_project(
-    name = "types",
-    srcs = [":srcs"],
-    declaration = True,
-    emit_declaration_only = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
-    tsconfig = packages_tsconfig(),
-    visibility = ["//visibility:public"],
-    deps = SRC_DEPS,
-)
-
-vitest(
+formatjs_test(
     name = "unit_test",
     srcs = SRCS + glob(["tests/**/*.ts"]),
     data = ["//:package.json"],
     no_copy_to_bin = ["//:package.json"],
+    project_references = SRC_DEPS,
     tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
-    deps = SRC_DEPS,
 )
-
-# Generate tsconfig.json with correct extends path
-generate_ide_tsconfig_json()
 
 generate_src_file(
     name = "regex",
@@ -116,19 +43,4 @@ generate_src_file(
         "//:node_modules/regenerate",
     ],
     tool = "//packages/icu-skeleton-parser/scripts:regex-gen",
-)
-
-package_json_test(
-    name = "package_json_test",
-    deps = SRC_DEPS,
-)
-
-copy_to_bin(
-    name = "srcs",
-    srcs = SRCS,
-)
-
-package_exports_test(
-    name = "package_exports_test",
-    pkg = ":pkg",
 )

--- a/packages/intl-datetimeformat/BUILD.bazel
+++ b/packages/intl-datetimeformat/BUILD.bazel
@@ -1,16 +1,14 @@
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
-load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_library")
-load("@aspect_rules_js//npm:defs.bzl", "npm_package")
-load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
-load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
+load("@aspect_rules_js//js:defs.bzl", "js_binary")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@rules_multirun//:defs.bzl", "multirun")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "no_internal_imports_test", "package_exports_test", "package_json_test", "ts_run_binary")
+load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:index.bzl", "generate_src_file", "ts_run_binary")
+load("//tools:package.bzl", "formatjs_package")
 load("//tools:rolldown.bzl", "rolldown_bundle")
-load("//tools:tsconfig.bzl", "BASE_TSCONFIG", "ESNEXT_TSCONFIG", "packages_tsconfig")
-load("//tools:vitest.bzl", "vitest")
+load("//tools:test.bzl", "formatjs_test")
+load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load(":defs.bzl", "ZONES")
 load(":index.bzl", "generate_dockerfile")
 
@@ -66,12 +64,6 @@ TEST_DEPS = SRC_DEPS + [
     "//:node_modules/@types/node",
 ]
 
-EXTERNAL_PACKAGES = [
-    dep.split("node_modules/")[1]
-    for dep in SRC_DEPS
-    if "node_modules/" in dep and "ecma402-abstract" not in dep
-]
-
 ENTRY_POINTS = [
     "index.ts",
     "polyfill.ts",
@@ -79,88 +71,59 @@ ENTRY_POINTS = [
     "should-polyfill.ts",
 ]
 
-[rolldown_bundle(
-    name = "%s-bundle" % entry.replace(".ts", ""),
-    srcs = [":srcs"],
-    dts = True,
-    entry_point = entry,
-    external = EXTERNAL_PACKAGES,
-    format = "esm",
-    output = "%s.js" % entry.replace(".ts", ""),
-    target = "es2020",
-    deps = SRC_DEPS,
-) for entry in ENTRY_POINTS]
-
-BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
-
-js_library(
-    name = PACKAGE_NAME,
-    srcs = BUNDLES + [
-        "package.json",
+formatjs_compile(
+    name = "dist",
+    srcs = SRCS,
+    entry_points = ENTRY_POINTS,
+    project_references = [
+        "//packages/ecma262-abstract",
+        "//packages/ecma402-abstract",
+        "//packages/ecma402-abstract/DateTimeFormat",
+        "//packages/ecma402-abstract/types",
     ],
-    visibility = ["//visibility:public"],
+    types = True,
+    deps = [
+        "//:node_modules/@formatjs/bigdecimal",
+        "//:node_modules/@formatjs/intl-localematcher",
+    ],
 )
 
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
+formatjs_package(
+    name = PACKAGE_NAME,
+    entry_points = ENTRY_POINTS,
+    extra_npm_srcs = [
         "add-all-tz.d.ts",
         "add-all-tz.js",
         "add-golden-tz.d.ts",
         "add-golden-tz.js",
-        "package.json",
-    ] + BUNDLES + [
         ":locale-data",
         # polyfill-library uses this
         "polyfill.iife.js",
     ],
-    package = "@formatjs/%s" % PACKAGE_NAME,
-    replace_prefixes = {
-        "%s-bundle/" % entry.replace(".ts", ""): ""
-        for entry in ENTRY_POINTS
-    },
-    visibility = ["//visibility:public"],
-)
-
-# Ensure no internal path aliases leak into published JS
-no_internal_imports_test(
-    name = "no_internal_imports_test",
-    data = BUNDLES,
-)
-
-ts_project(
-    name = "typecheck",
-    srcs = [":srcs"],
-    declaration = True,
-    no_emit = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
-    tsconfig = packages_tsconfig(),
     deps = SRC_DEPS,
 )
 
-# --- Generate .d.ts declarations ---
-ts_project(
-    name = "types",
-    srcs = [":srcs"],
-    declaration = True,
-    emit_declaration_only = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
-    tsconfig = packages_tsconfig(),
-    visibility = ["//visibility:public"],
-    deps = SRC_DEPS,
-)
-
-vitest(
+formatjs_test(
     name = "unit_test",
     srcs = SRCS + TESTS + TEST_LOCALE_DATA,
     data = ["//:package.json"],
     no_copy_to_bin = ["//:package.json"],
+    project_references = [
+        "//packages/ecma262-abstract",
+        "//packages/ecma402-abstract",
+        "//packages/ecma402-abstract/DateTimeFormat",
+        "//packages/ecma402-abstract/types",
+    ],
+    test_deps = [
+        "//:node_modules/@formatjs/intl-getcanonicallocales",
+        "//:node_modules/@formatjs/intl-locale",
+        "//:node_modules/@types/node",
+    ],
     tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
-    deps = TEST_DEPS,
+    deps = [
+        "//:node_modules/@formatjs/bigdecimal",
+        "//:node_modules/@formatjs/intl-localematcher",
+    ],
 )
 
 # Expand zdump files
@@ -957,9 +920,6 @@ genrule(
     cmd = "echo 'export {}' > $@",
 )
 
-# Generate tsconfig.json with correct extends path
-generate_ide_tsconfig_json()
-
 write_source_files(
     name = "generated-test-files",
     files = {
@@ -1003,11 +963,6 @@ js_binary(
     tags = ["manual"],
 )
 
-package_json_test(
-    name = "package_json_test",
-    deps = SRC_DEPS,
-)
-
 multirun(
     name = "tz_data.update",
     testonly = True,
@@ -1029,14 +984,4 @@ sh_binary(
         ":dockerfile",
     ],
     deps = ["@bazel_tools//tools/bash/runfiles"],
-)
-
-copy_to_bin(
-    name = "srcs",
-    srcs = SRCS,
-)
-
-package_exports_test(
-    name = "package_exports_test",
-    pkg = ":pkg",
 )

--- a/packages/intl-displaynames/BUILD.bazel
+++ b/packages/intl-displaynames/BUILD.bazel
@@ -1,15 +1,12 @@
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
-load("@aspect_rules_js//js:defs.bzl", "js_library")
-load("@aspect_rules_js//npm:defs.bzl", "npm_package")
-load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
-load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "no_internal_imports_test", "package_exports_test", "package_json_test", "ts_run_binary")
+load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:index.bzl", "generate_src_file", "ts_run_binary")
+load("//tools:package.bzl", "formatjs_package")
 load("//tools:rolldown.bzl", "rolldown_bundle")
-load("//tools:tsconfig.bzl", "BASE_TSCONFIG", "ESNEXT_TSCONFIG", "packages_tsconfig")
-load("//tools:vitest.bzl", "vitest")
+load("//tools:test.bzl", "formatjs_test")
+load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
 
 npm_link_all_packages()
 
@@ -41,17 +38,6 @@ SRC_DEPS = [
     "//:node_modules/@formatjs/intl-localematcher",
 ]
 
-TEST_DEPS = SRC_DEPS + [
-    "//:node_modules/@formatjs/intl-getcanonicallocales",
-    "//:node_modules/@formatjs/intl-locale",
-]
-
-EXTERNAL_PACKAGES = [
-    dep.split("node_modules/")[1]
-    for dep in SRC_DEPS
-    if "node_modules/" in dep and "ecma402-abstract" not in dep
-]
-
 ENTRY_POINTS = [
     "index.ts",
     "polyfill.ts",
@@ -59,84 +45,52 @@ ENTRY_POINTS = [
     "should-polyfill.ts",
 ]
 
-[rolldown_bundle(
-    name = "%s-bundle" % entry.replace(".ts", ""),
-    srcs = [":srcs"],
-    dts = True,
-    entry_point = entry,
-    external = EXTERNAL_PACKAGES,
-    format = "esm",
-    output = "%s.js" % entry.replace(".ts", ""),
-    target = "es2020",
-    deps = SRC_DEPS,
-) for entry in ENTRY_POINTS]
-
-BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
-
-js_library(
-    name = PACKAGE_NAME,
-    srcs = BUNDLES + [
-        "package.json",
+formatjs_compile(
+    name = "dist",
+    srcs = SRCS,
+    entry_points = ENTRY_POINTS,
+    project_references = [
+        "//packages/ecma262-abstract",
+        "//packages/ecma402-abstract",
+        "//packages/ecma402-abstract/types",
+        "//packages/ecma402-abstract/DisplayNames",
     ],
-    visibility = ["//visibility:public"],
+    types = True,
+    deps = [
+        "//:node_modules/@formatjs/intl-localematcher",
+    ],
 )
 
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-    ] + BUNDLES + [
+formatjs_package(
+    name = PACKAGE_NAME,
+    entry_points = ENTRY_POINTS,
+    extra_npm_srcs = [
         ":locale-data",
         # polyfill-library uses this
         "polyfill.iife.js",
     ],
-    package = "@formatjs/%s" % PACKAGE_NAME,
-    replace_prefixes = {
-        "%s-bundle/" % entry.replace(".ts", ""): ""
-        for entry in ENTRY_POINTS
-    },
-    visibility = ["//visibility:public"],
-)
-
-# Ensure no internal path aliases leak into published JS
-no_internal_imports_test(
-    name = "no_internal_imports_test",
-    data = BUNDLES,
-)
-
-ts_project(
-    name = "typecheck",
-    srcs = [":srcs"],
-    declaration = True,
-    no_emit = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
-    tsconfig = packages_tsconfig(),
     deps = SRC_DEPS,
 )
 
-# --- Generate .d.ts declarations ---
-ts_project(
-    name = "types",
-    srcs = [":srcs"],
-    declaration = True,
-    emit_declaration_only = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
-    tsconfig = packages_tsconfig(),
-    visibility = ["//visibility:public"],
-    deps = SRC_DEPS,
-)
-
-vitest(
+formatjs_test(
     name = "unit_test",
     srcs = SRCS + TESTS + TEST_LOCALE_DATA,
     data = ["//:package.json"],
     no_copy_to_bin = ["//:package.json"],
+    project_references = [
+        "//packages/ecma262-abstract",
+        "//packages/ecma402-abstract",
+        "//packages/ecma402-abstract/types",
+        "//packages/ecma402-abstract/DisplayNames",
+    ],
+    test_deps = [
+        "//:node_modules/@formatjs/intl-getcanonicallocales",
+        "//:node_modules/@formatjs/intl-locale",
+    ],
     tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
-    deps = TEST_DEPS,
+    deps = [
+        "//:node_modules/@formatjs/intl-localematcher",
+    ],
 )
 
 # CLDR
@@ -840,9 +794,6 @@ test262_harness_bin.test262_harness_test(
     tags = ["manual"],
 )
 
-# Generate tsconfig.json with correct extends path
-generate_ide_tsconfig_json()
-
 write_source_files(
     name = "generated-test-files",
     files = {
@@ -857,21 +808,5 @@ rolldown_bundle(
     srcs = [":srcs"],
     entry_point = "polyfill.ts",
     target = "es2020",
-    deps = [
-    ] + SRC_DEPS,
-)
-
-package_json_test(
-    name = "package_json_test",
     deps = SRC_DEPS,
-)
-
-copy_to_bin(
-    name = "srcs",
-    srcs = SRCS,
-)
-
-package_exports_test(
-    name = "package_exports_test",
-    pkg = ":pkg",
 )

--- a/packages/intl-durationformat/BUILD.bazel
+++ b/packages/intl-durationformat/BUILD.bazel
@@ -1,14 +1,10 @@
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
-load("@aspect_rules_js//js:defs.bzl", "js_library")
-load("@aspect_rules_js//npm:defs.bzl", "npm_package")
-load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
-load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "no_internal_imports_test", "package_exports_test")
-load("//tools:rolldown.bzl", "rolldown_bundle")
+load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:index.bzl", "generate_src_file")
+load("//tools:package.bzl", "formatjs_package")
+load("//tools:test.bzl", "formatjs_test")
 load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
-load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
 
@@ -29,12 +25,6 @@ SRC_DEPS = [
     "//:node_modules/@formatjs/intl-localematcher",
 ]
 
-EXTERNAL_PACKAGES = [
-    dep.split("node_modules/")[1]
-    for dep in SRC_DEPS
-    if "node_modules/" in dep and "ecma402-abstract" not in dep
-]
-
 ENTRY_POINTS = [
     "index.ts",
     "polyfill.ts",
@@ -42,84 +32,46 @@ ENTRY_POINTS = [
     "should-polyfill.ts",
 ]
 
-[rolldown_bundle(
-    name = "%s-bundle" % entry.replace(".ts", ""),
-    srcs = [":srcs"],
-    dts = True,
-    entry_point = entry,
-    external = EXTERNAL_PACKAGES,
-    format = "esm",
-    output = "%s.js" % entry.replace(".ts", ""),
-    target = "es2020",
-    deps = SRC_DEPS,
-) for entry in ENTRY_POINTS]
-
-BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
-
-js_library(
-    name = PACKAGE_NAME,
-    srcs = BUNDLES + [
-        "package.json",
+formatjs_compile(
+    name = "dist",
+    srcs = SRCS,
+    entry_points = ENTRY_POINTS,
+    project_references = [
+        "//packages/ecma262-abstract",
+        "//packages/ecma402-abstract",
+        "//packages/ecma402-abstract/DurationFormat",
+        "//packages/ecma402-abstract/types",
     ],
-    visibility = ["//visibility:public"],
+    types = True,
+    deps = [
+        "//:node_modules/@formatjs/intl-localematcher",
+    ],
 )
 
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-    ] + BUNDLES,
-    package = "@formatjs/%s" % PACKAGE_NAME,
-    replace_prefixes = {
-        "%s-bundle/" % entry.replace(".ts", ""): ""
-        for entry in ENTRY_POINTS
-    },
-    visibility = ["//visibility:public"],
-)
-
-no_internal_imports_test(
-    name = "no_internal_imports_test",
-    data = BUNDLES,
-)
-
-ts_project(
-    name = "typecheck",
-    srcs = [":srcs"],
-    declaration = True,
-    no_emit = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
-    tsconfig = packages_tsconfig(),
+formatjs_package(
+    name = PACKAGE_NAME,
+    entry_points = ENTRY_POINTS,
     deps = SRC_DEPS,
 )
 
-ts_project(
-    name = "types",
-    srcs = [":srcs"],
-    declaration = True,
-    emit_declaration_only = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
-    tsconfig = packages_tsconfig(),
-    visibility = ["//visibility:public"],
-    deps = SRC_DEPS,
-)
-
-vitest(
+formatjs_test(
     name = "unit_test",
     srcs = SRCS + glob([
         "tests/**/*.ts",
     ]),
     data = ["//:package.json"],
     no_copy_to_bin = ["//:package.json"],
+    project_references = [
+        "//packages/ecma262-abstract",
+        "//packages/ecma402-abstract",
+        "//packages/ecma402-abstract/DurationFormat",
+        "//packages/ecma402-abstract/types",
+    ],
     tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
-    deps = SRC_DEPS,
+    deps = [
+        "//:node_modules/@formatjs/intl-localematcher",
+    ],
 )
-
-# Generate tsconfig.json with correct extends path
-generate_ide_tsconfig_json()
 
 # numbering-systems
 write_source_files(
@@ -148,19 +100,4 @@ generate_src_file(
     ],
     tags = ["cldr"],
     tool = "//packages/intl-durationformat/scripts:time-separators",
-)
-
-copy_to_bin(
-    name = "srcs",
-    srcs = SRCS,
-)
-
-# package_json_test(
-#     name="package_json_test",
-#     deps=SRC_DEPS
-# )
-
-package_exports_test(
-    name = "package_exports_test",
-    pkg = ":pkg",
 )

--- a/packages/intl-getcanonicallocales/BUILD.bazel
+++ b/packages/intl-getcanonicallocales/BUILD.bazel
@@ -1,13 +1,9 @@
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
-load("@aspect_rules_js//js:defs.bzl", "js_library")
-load("@aspect_rules_js//npm:defs.bzl", "npm_package")
-load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
-load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "no_internal_imports_test", "package_exports_test", "package_json_test")
+load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:index.bzl", "generate_src_file")
+load("//tools:package.bzl", "formatjs_package")
 load("//tools:rolldown.bzl", "rolldown_bundle")
-load("//tools:tsconfig.bzl", "packages_tsconfig")
-load("//tools:vitest.bzl", "vitest")
+load("//tools:test.bzl", "formatjs_test")
 
 npm_link_all_packages()
 
@@ -38,58 +34,19 @@ ENTRY_POINTS = [
     "should-polyfill.ts",
 ]
 
-[rolldown_bundle(
-    name = "%s-bundle" % entry.replace(".ts", ""),
-    srcs = [":srcs"],
-    dts = True,
-    entry_point = entry,
-    external = [],
-    format = "esm",
-    output = "%s.js" % entry.replace(".ts", ""),
-    target = "es2020",
-    deps = SRC_DEPS,
-) for entry in ENTRY_POINTS]
-
-BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
-
-js_library(
-    name = PACKAGE_NAME,
-    srcs = BUNDLES + [
-        "package.json",
-    ],
-    visibility = ["//visibility:public"],
+formatjs_compile(
+    name = "dist",
+    srcs = SRCS,
+    entry_points = ENTRY_POINTS,
 )
 
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
+formatjs_package(
+    name = PACKAGE_NAME,
+    entry_points = ENTRY_POINTS,
+    extra_npm_srcs = [
         # polyfill-library uses this
         "polyfill.iife.js",
-    ] + BUNDLES,
-    package = "@formatjs/%s" % PACKAGE_NAME,
-    replace_prefixes = {
-        "%s-bundle/" % entry.replace(".ts", ""): ""
-        for entry in ENTRY_POINTS
-    },
-    visibility = ["//visibility:public"],
-)
-
-no_internal_imports_test(
-    name = "no_internal_imports_test",
-    data = BUNDLES,
-)
-
-ts_project(
-    name = "typecheck",
-    srcs = [":srcs"],
-    declaration = True,
-    no_emit = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
-    tsconfig = packages_tsconfig(),
+    ],
     deps = SRC_DEPS,
 )
 
@@ -97,17 +54,9 @@ TESTS = glob([
     "tests/*.test.ts",
 ])
 
-copy_to_bin(
-    name = "tests",
-    srcs = TESTS,
-)
-
-TEST_DEPS = SRC_DEPS
-
-vitest(
+formatjs_test(
     name = "unit_test",
     srcs = SRCS + TESTS,
-    deps = TEST_DEPS,
 )
 
 # aliases
@@ -135,28 +84,10 @@ generate_src_file(
     visibility = ["//:__pkg__"],
 )
 
-# Generate tsconfig.json with correct extends path
-generate_ide_tsconfig_json()
-
 rolldown_bundle(
     name = "polyfill.iife",
     srcs = [":srcs"],
     entry_point = "polyfill.ts",
     target = "es6",
     deps = SRC_DEPS,
-)
-
-package_json_test(
-    name = "package_json_test",
-    deps = SRC_DEPS,
-)
-
-copy_to_bin(
-    name = "srcs",
-    srcs = SRCS,
-)
-
-package_exports_test(
-    name = "package_exports_test",
-    pkg = ":pkg",
 )

--- a/packages/intl-listformat/BUILD.bazel
+++ b/packages/intl-listformat/BUILD.bazel
@@ -1,15 +1,12 @@
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
-load("@aspect_rules_js//js:defs.bzl", "js_library")
-load("@aspect_rules_js//npm:defs.bzl", "npm_package")
-load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
-load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "no_internal_imports_test", "package_exports_test", "package_json_test", "ts_run_binary")
+load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:index.bzl", "generate_src_file", "ts_run_binary")
+load("//tools:package.bzl", "formatjs_package")
 load("//tools:rolldown.bzl", "rolldown_bundle")
-load("//tools:tsconfig.bzl", "BASE_TSCONFIG", "ESNEXT_TSCONFIG", "packages_tsconfig")
-load("//tools:vitest.bzl", "vitest")
+load("//tools:test.bzl", "formatjs_test")
+load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
 
 npm_link_all_packages()
 
@@ -42,18 +39,6 @@ SRC_DEPS = [
     "//:node_modules/@formatjs/intl-localematcher",
 ]
 
-TEST_DEPS = SRC_DEPS + [
-    "//:node_modules/@formatjs/intl-getcanonicallocales",
-    "//:node_modules/@formatjs/intl-locale",
-    "//:node_modules/@types/node",
-]
-
-EXTERNAL_PACKAGES = [
-    dep.split("node_modules/")[1]
-    for dep in SRC_DEPS
-    if "node_modules/" in dep and "ecma402-abstract" not in dep
-]
-
 ENTRY_POINTS = [
     "index.ts",
     "polyfill.ts",
@@ -61,84 +46,49 @@ ENTRY_POINTS = [
     "should-polyfill.ts",
 ]
 
-[rolldown_bundle(
-    name = "%s-bundle" % entry.replace(".ts", ""),
-    srcs = [":srcs"],
-    dts = True,
-    entry_point = entry,
-    external = EXTERNAL_PACKAGES,
-    format = "esm",
-    output = "%s.js" % entry.replace(".ts", ""),
-    target = "es2020",
-    deps = SRC_DEPS,
-) for entry in ENTRY_POINTS]
-
-BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
-
-js_library(
-    name = PACKAGE_NAME,
-    srcs = BUNDLES + [
-        "package.json",
+formatjs_compile(
+    name = "dist",
+    srcs = SRCS,
+    entry_points = ENTRY_POINTS,
+    project_references = [
+        "//packages/ecma402-abstract",
+        "//packages/ecma402-abstract/types",
     ],
-    visibility = ["//visibility:public"],
+    types = True,
+    deps = [
+        "//:node_modules/@formatjs/intl-localematcher",
+    ],
 )
 
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-    ] + BUNDLES + [
+formatjs_package(
+    name = PACKAGE_NAME,
+    entry_points = ENTRY_POINTS,
+    extra_npm_srcs = [
         ":locale-data",
         # polyfill-library uses this
         "polyfill.iife.js",
     ],
-    package = "@formatjs/%s" % PACKAGE_NAME,
-    replace_prefixes = {
-        "%s-bundle/" % entry.replace(".ts", ""): ""
-        for entry in ENTRY_POINTS
-    },
-    visibility = ["//visibility:public"],
-)
-
-# Ensure no internal path aliases leak into published JS
-no_internal_imports_test(
-    name = "no_internal_imports_test",
-    data = BUNDLES,
-)
-
-ts_project(
-    name = "typecheck",
-    srcs = [":srcs"],
-    declaration = True,
-    no_emit = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
-    tsconfig = packages_tsconfig(),
     deps = SRC_DEPS,
 )
 
-# --- Generate .d.ts declarations ---
-ts_project(
-    name = "types",
-    srcs = [":srcs"],
-    declaration = True,
-    emit_declaration_only = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
-    tsconfig = packages_tsconfig(),
-    visibility = ["//visibility:public"],
-    deps = SRC_DEPS,
-)
-
-vitest(
+formatjs_test(
     name = "unit_test",
     srcs = SRCS + TESTS + TEST_LOCALE_DATA,
     data = ["//:package.json"],
     no_copy_to_bin = ["//:package.json"],
+    project_references = [
+        "//packages/ecma402-abstract",
+        "//packages/ecma402-abstract/types",
+    ],
+    test_deps = [
+        "//:node_modules/@formatjs/intl-getcanonicallocales",
+        "//:node_modules/@formatjs/intl-locale",
+        "//:node_modules/@types/node",
+    ],
     tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
-    deps = TEST_DEPS,
+    deps = [
+        "//:node_modules/@formatjs/intl-localematcher",
+    ],
 )
 
 # CLDR
@@ -840,21 +790,5 @@ rolldown_bundle(
     srcs = [":srcs"],
     entry_point = "polyfill.ts",
     target = "es2020",
-    deps = [
-    ] + SRC_DEPS,
-)
-
-package_json_test(
-    name = "package_json_test",
     deps = SRC_DEPS,
-)
-
-copy_to_bin(
-    name = "srcs",
-    srcs = SRCS,
-)
-
-package_exports_test(
-    name = "package_exports_test",
-    pkg = ":pkg",
 )

--- a/packages/intl-listformat/tsconfig.json
+++ b/packages/intl-listformat/tsconfig.json
@@ -4,5 +4,6 @@
       "#packages/*": ["../../packages/*"]
     }
   },
+  "exclude": ["./scripts/**/*"],
   "extends": "../../tsconfig.json"
 }

--- a/packages/intl-locale/BUILD.bazel
+++ b/packages/intl-locale/BUILD.bazel
@@ -1,25 +1,10 @@
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
-load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
-load("@aspect_rules_js//js:defs.bzl", "js_library")
-load("@aspect_rules_js//npm:defs.bzl", "npm_package")
-load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
-load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "no_internal_imports_test", "package_exports_test", "package_json_test")
+load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file")
+load("//tools:package.bzl", "formatjs_package")
 load("//tools:rolldown.bzl", "rolldown_bundle")
-load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
-load("//tools:vitest.bzl", "vitest")
-
-# tsconfig with #packages/* path alias for tsc resolution
-# From packages/intl-locale/, #packages/* → ../* resolves to sibling packages
-TSCONFIG = BASE_TSCONFIG | {
-    "compilerOptions": BASE_TSCONFIG["compilerOptions"] | {
-        "paths": {
-            "#packages/*": ["../*"],
-        },
-    },
-}
+load("//tools:test.bzl", "formatjs_test")
 
 npm_link_all_packages()
 
@@ -27,19 +12,7 @@ PACKAGE_NAME = "intl-locale"
 
 SRCS = glob(["*.ts"])
 
-# Node_modules deps for type checking and downstream consumers
-TYPECHECK_DEPS = [
-    "//:node_modules/@formatjs/intl-supportedvaluesof",
-    "//:node_modules/@formatjs/intl-getcanonicallocales",
-    "//:node_modules/cldr-core",
-    "//:node_modules/cldr-bcp47",
-    # Source files for #packages/* path resolution in tsc
-    "//packages/ecma262-abstract",
-    "//packages/ecma402-abstract",
-]
-
-# Deps for bundling — ecma402-abstract comes via #packages, not node_modules
-BUNDLE_DEPS = [
+SRC_DEPS = [
     "//:node_modules/@formatjs/intl-supportedvaluesof",
     "//:node_modules/@formatjs/intl-getcanonicallocales",
     "//:node_modules/cldr-core",
@@ -48,99 +21,40 @@ BUNDLE_DEPS = [
     "//packages/ecma402-abstract",
 ]
 
-# Derive external packages from BUNDLE_DEPS (node_modules only, not project deps)
-EXTERNAL_PACKAGES = [
-    dep.split("node_modules/")[1]
-    for dep in BUNDLE_DEPS
-    if "node_modules/" in dep
-]
-
-# --- Bundle each entry point with rolldown (resolves #packages/* imports) ---
-[rolldown_bundle(
-    name = "%s-bundle" % entry.replace(".ts", ""),
-    srcs = [":srcs"],
-    dts = True,
-    entry_point = entry,
-    external = EXTERNAL_PACKAGES,
-    format = "esm",
-    output = "%s.js" % entry.replace(".ts", ""),
-    target = "es2020",
-    deps = BUNDLE_DEPS,
-) for entry in [
+ENTRY_POINTS = [
     "index.ts",
     "polyfill.ts",
     "polyfill-force.ts",
     "should-polyfill.ts",
-]]
-
-BUNDLES = [
-    ":index-bundle",
-    ":polyfill-bundle",
-    ":polyfill-force-bundle",
-    ":should-polyfill-bundle",
 ]
 
-# --- Default target: esbuild bundle (no #packages in output) ---
-# This is what npm_link_all_packages serves to downstream workspace consumers.
-js_library(
+formatjs_compile(
+    name = "dist",
+    srcs = SRCS,
+    entry_points = ENTRY_POINTS,
+    project_references = [
+        "//packages/ecma262-abstract",
+        "//packages/ecma402-abstract",
+    ],
+    types = True,
+    deps = [
+        "//:node_modules/@formatjs/intl-getcanonicallocales",
+        "//:node_modules/@formatjs/intl-supportedvaluesof",
+        "//:node_modules/cldr-bcp47",
+        "//:node_modules/cldr-core",
+    ],
+)
+
+formatjs_package(
     name = PACKAGE_NAME,
-    srcs = BUNDLES + ["package.json"],
-    visibility = ["//visibility:public"],
-)
-
-# --- Type check only (no emit — esbuild handles JS output) ---
-ts_project(
-    name = "typecheck",
-    srcs = [":srcs"],
-    declaration = True,
-    no_emit = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
-    tsconfig = TSCONFIG,
-    deps = TYPECHECK_DEPS,
-)
-
-ts_project(
-    name = "types",
-    srcs = [":srcs"],
-    declaration = True,
-    emit_declaration_only = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
-    tsconfig = TSCONFIG,
-    visibility = ["//visibility:public"],
-    deps = TYPECHECK_DEPS,
-)
-
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-    ] + BUNDLES + [
+    entry_points = ENTRY_POINTS,
+    extra_npm_srcs = [
         "polyfill.iife.js",
     ],
-    package = "@formatjs/%s" % PACKAGE_NAME,
-    replace_prefixes = {
-        "%s-bundle/" % entry.replace(".ts", ""): ""
-        for entry in [
-            "index.ts",
-            "polyfill.ts",
-            "polyfill-force.ts",
-            "should-polyfill.ts",
-        ]
-    },
-    visibility = ["//visibility:public"],
+    deps = SRC_DEPS,
 )
 
-# Ensure no internal path aliases leak into published JS
-no_internal_imports_test(
-    name = "no_internal_imports_test",
-    data = BUNDLES,
-)
-
-vitest(
+formatjs_test(
     name = "unit_test",
     srcs = SRCS + glob([
         "tests/**/*.ts",
@@ -151,8 +65,16 @@ vitest(
     no_copy_to_bin = [
         "//:package.json",
     ],
-    tsconfig = TSCONFIG,
-    deps = BUNDLE_DEPS,
+    project_references = [
+        "//packages/ecma262-abstract",
+        "//packages/ecma402-abstract",
+    ],
+    deps = [
+        "//:node_modules/@formatjs/intl-getcanonicallocales",
+        "//:node_modules/@formatjs/intl-supportedvaluesof",
+        "//:node_modules/cldr-bcp47",
+        "//:node_modules/cldr-core",
+    ],
 )
 
 # Test262
@@ -161,7 +83,7 @@ rolldown_bundle(
     srcs = [":srcs"],
     entry_point = "polyfill-force.ts",
     target = "es2020",
-    deps = BUNDLE_DEPS,
+    deps = SRC_DEPS,
 )
 
 test262_harness_bin.test262_harness_test(
@@ -187,25 +109,12 @@ test262_harness_bin.test262_harness_test(
     tags = ["manual"],
 )
 
-# Generate tsconfig.json with correct extends path
-generate_ide_tsconfig_json(
-    project_references = [
-        "//packages/ecma262-abstract",
-        "//packages/ecma402-abstract",
-    ],
-)
-
 rolldown_bundle(
     name = "polyfill.iife",
     srcs = [":srcs"],
     entry_point = "polyfill.ts",
     target = "es2020",
-    deps = BUNDLE_DEPS,
-)
-
-package_json_test(
-    name = "package_json_test",
-    deps = TYPECHECK_DEPS,
+    deps = SRC_DEPS,
 )
 
 # character orders
@@ -282,14 +191,4 @@ generate_src_file(
     ],
     tags = ["cldr"],
     tool = "//packages/intl-locale/scripts:week-data",
-)
-
-copy_to_bin(
-    name = "srcs",
-    srcs = SRCS,
-)
-
-package_exports_test(
-    name = "package_exports_test",
-    pkg = ":pkg",
 )

--- a/packages/intl-locale/tsconfig.json
+++ b/packages/intl-locale/tsconfig.json
@@ -5,13 +5,5 @@
     }
   },
   "exclude": ["./scripts/**/*"],
-  "extends": "../../tsconfig.json",
-  "references": [
-    {
-      "path": "../ecma262-abstract/tsconfig.json"
-    },
-    {
-      "path": "../ecma402-abstract/tsconfig.json"
-    }
-  ]
+  "extends": "../../tsconfig.json"
 }

--- a/packages/intl-localematcher/BUILD.bazel
+++ b/packages/intl-localematcher/BUILD.bazel
@@ -2,7 +2,7 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:compile.bzl", "formatjs_compile")
 load("//tools:index.bzl", "generate_src_file")
 load("//tools:package.bzl", "formatjs_package")
-load("//tools:vitest.bzl", "vitest")
+load("//tools:test.bzl", "formatjs_test")
 
 npm_link_all_packages()
 
@@ -26,7 +26,7 @@ formatjs_package(
     deps = SRC_DEPS,
 )
 
-vitest(
+formatjs_test(
     name = "unit_test",
     srcs = SRCS + glob(["tests/**/*.ts"]),
     deps = SRC_DEPS,

--- a/packages/intl-messageformat/BUILD.bazel
+++ b/packages/intl-messageformat/BUILD.bazel
@@ -1,13 +1,10 @@
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
-load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_library")
-load("@aspect_rules_js//npm:defs.bzl", "npm_package")
-load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
-load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
+load("@aspect_rules_js//js:defs.bzl", "js_binary")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "no_internal_imports_test", "package_exports_test", "package_json_test")
+load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:package.bzl", "formatjs_package")
 load("//tools:rolldown.bzl", "rolldown_bundle")
+load("//tools:test.bzl", "formatjs_test")
 load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
-load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
 
@@ -26,95 +23,53 @@ SRC_DEPS = [
     "//packages/ecma402-abstract/types",
 ]
 
-EXTERNAL_PACKAGES = [
-    dep.split("node_modules/")[1]
-    for dep in SRC_DEPS
-    if "node_modules/" in dep and "ecma402-abstract" not in dep
-]
-
 TESTS = glob([
     "tests/*.test.ts",
 ])
-
-TEST_DEPS = SRC_DEPS
 
 ENTRY_POINTS = [
     "index.ts",
 ]
 
-[rolldown_bundle(
-    name = "%s-bundle" % entry.replace(".ts", ""),
-    srcs = [":srcs"],
-    dts = True,
-    entry_point = entry,
-    external = EXTERNAL_PACKAGES,
-    format = "esm",
-    output = "%s.js" % entry.replace(".ts", ""),
-    target = "es2020",
-    deps = SRC_DEPS,
-) for entry in ENTRY_POINTS]
-
-BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
-
-js_library(
-    name = PACKAGE_NAME,
-    srcs = BUNDLES + [
-        "package.json",
+formatjs_compile(
+    name = "dist",
+    srcs = SRCS,
+    entry_points = ENTRY_POINTS,
+    project_references = [
+        "//packages/ecma402-abstract",
+        "//packages/ecma402-abstract/types",
     ],
-    visibility = ["//visibility:public"],
+    types = True,
+    deps = [
+        "//:node_modules/@formatjs/fast-memoize",
+        "//:node_modules/@formatjs/icu-messageformat-parser",
+    ],
 )
 
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
+formatjs_package(
+    name = PACKAGE_NAME,
+    entry_points = ENTRY_POINTS,
+    extra_npm_srcs = [
         "%s.iife.js" % PACKAGE_NAME,
-    ] + BUNDLES,
-    package = PACKAGE_NAME,
-    replace_prefixes = {
-        "%s-bundle/" % entry.replace(".ts", ""): ""
-        for entry in ENTRY_POINTS
-    },
-    visibility = ["//visibility:public"],
-)
-
-no_internal_imports_test(
-    name = "no_internal_imports_test",
-    data = BUNDLES,
-)
-
-ts_project(
-    name = "typecheck",
-    srcs = [":srcs"],
-    declaration = True,
-    no_emit = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
-    tsconfig = packages_tsconfig(),
+    ],
+    npm_package_name = PACKAGE_NAME,
     deps = SRC_DEPS,
 )
 
-ts_project(
-    name = "types",
-    srcs = [":srcs"],
-    declaration = True,
-    emit_declaration_only = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
-    tsconfig = packages_tsconfig(),
-    visibility = ["//visibility:public"],
-    deps = SRC_DEPS,
-)
-
-vitest(
+formatjs_test(
     name = "unit_test",
     srcs = SRCS + TESTS,
     data = ["//:package.json"],
     no_copy_to_bin = ["//:package.json"],
+    project_references = [
+        "//packages/ecma402-abstract",
+        "//packages/ecma402-abstract/types",
+    ],
     tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
-    deps = SRC_DEPS + TEST_DEPS,
+    deps = [
+        "//:node_modules/@formatjs/fast-memoize",
+        "//:node_modules/@formatjs/icu-messageformat-parser",
+    ],
 )
 
 rolldown_bundle(
@@ -136,9 +91,6 @@ rolldown_bundle(
     deps = SRC_DEPS,
 )
 
-# Generate tsconfig.json with correct extends path
-generate_ide_tsconfig_json()
-
 # Use with `bazel run`.
 js_binary(
     name = "benchmark",
@@ -152,19 +104,4 @@ js_binary(
         "--experimental-transform-types",
     ],
     tags = ["manual"],
-)
-
-package_json_test(
-    name = "package_json_test",
-    deps = SRC_DEPS,
-)
-
-copy_to_bin(
-    name = "srcs",
-    srcs = SRCS,
-)
-
-package_exports_test(
-    name = "package_exports_test",
-    pkg = ":pkg",
 )

--- a/packages/intl-numberformat/BUILD.bazel
+++ b/packages/intl-numberformat/BUILD.bazel
@@ -1,16 +1,13 @@
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
-load("@aspect_rules_js//js:defs.bzl", "js_library")
-load("@aspect_rules_js//npm:defs.bzl", "npm_package")
-load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
-load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
 load("@rules_multirun//:defs.bzl", "multirun")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "no_internal_imports_test", "package_exports_test", "package_json_test", "ts_run_binary")
+load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:index.bzl", "generate_src_file", "ts_run_binary")
+load("//tools:package.bzl", "formatjs_package")
 load("//tools:rolldown.bzl", "rolldown_bundle")
-load("//tools:tsconfig.bzl", "BASE_TSCONFIG", "ESNEXT_TSCONFIG", "packages_tsconfig")
+load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
@@ -86,12 +83,6 @@ TEST_DEPS = SRC_DEPS + [
     "//:node_modules/@types/node",
 ]
 
-EXTERNAL_PACKAGES = [
-    dep.split("node_modules/")[1]
-    for dep in SRC_DEPS
-    if "node_modules/" in dep and "ecma402-abstract" not in dep
-]
-
 ENTRY_POINTS = [
     "index.ts",
     "polyfill.ts",
@@ -99,74 +90,31 @@ ENTRY_POINTS = [
     "should-polyfill.ts",
 ]
 
-[rolldown_bundle(
-    name = "%s-bundle" % entry.replace(".ts", ""),
-    srcs = [":srcs"],
-    dts = True,
-    entry_point = entry,
-    external = EXTERNAL_PACKAGES,
-    format = "esm",
-    output = "%s.js" % entry.replace(".ts", ""),
-    target = "es2020",
-    deps = SRC_DEPS,
-) for entry in ENTRY_POINTS]
-
-BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
-
-js_library(
-    name = PACKAGE_NAME,
-    srcs = BUNDLES + [
-        "package.json",
+formatjs_compile(
+    name = "dist",
+    srcs = SRCS,
+    entry_points = ENTRY_POINTS,
+    project_references = [
+        "//packages/ecma262-abstract",
+        "//packages/ecma402-abstract",
+        "//packages/ecma402-abstract/NumberFormat",
+        "//packages/ecma402-abstract/types",
     ],
-    visibility = ["//visibility:public"],
+    types = True,
+    deps = [
+        "//:node_modules/@formatjs/bigdecimal",
+        "//:node_modules/@formatjs/intl-localematcher",
+    ],
 )
 
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-    ] + BUNDLES + [
+formatjs_package(
+    name = PACKAGE_NAME,
+    entry_points = ENTRY_POINTS,
+    extra_npm_srcs = [
         ":locale-data",
         # polyfill-library uses this
         "polyfill.iife.js",
     ],
-    package = "@formatjs/%s" % PACKAGE_NAME,
-    replace_prefixes = {
-        "%s-bundle/" % entry.replace(".ts", ""): ""
-        for entry in ENTRY_POINTS
-    },
-    visibility = ["//visibility:public"],
-)
-
-# Ensure no internal path aliases leak into published JS
-no_internal_imports_test(
-    name = "no_internal_imports_test",
-    data = BUNDLES,
-)
-
-ts_project(
-    name = "typecheck",
-    srcs = [":srcs"],
-    declaration = True,
-    no_emit = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
-    tsconfig = packages_tsconfig(),
-    deps = SRC_DEPS,
-)
-
-# --- Generate .d.ts declarations ---
-ts_project(
-    name = "types",
-    srcs = [":srcs"],
-    declaration = True,
-    emit_declaration_only = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
-    tsconfig = packages_tsconfig(),
-    visibility = ["//visibility:public"],
     deps = SRC_DEPS,
 )
 
@@ -1051,19 +999,4 @@ rolldown_bundle(
     target = "es2020",
     deps = [
     ] + SRC_DEPS,
-)
-
-package_json_test(
-    name = "package_json_test",
-    deps = SRC_DEPS,
-)
-
-copy_to_bin(
-    name = "srcs",
-    srcs = SRCS,
-)
-
-package_exports_test(
-    name = "package_exports_test",
-    pkg = ":pkg",
 )

--- a/packages/intl-numberformat/tsconfig.json
+++ b/packages/intl-numberformat/tsconfig.json
@@ -4,5 +4,6 @@
       "#packages/*": ["../../packages/*"]
     }
   },
+  "exclude": ["./benchmark/**/*", "./scripts/**/*"],
   "extends": "../../tsconfig.json"
 }

--- a/packages/intl-pluralrules/BUILD.bazel
+++ b/packages/intl-pluralrules/BUILD.bazel
@@ -1,15 +1,12 @@
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
-load("@aspect_rules_js//js:defs.bzl", "js_library")
-load("@aspect_rules_js//npm:defs.bzl", "npm_package")
-load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
-load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "no_internal_imports_test", "package_exports_test", "package_json_test", "ts_run_binary")
+load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:index.bzl", "generate_src_file", "ts_run_binary")
+load("//tools:package.bzl", "formatjs_package")
 load("//tools:rolldown.bzl", "rolldown_bundle")
-load("//tools:tsconfig.bzl", "BASE_TSCONFIG", "ESNEXT_TSCONFIG", "packages_tsconfig")
-load("//tools:vitest.bzl", "vitest")
+load("//tools:test.bzl", "formatjs_test")
+load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
 
 npm_link_all_packages()
 
@@ -261,12 +258,6 @@ SRC_DEPS = [
     "//:node_modules/@formatjs/bigdecimal",
 ]
 
-EXTERNAL_PACKAGES = [
-    dep.split("node_modules/")[1]
-    for dep in SRC_DEPS
-    if "node_modules/" in dep and "ecma402-abstract" not in dep
-]
-
 ENTRY_POINTS = [
     "index.ts",
     "polyfill.ts",
@@ -274,86 +265,53 @@ ENTRY_POINTS = [
     "should-polyfill.ts",
 ]
 
-[rolldown_bundle(
-    name = "%s-bundle" % entry.replace(".ts", ""),
-    srcs = [":srcs"],
-    dts = True,
-    entry_point = entry,
-    external = EXTERNAL_PACKAGES,
-    format = "esm",
-    output = "%s.js" % entry.replace(".ts", ""),
-    target = "es2020",
-    deps = SRC_DEPS,
-) for entry in ENTRY_POINTS]
-
-BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
-
-js_library(
-    name = PACKAGE_NAME,
-    srcs = BUNDLES + [
-        "package.json",
+formatjs_compile(
+    name = "dist",
+    srcs = SRCS,
+    entry_points = ENTRY_POINTS,
+    project_references = [
+        "//packages/ecma402-abstract",
+        "//packages/ecma402-abstract/PluralRules",
+        "//packages/ecma402-abstract/NumberFormat",
+        "//packages/ecma402-abstract/types",
     ],
-    visibility = ["//visibility:public"],
+    types = True,
+    deps = [
+        "//:node_modules/@formatjs/bigdecimal",
+        "//:node_modules/@formatjs/intl-localematcher",
+    ],
 )
 
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-    ] + BUNDLES + [
+formatjs_package(
+    name = PACKAGE_NAME,
+    entry_points = ENTRY_POINTS,
+    extra_npm_srcs = [
         ":locale-data",
         # polyfill-library uses this
         "polyfill.iife.js",
     ],
-    package = "@formatjs/%s" % PACKAGE_NAME,
-    replace_prefixes = {
-        "%s-bundle/" % entry.replace(".ts", ""): ""
-        for entry in ENTRY_POINTS
-    },
-    visibility = ["//visibility:public"],
-)
-
-# Ensure no internal path aliases leak into published JS
-no_internal_imports_test(
-    name = "no_internal_imports_test",
-    data = BUNDLES,
-)
-
-ts_project(
-    name = "typecheck",
-    srcs = [":srcs"],
-    declaration = True,
-    no_emit = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
-    tsconfig = packages_tsconfig(),
     deps = SRC_DEPS,
 )
 
-# --- Generate .d.ts declarations ---
-ts_project(
-    name = "types",
-    srcs = [":srcs"],
-    declaration = True,
-    emit_declaration_only = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
-    tsconfig = packages_tsconfig(),
-    visibility = ["//visibility:public"],
-    deps = SRC_DEPS,
-)
-
-vitest(
+formatjs_test(
     name = "unit_test",
     srcs = SRCS + TESTS + TEST_LOCALE_DATA,
     data = ["//:package.json"],
     no_copy_to_bin = ["//:package.json"],
-    tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
-    deps = SRC_DEPS + [
+    project_references = [
+        "//packages/ecma402-abstract",
+        "//packages/ecma402-abstract/PluralRules",
+        "//packages/ecma402-abstract/NumberFormat",
+        "//packages/ecma402-abstract/types",
+    ],
+    test_deps = [
         "//:node_modules/@formatjs/intl-getcanonicallocales",
         "//:node_modules/@formatjs/intl-locale",
+    ],
+    tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
+    deps = [
+        "//:node_modules/@formatjs/bigdecimal",
+        "//:node_modules/@formatjs/intl-localematcher",
     ],
 )
 
@@ -493,21 +451,5 @@ rolldown_bundle(
     entry_point = "polyfill.ts",
     target = "es2020",
     # TODO: fix this and set it back to es5
-    deps = [
-    ] + SRC_DEPS,
-)
-
-package_json_test(
-    name = "package_json_test",
     deps = SRC_DEPS,
-)
-
-copy_to_bin(
-    name = "srcs",
-    srcs = SRCS,
-)
-
-package_exports_test(
-    name = "package_exports_test",
-    pkg = ":pkg",
 )

--- a/packages/intl-pluralrules/tsconfig.json
+++ b/packages/intl-pluralrules/tsconfig.json
@@ -4,5 +4,6 @@
       "#packages/*": ["../../packages/*"]
     }
   },
+  "exclude": ["./scripts/**/*"],
   "extends": "../../tsconfig.json"
 }

--- a/packages/intl-relativetimeformat/BUILD.bazel
+++ b/packages/intl-relativetimeformat/BUILD.bazel
@@ -1,15 +1,12 @@
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
-load("@aspect_rules_js//js:defs.bzl", "js_library")
-load("@aspect_rules_js//npm:defs.bzl", "npm_package")
-load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
-load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "no_internal_imports_test", "package_exports_test", "package_json_test", "ts_run_binary")
+load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:index.bzl", "generate_src_file", "ts_run_binary")
+load("//tools:package.bzl", "formatjs_package")
 load("//tools:rolldown.bzl", "rolldown_bundle")
-load("//tools:tsconfig.bzl", "BASE_TSCONFIG", "ESNEXT_TSCONFIG", "packages_tsconfig")
-load("//tools:vitest.bzl", "vitest")
+load("//tools:test.bzl", "formatjs_test")
+load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
 
 npm_link_all_packages()
 
@@ -44,12 +41,6 @@ SRC_DEPS = [
     "//:node_modules/@formatjs/intl-localematcher",
 ]
 
-EXTERNAL_PACKAGES = [
-    dep.split("node_modules/")[1]
-    for dep in SRC_DEPS
-    if "node_modules/" in dep and "ecma402-abstract" not in dep
-]
-
 ENTRY_POINTS = [
     "index.ts",
     "polyfill.ts",
@@ -57,87 +48,52 @@ ENTRY_POINTS = [
     "should-polyfill.ts",
 ]
 
-[rolldown_bundle(
-    name = "%s-bundle" % entry.replace(".ts", ""),
-    srcs = [":srcs"],
-    dts = True,
-    entry_point = entry,
-    external = EXTERNAL_PACKAGES,
-    format = "esm",
-    output = "%s.js" % entry.replace(".ts", ""),
-    target = "es2020",
-    deps = SRC_DEPS,
-) for entry in ENTRY_POINTS]
-
-BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
-
-js_library(
-    name = PACKAGE_NAME,
-    srcs = BUNDLES + [
-        "package.json",
+formatjs_compile(
+    name = "dist",
+    srcs = SRCS,
+    entry_points = ENTRY_POINTS,
+    project_references = [
+        "//packages/ecma262-abstract",
+        "//packages/ecma402-abstract",
+        "//packages/ecma402-abstract/RelativeTimeFormat",
+        "//packages/ecma402-abstract/types",
     ],
-    visibility = ["//visibility:public"],
+    types = True,
+    deps = [
+        "//:node_modules/@formatjs/intl-localematcher",
+    ],
 )
 
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-    ] + BUNDLES + [
+formatjs_package(
+    name = PACKAGE_NAME,
+    entry_points = ENTRY_POINTS,
+    extra_npm_srcs = [
         ":locale-data",
         # polyfill-library uses this
         "polyfill.iife.js",
     ],
-    package = "@formatjs/%s" % PACKAGE_NAME,
-    replace_prefixes = {
-        "%s-bundle/" % entry.replace(".ts", ""): ""
-        for entry in ENTRY_POINTS
-    },
-    visibility = ["//visibility:public"],
-)
-
-# Ensure no internal path aliases leak into published JS
-no_internal_imports_test(
-    name = "no_internal_imports_test",
-    data = BUNDLES,
-)
-
-ts_project(
-    name = "typecheck",
-    srcs = [":srcs"],
-    declaration = True,
-    no_emit = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
-    tsconfig = packages_tsconfig(),
     deps = SRC_DEPS,
 )
 
-# --- Generate .d.ts declarations ---
-ts_project(
-    name = "types",
-    srcs = [":srcs"],
-    declaration = True,
-    emit_declaration_only = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
-    tsconfig = packages_tsconfig(),
-    visibility = ["//visibility:public"],
-    deps = SRC_DEPS,
-)
-
-vitest(
+formatjs_test(
     name = "unit_test",
     srcs = SRCS + TESTS + TEST_LOCALE_DATA,
     data = ["//:package.json"],
     no_copy_to_bin = ["//:package.json"],
-    tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
-    deps = SRC_DEPS + [
+    project_references = [
+        "//packages/ecma262-abstract",
+        "//packages/ecma402-abstract",
+        "//packages/ecma402-abstract/RelativeTimeFormat",
+        "//packages/ecma402-abstract/types",
+    ],
+    test_deps = [
         "//:node_modules/@formatjs/intl-getcanonicallocales",
         "//:node_modules/@formatjs/intl-locale",
         "//:node_modules/@formatjs/intl-pluralrules",
+    ],
+    tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
+    deps = [
+        "//:node_modules/@formatjs/intl-localematcher",
     ],
 )
 
@@ -845,19 +801,4 @@ rolldown_bundle(
     target = "es2020",
     deps = [
     ] + SRC_DEPS,
-)
-
-package_json_test(
-    name = "package_json_test",
-    deps = SRC_DEPS,
-)
-
-copy_to_bin(
-    name = "srcs",
-    srcs = SRCS,
-)
-
-package_exports_test(
-    name = "package_exports_test",
-    pkg = ":pkg",
 )

--- a/packages/intl-relativetimeformat/tsconfig.json
+++ b/packages/intl-relativetimeformat/tsconfig.json
@@ -4,5 +4,6 @@
       "#packages/*": ["../../packages/*"]
     }
   },
+  "exclude": ["./scripts/**/*"],
   "extends": "../../tsconfig.json"
 }

--- a/packages/intl-segmenter/BUILD.bazel
+++ b/packages/intl-segmenter/BUILD.bazel
@@ -1,16 +1,13 @@
 load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
-load("@aspect_rules_js//js:defs.bzl", "js_library")
-load("@aspect_rules_js//npm:defs.bzl", "npm_package")
-load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
-load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "no_internal_imports_test", "package_exports_test")
+load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:index.bzl", "generate_src_file")
+load("//tools:package.bzl", "formatjs_package")
 load("//tools:rolldown.bzl", "rolldown_bundle")
+load("//tools:test.bzl", "formatjs_test")
 load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
-load("//tools:vitest.bzl", "vitest")
 load(":index.bzl", "unicode_file_name")
 
 npm_link_all_packages()
@@ -60,12 +57,6 @@ TESTS = glob([
     "tests/*.test.ts",
 ])
 
-EXTERNAL_PACKAGES = [
-    dep.split("node_modules/")[1]
-    for dep in SRC_DEPS
-    if "node_modules/" in dep
-]
-
 ENTRY_POINTS = [
     "index.ts",
     "polyfill.ts",
@@ -73,77 +64,30 @@ ENTRY_POINTS = [
     "should-polyfill.ts",
 ]
 
-[rolldown_bundle(
-    name = "%s-bundle" % entry.replace(".ts", ""),
-    srcs = [":srcs"],
-    dts = True,
-    entry_point = entry,
-    external = EXTERNAL_PACKAGES,
-    format = "esm",
-    output = "%s.js" % entry.replace(".ts", ""),
-    target = "es2020",
-    deps = SRC_DEPS,
-) for entry in ENTRY_POINTS]
-
-BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
-
-js_library(
-    name = PACKAGE_NAME,
-    srcs = BUNDLES + [
-        "package.json",
+formatjs_compile(
+    name = "dist",
+    srcs = SRCS,
+    entry_points = ENTRY_POINTS,
+    project_references = [
+        "//packages/ecma402-abstract",
     ],
-    visibility = ["//visibility:public"],
+    types = True,
+    deps = [
+        "//:node_modules/@formatjs/intl-localematcher",
+    ],
 )
 
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-    ] + BUNDLES + [
+formatjs_package(
+    name = PACKAGE_NAME,
+    entry_points = ENTRY_POINTS,
+    extra_npm_srcs = [
         # polyfill-library uses this
         "polyfill.iife.js",
     ],
-    package = "@formatjs/%s" % PACKAGE_NAME,
-    replace_prefixes = {
-        "%s-bundle/" % entry.replace(".ts", ""): ""
-        for entry in ENTRY_POINTS
-    },
-    visibility = ["//visibility:public"],
-)
-
-# Ensure no internal path aliases leak into published JS
-no_internal_imports_test(
-    name = "no_internal_imports_test",
-    data = BUNDLES,
-)
-
-ts_project(
-    name = "typecheck",
-    srcs = [":srcs"],
-    declaration = True,
-    no_emit = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
-    tsconfig = TSCONFIG,
     deps = SRC_DEPS,
 )
 
-# --- Generate .d.ts declarations ---
-ts_project(
-    name = "types",
-    srcs = [":srcs"],
-    declaration = True,
-    emit_declaration_only = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
-    tsconfig = TSCONFIG,
-    visibility = ["//visibility:public"],
-    deps = SRC_DEPS,
-)
-
-vitest(
+formatjs_test(
     name = "unit_test",
     srcs = SRCS + TESTS + ["tests/test-utils.ts"],
     data = [
@@ -155,8 +99,17 @@ vitest(
         "@WordBreakTest//file",
         "@SentenceBreakTest//file",
     ],
+    project_references = [
+        "//packages/ecma402-abstract",
+    ],
+    test_deps = [
+        "//:node_modules/@bazel/runfiles",
+        "//:node_modules/@types/node",
+    ] + TEST_UNICODE_FILES,
     tsconfig = TSCONFIG,
-    deps = TEST_DEPS,
+    deps = [
+        "//:node_modules/@formatjs/intl-localematcher",
+    ],
 )
 
 generate_src_file(
@@ -253,14 +206,4 @@ generate_src_file(
         ],
     tags = ["cldr"],
     tool = "//packages/intl-segmenter/scripts:generate-cldr-segmentation-rules",
-)
-
-copy_to_bin(
-    name = "srcs",
-    srcs = SRCS,
-)
-
-package_exports_test(
-    name = "package_exports_test",
-    pkg = ":pkg",
 )

--- a/packages/intl-segmenter/tsconfig.json
+++ b/packages/intl-segmenter/tsconfig.json
@@ -4,5 +4,6 @@
       "#packages/*": ["../../packages/*"]
     }
   },
+  "exclude": ["./scripts/**/*"],
   "extends": "../../tsconfig.json"
 }

--- a/packages/intl-supportedvaluesof/BUILD.bazel
+++ b/packages/intl-supportedvaluesof/BUILD.bazel
@@ -1,15 +1,12 @@
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
-load("@aspect_rules_js//js:defs.bzl", "js_library")
-load("@aspect_rules_js//npm:defs.bzl", "npm_package")
-load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
-load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//packages/intl-datetimeformat:defs.bzl", "ZONES")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "no_internal_imports_test", "package_exports_test")
+load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:index.bzl", "generate_src_file")
+load("//tools:package.bzl", "formatjs_package")
 load("//tools:rolldown.bzl", "rolldown_bundle")
+load("//tools:test.bzl", "formatjs_test")
 load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
-load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
 
@@ -31,12 +28,6 @@ SRC_DEPS = [
     "//:node_modules/@formatjs/fast-memoize",
 ]
 
-EXTERNAL_PACKAGES = [
-    dep.split("node_modules/")[1]
-    for dep in SRC_DEPS
-    if "node_modules/" in dep and "ecma402-abstract" not in dep
-]
-
 TESTS = glob([
     "tests/*.test.ts",
 ])
@@ -48,86 +39,42 @@ ENTRY_POINTS = [
     "should-polyfill.ts",
 ]
 
-[rolldown_bundle(
-    name = "%s-bundle" % entry.replace(".ts", ""),
-    srcs = [":srcs"],
-    dts = True,
-    entry_point = entry,
-    external = EXTERNAL_PACKAGES,
-    format = "esm",
-    output = "%s.js" % entry.replace(".ts", ""),
-    target = "es2020",
-    deps = SRC_DEPS,
-) for entry in ENTRY_POINTS]
-
-BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
-
-js_library(
-    name = PACKAGE_NAME,
-    srcs = BUNDLES + [
-        "package.json",
+formatjs_compile(
+    name = "dist",
+    srcs = SRCS,
+    entry_points = ENTRY_POINTS,
+    project_references = [
+        "//packages/ecma402-abstract",
     ],
-    visibility = ["//visibility:public"],
+    types = True,
+    deps = [
+        "//:node_modules/@formatjs/fast-memoize",
+    ],
 )
 
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-    ] + BUNDLES + [
+formatjs_package(
+    name = PACKAGE_NAME,
+    entry_points = ENTRY_POINTS,
+    extra_npm_srcs = [
         # polyfill-library uses this
         "polyfill.iife.js",
     ],
-    package = "@formatjs/%s" % PACKAGE_NAME,
-    replace_prefixes = {
-        "%s-bundle/" % entry.replace(".ts", ""): ""
-        for entry in ENTRY_POINTS
-    },
-    visibility = ["//visibility:public"],
-)
-
-no_internal_imports_test(
-    name = "no_internal_imports_test",
-    data = BUNDLES,
-)
-
-ts_project(
-    name = "typecheck",
-    srcs = [":srcs"],
-    declaration = True,
-    no_emit = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
-    tsconfig = packages_tsconfig(),
     deps = SRC_DEPS,
 )
 
-ts_project(
-    name = "types",
-    srcs = [":srcs"],
-    declaration = True,
-    emit_declaration_only = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
-    tsconfig = packages_tsconfig(),
-    visibility = ["//visibility:public"],
-    deps = SRC_DEPS,
-)
-
-vitest(
+formatjs_test(
     name = "unit_test",
     srcs = SRCS + TESTS,
     data = ["//:package.json"],
     no_copy_to_bin = ["//:package.json"],
+    project_references = [
+        "//packages/ecma402-abstract",
+    ],
     tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
-    deps = SRC_DEPS,
+    deps = [
+        "//:node_modules/@formatjs/fast-memoize",
+    ],
 )
-
-# Test262
-# Generate tsconfig.json with correct extends path
-generate_ide_tsconfig_json()
 
 # calendars
 generate_src_file(
@@ -199,16 +146,5 @@ rolldown_bundle(
     srcs = [":srcs"],
     entry_point = "polyfill.ts",
     target = "es2020",
-    deps = [
-    ] + SRC_DEPS,
-)
-
-copy_to_bin(
-    name = "srcs",
-    srcs = SRCS,
-)
-
-package_exports_test(
-    name = "package_exports_test",
-    pkg = ":pkg",
+    deps = SRC_DEPS,
 )

--- a/packages/intl/BUILD.bazel
+++ b/packages/intl/BUILD.bazel
@@ -1,16 +1,10 @@
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
-load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
-load("@aspect_rules_js//js:defs.bzl", "js_library")
-load("@aspect_rules_js//npm:defs.bzl", "npm_package")
-load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
-load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:tsd/package_json.bzl", tsd_bin = "bin")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "no_internal_imports_test", "package_exports_test", "package_json_test")
-load("//tools:rolldown.bzl", "rolldown_bundle")
+load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:package.bzl", "formatjs_package")
+load("//tools:test.bzl", "formatjs_test")
 load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
-load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
 
@@ -31,12 +25,6 @@ SRC_DEPS = [
     "//:node_modules/intl-messageformat",
 ]
 
-EXTERNAL_PACKAGES = [
-    dep.split("node_modules/")[1]
-    for dep in SRC_DEPS
-    if "node_modules/" in dep and "ecma402-abstract" not in dep
-]
-
 TESTS = glob(
     [
         "tests/*.ts*",
@@ -50,90 +38,48 @@ ENTRY_POINTS = [
     "index.ts",
 ]
 
-[rolldown_bundle(
-    name = "%s-bundle" % entry.replace(".ts", ""),
-    srcs = [":srcs"],
-    dts = True,
-    entry_point = entry,
-    external = EXTERNAL_PACKAGES,
-    format = "esm",
-    output = "%s.js" % entry.replace(".ts", ""),
-    target = "es2020",
-    deps = SRC_DEPS,
-) for entry in ENTRY_POINTS]
-
-BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
-
-js_library(
-    name = PACKAGE_NAME,
-    srcs = BUNDLES + [
-        "package.json",
+formatjs_compile(
+    name = "dist",
+    srcs = SRCS,
+    entry_points = ENTRY_POINTS,
+    project_references = [
+        "//packages/ecma402-abstract",
+        "//packages/ecma402-abstract/types",
     ],
-    visibility = ["//visibility:public"],
+    types = True,
+    deps = [
+        "//:node_modules/@formatjs/fast-memoize",
+        "//:node_modules/@formatjs/icu-messageformat-parser",
+        "//:node_modules/intl-messageformat",
+    ],
 )
 
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-    ] + BUNDLES,
+formatjs_package(
+    name = PACKAGE_NAME,
     allow_overwrites = True,
-    package = "@formatjs/%s" % PACKAGE_NAME,
-    replace_prefixes = {
-        "%s-bundle/" % entry.replace(".ts", ""): ""
-        for entry in ENTRY_POINTS
-    },
-    visibility = ["//visibility:public"],
-)
-
-no_internal_imports_test(
-    name = "no_internal_imports_test",
-    data = BUNDLES,
-)
-
-ts_project(
-    name = "typecheck",
-    srcs = [":srcs"],
-    declaration = True,
-    no_emit = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
-    tsconfig = packages_tsconfig(),
+    entry_points = ENTRY_POINTS,
     deps = SRC_DEPS,
 )
 
-ts_project(
-    name = "types",
-    srcs = [":srcs"],
-    declaration = True,
-    emit_declaration_only = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
-    tsconfig = packages_tsconfig(),
-    visibility = ["//visibility:public"],
-    deps = SRC_DEPS,
-)
-
-vitest(
+formatjs_test(
     name = "unit_test",
-    srcs = [":srcs"] + TESTS,
+    srcs = SRCS + TESTS,
     data = ["//:package.json"],
     no_copy_to_bin = ["//:package.json"],
+    project_references = [
+        "//packages/ecma402-abstract",
+        "//packages/ecma402-abstract/types",
+    ],
     snapshots = glob(["tests/__snapshots__/*.snap"]),
-    tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
-    deps = SRC_DEPS + [
+    test_deps = [
         "//:node_modules/@types/node",
     ],
-)
-
-# Generate tsconfig.json with correct extends path
-generate_ide_tsconfig_json()
-
-package_json_test(
-    name = "package_json_test",
-    deps = SRC_DEPS,
+    tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
+    deps = [
+        "//:node_modules/@formatjs/fast-memoize",
+        "//:node_modules/@formatjs/icu-messageformat-parser",
+        "//:node_modules/intl-messageformat",
+    ],
 )
 
 # TODO: make this a macro that paramtrizes on `.test-d.ts` files.
@@ -167,14 +113,4 @@ tsd_bin.tsd_test(
         ":global_type_overrides_test_files",
         "//:node_modules/tsd",
     ] + SRC_DEPS,
-)
-
-copy_to_bin(
-    name = "srcs",
-    srcs = SRCS,
-)
-
-package_exports_test(
-    name = "package_exports_test",
-    pkg = ":pkg",
 )

--- a/packages/react-intl/BUILD.bazel
+++ b/packages/react-intl/BUILD.bazel
@@ -1,15 +1,11 @@
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
-load("@aspect_rules_js//js:defs.bzl", "js_library")
-load("@aspect_rules_js//npm:defs.bzl", "npm_package")
-load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
-load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:tsd/package_json.bzl", tsd_bin = "bin")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "no_internal_imports_test", "package_exports_test", "package_json_test")
+load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:package.bzl", "formatjs_package")
 load("//tools:rolldown.bzl", "rolldown_bundle")
+load("//tools:test.bzl", "formatjs_test")
 load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
-load("//tools:vitest.bzl", "vitest")
 
 npm_link_all_packages()
 
@@ -35,12 +31,6 @@ SRC_DEPS = [
     "//:node_modules/react",
 ]
 
-EXTERNAL_PACKAGES = [
-    dep.split("node_modules/")[1]
-    for dep in SRC_DEPS
-    if "node_modules/" in dep and "ecma402-abstract" not in dep
-]
-
 TESTS = glob(
     [
         "tests/unit/**/*.ts*",
@@ -48,84 +38,66 @@ TESTS = glob(
     exclude = ["tests/unit/components/__snapshots__/*"],
 )
 
-TEST_DEPS = SRC_DEPS + [
-    "//:node_modules/@testing-library/jest-dom",
-    "//:node_modules/@testing-library/react",
-    "//:node_modules/@types/aria-query",
-    "//:node_modules/@types/node",
-    "//:node_modules/react-dom",
-    "//:node_modules/typescript",
-]
-
 ENTRY_POINTS = [
     "index.ts",
     "server.ts",
 ]
 
-[rolldown_bundle(
-    name = "%s-bundle" % entry.replace(".ts", ""),
-    srcs = [":srcs"],
-    dts = True,
-    entry_point = entry,
-    external = EXTERNAL_PACKAGES,
-    format = "esm",
-    output = "%s.js" % entry.replace(".ts", ""),
-    target = "es2020",
-    deps = SRC_DEPS,
-) for entry in ENTRY_POINTS]
-
-BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
-
-js_library(
-    name = PACKAGE_NAME,
-    srcs = BUNDLES + [
-        "package.json",
+formatjs_compile(
+    name = "dist",
+    srcs = SRCS,
+    entry_points = ENTRY_POINTS,
+    project_references = [
+        "//packages/ecma402-abstract",
+        "//packages/ecma402-abstract/types",
     ],
-    visibility = ["//visibility:public"],
+    types = True,
+    deps = [
+        "//:node_modules/@formatjs/icu-messageformat-parser",
+        "//:node_modules/@formatjs/intl",
+        "//:node_modules/@types/react",
+        "//:node_modules/intl-messageformat",
+        "//:node_modules/react",
+    ],
 )
 
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
+formatjs_package(
+    name = PACKAGE_NAME,
+    entry_points = ENTRY_POINTS,
+    extra_npm_srcs = [
         "%s.iife.js" % PACKAGE_NAME,
-    ] + BUNDLES,
-    package = PACKAGE_NAME,
-    replace_prefixes = {
-        "%s-bundle/" % entry.replace(".ts", ""): ""
-        for entry in ENTRY_POINTS
-    },
-    visibility = ["//visibility:public"],
-)
-
-no_internal_imports_test(
-    name = "no_internal_imports_test",
-    data = BUNDLES,
-)
-
-ts_project(
-    name = "typecheck",
-    srcs = [":srcs"],
-    declaration = True,
-    no_emit = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
-    tsconfig = packages_tsconfig(),
+    ],
+    npm_package_name = PACKAGE_NAME,
     deps = SRC_DEPS,
 )
 
-ts_project(
-    name = "types",
-    srcs = [":srcs"],
-    declaration = True,
-    emit_declaration_only = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
-    tsconfig = packages_tsconfig(),
-    visibility = ["//visibility:public"],
-    deps = SRC_DEPS,
+formatjs_test(
+    name = "unit_test",
+    srcs = SRCS + TESTS,
+    config = "vitest.config.mjs",
+    data = ["//:package.json"],
+    dom = True,
+    no_copy_to_bin = ["//:package.json"],
+    project_references = [
+        "//packages/ecma402-abstract",
+        "//packages/ecma402-abstract/types",
+    ],
+    test_deps = [
+        "//:node_modules/@testing-library/jest-dom",
+        "//:node_modules/@testing-library/react",
+        "//:node_modules/@types/aria-query",
+        "//:node_modules/@types/node",
+        "//:node_modules/react-dom",
+        "//:node_modules/typescript",
+    ],
+    tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
+    deps = [
+        "//:node_modules/@formatjs/icu-messageformat-parser",
+        "//:node_modules/@formatjs/intl",
+        "//:node_modules/@types/react",
+        "//:node_modules/intl-messageformat",
+        "//:node_modules/react",
+    ],
 )
 
 rolldown_bundle(
@@ -143,26 +115,6 @@ genrule(
     srcs = [":%s.esbuild.iife.js" % PACKAGE_NAME],
     outs = ["%s.iife.js" % PACKAGE_NAME],
     cmd = "cat $< | sed -E 's/__require\\(\"react\"\\)/window.React/g' > $@",
-)
-
-vitest(
-    name = "unit_test",
-    srcs = SRCS +
-           TESTS,
-    config = "vitest.config.mjs",
-    data = ["//:package.json"],
-    dom = True,
-    no_copy_to_bin = ["//:package.json"],
-    tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
-    deps = TEST_DEPS,
-)
-
-# Generate tsconfig.json with correct extends path
-generate_ide_tsconfig_json()
-
-package_json_test(
-    name = "package_json_test",
-    deps = SRC_DEPS,
 )
 
 # TODO: make this a macro that paramtrizes on `.test-d.ts` files.
@@ -196,14 +148,4 @@ tsd_bin.tsd_test(
         ":global_type_overrides_test_files",
         "//:node_modules/tsd",
     ] + SRC_DEPS,
-)
-
-copy_to_bin(
-    name = "srcs",
-    srcs = SRCS,
-)
-
-package_exports_test(
-    name = "package_exports_test",
-    pkg = ":pkg",
 )

--- a/packages/svelte-intl/BUILD.bazel
+++ b/packages/svelte-intl/BUILD.bazel
@@ -1,13 +1,7 @@
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
-load("@aspect_rules_js//js:defs.bzl", "js_library")
-load("@aspect_rules_js//npm:defs.bzl", "npm_package")
-load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
-load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "no_internal_imports_test", "package_exports_test", "package_json_test")
-load("//tools:rolldown.bzl", "rolldown_bundle")
-load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
-load("//tools:vitest.bzl", "vitest")
+load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:package.bzl", "formatjs_package")
+load("//tools:test.bzl", "formatjs_test")
 
 npm_link_all_packages()
 
@@ -22,89 +16,21 @@ SRC_DEPS = [
     "//:node_modules/@formatjs/icu-messageformat-parser",
 ]
 
-EXTERNAL_PACKAGES = [
-    dep.split("node_modules/")[1]
-    for dep in SRC_DEPS
-    if "node_modules/" in dep
-]
-
-ENTRY_POINTS = [
-    "index.ts",
-]
-
-[rolldown_bundle(
-    name = "%s-bundle" % entry.replace(".ts", ""),
-    srcs = [":srcs"],
-    dts = True,
-    entry_point = entry,
-    external = EXTERNAL_PACKAGES,
-    format = "esm",
-    output = "%s.js" % entry.replace(".ts", ""),
-    target = "es2020",
+formatjs_compile(
+    name = "dist",
+    srcs = SRCS,
     deps = SRC_DEPS,
-) for entry in ENTRY_POINTS]
+)
 
-BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
-
-js_library(
+formatjs_package(
     name = "svelte-intl",
-    srcs = BUNDLES + [
-        "package.json",
-    ],
-    visibility = ["//visibility:public"],
-)
-
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-    ] + BUNDLES,
-    replace_prefixes = {
-        "%s-bundle/" % entry.replace(".ts", ""): ""
-        for entry in ENTRY_POINTS
-    },
-    visibility = ["//visibility:public"],
-)
-
-no_internal_imports_test(
-    name = "no_internal_imports_test",
-    data = BUNDLES,
-)
-
-ts_project(
-    name = "typecheck",
-    srcs = [":srcs"],
-    declaration = True,
-    no_emit = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
-    tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
     deps = SRC_DEPS,
 )
 
-vitest(
+formatjs_test(
     name = "unit_test",
     srcs = SRCS + glob([
         "tests/*.ts",
     ]),
     deps = SRC_DEPS,
-)
-
-generate_ide_tsconfig_json()
-
-package_json_test(
-    name = "package_json_test",
-    deps = SRC_DEPS,
-)
-
-copy_to_bin(
-    name = "srcs",
-    srcs = SRCS,
-)
-
-package_exports_test(
-    name = "package_exports_test",
-    pkg = ":pkg",
 )

--- a/packages/ts-transformer/BUILD.bazel
+++ b/packages/ts-transformer/BUILD.bazel
@@ -1,14 +1,7 @@
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
-load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
-load("@aspect_rules_js//js:defs.bzl", "js_library")
-load("@aspect_rules_js//npm:defs.bzl", "npm_package")
-load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
-load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "no_internal_imports_test", "package_exports_test", "package_json_test")
-load("//tools:rolldown.bzl", "rolldown_bundle")
-load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
-load("//tools:vitest.bzl", "vitest")
+load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:package.bzl", "formatjs_package")
+load("//tools:test.bzl", "formatjs_test")
 
 npm_link_all_packages()
 
@@ -42,70 +35,18 @@ SRC_DEPS = [
     "//:node_modules/typescript",
 ]
 
-EXTERNAL_PACKAGES = [
-    dep.split("node_modules/")[1]
-    for dep in SRC_DEPS
-    if "node_modules/" in dep
-]
-
-ENTRY_POINTS = [
-    "index.ts",
-]
-
-[rolldown_bundle(
-    name = "%s-bundle" % entry.replace(".ts", ""),
-    srcs = [":srcs"],
-    dts = True,
-    entry_point = entry,
-    external = EXTERNAL_PACKAGES,
-    format = "esm",
-    output = "%s.js" % entry.replace(".ts", ""),
-    target = "es2020",
+formatjs_compile(
+    name = "dist",
+    srcs = SRCS,
     deps = SRC_DEPS,
-) for entry in ENTRY_POINTS]
+)
 
-BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
-
-js_library(
+formatjs_package(
     name = PACKAGE_NAME,
-    srcs = BUNDLES + [
-        "package.json",
-    ],
-    visibility = ["//visibility:public"],
-)
-
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-    ] + BUNDLES,
-    package = "@formatjs/%s" % PACKAGE_NAME,
-    replace_prefixes = {
-        "%s-bundle/" % entry.replace(".ts", ""): ""
-        for entry in ENTRY_POINTS
-    },
-    visibility = ["//visibility:public"],
-)
-
-no_internal_imports_test(
-    name = "no_internal_imports_test",
-    data = BUNDLES,
-)
-
-ts_project(
-    name = "typecheck",
-    srcs = [":srcs"],
-    declaration = True,
-    no_emit = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
-    tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
     deps = SRC_DEPS,
 )
 
-vitest(
+formatjs_test(
     name = "unit_test",
     srcs = SRCS + glob([
         "tests/*.ts*",
@@ -114,22 +55,4 @@ vitest(
         "tests/fixtures/*.ts*",
     ]),
     deps = SRC_DEPS,
-)
-
-# Generate tsconfig.json with correct extends path
-generate_ide_tsconfig_json()
-
-package_json_test(
-    name = "package_json_test",
-    deps = SRC_DEPS,
-)
-
-copy_to_bin(
-    name = "srcs",
-    srcs = SRCS,
-)
-
-package_exports_test(
-    name = "package_exports_test",
-    pkg = ":pkg",
 )

--- a/packages/unplugin/BUILD.bazel
+++ b/packages/unplugin/BUILD.bazel
@@ -1,12 +1,8 @@
 load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
-load("@aspect_rules_js//js:defs.bzl", "js_library")
-load("@aspect_rules_js//npm:defs.bzl", "npm_package")
-load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
-load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "no_internal_imports_test", "package_exports_test", "package_json_test")
-load("//tools:rolldown.bzl", "rolldown_bundle")
+load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:package.bzl", "formatjs_package")
+load("//tools:test.bzl", "formatjs_test")
 load("//tools:tsconfig.bzl", "ESNEXT_SKIP_LIB_CHECK_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
 
@@ -42,12 +38,6 @@ SRC_DEPS = [
     "//:node_modules/vite",
 ]
 
-EXTERNAL_PACKAGES = [
-    dep.split("node_modules/")[1]
-    for dep in SRC_DEPS
-    if "node_modules/" in dep
-]
-
 ENTRY_POINTS = [
     "index.ts",
     "vite.ts",
@@ -58,61 +48,22 @@ ENTRY_POINTS = [
     "transform.ts",
 ]
 
-[rolldown_bundle(
-    name = "%s-bundle" % entry.replace(".ts", ""),
-    srcs = [":srcs"],
-    dts = True,
-    entry_point = entry,
-    external = EXTERNAL_PACKAGES,
-    format = "esm",
-    output = "%s.js" % entry.replace(".ts", ""),
-    target = "es2020",
-    deps = SRC_DEPS,
-) for entry in ENTRY_POINTS]
-
-BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
-
-js_library(
+formatjs_compile(
     name = "dist",
-    srcs = BUNDLES + [
-        "package.json",
-    ],
-)
-
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-    ] + BUNDLES,
-    package = PACKAGE_NAME,
-    replace_prefixes = {
-        "%s-bundle/" % entry.replace(".ts", ""): ""
-        for entry in ENTRY_POINTS
-    },
-    visibility = ["//visibility:public"],
-)
-
-no_internal_imports_test(
-    name = "no_internal_imports_test",
-    data = BUNDLES,
-)
-
-# Type check only with tsgo (fast, parallel)
-# Uses skipLibCheck because unplugin's .d.ts imports types from many optional peer deps
-ts_project(
-    name = "typecheck",
-    srcs = [":srcs"],
-    declaration = True,
-    no_emit = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
+    srcs = SRCS,
+    entry_points = ENTRY_POINTS,
     tsconfig = packages_tsconfig(ESNEXT_SKIP_LIB_CHECK_TSCONFIG),
     deps = SRC_DEPS,
 )
 
-vitest(
+formatjs_package(
+    name = "unplugin",
+    entry_points = ENTRY_POINTS,
+    npm_package_name = PACKAGE_NAME,
+    deps = SRC_DEPS,
+)
+
+formatjs_test(
     name = "unit_test",
     srcs = SRCS + glob(["tests/**/*.ts"]),
     deps = SRC_DEPS,
@@ -129,21 +80,4 @@ vitest(
     deps = SRC_DEPS + [
         "//:node_modules/@bazel/runfiles",
     ],
-)
-
-copy_to_bin(
-    name = "srcs",
-    srcs = SRCS,
-)
-
-generate_ide_tsconfig_json()
-
-package_json_test(
-    name = "package_json_test",
-    deps = SRC_DEPS,
-)
-
-package_exports_test(
-    name = "package_exports_test",
-    pkg = ":pkg",
 )

--- a/packages/utils/BUILD.bazel
+++ b/packages/utils/BUILD.bazel
@@ -1,15 +1,9 @@
 load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
-load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
-load("@aspect_rules_js//js:defs.bzl", "js_library")
-load("@aspect_rules_js//npm:defs.bzl", "npm_package")
-load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
-load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "no_internal_imports_test", "package_exports_test", "package_json_test")
-load("//tools:rolldown.bzl", "rolldown_bundle")
-load("//tools:tsconfig.bzl", "packages_tsconfig")
-load("//tools:vitest.bzl", "vitest")
+load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:index.bzl", "generate_src_file")
+load("//tools:package.bzl", "formatjs_package")
+load("//tools:test.bzl", "formatjs_test")
 
 npm_link_all_packages()
 
@@ -20,8 +14,6 @@ exports_files([
     "data/list-one.xml",
 ])
 
-PACKAGE_NAME = "utils"
-
 SRCS = glob([
     "*.ts",
 ])
@@ -30,78 +22,18 @@ SRC_DEPS = [
     "//:node_modules/@formatjs/fast-memoize",
 ]
 
-EXTERNAL_PACKAGES = [
-    dep.split("node_modules/")[1]
-    for dep in SRC_DEPS
-    if "node_modules/" in dep
-]
-
-ENTRY_POINTS = [
-    "index.ts",
-]
-
-[rolldown_bundle(
-    name = "%s-bundle" % entry.replace(".ts", ""),
-    srcs = [":srcs"],
-    dts = True,
-    entry_point = entry,
-    external = EXTERNAL_PACKAGES,
-    format = "esm",
-    output = "%s.js" % entry.replace(".ts", ""),
-    target = "es2020",
-    deps = SRC_DEPS,
-) for entry in ENTRY_POINTS]
-
-BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
-
-js_library(
-    name = PACKAGE_NAME,
-    srcs = BUNDLES + [
-        "package.json",
-    ],
-    visibility = ["//visibility:public"],
-)
-
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-    ] + BUNDLES,
-    package = "@formatjs/%s" % PACKAGE_NAME,
-    replace_prefixes = {
-        "%s-bundle/" % entry.replace(".ts", ""): ""
-        for entry in ENTRY_POINTS
-    },
-    visibility = ["//visibility:public"],
-)
-
-no_internal_imports_test(
-    name = "no_internal_imports_test",
-    data = BUNDLES,
-)
-
-ts_project(
-    name = "typecheck",
-    srcs = [":srcs"],
-    declaration = True,
-    no_emit = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
-    tsconfig = packages_tsconfig(),
+formatjs_compile(
+    name = "dist",
+    srcs = SRCS,
     deps = SRC_DEPS,
 )
 
-# Generate tsconfig.json with correct extends path
-generate_ide_tsconfig_json()
-
-package_json_test(
-    name = "package_json_test",
+formatjs_package(
+    name = "utils",
     deps = SRC_DEPS,
 )
 
-vitest(
+formatjs_test(
     name = "unit_test",
     srcs = SRCS + glob([
         "tests/*.ts*",
@@ -147,14 +79,4 @@ generate_src_file(
         ":node_modules/fast-xml-parser",
     ],
     entry_point = "tools/extract-minor-currency-units.ts",
-)
-
-copy_to_bin(
-    name = "srcs",
-    srcs = SRCS,
-)
-
-package_exports_test(
-    name = "package_exports_test",
-    pkg = ":pkg",
 )

--- a/packages/vue-intl/BUILD.bazel
+++ b/packages/vue-intl/BUILD.bazel
@@ -1,13 +1,7 @@
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
-load("@aspect_rules_js//js:defs.bzl", "js_library")
-load("@aspect_rules_js//npm:defs.bzl", "npm_package")
-load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
-load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "no_internal_imports_test", "package_exports_test", "package_json_test")
-load("//tools:rolldown.bzl", "rolldown_bundle")
-load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
-load("//tools:vitest.bzl", "vitest")
+load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:package.bzl", "formatjs_package")
+load("//tools:test.bzl", "formatjs_test")
 
 npm_link_all_packages()
 
@@ -22,94 +16,28 @@ SRC_DEPS = [
     "//:node_modules/@formatjs/icu-messageformat-parser",
 ]
 
-EXTERNAL_PACKAGES = [
-    dep.split("node_modules/")[1]
-    for dep in SRC_DEPS
-    if "node_modules/" in dep
-]
-
-ENTRY_POINTS = [
-    "index.ts",
-]
-
-[rolldown_bundle(
-    name = "%s-bundle" % entry.replace(".ts", ""),
-    srcs = [":srcs"],
-    dts = True,
-    entry_point = entry,
-    external = EXTERNAL_PACKAGES,
-    format = "esm",
-    output = "%s.js" % entry.replace(".ts", ""),
-    target = "es2020",
+formatjs_compile(
+    name = "dist",
+    srcs = SRCS,
     deps = SRC_DEPS,
-) for entry in ENTRY_POINTS]
+)
 
-BUNDLES = [":%s-bundle" % entry.replace(".ts", "") for entry in ENTRY_POINTS]
-
-js_library(
+formatjs_package(
     name = "vue-intl",
-    srcs = BUNDLES + [
-        "package.json",
-    ],
-    visibility = ["//visibility:public"],
-)
-
-npm_package(
-    name = "pkg",
-    srcs = [
-        "LICENSE.md",
-        "README.md",
-        "package.json",
-    ] + BUNDLES,
-    replace_prefixes = {
-        "%s-bundle/" % entry.replace(".ts", ""): ""
-        for entry in ENTRY_POINTS
-    },
-    visibility = ["//visibility:public"],
-)
-
-no_internal_imports_test(
-    name = "no_internal_imports_test",
-    data = BUNDLES,
-)
-
-ts_project(
-    name = "typecheck",
-    srcs = [":srcs"],
-    declaration = True,
-    no_emit = True,
-    resolve_json_module = True,
-    transpiler = tsgo_bin.tsgo,
-    tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
+    npm_package_name = "vue-intl",
     deps = SRC_DEPS,
 )
 
-vitest(
+formatjs_test(
     name = "unit_test",
     srcs = SRCS + glob([
         "tests/*",
     ]),
     dom = True,
-    deps = SRC_DEPS + [
+    test_deps = [
         "//:node_modules/@vue/compiler-dom",
         "//:node_modules/@vue/server-renderer",
         "//:node_modules/@vue/test-utils",
     ],
-)
-
-generate_ide_tsconfig_json()
-
-package_json_test(
-    name = "package_json_test",
     deps = SRC_DEPS,
-)
-
-copy_to_bin(
-    name = "srcs",
-    srcs = SRCS,
-)
-
-package_exports_test(
-    name = "package_exports_test",
-    pkg = ":pkg",
 )

--- a/tools/compile.bzl
+++ b/tools/compile.bzl
@@ -12,7 +12,8 @@ def formatjs_compile(
         deps = [],
         project_references = [],
         entry_points = ["index.ts"],
-        types = False):
+        types = False,
+        tsconfig = None):
     """TypeScript compilation + rolldown bundling.
 
     Generates:
@@ -28,8 +29,10 @@ def formatjs_compile(
         project_references: internal package dependencies (e.g. //packages/ecma402-abstract)
         entry_points: list of .ts entry points to bundle
         types: if True, generate a "types" ts_project with emit_declaration_only
+        tsconfig: optional tsconfig dict override (defaults to packages_tsconfig())
     """
     all_deps = deps + project_references
+    effective_tsconfig = tsconfig or packages_tsconfig()
 
     # Compute external packages for rolldown (only node_modules deps are externalized)
     external_packages = [
@@ -50,7 +53,7 @@ def formatjs_compile(
         no_emit = True,
         resolve_json_module = True,
         transpiler = tsgo_bin.tsgo,
-        tsconfig = packages_tsconfig(),
+        tsconfig = effective_tsconfig,
         deps = all_deps,
     )
 

--- a/tools/compile.bzl
+++ b/tools/compile.bzl
@@ -78,7 +78,7 @@ def formatjs_compile(
             emit_declaration_only = True,
             resolve_json_module = True,
             transpiler = tsgo_bin.tsgo,
-            tsconfig = packages_tsconfig(),
+            tsconfig = effective_tsconfig,
             visibility = ["//visibility:public"],
             deps = all_deps,
         )

--- a/tools/test.bzl
+++ b/tools/test.bzl
@@ -1,0 +1,39 @@
+"Macro for formatjs test targets with separated dep tracking."
+
+load("//tools:vitest.bzl", "vitest")
+
+def formatjs_test(
+        name,
+        srcs = [],
+        deps = [],
+        project_references = [],
+        test_deps = [],
+        test_project_references = [],
+        **kwargs):
+    """Vitest wrapper with separated dependency tracking.
+
+    Separates deps into 4 categories for gazelle:
+    - deps: external npm deps from source files
+    - project_references: internal //packages/* deps from source files
+    - test_deps: external npm deps only in test files
+    - test_project_references: internal deps only in test files
+
+    All categories are merged and passed to vitest.
+
+    Args:
+        name: target name (e.g. "unit_test")
+        srcs: source + test files
+        deps: external npm dependencies from source files (gazelle-managed)
+        project_references: internal package deps from source files (gazelle-managed)
+        test_deps: external npm deps only in test files (gazelle-managed)
+        test_project_references: internal deps only in test files (gazelle-managed)
+        **kwargs: passed through to vitest (dom, config, size, tsconfig, data, etc.)
+    """
+    all_deps = deps + project_references + test_deps + test_project_references
+
+    vitest(
+        name = name,
+        srcs = srcs,
+        deps = all_deps,
+        **kwargs
+    )


### PR DESCRIPTION
## Summary
- Migrate all 28 rolldown-bundled packages to use `formatjs_compile`, `formatjs_package`, and `formatjs_test` macros
- Net reduction: **-1,805 lines** across 33 files
- Add `tsconfig` parameter to `formatjs_compile` for packages needing non-default tsconfigs (bigdecimal, eslint-plugin, unplugin)
- Update tsconfig.json files where `generate_ide_tsconfig_json()` now detects child subpackages

**Stack:** PR 4 of 6 (stacked on #6301)

## Test plan
- [x] `bazel test //...` — all 567 tests pass
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)