### PR TITLE
fix(deps): add Rust CLI smoke test to BuildBuddy config

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -11,3 +11,4 @@ actions:
       disk: 16GB
     bazel_commands:
       - 'test //...'
+      - 'build --compilation_mode=opt //crates/formatjs_cli'


### PR DESCRIPTION
## Summary
- Add `build --compilation_mode=opt //crates/formatjs_cli` to `buildbuddy.yaml` bazel commands
- Aligns BuildBuddy CI with `.github/workflows/test.yml` which already runs this Rust CLI smoke test

## Test plan
- [ ] Verify BuildBuddy action runs the optimized Rust CLI build on next push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)