### PR TITLE
fix(@formatjs/intl-durationformat): export duration format options

### DIFF
--- a/packages/intl-durationformat/index.ts
+++ b/packages/intl-durationformat/index.ts
@@ -1,1 +1,12 @@
 export * from '#packages/intl-durationformat/core.js'
+export type {
+  DurationFormatConstructor,
+  DurationFormatLocaleInternalData,
+  DurationFormatOptions,
+  DurationFormatPart,
+  DurationInput,
+  DurationRecord,
+  IntlDurationFormatInternal,
+  RawDurationLocaleData,
+  ResolvedDurationFormatOptions,
+} from '#packages/intl-durationformat/types.js'

--- a/packages/intl-durationformat/tests/index.test.ts
+++ b/packages/intl-durationformat/tests/index.test.ts
@@ -1,5 +1,7 @@
 import {DurationFormat} from '#packages/intl-durationformat/core.js'
+import {type DurationFormatOptions} from '#packages/intl-durationformat/index.js'
 import {test, expect} from 'vitest'
+
 test('Intl.DurationFormat resolvedOptions', function () {
   expect(new DurationFormat('en').resolvedOptions()).toEqual({
     days: 'short',
@@ -73,9 +75,11 @@ test('Intl.DurationFormat format', function () {
 })
 
 test('Intl.DurationFormat format digital', function () {
-  expect(new DurationFormat('en', {style: 'digital'}).format({years: 1})).toBe(
-    '1 yr, 0:00:00'
-  )
+  const customFormatterOptions: DurationFormatOptions = {style: 'digital'}
+
+  expect(
+    new DurationFormat('en', customFormatterOptions).format({years: 1})
+  ).toBe('1 yr, 0:00:00')
 })
 
 test('Intl.DurationFormat sub-second rollup is exact (#6462)', function () {


### PR DESCRIPTION
## Summary
- export DurationFormatOptions and related public duration-format types from @formatjs/intl-durationformat
- add a compile-time usage of the public DurationFormatOptions import

Fixes #6486

## Test Plan
- bazel test //packages/intl-durationformat:intl-durationformat_test --test_output=all
- bazel build //packages/intl-durationformat:intl-durationformat