### PR TITLE
fix(formatjs_cli): build Linux binary without glibc dependency

### DIFF
--- a/.github/workflows/rust-cli-release.yml
+++ b/.github/workflows/rust-cli-release.yml
@@ -17,24 +17,9 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build:
-    name: Build ${{ matrix.platform }}
-    runs-on: ${{ matrix.runner }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: macOS ARM64
-            runner: macos-latest
-            bazel_platform: //crates/formatjs_cli/platforms:darwin_arm64
-            artifact_name: formatjs_cli-darwin-arm64
-            config: ci-darwin
-          - platform: Linux x86_64
-            runner: ubuntu-latest
-            bazel_platform: //crates/formatjs_cli/platforms:linux_x86_64
-            artifact_name: formatjs_cli-linux-x64
-            config: ci
+  build_macos:
+    name: Build macOS ARM64
+    runs-on: macos-latest
 
     steps:
       - name: Checkout Repository
@@ -44,46 +29,99 @@ jobs:
         uses: bazel-contrib/setup-bazel@0.19.0
         with:
           bazelisk-cache: true
-          disk-cache: ${{ github.workflow }}-${{ matrix.platform }}
+          disk-cache: ${{ github.workflow }}-macOS ARM64
           repository-cache: true
 
       - name: Build Binary
         run: |
           if [ -n "${{ secrets.BUILDBUDDY_ORG_API_KEY }}" ]; then
             bazel build \
-              --config=${{ matrix.config }} \
+              --config=ci-darwin \
               --compilation_mode=opt \
-              --platforms=${{ matrix.bazel_platform }} \
+              --platforms=//crates/formatjs_cli/platforms:darwin_arm64 \
               --remote_download_outputs=all \
               --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
               //crates/formatjs_cli:release_binary
           else
             bazel build \
               --compilation_mode=opt \
-              --platforms=${{ matrix.bazel_platform }} \
+              --platforms=//crates/formatjs_cli/platforms:darwin_arm64 \
               //crates/formatjs_cli:release_binary
           fi
 
           # Copy binary to artifacts directory
           mkdir -p artifacts
-          cp bazel-bin/crates/formatjs_cli/formatjs_cli_release artifacts/${{ matrix.artifact_name }}
-          chmod +x artifacts/${{ matrix.artifact_name }}
+          cp bazel-bin/crates/formatjs_cli/formatjs_cli_release artifacts/formatjs_cli-darwin-arm64
+          chmod +x artifacts/formatjs_cli-darwin-arm64
 
       - name: Smoke Test
         run: |
-          ./artifacts/${{ matrix.artifact_name }} --version
-          ./artifacts/${{ matrix.artifact_name }} --help
+          ./artifacts/formatjs_cli-darwin-arm64 --version
+          ./artifacts/formatjs_cli-darwin-arm64 --help
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ matrix.artifact_name }}
-          path: artifacts/${{ matrix.artifact_name }}
+          name: formatjs_cli-darwin-arm64
+          path: artifacts/formatjs_cli-darwin-arm64
+          retention-days: 7
+
+  build_linux:
+    name: Build Linux x86_64
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Setup Bazel
+        uses: bazel-contrib/setup-bazel@0.19.0
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}-Linux x86_64-musl
+          repository-cache: true
+
+      - name: Build Binary
+        run: |
+          bazel build //crates/formatjs_cli:release_binary_linux_x64
+
+          # Copy binary to artifacts directory
+          BINARY_PATH="$(bazel cquery --output=files //crates/formatjs_cli:release_binary_linux_x64)"
+          mkdir -p artifacts
+          cp "$BINARY_PATH" artifacts/formatjs_cli-linux-x64
+          chmod +x artifacts/formatjs_cli-linux-x64
+
+      - name: Smoke Test
+        run: |
+          ./artifacts/formatjs_cli-linux-x64 --version
+          ./artifacts/formatjs_cli-linux-x64 --help
+
+      - name: Verify glibc Compatibility
+        run: |
+          file artifacts/formatjs_cli-linux-x64
+          ldd_output="$(ldd artifacts/formatjs_cli-linux-x64 2>&1 || true)"
+          echo "$ldd_output"
+          if echo "$ldd_output" | grep -q "not a dynamic executable"; then
+            echo "Linux binary is statically linked and does not require glibc"
+          elif strings artifacts/formatjs_cli-linux-x64 | grep -q 'GLIBC_'; then
+            echo "Linux musl binary unexpectedly references glibc symbols" >&2
+            exit 1
+          else
+            echo "Linux binary does not reference glibc symbols"
+          fi
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: formatjs_cli-linux-x64
+          path: artifacts/formatjs_cli-linux-x64
           retention-days: 7
 
   release:
     name: Create Release
