### PR TITLE
feat(formatjs_cli): expose compile through napi

### DIFF
--- a/crates/formatjs_cli/src/compile.rs
+++ b/crates/formatjs_cli/src/compile.rs
@@ -73,6 +73,48 @@ pub fn compile(
     ignore_tag: bool,
     follow_links: bool,
 ) -> Result<()> {
+    let output = compile_to_string(
+        translation_files,
+        format,
+        ast,
+        skip_errors,
+        pseudo_locale,
+        ignore_tag,
+        follow_links,
+    )?;
+
+    if let Some(out_path) = out_file {
+        // Create parent directories if they don't exist
+        if let Some(parent) = out_path.parent() {
+            std::fs::create_dir_all(parent).with_context(|| {
+                format!(
+                    "Failed to create parent directories for {}",
+                    out_path.display()
+                )
+            })?;
+        }
+        // Write to file with trailing newline
+        std::fs::write(out_path, format!("{}\n", output))
+            .with_context(|| format!("Failed to write output to {}", out_path.display()))?;
+        // Silently succeed (matches TypeScript CLI behavior)
+    } else {
+        // Print to stdout (no trailing newline for piping)
+        println!("{}", output);
+    }
+
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn compile_to_string(
+    translation_files: &[PathBuf],
+    format: Option<Formatter>,
+    ast: bool,
+    skip_errors: bool,
+    pseudo_locale: Option<PseudoLocale>,
+    ignore_tag: bool,
+    follow_links: bool,
+) -> Result<String> {
     use formatjs_icu_messageformat_parser::{Parser, ParserOptions};
 
     // Validate pseudo-locale requires ast
@@ -203,26 +245,7 @@ pub fn compile(
     let output = serde_json::to_string_pretty(&output_json)
         .context("Failed to serialize compiled messages to JSON")?;
 
-    if let Some(out_path) = out_file {
-        // Create parent directories if they don't exist
-        if let Some(parent) = out_path.parent() {
-            std::fs::create_dir_all(parent).with_context(|| {
-                format!(
-                    "Failed to create parent directories for {}",
-                    out_path.display()
-                )
-            })?;
-        }
-        // Write to file with trailing newline
-        std::fs::write(out_path, format!("{}\n", output))
-            .with_context(|| format!("Failed to write output to {}", out_path.display()))?;
-        // Silently succeed (matches TypeScript CLI behavior)
-    } else {
-        // Print to stdout (no trailing newline for piping)
-        println!("{}", output);
-    }
-
-    Ok(())
+    Ok(output)
 }
 
 #[cfg(test)]

--- a/crates/formatjs_cli_napi/src/lib.rs
+++ b/crates/formatjs_cli_napi/src/lib.rs
@@ -1,5 +1,19 @@
+use std::path::PathBuf;
+
+use formatjs_cli::compile::{self as cli_compile, PseudoLocale};
 use formatjs_cli::formatters::Formatter;
+use napi::Error;
 use napi_derive::napi;
+
+#[napi(object)]
+pub struct CompileOptions {
+    pub format: Option<String>,
+    pub ast: Option<bool>,
+    pub skip_errors: Option<bool>,
+    pub pseudo_locale: Option<String>,
+    pub ignore_tag: Option<bool>,
+    pub follow_links: Option<bool>,
+}
 
 #[napi]
 pub fn supported_builtin_formatters() -> Vec<String> {
@@ -14,4 +28,60 @@ pub fn supported_builtin_formatters() -> Vec<String> {
     .into_iter()
     .map(|formatter| formatter.as_str().to_string())
     .collect()
+}
+
+#[napi]
+pub fn compile(translation_files: Vec<String>, opts: Option<CompileOptions>) -> napi::Result<String> {
+    let opts = opts.unwrap_or_default();
+    let files = translation_files.into_iter().map(PathBuf::from).collect::<Vec<_>>();
+
+    cli_compile::compile_to_string(
+        &files,
+        parse_formatter(opts.format)?,
+        opts.ast.unwrap_or(false),
+        opts.skip_errors.unwrap_or(false),
+        parse_pseudo_locale(opts.pseudo_locale)?,
+        opts.ignore_tag.unwrap_or(false),
+        opts.follow_links.unwrap_or(true),
+    )
+    .map_err(to_napi_error)
+}
+
+impl Default for CompileOptions {
+    fn default() -> Self {
+        Self {
+            format: None,
+            ast: None,
+            skip_errors: None,
+            pseudo_locale: None,
+            ignore_tag: None,
+            follow_links: None,
+        }
+    }
+}
+
+fn parse_formatter(format: Option<String>) -> napi::Result<Option<Formatter>> {
+    format
+        .map(|name| Formatter::from_str(&name).map_err(to_napi_error))
+        .transpose()
+}
+
+fn parse_pseudo_locale(pseudo_locale: Option<String>) -> napi::Result<Option<PseudoLocale>> {
+    pseudo_locale
+        .map(|locale| match locale.as_str() {
+            "xx-LS" => Ok(PseudoLocale::XxLs),
+            "xx-AC" => Ok(PseudoLocale::XxAc),
+            "xx-HA" => Ok(PseudoLocale::XxHa),
+            "en-XA" => Ok(PseudoLocale::EnXa),
+            "en-XB" => Ok(PseudoLocale::EnXb),
+            _ => Err(Error::from_reason(format!(
+                "Unknown pseudo locale '{}'. Available pseudo locales: xx-LS, xx-AC, xx-HA, en-XA, en-XB",
+                locale
+            ))),
+        })
+        .transpose()
+}
+
+fn to_napi_error(error: impl std::fmt::Display) -> Error {
+    Error::from_reason(error.to_string())
 }


### PR DESCRIPTION
## Summary
- add compile_to_string to the Rust CLI core for library/native callers
- expose a napi compile binding that returns serialized JSON
- keep the existing Rust CLI write-to-file/stdout behavior unchanged

## Test plan
- bazel build //crates/formatjs_cli:formatjs_cli //crates/formatjs_cli_napi:formatjs_cli_napi
- bazel test //crates/formatjs_cli:formatjs_cli_test
- node require smoke test for native compile