### PR TITLE
build(formatjs_cli): add cross platform release artifacts

### DIFF
--- a/crates/formatjs_cli/BUILD.bazel
+++ b/crates/formatjs_cli/BUILD.bazel
@@ -1,7 +1,11 @@
 load("@rules_rs//rs:rust_binary.bzl", "rust_binary")
 load("@rules_rs//rs:rust_library.bzl", "rust_library")
 load("@rules_rs//rs:rust_test.bzl", "rust_test")
-load(":release_binary.bzl", "release_binary_linux_x64")
+load(
+    ":release_binary.bzl",
+    "release_binary_darwin_arm64",
+    "release_binary_linux_x64",
+)
 
 exports_files(
     [
@@ -125,5 +129,22 @@ release_binary_linux_x64(
     srcs = [":formatjs_cli"],
     outs = ["formatjs_cli_linux_x64"],
     cmd = "cp $< $@ && chmod +x $@",
+    visibility = ["//visibility:public"],
+)
+
+release_binary_darwin_arm64(
+    name = "release_binary_darwin_arm64",
+    srcs = [":formatjs_cli"],
+    outs = ["formatjs_cli_darwin_arm64"],
+    cmd = "cp $< $@ && chmod +x $@",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "release_binaries",
+    srcs = [
+        ":release_binary_darwin_arm64",
+        ":release_binary_linux_x64",
+    ],
     visibility = ["//visibility:public"],
 )

--- a/crates/formatjs_cli/platforms/BUILD.bazel
+++ b/crates/formatjs_cli/platforms/BUILD.bazel
@@ -14,7 +14,7 @@ platform(
     visibility = ["//visibility:public"],
 )
 
-# Linux x86_64 with musl libc. This produces a static binary that avoids a
+# Linux x86_64 with musl libc. This produces a static CLI binary that avoids a
 # host glibc runtime requirement.
 platform(
     name = "linux_x86_64_musl",

--- a/crates/formatjs_cli/release_binary.bzl
+++ b/crates/formatjs_cli/release_binary.bzl
@@ -1,33 +1,54 @@
 load("@with_cfg.bzl", "with_cfg")
 
-release_binary_linux_x64, _release_binary_linux_x64_internal = with_cfg(
-    native.genrule,
-).set(
-    "compilation_mode",
-    "opt",
-).set(
-    "platforms",
-    [Label("//crates/formatjs_cli/platforms:linux_x86_64_musl")],
-).extend(
-    "extra_toolchains",
-    [
-        Label("@llvm_toolchains//:bootstrap_linux_aarch64_to_linux_x86_64"),
-        Label("@llvm_toolchains//:bootstrap_linux_x86_64_to_linux_x86_64"),
-        Label("@llvm_toolchains//:bootstrap_macos_aarch64_to_linux_x86_64"),
-        Label("@llvm_toolchains//:bootstrap_macos_x86_64_to_linux_x86_64"),
-        Label("@llvm_toolchains//:bootstrap_windows_aarch64_to_linux_x86_64"),
-        Label("@llvm_toolchains//:bootstrap_windows_x86_64_to_linux_x86_64"),
-        Label("@llvm_toolchains//:linux_aarch64_to_linux_x86_64"),
-        Label("@llvm_toolchains//:linux_x86_64_to_linux_x86_64"),
-        Label("@llvm_toolchains//:macos_aarch64_to_linux_x86_64"),
-        Label("@llvm_toolchains//:macos_x86_64_to_linux_x86_64"),
-        Label("@llvm_toolchains//:windows_aarch64_to_linux_x86_64"),
-        Label("@llvm_toolchains//:windows_x86_64_to_linux_x86_64"),
-    ],
-).set(
-    Label("@llvm//config:experimental_stub_libgcc_s"),
-    True,
-).set(
-    Label("@llvm//config/bootstrap:experimental_stub_libgcc_s"),
-    True,
-).build()
+_HOSTS = [
+    "linux_aarch64",
+    "linux_x86_64",
+    "macos_aarch64",
+    "macos_x86_64",
+    "windows_aarch64",
+    "windows_x86_64",
+]
+
+def _llvm_toolchains(target):
+    return [
+        Label("@llvm_toolchains//:bootstrap_%s_to_%s" % (host, target))
+        for host in _HOSTS
+    ] + [
+        Label("@llvm_toolchains//:%s_to_%s" % (host, target))
+        for host in _HOSTS
+    ]
+
+def _release_binary(platform, llvm_target):
+    return with_cfg(
+        native.genrule,
+    ).set(
+        "compilation_mode",
+        "opt",
+    ).set(
+        "platforms",
+        [Label(platform)],
+    ).extend(
+        "extra_toolchains",
+        _llvm_toolchains(llvm_target),
+    ).set(
+        Label("@llvm//config:experimental_stub_libgcc_s"),
+        True,
+    ).set(
+        Label("@llvm//config/bootstrap:experimental_stub_libgcc_s"),
+        True,
+    ).build()
+
+release_binary_darwin_arm64, _release_binary_darwin_arm64_internal = _release_binary(
+    "//crates/formatjs_cli/platforms:darwin_arm64",
+    "macos_aarch64",
+)
+
+release_binary_linux_x64, _release_binary_linux_x64_internal = _release_binary(
+    "//crates/formatjs_cli/platforms:linux_x86_64_musl",
+    "linux_x86_64",
+)
+
+release_binary_linux_x64_gnu, _release_binary_linux_x64_gnu_internal = _release_binary(
+    "//crates/formatjs_cli/platforms:linux_x86_64",
+    "linux_x86_64",
+)

--- a/crates/formatjs_cli_napi/BUILD.bazel
+++ b/crates/formatjs_cli_napi/BUILD.bazel
@@ -1,4 +1,9 @@
 load("@rules_rs//rs:rust_shared_library.bzl", "rust_shared_library")
+load(
+    ":release_node.bzl",
+    "release_node_darwin_arm64",
+    "release_node_linux_x64",
+)
 
 exports_files(
     [
@@ -29,4 +34,29 @@ rust_shared_library(
         "//crates/formatjs_cli:formatjs_cli_lib",
         "@crates//:napi",
     ],
+)
+
+release_node_darwin_arm64(
+    name = "release_node_darwin_arm64",
+    srcs = [":formatjs_cli_napi"],
+    outs = ["formatjs_cli_napi_darwin_arm64.node"],
+    cmd = "cp $< $@",
+    visibility = ["//visibility:public"],
+)
+
+release_node_linux_x64(
+    name = "release_node_linux_x64",
+    srcs = [":formatjs_cli_napi"],
+    outs = ["formatjs_cli_napi_linux_x64.node"],
+    cmd = "cp $< $@",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "release_nodes",
+    srcs = [
+        ":release_node_darwin_arm64",
+        ":release_node_linux_x64",
+    ],
+    visibility = ["//visibility:public"],
 )

--- a/crates/formatjs_cli_napi/release_node.bzl
+++ b/crates/formatjs_cli_napi/release_node.bzl
@@ -1,0 +1,4 @@
+load("//crates/formatjs_cli:release_binary.bzl", "release_binary_darwin_arm64", "release_binary_linux_x64_gnu")
+
+release_node_darwin_arm64 = release_binary_darwin_arm64
+release_node_linux_x64 = release_binary_linux_x64_gnu


### PR DESCRIPTION
## Summary

Foundation PR for the native CLI stack.

- Adds Bazel release artifact targets for the supported platforms only:
  - `darwin_arm64`
  - `linux_x64`
- Keeps the standalone `formatjs_cli` Linux x64 release binary on the musl/static toolchain.
- Adds a separate GNU Linux x64 release path for `formatjs_cli_napi`, since Rust `cdylib` outputs are not supported for the musl target in this setup.
- Removes the unused Darwin x64 and Linux arm64 release targets from this path.

## Stack

This is the base PR for #6519, which wires the native artifacts into `@formatjs/cli-lib` and npm platform packages.

## Verification

- `bazel build --nobuild //crates/formatjs_cli:release_binaries //crates/formatjs_cli_napi:release_nodes`
- `bazel build //crates/formatjs_cli:release_binary_linux_x64 //crates/formatjs_cli_napi:release_node_linux_x64`
- `bazel build //crates/formatjs_cli:release_binary_darwin_arm64 //crates/formatjs_cli_napi:release_node_darwin_arm64`
