### PR TITLE
refactor(deps): move generate_ide_tsconfig_json into formatjs_library

### DIFF
--- a/packages/ecma262-abstract/BUILD.bazel
+++ b/packages/ecma262-abstract/BUILD.bazel
@@ -1,5 +1,4 @@
 load("//tools:compile.bzl", "formatjs_library")
-load("//tools:index.bzl", "generate_ide_tsconfig_json")
 
 formatjs_library(
     name = "dist",
@@ -19,8 +18,4 @@ formatjs_library(
     package_json = False,
     visibility = ["//visibility:public"],
     deps = ["//:node_modules/@formatjs/bigdecimal"],
-)
-
-generate_ide_tsconfig_json(
-    composite = True,
 )

--- a/packages/ecma402-abstract/BUILD.bazel
+++ b/packages/ecma402-abstract/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//tools:compile.bzl", "formatjs_library")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file")
+load("//tools:index.bzl", "generate_src_file")
 load("//tools:test.bzl", "formatjs_test")
 
 formatjs_library(
@@ -63,11 +63,6 @@ formatjs_test(
         "//packages/ecma402-abstract/NumberFormat",
         "//packages/ecma402-abstract/types",
     ],
-)
-
-# Generate tsconfig.json with correct extends path
-generate_ide_tsconfig_json(
-    composite = True,
 )
 
 generate_src_file(

--- a/packages/ecma402-abstract/DateTimeFormat/BUILD.bazel
+++ b/packages/ecma402-abstract/DateTimeFormat/BUILD.bazel
@@ -1,5 +1,4 @@
 load("//tools:compile.bzl", "formatjs_library")
-load("//tools:index.bzl", "generate_ide_tsconfig_json")
 
 formatjs_library(
     name = "dist",
@@ -30,14 +29,5 @@ formatjs_library(
     deps = [
         "//:node_modules/@formatjs/bigdecimal",
         "//:node_modules/@formatjs/intl-localematcher",
-    ],
-)
-
-generate_ide_tsconfig_json(
-    composite = True,
-    project_references = [
-        "//packages/ecma262-abstract",
-        "//packages/ecma402-abstract",
-        "//packages/ecma402-abstract/types",
     ],
 )

--- a/packages/ecma402-abstract/DisplayNames/BUILD.bazel
+++ b/packages/ecma402-abstract/DisplayNames/BUILD.bazel
@@ -1,5 +1,4 @@
 load("//tools:compile.bzl", "formatjs_library")
-load("//tools:index.bzl", "generate_ide_tsconfig_json")
 
 formatjs_library(
     name = "dist",
@@ -12,11 +11,4 @@ formatjs_library(
         "//packages/ecma402-abstract",
     ],
     visibility = ["//visibility:public"],
-)
-
-generate_ide_tsconfig_json(
-    composite = True,
-    project_references = [
-        "//packages/ecma402-abstract",
-    ],
 )

--- a/packages/ecma402-abstract/DurationFormat/BUILD.bazel
+++ b/packages/ecma402-abstract/DurationFormat/BUILD.bazel
@@ -1,5 +1,4 @@
 load("//tools:compile.bzl", "formatjs_library")
-load("//tools:index.bzl", "generate_ide_tsconfig_json")
 
 formatjs_library(
     name = "dist",
@@ -18,13 +17,4 @@ formatjs_library(
         "//packages/ecma402-abstract/types",
     ],
     visibility = ["//visibility:public"],
-)
-
-generate_ide_tsconfig_json(
-    composite = True,
-    project_references = [
-        "//packages/ecma262-abstract",
-        "//packages/ecma402-abstract",
-        "//packages/ecma402-abstract/types",
-    ],
 )

--- a/packages/ecma402-abstract/NumberFormat/BUILD.bazel
+++ b/packages/ecma402-abstract/NumberFormat/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//tools:compile.bzl", "formatjs_library")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file")
+load("//tools:index.bzl", "generate_src_file")
 
 formatjs_library(
     name = "dist",
@@ -48,12 +48,4 @@ generate_src_file(
         "//:node_modules/json-stable-stringify",
     ],
     tool = "//packages/ecma402-abstract/scripts:digit-mapping",
-)
-
-generate_ide_tsconfig_json(
-    composite = True,
-    project_references = [
-        "//packages/ecma402-abstract",
-        "//packages/ecma402-abstract/types",
-    ],
 )

--- a/packages/ecma402-abstract/NumberFormat/tsconfig.json
+++ b/packages/ecma402-abstract/NumberFormat/tsconfig.json
@@ -12,6 +12,9 @@
     },
     {
       "path": "../types/tsconfig.json"
+    },
+    {
+      "path": "../../ecma262-abstract/tsconfig.json"
     }
   ]
 }

