### PR TITLE
refactor(deps): migrate ts_compile packages to formatjs_library

### DIFF
--- a/tools/gazelle/ts/language.go
+++ b/tools/gazelle/ts/language.go
@@ -130,16 +130,14 @@ func (l *tsLang) GenerateRules(args language.GenerateArgs) language.GenerateResu
 			})
 
 		case KindFormatjsTest:
-			{
-				newRule := rule.NewRule(r.Kind(), r.Name())
-				if len(testSrcs) > 0 {
-					newRule.SetAttr("srcs", testSrcs)
-				}
-				genRules = append(genRules, newRule)
-				genImports = append(genImports, ImportData{
-					TestImports: testImports,
-				})
+			newRule := rule.NewRule(r.Kind(), r.Name())
+			if len(testSrcs) > 0 {
+				newRule.SetAttr("srcs", testSrcs)
 			}
+			genRules = append(genRules, newRule)
+			genImports = append(genImports, ImportData{
+				TestImports: testImports,
+			})
 		}
 	}
 
@@ -148,7 +146,6 @@ func (l *tsLang) GenerateRules(args language.GenerateArgs) language.GenerateResu
 		Imports: genImports,
 	}
 }
-
 
 func isTypeScriptFile(name string) bool {
 	return strings.HasSuffix(name, ".ts") || strings.HasSuffix(name, ".tsx")

--- a/tools/gazelle/ts/resolve.go
+++ b/tools/gazelle/ts/resolve.go
@@ -2,8 +2,8 @@ package ts
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 
@@ -283,14 +283,6 @@ func loadPackageJSONDeps(repoRoot string) {
 	})
 }
 
-func toSet(items []string) map[string]bool {
-	m := make(map[string]bool, len(items))
-	for _, item := range items {
-		m[item] = true
-	}
-	return m
-}
-
 func deduplicateAndSort(items []string) []string {
 	if len(items) == 0 {
 		return nil
@@ -303,20 +295,6 @@ func deduplicateAndSort(items []string) []string {
 			seen[item] = true
 		}
 	}
-	// Sort for deterministic output
-	for i := 0; i < len(result); i++ {
-		for j := i + 1; j < len(result); j++ {
-			if result[j] < result[i] {
-				result[i], result[j] = result[j], result[i]
-			}
-		}
-	}
+	sort.Strings(result)
 	return result
-}
-
-// Unused but kept for debugging.
-func debugLog(format string, args ...interface{}) {
-	if os.Getenv("FORMATJS_GAZELLE_DEBUG") != "" {
-		fmt.Fprintf(os.Stderr, format, args...)
-	}
 }


### PR DESCRIPTION
## Summary
- Add internal package support to `formatjs_library`: when no `package.json` exists, uses oxc per-file transpilation instead of rolldown bundling
- Migrate `ecma262-abstract` and `ecma402-abstract` (+ 7 sub-packages) from `ts_compile` to `formatjs_library`
- Gazelle now manages `srcs`/`deps` for all TypeScript packages

## Test plan
- [x] `bazel test //packages/ecma402-abstract:unit_test` — passes
- [x] `bazel test //packages/intl-messageformat:unit_test` — passes (depends on internal packages)
- [x] `bazel test //packages/intl-displaynames:unit_test` — passes
- [x] `bazel run //:gazelle` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)