### PR TITLE
fix(@formatjs/ts-transformer): restore ts-jest-integration import

### DIFF
--- a/packages/ts-transformer/package.json
+++ b/packages/ts-transformer/package.json
@@ -7,7 +7,8 @@
   "type": "module",
   "types": "index.d.ts",
   "exports": {
-    ".": "./index.js"
+    ".": "./index.js",
+    "./ts-jest-integration.js": "./ts-jest-integration.js"
   },
   "engines": {
     "node": ">= 20.12.0"


### PR DESCRIPTION
PR #6080 added `"exports": { ".": "./index.js" }` to `@formatjs/ts-transformer`, which inadvertently broke the ts-jest-integration deep import that ts-jest users rely on for AST transformer configuration.

#### Problem
After upgrading to `@formatjs/ts-transformer@4.4.3`, any project using `ts-jest` with the formatjs ast transformer fails before tests execute with error:
`File not found: @formatjs/ts-transformer/ts-jest-integration`

This affects the documented ts-jest configuration pattern:

#### Fix
Expose `ts-jest-integration` as an explicit subpath export

#### Impact
No breaking changes — existing "." export is unchanged
Restores the documented ts-jest integration path without requiring any workaround on the consumer side
ts-jest-integration.js already exists in the published package; this change only makes it reachable via the exports map
#### Related
Regression introduced by: #6080