--- a/packages/ecma402-abstract/PluralRules/BUILD.bazel
+++ b/packages/ecma402-abstract/PluralRules/BUILD.bazel
@@ -1,5 +1,4 @@
 load("//tools:compile.bzl", "formatjs_library")
-load("//tools:index.bzl", "generate_ide_tsconfig_json")
 
 formatjs_library(
     name = "dist",
@@ -20,15 +19,5 @@ formatjs_library(
     deps = [
         "//:node_modules/@formatjs/bigdecimal",
         "//:node_modules/@formatjs/intl-localematcher",
-    ],
-)
-
-generate_ide_tsconfig_json(
-    composite = True,
-    project_references = [
-        "//packages/ecma262-abstract",
-        "//packages/ecma402-abstract",
-        "//packages/ecma402-abstract/NumberFormat",
-        "//packages/ecma402-abstract/types",
     ],
 )

--- a/packages/ecma402-abstract/RelativeTimeFormat/BUILD.bazel
+++ b/packages/ecma402-abstract/RelativeTimeFormat/BUILD.bazel
@@ -1,5 +1,4 @@
 load("//tools:compile.bzl", "formatjs_library")
-load("//tools:index.bzl", "generate_ide_tsconfig_json")
 
 formatjs_library(
     name = "dist",
@@ -19,13 +18,4 @@ formatjs_library(
     ],
     visibility = ["//visibility:public"],
     deps = ["//:node_modules/@formatjs/intl-localematcher"],
-)
-
-generate_ide_tsconfig_json(
-    composite = True,
-    project_references = [
-        "//packages/ecma262-abstract",
-        "//packages/ecma402-abstract",
-        "//packages/ecma402-abstract/types",
-    ],
 )

--- a/packages/ecma402-abstract/tsconfig.json
+++ b/packages/ecma402-abstract/tsconfig.json
@@ -15,5 +15,10 @@
     "./scripts/**/*",
     "./types/**/*"
   ],
-  "extends": "../../tsconfig.json"
+  "extends": "../../tsconfig.json",
+  "references": [
+    {
+      "path": "../ecma262-abstract/tsconfig.json"
+    }
+  ]
 }

--- a/packages/ecma402-abstract/types/BUILD.bazel
+++ b/packages/ecma402-abstract/types/BUILD.bazel
@@ -1,5 +1,4 @@
 load("//tools:compile.bzl", "formatjs_library")
-load("//tools:index.bzl", "generate_ide_tsconfig_json")
 
 formatjs_library(
     name = "dist",
@@ -18,8 +17,4 @@ formatjs_library(
     deps = [
         "//:node_modules/@formatjs/bigdecimal",
     ],
-)
-
-generate_ide_tsconfig_json(
-    composite = True,
 )

--- a/packages/icu-messageformat-parser/tsconfig.json
+++ b/packages/icu-messageformat-parser/tsconfig.json
@@ -5,5 +5,10 @@
     }
   },
   "exclude": ["./benchmark/**/*", "./integration-tests/**/*", "./tools/**/*"],
-  "extends": "../../tsconfig.json"
+  "extends": "../../tsconfig.json",
+  "references": [
+    {
+      "path": "../ecma402-abstract/types/tsconfig.json"
+    }
+  ]
 }

--- a/packages/icu-skeleton-parser/tsconfig.json
+++ b/packages/icu-skeleton-parser/tsconfig.json
@@ -5,5 +5,10 @@
     }
   },
   "exclude": ["./scripts/**/*"],
-  "extends": "../../tsconfig.json"
+  "extends": "../../tsconfig.json",
+  "references": [
+    {
+      "path": "../ecma402-abstract/types/tsconfig.json"
+    }
+  ]
 }

--- a/packages/intl-datetimeformat/tsconfig.json
+++ b/packages/intl-datetimeformat/tsconfig.json
@@ -5,5 +5,19 @@
     }
   },
   "exclude": ["./scripts/**/*"],
