### PR TITLE
fix(formatjs_cli): extract formatMessage from callbacks inside optional chains

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -113,7 +113,8 @@
     "https://bcr.bazel.build/modules/jsoncpp/1.9.6/source.json": "a04756d367a2126c3541682864ecec52f92cdee80a35735a3cb249ce015ca000",
     "https://bcr.bazel.build/modules/libpfm/4.11.0/MODULE.bazel": "45061ff025b301940f1e30d2c16bea596c25b176c8b6b3087e92615adbd52902",
     "https://bcr.bazel.build/modules/llvm/0.7.3/MODULE.bazel": "b8ffe1ec9d18c0deb6d6dc1a6f78a64bcfcec8648c97b92ed6cd98a7fe49c64f",
-    "https://bcr.bazel.build/modules/llvm/0.7.3/source.json": "44d694e1559683ea4cf96052c56c5426d2604016636133798fcd57cc78542984",
+    "https://bcr.bazel.build/modules/llvm/0.7.5/MODULE.bazel": "5a2b497560edcd2d747f9b1d4df18f79c92834cf885e9a54e129654b03de7f99",
+    "https://bcr.bazel.build/modules/llvm/0.7.5/source.json": "f9360048eb1e964dcf1cdd5a204fcb62b5cbc6ce8708aeb5b384534d259b49a8",
     "https://bcr.bazel.build/modules/nlohmann_json/3.6.1/MODULE.bazel": "6f7b417dcc794d9add9e556673ad25cb3ba835224290f4f848f8e2db1e1fca74",
     "https://bcr.bazel.build/modules/package_metadata/0.0.2/MODULE.bazel": "fb8d25550742674d63d7b250063d4580ca530499f045d70748b1b142081ebb92",
     "https://bcr.bazel.build/modules/package_metadata/0.0.5/MODULE.bazel": "ef4f9439e3270fdd6b9fd4dbc3d2f29d13888e44c529a1b243f7a31dfbc2e8e4",
