### PR TITLE
docs: clarify native CLI install and compatibility

### DIFF
--- a/crates/formatjs_cli/README.md
+++ b/crates/formatjs_cli/README.md
@@ -4,29 +4,29 @@ A high-performance Rust-based command-line interface for FormatJS internationali
 
 ## Overview
 
-`formatjs_cli` is a high-performance Rust implementation of the FormatJS CLI, providing fast and efficient tools for working with ICU MessageFormat messages in your internationalization workflow.
+`formatjs_cli` is a high-performance Rust implementation of core FormatJS CLI workflows, providing fast tools for working with ICU MessageFormat messages in your internationalization workflow.
 
 ### Why Use the Native CLI?
 
 The native Rust CLI offers significant advantages over the Node.js-based `@formatjs/cli`:
 
-- **🚀 Faster Performance**: Up to 10-100x faster for large codebases
-- **📦 Zero Dependencies**: Single binary with no Node.js or npm packages required
-- **💾 Lower Memory Usage**: Minimal memory footprint compared to Node.js
-- **⚡ Instant Startup**: No Node.js initialization overhead
-- **🔧 Easy Distribution**: Standalone binaries for CI/CD pipelines
-- **🎯 Perfect for CI/CD**: Fast, reliable, and cache-friendly
+- **Faster Performance**: Up to 10-100x faster for large codebases
+- **Zero Node.js Runtime Dependency**: Single binary with no Node.js runtime required for supported features
+- **Lower Memory Usage**: Minimal memory footprint compared to Node.js
+- **Instant Startup**: No Node.js initialization overhead
+- **Easy Distribution**: Standalone binaries for CI/CD pipelines
+- **CI/CD Friendly**: Fast, reliable, and cache-friendly
 
 **Benchmark results** (processing ~1000 message files):
 
 - Node.js CLI: ~8.5 seconds
 - Rust CLI: ~0.5 seconds (17x faster)
 
-The native CLI is a drop-in replacement for `@formatjs/cli` with identical command-line interface and output format.
+The native CLI aims to match `@formatjs/cli` for supported workflows. Some Node-specific behavior is intentionally not available in the standalone Rust binary, including loading arbitrary JavaScript formatter files with `--format`.
 
 ## Features
 
-- **Extract**: Extract messages from source files (React, Vue, etc.)
+- **Extract**: Extract messages from JavaScript and TypeScript source files
 - **Compile**: Compile messages for production use with optional minification
 - **Verify**: Validate message files and check for missing/extra keys
 - **Compile-Folder**: Batch compile all translation files in a folder
@@ -34,32 +34,64 @@ The native CLI is a drop-in replacement for `@formatjs/cli` with identical comma
 ## Quick Start
 
 ```bash
-# Download the binary (macOS Apple Silicon example)
-curl -L https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v0.1.6/formatjs-darwin-arm64 -o formatjs
-chmod +x formatjs
+# Install from Cargo
+cargo install formatjs_cli
 
 # Extract messages from your source code
-./formatjs extract "src/**/*.tsx" --out-file messages.json
+formatjs extract "src/**/*.tsx" --out-file messages.json
 
 # Compile translations for production
-./formatjs compile "translations/*.json" --out-file compiled.json --ast
+formatjs compile "translations/*.json" --out-file compiled.json --ast
 
 # Verify translations are complete
-./formatjs verify "translations/*.json" --source-locale en --missing-keys
+formatjs verify "translations/*.json" --source-locale en --missing-keys
 ```
 
 ## Installation
 
-### Pre-built Binaries (Recommended)
+### Cargo
 
