### PR TITLE
refactor(formatjs_cli): expose shared rust library

### DIFF
--- a/crates/formatjs_cli/BUILD.bazel
+++ b/crates/formatjs_cli/BUILD.bazel
@@ -1,10 +1,12 @@
 load("@rules_rs//rs:rust_binary.bzl", "rust_binary")
+load("@rules_rs//rs:rust_library.bzl", "rust_library")
 load("@rules_rs//rs:rust_test.bzl", "rust_test")
 load(":release_binary.bzl", "release_binary_linux_x64")
 
 exports_files(
     [
         "Cargo.toml",
+        "src/lib.rs",
         "src/main.rs",
         "src/extract.rs",
         "src/extractor.rs",
@@ -49,9 +51,8 @@ TEST_DEPS = COMMON_DEPS + [
     "@crates//:tempfile",
 ]
 
-# Base rust binary (builds for host platform)
-rust_binary(
-    name = "formatjs_cli",
+rust_library(
+    name = "formatjs_cli_lib",
     srcs = [
         "src/compile.rs",
         "src/compile_folder.rs",
@@ -65,18 +66,34 @@ rust_binary(
         "src/formatters/smartling.rs",
         "src/formatters/transifex.rs",
         "src/id_generator.rs",
-        "src/main.rs",
+        "src/lib.rs",
         "src/verify.rs",
     ],
-    crate_name = "formatjs",
+    crate_name = "formatjs_cli",
     edition = "2024",
     visibility = ["//visibility:public"],
     deps = COMMON_DEPS,
 )
 
+# Base rust binary (builds for host platform)
+rust_binary(
+    name = "formatjs_cli",
+    srcs = [
+        "src/main.rs",
+    ],
+    crate_name = "formatjs",
+    edition = "2024",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":formatjs_cli_lib",
+        "@crates//:anyhow",
+        "@crates//:clap",
+    ],
+)
+
 rust_test(
     name = "formatjs_cli_test",
-    crate = ":formatjs_cli",
+    crate = ":formatjs_cli_lib",
     data = [
         "//packages/ts-transformer:test_fixtures",
     ],

--- a/crates/formatjs_cli/src/lib.rs
+++ b/crates/formatjs_cli/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod compile;
+pub mod compile_folder;
+pub mod extract;
+pub mod extractor;
+pub mod formatters;
+pub mod id_generator;
+pub mod verify;

--- a/crates/formatjs_cli/src/main.rs
+++ b/crates/formatjs_cli/src/main.rs
@@ -1,15 +1,7 @@
 use anyhow::Result;
 use clap::{Parser, Subcommand, ValueEnum};
+use formatjs_cli::{compile, compile_folder, extract, formatters, verify};
 use std::path::PathBuf;
-
-// Module declarations
-pub mod compile;
-pub mod compile_folder;
-pub mod extract;
-pub mod extractor;
-pub mod formatters;
-pub mod id_generator;
-pub mod verify;
 
 #[derive(Parser)]
 #[command(name = "formatjs")]


### PR DESCRIPTION
## Summary
- move formatjs_cli modules behind a shared Rust library target
- keep the existing CLI binary as a thin clap shell over the library
- update Bazel so tests exercise the library target

## Test plan
- bazel build //crates/formatjs_cli:formatjs_cli
- bazel test //crates/formatjs_cli:formatjs_cli_test