### PR TITLE
fix(@formatjs/intl-durationformat): declare @formatjs/bigdecimal dependency

### DIFF
--- a/packages/intl-durationformat/package.json
+++ b/packages/intl-durationformat/package.json
@@ -13,6 +13,7 @@
     "./should-polyfill.js": "./should-polyfill.js"
   },
   "dependencies": {
+    "@formatjs/bigdecimal": "workspace:*",
     "@formatjs/intl-localematcher": "workspace:*"
   },
   "bugs": "https://github.com/formatjs/formatjs/issues",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -745,6 +745,9 @@ importers:
 
   packages/intl-durationformat:
     dependencies:
+      '@formatjs/bigdecimal':
+        specifier: workspace:*
+        version: link:../bigdecimal
       '@formatjs/intl-localematcher':
         specifier: workspace:*
         version: link:../intl-localematcher


### PR DESCRIPTION
## Summary
- Add `@formatjs/bigdecimal` to `@formatjs/intl-durationformat`'s `dependencies`. The polyfill bundle externalizes it (introduced in #6466 for sub-second rollup precision), but it was only declared in BUILD.bazel — not in `package.json`. Consumers updating to 0.10.6 hit `Rolldown failed to resolve import @formatjs/bigdecimal` at build time.

Fixes #6467.

## Why this slipped past CI
`tools/check-package-json.ts` exists for exactly this validation, but the Bazel rule that wires it up (`package_json_test` in `tools/index.bzl:410-439`) is commented out as a TODO. Will follow up with a separate PR to re-enable it across all packages.

## Test plan
- [x] `bazel test //packages/intl-durationformat:intl-durationformat_test`
- [x] Inspected `bazel-bin/packages/intl-durationformat/pkg/package.json` — `@formatjs/bigdecimal` now appears in `dependencies`

🤖 Generated with [Claude Code](https://claude.com/claude-code)