### PR TITLE
refactor(deps): rename formatjs_compile to formatjs_library

### DIFF
--- a/docs/src/docs/tooling/bazel.mdx
+++ b/docs/src/docs/tooling/bazel.mdx
@@ -50,9 +50,9 @@ formatjs_extract(
 Compile extracted messages for optimized runtime:
 
 ```starlark
-load("@rules_formatjs//formatjs:defs.bzl", "formatjs_compile")
+load("@rules_formatjs//formatjs:defs.bzl", "formatjs_library")
 
-formatjs_compile(
+formatjs_library(
     name = "messages_compiled",
     src = ":messages_extracted",
     out = "en-compiled.json",
@@ -107,7 +107,7 @@ bazel build //:all_messages \
 ### Complete Example
 
 ```starlark
-load("@rules_formatjs//formatjs:defs.bzl", "formatjs_extract", "formatjs_compile", "formatjs_verify")
+load("@rules_formatjs//formatjs:defs.bzl", "formatjs_extract", "formatjs_library", "formatjs_verify")
 
 # Extract messages from source files
 formatjs_extract(
@@ -122,7 +122,7 @@ formatjs_extract(
 )
 
 # Compile for production
-formatjs_compile(
+formatjs_library(
     name = "compile_en",
     src = ":extract_en",
     out = "lang/en-compiled.json",
@@ -130,7 +130,7 @@ formatjs_compile(
 )
 
 # Compile translations
-formatjs_compile(
+formatjs_library(
     name = "compile_es",
     src = "translations/es.json",
     out = "lang/es-compiled.json",
@@ -185,7 +185,7 @@ formatjs_extract(
 )
 ```
 
-### formatjs_compile
+### formatjs_library
 
 Compile extracted messages for optimized runtime.
 
@@ -202,7 +202,7 @@ Compile extracted messages for optimized runtime.
 **Example:**
 
 ```starlark
-formatjs_compile(
+formatjs_library(
     name = "compile_messages",
     src = ":extract_en",
     out = "en-compiled.json",
@@ -437,7 +437,7 @@ formatjs_extract(
     id_interpolation_pattern = "[sha512:contenthash:base64:6]",
 )
 
-formatjs_compile(
+formatjs_library(
     name = "compile_dev",
     src = ":extract_dev",
     ast = True,
@@ -470,7 +470,7 @@ formatjs_aggregate(
 )
 
 # Compile with AST
-formatjs_compile(
+formatjs_library(
     name = "compile_prod",
     src = ":all_app_messages",
     out = "app-messages.json",

--- a/knowledge-base/001a-bazel-toolchain.md
+++ b/knowledge-base/001a-bazel-toolchain.md
@@ -37,7 +37,7 @@ Node 24.14.0 pinned with SHA256 hashes for 5 platforms (darwin_arm64, darwin_amd
 
 ### Two Compilation Patterns
 
-**Pattern 1: formatjs_compile packages** (28 npm-published packages)
+**Pattern 1: formatjs_library packages** (28 npm-published packages)
 
 ```
 Source .ts files

--- a/knowledge-base/migrations/001-gazelle-migration.md
+++ b/knowledge-base/migrations/001-gazelle-migration.md
@@ -1,6 +1,6 @@
 # Gazelle Migration Plan: Custom Macros to Stock Rules
 
-> **Status: COMPLETED.** Phases 1-3 below were superseded by 3 custom macros (`formatjs_compile`, `formatjs_package`, `formatjs_test`) + a custom Go gazelle plugin at `tools/gazelle/ts/`. See `knowledge-base/001a-bazel-toolchain.md`.
+> **Status: COMPLETED.** Phases 1-3 below were superseded by 3 custom macros (`formatjs_library`, `formatjs_package`, `formatjs_test`) + a custom Go gazelle plugin at `tools/gazelle/ts/`. See `knowledge-base/001a-bazel-toolchain.md`.
 
 ## Goal
 

--- a/packages/babel-plugin-formatjs/BUILD.bazel
+++ b/packages/babel-plugin-formatjs/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:compile.bzl", "formatjs_library")
 load("//tools:package.bzl", "formatjs_package")
 load("//tools:test.bzl", "formatjs_test")
 
@@ -10,7 +10,7 @@ SRCS = glob(
     exclude = ["tests/**/*"],
 )
 
-formatjs_compile(
+formatjs_library(
     name = "dist",
     srcs = SRCS,
     deps = [

--- a/packages/bigdecimal/BUILD.bazel
+++ b/packages/bigdecimal/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:compile.bzl", "formatjs_library")
 load("//tools:package.bzl", "formatjs_package")
 load("//tools:test.bzl", "formatjs_test")
 load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
@@ -14,7 +14,7 @@ SRCS = glob([
     "*.ts",
 ])
 
-formatjs_compile(
+formatjs_library(
     name = "dist",
     srcs = SRCS,
     tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),

--- a/packages/cli-lib/BUILD.bazel
+++ b/packages/cli-lib/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:compile.bzl", "formatjs_library")
 load("//tools:package.bzl", "formatjs_package")
 load("//tools:rolldown.bzl", "rolldown_bundle")
 load("//tools:test.bzl", "formatjs_test")
@@ -18,7 +18,7 @@ SRCS = glob(
     ],
 )
 
-formatjs_compile(
+formatjs_library(
     name = "dist",
     srcs = SRCS,
     deps = [

--- a/packages/ecma376/BUILD.bazel
+++ b/packages/ecma376/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:compile.bzl", "formatjs_library")
 load("//tools:package.bzl", "formatjs_package")
 load("//tools:test.bzl", "formatjs_test")
 
@@ -13,7 +13,7 @@ SRCS = glob([
 SRC_DEPS = [
 ]
 
-formatjs_compile(
+formatjs_library(
     name = "dist",
     srcs = SRCS,
 )

--- a/packages/fast-memoize/BUILD.bazel
+++ b/packages/fast-memoize/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:compile.bzl", "formatjs_library")
 load("//tools:package.bzl", "formatjs_package")
 
 npm_link_all_packages()
@@ -12,7 +12,7 @@ SRCS = glob([
     "*.ts",
 ])
 
-formatjs_compile(
+formatjs_library(
     name = "dist",
     srcs = SRCS,
 )

--- a/packages/icu-messageformat-parser/BUILD.bazel
+++ b/packages/icu-messageformat-parser/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:compile.bzl", "formatjs_library")
 load("//tools:index.bzl", "generate_src_file")
 load("//tools:package.bzl", "formatjs_package")
 load("//tools:test.bzl", "formatjs_test")
@@ -20,7 +20,7 @@ ENTRY_POINTS = [
     "manipulator.ts",
 ]
 
-formatjs_compile(
+formatjs_library(
     name = "dist",
     srcs = SRCS,
     entry_points = ENTRY_POINTS,

--- a/packages/icu-skeleton-parser/BUILD.bazel
+++ b/packages/icu-skeleton-parser/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:compile.bzl", "formatjs_library")
 load("//tools:index.bzl", "generate_src_file")
 load("//tools:package.bzl", "formatjs_package")
 load("//tools:test.bzl", "formatjs_test")
@@ -9,7 +9,7 @@ npm_link_all_packages()
 
 SRCS = glob(["*.ts"])
 
-formatjs_compile(
+formatjs_library(
     name = "dist",
     srcs = SRCS,
     project_references = ["//packages/ecma402-abstract/types"],

--- a/packages/intl-datetimeformat/BUILD.bazel
+++ b/packages/intl-datetimeformat/BUILD.bazel
@@ -3,7 +3,7 @@ load("@aspect_rules_js//js:defs.bzl", "js_binary")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@rules_multirun//:defs.bzl", "multirun")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
-load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:compile.bzl", "formatjs_library")
 load("//tools:index.bzl", "generate_src_file", "ts_run_binary")
 load("//tools:package.bzl", "formatjs_package")
 load("//tools:rolldown.bzl", "rolldown_bundle")
@@ -68,7 +68,7 @@ ENTRY_POINTS = [
     "should-polyfill.ts",
 ]
 
-formatjs_compile(
+formatjs_library(
     name = "dist",
     srcs = SRCS,
     entry_points = ENTRY_POINTS,

--- a/packages/intl-displaynames/BUILD.bazel
+++ b/packages/intl-displaynames/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
-load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:compile.bzl", "formatjs_library")
 load("//tools:index.bzl", "generate_src_file", "ts_run_binary")
 load("//tools:package.bzl", "formatjs_package")
 load("//tools:rolldown.bzl", "rolldown_bundle")
@@ -37,7 +37,7 @@ ENTRY_POINTS = [
     "should-polyfill.ts",
 ]
 
-formatjs_compile(
+formatjs_library(
     name = "dist",
     srcs = SRCS,
     entry_points = ENTRY_POINTS,

--- a/packages/intl-durationformat/BUILD.bazel
+++ b/packages/intl-durationformat/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:compile.bzl", "formatjs_library")
 load("//tools:index.bzl", "generate_src_file")
 load("//tools:package.bzl", "formatjs_package")
 load("//tools:test.bzl", "formatjs_test")
@@ -24,7 +24,7 @@ ENTRY_POINTS = [
     "should-polyfill.ts",
 ]
 
-formatjs_compile(
+formatjs_library(
     name = "dist",
     srcs = SRCS,
     entry_points = ENTRY_POINTS,

--- a/packages/intl-getcanonicallocales/BUILD.bazel
+++ b/packages/intl-getcanonicallocales/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:compile.bzl", "formatjs_library")
 load("//tools:index.bzl", "generate_src_file")
 load("//tools:package.bzl", "formatjs_package")
 load("//tools:rolldown.bzl", "rolldown_bundle")
@@ -31,7 +31,7 @@ ENTRY_POINTS = [
     "should-polyfill.ts",
 ]
 
-formatjs_compile(
+formatjs_library(
     name = "dist",
     srcs = SRCS,
     entry_points = ENTRY_POINTS,

--- a/packages/intl-listformat/BUILD.bazel
+++ b/packages/intl-listformat/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
-load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:compile.bzl", "formatjs_library")
 load("//tools:index.bzl", "generate_src_file", "ts_run_binary")
 load("//tools:package.bzl", "formatjs_package")
 load("//tools:rolldown.bzl", "rolldown_bundle")
@@ -40,7 +40,7 @@ ENTRY_POINTS = [
     "should-polyfill.ts",
 ]
 
-formatjs_compile(
+formatjs_library(
     name = "dist",
     srcs = SRCS,
     entry_points = ENTRY_POINTS,

--- a/packages/intl-locale/BUILD.bazel
+++ b/packages/intl-locale/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
-load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:compile.bzl", "formatjs_library")
 load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file")
 load("//tools:package.bzl", "formatjs_package")
 load("//tools:rolldown.bzl", "rolldown_bundle")
@@ -19,7 +19,7 @@ ENTRY_POINTS = [
     "should-polyfill.ts",
 ]
 
-formatjs_compile(
+formatjs_library(
     name = "dist",
     srcs = SRCS,
     entry_points = ENTRY_POINTS,

--- a/packages/intl-localematcher/BUILD.bazel
+++ b/packages/intl-localematcher/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:compile.bzl", "formatjs_library")
 load("//tools:index.bzl", "generate_src_file")
 load("//tools:package.bzl", "formatjs_package")
 load("//tools:test.bzl", "formatjs_test")
@@ -11,7 +11,7 @@ SRCS = glob(
     exclude = ["tests/*"],
 ) + ["index.ts"]
 
-formatjs_compile(
+formatjs_library(
     name = "dist",
     srcs = SRCS,
     deps = [

--- a/packages/intl-messageformat/BUILD.bazel
+++ b/packages/intl-messageformat/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@aspect_rules_js//js:defs.bzl", "js_binary")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:compile.bzl", "formatjs_library")
 load("//tools:package.bzl", "formatjs_package")
 load("//tools:rolldown.bzl", "rolldown_bundle")
 load("//tools:test.bzl", "formatjs_test")
@@ -24,7 +24,7 @@ ENTRY_POINTS = [
     "index.ts",
 ]
 
-formatjs_compile(
+formatjs_library(
     name = "dist",
     srcs = SRCS,
     entry_points = ENTRY_POINTS,

--- a/packages/intl-numberformat/BUILD.bazel
+++ b/packages/intl-numberformat/BUILD.bazel
@@ -3,7 +3,7 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
 load("@rules_multirun//:defs.bzl", "multirun")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
-load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:compile.bzl", "formatjs_library")
 load("//tools:index.bzl", "generate_src_file", "ts_run_binary")
 load("//tools:package.bzl", "formatjs_package")
 load("//tools:rolldown.bzl", "rolldown_bundle")
@@ -87,7 +87,7 @@ ENTRY_POINTS = [
     "should-polyfill.ts",
 ]
 
-formatjs_compile(
+formatjs_library(
     name = "dist",
     srcs = SRCS,
     entry_points = ENTRY_POINTS,

--- a/packages/intl-pluralrules/BUILD.bazel
+++ b/packages/intl-pluralrules/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
-load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:compile.bzl", "formatjs_library")
 load("//tools:index.bzl", "generate_src_file", "ts_run_binary")
 load("//tools:package.bzl", "formatjs_package")
 load("//tools:rolldown.bzl", "rolldown_bundle")
@@ -256,7 +256,7 @@ ENTRY_POINTS = [
     "should-polyfill.ts",
 ]
 
-formatjs_compile(
+formatjs_library(
     name = "dist",
     srcs = SRCS,
     entry_points = ENTRY_POINTS,

--- a/packages/intl-relativetimeformat/BUILD.bazel
+++ b/packages/intl-relativetimeformat/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
-load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:compile.bzl", "formatjs_library")
 load("//tools:index.bzl", "generate_src_file", "ts_run_binary")
 load("//tools:package.bzl", "formatjs_package")
 load("//tools:rolldown.bzl", "rolldown_bundle")
@@ -40,7 +40,7 @@ ENTRY_POINTS = [
     "should-polyfill.ts",
 ]
 
-formatjs_compile(
+formatjs_library(
     name = "dist",
     srcs = SRCS,
     entry_points = ENTRY_POINTS,

--- a/packages/intl-segmenter/BUILD.bazel
+++ b/packages/intl-segmenter/BUILD.bazel
@@ -2,7 +2,7 @@ load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
-load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:compile.bzl", "formatjs_library")
 load("//tools:index.bzl", "generate_src_file")
 load("//tools:package.bzl", "formatjs_package")
 load("//tools:rolldown.bzl", "rolldown_bundle")
@@ -61,7 +61,7 @@ ENTRY_POINTS = [
     "should-polyfill.ts",
 ]
 
-formatjs_compile(
+formatjs_library(
     name = "dist",
     srcs = SRCS,
     entry_points = ENTRY_POINTS,

--- a/packages/intl-supportedvaluesof/BUILD.bazel
+++ b/packages/intl-supportedvaluesof/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//packages/intl-datetimeformat:defs.bzl", "ZONES")
-load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:compile.bzl", "formatjs_library")
 load("//tools:index.bzl", "generate_src_file")
 load("//tools:package.bzl", "formatjs_package")
 load("//tools:rolldown.bzl", "rolldown_bundle")
@@ -34,7 +34,7 @@ ENTRY_POINTS = [
     "should-polyfill.ts",
 ]
 
-formatjs_compile(
+formatjs_library(
     name = "dist",
     srcs = SRCS,
     entry_points = ENTRY_POINTS,

--- a/packages/intl/BUILD.bazel
+++ b/packages/intl/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:tsd/package_json.bzl", tsd_bin = "bin")
-load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:compile.bzl", "formatjs_library")
 load("//tools:package.bzl", "formatjs_package")
 load("//tools:test.bzl", "formatjs_test")
 load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
@@ -30,7 +30,7 @@ ENTRY_POINTS = [
     "index.ts",
 ]
 
-formatjs_compile(
+formatjs_library(
     name = "dist",
     srcs = SRCS,
     entry_points = ENTRY_POINTS,

--- a/packages/react-intl/BUILD.bazel
+++ b/packages/react-intl/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:tsd/package_json.bzl", tsd_bin = "bin")
-load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:compile.bzl", "formatjs_library")
 load("//tools:package.bzl", "formatjs_package")
 load("//tools:rolldown.bzl", "rolldown_bundle")
 load("//tools:test.bzl", "formatjs_test")
@@ -33,7 +33,7 @@ ENTRY_POINTS = [
     "server.ts",
 ]
 
-formatjs_compile(
+formatjs_library(
     name = "dist",
     srcs = SRCS,
     entry_points = ENTRY_POINTS,

--- a/packages/svelte-intl/BUILD.bazel
+++ b/packages/svelte-intl/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:compile.bzl", "formatjs_library")
 load("//tools:package.bzl", "formatjs_package")
 load("//tools:test.bzl", "formatjs_test")
 
@@ -9,7 +9,7 @@ SRCS = glob([
     "*.ts",
 ])
 
-formatjs_compile(
+formatjs_library(
     name = "dist",
     srcs = SRCS,
     deps = [

--- a/packages/ts-transformer/BUILD.bazel
+++ b/packages/ts-transformer/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:compile.bzl", "formatjs_library")
 load("//tools:package.bzl", "formatjs_package")
 load("//tools:test.bzl", "formatjs_test")
 
@@ -25,7 +25,7 @@ SRCS = glob([
     "*.ts",
 ])
 
-formatjs_compile(
+formatjs_library(
     name = "dist",
     srcs = SRCS,
     deps = [

--- a/packages/unplugin/BUILD.bazel
+++ b/packages/unplugin/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:compile.bzl", "formatjs_library")
 load("//tools:package.bzl", "formatjs_package")
 load("//tools:test.bzl", "formatjs_test")
 load("//tools:tsconfig.bzl", "ESNEXT_SKIP_LIB_CHECK_TSCONFIG", "packages_tsconfig")
@@ -38,7 +38,7 @@ ENTRY_POINTS = [
     "transform.ts",
 ]
 
-formatjs_compile(
+formatjs_library(
     name = "dist",
     srcs = SRCS,
     entry_points = ENTRY_POINTS,

--- a/packages/utils/BUILD.bazel
+++ b/packages/utils/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:compile.bzl", "formatjs_library")
 load("//tools:index.bzl", "generate_src_file")
 load("//tools:package.bzl", "formatjs_package")
 load("//tools:test.bzl", "formatjs_test")
@@ -18,7 +18,7 @@ SRCS = glob([
     "*.ts",
 ])
 
-formatjs_compile(
+formatjs_library(
     name = "dist",
     srcs = SRCS,
     deps = ["//:node_modules/@formatjs/fast-memoize"],

--- a/packages/vue-intl/BUILD.bazel
+++ b/packages/vue-intl/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//tools:compile.bzl", "formatjs_compile")
+load("//tools:compile.bzl", "formatjs_library")
 load("//tools:package.bzl", "formatjs_package")
 load("//tools:test.bzl", "formatjs_test")
 
@@ -9,7 +9,7 @@ SRCS = glob([
     "*.ts",
 ])
 
-formatjs_compile(
+formatjs_library(
     name = "dist",
     srcs = SRCS,
     deps = [

--- a/tools/compile.bzl
+++ b/tools/compile.bzl
@@ -6,7 +6,7 @@ load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("//tools:rolldown.bzl", "rolldown_bundle")
 load("//tools:tsconfig.bzl", "packages_tsconfig")
 
-def formatjs_compile(
+def formatjs_library(
         name,
         srcs,
         deps = [],

--- a/tools/gazelle/ts/kinds.go
+++ b/tools/gazelle/ts/kinds.go
@@ -3,13 +3,13 @@ package ts
 import "github.com/bazelbuild/bazel-gazelle/rule"
 
 const (
-	KindFormatjsCompile = "formatjs_compile"
+	KindFormatjsLibrary = "formatjs_library"
 	KindFormatjsTest    = "formatjs_test"
 	KindTsCompile       = "ts_compile"
 )
 
 var tsKinds = map[string]rule.KindInfo{
-	KindFormatjsCompile: {
+	KindFormatjsLibrary: {
 		NonEmptyAttrs: map[string]bool{"name": true},
 		ResolveAttrs: map[string]bool{
 			"deps":               true,

--- a/tools/gazelle/ts/language.go
+++ b/tools/gazelle/ts/language.go
@@ -1,5 +1,5 @@
 // Package ts implements a Gazelle language extension for formatjs TypeScript packages.
-// It manages deps and project_references on formatjs_compile and formatjs_test targets
+// It manages deps and project_references on formatjs_library and formatjs_test targets
 // by parsing TypeScript imports and resolving them to Bazel labels.
 package ts
 
@@ -35,7 +35,7 @@ func (l *tsLang) Loads() []rule.LoadInfo {
 	return []rule.LoadInfo{
 		{
 			Name:    "//tools:compile.bzl",
-			Symbols: []string{KindFormatjsCompile},
+			Symbols: []string{KindFormatjsLibrary},
 		},
 		{
 			Name:    "//tools:test.bzl",
@@ -58,10 +58,10 @@ type ImportData struct {
 }
 
 // Imports returns the import specs that a rule provides, used to build the RuleIndex.
-// Both formatjs_compile and ts_compile rules provide their package path so other
+// Both formatjs_library and ts_compile rules provide their package path so other
 // packages can resolve #packages/* imports to project_references.
 func (l *tsLang) Imports(c *config.Config, r *rule.Rule, f *rule.File) []resolve.ImportSpec {
-	if r.Kind() != KindFormatjsCompile && r.Kind() != KindTsCompile {
+	if r.Kind() != KindFormatjsLibrary && r.Kind() != KindTsCompile {
 		return nil
 	}
 
@@ -76,7 +76,7 @@ func (l *tsLang) Imports(c *config.Config, r *rule.Rule, f *rule.File) []resolve
 func (l *tsLang) Embeds(r *rule.Rule, from label.Label) []label.Label { return nil }
 
 // GenerateRules scans TypeScript files and attaches import data to existing rules.
-// It does NOT create new rules — it only updates deps on existing formatjs_compile
+// It does NOT create new rules — it only updates deps on existing formatjs_library
 // and formatjs_test targets.
 func (l *tsLang) GenerateRules(args language.GenerateArgs) language.GenerateResult {
 	cfg, ok := args.Config.Exts[languageName].(*tsConfig)
@@ -121,7 +121,7 @@ func (l *tsLang) GenerateRules(args language.GenerateArgs) language.GenerateResu
 
 	for _, r := range args.File.Rules {
 		switch r.Kind() {
-		case KindFormatjsCompile:
+		case KindFormatjsLibrary:
 			newRule := rule.NewRule(r.Kind(), r.Name())
 			genRules = append(genRules, newRule)
 			genImports = append(genImports, ImportData{

--- a/tools/package.bzl
+++ b/tools/package.bzl
@@ -21,12 +21,12 @@ def formatjs_package(
     - package_exports_test
     - generate_ide_tsconfig_json()
 
-    Expects formatjs_compile to have been called first, producing
+    Expects formatjs_library to have been called first, producing
     "{entry}-bundle" targets for each entry point.
 
     Args:
         name: package name (e.g. "fast-memoize"), used as js_library target name
-        entry_points: list of .ts entry points (must match formatjs_compile's entry_points)
+        entry_points: list of .ts entry points (must match formatjs_library's entry_points)
         npm_package_name: npm package name for publishing (default "@formatjs/{name}")
         extra_npm_srcs: additional files for npm_package (iife bundles, locale-data, etc.)
         allow_overwrites: passed to npm_package (default False)


### PR DESCRIPTION
## Summary
- Rename `formatjs_compile` Bazel macro to `formatjs_library` across the entire repo
- Updates the macro definition in `tools/compile.bzl`, all 27 `packages/*/BUILD.bazel` files, the gazelle plugin Go code, and documentation

## Test plan
- [ ] `bazel build //...` passes
- [ ] `bazel test //...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)