### PR TITLE
refactor(deps): restructure gazelle TS plugin architecture

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,14 +1,14 @@
 module github.com/nicolo-ribaudo/formatjs
 
-go 1.24.4
+go 1.24.12
 
 require (
-	github.com/bazelbuild/bazel-gazelle v0.42.0 // matches gazelle 0.50.0 bzlmod
+	github.com/bazelbuild/bazel-gazelle v0.50.0
 	github.com/bazelbuild/rules_go v0.60.0
 )
 
 require (
-	github.com/bazelbuild/buildtools v0.0.0-20240918101019-be1c24cc9a44 // indirect
+	github.com/bazelbuild/buildtools v0.0.0-20250930140053-2eb4fccefb52 // indirect
 	golang.org/x/mod v0.25.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/tools/go/vcs v0.1.0-deprecated // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
-github.com/bazelbuild/bazel-gazelle v0.42.0 h1:BpkUzE3H2l6buJYFTKgzVMecJimQgWwYud25qVIx0SQ=
-github.com/bazelbuild/bazel-gazelle v0.42.0/go.mod h1:SRCc60YGZ27y+BqLzQ+nMh249+FyZz7YtX/V2ng+/z4=
-github.com/bazelbuild/buildtools v0.0.0-20240918101019-be1c24cc9a44 h1:FGzENZi+SX9I7h9xvMtRA3rel8hCEfyzSixteBgn7MU=
-github.com/bazelbuild/buildtools v0.0.0-20240918101019-be1c24cc9a44/go.mod h1:PLNUetjLa77TCCziPsz0EI8a6CUxgC+1jgmWv0H25tg=
+github.com/bazelbuild/bazel-gazelle v0.50.0 h1:/QNWnew6d0y9afP+0uWiGFIApw+spvE5fdVdNjcpHg0=
+github.com/bazelbuild/bazel-gazelle v0.50.0/go.mod h1:qtev3UlNStnHm6TEBM0pkDgOc1wSMBcbD/3wktJL7i8=
+github.com/bazelbuild/buildtools v0.0.0-20250930140053-2eb4fccefb52 h1:njQAmjTv/YHRm/0Lfv9DXHFZ4MdT2IA/RKHTnqZkgDw=
+github.com/bazelbuild/buildtools v0.0.0-20250930140053-2eb4fccefb52/go.mod h1:PLNUetjLa77TCCziPsz0EI8a6CUxgC+1jgmWv0H25tg=
 github.com/bazelbuild/rules_go v0.60.0 h1:apGSxTTrFUyLNvX9NQmF4CbntWAO0/S5eALeVgB/6Qk=
 github.com/bazelbuild/rules_go v0.60.0/go.mod h1:CYcohJVxs4n7eftbC39GCqaEJm3E1EME+6QAkGguKoI=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=

--- a/knowledge-base/001a-bazel-toolchain.md
+++ b/knowledge-base/001a-bazel-toolchain.md
@@ -175,14 +175,19 @@ Custom Go gazelle plugin that auto-generates and maintains `formatjs_library` an
 
 **Source files (Go — tools/gazelle/ts/):**
 
-| File            | Purpose                                                             |
-| --------------- | ------------------------------------------------------------------- |
-| `language.go`   | Main entry point: GenerateRules (file scanning), Imports (indexing) |
-| `resolve.go`    | Resolve phase: converts imports → Bazel labels, reads package.json  |
-| `config.go`     | Per-directory config, `formatjs_enabled` directive                  |
-| `kinds.go`      | Rule type definitions and merge behavior (MergeableAttrs, etc.)     |
-| `parser.go`     | Import extraction entry point (delegates to oxc subprocess)         |
-| `parser_oxc.go` | Oxc subprocess client (length-prefixed JSON over stdin/stdout)      |
+| File            | Purpose                                                                            |
+| --------------- | ---------------------------------------------------------------------------------- |
+| `language.go`   | Plugin struct (`tsLang`) with state: lifecycle manager + pkg.json cache            |
+| `lifecycle.go`  | `lifeCycleManager`: starts/stops oxc subprocess via `Before`/`DoneGeneratingRules` |
+| `generate.go`   | `GenerateRules`: file scanning, import extraction, rule creation                   |
+| `imports.go`    | `Imports`: registers rules in RuleIndex (exact + wildcard paths)                   |
+| `resolve.go`    | `Resolve`: converts imports → Bazel labels, reads package.json                     |
+| `config.go`     | `tsConfig` data struct for per-directory configuration                             |
+| `configure.go`  | `Configure`: reads BUILD directives, manages config inheritance                    |
+| `kinds.go`      | Rule type definitions, merge behavior, `Kinds()`, `Loads()`                        |
+| `fix.go`        | `Fix`: post-processing hook (currently no-op)                                      |
+| `parser.go`     | `ImportStatement` type + `extractImportsBatch` method                              |
+| `parser_oxc.go` | `OxcParser` subprocess client (length-prefixed JSON over stdin/stdout)             |
 
 **Source files (Rust — crates/ts_import_extractor/):**
 
@@ -249,15 +254,15 @@ Go (gazelle plugin)                     Rust (ts_import_extractor)
   Each frame: `[4-byte big-endian u32 length][JSON payload]`
   - Request: `{"id": N, "files": ["path/to/file.ts", ...]}`
   - Response: `{"id": N, "imports": [{"file": "...", "importPaths": [...]}, ...]}`
-- **Lifecycle:** Subprocess spawned lazily on first parse request (via `sync.Once`),
-  stays alive for entire gazelle run, exits when Go closes stdin.
+- **Lifecycle:** Subprocess spawned in `lifeCycleManager.Before()` at plugin startup,
+  shut down in `DoneGeneratingRules()`. Stays alive for entire gazelle run.
 - **Binary discovery:** `runfiles.Rlocation("_main/crates/ts_import_extractor/bin")`.
   The binary is a `data` dep on the `go_library` rule.
 - **Batching:** All TypeScript files in a directory are sent in one request (not per-file).
   rayon thread pool on the Rust side parses files within the batch in parallel.
 - **Error handling:**
-  - Go: `getOxcParser()` returns nil on startup failure (graceful degradation, logs warning).
-    `extractImportsBatch()` returns nil map if parser unavailable — caller skips imports.
+  - Go: `Before()` logs warning on startup failure; `extractImportsBatch()` returns nil map
+    if parser unavailable — caller skips imports.
   - Rust: checks `ret.errors` after parsing — malformed files return `Err` with oxc diagnostics
     instead of extracting from partially-recovered ASTs (avoids incorrect dep graphs).
     Stdout write errors exit cleanly instead of panicking.
@@ -276,9 +281,15 @@ Go (gazelle plugin)                     Rust (ts_import_extractor)
 
 **Three-phase pipeline:**
 
-1. **GenerateRules** (language.go): Scan `.ts`/`.tsx` files, extract imports via oxc subprocess, create rules with `srcs`
-2. **Imports** (language.go): Register each rule in the RuleIndex (exact + wildcard paths)
+1. **GenerateRules** (generate.go): Scan `.ts`/`.tsx` files, extract imports via oxc subprocess, create rules with `srcs`
+2. **Imports** (imports.go): Register each rule in the RuleIndex (exact + wildcard paths)
 3. **Resolve** (resolve.go): Query RuleIndex to convert imports → Bazel labels, set `deps`/`project_references`
+
+**Architecture pattern:** The plugin follows the same separation-of-concerns pattern as
+[gazelle-ts-plugin](https://github.com/aspect-build/gazelle-ts-plugin):
+stateful language struct with lifecycle management, one file per Gazelle interface method
+(`generate.go`, `imports.go`, `resolve.go`, `configure.go`, `fix.go`), and config data
+separate from config interface (`config.go` vs `configure.go`).
 
 ### generate_ide_tsconfig_json (tools/index.bzl)
 

--- a/tools/gazelle/ts/BUILD.bazel
+++ b/tools/gazelle/ts/BUILD.bazel
@@ -4,8 +4,13 @@ go_library(
     name = "ts",
     srcs = [
         "config.go",
+        "configure.go",
+        "fix.go",
+        "generate.go",
+        "imports.go",
         "kinds.go",
         "language.go",
+        "lifecycle.go",
         "parser.go",
         "parser_oxc.go",
         "resolve.go",

--- a/tools/gazelle/ts/config.go
+++ b/tools/gazelle/ts/config.go
@@ -1,22 +1,8 @@
-// config.go implements per-directory configuration for the formatjs TS gazelle plugin.
+// config.go defines the per-directory configuration data struct for the formatjs TS plugin.
 //
-// Configuration is inherited from parent directories and can be overridden via
-// BUILD file directives. Currently supports one directive:
-//
-//	# gazelle:formatjs_enabled false
-//
-// This disables the plugin for a directory and all its subdirectories (unless
-// re-enabled by a child directory's directive). Use this for directories that
-// have custom build rules and shouldn't get auto-generated formatjs_library
-// or formatjs_test targets.
+// The Gazelle interface methods (RegisterFlags, CheckFlags, KnownDirectives, Configure)
+// that populate this config live in configure.go.
 package ts
-
-import (
-	"flag"
-
-	"github.com/bazelbuild/bazel-gazelle/config"
-	"github.com/bazelbuild/bazel-gazelle/rule"
-)
 
 // tsConfig holds per-directory configuration for the formatjs TS gazelle plugin.
 // Gazelle calls Configure() for each directory during the walk, building up
@@ -40,55 +26,4 @@ func (c *tsConfig) clone() *tsConfig {
 	return &tsConfig{
 		enabled: c.enabled,
 	}
-}
-
-// RegisterFlags is a no-op — we don't support command-line flags.
-// All configuration is via BUILD file directives.
-func (l *tsLang) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Config) {}
-
-// CheckFlags is a no-op — no flags to validate.
-func (l *tsLang) CheckFlags(fs *flag.FlagSet, c *config.Config) error { return nil }
-
-// KnownDirectives returns the list of BUILD file directives this plugin recognizes.
-// Gazelle ignores directives not in this list (they may belong to other plugins).
-//
-// Supported directives:
-//
-//	# gazelle:formatjs_enabled true|false
-//	    Enable or disable the plugin for this directory and its children.
-//	    Default: true (inherited from parent, or true at repo root).
-func (l *tsLang) KnownDirectives() []string {
-	return []string{
-		"formatjs_enabled",
-	}
-}
-
-// Configure is called by Gazelle for each directory during the walk.
-// It builds up per-directory configuration by:
-//  1. Cloning the parent directory's config (or creating a new default)
-//  2. Applying any BUILD file directives found in this directory
-//  3. Storing the result in c.Exts[languageName] for GenerateRules to read
-//
-// The config inheritance chain means a single directive in a parent BUILD file
-// affects all descendant directories until overridden.
-func (l *tsLang) Configure(c *config.Config, rel string, f *rule.File) {
-	// Clone parent config or create default.
-	var cfg *tsConfig
-	if raw, ok := c.Exts[languageName]; ok {
-		cfg = raw.(*tsConfig).clone()
-	} else {
-		cfg = newTsConfig()
-	}
-
-	// Apply directives from the BUILD file in this directory.
-	if f != nil {
-		for _, d := range f.Directives {
-			switch d.Key {
-			case "formatjs_enabled":
-				cfg.enabled = d.Value == "true"
-			}
-		}
-	}
-
-	c.Exts[languageName] = cfg
 }

--- a/tools/gazelle/ts/configure.go
+++ b/tools/gazelle/ts/configure.go
@@ -1,0 +1,71 @@
+// configure.go implements the Gazelle Configurer interface for the formatjs TS plugin.
+//
+// This handles per-directory configuration by reading BUILD file directives and
+// managing the config inheritance chain. The actual config data struct lives in config.go.
+package ts
+
+import (
+	"flag"
+
+	"github.com/bazelbuild/bazel-gazelle/config"
+	"github.com/bazelbuild/bazel-gazelle/rule"
+)
+
+// RegisterFlags is a no-op — we don't support command-line flags.
+// All configuration is via BUILD file directives.
+func (l *tsLang) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Config) {}
+
+// CheckFlags is a no-op — no flags to validate.
+func (l *tsLang) CheckFlags(fs *flag.FlagSet, c *config.Config) error { return nil }
+
+// KnownDirectives returns the list of BUILD file directives this plugin recognizes.
+// Gazelle ignores directives not in this list (they may belong to other plugins).
+//
+// Supported directives:
+//
+//	# gazelle:formatjs_enabled true|false
+//	    Enable or disable the plugin for this directory and its children.
+//	    Default: true (inherited from parent, or true at repo root).
+func (l *tsLang) KnownDirectives() []string {
+	return []string{
+		"formatjs_enabled",
+	}
+}
+
+// Configure is called by Gazelle for each directory during the walk.
+// It builds up per-directory configuration by:
+//  1. Cloning the parent directory's config (or creating a new default)
+//  2. Applying any BUILD file directives found in this directory
+//  3. Storing the result in c.Exts[languageName] for GenerateRules to read
+//
+// The config inheritance chain means a single directive in a parent BUILD file
+// affects all descendant directories until overridden.
+//
+// At the repo root (rel == ""), this also loads the package.json data
+// that is needed for import resolution.
+func (l *tsLang) Configure(c *config.Config, rel string, f *rule.File) {
+	// Clone parent config or create default.
+	var cfg *tsConfig
+	if raw, ok := c.Exts[languageName]; ok {
+		cfg = raw.(*tsConfig).clone()
+	} else {
+		cfg = newTsConfig()
+	}
+
+	// Apply directives from the BUILD file in this directory.
+	if f != nil {
+		for _, d := range f.Directives {
+			switch d.Key {
+			case "formatjs_enabled":
+				cfg.enabled = d.Value == "true"
+			}
+		}
+	}
+
+	c.Exts[languageName] = cfg
+
+	// Load package.json data at the repo root for import resolution.
+	if rel == "" {
+		l.loadPackageJSONDeps(c.RepoRoot)
+	}
+}

--- a/tools/gazelle/ts/fix.go
+++ b/tools/gazelle/ts/fix.go
@@ -1,0 +1,9 @@
+package ts
+
+import (
+	"github.com/bazelbuild/bazel-gazelle/config"
+	"github.com/bazelbuild/bazel-gazelle/rule"
+)
+
+// Fix performs post-processing on BUILD files after merge. Currently a no-op.
+func (l *tsLang) Fix(c *config.Config, f *rule.File) {}

--- a/tools/gazelle/ts/generate.go
+++ b/tools/gazelle/ts/generate.go
@@ -1,0 +1,145 @@
+// generate.go implements the GenerateRules phase of Gazelle's pipeline.
+//
+// For each directory, it:
+//  1. Checks if the plugin is enabled for this directory
+//  2. Scans all .ts/.tsx files and extracts import statements via the oxc subprocess
+//  3. Partitions files into source files and test files
+//  4. Generates formatjs_library rule (if source files exist) with srcs + visibility
+//  5. Generates formatjs_test rule (if test files exist) with srcs
+//  6. Attaches ImportData to each generated rule for later resolution in Resolve()
+package ts
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/bazelbuild/bazel-gazelle/language"
+	"github.com/bazelbuild/bazel-gazelle/rule"
+)
+
+// ImportData carries parsed import statements from GenerateRules to Resolve.
+// Gazelle's architecture requires this two-phase approach because GenerateRules
+// runs during the directory walk (before the full RuleIndex is built), while
+// Resolve runs after all directories have been scanned and the RuleIndex is complete.
+//
+// The separation of Imports vs TestImports matters because:
+//   - Source imports become deps + project_references on formatjs_library
+//   - Test imports become deps on formatjs_test (source deps are transitive via :lib)
+type ImportData struct {
+	Imports     []ImportStatement // Source file imports
+	TestImports []ImportStatement // Test file imports
+}
+
+// GenerateRules is called by Gazelle for each directory during the "generate" phase.
+//
+// The generated rules are merged with existing BUILD file content by Gazelle's merge
+// engine. The merge behavior is controlled by KindInfo in kinds.go:
+//   - MergeableAttrs (srcs):             merged with existing, preserving "# keep" entries
+//   - ResolveAttrs (deps, project_refs): set by Resolve(), replacing existing values
+//   - Other attrs (visibility, etc.):    set here, overwriting existing values
+//   - Unset attrs:                       preserved from existing BUILD file
+//
+// This means manually-set attrs like entry_points, types, npm_package_name, etc.
+// survive gazelle runs because we don't set them on the generated rule.
+func (l *tsLang) GenerateRules(args language.GenerateArgs) language.GenerateResult {
+	cfg, ok := args.Config.Exts[languageName].(*tsConfig)
+	if !ok || !cfg.enabled {
+		return language.GenerateResult{}
+	}
+
+	// Phase 1: Collect all TypeScript files and partition into source/test srcs.
+	libSrcs, testSrcs := collectSrcs(args.RegularFiles)
+
+	// Phase 2: Batch-parse all TypeScript files in one subprocess call.
+	var tsFiles []string
+	for _, f := range args.RegularFiles {
+		if isTypeScriptFile(f) {
+			tsFiles = append(tsFiles, filepath.Join(args.Dir, f))
+		}
+	}
+
+	var sourceImports, testImports []ImportStatement
+	if len(tsFiles) > 0 {
+		allImports, _ := l.extractImportsBatch(tsFiles)
+		for _, f := range args.RegularFiles {
+			if !isTypeScriptFile(f) {
+				continue
+			}
+			fullPath := filepath.Join(args.Dir, f)
+			imps := allImports[fullPath]
+			if isTestFile(f) {
+				testImports = append(testImports, imps...)
+			} else {
+				sourceImports = append(sourceImports, imps...)
+			}
+		}
+	}
+
+	// Early return if no TypeScript files at all — don't generate empty rules.
+	if len(libSrcs) == 0 && len(testSrcs) == 0 {
+		return language.GenerateResult{}
+	}
+
+	// Phase 3: Generate rules.
+	var genRules []*rule.Rule
+	var genImports []interface{}
+
+	if len(libSrcs) > 0 {
+		newRule := rule.NewRule(KindFormatjsLibrary, "dist")
+		newRule.SetAttr("srcs", libSrcs)
+		newRule.SetAttr("visibility", []string{"//visibility:public"})
+		genRules = append(genRules, newRule)
+		genImports = append(genImports, ImportData{
+			Imports: sourceImports,
+		})
+	}
+
+	if len(testSrcs) > 0 {
+		newRule := rule.NewRule(KindFormatjsTest, "unit_test")
+		newRule.SetAttr("srcs", testSrcs)
+		genRules = append(genRules, newRule)
+		genImports = append(genImports, ImportData{
+			TestImports: testImports,
+		})
+	}
+
+	return language.GenerateResult{
+		Gen:     genRules,
+		Imports: genImports,
+	}
+}
+
+// isTypeScriptFile returns true for .ts and .tsx files.
+func isTypeScriptFile(name string) bool {
+	return strings.HasSuffix(name, ".ts") || strings.HasSuffix(name, ".tsx")
+}
+
+// isTestFile returns true for files that should be treated as test code.
+func isTestFile(name string) bool {
+	return strings.Contains(name, ".test.ts") ||
+		strings.Contains(name, ".test.tsx") ||
+		strings.HasPrefix(name, "tests/") ||
+		strings.HasPrefix(name, "test/")
+}
+
+// collectSrcs partitions args.RegularFiles into source and test file lists.
+//
+// Source files: .ts/.tsx files that aren't test files.
+// Test files:   .ts/.tsx files AND .json files under tests/ directories.
+//
+// Both lists are sorted for deterministic BUILD file output.
+func collectSrcs(regularFiles []string) (srcFiles, testFiles []string) {
+	for _, f := range regularFiles {
+		if isTestFile(f) {
+			if isTypeScriptFile(f) || strings.HasSuffix(f, ".json") {
+				testFiles = append(testFiles, f)
+			}
+		} else if isTypeScriptFile(f) {
+			srcFiles = append(srcFiles, f)
+		}
+	}
+	sort.Strings(srcFiles)
+	sort.Strings(testFiles)
+	return
+}

--- a/tools/gazelle/ts/imports.go
+++ b/tools/gazelle/ts/imports.go
@@ -1,0 +1,37 @@
+// imports.go determines what each rule provides to the RuleIndex.
+//
+// This is called during the "index" phase for every rule in every BUILD file.
+// The returned ImportSpecs are stored in a reverse index that maps import paths
+// to Bazel labels. Later, during Resolve(), we query this index to find which
+// rule provides a given import.
+package ts
+
+import (
+	"github.com/bazelbuild/bazel-gazelle/config"
+	"github.com/bazelbuild/bazel-gazelle/resolve"
+	"github.com/bazelbuild/bazel-gazelle/rule"
+)
+
+// Imports returns the import specs that a rule provides, used to build the RuleIndex.
+//
+// For a rule at //packages/ecma402-abstract/NumberFormat, we register:
+//   - "packages/ecma402-abstract/NumberFormat"   (exact match)
+//   - "packages/ecma402-abstract/NumberFormat/*"  (wildcard for subpath imports)
+//
+// This allows imports like:
+//   - #packages/ecma402-abstract/NumberFormat/ToRawFixed.js → //packages/ecma402-abstract/NumberFormat
+//   - #packages/ecma402-abstract/NumberFormat               → //packages/ecma402-abstract/NumberFormat
+//
+// Only formatjs_library and ts_compile rules provide imports — formatjs_test
+// rules don't export reusable modules.
+func (l *tsLang) Imports(c *config.Config, r *rule.Rule, f *rule.File) []resolve.ImportSpec {
+	if r.Kind() != KindFormatjsLibrary && r.Kind() != KindTsCompile {
+		return nil
+	}
+
+	pkg := f.Pkg
+	return []resolve.ImportSpec{
+		{Lang: languageName, Imp: pkg},
+		{Lang: languageName, Imp: pkg + "/*"},
+	}
+}

--- a/tools/gazelle/ts/kinds.go
+++ b/tools/gazelle/ts/kinds.go
@@ -14,7 +14,9 @@
 // entry_points, types, npm_package_name, etc. survive gazelle runs.
 package ts
 
-import "github.com/bazelbuild/bazel-gazelle/rule"
+import (
+	"github.com/bazelbuild/bazel-gazelle/rule"
+)
 
 const (
 	// KindFormatjsLibrary is the main TypeScript compilation rule.
@@ -70,4 +72,28 @@ var tsKinds = map[string]rule.KindInfo{
 	KindTsCompile: {
 		NonEmptyAttrs: map[string]bool{"name": true},
 	},
+}
+
+// Kinds tells Gazelle which rule types this plugin manages and how to merge them.
+func (l *tsLang) Kinds() map[string]rule.KindInfo {
+	return tsKinds
+}
+
+// Loads declares the .bzl files that provide the rule kinds we generate.
+// Gazelle uses this to add the correct load() statements at the top of BUILD files.
+func (l *tsLang) Loads() []rule.LoadInfo {
+	return []rule.LoadInfo{
+		{
+			Name:    "//tools:compile.bzl",
+			Symbols: []string{KindFormatjsLibrary},
+		},
+		{
+			Name:    "//tools:test.bzl",
+			Symbols: []string{KindFormatjsTest},
+		},
+		{
+			Name:    "//tools:index.bzl",
+			Symbols: []string{KindTsCompile},
+		},
+	}
 }

--- a/tools/gazelle/ts/language.go
+++ b/tools/gazelle/ts/language.go
@@ -8,273 +8,47 @@
 //
 // The plugin operates in Gazelle's three-phase pipeline:
 //
-//  1. GenerateRules (this file): Scan .ts/.tsx files, extract imports, create/update rules
-//  2. Imports (this file):       Register rules in the RuleIndex so other packages can find them
-//  3. Resolve (resolve.go):      Convert parsed imports into Bazel dep labels
+//  1. GenerateRules (generate.go): Scan .ts/.tsx files, extract imports, create/update rules
+//  2. Imports (imports.go):        Register rules in the RuleIndex so other packages can find them
+//  3. Resolve (resolve.go):        Convert parsed imports into Bazel dep labels
 //
-// The plugin uses tree-sitter (parser.go) to parse TypeScript files and extract import
-// statements, which are then resolved to Bazel labels in the Resolve phase.
-//
-// Configuration is per-directory via BUILD file directives (config.go):
+// Configuration is per-directory via BUILD file directives (configure.go):
 //
 //	# gazelle:formatjs_enabled false   ← disable plugin for a directory
 package ts
 
 import (
-	"path/filepath"
-	"sort"
-	"strings"
-
-	"github.com/bazelbuild/bazel-gazelle/config"
 	"github.com/bazelbuild/bazel-gazelle/label"
 	"github.com/bazelbuild/bazel-gazelle/language"
-	"github.com/bazelbuild/bazel-gazelle/resolve"
 	"github.com/bazelbuild/bazel-gazelle/rule"
 )
 
 // languageName is the unique identifier for this Gazelle extension.
-// It is used as the key in config.Config.Exts and in resolve.ImportSpec.Lang
-// so that Gazelle can route import resolution to the correct plugin.
 const languageName = "formatjs_ts"
 
 // tsLang implements the language.Language interface from Gazelle.
-// It is stateless — all per-directory state lives in tsConfig (config.go)
-// and all per-run state lives in package-level vars (resolve.go).
-type tsLang struct{}
+// It holds the parser subprocess (via lifeCycleManager) and cached
+// package.json data needed for import resolution.
+type tsLang struct {
+	lifeCycleManager
+
+	// packageDeps is a set of all npm package names from the root package.json.
+	packageDeps map[string]bool
+
+	// subpathImportsMap stores the "imports" field from root package.json.
+	// Maps patterns like "#packages/*" → "./packages/*".
+	subpathImportsMap map[string]string
+}
 
 // NewLanguage creates a new formatjs TypeScript language extension.
-// Called once by Gazelle at startup when the plugin is loaded.
 func NewLanguage() language.Language {
-	return &tsLang{}
+	return &tsLang{
+		packageDeps:       make(map[string]bool),
+		subpathImportsMap: make(map[string]string),
+	}
 }
 
 func (l *tsLang) Name() string { return languageName }
 
-// Kinds tells Gazelle which rule types this plugin manages and how to merge them.
-// See kinds.go for the KindInfo definitions that control merge behavior.
-func (l *tsLang) Kinds() map[string]rule.KindInfo {
-	return tsKinds
-}
-
-// Loads declares the .bzl files that provide the rule kinds we generate.
-// Gazelle uses this to add the correct load() statements at the top of BUILD files
-// when it creates new rules. For example, if we generate a formatjs_library rule,
-// Gazelle adds: load("//tools:compile.bzl", "formatjs_library")
-func (l *tsLang) Loads() []rule.LoadInfo {
-	return []rule.LoadInfo{
-		{
-			Name:    "//tools:compile.bzl",
-			Symbols: []string{KindFormatjsLibrary},
-		},
-		{
-			Name:    "//tools:test.bzl",
-			Symbols: []string{KindFormatjsTest},
-		},
-		{
-			Name:    "//tools:index.bzl",
-			Symbols: []string{KindTsCompile},
-		},
-	}
-}
-
-// Fix performs post-processing on BUILD files after merge. Currently a no-op.
-// This could be used for validation or cleanup after Gazelle merges generated
-// rules with existing BUILD file content.
-func (l *tsLang) Fix(c *config.Config, f *rule.File) {}
-
-// ImportData carries parsed import statements from GenerateRules to Resolve.
-// Gazelle's architecture requires this two-phase approach because GenerateRules
-// runs during the directory walk (before the full RuleIndex is built), while
-// Resolve runs after all directories have been scanned and the RuleIndex is complete.
-//
-// The separation of Imports vs TestImports matters because:
-//   - Source imports become deps + project_references on formatjs_library
-//   - Test imports become deps on formatjs_test (source deps are transitive via :lib)
-type ImportData struct {
-	Imports     []ImportStatement // Source file imports
-	TestImports []ImportStatement // Test file imports
-}
-
-// Imports returns the import specs that a rule provides, used to build the RuleIndex.
-//
-// This is called during the "index" phase for every rule in every BUILD file.
-// The returned ImportSpecs are stored in a reverse index that maps import paths
-// to Bazel labels. Later, during Resolve(), we query this index to find which
-// rule provides a given import.
-//
-// For a rule at //packages/ecma402-abstract/NumberFormat, we register:
-//   - "packages/ecma402-abstract/NumberFormat"   (exact match)
-//   - "packages/ecma402-abstract/NumberFormat/*"  (wildcard for subpath imports)
-//
-// This allows imports like:
-//   - #packages/ecma402-abstract/NumberFormat/ToRawFixed.js → //packages/ecma402-abstract/NumberFormat
-//   - #packages/ecma402-abstract/NumberFormat               → //packages/ecma402-abstract/NumberFormat
-//
-// Only formatjs_library and ts_compile rules provide imports — formatjs_test
-// rules don't export reusable modules.
-func (l *tsLang) Imports(c *config.Config, r *rule.Rule, f *rule.File) []resolve.ImportSpec {
-	if r.Kind() != KindFormatjsLibrary && r.Kind() != KindTsCompile {
-		return nil
-	}
-
-	// f.Pkg is the full Bazel package path (e.g., "packages/ecma402-abstract/NumberFormat").
-	// We register both exact and wildcard specs so that deep imports like
-	// #packages/ecma402-abstract/NumberFormat/ToRawFixed.js resolve correctly
-	// via the walk-up logic in resolveSubpathImport (resolve.go).
-	pkg := f.Pkg
-	return []resolve.ImportSpec{
-		{Lang: languageName, Imp: pkg},
-		{Lang: languageName, Imp: pkg + "/*"},
-	}
-}
-
 // Embeds returns empty — TypeScript doesn't use Bazel's rule embedding mechanism.
-// Embedding allows one rule to inherit the imports of another; we handle dependencies
-// through TypeScript's import system instead.
 func (l *tsLang) Embeds(r *rule.Rule, from label.Label) []label.Label { return nil }
-
-// GenerateRules is called by Gazelle for each directory during the "generate" phase.
-//
-// This is the main entry point for the plugin. For each directory, it:
-//  1. Checks if the plugin is enabled for this directory (via formatjs_enabled directive)
-//  2. Scans all .ts/.tsx files and extracts import statements using tree-sitter
-//  3. Partitions files into source files and test files
-//  4. Generates formatjs_library rule (if source files exist) with srcs + visibility
-//  5. Generates formatjs_test rule (if test files exist) with srcs
-//  6. Attaches ImportData to each generated rule for later resolution in Resolve()
-//
-// The generated rules are merged with existing BUILD file content by Gazelle's merge
-// engine. The merge behavior is controlled by KindInfo in kinds.go:
-//   - MergeableAttrs (srcs):             merged with existing, preserving "# keep" entries
-//   - ResolveAttrs (deps, project_refs): set by Resolve(), replacing existing values
-//   - Other attrs (visibility, etc.):    set here, overwriting existing values
-//   - Unset attrs:                       preserved from existing BUILD file
-//
-// This means manually-set attrs like entry_points, types, npm_package_name, etc.
-// survive gazelle runs because we don't set them on the generated rule.
-func (l *tsLang) GenerateRules(args language.GenerateArgs) language.GenerateResult {
-	cfg, ok := args.Config.Exts[languageName].(*tsConfig)
-	if !ok || !cfg.enabled {
-		return language.GenerateResult{}
-	}
-
-	// Phase 1: Collect all TypeScript files and partition into source/test srcs.
-	libSrcs, testSrcs := collectSrcs(args.RegularFiles)
-
-	// Phase 2: Batch-parse all TypeScript files in one subprocess call.
-	// This is much more efficient than per-file calls: one round-trip to the
-	// Rust subprocess, which uses rayon to parse files in parallel.
-	var tsFiles []string
-	for _, f := range args.RegularFiles {
-		if isTypeScriptFile(f) {
-			tsFiles = append(tsFiles, filepath.Join(args.Dir, f))
-		}
-	}
-
-	var sourceImports, testImports []ImportStatement
-	if len(tsFiles) > 0 {
-		allImports, _ := extractImportsBatch(tsFiles)
-		for _, f := range args.RegularFiles {
-			if !isTypeScriptFile(f) {
-				continue
-			}
-			fullPath := filepath.Join(args.Dir, f)
-			imps := allImports[fullPath]
-			if isTestFile(f) {
-				testImports = append(testImports, imps...)
-			} else {
-				sourceImports = append(sourceImports, imps...)
-			}
-		}
-	}
-
-	// Early return if no TypeScript files at all — don't generate empty rules.
-	if len(libSrcs) == 0 && len(testSrcs) == 0 {
-		return language.GenerateResult{}
-	}
-
-	// Phase 3: Generate rules. We always generate the rules we want and let
-	// Gazelle's merge handle reconciliation with existing BUILD file content.
-	// This is simpler than iterating existing rules — the merge engine handles:
-	//   - Matching generated rules to existing rules by kind + name
-	//   - Preserving "# keep" entries in MergeableAttrs (srcs)
-	//   - Keeping attrs we don't set (entry_points, types, npm_package_name, etc.)
-	var genRules []*rule.Rule
-	var genImports []interface{}
-
-	// Generate formatjs_library for source files.
-	// All formatjs_library rules are public since any package in the monorepo
-	// may depend on any other via #packages/* imports.
-	if len(libSrcs) > 0 {
-		newRule := rule.NewRule(KindFormatjsLibrary, "dist")
-		newRule.SetAttr("srcs", libSrcs)
-		newRule.SetAttr("visibility", []string{"//visibility:public"})
-		genRules = append(genRules, newRule)
-		genImports = append(genImports, ImportData{
-			Imports: sourceImports,
-		})
-	}
-
-	// Generate formatjs_test for test files.
-	// The formatjs_test macro auto-depends on :lib from the same package's
-	// formatjs_library, so test code gets source deps transitively.
-	if len(testSrcs) > 0 {
-		newRule := rule.NewRule(KindFormatjsTest, "unit_test")
-		newRule.SetAttr("srcs", testSrcs)
-		genRules = append(genRules, newRule)
-		genImports = append(genImports, ImportData{
-			TestImports: testImports,
-		})
-	}
-
-	return language.GenerateResult{
-		Gen:     genRules,
-		Imports: genImports,
-	}
-}
-
-// isTypeScriptFile returns true for .ts and .tsx files.
-func isTypeScriptFile(name string) bool {
-	return strings.HasSuffix(name, ".ts") || strings.HasSuffix(name, ".tsx")
-}
-
-// isTestFile returns true for files that should be treated as test code.
-// Test files are partitioned separately from source files because:
-//   - Their imports go into formatjs_test deps (not formatjs_library deps)
-//   - The formatjs_test macro provides source deps transitively via :lib
-//
-// A file is a test file if it:
-//   - Contains ".test.ts" or ".test.tsx" in its name (e.g., utils.test.ts)
-//   - Lives under a "tests/" or "test/" directory (e.g., tests/format.test.ts)
-func isTestFile(name string) bool {
-	return strings.Contains(name, ".test.ts") ||
-		strings.Contains(name, ".test.tsx") ||
-		strings.HasPrefix(name, "tests/") ||
-		strings.HasPrefix(name, "test/")
-}
-
-// collectSrcs partitions args.RegularFiles into source and test file lists.
-//
-// Source files: .ts/.tsx files that aren't test files.
-// Test files:   .ts/.tsx files AND .json files under tests/ directories.
-//               JSON files are included because tests often import locale data
-//               fixtures (e.g., tests/locale-data/en.json).
-//
-// The formatjs_test macro internally separates fixture files from test srcs,
-// so we include all test-directory files here and let the macro sort them out.
-//
-// Both lists are sorted for deterministic BUILD file output.
-func collectSrcs(regularFiles []string) (srcFiles, testFiles []string) {
-	for _, f := range regularFiles {
-		if isTestFile(f) {
-			if isTypeScriptFile(f) || strings.HasSuffix(f, ".json") {
-				testFiles = append(testFiles, f)
-			}
-		} else if isTypeScriptFile(f) {
-			srcFiles = append(srcFiles, f)
-		}
-	}
-	sort.Strings(srcFiles)
-	sort.Strings(testFiles)
-	return
-}

--- a/tools/gazelle/ts/lifecycle.go
+++ b/tools/gazelle/ts/lifecycle.go
@@ -1,0 +1,51 @@
+// lifecycle.go manages the parser subprocess lifecycle.
+//
+// The lifeCycleManager implements Gazelle's LifecycleManager interface to
+// properly start and stop the Rust subprocess (crates/ts_import_extractor)
+// that parses TypeScript files. This replaces the previous global singleton
+// pattern (sync.Once) with proper lifecycle hooks.
+//
+// Timeline:
+//   - Before():              Spawns the Rust subprocess
+//   - GenerateRules():       Uses the subprocess to parse files (via l.parser)
+//   - DoneGeneratingRules(): Shuts down the subprocess
+//   - AfterResolvingDeps():  No-op
+package ts
+
+import (
+	"context"
+	"log"
+
+	"github.com/bazelbuild/bazel-gazelle/language"
+)
+
+// lifeCycleManager manages the parser subprocess lifecycle.
+// It embeds BaseLifecycleManager for forward compatibility with new hooks.
+type lifeCycleManager struct {
+	language.BaseLifecycleManager
+	parser *OxcParser
+}
+
+// Before is called once at plugin startup. It spawns the Rust subprocess.
+func (l *lifeCycleManager) Before(ctx context.Context) {
+	p, err := newOxcParser()
+	if err != nil {
+		log.Printf("formatjs_ts: oxc parser unavailable: %v", err)
+		return
+	}
+	l.parser = p
+}
+
+// DoneGeneratingRules is called after all directories have been scanned.
+// It shuts down the Rust subprocess.
+func (l *lifeCycleManager) DoneGeneratingRules() {
+	if l.parser != nil {
+		if err := l.parser.Close(); err != nil {
+			log.Printf("formatjs_ts: oxc parser shutdown error: %v", err)
+		}
+		l.parser = nil
+	}
+}
+
+// AfterResolvingDeps is called after all dependencies have been resolved. No-op.
+func (l *lifeCycleManager) AfterResolvingDeps(ctx context.Context) {}

--- a/tools/gazelle/ts/parser.go
+++ b/tools/gazelle/ts/parser.go
@@ -21,13 +21,12 @@ type ImportStatement struct {
 // This is much more efficient than per-file calls because:
 //   - One subprocess round-trip instead of N
 //   - Rust side uses rayon to parse files in parallel
-func extractImportsBatch(filePaths []string) (map[string][]ImportStatement, error) {
-	parser := getOxcParser()
-	if parser == nil {
+func (l *tsLang) extractImportsBatch(filePaths []string) (map[string][]ImportStatement, error) {
+	if l.parser == nil {
 		return nil, nil
 	}
 
-	result, err := parser.ExtractImports(filePaths)
+	result, err := l.parser.ExtractImports(filePaths)
 	if err != nil {
 		return nil, err
 	}

--- a/tools/gazelle/ts/parser_bench_test.go
+++ b/tools/gazelle/ts/parser_bench_test.go
@@ -35,15 +35,16 @@ func BenchmarkOxc(b *testing.B) {
 		b.Skip("no TypeScript files found")
 	}
 
-	parser := getOxcParser()
-	if parser == nil {
-		b.Skip("oxc parser not available")
+	p, err := newOxcParser()
+	if err != nil {
+		b.Skipf("oxc parser not available: %v", err)
 	}
+	defer p.Close()
 
 	b.Logf("Benchmarking %d files", len(files))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := parser.ExtractImports(files)
+		_, err := p.ExtractImports(files)
 		if err != nil {
 			b.Fatalf("oxc parse error: %v", err)
 		}

--- a/tools/gazelle/ts/parser_oxc.go
+++ b/tools/gazelle/ts/parser_oxc.go
@@ -1,7 +1,8 @@
 // parser_oxc.go — Go client for the oxc-based TypeScript import extractor.
 //
-// This file manages a long-lived Rust subprocess (crates/ts_import_extractor)
+// This file manages the Rust subprocess (crates/ts_import_extractor)
 // that parses TypeScript files using oxc and returns extracted import paths.
+// The subprocess lifecycle is managed by lifeCycleManager (lifecycle.go).
 //
 // Architecture:
 //
@@ -17,10 +18,6 @@
 //   - Request:  {"id": N, "files": ["path/to/file.ts", ...]}
 //   - Response: {"id": N, "imports": [{"file": "...", "importPaths": [...]}, ...]}
 //
-// The subprocess is spawned lazily on first use and stays alive for the entire
-// gazelle run. This amortizes the process startup cost and allows the Rust side
-// to reuse its rayon thread pool across requests.
-//
 // Binary location: discovered via Bazel runfiles (github.com/bazelbuild/rules_go/go/runfiles).
 package ts
 
@@ -29,7 +26,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"os/exec"
 	"sync"
@@ -65,27 +61,6 @@ type OxcParser struct {
 	stdout io.Reader
 	mu     sync.Mutex
 	nextID uint32
-}
-
-// Global singleton — initialized lazily on first use via sync.Once.
-// The subprocess stays alive for the entire gazelle run.
-var (
-	globalOxcParser *OxcParser
-	oxcParserOnce   sync.Once
-)
-
-// getOxcParser returns the global OxcParser, starting the subprocess on first call.
-// Returns nil if the subprocess cannot be started (caller should handle gracefully).
-func getOxcParser() *OxcParser {
-	oxcParserOnce.Do(func() {
-		p, err := newOxcParser()
-		if err != nil {
-			log.Printf("formatjs_ts: oxc parser unavailable: %v", err)
-			return // globalOxcParser stays nil
-		}
-		globalOxcParser = p
-	})
-	return globalOxcParser
 }
 
 // newOxcParser locates the Rust binary via Bazel runfiles and starts it as a subprocess.
@@ -143,9 +118,6 @@ func (p *OxcParser) Close() error {
 
 // ExtractImports sends a batch of file paths to the Rust subprocess and returns
 // the parsed imports. The result maps file paths to their import path lists.
-//
-// The Rust side uses rayon to parse files in parallel, so batching multiple
-// files in a single request is more efficient than one-at-a-time calls.
 func (p *OxcParser) ExtractImports(files []string) (map[string][]string, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -153,12 +125,10 @@ func (p *OxcParser) ExtractImports(files []string) (map[string][]string, error) 
 	p.nextID++
 	req := oxcRequest{ID: p.nextID, Files: files}
 
-	// Write request as a length-prefixed JSON frame.
 	if err := p.writeFrame(req); err != nil {
 		return nil, err
 	}
 
-	// Read response frame.
 	resp, err := p.readFrame()
 	if err != nil {
 		return nil, err
@@ -211,4 +181,3 @@ func (p *OxcParser) readFrame() (*oxcResponse, error) {
 	}
 	return &resp, nil
 }
-

--- a/tools/gazelle/ts/parser_test.go
+++ b/tools/gazelle/ts/parser_test.go
@@ -77,6 +77,19 @@ import {b} from 'react'`,
 	// The oxc parser reads files from disk, so write temp files.
 	tmpDir := t.TempDir()
 
+	// Create a tsLang with a parser for testing.
+	p, err := newOxcParser()
+	if err != nil {
+		t.Skipf("oxc parser not available: %v", err)
+	}
+	defer p.Close()
+
+	l := &tsLang{
+		packageDeps:       make(map[string]bool),
+		subpathImportsMap: make(map[string]string),
+	}
+	l.parser = p
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tmpFile := filepath.Join(tmpDir, "test.ts")
@@ -84,7 +97,7 @@ import {b} from 'react'`,
 				t.Fatalf("write temp file: %v", err)
 			}
 
-			allImports, err := extractImportsBatch([]string{tmpFile})
+			allImports, err := l.extractImportsBatch([]string{tmpFile})
 			if err != nil {
 				t.Fatalf("extractImportsBatch: %v", err)
 			}

--- a/tools/gazelle/ts/resolve.go
+++ b/tools/gazelle/ts/resolve.go
@@ -7,17 +7,8 @@
 // Resolve handles three categories of TypeScript imports:
 //
 //  1. Internal #packages/* imports → project_references (TypeScript project references)
-//     Example: #packages/ecma402-abstract/types/number.js → //packages/ecma402-abstract/types
-//
 //  2. Node.js built-in modules → //:node_modules/@types/node
-//     Example: import fs from 'node:fs'
-//
 //  3. npm package imports → //:node_modules/<pkg> (+ auto @types/<pkg> if exists)
-//     Example: import React from 'react' → //:node_modules/react + //:node_modules/@types/react
-//
-// Import resolution relies on the root package.json for:
-//   - "imports" field: maps #packages/* to ./packages/* (Node.js subpath imports)
-//   - "dependencies" / "devDependencies": validates that npm packages exist before adding deps
 package ts
 
 import (
@@ -25,7 +16,6 @@ import (
 	"os"
 	"sort"
 	"strings"
-	"sync"
 
 	"github.com/bazelbuild/bazel-gazelle/config"
 	"github.com/bazelbuild/bazel-gazelle/label"
@@ -34,24 +24,8 @@ import (
 	"github.com/bazelbuild/bazel-gazelle/rule"
 )
 
-// Package-level caches, loaded once per gazelle run via sync.Once.
-// These are populated from the root package.json on first access.
-var (
-	// packageDeps is a set of all npm package names found in the root package.json
-	// (dependencies + devDependencies + optionalDependencies). Used to validate
-	// that an npm import actually has a corresponding Bazel target before adding it.
-	packageDeps map[string]bool
-
-	// subpathImportsMap stores the "imports" field from root package.json.
-	// Maps patterns like "#packages/*" → "./packages/*" for resolving internal imports.
-	subpathImportsMap map[string]string
-
-	packageDepsOnce sync.Once
-)
-
 // nodeBuiltinModules lists Node.js built-in modules that should resolve to
-// @types/node instead of npm packages. Both bare (e.g., "fs") and prefixed
-// (e.g., "node:fs") forms are handled — the "node:" prefix is stripped before lookup.
+// @types/node instead of npm packages.
 var nodeBuiltinModules = map[string]bool{
 	"assert": true, "buffer": true, "child_process": true, "cluster": true,
 	"crypto": true, "dgram": true, "dns": true, "events": true, "fs": true,
@@ -73,12 +47,6 @@ type packageJSON struct {
 }
 
 // resolvedDeps holds the two categories of resolved Bazel dependencies.
-// They map to different rule attributes:
-//   - internal → project_references on formatjs_library (TypeScript project references)
-//   - external → deps on both formatjs_library and formatjs_test (npm packages)
-//
-// For formatjs_test, both internal and external go into a single deps attr
-// because the test macro handles the distinction internally.
 type resolvedDeps struct {
 	internal []string // //packages/* labels → project_references
 	external []string // //:node_modules/* labels → deps
@@ -87,14 +55,6 @@ type resolvedDeps struct {
 // Resolve is called by Gazelle after GenerateRules for every generated rule.
 // It reads the ImportData attached during GenerateRules and converts each import
 // statement into a Bazel label, then sets the appropriate attributes on the rule.
-//
-// For formatjs_library rules:
-//   - Source imports are split into deps (npm) and project_references (internal)
-//   - If no deps/project_references, the attr is deleted to keep BUILD files clean
-//
-// For formatjs_test rules:
-//   - All test imports (both npm and internal) go into a single deps attr
-//   - Source deps come transitively via :lib (the formatjs_test macro auto-depends on it)
 func (l *tsLang) Resolve(
 	c *config.Config,
 	ix *resolve.RuleIndex,
@@ -103,9 +63,6 @@ func (l *tsLang) Resolve(
 	rawImportData interface{},
 	from label.Label,
 ) {
-	// Load package.json data on first call (cached for subsequent calls).
-	loadPackageJSONDeps(c.RepoRoot)
-
 	importData, ok := rawImportData.(ImportData)
 	if !ok {
 		return
@@ -115,13 +72,7 @@ func (l *tsLang) Resolve(
 
 	switch kind {
 	case KindFormatjsLibrary:
-		// Resolve source imports into two separate attrs:
-		// - deps: external npm packages (//:node_modules/*)
-		// - project_references: internal packages (//packages/*)
-		//
-		// This separation matters because formatjs_library passes both to ts_project
-		// but only project_references become TypeScript project references in tsconfig.
-		resolved := resolveImportsToDeps(importData.Imports, from, ix)
+		resolved := l.resolveImportsToDeps(importData.Imports, from, ix)
 
 		if len(resolved.external) > 0 {
 			r.SetAttr("deps", deduplicateAndSort(resolved.external))
@@ -136,11 +87,7 @@ func (l *tsLang) Resolve(
 		}
 
 	case KindFormatjsTest:
-		// Resolve test imports into a single deps attr.
-		// Both internal and external deps are combined because the formatjs_test
-		// macro treats them uniformly — source deps are already provided
-		// transitively via the :lib dependency (which the macro auto-adds).
-		testResolved := resolveImportsToDeps(importData.TestImports, from, ix)
+		testResolved := l.resolveImportsToDeps(importData.TestImports, from, ix)
 		allDeps := append(testResolved.external, testResolved.internal...)
 
 		if len(allDeps) > 0 {
@@ -152,17 +99,7 @@ func (l *tsLang) Resolve(
 }
 
 // resolveImportsToDeps converts a list of import statements into categorized Bazel labels.
-//
-// It processes imports in priority order:
-//  1. Relative imports (./foo) → skipped (same-package, not a dep)
-//  2. Subpath imports (#packages/*) → internal project_references
-//  3. Node builtins (node:fs, fs) → //:node_modules/@types/node
-//  4. npm packages (react, @babel/core) → //:node_modules/<pkg> + optional @types
-//
-// Deduplication happens at two levels:
-//   - Per-import: seen map prevents processing the same import path twice
-//   - Per-result: deduplicateAndSort on the final lists
-func resolveImportsToDeps(imports []ImportStatement, from label.Label, ix *resolve.RuleIndex) resolvedDeps {
+func (l *tsLang) resolveImportsToDeps(imports []ImportStatement, from label.Label, ix *resolve.RuleIndex) resolvedDeps {
 	result := resolvedDeps{}
 	seen := make(map[string]bool)
 
@@ -174,22 +111,14 @@ func resolveImportsToDeps(imports []ImportStatement, from label.Label, ix *resol
 
 		importPath := imp.ImportPath
 
-		// Skip relative imports — they reference files within the same Bazel package
-		// and don't create cross-package dependencies.
+		// Skip relative imports.
 		if strings.HasPrefix(importPath, ".") {
 			continue
 		}
 
 		// Handle Node.js subpath imports (#packages/* convention).
-		// These are internal monorepo imports defined in the root package.json "imports"
-		// field. They resolve to Bazel project_references (TypeScript project references).
-		//
-		// Example: #packages/ecma402-abstract/types/number.js
-		//   → resolves via "#packages/*" → "./packages/*"
-		//   → walks up to find //packages/ecma402-abstract/types in RuleIndex
-		//   → becomes project_references = ["//packages/ecma402-abstract/types"]
 		if strings.HasPrefix(importPath, "#") {
-			target := resolveSubpathImport(importPath, from, ix)
+			target := l.resolveSubpathImport(importPath, from, ix)
 			if target != "" {
 				result.internal = append(result.internal, target)
 			}
@@ -197,8 +126,6 @@ func resolveImportsToDeps(imports []ImportStatement, from label.Label, ix *resol
 		}
 
 		// Handle Node.js built-in modules.
-		// Both "node:fs" and bare "fs" are supported. These resolve to @types/node
-		// for type checking (the runtime doesn't need a dep since Node provides them).
 		modulePath := strings.TrimPrefix(importPath, "node:")
 		baseModule := strings.Split(modulePath, "/")[0]
 		if nodeBuiltinModules[baseModule] {
@@ -207,17 +134,12 @@ func resolveImportsToDeps(imports []ImportStatement, from label.Label, ix *resol
 		}
 
 		// Handle npm package imports.
-		// Only adds a dep if the package exists in the root package.json — this prevents
-		// generating references to non-existent Bazel targets.
-		npmLabel := resolveNpmImport(importPath)
+		npmLabel := l.resolveNpmImport(importPath)
 		if npmLabel != "" {
 			result.external = append(result.external, npmLabel)
 
-			// Auto-add @types/<pkg> if it exists in package.json.
-			// Many npm packages ship without types and need a separate @types package.
-			// Example: react → also add @types/react
 			pkgName := strings.TrimPrefix(npmLabel, "//:node_modules/")
-			if typesLabel := getTypesPackage(pkgName); typesLabel != "" {
+			if typesLabel := l.getTypesPackage(pkgName); typesLabel != "" {
 				result.external = append(result.external, typesLabel)
 			}
 		}
@@ -229,35 +151,9 @@ func resolveImportsToDeps(imports []ImportStatement, from label.Label, ix *resol
 }
 
 // resolveSubpathImport resolves a Node.js #-prefixed subpath import to a Bazel label.
-//
-// The resolution works in three steps:
-//
-// Step 1: Pattern matching against package.json "imports" field.
-// The root package.json defines: { "imports": { "#packages/*": "./packages/*" } }
-// So "#packages/ecma402-abstract/types/number.js" becomes "packages/ecma402-abstract/types/number"
-//
-// Step 2: Strip file extensions (.js/.ts/.tsx/.jsx).
-// TypeScript imports use .js extensions (for ESM compatibility) but the Bazel package
-// path doesn't include extensions.
-//
-// Step 3: Walk up the path hierarchy to find the owning Bazel package.
-// Starting from the most specific path and walking up, we check the RuleIndex
-// for both exact and wildcard matches:
-//
-//	"packages/ecma402-abstract/types/number" → not found
-//	"packages/ecma402-abstract/types"        → found! (has formatjs_library rule)
-//
-// Self-references are skipped — if the resolved path matches the current package,
-// it's a same-package import and doesn't need a dep.
-func resolveSubpathImport(importPath string, from label.Label, ix *resolve.RuleIndex) string {
-	// Step 1: Find matching subpath import pattern.
-	// Iterate over patterns from package.json "imports" field.
-	// Example: "#packages/*" → "./packages/*"
-	//   prefix = "#packages/"
-	//   targetPrefix = "packages/"
-	//   resolvedPath = "packages/" + "ecma402-abstract/types/number.js"
+func (l *tsLang) resolveSubpathImport(importPath string, from label.Label, ix *resolve.RuleIndex) string {
 	var resolvedPath string
-	for pattern, target := range subpathImportsMap {
+	for pattern, target := range l.subpathImportsMap {
 		prefix := strings.TrimSuffix(pattern, "*")
 		if strings.HasPrefix(importPath, prefix) {
 			targetPrefix := strings.TrimSuffix(target, "*")
@@ -270,32 +166,19 @@ func resolveSubpathImport(importPath string, from label.Label, ix *resolve.RuleI
 		return ""
 	}
 
-	// Step 2: Strip file extensions.
-	// TypeScript uses .js extensions in imports for ESM compatibility
-	// (rewriteRelativeImportExtensions in tsconfig), but Bazel package paths
-	// don't include extensions.
 	for _, ext := range []string{".js", ".ts", ".tsx", ".jsx"} {
 		resolvedPath = strings.TrimSuffix(resolvedPath, ext)
 	}
 
 	parts := strings.Split(resolvedPath, "/")
 
-	// Step 3: Walk up from most specific to least specific path.
-	// For "packages/ecma402-abstract/types/number", we try:
-	//   1. "packages/ecma402-abstract/types/number"  → no rule
-	//   2. "packages/ecma402-abstract/types"          → found! → //packages/ecma402-abstract/types
-	//
-	// We check both exact match and wildcard ("path/*") because Imports()
-	// registers both forms for each rule.
 	for i := len(parts); i > 0; i-- {
 		testPath := strings.Join(parts[:i], "/")
 
-		// Skip self-references — importing from your own package isn't a dep.
 		if testPath == from.Pkg {
 			return ""
 		}
 
-		// Check RuleIndex for exact match.
 		results := ix.FindRulesByImportWithConfig(
 			nil,
 			resolve.ImportSpec{Lang: languageName, Imp: testPath},
@@ -305,7 +188,6 @@ func resolveSubpathImport(importPath string, from label.Label, ix *resolve.RuleI
 			return "//" + testPath
 		}
 
-		// Check wildcard match — rules register "path/*" for subpath imports.
 		results = ix.FindRulesByImportWithConfig(
 			nil,
 			resolve.ImportSpec{Lang: languageName, Imp: testPath + "/*"},
@@ -320,114 +202,77 @@ func resolveSubpathImport(importPath string, from label.Label, ix *resolve.RuleI
 }
 
 // resolveNpmImport converts an npm import path to a //:node_modules/<pkg> Bazel label.
-//
-// It handles both scoped and unscoped packages:
-//   - "react"           → pkgName = "react"         → //:node_modules/react
-//   - "@babel/core"     → pkgName = "@babel/core"   → //:node_modules/@babel/core
-//   - "react/jsx-runtime" → pkgName = "react"       → //:node_modules/react
-//   - "@babel/core/lib" → pkgName = "@babel/core"   → //:node_modules/@babel/core
-//
-// Returns "" if the package is not found in the root package.json, to avoid
-// generating deps on non-existent Bazel targets.
-//
-// Special case: if the package itself isn't in package.json but @types/<pkg> is,
-// return the @types label. This handles packages that are only used for their types
-// (e.g., import type patterns).
-func resolveNpmImport(importPath string) string {
-	// Extract the npm package name from the import path.
-	// Scoped packages have the form @scope/name, so we need the first two segments.
+func (l *tsLang) resolveNpmImport(importPath string) string {
 	var pkgName string
 	if strings.HasPrefix(importPath, "@") {
-		// Scoped: @babel/core/lib → ["@babel", "core", "lib"] → "@babel/core"
 		parts := strings.SplitN(importPath, "/", 3)
 		if len(parts) < 2 {
 			return ""
 		}
 		pkgName = parts[0] + "/" + parts[1]
 	} else {
-		// Unscoped: react/jsx-runtime → ["react", "jsx-runtime"] → "react"
 		parts := strings.SplitN(importPath, "/", 2)
 		pkgName = parts[0]
 	}
 
-	if packageDeps[pkgName] {
+	if l.packageDeps[pkgName] {
 		return "//:node_modules/" + pkgName
 	}
 
 	// Fallback: check if only @types exists (for type-only imports).
-	// This handles cases where a package is used only for its type definitions.
 	if !strings.HasPrefix(pkgName, "@") {
-		if packageDeps["@types/"+pkgName] {
+		if l.packageDeps["@types/"+pkgName] {
 			return "//:node_modules/@types/" + pkgName
 		}
 	}
 
-	// Package not found in package.json — skip to avoid generating
-	// references to non-existent Bazel targets.
 	return ""
 }
 
 // getTypesPackage returns the @types Bazel label if a DefinitelyTyped package exists.
-//
-// DefinitelyTyped naming conventions:
-//   - Unscoped: react       → @types/react
-//   - Scoped:   @babel/core → @types/babel__core  (@ stripped, / replaced with __)
-//
-// Returns "" if no @types package exists in the root package.json.
-func getTypesPackage(pkgName string) string {
+func (l *tsLang) getTypesPackage(pkgName string) string {
 	var typesName string
 	if strings.HasPrefix(pkgName, "@") {
-		// @babel/core → @types/babel__core
 		withoutAt := strings.TrimPrefix(pkgName, "@")
 		typesName = "@types/" + strings.Replace(withoutAt, "/", "__", 1)
 	} else {
 		typesName = "@types/" + pkgName
 	}
-	if packageDeps[typesName] {
+	if l.packageDeps[typesName] {
 		return "//:node_modules/" + typesName
 	}
 	return ""
 }
 
-// loadPackageJSONDeps reads the root package.json and caches its contents.
-// Called once per gazelle run (guarded by sync.Once).
-//
-// It populates two caches:
-//   - packageDeps: set of all npm package names (dependencies + devDependencies + optional)
-//   - subpathImportsMap: the "imports" field (e.g., "#packages/*" → "./packages/*")
-//
-// The root package.json is the single source of truth for:
-//   - Which npm packages have corresponding Bazel targets (//:node_modules/*)
-//   - How #-prefixed subpath imports resolve to filesystem paths
-func loadPackageJSONDeps(repoRoot string) {
-	packageDepsOnce.Do(func() {
-		packageDeps = make(map[string]bool)
-		subpathImportsMap = make(map[string]string)
-		data, err := os.ReadFile(repoRoot + "/package.json")
-		if err != nil {
-			return
-		}
-		var pkg packageJSON
-		if err := json.Unmarshal(data, &pkg); err != nil {
-			return
-		}
-		for dep := range pkg.Dependencies {
-			packageDeps[dep] = true
-		}
-		for dep := range pkg.DevDependencies {
-			packageDeps[dep] = true
-		}
-		for dep := range pkg.OptionalDependencies {
-			packageDeps[dep] = true
-		}
-		for k, v := range pkg.Imports {
-			subpathImportsMap[k] = v
-		}
-	})
+// loadPackageJSONDeps reads the root package.json and populates the struct caches.
+func (l *tsLang) loadPackageJSONDeps(repoRoot string) {
+	if len(l.packageDeps) > 0 {
+		return // already loaded
+	}
+
+	data, err := os.ReadFile(repoRoot + "/package.json")
+	if err != nil {
+		return
+	}
+	var pkg packageJSON
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return
+	}
+	for dep := range pkg.Dependencies {
+		l.packageDeps[dep] = true
+	}
+	for dep := range pkg.DevDependencies {
+		l.packageDeps[dep] = true
+	}
+	for dep := range pkg.OptionalDependencies {
+		l.packageDeps[dep] = true
+	}
+	for k, v := range pkg.Imports {
+		l.subpathImportsMap[k] = v
+	}
 }
 
 // deduplicateAndSort removes duplicates and sorts a string slice alphabetically.
-// Returns nil for empty input to avoid setting empty list attrs in BUILD files.
 func deduplicateAndSort(items []string) []string {
 	if len(items) == 0 {
 		return nil

--- a/tools/gazelle/ts/resolve_test.go
+++ b/tools/gazelle/ts/resolve_test.go
@@ -2,16 +2,21 @@ package ts
 
 import (
 	"sort"
-	"sync"
 	"testing"
 
 	"github.com/bazelbuild/bazel-gazelle/label"
 )
 
+// newTestLang creates a tsLang with the given packageDeps for testing.
+func newTestLang(deps map[string]bool) *tsLang {
+	return &tsLang{
+		packageDeps:       deps,
+		subpathImportsMap: make(map[string]string),
+	}
+}
+
 func TestResolveNpmImport(t *testing.T) {
-	// Reset and set up package deps for tests
-	packageDepsOnce = sync.Once{}
-	packageDeps = map[string]bool{
+	l := newTestLang(map[string]bool{
 		"react":                              true,
 		"@types/react":                       true,
 		"@formatjs/intl":                     true,
@@ -21,7 +26,7 @@ func TestResolveNpmImport(t *testing.T) {
 		"@types/lodash-es":                   true,
 		"typescript":                         true,
 		"eslint":                             true,
-	}
+	})
 
 	tests := []struct {
 		name     string
@@ -62,7 +67,7 @@ func TestResolveNpmImport(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := resolveNpmImport(tt.input)
+			got := l.resolveNpmImport(tt.input)
 			if got != tt.expected {
 				t.Errorf("resolveNpmImport(%q) = %q, want %q", tt.input, got, tt.expected)
 			}
@@ -71,18 +76,17 @@ func TestResolveNpmImport(t *testing.T) {
 }
 
 func TestGetTypesPackage(t *testing.T) {
-	packageDepsOnce = sync.Once{}
-	packageDeps = map[string]bool{
-		"react":                          true,
-		"@types/react":                   true,
-		"lodash-es":                      true,
-		"@types/node":                    true,
-		"@formatjs/intl":                 true,
-		"@babel/core":                    true,
-		"@types/babel__core":             true,
-		"@babel/helper-plugin-utils":     true,
-		"@types/babel__helper-plugin-utils": true,
-	}
+	l := newTestLang(map[string]bool{
+		"react":                                true,
+		"@types/react":                         true,
+		"lodash-es":                            true,
+		"@types/node":                          true,
+		"@formatjs/intl":                       true,
+		"@babel/core":                          true,
+		"@types/babel__core":                   true,
+		"@babel/helper-plugin-utils":           true,
+		"@types/babel__helper-plugin-utils":    true,
+	})
 
 	tests := []struct {
 		name     string
@@ -123,7 +127,7 @@ func TestGetTypesPackage(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := getTypesPackage(tt.input)
+			got := l.getTypesPackage(tt.input)
 			if got != tt.expected {
 				t.Errorf("getTypesPackage(%q) = %q, want %q", tt.input, got, tt.expected)
 			}
@@ -132,13 +136,12 @@ func TestGetTypesPackage(t *testing.T) {
 }
 
 func TestResolveImportsToDeps_Categories(t *testing.T) {
-	packageDepsOnce = sync.Once{}
-	packageDeps = map[string]bool{
+	l := newTestLang(map[string]bool{
 		"react":                              true,
 		"@types/react":                       true,
 		"@formatjs/icu-messageformat-parser": true,
 		"@formatjs/icu-skeleton-parser":      true,
-	}
+	})
 
 	imports := []ImportStatement{
 		{ImportPath: "./relative", SourceFile: "index.ts"},
@@ -151,7 +154,7 @@ func TestResolveImportsToDeps_Categories(t *testing.T) {
 	}
 
 	from := label.Label{Pkg: "packages/intl-messageformat"}
-	result := resolveImportsToDeps(imports, from, nil)
+	result := l.resolveImportsToDeps(imports, from, nil)
 
 	expectedExt := []string{
 		"//:node_modules/@formatjs/icu-skeleton-parser",
@@ -171,15 +174,13 @@ func TestResolveImportsToDeps_Categories(t *testing.T) {
 		}
 	}
 
-	// Relative imports should be skipped, #packages/* needs RuleIndex
 	if len(result.internal) != 0 {
 		t.Errorf("internal deps: got %v, want empty (no RuleIndex)", result.internal)
 	}
 }
 
 func TestResolveImportsToDeps_NodeBuiltins(t *testing.T) {
-	packageDepsOnce = sync.Once{}
-	packageDeps = map[string]bool{}
+	l := newTestLang(map[string]bool{})
 
 	imports := []ImportStatement{
 		{ImportPath: "node:path", SourceFile: "index.ts"},
@@ -190,9 +191,8 @@ func TestResolveImportsToDeps_NodeBuiltins(t *testing.T) {
 	}
 
 	from := label.Label{Pkg: "packages/cli-lib"}
-	result := resolveImportsToDeps(imports, from, nil)
+	result := l.resolveImportsToDeps(imports, from, nil)
 
-	// All should resolve to @types/node (deduplicated)
 	if len(result.external) != 1 {
 		t.Errorf("expected 1 external dep (@types/node), got %d: %v",
 			len(result.external), result.external)
@@ -203,11 +203,10 @@ func TestResolveImportsToDeps_NodeBuiltins(t *testing.T) {
 }
 
 func TestResolveImportsToDeps_Deduplication(t *testing.T) {
-	packageDepsOnce = sync.Once{}
-	packageDeps = map[string]bool{
+	l := newTestLang(map[string]bool{
 		"react":        true,
 		"@types/react": true,
-	}
+	})
 
 	imports := []ImportStatement{
 		{ImportPath: "react", SourceFile: "a.ts"},
@@ -216,7 +215,7 @@ func TestResolveImportsToDeps_Deduplication(t *testing.T) {
 	}
 
 	from := label.Label{Pkg: "packages/react-intl"}
-	result := resolveImportsToDeps(imports, from, nil)
+	result := l.resolveImportsToDeps(imports, from, nil)
 
 	expected := []string{"//:node_modules/@types/react", "//:node_modules/react"}
 	if len(result.external) != len(expected) {
@@ -225,8 +224,7 @@ func TestResolveImportsToDeps_Deduplication(t *testing.T) {
 }
 
 func TestResolveImportsToDeps_SkipsRelative(t *testing.T) {
-	packageDepsOnce = sync.Once{}
-	packageDeps = map[string]bool{}
+	l := newTestLang(map[string]bool{})
 
 	imports := []ImportStatement{
 		{ImportPath: "./utils", SourceFile: "index.ts"},
@@ -235,7 +233,7 @@ func TestResolveImportsToDeps_SkipsRelative(t *testing.T) {
 	}
 
 	from := label.Label{Pkg: "packages/react-intl"}
-	result := resolveImportsToDeps(imports, from, nil)
+	result := l.resolveImportsToDeps(imports, from, nil)
 
 	if len(result.external) != 0 {
 		t.Errorf("relative imports should be skipped, got external: %v", result.external)
@@ -246,18 +244,16 @@ func TestResolveImportsToDeps_SkipsRelative(t *testing.T) {
 }
 
 func TestResolveImportsToDeps_TypesOnlyPackage(t *testing.T) {
-	packageDepsOnce = sync.Once{}
-	packageDeps = map[string]bool{
+	l := newTestLang(map[string]bool{
 		"@types/estree-jsx": true,
-		// Note: "estree-jsx" is NOT in deps — only @types version exists
-	}
+	})
 
 	imports := []ImportStatement{
 		{ImportPath: "estree-jsx", SourceFile: "index.ts"},
 	}
 
 	from := label.Label{Pkg: "packages/eslint-plugin-formatjs"}
-	result := resolveImportsToDeps(imports, from, nil)
+	result := l.resolveImportsToDeps(imports, from, nil)
 
 	if len(result.external) != 1 {
 		t.Errorf("expected 1 dep, got %d: %v", len(result.external), result.external)


### PR DESCRIPTION
## Summary

- Upgrade bazel-gazelle Go module from v0.42.0 to v0.50.0
- Restructure the gazelle TypeScript plugin (`tools/gazelle/ts/`) to match the reference architecture at `gazelle-ts-plugin`
- Update knowledge base documentation

## Architecture Changes

**File organization** — split monolithic `language.go` into one file per concern:
| File | Responsibility |
|------|---------------|
| `language.go` | Stateful `tsLang` struct + `NewLanguage` |
| `lifecycle.go` | Parser subprocess lifecycle (`Before`/`DoneGeneratingRules`) |
| `generate.go` | `GenerateRules` + file classification |
| `imports.go` | `Imports` (RuleIndex registration) |
| `resolve.go` | `Resolve` + dependency resolution (now methods) |
| `configure.go` | `Configure` + directive handling |
| `fix.go` | `Fix` hook |
| `kinds.go` | Rule kinds + `Kinds()`/`Loads()` |

**Stateful struct** — `tsLang` now holds parser, `packageDeps`, and `subpathImportsMap` as instance fields instead of global singletons with `sync.Once`.

**Lifecycle management** — Parser subprocess managed via Gazelle's `LifecycleManager` interface (`Before`/`DoneGeneratingRules`) instead of a global lazy singleton.

**Methods over globals** — Resolution functions (`resolveNpmImport`, `getTypesPackage`, `resolveSubpathImport`, etc.) are methods on `*tsLang` instead of package-level functions accessing global state.

## Test plan

- [x] `bazel build //tools/gazelle/ts:ts` — builds cleanly
- [x] `bazel test //tools/gazelle/ts:ts_test` — all tests pass
- [x] `bazel run //:gazelle` — generates correct BUILD files
- [x] Pre-commit hooks (buildifier, gazelle, commitlint) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)