### PR TITLE
perf: shard CLDR raw generation

### DIFF
--- a/packages/intl-datetimeformat/BUILD.bazel
+++ b/packages/intl-datetimeformat/BUILD.bazel
@@ -710,33 +710,51 @@ ALL_LOCALES = [
 
 CLDR_RAW_FILES = ["cldr-raw/%s.json" % locale for locale in ALL_LOCALES]
 
-ts_run_binary(
-    name = "cldr-raw",
-    srcs = [
-        "types.ts",
-        "//:node_modules/@formatjs/intl-locale",
-        "//:node_modules/cldr-bcp47",
-        "//:node_modules/cldr-core",
-        "//:node_modules/cldr-dates-full",
-        "//:node_modules/cldr-numbers-full",
-        "//:node_modules/fast-glob",
-        "//:node_modules/fs-extra",
-        "//:node_modules/json-stable-stringify",
-        "//:node_modules/lodash-es",
-        "//:node_modules/minimist",
-        "//:root_package_json",
-        "//packages/ecma262-abstract",
-        "//packages/ecma402-abstract",
-        "//packages/ecma402-abstract/DateTimeFormat",
-        "//packages/ecma402-abstract/types",
-    ],
-    outs = CLDR_RAW_FILES,
+CLDR_RAW_SHARDS = [
+    ALL_LOCALES[i:i + 128]
+    for i in range(
+        0,
+        len(ALL_LOCALES),
+        128,
+    )
+]
+
+CLDR_RAW_SRCS = [
+    "types.ts",
+    "//:node_modules/@formatjs/intl-locale",
+    "//:node_modules/cldr-bcp47",
+    "//:node_modules/cldr-core",
+    "//:node_modules/cldr-dates-full",
+    "//:node_modules/cldr-numbers-full",
+    "//:node_modules/fast-glob",
+    "//:node_modules/fs-extra",
+    "//:node_modules/json-stable-stringify",
+    "//:node_modules/lodash-es",
+    "//:node_modules/minimist",
+    "//:root_package_json",
+    "//packages/ecma262-abstract",
+    "//packages/ecma402-abstract",
+    "//packages/ecma402-abstract/DateTimeFormat",
+    "//packages/ecma402-abstract/types",
+]
+
+[ts_run_binary(
+    name = "cldr-raw-%d" % i,
+    srcs = CLDR_RAW_SRCS,
+    outs = ["cldr-raw/%s.json" % locale for locale in shard],
     args = [
         "--outDir",
         "cldr-raw",
+        "--locales",
+        ",".join(shard),
     ],
     chdir = package_name(),
     tool = "//packages/intl-datetimeformat/scripts:cldr-raw",
+) for i, shard in enumerate(CLDR_RAW_SHARDS)]
+
+filegroup(
+    name = "cldr-raw",
+    srcs = CLDR_RAW_FILES,
 )
 
 ts_run_binary(

--- a/packages/intl-datetimeformat/scripts/cldr-raw.ts
+++ b/packages/intl-datetimeformat/scripts/cldr-raw.ts
@@ -6,9 +6,15 @@ import minimist from 'minimist'
 
 async function main(args: minimist.ParsedArgs) {
   const {outDir} = args
-  const locales = getAllLocales()
+  const requestedLocales =
+    typeof args.locales === 'string'
+      ? new Set(args.locales.split(',').filter(Boolean))
+      : undefined
+  const locales = getAllLocales().filter(
+    locale => !requestedLocales || requestedLocales.has(locale)
+  )
   const data = await extractDatesFields(locales)
-  getAllLocales().forEach(locale =>
+  locales.forEach(locale =>
     outputJSONSync(
       join(outDir, `${locale}.json`),
       {

--- a/packages/intl-displaynames/BUILD.bazel
+++ b/packages/intl-displaynames/BUILD.bazel
@@ -647,28 +647,46 @@ ALL_LOCALES = [
 
 CLDR_RAW_FILES = ["cldr-raw/%s.json" % locale for locale in ALL_LOCALES]
 
-ts_run_binary(
-    name = "cldr-raw",
-    srcs = [
-        "//:node_modules/cldr-core",
-        "//:node_modules/cldr-dates-full",
-        "//:node_modules/cldr-localenames-full",
-        "//:node_modules/cldr-numbers-full",
-        "//:node_modules/fast-glob",
-        "//:node_modules/fs-extra",
-        "//:node_modules/json-stable-stringify",
-        "//:node_modules/minimist",
-        "//packages/ecma262-abstract",
-        "//packages/ecma402-abstract",
-        "//packages/ecma402-abstract/types",
-    ],
-    outs = CLDR_RAW_FILES,
+CLDR_RAW_SHARDS = [
+    ALL_LOCALES[i:i + 128]
+    for i in range(
+        0,
+        len(ALL_LOCALES),
+        128,
+    )
+]
+
+CLDR_RAW_SRCS = [
+    "//:node_modules/cldr-core",
+    "//:node_modules/cldr-dates-full",
+    "//:node_modules/cldr-localenames-full",
+    "//:node_modules/cldr-numbers-full",
+    "//:node_modules/fast-glob",
+    "//:node_modules/fs-extra",
+    "//:node_modules/json-stable-stringify",
+    "//:node_modules/minimist",
+    "//packages/ecma262-abstract",
+    "//packages/ecma402-abstract",
+    "//packages/ecma402-abstract/types",
+]
+
+[ts_run_binary(
+    name = "cldr-raw-%d" % i,
+    srcs = CLDR_RAW_SRCS,
+    outs = ["cldr-raw/%s.json" % locale for locale in shard],
     args = [
         "--outDir",
         "cldr-raw",
+        "--locales",
+        ",".join(shard),
     ],
     chdir = package_name(),
     tool = "//packages/intl-displaynames/scripts:cldr-raw",
+) for i, shard in enumerate(CLDR_RAW_SHARDS)]
+
+filegroup(
+    name = "cldr-raw",
+    srcs = CLDR_RAW_FILES,
 )
 
 ts_run_binary(

--- a/packages/intl-displaynames/scripts/cldr-raw.ts
+++ b/packages/intl-displaynames/scripts/cldr-raw.ts
@@ -7,7 +7,13 @@ import minimist from 'minimist'
 
 async function main(args: minimist.ParsedArgs) {
   const {outDir} = args
-  const locales = await getAllLocales()
+  const requestedLocales =
+    typeof args.locales === 'string'
+      ? new Set(args.locales.split(',').filter(Boolean))
+      : undefined
+  const locales = (await getAllLocales()).filter(
+    locale => !requestedLocales || requestedLocales.has(locale)
+  )
   const data = await extractDisplayNames(locales)
   locales.forEach(locale =>
     outputFileSync(

--- a/packages/intl-numberformat/BUILD.bazel
+++ b/packages/intl-numberformat/BUILD.bazel
@@ -783,30 +783,48 @@ ALL_LOCALES = [
 
 CLDR_RAW_FILES = ["cldr-raw/%s.json" % locale for locale in ALL_LOCALES]
 
-ts_run_binary(
-    name = "cldr-raw",
-    srcs = [
-        "//:node_modules/@types/lodash-es",
-        "//:node_modules/cldr-core",
-        "//:node_modules/cldr-numbers-full",
-        "//:node_modules/cldr-units-full",
-        "//:node_modules/fast-glob",
-        "//:node_modules/fs-extra",
-        "//:node_modules/json-stable-stringify",
-        "//:node_modules/lodash-es",
-        "//:node_modules/minimist",
-        "//packages/ecma262-abstract",
-        "//packages/ecma402-abstract",
-        "//packages/ecma402-abstract/NumberFormat",
-        "//packages/ecma402-abstract/types",
-    ],
-    outs = CLDR_RAW_FILES,
+CLDR_RAW_SHARDS = [
+    ALL_LOCALES[i:i + 128]
+    for i in range(
+        0,
+        len(ALL_LOCALES),
+        128,
+    )
+]
+
+CLDR_RAW_SRCS = [
+    "//:node_modules/@types/lodash-es",
+    "//:node_modules/cldr-core",
+    "//:node_modules/cldr-numbers-full",
+    "//:node_modules/cldr-units-full",
+    "//:node_modules/fast-glob",
+    "//:node_modules/fs-extra",
+    "//:node_modules/json-stable-stringify",
+    "//:node_modules/lodash-es",
+    "//:node_modules/minimist",
+    "//packages/ecma262-abstract",
+    "//packages/ecma402-abstract",
+    "//packages/ecma402-abstract/NumberFormat",
+    "//packages/ecma402-abstract/types",
+]
+
+[ts_run_binary(
+    name = "cldr-raw-%d" % i,
+    srcs = CLDR_RAW_SRCS,
+    outs = ["cldr-raw/%s.json" % locale for locale in shard],
     args = [
         "--outDir",
         "cldr-raw",
+        "--locales",
+        ",".join(shard),
     ],
     chdir = package_name(),
     tool = "//packages/intl-numberformat/scripts:cldr-raw",
+) for i, shard in enumerate(CLDR_RAW_SHARDS)]
+
+filegroup(
+    name = "cldr-raw",
+    srcs = CLDR_RAW_FILES,
     visibility = [
         "//packages/intl:__subpackages__",
         "//packages/react-intl:__subpackages__",

--- a/packages/intl-numberformat/scripts/cldr-raw.ts
+++ b/packages/intl-numberformat/scripts/cldr-raw.ts
@@ -9,8 +9,15 @@ import minimist from 'minimist'
 
 async function main(args: minimist.ParsedArgs) {
   const {outDir} = args
+  const requestedLocales =
+    typeof args.locales === 'string'
+      ? new Set(args.locales.split(',').filter(Boolean))
+      : undefined
   // Dist all locale files to locale-data
   const locales = AVAILABLE_LOCALES.availableLocales.full.filter(l => {
+    if (requestedLocales && !requestedLocales.has(l)) {
+      return false
+    }
     try {
       return (Intl as any).getCanonicalLocales(l).length
     } catch {


### PR DESCRIPTION
## Summary
- add --locales filtering to the datetimeformat, numberformat, and displaynames CLDR raw generators
- split each package's cldr-raw target into 128-locale shard actions
- preserve the existing :cldr-raw target as a filegroup over the same generated JSON outputs

## Perf Notes
- focused cldr-raw build critical path after sharding: 13.85s
- prior full-run profile had single cldr-raw actions at roughly 25.1s for datetimeformat, 18.1s for numberformat, and 16.9s for displaynames

## Test Plan
- bazel build //packages/intl-datetimeformat:cldr-raw //packages/intl-numberformat:cldr-raw //packages/intl-displaynames:cldr-raw
- bazel test //packages/intl-datetimeformat/... //packages/intl-numberformat/... //packages/intl-displaynames/...
- bazel test //...
- git diff --check