### PR TITLE
fix(@formatjs/ts-transformer): include source location in extraction warnings

### DIFF
--- a/crates/formatjs_cli/src/extractor.rs
+++ b/crates/formatjs_cli/src/extractor.rs
@@ -91,6 +91,7 @@ pub fn extract_messages_from_source(
     // Visit the AST to extract messages
     let mut visitor = MessageExtractor::new(
         file_path,
+        source_text,
         extract_source_location,
         component_names,
         function_names,
@@ -185,6 +186,7 @@ pub fn determine_source_type(path: &Path) -> Result<SourceType> {
 /// AST visitor to extract message descriptors
 struct MessageExtractor<'a> {
     file_path: &'a Path,
+    source_text: &'a str,
     extract_source_location: bool,
     component_names: &'a [String],
     function_names: &'a [String],
@@ -197,6 +199,7 @@ struct MessageExtractor<'a> {
 impl<'a> MessageExtractor<'a> {
     fn new(
         file_path: &'a Path,
+        source_text: &'a str,
         extract_source_location: bool,
         component_names: &'a [String],
         function_names: &'a [String],
@@ -206,6 +209,7 @@ impl<'a> MessageExtractor<'a> {
     ) -> Self {
         Self {
             file_path,
+            source_text,
             extract_source_location,
             component_names,
             function_names,
@@ -214,6 +218,12 @@ impl<'a> MessageExtractor<'a> {
             throws,
             messages: Vec::new(),
         }
+    }
+
+    /// Format a source location string like "file.tsx:line:col"
+    fn format_location(&self, offset: u32) -> String {
+        let (line, col) = get_line_col(self.source_text, offset as usize);
+        format!("{}:{}:{}", self.file_path.display(), line, col)
     }
 
     fn extract_string_literal(
@@ -380,20 +390,34 @@ impl<'a> MessageExtractor<'a> {
                                     match attr_name {
                                         "id" => {
                                             descriptor.id = self.extract_string_literal(expr, None);
-                                            // Validate id is static if throws is enabled
-                                            if self.throws && descriptor.id.is_none() {
-                                                panic!(
-                                                    "defaultMessage must be a string literal to be extracted."
+                                            if descriptor.id.is_none() {
+                                                let loc = self.format_location(jsx_attr.span.start);
+                                                if self.throws {
+                                                    panic!(
+                                                        "{} [FormatJS] `id` must be a string literal to be extracted.",
+                                                        loc
+                                                    );
+                                                }
+                                                eprintln!(
+                                                    "{} [FormatJS] `id` must be a string literal to be extracted.",
+                                                    loc
                                                 );
                                             }
                                         }
                                         "defaultMessage" => {
                                             descriptor.default_message =
                                                 self.extract_string_literal(expr, None);
-                                            // Validate defaultMessage is static if throws is enabled
-                                            if self.throws && descriptor.default_message.is_none() {
-                                                panic!(
-                                                    "defaultMessage must be a string literal to be extracted."
+                                            if descriptor.default_message.is_none() {
+                                                let loc = self.format_location(jsx_attr.span.start);
+                                                if self.throws {
+                                                    panic!(
+                                                        "{} [FormatJS] `defaultMessage` must be a string literal to be extracted.",
+                                                        loc
+                                                    );
+                                                }
+                                                eprintln!(
+                                                    "{} [FormatJS] `defaultMessage` must be a string literal to be extracted.",
+                                                    loc
                                                 );
                                             }
                                         }
@@ -498,17 +522,35 @@ impl<'a> MessageExtractor<'a> {
                     match key.name.as_str() {
                         "id" => {
                             descriptor.id = self.extract_string_literal(&p.value, None);
-                            // Validate id is static if throws is enabled
-                            if self.throws && descriptor.id.is_none() {
-                                panic!("defaultMessage must be a string literal to be extracted.");
+                            if descriptor.id.is_none() {
+                                let loc = self.format_location(p.span.start);
+                                if self.throws {
+                                    panic!(
+                                        "{} [FormatJS] `id` must be a string literal to be extracted.",
+                                        loc
+                                    );
+                                }
+                                eprintln!(
+                                    "{} [FormatJS] `id` must be a string literal to be extracted.",
+                                    loc
+                                );
                             }
                         }
                         "defaultMessage" => {
                             descriptor.default_message =
                                 self.extract_string_literal(&p.value, None);
-                            // Validate defaultMessage is static if throws is enabled
-                            if self.throws && descriptor.default_message.is_none() {
-                                panic!("defaultMessage must be a string literal to be extracted.");
+                            if descriptor.default_message.is_none() {
+                                let loc = self.format_location(p.span.start);
+                                if self.throws {
+                                    panic!(
+                                        "{} [FormatJS] `defaultMessage` must be a string literal to be extracted.",
+                                        loc
+                                    );
+                                }
+                                eprintln!(
+                                    "{} [FormatJS] `defaultMessage` must be a string literal to be extracted.",
+                                    loc
+                                );
                             }
                         }
                         "description" => {

--- a/crates/formatjs_cli/src/extractor.rs
+++ b/crates/formatjs_cli/src/extractor.rs
@@ -1658,4 +1658,152 @@ export default function Test() {
         assert!(error.contains("Cannot hoist plural/select within a tag element"), "Error should include original error message");
         assert!(error.contains("<b>{count"), "Error should include problematic message");
     }
+
+    #[test]
+    fn test_non_static_id_throws_includes_location() {
+        // When throws=true and id is non-static, the panic message should include file:line:col
+        let source = r#"import { defineMessage } from 'react-intl';
+const dynamicId = 'foo';
+const msg = defineMessage({
+    id: dynamicId,
+    defaultMessage: 'Hello',
+});
+"#;
+
+        let file_path = PathBuf::from("src/App.tsx");
+        let source_type = SourceType::default().with_typescript(true).with_jsx(true);
+        let component_names = vec!["FormattedMessage".to_string()];
+        let function_names = vec![
+            "defineMessage".to_string(),
+            "defineMessages".to_string(),
+            "formatMessage".to_string(),
+        ];
+
+        let result = std::panic::catch_unwind(|| {
+            extract_messages_from_source(
+                source,
+                &file_path,
+                source_type,
+                false,
+                &component_names,
+                &function_names,
+                HashMap::new(),
+                false,
+                false,
+                true, // throws = true
+            )
+        });
+
+        assert!(result.is_err(), "Should panic with throws=true on non-static id");
+        let panic_msg = result
+            .unwrap_err()
+            .downcast_ref::<String>()
+            .cloned()
+            .unwrap_or_default();
+        assert!(
+            panic_msg.contains("src/App.tsx:4:"),
+            "Panic message should include file:line:col, got: {}",
+            panic_msg
+        );
+        assert!(
+            panic_msg.contains("[FormatJS]"),
+            "Panic message should include [FormatJS] prefix, got: {}",
+            panic_msg
+        );
+    }
+
+    #[test]
+    fn test_non_static_default_message_throws_includes_location() {
+        // When throws=true and defaultMessage is non-static, the panic message should include file:line:col
+        let source = r#"import { FormattedMessage } from 'react-intl';
+export default function App() {
+    const msg = getDynamicMessage();
+    return <FormattedMessage id="test" defaultMessage={msg} />;
+}
+"#;
+
+        let file_path = PathBuf::from("src/Component.tsx");
+        let source_type = SourceType::default().with_typescript(true).with_jsx(true);
+        let component_names = vec!["FormattedMessage".to_string()];
+        let function_names = vec!["formatMessage".to_string()];
+
+        let result = std::panic::catch_unwind(|| {
+            extract_messages_from_source(
+                source,
+                &file_path,
+                source_type,
+                false,
+                &component_names,
+                &function_names,
+                HashMap::new(),
+                false,
+                false,
+                true, // throws = true
+            )
+        });
+
+        assert!(result.is_err(), "Should panic with throws=true on non-static defaultMessage");
+        let panic_msg = result
+            .unwrap_err()
+            .downcast_ref::<String>()
+            .cloned()
+            .unwrap_or_default();
+        assert!(
+            panic_msg.contains("src/Component.tsx:4:"),
+            "Panic message should include file:line:col, got: {}",
+            panic_msg
+        );
+        assert!(
+            panic_msg.contains("`defaultMessage`"),
+            "Panic message should mention defaultMessage, got: {}",
+            panic_msg
+        );
+    }
+
+    #[test]
+    fn test_non_static_values_no_throw_skips_and_warns() {
+        // When throws=false and defaultMessage is non-static, messages should be skipped (not panic)
+        let source = r#"import { defineMessage } from 'react-intl';
+const dynamic = getDynamic();
+const msg1 = defineMessage({
+    id: 'skip.me',
+    defaultMessage: dynamic,
+});
+const msg2 = defineMessage({
+    id: 'valid.message',
+    defaultMessage: 'This is valid',
+});
+"#;
+
+        let file_path = PathBuf::from("src/App.tsx");
+        let source_type = SourceType::default().with_typescript(true).with_jsx(true);
+        let component_names = vec!["FormattedMessage".to_string()];
+        let function_names = vec![
+            "defineMessage".to_string(),
+            "defineMessages".to_string(),
+            "formatMessage".to_string(),
+        ];
+
+        let messages = extract_messages_from_source(
+            source,
+            &file_path,
+            source_type,
+            false,
+            &component_names,
+            &function_names,
+            HashMap::new(),
+            false,
+            false,
+            false, // throws = false
+        )
+        .unwrap();
+
+        // Only the valid message should be extracted (the one with non-static defaultMessage is skipped)
+        assert_eq!(messages.len(), 1, "Should extract only the valid message");
+        assert_eq!(messages[0].id.as_deref(), Some("valid.message"));
+        assert_eq!(
+            messages[0].default_message.as_deref(),
+            Some("This is valid")
+        );
+    }
 }

--- a/packages/ts-transformer/tests/index.test.ts
+++ b/packages/ts-transformer/tests/index.test.ts
@@ -726,6 +726,26 @@ describe('emit asserts for', function () {
       /\[formatjs\] Cannot flatten message in file.*flattenError\.tsx.*at line \d+, column \d+.*with id "test\.message".*Cannot hoist plural\/select within a tag element/
     )
   })
+
+  it('GH #6428 - extraction error with throws=true includes file:line:col', async function () {
+    await expect(
+      compile(join(FIXTURES_DIR, 'nonStaticMessages.tsx'), {})
+    ).rejects.toThrow(/nonStaticMessages\.tsx:\d+:\d+ \[FormatJS\]/)
+  })
+
+  it('GH #6428 - extraction error with throws=false reports file:line:col via onMsgError', async function () {
+    const errors: Error[] = []
+    await compile(join(FIXTURES_DIR, 'nonStaticMessages.tsx'), {
+      throws: false,
+      onMsgError: (_filePath: string, error: Error) => {
+        errors.push(error)
+      },
+    })
+    expect(errors.length).toBeGreaterThan(0)
+    expect(errors[0].message).toMatch(
+      /nonStaticMessages\.tsx:\d+:\d+ \[FormatJS\]/
+    )
+  })
 })
 
 async function compile(filePath: string, options?: Partial<Opts>) {

--- a/packages/ts-transformer/transform.ts
+++ b/packages/ts-transformer/transform.ts
@@ -286,8 +286,16 @@ function extractMessageDescriptor(
   let extractionError: Error | null = null
 
   // Helper to handle errors based on throws option
-  function handleError(errorMsg: string): void {
-    const error = new Error(errorMsg)
+  function handleError(errorMsg: string, errorNode?: typescript.Node): void {
+    let locationMsg = errorMsg
+    if (errorNode) {
+      const {line, character} = ts.getLineAndCharacterOfPosition(
+        sf,
+        errorNode.getStart(sf)
+      )
+      locationMsg = `${sf.fileName}:${line + 1}:${character + 1} ${errorMsg}`
+    }
+    const error = new Error(locationMsg)
     if (throws) {
       throw error
     }
@@ -364,7 +372,8 @@ function extractMessageDescriptor(
         const {template} = initializer
         if (!ts.isNoSubstitutionTemplateLiteral(template)) {
           handleError(
-            '[FormatJS] Tagged template expression must be no substitution'
+            '[FormatJS] Tagged template expression must be no substitution',
+            prop
           )
           return
         }
@@ -437,7 +446,8 @@ function extractMessageDescriptor(
           } = initializer
           if (!ts.isNoSubstitutionTemplateLiteral(template)) {
             handleError(
-              '[FormatJS] Tagged template expression must be no substitution'
+              '[FormatJS] Tagged template expression must be no substitution',
+              prop
             )
             return
           }
@@ -475,7 +485,8 @@ function extractMessageDescriptor(
           ) {
             // Non-static expression for defaultMessage or id
             handleError(
-              `[FormatJS] \`${name.text}\` must be a string literal or statically evaluable expression to be extracted.`
+              `[FormatJS] \`${name.text}\` must be a string literal or statically evaluable expression to be extracted.`,
+              prop
             )
             return
           }
@@ -486,7 +497,8 @@ function extractMessageDescriptor(
           name.text !== 'description'
         ) {
           handleError(
-            `[FormatJS] \`${name.text}\` must be a string literal to be extracted.`
+            `[FormatJS] \`${name.text}\` must be a string literal to be extracted.`,
+            prop
           )
           return
         }
@@ -512,7 +524,8 @@ function extractMessageDescriptor(
         ) {
           // Non-static expression for defaultMessage or id
           handleError(
-            `[FormatJS] \`${name.text}\` must be a string literal or statically evaluable expression to be extracted.`
+            `[FormatJS] \`${name.text}\` must be a string literal or statically evaluable expression to be extracted.`,
+            prop
           )
           return
         }
@@ -530,7 +543,8 @@ function extractMessageDescriptor(
         name.text !== 'description'
       ) {
         handleError(
-          `[FormatJS] \`${name.text}\` must be a string literal to be extracted.`
+          `[FormatJS] \`${name.text}\` must be a string literal to be extracted.`,
+          prop
         )
         return
       }


### PR DESCRIPTION
## Summary
- Add `file:line:col` context to extraction error/warning messages in both the TypeScript transformer and Rust CLI extractor
- TS side: `handleError` now accepts an optional AST node and uses `ts.getLineAndCharacterOfPosition()` to prepend location
- Rust side: `MessageExtractor` stores source text and uses `get_line_col()` to format `file:line:col` in warnings/panics. Also emits `eprintln!` warnings when `throws=false` (previously silently skipped)

**Before:** `[FormatJS] \`id\` must be a string literal to be extracted.`
**After:** `src/components/Foo.tsx:12:5 [FormatJS] \`id\` must be a string literal to be extracted.`

Closes #6428

## Test plan
- [x] `bazel test //crates/formatjs_cli:formatjs_cli_test` — 176 tests pass
- [x] `bazel test //packages/ts-transformer:unit_test` — all tests pass
- [x] `bazel test //packages/cli/integration-tests:conformance_test` — 60/60 conformance tests pass
- [x] All pre-commit hooks pass (oxfmt, rustfmt, gazelle, ast-grep, oxlint, commitlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)