### PR TITLE
refactor(deps): clean up gazelle structural assumptions

### DIFF
--- a/tools/gazelle/ts/config.go
+++ b/tools/gazelle/ts/config.go
@@ -2,8 +2,6 @@ package ts
 
 import (
 	"flag"
-	"path/filepath"
-	"strings"
 
 	"github.com/bazelbuild/bazel-gazelle/config"
 	"github.com/bazelbuild/bazel-gazelle/rule"
@@ -11,21 +9,18 @@ import (
 
 // tsConfig holds per-directory configuration for the formatjs TS gazelle plugin.
 type tsConfig struct {
-	enabled     bool   // Whether this plugin is active for this directory
-	packageType string // "internal" (default) or "npm_package"
+	enabled bool // Whether this plugin is active for this directory
 }
 
 func newTsConfig() *tsConfig {
 	return &tsConfig{
-		enabled:     true,
-		packageType: "internal",
+		enabled: true,
 	}
 }
 
 func (c *tsConfig) clone() *tsConfig {
 	return &tsConfig{
-		enabled:     c.enabled,
-		packageType: c.packageType,
+		enabled: c.enabled,
 	}
 }
 
@@ -39,7 +34,6 @@ func (l *tsLang) CheckFlags(fs *flag.FlagSet, c *config.Config) error { return n
 func (l *tsLang) KnownDirectives() []string {
 	return []string{
 		"formatjs_enabled",
-		"formatjs_package_type",
 	}
 }
 
@@ -58,16 +52,9 @@ func (l *tsLang) Configure(c *config.Config, rel string, f *rule.File) {
 			switch d.Key {
 			case "formatjs_enabled":
 				cfg.enabled = d.Value == "true"
-			case "formatjs_package_type":
-				cfg.packageType = d.Value
 			}
 		}
 	}
 
 	c.Exts[languageName] = cfg
-}
-
-// isUnderPackagesDir checks if a relative path is under the packages/ directory.
-func isUnderPackagesDir(rel string) bool {
-	return strings.HasPrefix(rel, "packages/") || strings.HasPrefix(filepath.ToSlash(rel), "packages/")
 }

--- a/tools/gazelle/ts/language.go
+++ b/tools/gazelle/ts/language.go
@@ -85,11 +85,6 @@ func (l *tsLang) GenerateRules(args language.GenerateArgs) language.GenerateResu
 		return language.GenerateResult{}
 	}
 
-	// Only operate under packages/ directory
-	if !isUnderPackagesDir(args.Rel) {
-		return language.GenerateResult{}
-	}
-
 	// Collect TypeScript files from args.RegularFiles (provided by gazelle).
 	var sourceImports, testImports []ImportStatement
 


### PR DESCRIPTION
## Summary
- Remove `isUnderPackagesDir` — gazelle `update_only` mode already limits to dirs with existing rules
- Remove unused `packageType` config and `formatjs_package_type` directive
- Add `fixtures/` convention: `formatjs_test` auto-discovers `tests/fixtures/**`, gazelle skips `fixtures/` dirs
- Remove `excludeFixtures` and its glob-parsing logic from gazelle

## Test plan
- [x] `bazel test //packages/ts-transformer:unit_test` — passes
- [x] `bazel run //:gazelle` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)