### PR TITLE
build(deps): switch gazelle_ts to official BCR v0.3.3 release

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -101,17 +101,7 @@ go_sdk.download(version = "1.24.12")
 
 ######### gazelle_ts (TypeScript Gazelle extension) #########
 
-# Pinned to a post-v0.2.0 commit that links the import_extractor crate
-# statically into the gazelle plugin via cgo (no subprocess, no prebuilt
-# binary). The rust toolchain + crate.from_cargo extensions below propagate
-# from this module — keep our own toolchain/crate config in sync.
-bazel_dep(name = "gazelle_ts", version = "0.2.0")
-archive_override(
-    module_name = "gazelle_ts",
-    integrity = "sha256-C0PdbsYJz+F1QMNriPR0LIPeyhPFiC1uLoBl0ylDLkc=",
-    strip_prefix = "gazelle_ts-3c4b42d59439c6bdbb1af893155ea79442f2ad3e",
-    urls = ["https://github.com/hermeticbuild/gazelle_ts/archive/3c4b42d59439c6bdbb1af893155ea79442f2ad3e.tar.gz"],
-)
+bazel_dep(name = "gazelle_ts", version = "0.3.3")
 
 ######### Rust rules #########
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -98,6 +98,8 @@
     "https://bcr.bazel.build/modules/gazelle/0.36.0/MODULE.bazel": "e375d5d6e9a6ca59b0cb38b0540bc9a05b6aa926d322f2de268ad267a2ee74c0",
     "https://bcr.bazel.build/modules/gazelle/0.50.0/MODULE.bazel": "5dce69aa1d7b5bc85d1e1cfe61f0a9a27426c46425ec1d064685f941a5977329",
     "https://bcr.bazel.build/modules/gazelle/0.50.0/source.json": "3cadcd284172c4274dc44c71b571f08ec4f22b28d5e9ad2708347c6e6c3a41b9",
+    "https://bcr.bazel.build/modules/gazelle_ts/0.3.3/MODULE.bazel": "8964b229db909214a70abf7825690e7aec441d5285960514036ca83ebeb3f71d",
+    "https://bcr.bazel.build/modules/gazelle_ts/0.3.3/source.json": "9b4c7e1f6e7c79b459db8a7f1f4cefb39c5f33ef1b4567116dc1ec1f0c69b9e6",
     "https://bcr.bazel.build/modules/google_benchmark/1.8.2/MODULE.bazel": "a70cf1bba851000ba93b58ae2f6d76490a9feb74192e57ab8e8ff13c34ec50cb",
     "https://bcr.bazel.build/modules/googletest/1.11.0/MODULE.bazel": "3a83f095183f66345ca86aa13c58b59f9f94a2f81999c093d4eeaa2d262d12f4",
     "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/MODULE.bazel": "22c31a561553727960057361aa33bf20fb2e98584bc4fec007906e27053f80c6",


### PR DESCRIPTION
## Summary
- Drop the `archive_override` pin on `hermeticbuild/gazelle_ts@3c4b42d` and use the tagged v0.3.3 release published to BCR.
- v0.3.3 is 6 commits ahead of the previously pinned commit (cgo static-linking is already in the pin; v0.3.x adds a Linux `-ldl` clinkopt for the cgo'd Rust staticlib plus CI/BCR cleanups).

## Test plan
- [x] `bazel mod show_repo gazelle_ts` resolves to v0.3.3 from BCR
- [x] `bazel build @gazelle_ts//ts` succeeds
- [x] `bazel run //:gazelle` produces no BUILD churn
- [x] `bazel test //packages/intl-localematcher:intl-localematcher_test` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)