-Download pre-built native binaries from the [GitHub Releases](https://github.com/formatjs/formatjs/releases) page:
+Install the published crate with Cargo:
 
-**Latest Release:** [formatjs_cli_v0.1.6](https://github.com/formatjs/formatjs/releases/tag/formatjs_cli_v0.1.6)
+```bash
+cargo install formatjs_cli
+```
+
+Cargo installs the command as `formatjs` in `~/.cargo/bin`:
+
+```bash
+formatjs --help
+formatjs --version
+```
+
+If `formatjs` is not found, add Cargo's bin directory to your `PATH`:
+
+```bash
+export PATH="$HOME/.cargo/bin:$PATH"
+```
+
+For local development from this repository:
+
+```bash
+cargo install --path crates/formatjs_cli
+formatjs --help
+```
+
+You can also run without installing:
+
+```bash
+cargo run -p formatjs_cli -- --help
+cargo run -p formatjs_cli -- extract "src/**/*.tsx"
+```
+
+### Pre-Built Binaries
+
+Download pre-built native binaries from the [GitHub Releases](https://github.com/formatjs/formatjs/releases) page.
 
 **Available binaries:**
 
-- `formatjs-darwin-arm64` - macOS Apple Silicon (M1/M2/M3)
-- `formatjs-linux-x86_64` - Linux x86_64
+- `formatjs_cli-darwin-arm64` - macOS Apple Silicon
+- `formatjs_cli-linux-x64` - Linux x86_64
 
 **Installation steps:**
 
@@ -67,10 +99,10 @@ Download pre-built native binaries from the [GitHub Releases](https://github.com
 
    ```bash
    # macOS Apple Silicon
-   curl -L https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v0.1.6/formatjs-darwin-arm64 -o formatjs
+   curl -L https://github.com/formatjs/formatjs/releases/download/<version>/formatjs_cli-darwin-arm64 -o formatjs
 
    # Linux x86_64
-   curl -L https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v0.1.6/formatjs-linux-x86_64 -o formatjs
+   curl -L https://github.com/formatjs/formatjs/releases/download/<version>/formatjs_cli-linux-x64 -o formatjs
    ```
 
 2. Make it executable:
@@ -128,15 +160,17 @@ bazel build --platforms=//crates/formatjs_cli/platforms:darwin_arm64 //crates/fo
 bazel build --platforms=//crates/formatjs_cli/platforms:linux_x86_64 //crates/formatjs_cli:formatjs_cli
 ```
 
-### Using Cargo
+### Local Cargo Build
 
-Build and install using Cargo (host platform only):
+Build and install from the local checkout using Cargo:
 
 ```bash
 cd crates/formatjs_cli
 cargo build --release
 cargo install --path .
 ```
+
+The built binary is `target/release/formatjs`.
 
 ## Usage
 
@@ -162,7 +196,7 @@ formatjs extract "src/**/*.{js,ts,tsx}" \
 **Options:**
 
 - `[FILES]...` - File glob patterns to extract from (e.g., `src/**/*.tsx`)
-- `--format <PATH>` - Path to formatter file controlling JSON output shape
+- `--format <FORMATTER>` - Built-in formatter controlling JSON output shape (`default`, `simple`, `transifex`, `smartling`, `lokalise`, or `crowdin`)
 - `--in-file <PATH>` - File containing list of files to extract (one per line)
 - `--out-file <PATH>` - Target file for aggregated .json output
 - `--id-interpolation-pattern <PATTERN>` - Pattern to auto-generate message IDs (default: `[sha512:contenthash:base64:6]`)
@@ -188,18 +222,17 @@ formatjs compile "lang/*.json" --out-file compiled.json
 ```bash
 formatjs compile "lang/*.json" \
   --out-file compiled.json \
-  --ast \
-  --pseudo-locale en-XA
+  --ast
 ```
 
 **Options:**
 
 - `[TRANSLATION_FILES]...` - Glob patterns for translation files (e.g., `foo/**/en.json`)
-- `--format <PATH>` - Path to formatter file that converts input to `Record<string, string>`
+- `--format <FORMATTER>` - Built-in formatter that converts input to `Record<string, string>` (`default`, `simple`, `transifex`, `smartling`, `lokalise`, or `crowdin`)
 - `--out-file <PATH>` - Output file path (prints to stdout if not provided)
 - `--ast` - Compile to AST instead of strings
 - `--skip-errors` - Continue compiling after errors (excludes keys with errors)
-- `--pseudo-locale <LOCALE>` - Generate pseudo-locale files (requires `--ast`)
+- `--pseudo-locale <LOCALE>` - Accept pseudo-locale selection with `--ast`; pseudo-locale transformations are not yet implemented in the Rust CLI
   - Values: `xx-LS`, `xx-AC`, `xx-HA`, `en-XA`, `en-XB`
 - `--ignore-tag` - Treat HTML/XML tags as string literals
 
@@ -221,7 +254,7 @@ formatjs compile-folder lang/ dist/lang/ --ast
 
 - `<FOLDER>` - Source directory containing translation JSON files
 - `<OUT_FOLDER>` - Output directory for compiled files
-- `--format <PATH>` - Path to formatter file
+- `--format <FORMATTER>` - Built-in formatter (`default`, `simple`, `transifex`, `smartling`, `lokalise`, or `crowdin`)
 - `--ast` - Compile to AST
 
 ### Verify Command
@@ -250,6 +283,14 @@ formatjs verify "lang/*.json" \
 - `--missing-keys` - Check for missing keys in target locales
 - `--extra-keys` - Check for extra keys not in source locale
 - `--structural-equality` - Check structural equality of messages
+
+## Compatibility Notes
+
+`formatjs_cli` is intended to match `@formatjs/cli` where the Rust implementation supports the same feature. Known differences include:
+
+- `--format` accepts built-in formatter names only. The Node.js CLI can also load custom JavaScript formatter files.
+- Extraction currently targets JavaScript and TypeScript source files. Framework template extraction for Vue, Svelte, Handlebars, Glimmer, GTS, and GJS is handled by the Node.js CLI.
+- Pseudo-locale options are accepted for CLI compatibility, but pseudo-locale AST transformations are not yet implemented.
 
 ## Development
 

--- a/crates/formatjs_cli/RELEASE.md
+++ b/crates/formatjs_cli/RELEASE.md
@@ -47,14 +47,37 @@ git push origin formatjs_cli_v0.1.0
 - `formatjs_cli-linux-x64` (Linux x86_64)
 - `checksums.txt` (SHA-256 checksums)
 
-### Option 2: Using Cargo
+### Option 2: Using Cargo For Local Binaries
 
 ```bash
 cd crates/formatjs_cli
 ./release.sh
 ```
 
-This uses native Cargo cross-compilation. Requires additional setup for cross-compilation (see below).
+This uses native Cargo cross-compilation. Requires additional setup for cross-compilation (see below). Cargo builds the executable as `formatjs`; release packaging may rename that executable to the platform-specific artifact names listed below.
+
+### Option 3: Publishing to crates.io
+
+Cargo distribution is source-based: users install the package and build the `formatjs` executable locally.
+
+```bash
+cargo install formatjs_cli
+formatjs --help
+```
+
+Before publishing `formatjs_cli`, ensure any workspace dependencies are already published with compatible versions. This crate depends on the FormatJS Rust parser crates, so publish or update those crates first:
+
+1. `formatjs_icu_skeleton_parser`
+2. `formatjs_icu_messageformat_parser`
+3. `formatjs_cli`
+
+The package name is `formatjs_cli`, but the installed command is `formatjs` because `Cargo.toml` defines:
+
+```toml
+[[bin]]
+name = "formatjs"
+path = "src/main.rs"
+```
 
 ## Platform Support
 
@@ -136,7 +159,7 @@ cargo build --release --target x86_64-apple-darwin
 cargo build --release --target x86_64-unknown-linux-gnu
 ```
 
-Binaries will be in `target/<triple>/release/formatjs_cli`.
+Binaries will be in `target/<triple>/release/formatjs`.
 
 ## Release Artifacts
 
@@ -185,7 +208,7 @@ chmod +x formatjs_cli-linux-x64
 
 ## Publishing
 
-The GitHub Actions workflow automates the entire release process:
+The GitHub Actions workflow automates the GitHub binary release process:
 
 1. **Tag the release**:
 
@@ -206,10 +229,25 @@ The GitHub Actions workflow automates the entire release process:
    - Verify checksums
 
 4. **Publish to npm** (if applicable):
+
    ```bash
    # Update package.json with release URLs
    # Point to GitHub release assets
    npm publish
+   ```
+
+5. **Publish to crates.io** (if applicable):
+
+   ```bash
+   # From the repository root, after publishing dependent parser crates
+   cargo publish -p formatjs_cli
+   ```
+
+   Users can then install and run:
+
+   ```bash
+   cargo install formatjs_cli
+   formatjs --version
    ```
 
 ## Troubleshooting

--- a/docs/src/docs/tooling/bazel.mdx
+++ b/docs/src/docs/tooling/bazel.mdx
@@ -415,10 +415,16 @@ The toolchain is registered automatically when you add the MODULE.bazel dependen
 The native Rust CLI is significantly faster than the Node.js-based tools:
 
 - **4-17x faster** message extraction
-- **Zero dependencies** - no Node.js or npm required
+- **No Node.js runtime required** for supported extraction, compilation, and verification workflows
 - **Minimal memory footprint**
 - **Instant startup** - no JavaScript runtime initialization
-- **Perfect for CI/CD** - fast builds in continuous integration
+- **CI/CD friendly** - fast builds in continuous integration
+
+The Rust CLI used by these rules covers the native toolchain's supported
+FormatJS workflows. Node.js-only behavior from `@formatjs/cli`, such as custom
+JavaScript formatter files and framework template extraction for Vue, Svelte,
+Handlebars, Glimmer, GTS, and GJS, is not available in the standalone native
+binary.
 
 ## Common Workflows
 

--- a/docs/src/docs/tooling/cli.mdx
+++ b/docs/src/docs/tooling/cli.mdx
@@ -45,21 +45,37 @@ Add the following command to your `package.json` `scripts`:
 ## Native CLI (Rust)
 
 <Admonition type="tip" title="4x Faster Performance">
-We provide a high-performance native Rust CLI that's **4-17x faster** than the Node.js version with zero dependencies. Perfect for CI/CD pipelines and large codebases.
+We provide a high-performance native Rust CLI that's **4-17x faster** than the Node.js version for supported workflows. It is useful for CI/CD pipelines and large JavaScript/TypeScript codebases that do not need Node.js-specific CLI features.
 
-**Download:** [GitHub Releases](https://github.com/formatjs/formatjs/releases/tag/formatjs_cli_v0.1.6)
+Install it from Cargo with `cargo install formatjs_cli`, or download a pre-built binary from [GitHub Releases](https://github.com/formatjs/formatjs/releases).
 
 </Admonition>
 
 <Admonition type="caution">
-  The native CLI currently only supports **JavaScript/TypeScript with JSX/TSX**.
-  Vue and Glimmer are not supported due to lack of Rust parsers for these
-  frameworks. If you need Vue or Glimmer support, use the Node.js CLI above.
+  The native CLI is not a full drop-in replacement for every `@formatjs/cli`
+  feature. It currently focuses on **JavaScript/TypeScript with JSX/TSX**,
+  supports built-in formatters only, and does not load custom JavaScript
+  formatter files. If you need Vue, Svelte, Glimmer, Handlebars, GTS/GJS, or
+  custom formatter support, use the Node.js CLI above.
 </Admonition>
 
 ### Installation
 
-Download pre-built binaries for your platform:
+Install from Cargo:
+
+```sh
+cargo install formatjs_cli
+formatjs --version
+```
+
+Cargo installs the `formatjs` command into `~/.cargo/bin`. If your shell cannot
+find it, add Cargo's bin directory to your `PATH`:
+
+```sh
+export PATH="$HOME/.cargo/bin:$PATH"
+```
+
+You can also download pre-built binaries for your platform:
 
 <Tabs
 groupId="platform"
@@ -72,7 +88,7 @@ values={[
 
 ```sh
 # Download and install
-curl -L https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v0.1.6/formatjs-darwin-arm64 -o formatjs
+curl -L https://github.com/formatjs/formatjs/releases/download/<version>/formatjs_cli-darwin-arm64 -o formatjs
 chmod +x formatjs
 sudo mv formatjs /usr/local/bin/
 
@@ -85,7 +101,7 @@ formatjs --version
 
 ```sh
 # Download and install
-curl -L https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v0.1.6/formatjs-linux-x86_64 -o formatjs
+curl -L https://github.com/formatjs/formatjs/releases/download/<version>/formatjs_cli-linux-x64 -o formatjs
 chmod +x formatjs
 sudo mv formatjs /usr/local/bin/
 
@@ -98,15 +114,15 @@ formatjs --version
 
 ### Benefits
 
-- **🚀 4-17x Faster**: Dramatically faster extraction and compilation
-- **📦 Zero Dependencies**: Single binary, no Node.js or npm required
-- **💾 Low Memory**: Minimal memory footprint
-- **⚡ Instant Startup**: No Node.js initialization overhead
-- **🔧 CI/CD Friendly**: Perfect for build pipelines and automation
+- **4-17x Faster**: Dramatically faster extraction and compilation for supported workflows
+- **No Node.js Runtime for Supported Features**: Single binary, no Node.js runtime required
+- **Low Memory**: Minimal memory footprint
+- **Instant Startup**: No Node.js initialization overhead
+- **CI/CD Friendly**: Useful for build pipelines and automation
 
 ### Usage
 
-The native CLI is a drop-in replacement with identical command-line interface:
+The native CLI uses the same `formatjs` command name for supported workflows:
 
 ```sh
 # Extract messages
@@ -119,7 +135,12 @@ formatjs compile "lang/*.json" --out-file compiled.json --ast
 formatjs verify "lang/*.json" --source-locale en --missing-keys
 ```
 
-All the same options and formatters work with the native CLI. See the sections below for detailed documentation.
+Most common extraction, compilation, and verification options work with the native CLI. Notable differences from the Node.js CLI:
+
+- `--format` accepts built-in formatter names only: `default`, `simple`, `transifex`, `smartling`, `lokalise`, or `crowdin`.
+- Custom JavaScript formatter files are only supported by the Node.js CLI.
+- Framework template extraction for Vue, Svelte, Handlebars, Glimmer, GTS, and GJS is only supported by the Node.js CLI.
+- Pseudo-locale options are accepted by the Rust CLI for CLI compatibility, but pseudo-locale AST transformations are not yet implemented there.
 
 ---
 

--- a/docs/src/docs/tooling/rust-icu-messageformat-parser.mdx
+++ b/docs/src/docs/tooling/rust-icu-messageformat-parser.mdx
@@ -216,6 +216,6 @@ bazel run -c opt //crates/icu_messageformat_parser:comparison_bench
 
 ## Related Packages
 
-- [`formatjs_cli`](/docs/tooling/rust-cli) - Native Rust CLI for message extraction
+- [`formatjs_cli`](/docs/tooling/cli#native-cli-rust) - Native Rust CLI for supported extraction, compilation, and verification workflows
 - [`formatjs_icu_skeleton_parser`](/docs/tooling/rust-icu-skeleton-parser) - Number and date skeleton parser
 - [`@formatjs/icu-messageformat-parser`](https://www.npmjs.com/package/@formatjs/icu-messageformat-parser) - JavaScript implementation

--- a/docs/src/docs/tooling/rust-icu-skeleton-parser.mdx
+++ b/docs/src/docs/tooling/rust-icu-skeleton-parser.mdx
@@ -328,5 +328,5 @@ let ast = parser.parse().unwrap();
 ## Related Packages
 
 - [`formatjs_icu_messageformat_parser`](/docs/tooling/rust-icu-messageformat-parser) - ICU MessageFormat parser
-- [`formatjs_cli`](/docs/tooling/rust-cli) - Native Rust CLI for message extraction
+- [`formatjs_cli`](/docs/tooling/cli#native-cli-rust) - Native Rust CLI for supported extraction, compilation, and verification workflows
 - [`@formatjs/icu-skeleton-parser`](https://www.npmjs.com/package/@formatjs/icu-skeleton-parser) - JavaScript implementation

--- a/packages/cli/integration-tests/conformance-tests/README.md
+++ b/packages/cli/integration-tests/conformance-tests/README.md
@@ -1,15 +1,15 @@
 # CLI Conformance Test Suite
 
-This directory contains a conformance test suite that ensures the Rust CLI (`crates/formatjs_cli`) and TypeScript CLI (`packages/cli`) produce identical outputs.
+This directory contains a conformance test suite for the overlapping feature set shared by the Rust CLI (`crates/formatjs_cli`) and TypeScript CLI (`packages/cli`).
 
 ## Purpose
 
-The conformance tests verify that:
+The conformance tests verify that, for covered cases:
 
 1. Both CLIs produce identical JSON output for the same inputs
 2. Both CLIs handle edge cases consistently
-3. Both CLIs support all output formats (simple, transifex, lokalise, crowdin, smartling)
-4. Both CLIs handle errors in the same way
+3. Both CLIs support the same built-in output formats (simple, transifex, lokalise, crowdin, smartling)
+4. Both CLIs agree on success and failure behavior
 
 ## Test Case Format
 
@@ -60,6 +60,7 @@ The test suite covers:
 - `02_plural_messages.txt` - Plural format messages
 - `15_inline_formatmessage.txt` - Inline FormattedMessage components
 - `16_typescript_file.txt` - TypeScript file extraction
+- `21_formatmessage_any_object.txt` - formatMessage on arbitrary member chains
 
 ### Options and Flags
 
@@ -85,6 +86,7 @@ The test suite covers:
 - `18_optional_chaining.txt` - Optional chaining in code
 - `19_no_id_with_hash.txt` - Messages without IDs using content hashing
 - `20_flatten_with_hash.txt` - Flatten + content hashing combination
+- `22_callback_in_optional_chain.txt` - formatMessage nested inside optional-chain callbacks
 
 ## Running the Tests
 
@@ -114,13 +116,15 @@ Test case options support these fields:
 
 ## Known Differences
 
-Some minor differences between the CLIs are acceptable:
+The Rust CLI is a standalone binary and does not implement every Node.js CLI feature. Known differences include:
 
-1. **Error messages**: The exact wording may differ, but both should fail/succeed in the same cases
-2. **File paths**: When using `--extract-source-location`, absolute paths will differ
-3. **Stderr output**: Warning/error messages may be formatted differently
+1. **Custom formatters**: Rust `--format` accepts built-in formatter names only. The TypeScript CLI can also load JavaScript formatter files.
+2. **Framework template files**: Vue, Svelte, Handlebars, Glimmer, GTS, and GJS extraction are covered by the TypeScript CLI. Rust extraction currently focuses on JavaScript and TypeScript inputs.
+3. **Error messages**: The exact wording may differ, but both should fail/succeed in covered cases.
+4. **File paths**: When using `--extract-source-location`, absolute paths will differ.
+5. **Stderr output**: Warning/error messages may be formatted differently.
 
-The conformance tests focus on the **JSON output structure and content**, which must be identical.
+The conformance tests focus on the **JSON output structure and content** for shared, covered behavior.
 
 ## Related Files
 

--- a/packages/cli/integration-tests/conformance-tests/SUMMARY.md
+++ b/packages/cli/integration-tests/conformance-tests/SUMMARY.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Created a comprehensive conformance test suite to ensure the Rust CLI (`crates/formatjs_cli`) and TypeScript CLI (`packages/cli`) produce identical outputs.
+Created a conformance test suite to ensure the Rust CLI (`crates/formatjs_cli`) and TypeScript CLI (`packages/cli`) produce identical outputs for the shared feature set covered by these tests.
 
 ## What Was Created
 
@@ -20,41 +20,43 @@ Created a comprehensive conformance test suite to ensure the Rust CLI (`crates/f
 - [BUILD.bazel](../BUILD.bazel) - Bazel test configuration
 - [README.md](./README.md) - Documentation and usage guide
 
-### Test Cases (20 total)
+### Test Cases (22 total)
 
 Located in [test_cases/](./test_cases/):
 
-#### Basic Extraction (5 tests)
+#### Basic Extraction (6 tests)
 
-1. `01_basic_extract.txt` - Basic message extraction with IDs
-2. `02_plural_messages.txt` - Plural format messages
-3. `15_inline_formatmessage.txt` - Inline FormattedMessage components
-4. `16_typescript_file.txt` - TypeScript file extraction
-5. `18_optional_chaining.txt` - Optional chaining in code
+- `01_basic_extract.txt` - Basic message extraction with IDs
+- `02_plural_messages.txt` - Plural format messages
+- `15_inline_formatmessage.txt` - Inline FormattedMessage components
+- `16_typescript_file.txt` - TypeScript file extraction
+- `18_optional_chaining.txt` - Optional chaining in code
+- `21_formatmessage_any_object.txt` - formatMessage on arbitrary member chains
 
 #### CLI Options & Flags (5 tests)
 
-6. `03_flatten_option.txt` - `--flatten` flag
-7. `04_content_hash_id.txt` - `--id-interpolation-pattern` with content hashing
-8. `05_additional_function_names.txt` - `--additional-function-names` flag
-9. `06_extract_source_location.txt` - `--extract-source-location` flag
-10. `17_pragma.txt` - `--pragma` flag for file filtering
+- `03_flatten_option.txt` - `--flatten` flag
+- `04_content_hash_id.txt` - `--id-interpolation-pattern` with content hashing
+- `05_additional_function_names.txt` - `--additional-function-names` flag
+- `06_extract_source_location.txt` - `--extract-source-location` flag
+- `17_pragma.txt` - `--pragma` flag for file filtering
 
 #### Output Formats (5 tests)
 
-11. `07_format_simple.txt` - Simple format (ID -> string mapping)
-12. `11_format_transifex.txt` - Transifex format
-13. `12_format_lokalise.txt` - Lokalise format
-14. `13_format_crowdin.txt` - Crowdin format
-15. `14_format_smartling.txt` - Smartling format
+- `07_format_simple.txt` - Simple format (ID -> string mapping)
+- `11_format_transifex.txt` - Transifex format
+- `12_format_lokalise.txt` - Lokalise format
+- `13_format_crowdin.txt` - Crowdin format
+- `14_format_smartling.txt` - Smartling format
 
-#### Edge Cases (5 tests)
+#### Edge Cases (6 tests)
 
-16. `08_whitespace_preservation.txt` - Leading/trailing whitespace handling
-17. `09_escaped_quotes.txt` - Escaped apostrophes in ICU messages
-18. `10_nested_select_plural.txt` - Nested select and plural formats
-19. `19_no_id_with_hash.txt` - Messages without IDs using content hashing
-20. `20_flatten_with_hash.txt` - Flatten + content hashing combination
+- `08_whitespace_preservation.txt` - Leading/trailing whitespace handling
+- `09_escaped_quotes.txt` - Escaped apostrophes in ICU messages
+- `10_nested_select_plural.txt` - Nested select and plural formats
+- `19_no_id_with_hash.txt` - Messages without IDs using content hashing
+- `20_flatten_with_hash.txt` - Flatten + content hashing combination
+- `22_callback_in_optional_chain.txt` - formatMessage nested inside optional-chain callbacks
 
 ## Test Format
 
@@ -99,12 +101,12 @@ const messages = defineMessages({
 
 ### Current Status
 
-- ✅ **60 out of 60 tests pass** (100% conformance)
-- ✅ **All conformance issues resolved**
+- Covered conformance tests pass for the shared JS/TS extraction cases.
+- The suite is not a claim of complete parity with every `@formatjs/cli` feature.
 
 ### Resolved Conformance Issues
 
-All implementation differences between TypeScript and Rust CLIs have been fixed:
+The tracked implementation differences for covered test cases have been fixed:
 
 #### 1. ✅ Newline Handling (Fixed)
 
@@ -136,9 +138,9 @@ All implementation differences between TypeScript and Rust CLIs have been fixed:
   - `13_format_crowdin.txt` - Changed "context" to "description"
   - `20_flatten_with_hash.txt` - Updated hash for flattened message
 
-### All Tests Pass
+### Covered Tests Pass
 
-Both CLIs now work identically for:
+Both CLIs now work identically for these covered scenarios:
 
 - ✅ Basic message extraction with IDs
 - ✅ Plural and select messages
@@ -155,7 +157,7 @@ Both CLIs now work identically for:
 - ✅ TypeScript file extraction
 - ✅ Pragma handling
 - ✅ Optional chaining support
-- ✅ Optional chaining support
+- ✅ formatMessage inside optional-chain callbacks
 - ✅ Pragma filtering
 - ✅ TypeScript file support
 
@@ -174,32 +176,19 @@ bazel test //packages/cli/integration-tests:conformance_test --test_output=error
 
 ## Next Steps
 
-To achieve 100% conformance:
+To broaden parity:
 
-1. **Decide on whitespace normalization behavior**:
-   - Should newlines be preserved or normalized?
-   - Should ICU message spacing be strict?
-   - Update one CLI to match the other
-
-2. **Fix whitespace handling** in either Rust or TypeScript CLI to be consistent
-
-3. **Update hash generation** to be consistent after whitespace normalization is aligned
-
-4. **Add more test cases** for:
-   - Error conditions (invalid syntax, duplicate IDs)
-   - More complex ICU message formats
-   - Different file types (`.vue`, `.js`, `.mts`, etc.)
-   - Glob patterns
-   - Multiple files
-   - Output to file vs stdout
-
-5. **Document intentional differences** if some behavior should diverge (like error message wording)
+1. Add conformance coverage for CLI semantics: stdin, `--in-file`, glob ordering, no-match behavior, output files, and duplicate IDs.
+2. Decide whether standalone Rust should support custom JavaScript formatter files. Today Rust supports built-in formatter names only.
+3. Add or explicitly scope framework-file extraction for Vue, Svelte, Handlebars, Glimmer, GTS, and GJS.
+4. Port pseudo-locale transformations to Rust or document them as unsupported in the standalone binary.
+5. Add compile, compile-folder, and verify conformance cases that compare stdout, stderr, output files, and exit status.
 
 ## Benefits
 
 This conformance test suite:
 
-- ✅ Ensures both CLIs produce identical outputs
+- ✅ Ensures both CLIs produce identical outputs for covered shared behavior
 - ✅ Catches regressions when modifying either CLI
 - ✅ Provides clear examples of expected behavior
 - ✅ Documents the CLI's capabilities through test cases


### PR DESCRIPTION
## Summary
- document Cargo install and runtime command for formatjs_cli
- update docs site native CLI install examples and release asset names
- clarify standalone Rust CLI compatibility gaps and conformance scope

## Testing
- pre-commit hooks ran during commit: format-oxfmt, gazelle, commitlint
- not run: docs build/tests (docs-only changes)