-    needs: build
+    needs:
+      - build_macos
+      - build_linux
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,3 +63,61 @@ jobs:
           BINARY_PATH=bazel-bin/crates/formatjs_cli/formatjs_cli
           $BINARY_PATH --version
           $BINARY_PATH --help
+
+  rust_cli_linux_x64_compat:
+    name: Rust CLI Linux x64 Compatibility
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:20.04
+    env:
+      DEBIAN_FRONTEND: noninteractive
+
+    steps:
+      - name: Install Build Dependencies
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            build-essential \
+            ca-certificates \
+            curl \
+            file \
+            git \
+            openjdk-17-jdk \
+            python3 \
+            unzip \
+            xz-utils \
+            zip \
+            zstd
+
+      - name: Install Bazelisk
+        run: |
+          curl -fsSL \
+            https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64 \
+            -o /usr/local/bin/bazel
+          chmod +x /usr/local/bin/bazel
+          bazel version
+
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Build Linux x64 Binary
+        run: |
+          bazel build //crates/formatjs_cli:release_binary_linux_x64
+
+      - name: Smoke Test Linux x64 Binary
+        run: |
+          BINARY_PATH="$(bazel cquery --output=files //crates/formatjs_cli:release_binary_linux_x64)"
+          file "$BINARY_PATH"
+          "$BINARY_PATH" --version
+          "$BINARY_PATH" --help
+
+          ldd_output="$(ldd "$BINARY_PATH" 2>&1 || true)"
+          echo "$ldd_output"
+          if echo "$ldd_output" | grep -q "not a dynamic executable"; then
+            echo "Linux binary is statically linked and does not require glibc"
+          elif strings "$BINARY_PATH" | grep -q 'GLIBC_'; then
+            echo "Linux musl binary unexpectedly references glibc symbols" >&2
+            exit 1
+          else
+            echo "Linux binary does not reference glibc symbols"
+          fi

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -125,6 +125,10 @@ archive_override(
 )
 
 bazel_dep(name = "llvm", version = "0.7.5")
+bazel_dep(name = "with_cfg.bzl", version = "0.14.6")
+
+llvm_toolchain = use_extension("@llvm//extensions:toolchain.bzl", "toolchain")
+use_repo(llvm_toolchain, "llvm_toolchains")
 
 toolchains = use_extension("@rules_rs//rs/toolchains:module_extension.bzl", "toolchains")
 toolchains.toolchain(
@@ -152,6 +156,7 @@ crate.from_cargo(
         "aarch64-unknown-linux-gnu",
         "x86_64-apple-darwin",
         "x86_64-unknown-linux-gnu",
+        "x86_64-unknown-linux-musl",
     ],
 )
 use_repo(crate, "crates")

--- a/crates/formatjs_cli/BUILD.bazel
+++ b/crates/formatjs_cli/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@rules_rs//rs:rust_binary.bzl", "rust_binary")
 load("@rules_rs//rs:rust_test.bzl", "rust_test")