@@ -307,7 +308,7 @@
         "recordedInputs": [
           "REPO_MAPPING:aspect_rules_ts+,aspect_rules_ts aspect_rules_ts+",
           "REPO_MAPPING:aspect_rules_ts+,bazel_tools bazel_tools",
-          "FILE:@@//package.json 7fe32ef08f7f1b2703b131b911811d2e0725264c1568e67909472e03f6829c52"
+          "FILE:@@//package.json ae0f84eeeb91a5068eb3f910a1752c5da3fa26fef93be60ad101b5f3262ea58b"
         ],
         "generatedRepoSpecs": {
           "npm_typescript": {

--- a/crates/formatjs_cli/src/extractor.rs
+++ b/crates/formatjs_cli/src/extractor.rs
@@ -1379,6 +1379,14 @@ mod tests {
                 start: None,
                 end: None,
             },
+            MessageDescriptor {
+                id: None,
+                default_message: Some("In a callback inside an optional chain".to_string()),
+                description: Some(Value::String("Test callbacks inside an optional chain".to_string())),
+                file: None,
+                start: None,
+                end: None,
+            },
         ];
 
         assert_eq!(messages, expected);

--- a/crates/formatjs_cli/src/extractor.rs
+++ b/crates/formatjs_cli/src/extractor.rs
@@ -591,18 +591,13 @@ impl<'a> Visit<'a> for MessageExtractor<'a> {
             oxc_ast::ast::ChainElement::CallExpression(call) => {
                 // Extract the message from this call expression
                 self.extract_call_expression_message(call);
-                // Don't walk - this prevents double extraction since walk would
-                // visit the arguments which may contain nested chains
-                // Instead, manually walk just the arguments to find nested messages
+                // Walk both callee and arguments to find nested messages
+                walk::walk_expression(self, &call.callee);
                 for arg in &call.arguments {
                     if let Some(expr) = arg.as_expression() {
                         walk::walk_expression(self, expr);
                     }
                 }
-            }
-            oxc_ast::ast::ChainElement::StaticMemberExpression(_) => {
-                // For member expressions in chains, walk normally to find nested patterns
-                walk::walk_chain_expression(self, it);
             }
             _ => {
                 // For other chain elements, walk normally

--- a/packages/cli/integration-tests/conformance-tests/test_cases/22_callback_in_optional_chain.txt
+++ b/packages/cli/integration-tests/conformance-tests/test_cases/22_callback_in_optional_chain.txt
@@ -1,0 +1,31 @@
+import React from 'react';
+
+function getUsers(): Array<string> | undefined {
+  return undefined;
+}
+
+function MyComponent({intl}) {
+  // formatMessage nested in a callback inside an optional chain.
+  const messages = getUsers()?.map(() =>
+    intl.formatMessage({
+      id: 'callback.in.optional.chain',
+      defaultMessage: 'In a callback inside an optional chain',
+      description: 'Test callbacks inside an optional chain'
+    })
+  ).join(', ');
+
+  return <div>{messages}</div>;
+}
+---
+{
+  "command": "extract",
+  "args": ["--throws"],
+  "fileType": "tsx"
+}
+---
+{
+  "callback.in.optional.chain": {
+    "defaultMessage": "In a callback inside an optional chain",
+    "description": "Test callbacks inside an optional chain"
+  }
+}

--- a/packages/ts-transformer/tests/fixtures/optionalChaining.tsx
+++ b/packages/ts-transformer/tests/fixtures/optionalChaining.tsx
@@ -1,8 +1,12 @@
 // @ts-ignore
 const intl = {} as any
 
+function getUsers(): Array<string> | undefined {
+  return undefined;
+}
+
 // GH #4471: Test optional chaining with generics
-export function testOptionalChainingWithGenerics() {
+export function testOptionalChainingWithGenerics(): void {
   // Case 1: Normal call (baseline - should work)
   intl.formatMessage({
     defaultMessage: 'Normal call',
@@ -33,4 +37,14 @@ export function testOptionalChainingWithGenerics() {
     defaultMessage: 'Nested optional chaining',
     description: 'Test nested optional chaining',
   })
+
+  // Case 6: formatMessage nested in a callback inside an optional chain.
+  getUsers()?.map(() =>
+    intl.formatMessage(
+      {
+        defaultMessage: 'In a callback inside an optional chain',
+        description: 'Test callbacks inside an optional chain',
+      },
+    ),
+  ).join(', ')
 }

--- a/packages/ts-transformer/tests/index.test.ts
+++ b/packages/ts-transformer/tests/index.test.ts
@@ -710,6 +710,11 @@ describe('emit asserts for', function () {
         description: 'Test nested optional chaining',
         id: 'DZ/55FDtO6',
       },
+      {
+        defaultMessage: 'In a callback inside an optional chain',
+        description: 'Test callbacks inside an optional chain',
+        id: '7SldKmH/WX',
+      },
     ])
   })
 


### PR DESCRIPTION
Fixes #6459.

The Rust CLI's chain-expression visitor walked into call expression arguments, but skipped the callee. As a result, `formatMessage` calls inside callbacks passed to optional-chain methods (e.g. `getUsers()?.map(() => intl.formatMessage(...))`) were never extracted.

## Changes
- Walk both the callee and arguments of a `CallExpression` chain element so nested `formatMessage` calls inside callback bodies are extracted.
- Drop the `StaticMemberExpression` arm — `walk_chain_expression` covers it via the default case.
- Add fixture case in `packages/ts-transformer/tests/fixtures/optionalChaining.tsx`.
- Add Rust unit-test expectation in `crates/formatjs_cli/src/extractor.rs`.
- Add ts-transformer assertion in `packages/ts-transformer/tests/index.test.ts`.
- Add CLI conformance case `22_callback_in_optional_chain.txt` so both Rust and TS extractors are guarded.

## Test plan
- [x] `bazel test //crates/formatjs_cli:formatjs_cli_test`
- [x] `bazel test //packages/ts-transformer:ts-transformer_test`
- [x] `bazel test //packages/cli/integration-tests:conformance_test`