### PR TITLE
fix(deps): add id-token: write permission to Claude Code workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,6 +25,7 @@ jobs:
       contents: read
       pull-requests: read
       issues: read
+      id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- Add missing `id-token: write` permission to the Claude Code GitHub Actions workflow
- Without this permission, the `claude-code-action` fails with "Could not fetch an OIDC token"
- Fixes https://github.com/formatjs/formatjs/actions/runs/24283551629/job/70909109627

## Test plan
- [ ] Trigger the Claude Code workflow by tagging `@claude` in an issue or PR comment and verify it no longer fails with OIDC token error

🤖 Generated with [Claude Code](https://claude.com/claude-code)