+load(":release_binary.bzl", "release_binary_linux_x64")
 
 exports_files(
     [
@@ -98,6 +99,14 @@ genrule(
     name = "release_binary",
     srcs = [":formatjs_cli"],
     outs = ["formatjs_cli_release"],
+    cmd = "cp $< $@ && chmod +x $@",
+    visibility = ["//visibility:public"],
+)
+
+release_binary_linux_x64(
+    name = "release_binary_linux_x64",
+    srcs = [":formatjs_cli"],
+    outs = ["formatjs_cli_linux_x64"],
     cmd = "cp $< $@ && chmod +x $@",
     visibility = ["//visibility:public"],
 )

--- a/crates/formatjs_cli/platforms/BUILD.bazel
+++ b/crates/formatjs_cli/platforms/BUILD.bazel
@@ -13,3 +13,11 @@ platform(
     parents = ["@rules_rs//rs/platforms:x86_64-unknown-linux-gnu"],
     visibility = ["//visibility:public"],
 )
+
+# Linux x86_64 with musl libc. This produces a static binary that avoids a
+# host glibc runtime requirement.
+platform(
+    name = "linux_x86_64_musl",
+    parents = ["@rules_rs//rs/platforms:x86_64-unknown-linux-musl"],
+    visibility = ["//visibility:public"],
+)

--- a/crates/formatjs_cli/release_binary.bzl
+++ b/crates/formatjs_cli/release_binary.bzl
@@ -1,0 +1,33 @@
+load("@with_cfg.bzl", "with_cfg")
+
+release_binary_linux_x64, _release_binary_linux_x64_internal = with_cfg(
+    native.genrule,
+).set(
+    "compilation_mode",
+    "opt",
+).set(
+    "platforms",
+    [Label("//crates/formatjs_cli/platforms:linux_x86_64_musl")],
+).extend(
+    "extra_toolchains",
+    [
+        Label("@llvm_toolchains//:bootstrap_linux_aarch64_to_linux_x86_64"),
+        Label("@llvm_toolchains//:bootstrap_linux_x86_64_to_linux_x86_64"),
+        Label("@llvm_toolchains//:bootstrap_macos_aarch64_to_linux_x86_64"),
+        Label("@llvm_toolchains//:bootstrap_macos_x86_64_to_linux_x86_64"),
+        Label("@llvm_toolchains//:bootstrap_windows_aarch64_to_linux_x86_64"),
+        Label("@llvm_toolchains//:bootstrap_windows_x86_64_to_linux_x86_64"),
+        Label("@llvm_toolchains//:linux_aarch64_to_linux_x86_64"),
+        Label("@llvm_toolchains//:linux_x86_64_to_linux_x86_64"),
+        Label("@llvm_toolchains//:macos_aarch64_to_linux_x86_64"),
+        Label("@llvm_toolchains//:macos_x86_64_to_linux_x86_64"),
+        Label("@llvm_toolchains//:windows_aarch64_to_linux_x86_64"),
+        Label("@llvm_toolchains//:windows_x86_64_to_linux_x86_64"),
+    ],
+).set(
+    Label("@llvm//config:experimental_stub_libgcc_s"),
+    True,
+).set(
+    Label("@llvm//config/bootstrap:experimental_stub_libgcc_s"),
+    True,
+).build()


### PR DESCRIPTION
Fixes #6488.

## Summary
- Add a Bazel musl platform for the Rust CLI Linux x64 release binary.
- Add a `with_cfg.bzl` release target that owns the musl platform, opt mode, LLVM toolchains, and LLVM libgcc stub settings.
- Build the release Linux artifact from that target while preserving the existing artifact name.
- Add a CI smoke job that builds and runs the Linux x64 binary in Ubuntu 20.04 and verifies it has no glibc symbols.

## Verification
- `bazel build //crates/formatjs_cli:release_binary_linux_x64`
- `bazel cquery --output=files //crates/formatjs_cli:release_binary_linux_x64` returns the transitioned Linux x64 musl output.
- `file "$BINARY_PATH"` reports a static-pie linked Linux ELF.
- `strings "$BINARY_PATH" | rg GLIBC_` has no matches.
- YAML parse for modified workflows.
- `git diff --check`.
- PR checks are passing, including `Rust CLI Linux x64 Compatibility` on Ubuntu 20.04.
