### PR TITLE
refactor(deps): switch gazelle IPC from JSON to protobuf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,9 +108,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -1044,9 +1044,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libm"
@@ -1519,9 +1519,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -1824,8 +1824,6 @@ dependencies = [
  "oxc_span",
  "pretty_assertions",
  "rayon",
- "serde",
- "serde_json",
 ]
 
 [[package]]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -86,6 +86,19 @@ bazel_dep(
     dev_dependency = True,
 )
 
+######### Protobuf rules #########
+
+bazel_dep(name = "protobuf", version = "33.4")
+bazel_dep(name = "rules_proto", version = "7.1.0")
+bazel_dep(name = "rules_rust_prost", version = "0.69.0")
+
+git_override(
+    module_name = "rules_rust_prost",
+    remote = "https://github.com/bazelbuild/rules_rust.git",
+    tag = "0.69.0",
+    strip_prefix = "extensions/prost",
+)
+
 ######### Go + Gazelle #########
 
 bazel_dep(name = "rules_go", version = "0.60.0")
@@ -96,7 +109,7 @@ go_sdk.download(version = "1.24.12")
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")
-use_repo(go_deps)
+use_repo(go_deps, "org_golang_google_protobuf")
 
 ######### Rust rules #########
 

--- a/crates/BUILD.bazel
+++ b/crates/BUILD.bazel
@@ -1,0 +1,1 @@
+# Bazel package marker for crates/ directory.

--- a/crates/ts_import_extractor/BUILD.bazel
+++ b/crates/ts_import_extractor/BUILD.bazel
@@ -35,9 +35,9 @@ rust_binary(
     visibility = ["//visibility:public"],
     deps = [
         ":ts_import_extractor",
+        "//crates/ts_import_extractor/proto:ts_import_extractor_rust_proto",
         "@crates//:rayon",
-        "@crates//:serde",
-        "@crates//:serde_json",
+        "@rules_rust_prost//private/3rdparty/crates:prost",
     ],
 )
 

--- a/crates/ts_import_extractor/Cargo.toml
+++ b/crates/ts_import_extractor/Cargo.toml
@@ -15,8 +15,6 @@ oxc_ast = "0.120"
 oxc_parser = "0.120"
 oxc_span = "0.120"
 rayon = "1.8"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/crates/ts_import_extractor/proto/BUILD.bazel
+++ b/crates/ts_import_extractor/proto/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//proto:def.bzl", "go_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_rust_prost//:defs.bzl", "rust_prost_library")
+
+proto_library(
+    name = "message_proto",
+    srcs = ["message.proto"],
+)
+
+rust_prost_library(
+    name = "ts_import_extractor_rust_proto",
+    proto = ":message_proto",
+    visibility = ["//crates/ts_import_extractor:__pkg__"],
+)
+
+go_proto_library(
+    name = "ts_import_extractor_go_proto",
+    importpath = "github.com/nicolo-ribaudo/formatjs/crates/ts_import_extractor/proto",
+    proto = ":message_proto",
+)
+
+go_library(
+    name = "proto",
+    embed = [":ts_import_extractor_go_proto"],
+    importpath = "github.com/nicolo-ribaudo/formatjs/crates/ts_import_extractor/proto",
+    visibility = ["//tools/gazelle/ts:__pkg__"],
+)

--- a/crates/ts_import_extractor/proto/message.proto
+++ b/crates/ts_import_extractor/proto/message.proto
@@ -1,0 +1,28 @@
+syntax = "proto3";
+package ts_import_extractor;
+
+message Request {
+  uint32 id = 1;
+  repeated string files = 2;
+}
+
+message Response {
+  uint32 id = 1;
+  oneof data {
+    ResponseResult result = 2;
+    ResponseError error = 3;
+  }
+}
+
+message ResponseResult {
+  repeated ImportByFile imports = 1;
+}
+
+message ResponseError {
+  string message = 1;
+}
+
+message ImportByFile {
+  string file = 1;
+  repeated string import_paths = 2;
+}

--- a/crates/ts_import_extractor/src/main.rs
+++ b/crates/ts_import_extractor/src/main.rs
@@ -1,45 +1,18 @@
 // main.rs — Long-lived subprocess for extracting TypeScript imports.
 //
-// This binary is spawned by the Go gazelle plugin (tools/gazelle/ts/parser_oxc.go)
-// and stays alive for the entire gazelle run. Communication is over stdin/stdout
-// using length-prefixed JSON frames.
+// Communication is over stdin/stdout using length-prefixed protobuf frames.
+// Frame format: [4-byte big-endian u32 length][protobuf payload of that length]
 //
