### PR TITLE
fix(@formatjs/unplugin): strip query/hash in transformInclude

### DIFF
--- a/packages/unplugin/index.ts
+++ b/packages/unplugin/index.ts
@@ -13,7 +13,11 @@ export const unpluginFactory: UnpluginFactory<Options | undefined> = (
   name: 'formatjs',
   enforce: 'pre' as const,
   transformInclude(id: string): boolean {
-    return /\.[jt]sx?$/.test(id) && !id.includes('node_modules')
+    // Strip query/hash so virtual chunk IDs like
+    // `route.tsx?route-chunk=main` (e.g. React Router's clientLoader/
+    // clientAction split) still match the JS/TS extension test.
+    const path = id.replace(/[?#].*$/, '')
+    return /\.[jt]sx?$/.test(path) && !path.includes('node_modules')
   },
   transform(code: string, id: string) {
     return transform(code, id, options)

--- a/packages/unplugin/tests/transform.test.ts
+++ b/packages/unplugin/tests/transform.test.ts
@@ -518,6 +518,21 @@ describe('@formatjs/unplugin factory', () => {
     expect(plugin.transformInclude('/node_modules/react/index.js')).toBe(false)
   })
 
+  test('transformInclude ignores query/hash on the id (#6455)', async () => {
+    const {unpluginFactory} = await import('../index.js')
+    const plugin = getPlugin(unpluginFactory)
+    // React Router splits routes that export clientLoader/clientAction into
+    // virtual chunk modules — IDs come in with a `?route-chunk=...` query.
+    expect(plugin.transformInclude('/src/route.tsx?route-chunk=main')).toBe(
+      true
+    )
+    expect(plugin.transformInclude('/src/route.ts?v=123')).toBe(true)
+    expect(plugin.transformInclude('/src/route.tsx#anchor')).toBe(true)
+    expect(plugin.transformInclude('/node_modules/foo/index.js?v=123')).toBe(
+      false
+    )
+  })
+
   test('transform processes formatjs descriptors', async () => {
     const {unpluginFactory} = await import('../index.js')
     const plugin = getPlugin(unpluginFactory)


### PR DESCRIPTION
## Summary
- React Router splits routes that export `clientLoader`/`clientAction` into virtual chunk modules with IDs like `route.tsx?route-chunk=main`. The plain `\.[jt]sx?$` test in `transformInclude` rejected those, so `defineMessage` calls in those chunks never got their `id` injected during production builds.
- Strip `?…` and `#…` off the id before the extension check.
- Added a regression test covering query-string and hash IDs (and the negative `node_modules` case with a query).

Fixes #6455

## Test plan
- [x] `bazel test //packages/unplugin/...` — all tests pass, including the new regression case
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)