### PR TITLE
chore(formatjs_cli): bump version to 1.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,7 +456,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "formatjs_cli"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "anyhow",
  "base64",

--- a/crates/formatjs_cli/Cargo.toml
+++ b/crates/formatjs_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "formatjs_cli"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2024"
 authors = ["FormatJS Team", "Long Ho <holevietlong@gmail.com>"]
 description = "Command-line interface for FormatJS - A Rust-based CLI for internationalization"


### PR DESCRIPTION
## Summary
- Bumps `formatjs_cli` from 1.1.1 → 1.1.2
- Picks up the optional-chain callback extraction fix from #6460

## Test plan
- [x] `bazel build //crates/formatjs_cli:formatjs_cli`
- [x] `bazel test //crates/formatjs_cli:formatjs_cli_test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)