### PR TITLE
refactor(deps): expose js_library from formatjs_library, use in tests

### DIFF
--- a/packages/babel-plugin-formatjs/BUILD.bazel
+++ b/packages/babel-plugin-formatjs/BUILD.bazel
@@ -29,7 +29,7 @@ formatjs_library(
 
 formatjs_test(
     name = "unit_test",
-    srcs = SRCS + glob(
+    srcs = glob(
         [
             "tests/**/*.test.ts",
         ],

--- a/packages/bigdecimal/BUILD.bazel
+++ b/packages/bigdecimal/BUILD.bazel
@@ -21,7 +21,7 @@ formatjs_library(
 
 formatjs_test(
     name = "unit_test",
-    srcs = SRCS + glob([
+    srcs = glob([
         "tests/*.test.ts",
     ]),
     test_deps = ["//:node_modules/vitest"],

--- a/packages/cli-lib/BUILD.bazel
+++ b/packages/cli-lib/BUILD.bazel
@@ -42,7 +42,7 @@ formatjs_library(
 
 formatjs_test(
     name = "unit_test",
-    srcs = [":srcs"] + glob(
+    srcs = glob(
         ["tests/unit/**/*.test.ts"],
     ),
     fixtures = glob(

--- a/packages/ecma376/BUILD.bazel
+++ b/packages/ecma376/BUILD.bazel
@@ -19,6 +19,6 @@ formatjs_library(
 
 formatjs_test(
     name = "unit_test",
-    srcs = SRCS + glob(["tests/*"]),
+    srcs = glob(["tests/*"]),
     test_deps = ["//:node_modules/vitest"],
 )

--- a/packages/icu-messageformat-parser/BUILD.bazel
+++ b/packages/icu-messageformat-parser/BUILD.bazel
@@ -30,7 +30,7 @@ formatjs_library(
 
 formatjs_test(
     name = "unit_test",
-    srcs = SRCS + glob([
+    srcs = glob([
         "tests/**/*.ts",
     ]),
     data = ["//:package.json"],

--- a/packages/icu-skeleton-parser/BUILD.bazel
+++ b/packages/icu-skeleton-parser/BUILD.bazel
@@ -17,7 +17,7 @@ formatjs_library(
 
 formatjs_test(
     name = "unit_test",
-    srcs = SRCS + glob(["tests/**/*.ts"]),
+    srcs = glob(["tests/**/*.ts"]),
     data = ["//:package.json"],
     no_copy_to_bin = ["//:package.json"],
     project_references = ["//packages/ecma402-abstract/types"],

--- a/packages/intl-datetimeformat/BUILD.bazel
+++ b/packages/intl-datetimeformat/BUILD.bazel
@@ -94,7 +94,7 @@ formatjs_library(
 
 formatjs_test(
     name = "unit_test",
-    srcs = SRCS + TESTS + TEST_LOCALE_DATA,
+    srcs = TESTS + TEST_LOCALE_DATA,
     data = ["//:package.json"],
     no_copy_to_bin = ["//:package.json"],
     project_references = [

--- a/packages/intl-displaynames/BUILD.bazel
+++ b/packages/intl-displaynames/BUILD.bazel
@@ -56,7 +56,7 @@ formatjs_library(
 
 formatjs_test(
     name = "unit_test",
-    srcs = SRCS + TESTS + TEST_LOCALE_DATA,
+    srcs = TESTS + TEST_LOCALE_DATA,
     data = ["//:package.json"],
     no_copy_to_bin = ["//:package.json"],
     project_references = [

--- a/packages/intl-durationformat/BUILD.bazel
+++ b/packages/intl-durationformat/BUILD.bazel
@@ -39,7 +39,7 @@ formatjs_library(
 
 formatjs_test(
     name = "unit_test",
-    srcs = SRCS + glob([
+    srcs = glob([
         "tests/**/*.ts",
     ]),
     data = ["//:package.json"],

--- a/packages/intl-getcanonicallocales/BUILD.bazel
+++ b/packages/intl-getcanonicallocales/BUILD.bazel
@@ -43,7 +43,7 @@ TESTS = glob([
 
 formatjs_test(
     name = "unit_test",
-    srcs = SRCS + TESTS,
+    srcs = TESTS,
     test_deps = ["//:node_modules/vitest"],
 )
 

--- a/packages/intl-listformat/BUILD.bazel
+++ b/packages/intl-listformat/BUILD.bazel
@@ -57,7 +57,7 @@ formatjs_library(
 
 formatjs_test(
     name = "unit_test",
-    srcs = SRCS + TESTS + TEST_LOCALE_DATA,
+    srcs = TESTS + TEST_LOCALE_DATA,
     data = ["//:package.json"],
     no_copy_to_bin = ["//:package.json"],
     project_references = [

--- a/packages/intl-locale/BUILD.bazel
+++ b/packages/intl-locale/BUILD.bazel
@@ -36,7 +36,7 @@ formatjs_library(
 
 formatjs_test(
     name = "unit_test",
-    srcs = SRCS + glob([
+    srcs = glob([
         "tests/**/*.ts",
     ]),
     data = [

--- a/packages/intl-localematcher/BUILD.bazel
+++ b/packages/intl-localematcher/BUILD.bazel
@@ -20,7 +20,7 @@ formatjs_library(
 
 formatjs_test(
     name = "unit_test",
-    srcs = SRCS + glob(["tests/**/*.ts"]),
+    srcs = glob(["tests/**/*.ts"]),
     test_deps = ["//:node_modules/vitest"],
     deps = [
         "//:node_modules/@formatjs/fast-memoize",  # keep: imported from abstract/

--- a/packages/intl-messageformat/BUILD.bazel
+++ b/packages/intl-messageformat/BUILD.bazel
@@ -39,7 +39,7 @@ formatjs_library(
 
 formatjs_test(
     name = "unit_test",
-    srcs = SRCS + TESTS,
+    srcs = TESTS,
     data = ["//:package.json"],
     no_copy_to_bin = ["//:package.json"],
     project_references = ["//packages/ecma402-abstract/types"],

--- a/packages/intl-pluralrules/BUILD.bazel
+++ b/packages/intl-pluralrules/BUILD.bazel
@@ -277,7 +277,7 @@ formatjs_library(
 
 formatjs_test(
     name = "unit_test",
-    srcs = SRCS + TESTS + TEST_LOCALE_DATA,
+    srcs = TESTS + TEST_LOCALE_DATA,
     data = ["//:package.json"],
     no_copy_to_bin = ["//:package.json"],
     project_references = [

--- a/packages/intl-relativetimeformat/BUILD.bazel
+++ b/packages/intl-relativetimeformat/BUILD.bazel
@@ -59,7 +59,7 @@ formatjs_library(
 
 formatjs_test(
     name = "unit_test",
-    srcs = SRCS + TESTS + TEST_LOCALE_DATA,
+    srcs = TESTS + TEST_LOCALE_DATA,
     data = ["//:package.json"],
     no_copy_to_bin = ["//:package.json"],
     project_references = [

--- a/packages/intl-segmenter/BUILD.bazel
+++ b/packages/intl-segmenter/BUILD.bazel
@@ -75,7 +75,7 @@ formatjs_library(
 
 formatjs_test(
     name = "unit_test",
-    srcs = SRCS + TESTS + ["tests/test-utils.ts"],
+    srcs = TESTS + ["tests/test-utils.ts"],
     data = [
         "//:package.json",
     ] + TEST_UNICODE_FILES,

--- a/packages/intl-supportedvaluesof/BUILD.bazel
+++ b/packages/intl-supportedvaluesof/BUILD.bazel
@@ -45,7 +45,7 @@ formatjs_library(
 
 formatjs_test(
     name = "unit_test",
-    srcs = SRCS + TESTS,
+    srcs = TESTS,
     data = ["//:package.json"],
     no_copy_to_bin = ["//:package.json"],
     project_references = ["//packages/ecma402-abstract"],

--- a/packages/intl/BUILD.bazel
+++ b/packages/intl/BUILD.bazel
@@ -45,7 +45,7 @@ formatjs_library(
 
 formatjs_test(
     name = "unit_test",
-    srcs = SRCS + TESTS,
+    srcs = TESTS,
     data = ["//:package.json"],
     no_copy_to_bin = ["//:package.json"],
     project_references = ["//packages/ecma402-abstract/types"],

--- a/packages/react-intl/BUILD.bazel
+++ b/packages/react-intl/BUILD.bazel
@@ -51,7 +51,7 @@ formatjs_library(
 
 formatjs_test(
     name = "unit_test",
-    srcs = SRCS + TESTS,
+    srcs = TESTS,
     config = "vitest.config.mjs",
     data = ["//:package.json"],
     dom = True,

--- a/packages/svelte-intl/BUILD.bazel
+++ b/packages/svelte-intl/BUILD.bazel
@@ -20,7 +20,7 @@ formatjs_library(
 
 formatjs_test(
     name = "unit_test",
-    srcs = SRCS + glob([
+    srcs = glob([
         "tests/*.ts",
     ]),
     test_deps = ["//:node_modules/vitest"],

--- a/packages/ts-transformer/BUILD.bazel
+++ b/packages/ts-transformer/BUILD.bazel
@@ -39,7 +39,7 @@ formatjs_library(
 
 formatjs_test(
     name = "unit_test",
-    srcs = SRCS + glob([
+    srcs = glob([
         "tests/*.ts*",
     ]),
     fixtures = glob([

--- a/packages/unplugin/BUILD.bazel
+++ b/packages/unplugin/BUILD.bazel
@@ -55,7 +55,7 @@ formatjs_library(
 
 formatjs_test(
     name = "unit_test",
-    srcs = SRCS + glob(["tests/**/*.ts"]),
+    srcs = glob(["tests/**/*.ts"]),
     test_deps = ["//:node_modules/vitest"],
     deps = [
         "//:node_modules/@bazel/runfiles",

--- a/packages/utils/BUILD.bazel
+++ b/packages/utils/BUILD.bazel
@@ -25,7 +25,7 @@ formatjs_library(
 
 formatjs_test(
     name = "unit_test",
-    srcs = SRCS + glob([
+    srcs = glob([
         "tests/*.ts*",
     ]),
     test_deps = ["//:node_modules/vitest"],

--- a/packages/vue-intl/BUILD.bazel
+++ b/packages/vue-intl/BUILD.bazel
@@ -21,7 +21,7 @@ formatjs_library(
 
 formatjs_test(
     name = "unit_test",
-    srcs = SRCS + glob([
+    srcs = glob([
         "tests/*",
     ]),
     dom = True,

--- a/tools/compile.bzl
+++ b/tools/compile.bzl
@@ -119,6 +119,12 @@ def formatjs_library(
         srcs = srcs,
     )
 
+    js_library(
+        name = "lib",
+        srcs = [":srcs"],
+        deps = all_deps,
+    )
+
     ts_project(
         name = "typecheck",
         srcs = [":srcs"],

--- a/tools/compile.bzl
+++ b/tools/compile.bzl
@@ -12,12 +12,15 @@ load("//tools:tsconfig.bzl", "packages_tsconfig")
 def _formatjs_package(
         package_name,
         entry_points,
+        deps,
+        external_packages,
         npm_package_name,
         extra_npm_srcs,
         allow_overwrites):
-    """npm packaging + validation tests (private).
+    """Rolldown bundling + npm packaging + validation tests (private).
 
     Generates:
+    - rolldown_bundle per entry point (dts=True, esm, es2020)
     - js_library(name = {package_name}) with bundles + package.json
     - npm_package(name = "pkg")
     - no_internal_imports_test
@@ -26,6 +29,19 @@ def _formatjs_package(
     - generate_ide_tsconfig_json()
     """
     effective_npm_name = npm_package_name or ("@formatjs/%s" % package_name)
+
+    for entry in entry_points:
+        rolldown_bundle(
+            name = "%s-bundle" % entry.replace(".ts", ""),
+            srcs = [":srcs"],
+            dts = True,
+            entry_point = entry,
+            external = external_packages,
+            format = "esm",
+            output = "%s.js" % entry.replace(".ts", ""),
+            target = "es2020",
+            deps = deps,
+        )
 
     bundles = [":%s-bundle" % entry.replace(".ts", "") for entry in entry_points]
     replace_prefixes = {
@@ -83,14 +99,14 @@ def formatjs_library(
         npm_package_name = None,
         extra_npm_srcs = [],
         allow_overwrites = False):
-    """TypeScript compilation + rolldown bundling + optional npm packaging.
+    """TypeScript compilation + optional npm packaging.
 
     Generates:
     - copy_to_bin(name = "srcs") for sandbox compatibility
+    - js_library(name = "lib") wrapping sources + deps
     - ts_project(name = "typecheck") for type checking (tsgo, no emit)
-    - rolldown_bundle per entry point (dts=True, esm, es2020)
     - Optionally ts_project(name = "types") with emit_declaration_only
-    - If package.json exists: js_library, npm_package, and validation tests
+    - If package.json exists: rolldown bundles, npm_package, and validation tests
 
     Args:
         name: target name (e.g. "dist")
@@ -136,19 +152,6 @@ def formatjs_library(
         deps = all_deps,
     )
 
-    for entry in entry_points:
-        rolldown_bundle(
-            name = "%s-bundle" % entry.replace(".ts", ""),
-            srcs = [":srcs"],
-            dts = True,
-            entry_point = entry,
-            external = external_packages,
-            format = "esm",
-            output = "%s.js" % entry.replace(".ts", ""),
-            target = "es2020",
-            deps = all_deps,
-        )
-
     if types:
         ts_project(
             name = "types",
@@ -168,6 +171,8 @@ def formatjs_library(
         _formatjs_package(
             package_name = package_dir_name,
             entry_points = entry_points,
+            deps = all_deps,
+            external_packages = external_packages,
             npm_package_name = npm_package_name,
             extra_npm_srcs = extra_npm_srcs,
             allow_overwrites = allow_overwrites,

--- a/tools/test.bzl
+++ b/tools/test.bzl
@@ -33,7 +33,7 @@ def formatjs_test(
 
     vitest(
         name = name,
-        srcs = srcs,
+        srcs = [":srcs"] + srcs,
         deps = all_deps,
         **kwargs
     )

--- a/tools/test.bzl
+++ b/tools/test.bzl
@@ -29,7 +29,7 @@ def formatjs_test(
         test_project_references: internal deps only in test files (gazelle-managed)
         **kwargs: passed through to vitest (dom, config, size, tsconfig, data, etc.)
     """
-    all_deps = deps + project_references + test_deps + test_project_references
+    all_deps = deps + project_references + test_deps + test_project_references + [":lib"]
 
     vitest(
         name = name,


### PR DESCRIPTION
## Summary
- `formatjs_library` now creates a `js_library(name = "lib")` wrapping copy_to_bin'd sources
- `formatjs_test` auto-depends on `:lib`, so BUILD.bazel files no longer pass SRCS to `formatjs_test`
- Test targets only declare test files in `srcs`, source files come via the `:lib` dependency

Stacked on #6344.

## Test plan
- [ ] `bazel build //...` passes
- [ ] `bazel test //...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)