-  "extends": "../../tsconfig.json"
+  "extends": "../../tsconfig.json",
+  "references": [
+    {
+      "path": "../ecma262-abstract/tsconfig.json"
+    },
+    {
+      "path": "../ecma402-abstract/tsconfig.json"
+    },
+    {
+      "path": "../ecma402-abstract/DateTimeFormat/tsconfig.json"
+    },
+    {
+      "path": "../ecma402-abstract/types/tsconfig.json"
+    }
+  ]
 }

--- a/packages/intl-displaynames/tsconfig.json
+++ b/packages/intl-displaynames/tsconfig.json
@@ -5,5 +5,19 @@
     }
   },
   "exclude": ["./scripts/**/*"],
-  "extends": "../../tsconfig.json"
+  "extends": "../../tsconfig.json",
+  "references": [
+    {
+      "path": "../ecma262-abstract/tsconfig.json"
+    },
+    {
+      "path": "../ecma402-abstract/tsconfig.json"
+    },
+    {
+      "path": "../ecma402-abstract/DisplayNames/tsconfig.json"
+    },
+    {
+      "path": "../ecma402-abstract/types/tsconfig.json"
+    }
+  ]
 }

--- a/packages/intl-durationformat/tsconfig.json
+++ b/packages/intl-durationformat/tsconfig.json
@@ -5,5 +5,19 @@
     }
   },
   "exclude": ["./benchmark/**/*", "./scripts/**/*"],
-  "extends": "../../tsconfig.json"
+  "extends": "../../tsconfig.json",
+  "references": [
+    {
+      "path": "../ecma262-abstract/tsconfig.json"
+    },
+    {
+      "path": "../ecma402-abstract/tsconfig.json"
+    },
+    {
+      "path": "../ecma402-abstract/DurationFormat/tsconfig.json"
+    },
+    {
+      "path": "../ecma402-abstract/types/tsconfig.json"
+    }
+  ]
 }

--- a/packages/intl-listformat/tsconfig.json
+++ b/packages/intl-listformat/tsconfig.json
@@ -5,5 +5,13 @@
     }
   },
   "exclude": ["./scripts/**/*"],
-  "extends": "../../tsconfig.json"
+  "extends": "../../tsconfig.json",
+  "references": [
+    {
+      "path": "../ecma402-abstract/tsconfig.json"
+    },
+    {
+      "path": "../ecma402-abstract/types/tsconfig.json"
+    }
+  ]
 }

--- a/packages/intl-locale/BUILD.bazel
+++ b/packages/intl-locale/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:test262-harness/package_json.bzl", test262_harness_bin = "bin")
 load("//tools:compile.bzl", "formatjs_library")
-load("//tools:index.bzl", "generate_ide_tsconfig_json", "generate_src_file")
+load("//tools:index.bzl", "generate_src_file")
 load("//tools:rolldown.bzl", "rolldown_bundle")
 load("//tools:test.bzl", "formatjs_test")
 

--- a/packages/intl-locale/tsconfig.json
+++ b/packages/intl-locale/tsconfig.json
@@ -5,5 +5,13 @@
     }
   },
   "exclude": ["./scripts/**/*"],
-  "extends": "../../tsconfig.json"
+  "extends": "../../tsconfig.json",
+  "references": [
+    {
+      "path": "../ecma262-abstract/tsconfig.json"
+    },
+    {
+      "path": "../ecma402-abstract/tsconfig.json"
+    }
+  ]
 }

--- a/packages/intl-messageformat/tsconfig.json
+++ b/packages/intl-messageformat/tsconfig.json
@@ -4,5 +4,10 @@
       "#packages/*": ["../../packages/*"]
     }
   },
-  "extends": "../../tsconfig.json"
+  "extends": "../../tsconfig.json",
+  "references": [
+    {
+      "path": "../ecma402-abstract/types/tsconfig.json"
+    }
+  ]
 }

--- a/packages/intl-numberformat/tsconfig.json
+++ b/packages/intl-numberformat/tsconfig.json
@@ -5,5 +5,19 @@
     }
   },
   "exclude": ["./benchmark/**/*", "./scripts/**/*"],
-  "extends": "../../tsconfig.json"
+  "extends": "../../tsconfig.json",
+  "references": [
+    {
+      "path": "../ecma262-abstract/tsconfig.json"
+    },
+    {
+      "path": "../ecma402-abstract/tsconfig.json"
+    },
+    {
+      "path": "../ecma402-abstract/NumberFormat/tsconfig.json"
+    },
+    {
+      "path": "../ecma402-abstract/types/tsconfig.json"
+    }
+  ]
 }

