### PR TITLE
fix(formatjs): support TS assertions in message extraction

### DIFF
--- a/crates/formatjs_cli/src/extractor.rs
+++ b/crates/formatjs_cli/src/extractor.rs
@@ -231,6 +231,7 @@ impl<'a> MessageExtractor<'a> {
         expr: &Expression,
         preserve_whitespace: Option<bool>,
     ) -> Option<String> {
+        let expr = self.unwrap_transparent_ts_expression(expr);
         match expr {
             Expression::StringLiteral(lit) => {
                 let value = lit.value.to_string();
@@ -266,6 +267,7 @@ impl<'a> MessageExtractor<'a> {
             return Some(Value::String(string_val));
         }
 
+        let expr = self.unwrap_transparent_ts_expression(expr);
         // Handle object literal descriptions
         if let Expression::ObjectExpression(obj) = expr {
             let mut map = serde_json::Map::new();
@@ -292,6 +294,23 @@ impl<'a> MessageExtractor<'a> {
         }
 
         None
+    }
+
+    fn unwrap_transparent_ts_expression<'b>(
+        &self,
+        mut expr: &'b Expression<'a>,
+    ) -> &'b Expression<'a> {
+        loop {
+            match expr {
+                Expression::TSAsExpression(ts_as) => expr = &ts_as.expression,
+                Expression::TSSatisfiesExpression(ts_satisfies) => expr = &ts_satisfies.expression,
+                Expression::TSTypeAssertion(ts_type_assertion) => {
+                    expr = &ts_type_assertion.expression
+                }
+                Expression::TSNonNullExpression(ts_non_null) => expr = &ts_non_null.expression,
+                _ => return expr,
+            }
+        }
     }
 
     /// Extract function name from callee expression, handling:
@@ -467,17 +486,16 @@ impl<'a> MessageExtractor<'a> {
             None => return,
         };
 
-        // Unwrap TSAsExpression (e.g., `{...} as const`)
-        while let Expression::TSAsExpression(ts_as) = arg_expr {
-            arg_expr = &ts_as.expression;
-        }
+        arg_expr = self.unwrap_transparent_ts_expression(arg_expr);
 
         // For defineMessages, the argument is an object with message descriptors
         if function_name == "defineMessages" {
             if let Expression::ObjectExpression(obj) = arg_expr {
                 for prop in &obj.properties {
                     if let ObjectPropertyKind::ObjectProperty(p) = prop {
-                        if let Expression::ObjectExpression(msg_obj) = &p.value {
+                        if let Expression::ObjectExpression(msg_obj) =
+                            self.unwrap_transparent_ts_expression(&p.value)
+                        {
                             if let Some(descriptor) =
                                 self.extract_object_descriptor(&msg_obj, call.span.start)
                             {
@@ -1056,6 +1074,58 @@ mod tests {
                 Some(Value::String("The default message.".to_string()))
             );
         }
+    }
+
+    #[test]
+    fn test_fixture_type_assertions() {
+        let component_names = vec!["FormattedMessage".to_string()];
+        let function_names = vec![
+            "defineMessage".to_string(),
+            "defineMessages".to_string(),
+            "formatMessage".to_string(),
+        ];
+
+        let messages = extract_from_fixture(
+            "typeAssertions.tsx",
+            &component_names,
+            &function_names,
+            None,
+        )
+        .expect("Failed to extract from typeAssertions.tsx");
+
+        assert_eq!(messages.len(), 8);
+        assert!(messages.iter().any(|msg| {
+            msg.id == Some("define.satisfies".to_string())
+                && msg.default_message == Some("Define satisfies".to_string())
+        }));
+        assert!(messages.iter().any(|msg| {
+            msg.id == Some("define.as".to_string())
+                && msg.default_message == Some("Define as".to_string())
+        }));
+        assert!(messages.iter().any(|msg| {
+            msg.id == Some("define.object.satisfies".to_string())
+                && msg.default_message == Some("Define object satisfies".to_string())
+        }));
+        assert!(messages.iter().any(|msg| {
+            msg.id == Some("messages.satisfies".to_string())
+                && msg.default_message == Some("Messages satisfies".to_string())
+        }));
+        assert!(messages.iter().any(|msg| {
+            msg.id == Some("messages.as".to_string())
+                && msg.default_message == Some("Messages as".to_string())
+        }));
+        assert!(messages.iter().any(|msg| {
+            msg.id == Some("format.satisfies".to_string())
+                && msg.default_message == Some("Format satisfies".to_string())
+        }));
+        assert!(messages.iter().any(|msg| {
+            msg.id == Some("jsx.satisfies".to_string())
+                && msg.default_message == Some("JSX satisfies".to_string())
+        }));
+        assert!(messages.iter().any(|msg| {
+            msg.id == Some("jsx.as".to_string())
+                && msg.default_message == Some("JSX as".to_string())
+        }));
     }
 
     #[test]

--- a/packages/cli-lib/BUILD.bazel
+++ b/packages/cli-lib/BUILD.bazel
@@ -62,6 +62,7 @@ formatjs_test(
     name = "cli-lib_test",
     data = [
         "tests/unit/abort_signal.test.ts",
+        "tests/unit/extract.test.ts",
         "tests/unit/gts_extractor.test.ts",
         "tests/unit/hbs_extractor.test.ts",
         "tests/unit/pseudo_locale.test.ts",

--- a/packages/cli-lib/tests/unit/extract.test.ts
+++ b/packages/cli-lib/tests/unit/extract.test.ts
@@ -1,0 +1,57 @@
+import {mkdtemp, rm, writeFile} from 'fs/promises'
+import {tmpdir} from 'os'
+import {join} from 'path'
+import {afterEach, describe, expect, it} from 'vitest'
+import {extract} from '#packages/cli-lib/extract.js'
+
+describe('extract', () => {
+  let tempDir: string | undefined
+
+  afterEach(async () => {
+    if (tempDir) {
+      await rm(tempDir, {recursive: true, force: true})
+      tempDir = undefined
+    }
+  })
+
+  it('extracts messages wrapped in TypeScript assertions', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'formatjs-cli-lib-'))
+    const filePath = join(tempDir, 'typeAssertions.tsx')
+    await writeFile(
+      filePath,
+      `
+type DefaultMessage = string
+type MessageDescriptor = {id: string; defaultMessage: string}
+
+intl.formatMessage({
+  id: 'format.satisfies',
+  defaultMessage: \`Format satisfies\` satisfies DefaultMessage,
+})
+
+intl.formatMessage({
+  id: 'format.as',
+  defaultMessage: 'Format as' as DefaultMessage,
+})
+
+defineMessage({
+  id: 'define.object.satisfies',
+  defaultMessage: 'Define object satisfies',
+} satisfies MessageDescriptor)
+`
+    )
+
+    const result = JSON.parse(await extract([filePath], {throws: true}))
+
+    expect(result).toEqual({
+      'define.object.satisfies': {
+        defaultMessage: 'Define object satisfies',
+      },
+      'format.as': {
+        defaultMessage: 'Format as',
+      },
+      'format.satisfies': {
+        defaultMessage: 'Format satisfies',
+      },
+    })
+  })
+})

--- a/packages/eslint-plugin-formatjs/tests/enforce-default-message.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/enforce-default-message.test.ts
@@ -41,10 +41,30 @@ defineMessage({
 \`,
   description: 'asd'
 })`,
+    `type DefaultMessage = string
+intl.formatMessage({
+  defaultMessage: \`a template
+  literal
+\` satisfies DefaultMessage,
+  description: 'asd'
+})`,
+    `type Foo = string
+intl.formatMessage({
+  defaultMessage: 'foo' as Foo,
+  description: 'asd'
+})`,
+    `type Bar = string
+intl.formatMessage({
+  defaultMessage: \`foo\` as Bar,
+  description: 'asd'
+})`,
     `import {FormattedMessage} from 'react-intl'
 const a = <FormattedMessage defaultMessage={'asf' + 'bar'}/>`,
     `import {FormattedMessage} from 'react-intl'
 const a = <FormattedMessage defaultMessage={dedent\`asf\`}/>`,
+    `import {FormattedMessage} from 'react-intl'
+type DefaultMessage = string
+const a = <FormattedMessage defaultMessage={\`asf\` satisfies DefaultMessage}/>`,
     dynamicMessage,
     noMatch,
     spreadJsx,
@@ -195,6 +215,18 @@ const a = <FormattedMessage defaultMessage={dedent\`asf\`}/>`,
       code: `
             import {FormattedMessage} from 'react-intl'
             const a = <FormattedMessage defaultMessage={\`asf \${aas}\`}/>`,
+      errors: [
+        {
+          messageId: 'defaultMessageLiteral',
+        },
+      ],
+      options: [Option.literal],
+    },
+    {
+      code: `
+            import {FormattedMessage} from 'react-intl'
+            type DefaultMessage = string
+            const a = <FormattedMessage defaultMessage={\`asf \${aas}\` satisfies DefaultMessage}/>`,
       errors: [
         {
           messageId: 'defaultMessageLiteral',

--- a/packages/eslint-plugin-formatjs/util.ts
+++ b/packages/eslint-plugin-formatjs/util.ts
@@ -3,7 +3,6 @@ import type {Rule} from 'eslint'
 import type {
   BinaryExpression,
   Expression,
-  Literal,
   Node,
   ObjectExpression,
   Property,
@@ -41,32 +40,110 @@ export function getSettings({settings}: Rule.RuleContext): Settings {
   return settings.formatjs ?? settings
 }
 
-function isStringLiteral(node: Node): node is Literal & {value: string} {
-  return node.type === 'Literal' && typeof node.value === 'string'
-}
+type BinaryExpressionOperand =
+  | BinaryExpression['left']
+  | BinaryExpression['right']
 
 function isTemplateLiteralWithoutVar(node: Node): node is TemplateLiteral {
   return node.type === 'TemplateLiteral' && node.quasis.length === 1
 }
 
+type TransparentTypeScriptExpressionType =
+  | 'TSAsExpression'
+  | 'TSSatisfiesExpression'
+  | 'TSNonNullExpression'
+  | 'TSTypeAssertion'
+
+interface TypeScriptExpressionWrapper {
+  type: TransparentTypeScriptExpressionType
+  expression: StaticMessageExpression
+}
+
+interface TypeScriptBinaryExpressionOperandWrapper {
+  type: TransparentTypeScriptExpressionType
+  expression: StaticStringConcatOperand
+}
+
+type StaticMessageExpression = Expression | TypeScriptExpressionWrapper
+type MessagePropertyValue = Property['value'] | TypeScriptExpressionWrapper
+type StaticStringConcatOperand =
+  | BinaryExpressionOperand
+  | TypeScriptBinaryExpressionOperandWrapper
+
+function getStaticStringFromTemplateLiteral(
+  node: TemplateLiteral
+): string | undefined {
+  return node.quasis.length === 1
+    ? (node.quasis[0].value.cooked ?? undefined)
+    : undefined
+}
+
+function isStaticMessageExpression(
+  node: MessagePropertyValue
+): node is StaticMessageExpression {
+  switch (node.type) {
+    case 'ArrayPattern':
+    case 'AssignmentPattern':
+    case 'ObjectPattern':
+      return false
+    default:
+      return true
+  }
+}
+
+function getStaticStringFromMessageExpression(
+  node: StaticMessageExpression
+): string | undefined {
+  switch (node.type) {
+    case 'TSAsExpression':
+    case 'TSSatisfiesExpression':
+    case 'TSNonNullExpression':
+    case 'TSTypeAssertion':
+      return getStaticStringFromMessageExpression(node.expression)
+    case 'Literal':
+      return typeof node.value === 'string' ? node.value : undefined
+    case 'TemplateLiteral':
+      return getStaticStringFromTemplateLiteral(node)
+    case 'TaggedTemplateExpression':
+      if (!isTemplateLiteralWithoutVar(node.quasi)) {
+        throw new Error('Tagged template expression must be no substitution')
+      }
+      return getStaticStringFromTemplateLiteral(node.quasi)
+    case 'BinaryExpression': {
+      const [result, isStaticallyEvaluatable] =
+        staticallyEvaluateStringConcat(node)
+      return isStaticallyEvaluatable ? result : undefined
+    }
+  }
+}
+
+function getStaticStringFromBinaryExpressionOperand(
+  node: StaticStringConcatOperand
+): string | undefined {
+  switch (node.type) {
+    case 'TSAsExpression':
+    case 'TSSatisfiesExpression':
+    case 'TSNonNullExpression':
+    case 'TSTypeAssertion':
+      return getStaticStringFromBinaryExpressionOperand(node.expression)
+    case 'Literal':
+      return typeof node.value === 'string' ? node.value : undefined
+    case 'BinaryExpression': {
+      const [result, isStaticallyEvaluatable] =
+        staticallyEvaluateStringConcat(node)
+      return isStaticallyEvaluatable ? result : undefined
+    }
+  }
+}
+
 function staticallyEvaluateStringConcat(
   node: BinaryExpression
 ): [result: string, isStaticallyEvaluatable: boolean] {
-  const right = node.right as Node
-  const left = node.left as Node
-  if (!isStringLiteral(right)) {
-    return ['', false]
-  }
-  if (isStringLiteral(left)) {
-    return [left.value + right.value, true]
-  }
-  if (node.left.type === 'BinaryExpression') {
-    const [result, isStaticallyEvaluatable] = staticallyEvaluateStringConcat(
-      node.left
-    )
-    return [result + right.value, isStaticallyEvaluatable]
-  }
-  return ['', false]
+  const right = getStaticStringFromBinaryExpressionOperand(node.right)
+  const left = getStaticStringFromBinaryExpressionOperand(node.left)
+  return left !== undefined && right !== undefined
+    ? [left + right, true]
+    : ['', false]
 }
 
 export function isIntlFormatMessageCall(node: Node): boolean {
@@ -154,30 +231,10 @@ export function extractMessageDescriptor(
       continue
     }
 
-    const valueNode = prop.value
-    let value: string | undefined = undefined
-    if (isStringLiteral(valueNode as Node)) {
-      value = (valueNode as Literal & {value: string}).value
-    }
-    // like "`asd`"
-    else if (isTemplateLiteralWithoutVar(valueNode as Node)) {
-      value = (valueNode as TemplateLiteral).quasis[0].value.cooked ?? undefined
-    }
-    // like "dedent`asd`"
-    else if (valueNode.type === 'TaggedTemplateExpression') {
-      const {quasi} = valueNode
-      if (!isTemplateLiteralWithoutVar(quasi as Node)) {
-        throw new Error('Tagged template expression must be no substitution')
-      }
-      value = quasi.quasis[0].value.cooked ?? undefined
-    }
-    // like "`asd` + `asd`"
-    else if (valueNode.type === 'BinaryExpression') {
-      const [result, isStatic] = staticallyEvaluateStringConcat(valueNode)
-      if (isStatic) {
-        value = result
-      }
-    }
+    const valueNode: MessagePropertyValue = prop.value
+    const value = isStaticMessageExpression(valueNode)
+      ? getStaticStringFromMessageExpression(valueNode)
+      : undefined
 
     switch (propName) {
       case 'defaultMessage':
@@ -238,30 +295,12 @@ function extractMessageDescriptorFromJSXElement(
     let valueNode = prop.value
     let value: string | undefined = undefined
     if (valueNode && isMessageProp) {
-      if (isStringLiteral(valueNode as Node)) {
-        value = (valueNode as Literal & {value: string}).value
+      if (valueNode.type === 'Literal' && typeof valueNode.value === 'string') {
+        value = valueNode.value
       } else if (valueNode?.type === 'JSXExpressionContainer') {
         const {expression} = valueNode
-        if (expression.type === 'BinaryExpression') {
-          const [result, isStatic] = staticallyEvaluateStringConcat(expression)
-          if (isStatic) {
-            value = result
-          }
-        }
-        // like "`asd`"
-        else if (isTemplateLiteralWithoutVar(expression as Node)) {
-          value =
-            (expression as TemplateLiteral).quasis[0].value.cooked ?? undefined
-        }
-        // like "dedent`asd`"
-        else if (expression.type === 'TaggedTemplateExpression') {
-          const {quasi} = expression
-          if (!isTemplateLiteralWithoutVar(quasi as Node)) {
-            throw new Error(
-              'Tagged template expression must be no substitution'
-            )
-          }
-          value = quasi.quasis[0].value.cooked ?? undefined
+        if (expression.type !== 'JSXEmptyExpression') {
+          value = getStaticStringFromMessageExpression(expression)
         }
       }
     }

--- a/packages/ts-transformer/BUILD.bazel
+++ b/packages/ts-transformer/BUILD.bazel
@@ -70,6 +70,7 @@ formatjs_test(
         "tests/fixtures/resourcePath.tsx",
         "tests/fixtures/stringConcat.tsx",
         "tests/fixtures/templateLiteral.tsx",
+        "tests/fixtures/typeAssertions.tsx",
         "tests/index.test.ts",
         "tests/interpolate-name.test.ts",
         ":ts-transformer",

--- a/packages/ts-transformer/tests/fixtures/typeAssertions.tsx
+++ b/packages/ts-transformer/tests/fixtures/typeAssertions.tsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import {defineMessage, defineMessages, FormattedMessage} from 'react-intl'
+
+type DefaultMessage = string
+type MessageDescriptor = {
+  id: string
+  defaultMessage: string
+}
+
+defineMessage({
+  id: 'define.satisfies',
+  defaultMessage: `Define satisfies` satisfies DefaultMessage,
+})
+
+defineMessage({
+  id: 'define.as',
+  defaultMessage: 'Define as' as DefaultMessage,
+})
+
+defineMessage({
+  id: 'define.object.satisfies',
+  defaultMessage: 'Define object satisfies',
+} satisfies MessageDescriptor)
+
+defineMessages({
+  one: {
+    id: 'messages.satisfies',
+    defaultMessage: 'Messages satisfies' satisfies DefaultMessage,
+  },
+  two: {
+    id: 'messages.as',
+    defaultMessage: `Messages as` as DefaultMessage,
+  },
+} satisfies Record<string, MessageDescriptor>)
+
+intl.formatMessage({
+  id: 'format.satisfies',
+  defaultMessage: `Format satisfies` satisfies DefaultMessage,
+})
+
+export function Component() {
+  return (
+    <>
+      <FormattedMessage
+        id="jsx.satisfies"
+        defaultMessage={`JSX satisfies` satisfies DefaultMessage}
+      />
+      <FormattedMessage
+        id="jsx.as"
+        defaultMessage={'JSX as' as DefaultMessage}
+      />
+    </>
+  )
+}

--- a/packages/ts-transformer/tests/index.test.ts
+++ b/packages/ts-transformer/tests/index.test.ts
@@ -198,6 +198,45 @@ describe('emit asserts for', function () {
     ])
   })
 
+  it('typeAssertions', async function () {
+    const output = await compile(join(FIXTURES_DIR, 'typeAssertions.tsx'), {})
+    expect(output.meta).toEqual({})
+    expect(output.msgs).toEqual([
+      {
+        defaultMessage: 'Define satisfies',
+        id: 'define.satisfies',
+      },
+      {
+        defaultMessage: 'Define as',
+        id: 'define.as',
+      },
+      {
+        defaultMessage: 'Define object satisfies',
+        id: 'define.object.satisfies',
+      },
+      {
+        defaultMessage: 'Messages satisfies',
+        id: 'messages.satisfies',
+      },
+      {
+        defaultMessage: 'Messages as',
+        id: 'messages.as',
+      },
+      {
+        defaultMessage: 'Format satisfies',
+        id: 'format.satisfies',
+      },
+      {
+        defaultMessage: 'JSX satisfies',
+        id: 'jsx.satisfies',
+      },
+      {
+        defaultMessage: 'JSX as',
+        id: 'jsx.as',
+      },
+    ])
+  })
+
   it('inline', async function () {
     const output = await compile(join(FIXTURES_DIR, 'inline.tsx'), {})
     expect(output.code).toMatchSnapshot()

--- a/packages/ts-transformer/transform.ts
+++ b/packages/ts-transformer/transform.ts
@@ -253,7 +253,8 @@ function evaluateStringConcat(
   ts: TypeScript,
   node: typescript.BinaryExpression
 ): [result: string, isStaticallyEvaluatable: boolean] {
-  const {right, left} = node
+  const right = unwrapTransparentTypeScriptExpression(ts, node.right)
+  const left = unwrapTransparentTypeScriptExpression(ts, node.left)
   if (!ts.isStringLiteral(right)) {
     return ['', false]
   }
@@ -265,6 +266,30 @@ function evaluateStringConcat(
     return [result + right.text, isStatic]
   }
   return ['', false]
+}
+
+function unwrapTransparentTypeScriptExpression(
+  ts: TypeScript,
+  node: typescript.Expression
+): typescript.Expression {
+  let current = node
+  while (
+    ts.isAsExpression(current) ||
+    ts.isSatisfiesExpression(current) ||
+    ts.isNonNullExpression(current) ||
+    ts.isTypeAssertionExpression(current)
+  ) {
+    current = current.expression
+  }
+  return current
+}
+
+function unwrapObjectLiteralExpression(
+  ts: TypeScript,
+  node: typescript.Expression
+): typescript.ObjectLiteralExpression | undefined {
+  const expression = unwrapTransparentTypeScriptExpression(ts, node)
+  return ts.isObjectLiteralExpression(expression) ? expression : undefined
 }
 
 function extractMessageDescriptor(
@@ -329,37 +354,40 @@ function extractMessageDescriptor(
         : undefined
 
     if (name && ts.isIdentifier(name) && initializer) {
+      const value = ts.isPropertyAssignment(prop)
+        ? unwrapTransparentTypeScriptExpression(ts, prop.initializer)
+        : initializer
       // {id: 'id'}
-      if (ts.isStringLiteral(initializer)) {
+      if (ts.isStringLiteral(value)) {
         switch (name.text) {
           case 'id':
-            msg.id = initializer.text
+            msg.id = value.text
             break
           case 'defaultMessage':
-            msg.defaultMessage = initializer.text
+            msg.defaultMessage = value.text
             break
           case 'description':
-            msg.description = initializer.text
+            msg.description = value.text
             break
         }
       }
       // {id: `id`}
-      else if (ts.isNoSubstitutionTemplateLiteral(initializer)) {
+      else if (ts.isNoSubstitutionTemplateLiteral(value)) {
         switch (name.text) {
           case 'id':
-            msg.id = initializer.text
+            msg.id = value.text
             break
           case 'defaultMessage':
-            msg.defaultMessage = initializer.text
+            msg.defaultMessage = value.text
             break
           case 'description':
-            msg.description = initializer.text
+            msg.description = value.text
             break
         }
       }
       // {id: dedent`id`}
       // GH #5069: Only check for substitutions on message-related props
-      else if (ts.isTaggedTemplateExpression(initializer)) {
+      else if (ts.isTaggedTemplateExpression(value)) {
         const isMessageProp =
           name.text === 'id' ||
           name.text === 'defaultMessage' ||
@@ -369,7 +397,7 @@ function extractMessageDescriptor(
           return
         }
 
-        const {template} = initializer
+        const {template} = value
         if (!ts.isNoSubstitutionTemplateLiteral(template)) {
           handleError(
             '[FormatJS] Tagged template expression must be no substitution',
@@ -389,34 +417,34 @@ function extractMessageDescriptor(
             msg.description = template.text
             break
         }
-      } else if (ts.isJsxExpression(initializer) && initializer.expression) {
+      } else if (ts.isJsxExpression(value) && value.expression) {
+        const expression = unwrapTransparentTypeScriptExpression(
+          ts,
+          value.expression
+        )
         // <FormattedMessage foo={'barbaz'} />
-        if (ts.isStringLiteral(initializer.expression)) {
+        if (ts.isStringLiteral(expression)) {
           switch (name.text) {
             case 'id':
-              msg.id = initializer.expression.text
+              msg.id = expression.text
               break
             case 'defaultMessage':
-              msg.defaultMessage = initializer.expression.text
+              msg.defaultMessage = expression.text
               break
             case 'description':
-              msg.description = initializer.expression.text
+              msg.description = expression.text
               break
           }
         }
         // description={{custom: 1}}
         else if (
-          ts.isObjectLiteralExpression(initializer.expression) &&
+          ts.isObjectLiteralExpression(expression) &&
           name.text === 'description'
         ) {
-          msg.description = objectLiteralExpressionToObj(
-            ts,
-            initializer.expression
-          )
+          msg.description = objectLiteralExpressionToObj(ts, expression)
         }
         // <FormattedMessage foo={`bar`} />
-        else if (ts.isNoSubstitutionTemplateLiteral(initializer.expression)) {
-          const {expression} = initializer
+        else if (ts.isNoSubstitutionTemplateLiteral(expression)) {
           switch (name.text) {
             case 'id':
               msg.id = expression.text
@@ -431,7 +459,7 @@ function extractMessageDescriptor(
         }
         // <FormattedMessage foo={dedent`dedent Hello World!`} />
         // GH #5069: Only check for substitutions on message-related props
-        else if (ts.isTaggedTemplateExpression(initializer.expression)) {
+        else if (ts.isTaggedTemplateExpression(expression)) {
           const isMessageProp =
             name.text === 'id' ||
             name.text === 'defaultMessage' ||
@@ -441,9 +469,7 @@ function extractMessageDescriptor(
             return
           }
 
-          const {
-            expression: {template},
-          } = initializer
+          const {template} = expression
           if (!ts.isNoSubstitutionTemplateLiteral(template)) {
             handleError(
               '[FormatJS] Tagged template expression must be no substitution',
@@ -464,8 +490,7 @@ function extractMessageDescriptor(
           }
         }
         // <FormattedMessage foo={'bar' + 'baz'} />
-        else if (ts.isBinaryExpression(initializer.expression)) {
-          const {expression} = initializer
+        else if (ts.isBinaryExpression(expression)) {
           const [result, isStatic] = evaluateStringConcat(ts, expression)
           if (isStatic) {
             switch (name.text) {
@@ -504,8 +529,8 @@ function extractMessageDescriptor(
         }
       }
       // {defaultMessage: 'asd' + bar'}
-      else if (ts.isBinaryExpression(initializer)) {
-        const [result, isStatic] = evaluateStringConcat(ts, initializer)
+      else if (ts.isBinaryExpression(value)) {
+        const [result, isStatic] = evaluateStringConcat(ts, value)
         if (isStatic) {
           switch (name.text) {
             case 'id':
@@ -532,10 +557,10 @@ function extractMessageDescriptor(
       }
       // description: {custom: 1}
       else if (
-        ts.isObjectLiteralExpression(initializer) &&
+        ts.isObjectLiteralExpression(value) &&
         name.text === 'description'
       ) {
-        msg.description = objectLiteralExpressionToObj(ts, initializer)
+        msg.description = objectLiteralExpressionToObj(ts, value)
       }
       // Non-static value for defaultMessage or id
       else if (
@@ -804,15 +829,7 @@ function extractMessagesFromCallExpression(
   const {onMsgExtracted, additionalFunctionNames} = opts
   if (isMultipleMessageDecl(ts, node)) {
     const [arg, ...restArgs] = node.arguments
-    let descriptorsObj: typescript.ObjectLiteralExpression | undefined
-    if (ts.isObjectLiteralExpression(arg)) {
-      descriptorsObj = arg
-    } else if (
-      ts.isAsExpression(arg) &&
-      ts.isObjectLiteralExpression(arg.expression)
-    ) {
-      descriptorsObj = arg.expression
-    }
+    const descriptorsObj = unwrapObjectLiteralExpression(ts, arg)
     if (descriptorsObj) {
       const properties = descriptorsObj.properties
       const msgs = properties
@@ -820,11 +837,12 @@ function extractMessagesFromCallExpression(
           (prop): prop is typescript.PropertyAssignment =>
             ts.isPropertyAssignment(prop)
         )
-        .map(
-          prop =>
-            ts.isObjectLiteralExpression(prop.initializer) &&
-            extractMessageDescriptor(ts, prop.initializer, opts, sf)
-        )
+        .map(prop => {
+          const descriptor = unwrapObjectLiteralExpression(ts, prop.initializer)
+          return (
+            descriptor && extractMessageDescriptor(ts, descriptor, opts, sf)
+          )
+        })
         .filter((msg): msg is MessageDescriptor => !!msg)
       if (!msgs.length) {
         return node
@@ -874,8 +892,9 @@ function extractMessagesFromCallExpression(
     isMemberMethodFormatMessageCall(ts, node, additionalFunctionNames || [])
   ) {
     const [descriptorsObj, ...restArgs] = node.arguments
-    if (ts.isObjectLiteralExpression(descriptorsObj)) {
-      const msg = extractMessageDescriptor(ts, descriptorsObj, opts, sf)
+    const descriptor = unwrapObjectLiteralExpression(ts, descriptorsObj)
+    if (descriptor) {
+      const msg = extractMessageDescriptor(ts, descriptor, opts, sf)
       if (!msg) {
         return node
       }
@@ -892,7 +911,7 @@ function extractMessagesFromCallExpression(
           setAttributesInObject(
             ts,
             factory,
-            descriptorsObj,
+            descriptor,
             {
               defaultMessage: opts.removeDefaultMessage
                 ? undefined

--- a/packages/unplugin/conformance-tests/cli-unplugin-conformance.test.ts
+++ b/packages/unplugin/conformance-tests/cli-unplugin-conformance.test.ts
@@ -123,4 +123,22 @@ describe('formatjs_cli vs @formatjs/unplugin conformance', () => {
       'whitespace.tsx'
     )
   })
+
+  test('TypeScript satisfies expressions are transparent for extraction', async () => {
+    await assertConformance(
+      `type DefaultMessage = string
+intl.formatMessage({
+  defaultMessage: \`Hello from satisfies\` satisfies DefaultMessage,
+})`,
+      'satisfies-expression.tsx'
+    )
+  })
+
+  test('TypeScript as expressions are transparent for extraction', async () => {
+    await assertConformance(
+      `type DefaultMessage = string
+<FormattedMessage defaultMessage={'Hello from as' as DefaultMessage} />`,
+      'as-expression.tsx'
+    )
+  })
 }, 30000)

--- a/packages/unplugin/transform.ts
+++ b/packages/unplugin/transform.ts
@@ -82,7 +82,26 @@ export function transform(
 
   let s: MagicString | undefined
 
+  function unwrapTransparentTypeScriptExpression(node: any): any {
+    let current = node
+    while (
+      current?.type === 'TSAsExpression' ||
+      current?.type === 'TSSatisfiesExpression' ||
+      current?.type === 'TSTypeAssertion' ||
+      current?.type === 'TSNonNullExpression'
+    ) {
+      current = current.expression
+    }
+    return current
+  }
+
+  function unwrapObjectExpression(node: any): any {
+    const expression = unwrapTransparentTypeScriptExpression(node)
+    return expression?.type === 'ObjectExpression' ? expression : undefined
+  }
+
   function getStaticValue(node: any): string | undefined {
+    node = unwrapTransparentTypeScriptExpression(node)
     if (!node) return undefined
     if (node.type === 'StringLiteral' || node.type === 'Literal') {
       if (typeof node.value === 'string') return node.value
@@ -128,7 +147,8 @@ export function transform(
         continue
       const keyName: keyof MessageDescriptor = name
 
-      const val = getStaticValue(prop.value)
+      const valueNode = unwrapTransparentTypeScriptExpression(prop.value)
+      const val = getStaticValue(valueNode)
       if (val === undefined) continue
 
       descriptor[keyName] = val
@@ -397,8 +417,8 @@ export function transform(
       const componentName =
         firstArg?.type === 'Identifier' ? firstArg.name : undefined
       if (componentName && componentNames.has(componentName)) {
-        const propsArg = node.arguments?.[1]
-        if (propsArg?.type === 'ObjectExpression') {
+        const propsArg = unwrapObjectExpression(node.arguments?.[1])
+        if (propsArg) {
           const result = extractDescriptor(propsArg)
           if (result) {
             processDescriptor(result.descriptor, result.locations, false)
@@ -410,14 +430,13 @@ export function transform(
     if (calleeName && functionNames.has(calleeName)) {
       if (calleeName === 'defineMessages') {
         // Process each value in the object
-        const arg = node.arguments?.[0]
-        if (arg?.type === 'ObjectExpression') {
+        const arg = unwrapObjectExpression(node.arguments?.[0])
+        if (arg) {
           for (const prop of arg.properties) {
-            if (
-              prop.type === 'Property' &&
-              prop.value?.type === 'ObjectExpression'
-            ) {
-              const result = extractDescriptor(prop.value)
+            if (prop.type === 'Property') {
+              const value = unwrapObjectExpression(prop.value)
+              if (!value) continue
+              const result = extractDescriptor(value)
               if (result) {
                 processDescriptor(result.descriptor, result.locations, false)
               }
@@ -425,8 +444,8 @@ export function transform(
           }
         }
       } else {
-        const arg = node.arguments?.[0]
-        if (arg?.type === 'ObjectExpression') {
+        const arg = unwrapObjectExpression(node.arguments?.[0])
+        if (arg) {
           const result = extractDescriptor(arg)
           if (result) {
             processDescriptor(result.descriptor, result.locations, false)


### PR DESCRIPTION
## Summary
- fix(eslint-plugin-formatjs): allow literal message descriptor values wrapped in TypeScript `satisfies`, `as`, non-null, and type assertion expressions
- fix(@formatjs/ts-transformer): extract static message values through TypeScript assertion wrappers
- fix(@formatjs/cli-lib): cover TypeScript assertion extraction through the JS/TS extraction path
- fix(@formatjs/cli): extract static message values through TypeScript assertion wrappers in the Rust CLI
- fix(@formatjs/unplugin): keep CLI/unplugin extraction behavior conformant for TypeScript assertion wrappers

Fixes #6474

## Test Plan
- bazel test //packages/ts-transformer:ts-transformer_test //packages/cli-lib:cli-lib_test //crates/formatjs_cli:formatjs_cli_test //packages/eslint-plugin-formatjs:eslint-plugin-formatjs_test //packages/unplugin:conformance_test
- bazel test //packages/eslint-plugin-formatjs:typecheck_typecheck_test //packages/eslint-plugin-formatjs:eslint-plugin-formatjs_test_typecheck_typecheck_test //packages/eslint-plugin-formatjs:eslint-plugin-formatjs_test