### PR TITLE
refactor(deps): migrate ts_compile packages to formatjs_library

### DIFF
--- a/packages/ecma262-abstract/BUILD.bazel
+++ b/packages/ecma262-abstract/BUILD.bazel
@@ -1,27 +1,26 @@
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "ts_compile")
+load("//tools:compile.bzl", "formatjs_library")
+load("//tools:index.bzl", "generate_ide_tsconfig_json")
 
-PACKAGE_NAME = "ecma262-abstract"
-
-SRCS = glob(["*.ts"])
-
-SRC_DEPS = [
-    "//:node_modules/@formatjs/bigdecimal",
-]
-
-ts_compile(
-    name = PACKAGE_NAME,
-    srcs = [":srcs"],
+formatjs_library(
+    name = "dist",
+    srcs = [
+        "ArrayCreate.ts",
+        "DateOperations.ts",
+        "HasOwnProperty.ts",
+        "OrdinaryHasInstance.ts",
+        "SameValue.ts",
+        "TimeClip.ts",
+        "ToNumber.ts",
+        "ToObject.ts",
+        "ToPrimitive.ts",
+        "ToString.ts",
+        "Type.ts",
+    ],
     package_json = False,
     visibility = ["//visibility:public"],
-    deps = SRC_DEPS,
+    deps = ["//:node_modules/@formatjs/bigdecimal"],
 )
 
 generate_ide_tsconfig_json(
     composite = True,
-)
-
-copy_to_bin(
-    name = "srcs",
-    srcs = SRCS,
 )

--- a/packages/ecma402-abstract/BUILD.bazel
+++ b/packages/ecma402-abstract/BUILD.bazel
@@ -1,37 +1,65 @@
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile")
-load("//tools:vitest.bzl", "vitest")
+load("//tools:compile.bzl", "formatjs_library")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file")
+load("//tools:test.bzl", "formatjs_test")
 
-PACKAGE_NAME = "ecma402-abstract"
-
-SRCS = glob(
-    [
-        "*.ts",
+formatjs_library(
+    name = "dist",
+    srcs = [
+        "CanonicalizeLocaleList.ts",
+        "CanonicalizeTimeZoneName.ts",
+        "CoerceOptionsToObject.ts",
+        "DefaultNumberOption.ts",
+        "GetNumberOption.ts",
+        "GetOption.ts",
+        "GetOptionsObject.ts",
+        "GetStringOrBooleanOption.ts",
+        "IsSanctionedSimpleUnitIdentifier.ts",
+        "IsValidTimeZoneName.ts",
+        "IsWellFormedCurrencyCode.ts",
+        "IsWellFormedUnitIdentifier.ts",
+        "PartitionPattern.ts",
+        "SupportedLocales.ts",
+        "ToIntlMathematicalValue.ts",
+        "constants.ts",
+        "data.ts",
+        "regex.generated.ts",
+        "utils.ts",
+    ],
+    package_json = False,
+    project_references = ["//packages/ecma262-abstract"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//:node_modules/@formatjs/bigdecimal",
+        "//:node_modules/@formatjs/fast-memoize",
+        "//:node_modules/@formatjs/intl-localematcher",
     ],
 )
 
-SRC_DEPS = [
-    "//:node_modules/@formatjs/bigdecimal",
-    "//:node_modules/@formatjs/fast-memoize",
-    "//:node_modules/@formatjs/intl-localematcher",
-    "//packages/ecma262-abstract",
-]
-
-ts_compile(
-    name = PACKAGE_NAME,
-    srcs = [":srcs"],
-    package_json = False,
-    visibility = ["//visibility:public"],
-    deps = SRC_DEPS,
-)
-
-vitest(
+formatjs_test(
     name = "unit_test",
-    srcs = SRCS + glob([
-        "tests/**/*.ts",
-        "tests/**/*.tsx",
-    ]),
-    deps = SRC_DEPS + [
+    srcs = [
+        "tests/262.test.ts",
+        "tests/ApplyUnsignedRoundingMode.test.ts",
+        "tests/CanonicalizeTimeZoneName.test.ts",
+        "tests/CollapseNumberRange.test.ts",
+        "tests/FormatApproximately.test.ts",
+        "tests/FormatNumericRange.test.ts",
+        "tests/FormatNumericRangeToParts.test.ts",
+        "tests/GetStringOrBooleanOption.test.ts",
+        "tests/GetUnsignedRoundingMode.test.ts",
+        "tests/IsValidTimeZoneName.test.ts",
+        "tests/PartitionNumberPattern.test.ts",
+        "tests/PartitionNumberRangePattern.test.ts",
+        "tests/PartitionPattern.test.ts",
+        "tests/SetNumberFormatDigitOptions.test.ts",
+        "tests/ToRawFixed.test.tsx",
+        "tests/ToRawPrecision.test.tsx",
+        "tests/utils.ts",
+    ],
+    deps = [
+        "//:node_modules/@formatjs/bigdecimal",
+        "//:node_modules/vitest",
+        "//packages/ecma262-abstract",
         "//packages/ecma402-abstract/NumberFormat",
         "//packages/ecma402-abstract/types",
     ],
@@ -51,9 +79,4 @@ generate_src_file(
         "//:node_modules/regenerate",
     ],
     tool = "//packages/ecma402-abstract/scripts:regex-gen",
-)
-
-copy_to_bin(
-    name = "srcs",
-    srcs = SRCS,
 )

--- a/packages/ecma402-abstract/DateTimeFormat/BUILD.bazel
+++ b/packages/ecma402-abstract/DateTimeFormat/BUILD.bazel
@@ -1,23 +1,36 @@
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "ts_compile")
+load("//tools:compile.bzl", "formatjs_library")
+load("//tools:index.bzl", "generate_ide_tsconfig_json")
 
-PACKAGE_NAME = "DateTimeFormat"
-
-SRCS = glob(["*.ts"])
-
-SRC_DEPS = [
-    "//:node_modules/@formatjs/bigdecimal",
-    "//:node_modules/@formatjs/intl-localematcher",
-    "//packages/ecma262-abstract",
-    "//packages/ecma402-abstract",
-    "//packages/ecma402-abstract/types",
-]
-
-ts_compile(
-    name = PACKAGE_NAME,
-    srcs = SRCS,
+formatjs_library(
+    name = "dist",
+    srcs = [
+        "BasicFormatMatcher.ts",
+        "BestFitFormatMatcher.ts",
+        "DateTimeStyleFormat.ts",
+        "FormatDateTime.ts",
+        "FormatDateTimePattern.ts",
+        "FormatDateTimeRange.ts",
+        "FormatDateTimeRangeToParts.ts",
+        "FormatDateTimeToParts.ts",
+        "InitializeDateTimeFormat.ts",
+        "PartitionDateTimePattern.ts",
+        "PartitionDateTimeRangePattern.ts",
+        "ToDateTimeOptions.ts",
+        "ToLocalTime.ts",
+        "skeleton.ts",
+        "utils.ts",
+    ],
     package_json = False,
+    project_references = [
+        "//packages/ecma262-abstract",
+        "//packages/ecma402-abstract",
+        "//packages/ecma402-abstract/types",
+    ],
     visibility = ["//visibility:public"],
-    deps = SRC_DEPS,
+    deps = [
+        "//:node_modules/@formatjs/bigdecimal",
+        "//:node_modules/@formatjs/intl-localematcher",
+    ],
 )
 
 generate_ide_tsconfig_json(

--- a/packages/ecma402-abstract/DisplayNames/BUILD.bazel
+++ b/packages/ecma402-abstract/DisplayNames/BUILD.bazel
@@ -1,19 +1,17 @@
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "ts_compile")
+load("//tools:compile.bzl", "formatjs_library")
+load("//tools:index.bzl", "generate_ide_tsconfig_json")
 
-PACKAGE_NAME = "DisplayNames"
-
-SRCS = glob(["*.ts"])
-
-SRC_DEPS = [
-    "//packages/ecma402-abstract",
-]
-
-ts_compile(
-    name = PACKAGE_NAME,
-    srcs = SRCS,
+formatjs_library(
+    name = "dist",
+    srcs = [
+        "CanonicalCodeForDisplayNames.ts",
+        "IsValidDateTimeFieldCode.ts",
+    ],
     package_json = False,
+    project_references = [
+        "//packages/ecma402-abstract",
+    ],
     visibility = ["//visibility:public"],
-    deps = SRC_DEPS,
 )
 
 generate_ide_tsconfig_json(

--- a/packages/ecma402-abstract/DurationFormat/BUILD.bazel
+++ b/packages/ecma402-abstract/DurationFormat/BUILD.bazel
@@ -1,21 +1,23 @@
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "ts_compile")
+load("//tools:compile.bzl", "formatjs_library")
+load("//tools:index.bzl", "generate_ide_tsconfig_json")
 
-PACKAGE_NAME = "DurationFormat"
-
-SRCS = glob(["*.ts"])
-
-SRC_DEPS = [
-    "//packages/ecma262-abstract",
-    "//packages/ecma402-abstract",
-    "//packages/ecma402-abstract/types",
-]
-
-ts_compile(
-    name = PACKAGE_NAME,
-    srcs = SRCS,
+formatjs_library(
+    name = "dist",
+    srcs = [
+        "DurationRecordSign.ts",
+        "GetDurationUnitOptions.ts",
+        "IsValidDurationRecord.ts",
+        "ToDurationRecord.ts",
+        "ToIntegerIfIntegral.ts",
+        "constants.ts",
+    ],
     package_json = False,
+    project_references = [
+        "//packages/ecma262-abstract",
+        "//packages/ecma402-abstract",
+        "//packages/ecma402-abstract/types",
+    ],
     visibility = ["//visibility:public"],
-    deps = SRC_DEPS,
 )
 
 generate_ide_tsconfig_json(

--- a/packages/ecma402-abstract/NumberFormat/BUILD.bazel
+++ b/packages/ecma402-abstract/NumberFormat/BUILD.bazel
@@ -1,22 +1,44 @@
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file", "ts_compile")
+load("//tools:compile.bzl", "formatjs_library")
+load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file")
 
-PACKAGE_NAME = "NumberFormat"
-
-SRCS = glob(["*.ts"])
-
-SRC_DEPS = [
-    "//:node_modules/@formatjs/bigdecimal",
-    "//:node_modules/@formatjs/intl-localematcher",
-    "//packages/ecma402-abstract",
-    "//packages/ecma402-abstract/types",
-]
-
-ts_compile(
-    name = PACKAGE_NAME,
-    srcs = SRCS,
+formatjs_library(
+    name = "dist",
+    srcs = [
+        "ApplyUnsignedRoundingMode.ts",
+        "CollapseNumberRange.ts",
+        "ComputeExponent.ts",
+        "ComputeExponentForMagnitude.ts",
+        "CurrencyDigits.ts",
+        "FormatApproximately.ts",
+        "FormatNumeric.ts",
+        "FormatNumericRange.ts",
+        "FormatNumericRangeToParts.ts",
+        "FormatNumericToParts.ts",
+        "FormatNumericToString.ts",
+        "GetUnsignedRoundingMode.ts",
+        "InitializeNumberFormat.ts",
+        "PartitionNumberPattern.ts",
+        "PartitionNumberRangePattern.ts",
+        "SetNumberFormatDigitOptions.ts",
+        "SetNumberFormatUnitOptions.ts",
+        "ToRawFixed.ts",
+        "ToRawPrecision.ts",
+        "decimal-cache.ts",
+        "digit-mapping.generated.ts",
+        "format_to_parts.ts",
+    ],
     package_json = False,
+    project_references = [
+        "//packages/ecma402-abstract",
+        "//packages/ecma402-abstract/types",
+        "//packages/ecma262-abstract",
+    ],
     visibility = ["//visibility:public"],
-    deps = SRC_DEPS,
+    deps = [
+        "//:node_modules/@formatjs/bigdecimal",
+        "//:node_modules/@formatjs/fast-memoize",
+        "//:node_modules/@formatjs/intl-localematcher",
+    ],
 )
 
 generate_src_file(

--- a/packages/ecma402-abstract/PluralRules/BUILD.bazel
+++ b/packages/ecma402-abstract/PluralRules/BUILD.bazel
@@ -1,22 +1,26 @@
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "ts_compile")
+load("//tools:compile.bzl", "formatjs_library")
+load("//tools:index.bzl", "generate_ide_tsconfig_json")
 
-PACKAGE_NAME = "PluralRules"
-
-SRCS = glob(["*.ts"])
-
-SRC_DEPS = [
-    "//packages/ecma262-abstract",
-    "//packages/ecma402-abstract",
-    "//packages/ecma402-abstract/NumberFormat",
-    "//packages/ecma402-abstract/types",
-]
-
-ts_compile(
-    name = PACKAGE_NAME,
-    srcs = SRCS,
+formatjs_library(
+    name = "dist",
+    srcs = [
+        "GetOperands.ts",
+        "InitializePluralRules.ts",
+        "ResolvePlural.ts",
+        "ResolvePluralRange.ts",
+    ],
     package_json = False,
+    project_references = [
+        "//packages/ecma262-abstract",
+        "//packages/ecma402-abstract",
+        "//packages/ecma402-abstract/NumberFormat",
+        "//packages/ecma402-abstract/types",
+    ],
     visibility = ["//visibility:public"],
-    deps = SRC_DEPS,
+    deps = [
+        "//:node_modules/@formatjs/bigdecimal",
+        "//:node_modules/@formatjs/intl-localematcher",
+    ],
 )
 
 generate_ide_tsconfig_json(

--- a/packages/ecma402-abstract/RelativeTimeFormat/BUILD.bazel
+++ b/packages/ecma402-abstract/RelativeTimeFormat/BUILD.bazel
@@ -1,21 +1,24 @@
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "ts_compile")
+load("//tools:compile.bzl", "formatjs_library")
+load("//tools:index.bzl", "generate_ide_tsconfig_json")
 
-PACKAGE_NAME = "RelativeTimeFormat"
-
-SRCS = glob(["*.ts"])
-
-SRC_DEPS = [
-    "//packages/ecma262-abstract",
-    "//packages/ecma402-abstract",
-    "//packages/ecma402-abstract/types",
-]
-
-ts_compile(
-    name = PACKAGE_NAME,
-    srcs = SRCS,
+formatjs_library(
+    name = "dist",
+    srcs = [
+        "FormatRelativeTime.ts",
+        "FormatRelativeTimeToParts.ts",
+        "InitializeRelativeTimeFormat.ts",
+        "MakePartsList.ts",
+        "PartitionRelativeTimePattern.ts",
+        "SingularRelativeTimeUnit.ts",
+    ],
     package_json = False,
+    project_references = [
+        "//packages/ecma262-abstract",
+        "//packages/ecma402-abstract",
+        "//packages/ecma402-abstract/types",
+    ],
     visibility = ["//visibility:public"],
-    deps = SRC_DEPS,
+    deps = ["//:node_modules/@formatjs/intl-localematcher"],
 )
 
 generate_ide_tsconfig_json(

--- a/packages/ecma402-abstract/types/BUILD.bazel
+++ b/packages/ecma402-abstract/types/BUILD.bazel
@@ -1,19 +1,23 @@
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "ts_compile")
+load("//tools:compile.bzl", "formatjs_library")
+load("//tools:index.bzl", "generate_ide_tsconfig_json")
 
-PACKAGE_NAME = "types"
-
-SRCS = glob(["*.ts"])
-
-SRC_DEPS = [
-    "//:node_modules/@formatjs/bigdecimal",
-]
-
-ts_compile(
-    name = PACKAGE_NAME,
-    srcs = SRCS,
+formatjs_library(
+    name = "dist",
+    srcs = [
+        "core.ts",
+        "date-time.ts",
+        "displaynames.ts",
+        "duration.ts",
+        "list.ts",
+        "number.ts",
+        "plural-rules.ts",
+        "relative-time.ts",
+    ],
     package_json = False,
     visibility = ["//visibility:public"],
-    deps = SRC_DEPS,
+    deps = [
+        "//:node_modules/@formatjs/bigdecimal",
+    ],
 )
 
 generate_ide_tsconfig_json(

--- a/tools/compile.bzl
+++ b/tools/compile.bzl
@@ -6,6 +6,7 @@ load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 load("@npm//:@typescript/native-preview/package_json.bzl", tsgo_bin = "bin")
 load("//tools:index.bzl", "generate_ide_tsconfig_json", "no_internal_imports_test", "package_exports_test", "package_json_test")
+load("//tools:oxc_transpiler.bzl", "oxc_transpiler")
 load("//tools:rolldown.bzl", "rolldown_bundle")
 load("//tools:tsconfig.bzl", "packages_tsconfig")
 
@@ -98,8 +99,13 @@ def formatjs_library(
         tsconfig = None,
         npm_package_name = None,
         extra_npm_srcs = [],
-        allow_overwrites = False):
+        allow_overwrites = False,
+        package_json = True,
+        visibility = None):
     """TypeScript compilation + optional npm packaging.
+
+    For npm-published packages (with package.json): rolldown bundling + npm_package.
+    For internal packages (no package.json): oxc per-file transpilation.
 
     Generates:
     - copy_to_bin(name = "srcs") for sandbox compatibility
@@ -107,10 +113,11 @@ def formatjs_library(
     - ts_project(name = "typecheck") for type checking (tsgo, no emit)
     - Optionally ts_project(name = "types") with emit_declaration_only
     - If package.json exists: rolldown bundles, npm_package, and validation tests
+    - If no package.json: oxc per-file transpilation
 
     Args:
         name: target name (e.g. "dist")
-        srcs: source files (already globbed)
+        srcs: source files (gazelle-managed)
         deps: external npm dependencies (e.g. //:node_modules/react)
         project_references: internal package dependencies (e.g. //packages/ecma402-abstract)
         entry_points: list of .ts entry points to bundle
@@ -119,26 +126,16 @@ def formatjs_library(
         npm_package_name: npm package name for publishing (default "@formatjs/{dir_name}")
         extra_npm_srcs: additional files for npm_package (iife bundles, locale-data, etc.)
         allow_overwrites: passed to npm_package (default False)
+        package_json: whether to include package.json in js_library srcs (default True)
+        visibility: visibility for the js_library target
     """
     all_deps = deps + project_references
     effective_tsconfig = tsconfig or packages_tsconfig()
-
-    # Compute external packages for rolldown (only node_modules deps are externalized)
-    external_packages = [
-        dep.split("node_modules/")[1]
-        for dep in deps
-        if "node_modules/" in dep
-    ]
+    has_package_json = native.glob(["package.json"], allow_empty = True)
 
     copy_to_bin(
         name = "srcs",
         srcs = srcs,
-    )
-
-    js_library(
-        name = "lib",
-        srcs = [":srcs"],
-        deps = all_deps,
     )
 
     ts_project(
@@ -151,6 +148,43 @@ def formatjs_library(
         tsconfig = effective_tsconfig,
         deps = all_deps,
     )
+
+    if has_package_json:
+        # Published package: use :srcs for lib, rolldown for bundling
+        js_library(
+            name = "lib",
+            srcs = [":srcs"],
+            deps = all_deps,
+            visibility = visibility,
+        )
+    else:
+        # Internal package: oxc per-file transpilation
+        # The js_library name matches the directory name so that
+        # //packages/foo/bar resolves to the :bar target.
+        lib_name = native.package_name().split("/")[-1]
+
+        ts_project(
+            name = "%s-esm" % lib_name,
+            srcs = [":srcs"],
+            declaration = True,
+            tsconfig = effective_tsconfig,
+            resolve_json_module = True,
+            deps = all_deps + ["//:node_modules/oxc-transform"],
+            transpiler = oxc_transpiler,
+            declaration_transpiler = oxc_transpiler,
+        )
+
+        js_library(
+            name = lib_name,
+            srcs = [":%s-esm" % lib_name] + (["package.json"] if package_json else []),
+            visibility = visibility,
+        )
+
+        # Alias so formatjs_test's :lib reference works
+        native.alias(
+            name = "lib",
+            actual = ":%s" % lib_name,
+        )
 
     if types:
         ts_project(
@@ -166,7 +200,14 @@ def formatjs_library(
         )
 
     # Auto-generate npm packaging if package.json exists
-    if native.glob(["package.json"], allow_empty = True):
+    if has_package_json:
+        # Compute external packages for rolldown (only node_modules deps are externalized)
+        external_packages = [
+            dep.split("node_modules/")[1]
+            for dep in deps
+            if "node_modules/" in dep
+        ]
+
         package_dir_name = native.package_name().split("/")[-1]
         _formatjs_package(
             package_name = package_dir_name,


### PR DESCRIPTION
## Summary
- Add internal package support to `formatjs_library`: when no `package.json` exists, uses oxc per-file transpilation instead of rolldown bundling
- Migrate `ecma262-abstract` and `ecma402-abstract` (+ 7 sub-packages) from `ts_compile` to `formatjs_library`
- Gazelle now manages `srcs`/`deps` for all TypeScript packages

## Test plan
- [x] `bazel test //packages/ecma402-abstract:unit_test` — passes
- [x] `bazel test //packages/intl-messageformat:unit_test` — passes (depends on internal packages)
- [x] `bazel test //packages/intl-displaynames:unit_test` — passes
- [x] `bazel run //:gazelle` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)