### PR TITLE
refactor(deps): merge formatjs_package into formatjs_library

### DIFF
--- a/knowledge-base/migrations/001-gazelle-migration.md
+++ b/knowledge-base/migrations/001-gazelle-migration.md
@@ -1,6 +1,6 @@
 # Gazelle Migration Plan: Custom Macros to Stock Rules
 
-> **Status: COMPLETED.** Phases 1-3 below were superseded by 3 custom macros (`formatjs_library`, `formatjs_package`, `formatjs_test`) + a custom Go gazelle plugin at `tools/gazelle/ts/`. See `knowledge-base/001a-bazel-toolchain.md`.
+> **Status: COMPLETED.** Phases 1-3 below were superseded by 2 custom macros (`formatjs_library`, `formatjs_test`) + a custom Go gazelle plugin at `tools/gazelle/ts/`. See `knowledge-base/001a-bazel-toolchain.md`.
 
 ## Goal
 

--- a/packages/babel-plugin-formatjs/BUILD.bazel
+++ b/packages/babel-plugin-formatjs/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:compile.bzl", "formatjs_library")
-load("//tools:package.bzl", "formatjs_package")
 load("//tools:test.bzl", "formatjs_test")
 
 npm_link_all_packages()
@@ -13,28 +12,12 @@ SRCS = glob(
 formatjs_library(
     name = "dist",
     srcs = SRCS,
-    deps = [
-        "//:node_modules/@babel/core",
-        "//:node_modules/@babel/helper-plugin-utils",
-        "//:node_modules/@babel/plugin-syntax-jsx",
-        "//:node_modules/@babel/traverse",  # keep: imported from visitors/
-        "//:node_modules/@babel/types",
-        "//:node_modules/@formatjs/icu-messageformat-parser",
-        "//:node_modules/@formatjs/ts-transformer",
-        "//:node_modules/@types/babel__core",
-        "//:node_modules/@types/babel__helper-plugin-utils",
-        "//:node_modules/@types/babel__traverse",
-    ],
-)
-
-formatjs_package(
-    name = "babel-plugin-formatjs",
     npm_package_name = "babel-plugin-formatjs",
     deps = [
         "//:node_modules/@babel/core",
         "//:node_modules/@babel/helper-plugin-utils",
         "//:node_modules/@babel/plugin-syntax-jsx",
-        "//:node_modules/@babel/traverse",
+        "//:node_modules/@babel/traverse",  # keep: imported from visitors/
         "//:node_modules/@babel/types",
         "//:node_modules/@formatjs/icu-messageformat-parser",
         "//:node_modules/@formatjs/ts-transformer",

--- a/packages/bigdecimal/BUILD.bazel
+++ b/packages/bigdecimal/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:compile.bzl", "formatjs_library")
-load("//tools:package.bzl", "formatjs_package")
 load("//tools:test.bzl", "formatjs_test")
 load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
 
@@ -18,10 +17,6 @@ formatjs_library(
     name = "dist",
     srcs = SRCS,
     tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
-)
-
-formatjs_package(
-    name = "bigdecimal",
 )
 
 formatjs_test(

--- a/packages/cli-lib/BUILD.bazel
+++ b/packages/cli-lib/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:compile.bzl", "formatjs_library")
-load("//tools:package.bzl", "formatjs_package")
 load("//tools:rolldown.bzl", "rolldown_bundle")
 load("//tools:test.bzl", "formatjs_test")
 
@@ -26,30 +25,6 @@ formatjs_library(
         "//:node_modules/@formatjs/icu-messageformat-parser",
         "//:node_modules/@formatjs/ts-transformer",
         "//:node_modules/@glimmer/syntax",
-        "//:node_modules/@types/fs-extra",
-        "//:node_modules/@types/node",
-        "//:node_modules/@vue/compiler-core",
-        "//:node_modules/commander",
-        "//:node_modules/content-tag",
-        "//:node_modules/fast-glob",
-        "//:node_modules/fs-extra",
-        "//:node_modules/json-stable-stringify",
-        "//:node_modules/loud-rejection",
-        "//:node_modules/svelte",
-        "//:node_modules/typescript",
-        "//:node_modules/vue",
-    ],
-)
-
-formatjs_package(
-    name = PACKAGE_NAME,
-    deps = [
-        "//:node_modules/@babel/types",
-        "//:node_modules/@formatjs/icu-messageformat-parser",
-        "//:node_modules/@formatjs/icu-skeleton-parser",
-        "//:node_modules/@formatjs/ts-transformer",
-        "//:node_modules/@glimmer/syntax",
-        "//:node_modules/@types/estree",
         "//:node_modules/@types/fs-extra",
         "//:node_modules/@types/node",
         "//:node_modules/@vue/compiler-core",

--- a/packages/ecma376/BUILD.bazel
+++ b/packages/ecma376/BUILD.bazel
@@ -1,5 +1,4 @@
 load("//tools:compile.bzl", "formatjs_library")
-load("//tools:package.bzl", "formatjs_package")
 load("//tools:test.bzl", "formatjs_test")
 
 exports_files([
@@ -16,10 +15,6 @@ SRC_DEPS = [
 formatjs_library(
     name = "dist",
     srcs = SRCS,
-)
-
-formatjs_package(
-    name = "ecma376",
 )
 
 formatjs_test(

--- a/packages/fast-memoize/BUILD.bazel
+++ b/packages/fast-memoize/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:compile.bzl", "formatjs_library")
-load("//tools:package.bzl", "formatjs_package")
 
 npm_link_all_packages()
 
@@ -15,8 +14,4 @@ SRCS = glob([
 formatjs_library(
     name = "dist",
     srcs = SRCS,
-)
-
-formatjs_package(
-    name = "fast-memoize",
 )

--- a/packages/icu-messageformat-parser/BUILD.bazel
+++ b/packages/icu-messageformat-parser/BUILD.bazel
@@ -1,7 +1,6 @@
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:compile.bzl", "formatjs_library")
 load("//tools:index.bzl", "generate_src_file")
-load("//tools:package.bzl", "formatjs_package")
 load("//tools:test.bzl", "formatjs_test")
 load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
 
@@ -27,16 +26,6 @@ formatjs_library(
     project_references = ["//packages/ecma402-abstract/types"],
     types = True,
     deps = ["//:node_modules/@formatjs/icu-skeleton-parser"],
-)
-
-formatjs_package(
-    name = "icu-messageformat-parser",
-    entry_points = ENTRY_POINTS,
-    deps = [
-        "//:node_modules/@formatjs/icu-skeleton-parser",
-        "//packages/ecma402-abstract",
-        "//packages/ecma402-abstract/types",
-    ],
 )
 
 formatjs_test(

--- a/packages/icu-skeleton-parser/BUILD.bazel
+++ b/packages/icu-skeleton-parser/BUILD.bazel
@@ -1,7 +1,6 @@
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:compile.bzl", "formatjs_library")
 load("//tools:index.bzl", "generate_src_file")
-load("//tools:package.bzl", "formatjs_package")
 load("//tools:test.bzl", "formatjs_test")
 load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
 
@@ -14,14 +13,6 @@ formatjs_library(
     srcs = SRCS,
     project_references = ["//packages/ecma402-abstract/types"],
     types = True,
-)
-
-formatjs_package(
-    name = "icu-skeleton-parser",
-    deps = [
-        "//packages/ecma402-abstract",
-        "//packages/ecma402-abstract/types",
-    ],
 )
 
 formatjs_test(

--- a/packages/intl-datetimeformat/BUILD.bazel
+++ b/packages/intl-datetimeformat/BUILD.bazel
@@ -5,7 +5,6 @@ load("@rules_multirun//:defs.bzl", "multirun")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("//tools:compile.bzl", "formatjs_library")
 load("//tools:index.bzl", "generate_src_file", "ts_run_binary")
-load("//tools:package.bzl", "formatjs_package")
 load("//tools:rolldown.bzl", "rolldown_bundle")
 load("//tools:test.bzl", "formatjs_test")
 load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
@@ -72,6 +71,14 @@ formatjs_library(
     name = "dist",
     srcs = SRCS,
     entry_points = ENTRY_POINTS,
+    extra_npm_srcs = [
+        "add-all-tz.d.ts",
+        "add-all-tz.js",
+        "add-golden-tz.d.ts",
+        "add-golden-tz.js",
+        ":locale-data",
+        "polyfill.iife.js",
+    ],
     project_references = [
         "//packages/ecma262-abstract",
         "//packages/ecma402-abstract",
@@ -82,28 +89,6 @@ formatjs_library(
     deps = [
         "//:node_modules/@formatjs/bigdecimal",
         "//:node_modules/@formatjs/intl-localematcher",
-    ],
-)
-
-formatjs_package(
-    name = PACKAGE_NAME,
-    entry_points = ENTRY_POINTS,
-    extra_npm_srcs = [
-        "add-all-tz.d.ts",
-        "add-all-tz.js",
-        "add-golden-tz.d.ts",
-        "add-golden-tz.js",
-        ":locale-data",
-        # polyfill-library uses this
-        "polyfill.iife.js",
-    ],
-    deps = [
-        "//:node_modules/@formatjs/bigdecimal",
-        "//:node_modules/@formatjs/intl-localematcher",
-        "//packages/ecma262-abstract",
-        "//packages/ecma402-abstract",
-        "//packages/ecma402-abstract/DateTimeFormat",
-        "//packages/ecma402-abstract/types",
     ],
 )
 

--- a/packages/intl-displaynames/BUILD.bazel
+++ b/packages/intl-displaynames/BUILD.bazel
@@ -3,7 +3,6 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
 load("//tools:compile.bzl", "formatjs_library")
 load("//tools:index.bzl", "generate_src_file", "ts_run_binary")
-load("//tools:package.bzl", "formatjs_package")
 load("//tools:rolldown.bzl", "rolldown_bundle")
 load("//tools:test.bzl", "formatjs_test")
 load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
@@ -41,6 +40,10 @@ formatjs_library(
     name = "dist",
     srcs = SRCS,
     entry_points = ENTRY_POINTS,
+    extra_npm_srcs = [
+        ":locale-data",
+        "polyfill.iife.js",
+    ],
     project_references = [
         "//packages/ecma262-abstract",
         "//packages/ecma402-abstract",
@@ -49,23 +52,6 @@ formatjs_library(
     ],
     types = True,
     deps = ["//:node_modules/@formatjs/intl-localematcher"],
-)
-
-formatjs_package(
-    name = PACKAGE_NAME,
-    entry_points = ENTRY_POINTS,
-    extra_npm_srcs = [
-        ":locale-data",
-        # polyfill-library uses this
-        "polyfill.iife.js",
-    ],
-    deps = [
-        "//:node_modules/@formatjs/intl-localematcher",
-        "//packages/ecma262-abstract",
-        "//packages/ecma402-abstract",
-        "//packages/ecma402-abstract/DisplayNames",
-        "//packages/ecma402-abstract/types",
-    ],
 )
 
 formatjs_test(

--- a/packages/intl-durationformat/BUILD.bazel
+++ b/packages/intl-durationformat/BUILD.bazel
@@ -2,7 +2,6 @@ load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:compile.bzl", "formatjs_library")
 load("//tools:index.bzl", "generate_src_file")
-load("//tools:package.bzl", "formatjs_package")
 load("//tools:test.bzl", "formatjs_test")
 load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
 
@@ -36,18 +35,6 @@ formatjs_library(
     ],
     types = True,
     deps = ["//:node_modules/@formatjs/intl-localematcher"],
-)
-
-formatjs_package(
-    name = PACKAGE_NAME,
-    entry_points = ENTRY_POINTS,
-    deps = [
-        "//:node_modules/@formatjs/intl-localematcher",
-        "//packages/ecma262-abstract",
-        "//packages/ecma402-abstract",
-        "//packages/ecma402-abstract/DurationFormat",
-        "//packages/ecma402-abstract/types",
-    ],
 )
 
 formatjs_test(

--- a/packages/intl-getcanonicallocales/BUILD.bazel
+++ b/packages/intl-getcanonicallocales/BUILD.bazel
@@ -1,7 +1,6 @@
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:compile.bzl", "formatjs_library")
 load("//tools:index.bzl", "generate_src_file")
-load("//tools:package.bzl", "formatjs_package")
 load("//tools:rolldown.bzl", "rolldown_bundle")
 load("//tools:test.bzl", "formatjs_test")
 
@@ -35,15 +34,7 @@ formatjs_library(
     name = "dist",
     srcs = SRCS,
     entry_points = ENTRY_POINTS,
-)
-
-formatjs_package(
-    name = PACKAGE_NAME,
-    entry_points = ENTRY_POINTS,
-    extra_npm_srcs = [
-        # polyfill-library uses this
-        "polyfill.iife.js",
-    ],
+    extra_npm_srcs = ["polyfill.iife.js"],
 )
 
 TESTS = glob([

--- a/packages/intl-listformat/BUILD.bazel
+++ b/packages/intl-listformat/BUILD.bazel
@@ -3,7 +3,6 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
 load("//tools:compile.bzl", "formatjs_library")
 load("//tools:index.bzl", "generate_src_file", "ts_run_binary")
-load("//tools:package.bzl", "formatjs_package")
 load("//tools:rolldown.bzl", "rolldown_bundle")
 load("//tools:test.bzl", "formatjs_test")
 load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
@@ -44,27 +43,16 @@ formatjs_library(
     name = "dist",
     srcs = SRCS,
     entry_points = ENTRY_POINTS,
+    extra_npm_srcs = [
+        ":locale-data",
+        "polyfill.iife.js",
+    ],
     project_references = [
         "//packages/ecma402-abstract",
         "//packages/ecma402-abstract/types",
     ],
     types = True,
     deps = ["//:node_modules/@formatjs/intl-localematcher"],
-)
-
-formatjs_package(
-    name = PACKAGE_NAME,
-    entry_points = ENTRY_POINTS,
-    extra_npm_srcs = [
-        ":locale-data",
-        # polyfill-library uses this
-        "polyfill.iife.js",
-    ],
-    deps = [
-        "//:node_modules/@formatjs/intl-localematcher",
-        "//packages/ecma402-abstract",
-        "//packages/ecma402-abstract/types",
-    ],
 )
 
 formatjs_test(

--- a/packages/intl-locale/BUILD.bazel
+++ b/packages/intl-locale/BUILD.bazel
@@ -2,7 +2,6 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
 load("//tools:compile.bzl", "formatjs_library")
 load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file")
-load("//tools:package.bzl", "formatjs_package")
 load("//tools:rolldown.bzl", "rolldown_bundle")
 load("//tools:test.bzl", "formatjs_test")
 
@@ -23,6 +22,7 @@ formatjs_library(
     name = "dist",
     srcs = SRCS,
     entry_points = ENTRY_POINTS,
+    extra_npm_srcs = ["polyfill.iife.js"],
     project_references = [
         "//packages/ecma262-abstract",
         "//packages/ecma402-abstract",
@@ -31,22 +31,6 @@ formatjs_library(
     deps = [
         "//:node_modules/@formatjs/intl-getcanonicallocales",
         "//:node_modules/@formatjs/intl-supportedvaluesof",
-    ],
-)
-
-formatjs_package(
-    name = PACKAGE_NAME,
-    entry_points = ENTRY_POINTS,
-    extra_npm_srcs = [
-        "polyfill.iife.js",
-    ],
-    deps = [
-        "//:node_modules/@formatjs/intl-getcanonicallocales",
-        "//:node_modules/@formatjs/intl-supportedvaluesof",
-        "//:node_modules/cldr-bcp47",
-        "//:node_modules/cldr-core",
-        "//packages/ecma262-abstract",
-        "//packages/ecma402-abstract",
     ],
 )
 

--- a/packages/intl-localematcher/BUILD.bazel
+++ b/packages/intl-localematcher/BUILD.bazel
@@ -1,7 +1,6 @@
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:compile.bzl", "formatjs_library")
 load("//tools:index.bzl", "generate_src_file")
-load("//tools:package.bzl", "formatjs_package")
 load("//tools:test.bzl", "formatjs_test")
 
 npm_link_all_packages()
@@ -16,13 +15,6 @@ formatjs_library(
     srcs = SRCS,
     deps = [
         "//:node_modules/@formatjs/fast-memoize",  # keep: imported from abstract/
-    ],
-)
-
-formatjs_package(
-    name = "intl-localematcher",
-    deps = [
-        "//:node_modules/@formatjs/fast-memoize",
     ],
 )
 

--- a/packages/intl-messageformat/BUILD.bazel
+++ b/packages/intl-messageformat/BUILD.bazel
@@ -1,7 +1,6 @@
 load("@aspect_rules_js//js:defs.bzl", "js_binary")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:compile.bzl", "formatjs_library")
-load("//tools:package.bzl", "formatjs_package")
 load("//tools:rolldown.bzl", "rolldown_bundle")
 load("//tools:test.bzl", "formatjs_test")
 load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
@@ -28,26 +27,13 @@ formatjs_library(
     name = "dist",
     srcs = SRCS,
     entry_points = ENTRY_POINTS,
+    extra_npm_srcs = ["%s.iife.js" % PACKAGE_NAME],
+    npm_package_name = PACKAGE_NAME,
     project_references = ["//packages/ecma402-abstract/types"],
     types = True,
     deps = [
         "//:node_modules/@formatjs/fast-memoize",
         "//:node_modules/@formatjs/icu-messageformat-parser",
-    ],
-)
-
-formatjs_package(
-    name = PACKAGE_NAME,
-    entry_points = ENTRY_POINTS,
-    extra_npm_srcs = [
-        "%s.iife.js" % PACKAGE_NAME,
-    ],
-    npm_package_name = PACKAGE_NAME,
-    deps = [
-        "//:node_modules/@formatjs/fast-memoize",
-        "//:node_modules/@formatjs/icu-messageformat-parser",
-        "//packages/ecma402-abstract",
-        "//packages/ecma402-abstract/types",
     ],
 )
 

--- a/packages/intl-numberformat/BUILD.bazel
+++ b/packages/intl-numberformat/BUILD.bazel
@@ -5,7 +5,6 @@ load("@rules_multirun//:defs.bzl", "multirun")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("//tools:compile.bzl", "formatjs_library")
 load("//tools:index.bzl", "generate_src_file", "ts_run_binary")
-load("//tools:package.bzl", "formatjs_package")
 load("//tools:rolldown.bzl", "rolldown_bundle")
 load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
@@ -91,6 +90,10 @@ formatjs_library(
     name = "dist",
     srcs = SRCS,
     entry_points = ENTRY_POINTS,
+    extra_npm_srcs = [
+        ":locale-data",
+        "polyfill.iife.js",
+    ],
     project_references = [
         "//packages/ecma262-abstract",
         "//packages/ecma402-abstract",
@@ -101,24 +104,6 @@ formatjs_library(
     deps = [
         "//:node_modules/@formatjs/bigdecimal",
         "//:node_modules/@formatjs/intl-localematcher",
-    ],
-)
-
-formatjs_package(
-    name = PACKAGE_NAME,
-    entry_points = ENTRY_POINTS,
-    extra_npm_srcs = [
-        ":locale-data",
-        # polyfill-library uses this
-        "polyfill.iife.js",
-    ],
-    deps = [
-        "//:node_modules/@formatjs/bigdecimal",
-        "//:node_modules/@formatjs/intl-localematcher",
-        "//packages/ecma262-abstract",
-        "//packages/ecma402-abstract",
-        "//packages/ecma402-abstract/NumberFormat",
-        "//packages/ecma402-abstract/types",
     ],
 )
 

--- a/packages/intl-pluralrules/BUILD.bazel
+++ b/packages/intl-pluralrules/BUILD.bazel
@@ -3,7 +3,6 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
 load("//tools:compile.bzl", "formatjs_library")
 load("//tools:index.bzl", "generate_src_file", "ts_run_binary")
-load("//tools:package.bzl", "formatjs_package")
 load("//tools:rolldown.bzl", "rolldown_bundle")
 load("//tools:test.bzl", "formatjs_test")
 load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
@@ -260,6 +259,10 @@ formatjs_library(
     name = "dist",
     srcs = SRCS,
     entry_points = ENTRY_POINTS,
+    extra_npm_srcs = [
+        ":locale-data",
+        "polyfill.iife.js",
+    ],
     project_references = [
         "//packages/ecma402-abstract",
         "//packages/ecma402-abstract/PluralRules",
@@ -269,24 +272,6 @@ formatjs_library(
     deps = [
         "//:node_modules/@formatjs/bigdecimal",
         "//:node_modules/@formatjs/intl-localematcher",
-    ],
-)
-
-formatjs_package(
-    name = PACKAGE_NAME,
-    entry_points = ENTRY_POINTS,
-    extra_npm_srcs = [
-        ":locale-data",
-        # polyfill-library uses this
-        "polyfill.iife.js",
-    ],
-    deps = [
-        "//:node_modules/@formatjs/bigdecimal",
-        "//:node_modules/@formatjs/intl-localematcher",
-        "//packages/ecma402-abstract",
-        "//packages/ecma402-abstract/NumberFormat",
-        "//packages/ecma402-abstract/PluralRules",
-        "//packages/ecma402-abstract/types",
     ],
 )
 

--- a/packages/intl-relativetimeformat/BUILD.bazel
+++ b/packages/intl-relativetimeformat/BUILD.bazel
@@ -3,7 +3,6 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
 load("//tools:compile.bzl", "formatjs_library")
 load("//tools:index.bzl", "generate_src_file", "ts_run_binary")
-load("//tools:package.bzl", "formatjs_package")
 load("//tools:rolldown.bzl", "rolldown_bundle")
 load("//tools:test.bzl", "formatjs_test")
 load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
@@ -44,6 +43,10 @@ formatjs_library(
     name = "dist",
     srcs = SRCS,
     entry_points = ENTRY_POINTS,
+    extra_npm_srcs = [
+        ":locale-data",
+        "polyfill.iife.js",
+    ],
     project_references = [
         "//packages/ecma262-abstract",
         "//packages/ecma402-abstract",
@@ -52,23 +55,6 @@ formatjs_library(
     ],
     types = True,
     deps = ["//:node_modules/@formatjs/intl-localematcher"],
-)
-
-formatjs_package(
-    name = PACKAGE_NAME,
-    entry_points = ENTRY_POINTS,
-    extra_npm_srcs = [
-        ":locale-data",
-        # polyfill-library uses this
-        "polyfill.iife.js",
-    ],
-    deps = [
-        "//:node_modules/@formatjs/intl-localematcher",
-        "//packages/ecma262-abstract",
-        "//packages/ecma402-abstract",
-        "//packages/ecma402-abstract/RelativeTimeFormat",
-        "//packages/ecma402-abstract/types",
-    ],
 )
 
 formatjs_test(

--- a/packages/intl-segmenter/BUILD.bazel
+++ b/packages/intl-segmenter/BUILD.bazel
@@ -4,7 +4,6 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
 load("//tools:compile.bzl", "formatjs_library")
 load("//tools:index.bzl", "generate_src_file")
-load("//tools:package.bzl", "formatjs_package")
 load("//tools:rolldown.bzl", "rolldown_bundle")
 load("//tools:test.bzl", "formatjs_test")
 load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
@@ -65,24 +64,12 @@ formatjs_library(
     name = "dist",
     srcs = SRCS,
     entry_points = ENTRY_POINTS,
+    extra_npm_srcs = ["polyfill.iife.js"],
     project_references = ["//packages/ecma402-abstract"],
     types = True,
     deps = [
         "//:node_modules/@formatjs/intl-localematcher",
         "//:node_modules/tinybench",
-    ],
-)
-
-formatjs_package(
-    name = PACKAGE_NAME,
-    entry_points = ENTRY_POINTS,
-    extra_npm_srcs = [
-        # polyfill-library uses this
-        "polyfill.iife.js",
-    ],
-    deps = [
-        "//:node_modules/@formatjs/intl-localematcher",
-        "//packages/ecma402-abstract",
     ],
 )
 

--- a/packages/intl-supportedvaluesof/BUILD.bazel
+++ b/packages/intl-supportedvaluesof/BUILD.bazel
@@ -3,7 +3,6 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//packages/intl-datetimeformat:defs.bzl", "ZONES")
 load("//tools:compile.bzl", "formatjs_library")
 load("//tools:index.bzl", "generate_src_file")
-load("//tools:package.bzl", "formatjs_package")
 load("//tools:rolldown.bzl", "rolldown_bundle")
 load("//tools:test.bzl", "formatjs_test")
 load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
@@ -38,22 +37,10 @@ formatjs_library(
     name = "dist",
     srcs = SRCS,
     entry_points = ENTRY_POINTS,
+    extra_npm_srcs = ["polyfill.iife.js"],
     project_references = ["//packages/ecma402-abstract"],
     types = True,
     deps = ["//:node_modules/@formatjs/fast-memoize"],
-)
-
-formatjs_package(
-    name = PACKAGE_NAME,
-    entry_points = ENTRY_POINTS,
-    extra_npm_srcs = [
-        # polyfill-library uses this
-        "polyfill.iife.js",
-    ],
-    deps = [
-        "//:node_modules/@formatjs/fast-memoize",
-        "//packages/ecma402-abstract",
-    ],
 )
 
 formatjs_test(

--- a/packages/intl/BUILD.bazel
+++ b/packages/intl/BUILD.bazel
@@ -2,7 +2,6 @@ load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:tsd/package_json.bzl", tsd_bin = "bin")
 load("//tools:compile.bzl", "formatjs_library")
-load("//tools:package.bzl", "formatjs_package")
 load("//tools:test.bzl", "formatjs_test")
 load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
 
@@ -33,6 +32,7 @@ ENTRY_POINTS = [
 formatjs_library(
     name = "dist",
     srcs = SRCS,
+    allow_overwrites = True,
     entry_points = ENTRY_POINTS,
     project_references = ["//packages/ecma402-abstract/types"],
     types = True,
@@ -40,19 +40,6 @@ formatjs_library(
         "//:node_modules/@formatjs/fast-memoize",
         "//:node_modules/@formatjs/icu-messageformat-parser",
         "//:node_modules/intl-messageformat",
-    ],
-)
-
-formatjs_package(
-    name = PACKAGE_NAME,
-    allow_overwrites = True,
-    entry_points = ENTRY_POINTS,
-    deps = [
-        "//:node_modules/@formatjs/fast-memoize",
-        "//:node_modules/@formatjs/icu-messageformat-parser",
-        "//:node_modules/intl-messageformat",
-        "//packages/ecma402-abstract",
-        "//packages/ecma402-abstract/types",
     ],
 )
 

--- a/packages/react-intl/BUILD.bazel
+++ b/packages/react-intl/BUILD.bazel
@@ -2,7 +2,6 @@ load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:tsd/package_json.bzl", tsd_bin = "bin")
 load("//tools:compile.bzl", "formatjs_library")
-load("//tools:package.bzl", "formatjs_package")
 load("//tools:rolldown.bzl", "rolldown_bundle")
 load("//tools:test.bzl", "formatjs_test")
 load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
@@ -37,6 +36,8 @@ formatjs_library(
     name = "dist",
     srcs = SRCS,
     entry_points = ENTRY_POINTS,
+    extra_npm_srcs = ["%s.iife.js" % PACKAGE_NAME],
+    npm_package_name = PACKAGE_NAME,
     project_references = ["//packages/ecma402-abstract/types"],
     types = True,
     deps = [
@@ -45,24 +46,6 @@ formatjs_library(
         "//:node_modules/@types/react",
         "//:node_modules/intl-messageformat",
         "//:node_modules/react",
-    ],
-)
-
-formatjs_package(
-    name = PACKAGE_NAME,
-    entry_points = ENTRY_POINTS,
-    extra_npm_srcs = [
-        "%s.iife.js" % PACKAGE_NAME,
-    ],
-    npm_package_name = PACKAGE_NAME,
-    deps = [
-        "//:node_modules/@formatjs/icu-messageformat-parser",
-        "//:node_modules/@formatjs/intl",
-        "//:node_modules/@types/react",
-        "//:node_modules/intl-messageformat",
-        "//:node_modules/react",
-        "//packages/ecma402-abstract",
-        "//packages/ecma402-abstract/types",
     ],
 )
 

--- a/packages/svelte-intl/BUILD.bazel
+++ b/packages/svelte-intl/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:compile.bzl", "formatjs_library")
-load("//tools:package.bzl", "formatjs_package")
 load("//tools:test.bzl", "formatjs_test")
 
 npm_link_all_packages()
@@ -16,16 +15,6 @@ formatjs_library(
         "//:node_modules/@formatjs/icu-messageformat-parser",
         "//:node_modules/@formatjs/intl",
         "//:node_modules/svelte",
-    ],
-)
-
-formatjs_package(
-    name = "svelte-intl",
-    deps = [
-        "//:node_modules/@formatjs/icu-messageformat-parser",
-        "//:node_modules/@formatjs/intl",
-        "//:node_modules/svelte",
-        "//:node_modules/typescript",
     ],
 )
 

--- a/packages/ts-transformer/BUILD.bazel
+++ b/packages/ts-transformer/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:compile.bzl", "formatjs_library")
-load("//tools:package.bzl", "formatjs_package")
 load("//tools:test.bzl", "formatjs_test")
 
 npm_link_all_packages()
@@ -31,19 +30,6 @@ formatjs_library(
     deps = [
         "//:node_modules/@formatjs/icu-messageformat-parser",
         "//:node_modules/@types/babel__core",  # keep: transitive type dep required by ts-jest
-        "//:node_modules/@types/node",
-        "//:node_modules/json-stable-stringify",
-        "//:node_modules/ts-jest",
-        "//:node_modules/typescript",
-    ],
-)
-
-formatjs_package(
-    name = PACKAGE_NAME,
-    deps = [
-        "//:node_modules/@babel/core",
-        "//:node_modules/@formatjs/icu-messageformat-parser",
-        "//:node_modules/@types/babel__core",
         "//:node_modules/@types/node",
         "//:node_modules/json-stable-stringify",
         "//:node_modules/ts-jest",

--- a/packages/unplugin/BUILD.bazel
+++ b/packages/unplugin/BUILD.bazel
@@ -1,7 +1,6 @@
 load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:compile.bzl", "formatjs_library")
-load("//tools:package.bzl", "formatjs_package")
 load("//tools:test.bzl", "formatjs_test")
 load("//tools:tsconfig.bzl", "ESNEXT_SKIP_LIB_CHECK_TSCONFIG", "packages_tsconfig")
 load("//tools:vitest.bzl", "vitest")
@@ -51,21 +50,6 @@ formatjs_library(
         "//:node_modules/magic-string",
         "//:node_modules/oxc-parser",
         "//:node_modules/unplugin",
-    ],
-)
-
-formatjs_package(
-    name = "unplugin",
-    entry_points = ENTRY_POINTS,
-    npm_package_name = PACKAGE_NAME,
-    deps = [
-        "//:node_modules/@formatjs/icu-messageformat-parser",
-        "//:node_modules/@formatjs/ts-transformer",
-        "//:node_modules/@types/node",
-        "//:node_modules/magic-string",
-        "//:node_modules/oxc-parser",
-        "//:node_modules/unplugin",
-        "//:node_modules/vite",
     ],
 )
 

--- a/packages/utils/BUILD.bazel
+++ b/packages/utils/BUILD.bazel
@@ -2,7 +2,6 @@ load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:compile.bzl", "formatjs_library")
 load("//tools:index.bzl", "generate_src_file")
-load("//tools:package.bzl", "formatjs_package")
 load("//tools:test.bzl", "formatjs_test")
 
 npm_link_all_packages()
@@ -22,13 +21,6 @@ formatjs_library(
     name = "dist",
     srcs = SRCS,
     deps = ["//:node_modules/@formatjs/fast-memoize"],
-)
-
-formatjs_package(
-    name = "utils",
-    deps = [
-        "//:node_modules/@formatjs/fast-memoize",
-    ],
 )
 
 formatjs_test(

--- a/packages/vue-intl/BUILD.bazel
+++ b/packages/vue-intl/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:compile.bzl", "formatjs_library")
-load("//tools:package.bzl", "formatjs_package")
 load("//tools:test.bzl", "formatjs_test")
 
 npm_link_all_packages()
@@ -12,18 +11,8 @@ SRCS = glob([
 formatjs_library(
     name = "dist",
     srcs = SRCS,
-    deps = [
-        "//:node_modules/@formatjs/icu-messageformat-parser",
-        "//:node_modules/@formatjs/intl",
-        "//:node_modules/vue",
-    ],
-)
-
-formatjs_package(
-    name = "vue-intl",
     npm_package_name = "vue-intl",
     deps = [
-        "//:node_modules/@babel/types",
         "//:node_modules/@formatjs/icu-messageformat-parser",
         "//:node_modules/@formatjs/intl",
         "//:node_modules/vue",

--- a/tools/compile.bzl
+++ b/tools/compile.bzl
@@ -1,10 +1,76 @@
-"Macro for TypeScript compilation + rolldown bundling."
+"Macro for TypeScript compilation + rolldown bundling + npm packaging."
 
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
+load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "no_internal_imports_test", "package_exports_test", "package_json_test")
 load("//tools:rolldown.bzl", "rolldown_bundle")
 load("//tools:tsconfig.bzl", "packages_tsconfig")
+
+def _formatjs_package(
+        package_name,
+        entry_points,
+        npm_package_name,
+        extra_npm_srcs,
+        allow_overwrites):
+    """npm packaging + validation tests (private).
+
+    Generates:
+    - js_library(name = {package_name}) with bundles + package.json
+    - npm_package(name = "pkg")
+    - no_internal_imports_test
+    - package_json_test
+    - package_exports_test
+    - generate_ide_tsconfig_json()
+    """
+    effective_npm_name = npm_package_name or ("@formatjs/%s" % package_name)
+
+    bundles = [":%s-bundle" % entry.replace(".ts", "") for entry in entry_points]
+    replace_prefixes = {
+        "%s-bundle/" % entry.replace(".ts", ""): ""
+        for entry in entry_points
+    }
+
+    js_library(
+        name = package_name,
+        srcs = bundles + ["package.json"],
+        visibility = ["//visibility:public"],
+    )
+
+    npm_pkg_kwargs = {}
+    if allow_overwrites:
+        npm_pkg_kwargs["allow_overwrites"] = True
+
+    npm_package(
+        name = "pkg",
+        srcs = [
+            "LICENSE.md",
+            "README.md",
+            "package.json",
+        ] + bundles + extra_npm_srcs,
+        package = effective_npm_name,
+        replace_prefixes = replace_prefixes,
+        visibility = ["//visibility:public"],
+        **npm_pkg_kwargs
+    )
+
+    no_internal_imports_test(
+        name = "no_internal_imports_test",
+        data = bundles,
+    )
+
+    package_json_test(
+        name = "package_json_test",
+    )
+
+    package_exports_test(
+        name = "package_exports_test",
+        pkg = ":pkg",
+    )
+
+    generate_ide_tsconfig_json()
 
 def formatjs_library(
         name,
@@ -13,14 +79,18 @@ def formatjs_library(
         project_references = [],
         entry_points = ["index.ts"],
         types = False,
-        tsconfig = None):
-    """TypeScript compilation + rolldown bundling.
+        tsconfig = None,
+        npm_package_name = None,
+        extra_npm_srcs = [],
+        allow_overwrites = False):
+    """TypeScript compilation + rolldown bundling + optional npm packaging.
 
     Generates:
     - copy_to_bin(name = "srcs") for sandbox compatibility
     - ts_project(name = "typecheck") for type checking (tsgo, no emit)
     - rolldown_bundle per entry point (dts=True, esm, es2020)
     - Optionally ts_project(name = "types") with emit_declaration_only
+    - If package.json exists: js_library, npm_package, and validation tests
 
     Args:
         name: target name (e.g. "dist")
@@ -30,6 +100,9 @@ def formatjs_library(
         entry_points: list of .ts entry points to bundle
         types: if True, generate a "types" ts_project with emit_declaration_only
         tsconfig: optional tsconfig dict override (defaults to packages_tsconfig())
+        npm_package_name: npm package name for publishing (default "@formatjs/{dir_name}")
+        extra_npm_srcs: additional files for npm_package (iife bundles, locale-data, etc.)
+        allow_overwrites: passed to npm_package (default False)
     """
     all_deps = deps + project_references
     effective_tsconfig = tsconfig or packages_tsconfig()
@@ -81,4 +154,15 @@ def formatjs_library(
             tsconfig = effective_tsconfig,
             visibility = ["//visibility:public"],
             deps = all_deps,
+        )
+
+    # Auto-generate npm packaging if package.json exists
+    if native.glob(["package.json"], allow_empty = True):
+        package_dir_name = native.package_name().split("/")[-1]
+        _formatjs_package(
+            package_name = package_dir_name,
+            entry_points = entry_points,
+            npm_package_name = npm_package_name,
+            extra_npm_srcs = extra_npm_srcs,
+            allow_overwrites = allow_overwrites,
         )


### PR DESCRIPTION
## Summary
- Merge `formatjs_package` into `formatjs_library` as a private `_formatjs_package` helper
- `formatjs_library` now auto-generates npm packaging (js_library, npm_package, validation tests) when `package.json` exists in the source directory
- Remove all standalone `formatjs_package()` calls from BUILD.bazel files (~250 lines removed)
- Packaging params (`npm_package_name`, `extra_npm_srcs`, `allow_overwrites`) are now optional args on `formatjs_library`

Stacked on #6342.

## Test plan
- [ ] `bazel build //...` passes
- [ ] `bazel test //...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)