--- a/packages/intl-pluralrules/tsconfig.json
+++ b/packages/intl-pluralrules/tsconfig.json
@@ -5,5 +5,16 @@
     }
   },
   "exclude": ["./scripts/**/*"],
-  "extends": "../../tsconfig.json"
+  "extends": "../../tsconfig.json",
+  "references": [
+    {
+      "path": "../ecma402-abstract/tsconfig.json"
+    },
+    {
+      "path": "../ecma402-abstract/PluralRules/tsconfig.json"
+    },
+    {
+      "path": "../ecma402-abstract/types/tsconfig.json"
+    }
+  ]
 }

--- a/packages/intl-relativetimeformat/tsconfig.json
+++ b/packages/intl-relativetimeformat/tsconfig.json
@@ -5,5 +5,19 @@
     }
   },
   "exclude": ["./scripts/**/*"],
-  "extends": "../../tsconfig.json"
+  "extends": "../../tsconfig.json",
+  "references": [
+    {
+      "path": "../ecma262-abstract/tsconfig.json"
+    },
+    {
+      "path": "../ecma402-abstract/tsconfig.json"
+    },
+    {
+      "path": "../ecma402-abstract/RelativeTimeFormat/tsconfig.json"
+    },
+    {
+      "path": "../ecma402-abstract/types/tsconfig.json"
+    }
+  ]
 }

--- a/packages/intl-segmenter/tsconfig.json
+++ b/packages/intl-segmenter/tsconfig.json
@@ -5,5 +5,10 @@
     }
   },
   "exclude": ["./scripts/**/*"],
-  "extends": "../../tsconfig.json"
+  "extends": "../../tsconfig.json",
+  "references": [
+    {
+      "path": "../ecma402-abstract/tsconfig.json"
+    }
+  ]
 }

--- a/packages/intl-supportedvaluesof/tsconfig.json
+++ b/packages/intl-supportedvaluesof/tsconfig.json
@@ -5,5 +5,10 @@
     }
   },
   "exclude": ["./scripts/**/*"],
-  "extends": "../../tsconfig.json"
+  "extends": "../../tsconfig.json",
+  "references": [
+    {
+      "path": "../ecma402-abstract/tsconfig.json"
+    }
+  ]
 }

--- a/packages/intl/tsconfig.json
+++ b/packages/intl/tsconfig.json
@@ -4,5 +4,10 @@
       "#packages/*": ["../../packages/*"]
     }
   },
-  "extends": "../../tsconfig.json"
+  "extends": "../../tsconfig.json",
+  "references": [
+    {
+      "path": "../ecma402-abstract/types/tsconfig.json"
+    }
+  ]
 }

--- a/packages/react-intl/tsconfig.json
+++ b/packages/react-intl/tsconfig.json
@@ -10,5 +10,10 @@
     "./integration-tests/**/*",
     "./scripts/**/*"
   ],
-  "extends": "../../tsconfig.json"
+  "extends": "../../tsconfig.json",
+  "references": [
+    {
+      "path": "../ecma402-abstract/types/tsconfig.json"
+    }
+  ]
 }

--- a/tools/compile.bzl
+++ b/tools/compile.bzl
@@ -87,8 +87,6 @@ def _formatjs_package(
         pkg = ":pkg",
     )
 
-    generate_ide_tsconfig_json()
-
 def formatjs_library(
         name,
         srcs,
@@ -218,3 +216,8 @@ def formatjs_library(
             extra_npm_srcs = extra_npm_srcs,
             allow_overwrites = allow_overwrites,
         )
+
+    generate_ide_tsconfig_json(
+        composite = not has_package_json,
+        project_references = project_references,
+    )


### PR DESCRIPTION
## Summary
- Move `generate_ide_tsconfig_json` from individual BUILD files into `formatjs_library` macro
- `composite = not has_package_json` (internal packages are composite)
- Forward `project_references` to tsconfig so IDE gets correct `references`
- Regenerate all tsconfig.json files — published packages now include project references for better IDE navigation

## Test plan
- [x] `bazel test //packages/ecma402-abstract:unit_test` — passes
- [x] `bazel test //packages/ecma402-abstract/types:tsconfig_json_test` — passes
- [x] `bazel run //:gazelle` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)