-// Frame format: [4-byte big-endian u32 length][JSON payload of that length]
-//
-// Protocol:
-//   Request:  {"id": N, "files": ["path/to/file.ts", ...]}
-//   Response: {"id": N, "imports": [{"file": "path.ts", "importPaths": ["react", ...]}, ...]}
-//   Error:    {"id": N, "error": "message"}
-//
-// Files within a request are parsed in parallel using rayon. The binary exits
-// when stdin is closed (Go side closes stdin when gazelle finishes).
+// The binary exits when stdin is closed (Go side closes stdin when gazelle finishes).
 
-use ts_import_extractor::extract_imports_from_file;
 use rayon::prelude::*;
-use serde::{Deserialize, Serialize};
 use std::io::{Read, Write};
+use ts_import_extractor::extract_imports_from_file;
 
-#[derive(Deserialize)]
-struct Request {
-    id: u32,
-    files: Vec<String>,
-}
-
-#[derive(Serialize)]
-struct Response {
-    id: u32,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    imports: Option<Vec<FileImports>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    error: Option<String>,
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct FileImports {
-    file: String,
-    import_paths: Vec<String>,
-}
+// Generated protobuf types.
+use message_proto::ts_import_extractor::{
+    self as proto, response, ImportByFile, Response, ResponseError, ResponseResult,
+};
 
 fn main() {
     let stdin = std::io::stdin();
@@ -66,7 +39,7 @@ fn main() {
             }
 
             let frame = &stream[4..4 + len];
-            let request: Request = match serde_json::from_slice(frame) {
+            let request: proto::Request = match prost::Message::decode(frame) {
                 Ok(r) => r,
                 Err(e) => {
                     eprintln!("ts_import_extractor: invalid request: {e}");
@@ -77,9 +50,11 @@ fn main() {
             stream.drain(..4 + len);
 
             let response = handle_request(request);
-            let payload = serde_json::to_vec(&response).unwrap();
 
-            // Write response frame. Exit cleanly on pipe errors (Go side closed stdout).
+            let mut payload = Vec::new();
+            prost::Message::encode(&response, &mut payload).unwrap();
+
+            // Write response frame. Exit cleanly on pipe errors.
             let mut out = stdout.lock();
             if out
                 .write_all(&(payload.len() as u32).to_be_bytes())
@@ -93,12 +68,12 @@ fn main() {
     }
 }
 
-fn handle_request(req: Request) -> Response {
-    let results: Result<Vec<FileImports>, String> = req
+fn handle_request(req: proto::Request) -> Response {
+    let results: Result<Vec<ImportByFile>, String> = req
         .files
         .par_iter()
         .map(|file| {
-            extract_imports_from_file(file).map(|import_paths| FileImports {
+            extract_imports_from_file(file).map(|import_paths| ImportByFile {
                 file: file.clone(),
                 import_paths,
             })
@@ -108,13 +83,11 @@ fn handle_request(req: Request) -> Response {
     match results {
         Ok(imports) => Response {
             id: req.id,
-            imports: Some(imports),
-            error: None,
+            data: Some(response::Data::Result(ResponseResult { imports })),
         },
         Err(e) => Response {
             id: req.id,
-            imports: None,
-            error: Some(e),
+            data: Some(response::Data::Error(ResponseError { message: e })),
         },
     }
 }

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,9 @@ require (
 
 require (
 	github.com/bazelbuild/buildtools v0.0.0-20250930140053-2eb4fccefb52 // indirect
+	github.com/google/go-cmp v0.7.0 // indirect
 	golang.org/x/mod v0.25.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/tools/go/vcs v0.1.0-deprecated // indirect
+	google.golang.org/protobuf v1.36.11 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,11 +4,13 @@ github.com/bazelbuild/buildtools v0.0.0-20250930140053-2eb4fccefb52 h1:njQAmjTv/
 github.com/bazelbuild/buildtools v0.0.0-20250930140053-2eb4fccefb52/go.mod h1:PLNUetjLa77TCCziPsz0EI8a6CUxgC+1jgmWv0H25tg=
 github.com/bazelbuild/rules_go v0.60.0 h1:apGSxTTrFUyLNvX9NQmF4CbntWAO0/S5eALeVgB/6Qk=
 github.com/bazelbuild/rules_go v0.60.0/go.mod h1:CYcohJVxs4n7eftbC39GCqaEJm3E1EME+6QAkGguKoI=
-github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
-github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 golang.org/x/mod v0.25.0 h1:n7a+ZbQKQA/Ysbyb0/6IbB1H/X41mKgbhfv7AfG/44w=
 golang.org/x/mod v0.25.0/go.mod h1:IXM97Txy2VM4PJ3gI61r1YEk/gAj6zAHN3AdZt6S9Ww=
 golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
 golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/tools/go/vcs v0.1.0-deprecated h1:cOIJqWBl99H1dH5LWizPa+0ImeeJq3t3cJjaeOWUAL4=
 golang.org/x/tools/go/vcs v0.1.0-deprecated/go.mod h1:zUrvATBAvEI9535oC0yWYsLsHIV4Z7g63sNPVMtuBy8=
+google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
+google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=

--- a/knowledge-base/001a-bazel-toolchain.md
+++ b/knowledge-base/001a-bazel-toolchain.md
@@ -244,16 +244,16 @@ cgo overhead, FFI memory management, `cc_library` chains, and dylib path issues.
 Go (gazelle plugin)                     Rust (ts_import_extractor)
 ┌────────────────────────┐              ┌──────────────────────────────┐
 │ parser_oxc.go          │  stdin       │ main.rs                      │
-│   OxcParser struct     │ ────────────>│   length-prefixed JSON loop  │
+│   OxcParser struct     │ ────────────>│   length-prefixed protobuf   │
 │   writeFrame/readFrame │  stdout      │   rayon parallel file parse  │
 │   runfiles.Rlocation   │ <────────────│   oxc Visit AST walker       │
 └────────────────────────┘              └──────────────────────────────┘
 ```
 
-- **Protocol:** Length-prefixed JSON frames over stdin/stdout.
-  Each frame: `[4-byte big-endian u32 length][JSON payload]`
-  - Request: `{"id": N, "files": ["path/to/file.ts", ...]}`
-  - Response: `{"id": N, "imports": [{"file": "...", "importPaths": [...]}, ...]}`
+- **Protocol:** Length-prefixed protobuf frames over stdin/stdout.
+  Schema: `crates/ts_import_extractor/proto/message.proto`
+  Each frame: `[4-byte big-endian u32 length][protobuf payload]`
+  Go uses `google.golang.org/protobuf/proto`, Rust uses `prost`.
 - **Lifecycle:** Subprocess spawned in `lifeCycleManager.Before()` at plugin startup,
   shut down in `DoneGeneratingRules()`. Stays alive for entire gazelle run.
 - **Binary discovery:** `runfiles.Rlocation("_main/crates/ts_import_extractor/bin")`.

--- a/tools/gazelle/ts/BUILD.bazel
+++ b/tools/gazelle/ts/BUILD.bazel
@@ -21,12 +21,14 @@ go_library(
     importpath = "github.com/nicolo-ribaudo/formatjs/tools/gazelle/ts",
     visibility = ["//visibility:public"],
     deps = [
+        "//crates/ts_import_extractor/proto",
         "@gazelle//config",
         "@gazelle//label",
         "@gazelle//language",
         "@gazelle//repo",
         "@gazelle//resolve",
         "@gazelle//rule",
+        "@org_golang_google_protobuf//proto",
         "@rules_go//go/runfiles",
     ],
 )

--- a/tools/gazelle/ts/parser_oxc.go
+++ b/tools/gazelle/ts/parser_oxc.go
@@ -9,48 +9,30 @@
 //	Go (gazelle plugin)                 Rust (ts_import_extractor)
 //	┌──────────────────┐                ┌──────────────────────────┐
 //	│ parser_oxc.go    │  stdin/stdout  │ main.rs                  │
-//	│                  │ ──────────────>│   length-prefixed JSON   │
+//	│                  │ ──────────────>│   length-prefixed proto  │
 //	│ OxcParser struct │ <──────────────│   oxc parse + rayon      │
 //	└──────────────────┘                └──────────────────────────┘
 //
 // Communication protocol:
-//   - Each frame: [4-byte big-endian u32 length][JSON payload of that length]
-//   - Request:  {"id": N, "files": ["path/to/file.ts", ...]}
-//   - Response: {"id": N, "imports": [{"file": "...", "importPaths": [...]}, ...]}
+//   - Each frame: [4-byte big-endian u32 length][protobuf payload of that length]
+//   - Request/Response defined in crates/ts_import_extractor/proto/message.proto
 //
 // Binary location: discovered via Bazel runfiles (github.com/bazelbuild/rules_go/go/runfiles).
 package ts
 
 import (
 	"encoding/binary"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"sync"
 
+	pb "github.com/nicolo-ribaudo/formatjs/crates/ts_import_extractor/proto"
+
 	"github.com/bazelbuild/rules_go/go/runfiles"
+	"google.golang.org/protobuf/proto"
 )
-
-// oxcRequest is the JSON request sent to the Rust subprocess.
-type oxcRequest struct {
-	ID    uint32   `json:"id"`
-	Files []string `json:"files"`
-}
-
-// oxcResponse is the JSON response from the Rust subprocess.
-type oxcResponse struct {
-	ID      uint32           `json:"id"`
-	Imports []oxcFileImports `json:"imports,omitempty"`
-	Error   string           `json:"error,omitempty"`
-}
-
-// oxcFileImports holds the import paths extracted from a single file.
-type oxcFileImports struct {
-	File        string   `json:"file"`
-	ImportPaths []string `json:"importPaths"`
-}
 
 // OxcParser manages a long-lived Rust subprocess for import extraction.
 // All methods are serialized via the mutex since the subprocess communicates
@@ -123,7 +105,7 @@ func (p *OxcParser) ExtractImports(files []string) (map[string][]string, error) 
 	defer p.mu.Unlock()
 
 	p.nextID++
-	req := oxcRequest{ID: p.nextID, Files: files}
+	req := &pb.Request{Id: p.nextID, Files: files}
 
 	if err := p.writeFrame(req); err != nil {
 		return nil, err
@@ -134,20 +116,23 @@ func (p *OxcParser) ExtractImports(files []string) (map[string][]string, error) 
 		return nil, err
 	}
 
-	if resp.Error != "" {
-		return nil, fmt.Errorf("oxc parser error: %s", resp.Error)
+	switch data := resp.Data.(type) {
+	case *pb.Response_Error:
+		return nil, fmt.Errorf("oxc parser error: %s", data.Error.Message)
+	case *pb.Response_Result:
+		result := make(map[string][]string, len(data.Result.Imports))
+		for _, fi := range data.Result.Imports {
+			result[fi.File] = fi.ImportPaths
+		}
+		return result, nil
+	default:
+		return nil, fmt.Errorf("unexpected response type")
 	}
-
-	result := make(map[string][]string, len(resp.Imports))
-	for _, fi := range resp.Imports {
-		result[fi.File] = fi.ImportPaths
-	}
-	return result, nil
 }
 
-// writeFrame marshals the request to JSON and writes it as a length-prefixed frame.
-func (p *OxcParser) writeFrame(req oxcRequest) error {
-	payload, err := json.Marshal(req)
+// writeFrame marshals the request to protobuf and writes it as a length-prefixed frame.
+func (p *OxcParser) writeFrame(req *pb.Request) error {
+	payload, err := proto.Marshal(req)
 	if err != nil {
 		return fmt.Errorf("marshal request: %w", err)
 	}
@@ -163,8 +148,8 @@ func (p *OxcParser) writeFrame(req oxcRequest) error {
 	return nil
 }
 
-// readFrame reads a length-prefixed JSON frame from stdout and unmarshals it.
-func (p *OxcParser) readFrame() (*oxcResponse, error) {
+// readFrame reads a length-prefixed protobuf frame from stdout and unmarshals it.
+func (p *OxcParser) readFrame() (*pb.Response, error) {
 	var lenBuf [4]byte
 	if _, err := io.ReadFull(p.stdout, lenBuf[:]); err != nil {
 		return nil, fmt.Errorf("read response length: %w", err)
@@ -175,8 +160,8 @@ func (p *OxcParser) readFrame() (*oxcResponse, error) {
 		return nil, fmt.Errorf("read response payload: %w", err)
 	}
 
-	var resp oxcResponse
-	if err := json.Unmarshal(respBuf, &resp); err != nil {
+	var resp pb.Response
+	if err := proto.Unmarshal(respBuf, &resp); err != nil {
 		return nil, fmt.Errorf("unmarshal response: %w", err)
 	}
 	return &resp, nil


### PR DESCRIPTION
## Summary

- Switch Go↔Rust subprocess communication from JSON to protobuf (matching [gazelle-ts-plugin](https://github.com/aspect-build/gazelle-ts-plugin) architecture)
- Add protobuf schema at `crates/ts_import_extractor/proto/message.proto`
- Add `protobuf`, `rules_proto`, `rules_rust_prost` to MODULE.bazel
- Update knowledge base documentation

## Details

**Proto schema** (`crates/ts_import_extractor/proto/message.proto`):
- `Request`: id + files
- `Response`: id + result/error (oneof)
- `ResponseResult`: list of `ImportByFile` (file + import_paths)

**Rust side**: Replaces `serde`/`serde_json` with `prost::Message` encode/decode. The generated types come from `rust_prost_library`.

**Go side**: Replaces `encoding/json` with `google.golang.org/protobuf/proto`. Uses types from `go_proto_library`.

**Bazel setup**:
- `rules_rust_prost` via `git_override` (not yet on BCR for 0.69.0)
- Default prost toolchain with `@rules_rust_prost//private/3rdparty/crates:prost` for the binary dep
- Proto BUILD with `proto_library`, `rust_prost_library`, `go_proto_library`

The frame format (4-byte big-endian length prefix) remains unchanged — only the payload encoding changes.

## Test plan

- [x] `bazel test //tools/gazelle/ts:ts_test` — Go tests pass
- [x] `bazel test //crates/ts_import_extractor:unit_test` — Rust tests pass
- [x] `bazel run //:gazelle` — generates correct BUILD files
- [x] Pre-commit hooks pass (buildifier, gazelle, rustfmt, commitlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)