### PR TITLE
fix(deps): handle oxc parser errors gracefully

### DIFF
--- a/crates/ts_import_extractor/src/main.rs
+++ b/crates/ts_import_extractor/src/main.rs
@@ -79,10 +79,16 @@ fn main() {
             let response = handle_request(request);
             let payload = serde_json::to_vec(&response).unwrap();
 
+            // Write response frame. Exit cleanly on pipe errors (Go side closed stdout).
             let mut out = stdout.lock();
-            out.write_all(&(payload.len() as u32).to_be_bytes()).unwrap();
-            out.write_all(&payload).unwrap();
-            out.flush().unwrap();
+            if out
+                .write_all(&(payload.len() as u32).to_be_bytes())
+                .and_then(|_| out.write_all(&payload))
+                .and_then(|_| out.flush())
+                .is_err()
+            {
+                return;
+            }
         }
     }
 }

--- a/knowledge-base/001a-bazel-toolchain.md
+++ b/knowledge-base/001a-bazel-toolchain.md
@@ -173,7 +173,7 @@ vitest(name, srcs, deps, data, no_copy_to_bin, tsconfig, dom, snapshots, fixture
 
 Custom Go gazelle plugin that auto-generates and maintains `formatjs_library` and `formatjs_test` rules by parsing TypeScript imports with oxc (Rust).
 
-**Source files:**
+**Source files (Go — tools/gazelle/ts/):**
 
 | File            | Purpose                                                             |
 | --------------- | ------------------------------------------------------------------- |
@@ -181,8 +181,16 @@ Custom Go gazelle plugin that auto-generates and maintains `formatjs_library` an
 | `resolve.go`    | Resolve phase: converts imports → Bazel labels, reads package.json  |
 | `config.go`     | Per-directory config, `formatjs_enabled` directive                  |
 | `kinds.go`      | Rule type definitions and merge behavior (MergeableAttrs, etc.)     |
-| `parser.go`     | Import extraction entry point + tree-sitter fallback                |
+| `parser.go`     | Import extraction entry point (delegates to oxc subprocess)         |
 | `parser_oxc.go` | Oxc subprocess client (length-prefixed JSON over stdin/stdout)      |
+
+**Source files (Rust — crates/ts_import_extractor/):**
+
+| File                     | Purpose                                                    |
+| ------------------------ | ---------------------------------------------------------- |
+| `src/main.rs`            | Subprocess main loop: stdin/stdout framing, rayon dispatch |
+| `src/extract_imports.rs` | oxc AST visitor: extracts import paths from TS/TSX files   |
+| `src/lib.rs`             | Public API re-exports for the library                      |
 
 **Auto-generation behavior:**
 
@@ -222,18 +230,46 @@ Custom Go gazelle plugin that auto-generates and maintains `formatjs_library` an
 - npm packages → `//:node_modules/<pkg>` (with auto `@types` detection)
 - Only adds deps for packages found in root `package.json` (prevents non-existent targets)
 
-**Oxc parser subprocess (crates/ts_import_extractor/):**
+**Oxc parser subprocess architecture:**
 
-- Long-lived Rust binary communicating over stdin/stdout with length-prefixed JSON frames
-- Uses oxc 0.120 to parse TypeScript/TSX, walks AST via `Visit` trait
-- Extracts: `import_declaration`, `export_named_declaration`, `export_all_declaration`, `import_expression`
-- Uses rayon for parallel file parsing within a single request batch
-- ~36x faster than tree-sitter, ~195x less memory (benchmarked on 200 files, M4 Max, `-c opt`)
-- Falls back to tree-sitter if subprocess is unavailable
+The plugin uses a subprocess model (not cgo/FFI) for calling Rust from Go. This avoids
+cgo overhead, FFI memory management, `cc_library` chains, and dylib path issues.
+
+```
+Go (gazelle plugin)                     Rust (ts_import_extractor)
+┌────────────────────────┐              ┌──────────────────────────────┐
+│ parser_oxc.go          │  stdin       │ main.rs                      │
+│   OxcParser struct     │ ────────────>│   length-prefixed JSON loop  │
+│   writeFrame/readFrame │  stdout      │   rayon parallel file parse  │
+│   runfiles.Rlocation   │ <────────────│   oxc Visit AST walker       │
+└────────────────────────┘              └──────────────────────────────┘
+```
+
+- **Protocol:** Length-prefixed JSON frames over stdin/stdout.
+  Each frame: `[4-byte big-endian u32 length][JSON payload]`
+  - Request: `{"id": N, "files": ["path/to/file.ts", ...]}`
+  - Response: `{"id": N, "imports": [{"file": "...", "importPaths": [...]}, ...]}`
+- **Lifecycle:** Subprocess spawned lazily on first parse request (via `sync.Once`),
+  stays alive for entire gazelle run, exits when Go closes stdin.
+- **Binary discovery:** `runfiles.Rlocation("_main/crates/ts_import_extractor/bin")`.
+  The binary is a `data` dep on the `go_library` rule.
+- **Parallelism:** rayon thread pool on the Rust side processes files within a batch in parallel.
+- **Error handling:** Go side returns nil parser on startup failure (graceful degradation).
+  Rust side exits cleanly on stdout pipe errors instead of panicking.
+- **oxc AST visitor:** Implements `Visit<'a>` trait, extracts from 4 node types:
+  `ImportDeclaration`, `ExportNamedDeclaration`, `ExportAllDeclaration`, `ImportExpression`
+
+**Performance (200 files, M4 Max, `bazel test -c opt`):**
+
+| Metric    | Tree-sitter (old) | Oxc (current) | Improvement |
+| --------- | ----------------- | ------------- | ----------- |
+| Time/op   | 89.5ms            | 2.5ms         | ~36x faster |
+| Memory/op | 32.2MB            | 165KB         | ~195x less  |
+| Allocs/op | 323,058           | 1,283         | ~252x fewer |
 
 **Three-phase pipeline:**
 
-1. **GenerateRules** (language.go): Scan `.ts`/`.tsx` files, extract imports via oxc, create rules with `srcs`
+1. **GenerateRules** (language.go): Scan `.ts`/`.tsx` files, extract imports via oxc subprocess, create rules with `srcs`
 2. **Imports** (language.go): Register each rule in the RuleIndex (exact + wildcard paths)
 3. **Resolve** (resolve.go): Query RuleIndex to convert imports → Bazel labels, set `deps`/`project_references`
 

--- a/tools/gazelle/ts/parser_oxc.go
+++ b/tools/gazelle/ts/parser_oxc.go
@@ -75,11 +75,13 @@ var (
 )
 
 // getOxcParser returns the global OxcParser, starting the subprocess on first call.
+// Returns nil if the subprocess cannot be started (caller should handle gracefully).
 func getOxcParser() *OxcParser {
 	oxcParserOnce.Do(func() {
 		p, err := newOxcParser()
 		if err != nil {
-			log.Fatalf("formatjs_ts: failed to start oxc parser: %v", err)
+			log.Printf("formatjs_ts: oxc parser unavailable: %v", err)
+			return // globalOxcParser stays nil
 		}
 		globalOxcParser = p
 	})
@@ -90,6 +92,9 @@ func getOxcParser() *OxcParser {
 // The binary's stderr is forwarded to the Go process's stderr for debugging.
 func newOxcParser() (*OxcParser, error) {
 	binPath := findOxcBinary()
+	if binPath == "" {
+		return nil, fmt.Errorf("ts_import_extractor binary not found in runfiles")
+	}
 
 	cmd := exec.Command(binPath)
 	cmd.Stderr = os.Stderr
@@ -117,6 +122,7 @@ func newOxcParser() (*OxcParser, error) {
 
 // findOxcBinary locates the ts_import_extractor binary using Bazel runfiles.
 // Override with FORMATJS_OXC_PARSER_BIN env var for testing outside Bazel.
+// Returns empty string if the binary cannot be found.
 func findOxcBinary() string {
 	if bin := os.Getenv("FORMATJS_OXC_PARSER_BIN"); bin != "" {
 		return bin
@@ -124,7 +130,7 @@ func findOxcBinary() string {
 
 	bin, err := runfiles.Rlocation("_main/crates/ts_import_extractor/bin")
 	if err != nil {
-		log.Fatalf("formatjs_ts: cannot locate ts_import_extractor binary: %v", err)
+		return ""
 	}
 	return bin
 }
@@ -208,8 +214,12 @@ func (p *OxcParser) readFrame() (*oxcResponse, error) {
 
 // extractImportsOxc extracts imports from a single file using the oxc subprocess.
 // This is the function called by language.go's GenerateRules for each TypeScript file.
+// Returns an error if the oxc parser is unavailable (caller can fall back to other methods).
 func extractImportsOxc(filePath string) ([]ImportStatement, error) {
 	parser := getOxcParser()
+	if parser == nil {
+		return nil, fmt.Errorf("oxc parser not available")
+	}
 
 	result, err := parser.ExtractImports([]string{filePath})
 	if err != nil {


### PR DESCRIPTION
## Summary
- Addresses review comments from #6360
- Go: `getOxcParser()` now logs a warning and returns nil instead of crashing with `log.Fatalf` when the oxc binary is unavailable
- Go: `extractImportsOxc()` returns an error when parser is nil, allowing callers to handle gracefully
- Rust: stdout write errors exit cleanly instead of panicking via `unwrap()`

## Test plan
- [x] `bazel test //tools/gazelle/ts:ts_test //crates/ts_import_extractor:unit_test` — all tests pass
- [x] `bazel run //:gazelle` — end-to-end works

🤖 Generated with [Claude Code](https://claude.com/claude-code)