### PR TITLE
feat(@formatjs/cli-lib): prefer native compile and deprecate custom --format files

### DIFF
--- a/crates/formatjs_cli/src/compile.rs
+++ b/crates/formatjs_cli/src/compile.rs
@@ -6,6 +6,8 @@ use walkdir::WalkDir;
 
 use crate::formatters::Formatter;
 
+pub type CompiledInputMessages = BTreeMap<String, (String, PathBuf)>;
+
 /// Pseudo-locale variants for testing and expanding translations
 #[derive(Clone, Copy, Debug)]
 pub enum PseudoLocale {
@@ -115,18 +117,6 @@ pub fn compile_to_string(
     ignore_tag: bool,
     follow_links: bool,
 ) -> Result<String> {
-    use formatjs_icu_messageformat_parser::{Parser, ParserOptions};
-
-    // Validate pseudo-locale requires ast
-    if pseudo_locale.is_some() && !ast {
-        anyhow::bail!("Pseudo-locale generation requires --ast flag");
-    }
-
-    // Warn about unimplemented features
-    if pseudo_locale.is_some() {
-        eprintln!("Warning: Pseudo-locale transformations not yet implemented");
-    }
-
     // Default to "default" formatter if none provided (matches TypeScript CLI)
     let formatter = format.unwrap_or(Formatter::Default);
 
@@ -191,7 +181,29 @@ pub fn compile_to_string(
         eprintln!("Warning: No messages found in translation files");
     }
 
-    // Step 3: Parse and validate ICU MessageFormat, compile to output format
+    compile_messages_to_string(messages, ast, skip_errors, pseudo_locale, ignore_tag)
+}
+
+pub fn compile_messages_to_string(
+    messages: CompiledInputMessages,
+    ast: bool,
+    skip_errors: bool,
+    pseudo_locale: Option<PseudoLocale>,
+    ignore_tag: bool,
+) -> Result<String> {
+    use formatjs_icu_messageformat_parser::{Parser, ParserOptions};
+
+    // Validate pseudo-locale requires ast
+    if pseudo_locale.is_some() && !ast {
+        anyhow::bail!("Pseudo-locale generation requires --ast flag");
+    }
+
+    // Warn about unimplemented features
+    if pseudo_locale.is_some() {
+        eprintln!("Warning: Pseudo-locale transformations not yet implemented");
+    }
+
+    // Parse and validate ICU MessageFormat, compile to output format
     let mut compiled_messages: Map<String, Value> = Map::new();
     let mut error_count = 0;
 

--- a/crates/formatjs_cli_napi/src/lib.rs
+++ b/crates/formatjs_cli_napi/src/lib.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use formatjs_cli::compile::{self as cli_compile, PseudoLocale};
@@ -13,6 +14,13 @@ pub struct CompileOptions {
     pub pseudo_locale: Option<String>,
     pub ignore_tag: Option<bool>,
     pub follow_links: Option<bool>,
+}
+
+#[napi(object)]
+pub struct CompileMessage {
+    pub id: String,
+    pub message: String,
+    pub source_file: String,
 }
 
 #[napi]
@@ -43,6 +51,40 @@ pub fn compile(translation_files: Vec<String>, opts: Option<CompileOptions>) -> 
         parse_pseudo_locale(opts.pseudo_locale)?,
         opts.ignore_tag.unwrap_or(false),
         opts.follow_links.unwrap_or(true),
+    )
+    .map_err(to_napi_error)
+}
+
+#[napi]
+pub fn compile_messages(messages: Vec<CompileMessage>, opts: Option<CompileOptions>) -> napi::Result<String> {
+    let opts = opts.unwrap_or_default();
+    let mut compiled_messages: cli_compile::CompiledInputMessages = BTreeMap::new();
+
+    for message in messages {
+        if let Some((existing, existing_file)) = compiled_messages.get(&message.id) {
+            if existing != &message.message {
+                return Err(Error::from_reason(format!(
+                    "Conflicting ID \"{}\" with different translation found in these 2 files:\n  {}\n  {}",
+                    message.id, existing_file.display(), message.source_file
+                )));
+            }
+        }
+        compiled_messages.insert(
+            message.id,
+            (message.message, PathBuf::from(message.source_file)),
+        );
+    }
+
+    if compiled_messages.is_empty() {
+        eprintln!("Warning: No messages found in translation files");
+    }
+
+    cli_compile::compile_messages_to_string(
+        compiled_messages,
+        opts.ast.unwrap_or(false),
+        opts.skip_errors.unwrap_or(false),
+        parse_pseudo_locale(opts.pseudo_locale)?,
+        opts.ignore_tag.unwrap_or(false),
     )
     .map_err(to_napi_error)
 }

--- a/docs/src/docs/getting-started/message-distribution.mdx
+++ b/docs/src/docs/getting-started/message-distribution.mdx
@@ -69,7 +69,7 @@ yarn compile lang/fr.json --ast --out-file compiled-lang/fr.json
 
 ## Translation Management System (TMS) Integration
 
-If your TMS/vendor has a different JSON format you can specify a custom formatter with `--format <formatFile>` that converts that into `Record<string,string>` so `@formatjs/cli` can understand. For example:
+If your TMS/vendor has a different JSON format, prefer one of the built-in `--format` formatter names or pre-process the file before running `@formatjs/cli`. Passing a custom formatter file to `compile --format <formatFile>` is deprecated and prints a warning. For example, the deprecated formatter-file flow looks like this:
 
 If your vendor accepts the format like
 
@@ -119,7 +119,7 @@ export function compile(msgs) {
 }
 ```
 
-In the future we will provide formatters that work with popular TMSes by default.
+Prefer the built-in formatters for popular TMSes when possible.
 
 ## Distribution
 

--- a/docs/src/docs/tooling/bazel.mdx
+++ b/docs/src/docs/tooling/bazel.mdx
@@ -421,10 +421,11 @@ The native Rust CLI is significantly faster than the Node.js-based tools:
 - **CI/CD friendly** - fast builds in continuous integration
 
 The Rust CLI used by these rules covers the native toolchain's supported
-FormatJS workflows. Node.js-only behavior from `@formatjs/cli`, such as custom
-JavaScript formatter files and framework template extraction for Vue, Svelte,
-Handlebars, Glimmer, GTS, and GJS, is not available in the standalone native
-binary.
+FormatJS workflows. Node.js-only behavior from `@formatjs/cli`, such as
+framework template extraction for Vue, Svelte, Handlebars, Glimmer, GTS, and
+GJS, is not available in the standalone native binary. Custom JavaScript
+formatter files for compilation are deprecated in the Node.js CLI and are not
+supported by the standalone native binary.
 
 ## Common Workflows
 

--- a/docs/src/docs/tooling/cli.mdx
+++ b/docs/src/docs/tooling/cli.mdx
@@ -138,7 +138,7 @@ formatjs verify "lang/*.json" --source-locale en --missing-keys
 Most common extraction, compilation, and verification options work with the native CLI. Notable differences from the Node.js CLI:
 
 - `--format` accepts built-in formatter names only: `default`, `simple`, `transifex`, `smartling`, `lokalise`, or `crowdin`.
-- Custom JavaScript formatter files are only supported by the Node.js CLI.
+- Custom JavaScript formatter files for `compile` and `compile-folder` are deprecated in the Node.js CLI and are not supported by the standalone native CLI.
 - Framework template extraction for Vue, Svelte, Handlebars, Glimmer, GTS, and GJS is only supported by the Node.js CLI.
 - Pseudo-locale options are accepted by the Rust CLI for CLI compatibility, but pseudo-locale AST transformations are not yet implemented there.
 
@@ -444,9 +444,11 @@ yarn compile --help
 </TabItem>
 </Tabs>
 
-### `--format [path]`
+### `--format <name-or-path>`
 
-Path to a formatter file that converts `<translation_file>` to `Record<string, string>` so we can compile. The file must export a function named `compile` with the signature:
+Built-in formatter name that converts `<translation_file>` to `Record<string, string>` so we can compile. Built-in formatter names are `default`, `simple`, `transifex`, `smartling`, `lokalise`, and `crowdin`.
+
+Passing a custom formatter file path is deprecated and prints a warning. The file must export a function named `compile` with the signature:
 
 ```tsx
 type CompileFn = <T = Record<string, MessageDescriptor>>(
@@ -454,7 +456,7 @@ type CompileFn = <T = Record<string, MessageDescriptor>>(
 ) => Record<string, string>
 ```
 
-This is especially useful to convert from a TMS-specific format back to react-intl format.
+This was historically useful to convert from a TMS-specific format back to react-intl format. Prefer a built-in formatter name or pre-process translation files before running `formatjs compile`.
 
 See our [builtin formatters](https://github.com/formatjs/formatjs/tree/main/packages/cli-lib/src/formatters) for examples.
 
@@ -597,9 +599,11 @@ yarn formatjs compile-folder [options] <folder> <outFolder>
 
 Folder structure should be in the form of `<folder>/<locale>.json` and the output would be `<outFolder>/<locale>.json`.
 
-### `--format [path]`
+### `--format <name-or-path>`
 
-Path to a formatter file that converts `<translation_file>` to `Record<string, string>` so we can compile. The file must export a function named `compile` with the signature:
+Built-in formatter name that converts JSON files in `<folder>` to `Record<string, string>` so we can compile. Built-in formatter names are `default`, `simple`, `transifex`, `smartling`, `lokalise`, and `crowdin`.
+
+Passing a custom formatter file path is deprecated and prints a warning. The file must export a function named `compile` with the signature:
 
 ```tsx
 type CompileFn = <T = Record<string, MessageDescriptor>>(
@@ -607,7 +611,7 @@ type CompileFn = <T = Record<string, MessageDescriptor>>(
 ) => Record<string, string>
 ```
 
-This is especially useful to convert from a TMS-specific format back to react-intl format
+This was historically useful to convert from a TMS-specific format back to react-intl format. Prefer a built-in formatter name or pre-process translation files before running `formatjs compile-folder`.
 
 ### `--ast`
 
@@ -644,7 +648,14 @@ We provide the following built-in formatters to integrate with 3rd party TMSes:
 
 ## Custom Formatters
 
-You can provide your own formatter by using our interfaces:
+Custom formatter files for compilation are deprecated and will be removed in a
+future release. They still work in the Node.js CLI for now, but `formatjs
+compile` and `formatjs compile-folder` print a warning when a formatter file
+path is passed to `--format`. Prefer the built-in formatter names above or
+pre-process translation files before compilation.
+
+For extraction, or while deprecated compilation formatter-file support remains,
+you can provide your own formatter by using our interfaces:
 
 ```tsx
 interface VendorJson {}

--- a/packages/cli-lib/BUILD.bazel
+++ b/packages/cli-lib/BUILD.bazel
@@ -28,6 +28,7 @@ formatjs_library(
         "hbs_extractor.ts",
         "index.ts",
         "main.ts",
+        "native.ts",
         "parse_script.ts",
         "pseudo_locale.ts",
         "svelte_extractor.ts",

--- a/packages/cli-lib/cli.ts
+++ b/packages/cli-lib/cli.ts
@@ -181,15 +181,8 @@ sentences are not translator-friendly.`
       `Compile extracted translation file into react-intl consumable JSON We also verify that the messages are valid ICU and not malformed. <translation_files> can be a glob like "foo/**/en.json"`
     )
     .option(
-      '--format <path>',
-      `Path to a formatter file that converts \`<translation_file>\` to \`Record<string, string>\` so we can compile. The file must export a function named \`compile\` with the signature:
-\`\`\`
-type CompileFn = <T = Record<string, MessageDescriptor>>(
-  msgs: T
-) => Record<string, string>;
-\`\`\`
-This is especially useful to convert from a TMS-specific format back to react-intl format
-`
+      '--format <name-or-path>',
+      `Built-in formatter name that converts \`<translation_file>\` to \`Record<string, string>\` so we can compile. Custom formatter file paths are deprecated. Built-in formatters: default, simple, transifex, smartling, lokalise, crowdin.`
     )
     .option(
       '--out-file <path>',
@@ -219,14 +212,7 @@ This is especially useful to convert from a TMS-specific format back to react-in
     .action(async (filePatterns: string[], opts: CompileCLIOpts) => {
       debug('File pattern:', filePatterns)
       debug('Options:', opts)
-      const files = globSync(filePatterns, {
-        followSymbolicLinks: opts.followLinks ?? true,
-      })
-      if (!files.length) {
-        throw new Error(`No input file found with pattern ${filePatterns}`)
-      }
-      debug('Files to compile:', files)
-      await compile(files, opts)
+      await compile(filePatterns, opts)
     })
 
   program
@@ -235,15 +221,8 @@ This is especially useful to convert from a TMS-specific format back to react-in
       `Batch compile all extracted translation JSON files in <folder> to <outFolder> containing react-intl consumable JSON. We also verify that the messages are valid ICU and not malformed.`
     )
     .option(
-      '--format <path>',
-      `Path to a formatter file that converts JSON files in \`<folder>\` to \`Record<string, string>\` so we can compile. The file must export a function named \`compile\` with the signature:
-\`\`\`
-type CompileFn = <T = Record<string, MessageDescriptor>>(
-  msgs: T
-) => Record<string, string>;
-\`\`\`
-This is especially useful to convert from a TMS-specific format back to react-intl format
-`
+      '--format <name-or-path>',
+      `Built-in formatter name that converts JSON files in \`<folder>\` to \`Record<string, string>\` so we can compile. Custom formatter file paths are deprecated. Built-in formatters: default, simple, transifex, smartling, lokalise, crowdin.`
     )
     .option(
       '--ast',

--- a/packages/cli-lib/compile.ts
+++ b/packages/cli-lib/compile.ts
@@ -1,24 +1,33 @@
-import {
-  type MessageFormatElement,
-  parse,
-} from '@formatjs/icu-messageformat-parser'
 import {outputFile} from 'fs-extra/esm'
 import {readFile} from 'fs/promises'
+import * as glob from 'fast-glob'
 import * as stringifyNs from 'json-stable-stringify'
+import {resolve} from 'path'
+import {pathToFileURL} from 'url'
 import {debug, warn, writeStdout} from '#packages/cli-lib/console_utils.js'
+import {type Formatter} from '#packages/cli-lib/formatters/index.js'
 import {
-  type Formatter,
-  resolveBuiltinFormatter,
-} from '#packages/cli-lib/formatters/index.js'
-import {
-  generateENXA,
-  generateENXB,
-  generateXXAC,
-  generateXXHA,
-  generateXXLS,
-} from '#packages/cli-lib/pseudo_locale.js'
+  type NativeCompileMessage,
+  compileMessagesWithNative,
+  compileWithNative,
+} from '#packages/cli-lib/native.js'
 
+const dynamicImport = new Function('specifier', 'return import(specifier)') as (
+  specifier: string
+) => Promise<Formatter<unknown>>
+const globSync = glob.sync
 const stringify = (stringifyNs as any).default || stringifyNs
+const CUSTOM_FORMATTER_FILE_DEPRECATION_WARNING =
+  'Passing a custom formatter file to --format during compilation is deprecated and will be removed in a future release. Prefer a built-in formatter name or pre-process translation files before running formatjs compile.'
+
+const BUILTIN_FORMATTERS = new Set([
+  'default',
+  'simple',
+  'transifex',
+  'smartling',
+  'lokalise',
+  'crowdin',
+])
 
 export type CompileFn = (msgs: any) => Record<string, string>
 
@@ -29,12 +38,8 @@ export interface CompileCLIOpts extends Opts {
    * The target file that contains compiled messages.
    */
   outFile?: string
-  /**
-   * Whether to follow symbolic links when traversing directories.
-   * Defaults to true for compatibility with pnpm symlinked node_modules.
-   */
-  followLinks?: boolean
 }
+
 export interface Opts {
   /**
    * Whether to compile message into AST instead of just string
@@ -46,8 +51,9 @@ export interface Opts {
    */
   skipErrors?: boolean
   /**
-   * Path to a formatter file that converts <translation_files> to
-   * `Record<string, string>` so we can compile.
+   * Built-in formatter name or path to a formatter file that converts
+   * <translation_files> to `Record<string, string>` so we can compile.
+   * Formatter file paths are deprecated for compilation.
    */
   format?: string | Formatter<unknown>
   /**
@@ -62,17 +68,19 @@ export interface Opts {
    */
   ignoreTag?: boolean
   /**
-   * An AbortSignal to cancel the compilation
+   * An AbortSignal to cancel the compilation before invoking native code.
    */
   signal?: AbortSignal
+  /**
+   * Whether to follow symbolic links when traversing directories.
+   * Defaults to true for compatibility with pnpm symlinked node_modules.
+   */
+  followLinks?: boolean
 }
 
 /**
- * Aggregate `inputFiles` into a single JSON blob and compile.
- * Also checks for conflicting IDs.
- * Then returns the serialized result as a `string` since key order
- * makes a difference in some vendor.
- * @param inputFiles Input files
+ * Compile extracted translation files with the native formatjs CLI binding.
+ * @param inputFiles Input files or glob patterns
  * @param opts Options
  * @returns serialized result in string format
  */
@@ -81,83 +89,113 @@ export async function compile(
   opts: Opts = {}
 ): Promise<string> {
   debug('Compiling files:', inputFiles)
-  const {ast, format, pseudoLocale, skipErrors, ignoreTag, signal} = opts
+  const {
+    ast,
+    format,
+    pseudoLocale,
+    skipErrors,
+    ignoreTag,
+    signal,
+    followLinks,
+  } = opts
   signal?.throwIfAborted()
-  const formatter = await resolveBuiltinFormatter(format)
 
-  const messages: Record<string, string> = {}
-  const messageAsts: Record<string, MessageFormatElement[]> = {}
-  const idsWithFileName: Record<string, string> = {}
-  const compiledFiles = await Promise.all(
-    inputFiles.map(f =>
-      readFile(f, {encoding: 'utf8', signal})
-        .then(content => JSON.parse(content))
-        .then(formatter.compile)
-    )
-  )
-  debug('Compiled files:', compiledFiles)
-  for (let i = 0; i < inputFiles.length; i++) {
-    const inputFile = inputFiles[i]
-    debug('Processing file:', inputFile)
-    const compiled = compiledFiles[i]
-    for (const id in compiled) {
-      if (messages[id] && messages[id] !== compiled[id]) {
-        throw new Error(`Conflicting ID "${id}" with different translation found in these 2 files:
-ID: ${id}
-Message from ${idsWithFileName[id]}: ${messages[id]}
-Message from ${inputFile}: ${compiled[id]}
-`)
-      }
-      try {
-        const msgAst = parse(compiled[id], {ignoreTag})
-        messages[id] = compiled[id]
-        switch (pseudoLocale) {
-          case 'xx-LS':
-            messageAsts[id] = generateXXLS(msgAst)
-            break
-          case 'xx-AC':
-            messageAsts[id] = generateXXAC(msgAst)
-            break
-          case 'xx-HA':
-            messageAsts[id] = generateXXHA(msgAst)
-            break
-          case 'en-XA':
-            messageAsts[id] = generateENXA(msgAst)
-            break
-          case 'en-XB':
-            messageAsts[id] = generateENXB(msgAst)
-            break
-          default:
-            messageAsts[id] = msgAst
-            break
-        }
-        idsWithFileName[id] = inputFile
-      } catch (e) {
-        warn(
-          'Error validating message "%s" with ID "%s" in file "%s"',
-          compiled[id],
-          id,
-          inputFile
-        )
-        if (!skipErrors) {
-          throw e
-        }
-      }
-    }
+  if (format && !isBuiltinFormatter(format)) {
+    return compileWithCustomFormatter(inputFiles, opts)
   }
 
-  return (
-    stringify(ast ? messageAsts : messages, {
-      space: 2,
-      cmp: formatter.compareMessages || undefined,
-    }) ?? ''
+  return compileWithNative(inputFiles, {
+    ast,
+    format: typeof format === 'string' ? format : undefined,
+    followLinks,
+    ignoreTag,
+    pseudoLocale,
+    skipErrors,
+  })
+}
+
+function isBuiltinFormatter(
+  format: string | Formatter<unknown>
+): format is string {
+  return typeof format === 'string' && BUILTIN_FORMATTERS.has(format)
+}
+
+async function compileWithCustomFormatter(
+  inputFiles: string[],
+  opts: Opts
+): Promise<string> {
+  if (typeof opts.format === 'string') {
+    await warn(CUSTOM_FORMATTER_FILE_DEPRECATION_WARNING)
+  }
+
+  const formatter = await resolveCustomFormatter(opts.format)
+  const files = globSync(inputFiles, {
+    followSymbolicLinks: opts.followLinks ?? true,
+  })
+
+  if (!files.length) {
+    throw new Error('No translation files found matching the patterns')
+  }
+
+  const messages: NativeCompileMessage[] = []
+  await Promise.all(
+    files.map(async file => {
+      opts.signal?.throwIfAborted()
+      const content = await readFile(file, {
+        encoding: 'utf8',
+        signal: opts.signal,
+      })
+      const compiled = formatter.compile(JSON.parse(content))
+      for (const id of Object.keys(compiled)) {
+        messages.push({
+          id,
+          message: compiled[id],
+          sourceFile: file,
+        })
+      }
+    })
   )
+
+  const serialized = compileMessagesWithNative(messages, {
+    ast: opts.ast,
+    ignoreTag: opts.ignoreTag,
+    pseudoLocale: opts.pseudoLocale,
+    skipErrors: opts.skipErrors,
+  })
+
+  if (formatter.compareMessages) {
+    return (
+      stringify(JSON.parse(serialized), {
+        space: 2,
+        cmp: formatter.compareMessages,
+      }) ?? ''
+    )
+  }
+
+  return serialized
+}
+
+async function resolveCustomFormatter(
+  format: string | Formatter<unknown> | undefined
+): Promise<Formatter<unknown>> {
+  if (!format) {
+    throw new Error('A custom formatter is required')
+  }
+  if (typeof format !== 'string') {
+    return format
+  }
+  try {
+    return dynamicImport(pathToFileURL(resolve(process.cwd(), format)).href)
+  } catch (e) {
+    console.error(`Cannot resolve formatter ${format}`)
+    throw e
+  }
 }
 
 /**
- * Aggregate `inputFiles` into a single JSON blob and compile.
- * Also checks for conflicting IDs and write output to `outFile`.
- * @param inputFiles Input files
+ * Compile extracted translation files with the native formatjs CLI binding and
+ * write output to `outFile` when provided.
+ * @param inputFiles Input files or glob patterns
  * @param compileOpts options
  * @returns A `Promise` that resolves if file was written successfully
  */

--- a/packages/cli-lib/native.ts
+++ b/packages/cli-lib/native.ts
@@ -1,0 +1,90 @@
+import {createRequire} from 'module'
+
+const require = createRequire(import.meta.url)
+
+const NATIVE_PACKAGES: Record<string, string> = {
+  'darwin-arm64': '@formatjs/cli-native-darwin-arm64',
+  'linux-x64': '@formatjs/cli-native-linux-x64',
+}
+
+export interface NativeCompileOptions {
+  ast?: boolean
+  format?: string
+  ignoreTag?: boolean
+  pseudoLocale?: string
+  skipErrors?: boolean
+  followLinks?: boolean
+}
+
+export interface NativeCompileMessage {
+  id: string
+  message: string
+  sourceFile: string
+}
+
+export interface NativeBinding {
+  compile(inputFiles: string[], opts?: NativeCompileOptions): string
+  compileMessages(
+    messages: NativeCompileMessage[],
+    opts?: NativeCompileOptions
+  ): string
+  supportedBuiltinFormatters(): string[]
+}
+
+let nativeBinding: NativeBinding | null | undefined
+
+export function loadNative(): NativeBinding {
+  if (nativeBinding !== undefined) {
+    if (nativeBinding) {
+      return nativeBinding
+    }
+    throw new Error('Native @formatjs/cli-lib binding is unavailable')
+  }
+
+  const overridePath = process.env.FORMATJS_CLI_LIB_NATIVE_PATH
+  const platformPackage = NATIVE_PACKAGES[`${process.platform}-${process.arch}`]
+  const candidates = [overridePath, platformPackage].filter(Boolean) as string[]
+  const loadErrors: string[] = []
+
+  for (const candidate of candidates) {
+    try {
+      nativeBinding = require(candidate) as NativeBinding
+      return nativeBinding
+    } catch (e) {
+      loadErrors.push(`${candidate}: ${(e as Error).message}`)
+    }
+  }
+
+  nativeBinding = null
+  throw new Error(
+    `Native @formatjs/cli-lib binding is unavailable.\n${loadErrors.join('\n')}`
+  )
+}
+
+export function compileWithNative(
+  inputFiles: string[],
+  opts: NativeCompileOptions = {}
+): string {
+  const native = loadNative()
+  return native.compile(inputFiles, {
+    ast: opts.ast,
+    format: opts.format,
+    followLinks: opts.followLinks,
+    ignoreTag: opts.ignoreTag,
+    pseudoLocale: opts.pseudoLocale,
+    skipErrors: opts.skipErrors,
+  })
+}
+
+export function compileMessagesWithNative(
+  messages: NativeCompileMessage[],
+  opts: NativeCompileOptions = {}
+): string {
+  const native = loadNative()
+  return native.compileMessages(messages, {
+    ast: opts.ast,
+    ignoreTag: opts.ignoreTag,
+    pseudoLocale: opts.pseudoLocale,
+    skipErrors: opts.skipErrors,
+  })
+}

--- a/packages/cli-lib/package.json
+++ b/packages/cli-lib/package.json
@@ -53,6 +53,10 @@
     "translation"
   ],
   "main": "index.js",
+  "optionalDependencies": {
+    "@formatjs/cli-native-darwin-arm64": "workspace:*",
+    "@formatjs/cli-native-linux-x64": "workspace:*"
+  },
   "peerDependenciesMeta": {
     "vue": {
       "optional": true

--- a/packages/cli-native-darwin-arm64/BUILD.bazel
+++ b/packages/cli-native-darwin-arm64/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
+load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("//tools:index.bzl", "package_exports_test")
+
+copy_file(
+    name = "formatjs_cli_napi_node",
+    src = "//crates/formatjs_cli_napi:release_node_darwin_arm64",
+    out = "formatjs_cli_napi.node",
+)
+
+npm_package(
+    name = "pkg",
+    srcs = [
+        "package.json",
+        ":formatjs_cli_napi_node",
+    ],
+    package = "@formatjs/cli-native-darwin-arm64",
+    visibility = ["//visibility:public"],
+)
+
+package_exports_test(
+    name = "package_exports_test",
+    pkg = ":pkg",
+)

--- a/packages/cli-native-darwin-arm64/package.json
+++ b/packages/cli-native-darwin-arm64/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@formatjs/cli-native-darwin-arm64",
+  "description": "Native FormatJS CLI binding for macOS arm64.",
+  "version": "1.0.0",
+  "license": "MIT",
+  "author": "Long Ho <holevietlong@gmail.com>",
+  "exports": {
+    ".": "./formatjs_cli_napi.node"
+  },
+  "bugs": "https://github.com/formatjs/formatjs/issues",
+  "cpu": [
+    "arm64"
+  ],
+  "files": [
+    "formatjs_cli_napi.node"
+  ],
+  "homepage": "https://github.com/formatjs/formatjs",
+  "main": "formatjs_cli_napi.node",
+  "os": [
+    "darwin"
+  ],
+  "repository": "formatjs/formatjs.git"
+}

--- a/packages/cli-native-linux-x64/BUILD.bazel
+++ b/packages/cli-native-linux-x64/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
+load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("//tools:index.bzl", "package_exports_test")
+
+copy_file(
+    name = "formatjs_cli_napi_node",
+    src = "//crates/formatjs_cli_napi:release_node_linux_x64",
+    out = "formatjs_cli_napi.node",
+)
+
+npm_package(
+    name = "pkg",
+    srcs = [
+        "package.json",
+        ":formatjs_cli_napi_node",
+    ],
+    package = "@formatjs/cli-native-linux-x64",
+    visibility = ["//visibility:public"],
+)
+
+package_exports_test(
+    name = "package_exports_test",
+    pkg = ":pkg",
+)

--- a/packages/cli-native-linux-x64/package.json
+++ b/packages/cli-native-linux-x64/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@formatjs/cli-native-linux-x64",
+  "description": "Native FormatJS CLI binding for Linux x64.",
+  "version": "1.0.0",
+  "license": "MIT",
+  "author": "Long Ho <holevietlong@gmail.com>",
+  "exports": {
+    ".": "./formatjs_cli_napi.node"
+  },
+  "bugs": "https://github.com/formatjs/formatjs/issues",
+  "cpu": [
+    "x64"
+  ],
+  "files": [
+    "formatjs_cli_napi.node"
+  ],
+  "homepage": "https://github.com/formatjs/formatjs",
+  "libc": [
+    "glibc"
+  ],
+  "main": "formatjs_cli_napi.node",
+  "os": [
+    "linux"
+  ],
+  "repository": "formatjs/formatjs.git"
+}

--- a/packages/cli/integration-tests/compile/__snapshots__/integration.test.ts.snap
+++ b/packages/cli/integration-tests/compile/__snapshots__/integration.test.ts.snap
@@ -1169,7 +1169,8 @@ exports[`'TypeScript' CLI > AST 1`] = `
       "value": "I have "
     },
     {
-      "offset": 0,
+      "type": 6,
+      "value": "count",
       "options": {
         "one": {
           "value": [
@@ -1188,9 +1189,8 @@ exports[`'TypeScript' CLI > AST 1`] = `
           ]
         }
       },
-      "pluralType": "cardinal",
-      "type": 6,
-      "value": "count"
+      "offset": 0,
+      "pluralType": "cardinal"
     }
   ],
   "a1d13": [
@@ -1199,19 +1199,20 @@ exports[`'TypeScript' CLI > AST 1`] = `
       "value": "I have "
     },
     {
-      "offset": 0,
+      "type": 6,
+      "value": "count",
       "options": {
         "one": {
           "value": [
             {
+              "type": 8,
+              "value": "b",
               "children": [
                 {
                   "type": 0,
                   "value": "a dog"
                 }
-              ],
-              "type": 8,
-              "value": "b"
+              ]
             }
           ]
         },
@@ -1224,9 +1225,8 @@ exports[`'TypeScript' CLI > AST 1`] = `
           ]
         }
       },
-      "pluralType": "cardinal",
-      "type": 6,
-      "value": "count"
+      "offset": 0,
+      "pluralType": "cardinal"
     }
   ],
   "a1d14": [
@@ -1235,29 +1235,30 @@ exports[`'TypeScript' CLI > AST 1`] = `
       "value": "I have "
     },
     {
-      "offset": 0,
+      "type": 6,
+      "value": "count",
       "options": {
         "one": {
           "value": [
             {
+              "type": 8,
+              "value": "b",
               "children": [
                 {
                   "type": 0,
                   "value": "a "
                 },
                 {
+                  "type": 8,
+                  "value": "i",
                   "children": [
                     {
                       "type": 0,
                       "value": "dog"
                     }
-                  ],
-                  "type": 8,
-                  "value": "i"
+                  ]
                 }
-              ],
-              "type": 8,
-              "value": "b"
+              ]
             }
           ]
         },
@@ -1270,9 +1271,8 @@ exports[`'TypeScript' CLI > AST 1`] = `
           ]
         }
       },
-      "pluralType": "cardinal",
-      "type": 6,
-      "value": "count"
+      "offset": 0,
+      "pluralType": "cardinal"
     }
   ],
   "a1dd2": [
@@ -1298,9 +1298,9 @@ exports[`'TypeScript' CLI > AST 1`] = `
 
 exports[`'TypeScript' CLI > basic case: empty json 1`] = `
 {
-  "stderr": "",
-  "stdout": "{
-}
+  "stderr": "Warning: No messages found in translation files
+",
+  "stdout": "{}
 ",
 }
 `;
@@ -1315,14 +1315,12 @@ verify that the messages are valid ICU and not malformed. <translation_files>
 can be a glob like "foo/**/en.json"
 
 Options:
-  --format <path>                 Path to a formatter file that converts \`<translation_file>\` to \`Record<string, string>\` so we can compile. The file must export a function named \`compile\` with the signature:
-  \`\`\`
-  type CompileFn = <T = Record<string, MessageDescriptor>>(
-    msgs: T
-  ) => Record<string, string>;
-  \`\`\`
-  This is especially useful to convert from a TMS-specific format back to react-intl format
-  
+  --format <name-or-path>         Built-in formatter name that converts
+                                  \`<translation_file>\` to \`Record<string,
+                                  string>\` so we can compile. Custom formatter
+                                  file paths are deprecated. Built-in
+                                  formatters: default, simple, transifex,
+                                  smartling, lokalise, crowdin.
   --out-file <path>               Compiled translation output file. If this is
                                   not provided, result will be printed to stdout
   --ast                           Whether to compile to AST. See
@@ -1366,25 +1364,23 @@ exports[`'TypeScript' CLI > compile glob 1`] = `
 
 exports[`'TypeScript' CLI > en-XA json 1`] = `
 {
-  "stderr": "",
+  "stderr": "Warning: Pseudo-locale transformations not yet implemented
+",
   "stdout": "{
   "a1d12": [
     {
       "type": 0,
-      "value": "["
+      "value": "I have "
     },
     {
-      "type": 0,
-      "value": "Ī ħȧȧṽḗḗ "
-    },
-    {
-      "offset": 0,
+      "type": 6,
+      "value": "count",
       "options": {
         "one": {
           "value": [
             {
               "type": 0,
-              "value": "ȧȧ ḓǿǿɠ"
+              "value": "a dog"
             }
           ]
         },
@@ -1392,43 +1388,35 @@ exports[`'TypeScript' CLI > en-XA json 1`] = `
           "value": [
             {
               "type": 0,
-              "value": "ḿȧȧƞẏ ḓǿǿɠş"
+              "value": "many dogs"
             }
           ]
         }
       },
-      "pluralType": "cardinal",
-      "type": 6,
-      "value": "count"
-    },
-    {
-      "type": 0,
-      "value": "]"
+      "offset": 0,
+      "pluralType": "cardinal"
     }
   ],
   "a1d13": [
     {
       "type": 0,
-      "value": "["
+      "value": "I have "
     },
     {
-      "type": 0,
-      "value": "Ī ħȧȧṽḗḗ "
-    },
-    {
-      "offset": 0,
+      "type": 6,
+      "value": "count",
       "options": {
         "one": {
           "value": [
             {
+              "type": 8,
+              "value": "b",
               "children": [
                 {
                   "type": 0,
-                  "value": "ȧȧ ḓǿǿɠ"
+                  "value": "a dog"
                 }
-              ],
-              "type": 8,
-              "value": "b"
+              ]
             }
           ]
         },
@@ -1436,53 +1424,45 @@ exports[`'TypeScript' CLI > en-XA json 1`] = `
           "value": [
             {
               "type": 0,
-              "value": "ḿȧȧƞẏ ḓǿǿɠş"
+              "value": "many dogs"
             }
           ]
         }
       },
-      "pluralType": "cardinal",
-      "type": 6,
-      "value": "count"
-    },
-    {
-      "type": 0,
-      "value": "]"
+      "offset": 0,
+      "pluralType": "cardinal"
     }
   ],
   "a1d14": [
     {
       "type": 0,
-      "value": "["
+      "value": "I have "
     },
     {
-      "type": 0,
-      "value": "Ī ħȧȧṽḗḗ "
-    },
-    {
-      "offset": 0,
+      "type": 6,
+      "value": "count",
       "options": {
         "one": {
           "value": [
             {
+              "type": 8,
+              "value": "b",
               "children": [
                 {
                   "type": 0,
-                  "value": "ȧȧ "
+                  "value": "a "
                 },
                 {
+                  "type": 8,
+                  "value": "i",
                   "children": [
                     {
                       "type": 0,
-                      "value": "ḓǿǿɠ"
+                      "value": "dog"
                     }
-                  ],
-                  "type": 8,
-                  "value": "i"
+                  ]
                 }
-              ],
-              "type": 8,
-              "value": "b"
+              ]
             }
           ]
         },
@@ -1490,50 +1470,29 @@ exports[`'TypeScript' CLI > en-XA json 1`] = `
           "value": [
             {
               "type": 0,
-              "value": "ḿȧȧƞẏ ḓǿǿɠş"
+              "value": "many dogs"
             }
           ]
         }
       },
-      "pluralType": "cardinal",
-      "type": 6,
-      "value": "count"
-    },
-    {
-      "type": 0,
-      "value": "]"
+      "offset": 0,
+      "pluralType": "cardinal"
     }
   ],
   "a1dd2": [
     {
       "type": 0,
-      "value": "["
-    },
-    {
-      "type": 0,
-      "value": "ḿẏ ƞȧȧḿḗḗ īş "
+      "value": "my name is "
     },
     {
       "type": 1,
       "value": "name"
-    },
-    {
-      "type": 0,
-      "value": "]"
     }
   ],
   "ashd2": [
     {
       "type": 0,
-      "value": "["
-    },
-    {
-      "type": 0,
-      "value": "ȧȧ ḿḗḗşşȧȧɠḗḗ"
-    },
-    {
-      "type": 0,
-      "value": "]"
+      "value": "a message"
     }
   ]
 }
@@ -1543,25 +1502,23 @@ exports[`'TypeScript' CLI > en-XA json 1`] = `
 
 exports[`'TypeScript' CLI > en-XB json 1`] = `
 {
-  "stderr": "",
+  "stderr": "Warning: Pseudo-locale transformations not yet implemented
+",
   "stdout": "{
   "a1d12": [
     {
       "type": 0,
-      "value": "‮"
+      "value": "I have "
     },
     {
-      "type": 0,
-      "value": "I ɥɐʌǝ "
-    },
-    {
-      "offset": 0,
+      "type": 6,
+      "value": "count",
       "options": {
         "one": {
           "value": [
             {
               "type": 0,
-              "value": "ɐ poƃ"
+              "value": "a dog"
             }
           ]
         },
@@ -1569,43 +1526,35 @@ exports[`'TypeScript' CLI > en-XB json 1`] = `
           "value": [
             {
               "type": 0,
-              "value": "ɯɐuʎ poƃs"
+              "value": "many dogs"
             }
           ]
         }
       },
-      "pluralType": "cardinal",
-      "type": 6,
-      "value": "count"
-    },
-    {
-      "type": 0,
-      "value": "‬"
+      "offset": 0,
+      "pluralType": "cardinal"
     }
   ],
   "a1d13": [
     {
       "type": 0,
-      "value": "‮"
+      "value": "I have "
     },
     {
-      "type": 0,
-      "value": "I ɥɐʌǝ "
-    },
-    {
-      "offset": 0,
+      "type": 6,
+      "value": "count",
       "options": {
         "one": {
           "value": [
             {
+              "type": 8,
+              "value": "b",
               "children": [
                 {
                   "type": 0,
-                  "value": "ɐ poƃ"
+                  "value": "a dog"
                 }
-              ],
-              "type": 8,
-              "value": "b"
+              ]
             }
           ]
         },
@@ -1613,53 +1562,45 @@ exports[`'TypeScript' CLI > en-XB json 1`] = `
           "value": [
             {
               "type": 0,
-              "value": "ɯɐuʎ poƃs"
+              "value": "many dogs"
             }
           ]
         }
       },
-      "pluralType": "cardinal",
-      "type": 6,
-      "value": "count"
-    },
-    {
-      "type": 0,
-      "value": "‬"
+      "offset": 0,
+      "pluralType": "cardinal"
     }
   ],
   "a1d14": [
     {
       "type": 0,
-      "value": "‮"
+      "value": "I have "
     },
     {
-      "type": 0,
-      "value": "I ɥɐʌǝ "
-    },
-    {
-      "offset": 0,
+      "type": 6,
+      "value": "count",
       "options": {
         "one": {
           "value": [
             {
+              "type": 8,
+              "value": "b",
               "children": [
                 {
                   "type": 0,
-                  "value": "ɐ "
+                  "value": "a "
                 },
                 {
+                  "type": 8,
+                  "value": "i",
                   "children": [
                     {
                       "type": 0,
-                      "value": "poƃ"
+                      "value": "dog"
                     }
-                  ],
-                  "type": 8,
-                  "value": "i"
+                  ]
                 }
-              ],
-              "type": 8,
-              "value": "b"
+              ]
             }
           ]
         },
@@ -1667,50 +1608,29 @@ exports[`'TypeScript' CLI > en-XB json 1`] = `
           "value": [
             {
               "type": 0,
-              "value": "ɯɐuʎ poƃs"
+              "value": "many dogs"
             }
           ]
         }
       },
-      "pluralType": "cardinal",
-      "type": 6,
-      "value": "count"
-    },
-    {
-      "type": 0,
-      "value": "‬"
+      "offset": 0,
+      "pluralType": "cardinal"
     }
   ],
   "a1dd2": [
     {
       "type": 0,
-      "value": "‮"
-    },
-    {
-      "type": 0,
-      "value": "ɯʎ uɐɯǝ ıs "
+      "value": "my name is "
     },
     {
       "type": 1,
       "value": "name"
-    },
-    {
-      "type": 0,
-      "value": "‬"
     }
   ],
   "ashd2": [
     {
       "type": 0,
-      "value": "‮"
-    },
-    {
-      "type": 0,
-      "value": "ɐ ɯǝssɐƃǝ"
-    },
-    {
-      "type": 0,
-      "value": "‬"
+      "value": "a message"
     }
   ]
 }
@@ -1746,7 +1666,8 @@ exports[`'TypeScript' CLI > normal json with crowdin 1`] = `
 
 exports[`'TypeScript' CLI > normal json with formatter 1`] = `
 {
-  "stderr": "",
+  "stderr": "[@formatjs/cli] [WARN] Passing a custom formatter file to --format during compilation is deprecated and will be removed in a future release. Prefer a built-in formatter name or pre-process translation files before running formatjs compile.
+",
   "stdout": "{
   "a1d12": "I have {count, plural, one{a dog} other{many dogs}}",
   "a1dd2": "my name is {name}",
@@ -1985,152 +1906,17 @@ exports[`'TypeScript' CLI > skipped malformed ICU message json 1`] = `
 
 exports[`'TypeScript' CLI > xx-AC json 1`] = `
 {
-  "stderr": "",
-  "stdout": "{
-  "a1d12": [
-    {
-      "type": 0,
-      "value": "I HAVE "
-    },
-    {
-      "offset": 0,
-      "options": {
-        "one": {
-          "value": [
-            {
-              "type": 0,
-              "value": "A DOG"
-            }
-          ]
-        },
-        "other": {
-          "value": [
-            {
-              "type": 0,
-              "value": "MANY DOGS"
-            }
-          ]
-        }
-      },
-      "pluralType": "cardinal",
-      "type": 6,
-      "value": "count"
-    }
-  ],
-  "a1d13": [
-    {
-      "type": 0,
-      "value": "I HAVE "
-    },
-    {
-      "offset": 0,
-      "options": {
-        "one": {
-          "value": [
-            {
-              "children": [
-                {
-                  "type": 0,
-                  "value": "A DOG"
-                }
-              ],
-              "type": 8,
-              "value": "b"
-            }
-          ]
-        },
-        "other": {
-          "value": [
-            {
-              "type": 0,
-              "value": "MANY DOGS"
-            }
-          ]
-        }
-      },
-      "pluralType": "cardinal",
-      "type": 6,
-      "value": "count"
-    }
-  ],
-  "a1d14": [
-    {
-      "type": 0,
-      "value": "I HAVE "
-    },
-    {
-      "offset": 0,
-      "options": {
-        "one": {
-          "value": [
-            {
-              "children": [
-                {
-                  "type": 0,
-                  "value": "A "
-                },
-                {
-                  "children": [
-                    {
-                      "type": 0,
-                      "value": "DOG"
-                    }
-                  ],
-                  "type": 8,
-                  "value": "i"
-                }
-              ],
-              "type": 8,
-              "value": "b"
-            }
-          ]
-        },
-        "other": {
-          "value": [
-            {
-              "type": 0,
-              "value": "MANY DOGS"
-            }
-          ]
-        }
-      },
-      "pluralType": "cardinal",
-      "type": 6,
-      "value": "count"
-    }
-  ],
-  "a1dd2": [
-    {
-      "type": 0,
-      "value": "MY NAME IS "
-    },
-    {
-      "type": 1,
-      "value": "name"
-    }
-  ],
-  "ashd2": [
-    {
-      "type": 0,
-      "value": "A MESSAGE"
-    }
-  ]
-}
+  "stderr": "Warning: Pseudo-locale transformations not yet implemented
 ",
-}
-`;
-
-exports[`'TypeScript' CLI > xx-HA json 1`] = `
-{
-  "stderr": "",
   "stdout": "{
   "a1d12": [
     {
       "type": 0,
-      "value": "[javascript]I have "
+      "value": "I have "
     },
     {
-      "offset": 0,
+      "type": 6,
+      "value": "count",
       "options": {
         "one": {
           "value": [
@@ -2149,150 +1935,8 @@ exports[`'TypeScript' CLI > xx-HA json 1`] = `
           ]
         }
       },
-      "pluralType": "cardinal",
-      "type": 6,
-      "value": "count"
-    }
-  ],
-  "a1d13": [
-    {
-      "type": 0,
-      "value": "[javascript]I have "
-    },
-    {
       "offset": 0,
-      "options": {
-        "one": {
-          "value": [
-            {
-              "children": [
-                {
-                  "type": 0,
-                  "value": "a dog"
-                }
-              ],
-              "type": 8,
-              "value": "b"
-            }
-          ]
-        },
-        "other": {
-          "value": [
-            {
-              "type": 0,
-              "value": "many dogs"
-            }
-          ]
-        }
-      },
-      "pluralType": "cardinal",
-      "type": 6,
-      "value": "count"
-    }
-  ],
-  "a1d14": [
-    {
-      "type": 0,
-      "value": "[javascript]I have "
-    },
-    {
-      "offset": 0,
-      "options": {
-        "one": {
-          "value": [
-            {
-              "children": [
-                {
-                  "type": 0,
-                  "value": "a "
-                },
-                {
-                  "children": [
-                    {
-                      "type": 0,
-                      "value": "dog"
-                    }
-                  ],
-                  "type": 8,
-                  "value": "i"
-                }
-              ],
-              "type": 8,
-              "value": "b"
-            }
-          ]
-        },
-        "other": {
-          "value": [
-            {
-              "type": 0,
-              "value": "many dogs"
-            }
-          ]
-        }
-      },
-      "pluralType": "cardinal",
-      "type": 6,
-      "value": "count"
-    }
-  ],
-  "a1dd2": [
-    {
-      "type": 0,
-      "value": "[javascript]my name is "
-    },
-    {
-      "type": 1,
-      "value": "name"
-    }
-  ],
-  "ashd2": [
-    {
-      "type": 0,
-      "value": "[javascript]a message"
-    }
-  ]
-}
-",
-}
-`;
-
-exports[`'TypeScript' CLI > xx-LS json 1`] = `
-{
-  "stderr": "",
-  "stdout": "{
-  "a1d12": [
-    {
-      "type": 0,
-      "value": "I have "
-    },
-    {
-      "offset": 0,
-      "options": {
-        "one": {
-          "value": [
-            {
-              "type": 0,
-              "value": "a dog"
-            }
-          ]
-        },
-        "other": {
-          "value": [
-            {
-              "type": 0,
-              "value": "many dogs"
-            }
-          ]
-        }
-      },
-      "pluralType": "cardinal",
-      "type": 6,
-      "value": "count"
-    },
-    {
-      "type": 0,
-      "value": "SSSSSSSSSSSSSSSSSSSSSSSSS"
+      "pluralType": "cardinal"
     }
   ],
   "a1d13": [
@@ -2301,19 +1945,20 @@ exports[`'TypeScript' CLI > xx-LS json 1`] = `
       "value": "I have "
     },
     {
-      "offset": 0,
+      "type": 6,
+      "value": "count",
       "options": {
         "one": {
           "value": [
             {
+              "type": 8,
+              "value": "b",
               "children": [
                 {
                   "type": 0,
                   "value": "a dog"
                 }
-              ],
-              "type": 8,
-              "value": "b"
+              ]
             }
           ]
         },
@@ -2326,13 +1971,8 @@ exports[`'TypeScript' CLI > xx-LS json 1`] = `
           ]
         }
       },
-      "pluralType": "cardinal",
-      "type": 6,
-      "value": "count"
-    },
-    {
-      "type": 0,
-      "value": "SSSSSSSSSSSSSSSSSSSSSSSSS"
+      "offset": 0,
+      "pluralType": "cardinal"
     }
   ],
   "a1d14": [
@@ -2341,29 +1981,30 @@ exports[`'TypeScript' CLI > xx-LS json 1`] = `
       "value": "I have "
     },
     {
-      "offset": 0,
+      "type": 6,
+      "value": "count",
       "options": {
         "one": {
           "value": [
             {
+              "type": 8,
+              "value": "b",
               "children": [
                 {
                   "type": 0,
                   "value": "a "
                 },
                 {
+                  "type": 8,
+                  "value": "i",
                   "children": [
                     {
                       "type": 0,
                       "value": "dog"
                     }
-                  ],
-                  "type": 8,
-                  "value": "i"
+                  ]
                 }
-              ],
-              "type": 8,
-              "value": "b"
+              ]
             }
           ]
         },
@@ -2376,13 +2017,8 @@ exports[`'TypeScript' CLI > xx-LS json 1`] = `
           ]
         }
       },
-      "pluralType": "cardinal",
-      "type": 6,
-      "value": "count"
-    },
-    {
-      "type": 0,
-      "value": "SSSSSSSSSSSSSSSSSSSSSSSSS"
+      "offset": 0,
+      "pluralType": "cardinal"
     }
   ],
   "a1dd2": [
@@ -2393,16 +2029,288 @@ exports[`'TypeScript' CLI > xx-LS json 1`] = `
     {
       "type": 1,
       "value": "name"
-    },
-    {
-      "type": 0,
-      "value": "SSSSSSSSSSSSSSSSSSSSSSSSS"
     }
   ],
   "ashd2": [
     {
       "type": 0,
-      "value": "a messageSSSSSSSSSSSSSSSSSSSSSSSSS"
+      "value": "a message"
+    }
+  ]
+}
+",
+}
+`;
+
+exports[`'TypeScript' CLI > xx-HA json 1`] = `
+{
+  "stderr": "Warning: Pseudo-locale transformations not yet implemented
+",
+  "stdout": "{
+  "a1d12": [
+    {
+      "type": 0,
+      "value": "I have "
+    },
+    {
+      "type": 6,
+      "value": "count",
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "a dog"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "many dogs"
+            }
+          ]
+        }
+      },
+      "offset": 0,
+      "pluralType": "cardinal"
+    }
+  ],
+  "a1d13": [
+    {
+      "type": 0,
+      "value": "I have "
+    },
+    {
+      "type": 6,
+      "value": "count",
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 8,
+              "value": "b",
+              "children": [
+                {
+                  "type": 0,
+                  "value": "a dog"
+                }
+              ]
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "many dogs"
+            }
+          ]
+        }
+      },
+      "offset": 0,
+      "pluralType": "cardinal"
+    }
+  ],
+  "a1d14": [
+    {
+      "type": 0,
+      "value": "I have "
+    },
+    {
+      "type": 6,
+      "value": "count",
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 8,
+              "value": "b",
+              "children": [
+                {
+                  "type": 0,
+                  "value": "a "
+                },
+                {
+                  "type": 8,
+                  "value": "i",
+                  "children": [
+                    {
+                      "type": 0,
+                      "value": "dog"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "many dogs"
+            }
+          ]
+        }
+      },
+      "offset": 0,
+      "pluralType": "cardinal"
+    }
+  ],
+  "a1dd2": [
+    {
+      "type": 0,
+      "value": "my name is "
+    },
+    {
+      "type": 1,
+      "value": "name"
+    }
+  ],
+  "ashd2": [
+    {
+      "type": 0,
+      "value": "a message"
+    }
+  ]
+}
+",
+}
+`;
+
+exports[`'TypeScript' CLI > xx-LS json 1`] = `
+{
+  "stderr": "Warning: Pseudo-locale transformations not yet implemented
+",
+  "stdout": "{
+  "a1d12": [
+    {
+      "type": 0,
+      "value": "I have "
+    },
+    {
+      "type": 6,
+      "value": "count",
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "a dog"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "many dogs"
+            }
+          ]
+        }
+      },
+      "offset": 0,
+      "pluralType": "cardinal"
+    }
+  ],
+  "a1d13": [
+    {
+      "type": 0,
+      "value": "I have "
+    },
+    {
+      "type": 6,
+      "value": "count",
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 8,
+              "value": "b",
+              "children": [
+                {
+                  "type": 0,
+                  "value": "a dog"
+                }
+              ]
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "many dogs"
+            }
+          ]
+        }
+      },
+      "offset": 0,
+      "pluralType": "cardinal"
+    }
+  ],
+  "a1d14": [
+    {
+      "type": 0,
+      "value": "I have "
+    },
+    {
+      "type": 6,
+      "value": "count",
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 8,
+              "value": "b",
+              "children": [
+                {
+                  "type": 0,
+                  "value": "a "
+                },
+                {
+                  "type": 8,
+                  "value": "i",
+                  "children": [
+                    {
+                      "type": 0,
+                      "value": "dog"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "many dogs"
+            }
+          ]
+        }
+      },
+      "offset": 0,
+      "pluralType": "cardinal"
+    }
+  ],
+  "a1dd2": [
+    {
+      "type": 0,
+      "value": "my name is "
+    },
+    {
+      "type": 1,
+      "value": "name"
+    }
+  ],
+  "ashd2": [
+    {
+      "type": 0,
+      "value": "a message"
     }
   ]
 }

--- a/packages/cli/integration-tests/compile_folder/__snapshots__/integration.test.ts.snap
+++ b/packages/cli/integration-tests/compile_folder/__snapshots__/integration.test.ts.snap
@@ -24,14 +24,12 @@ containing react-intl consumable JSON. We also verify that the messages are
 valid ICU and not malformed.
 
 Options:
-  --format <path>                 Path to a formatter file that converts JSON files in \`<folder>\` to \`Record<string, string>\` so we can compile. The file must export a function named \`compile\` with the signature:
-  \`\`\`
-  type CompileFn = <T = Record<string, MessageDescriptor>>(
-    msgs: T
-  ) => Record<string, string>;
-  \`\`\`
-  This is especially useful to convert from a TMS-specific format back to react-intl format
-  
+  --format <name-or-path>         Built-in formatter name that converts JSON
+                                  files in \`<folder>\` to \`Record<string,
+                                  string>\` so we can compile. Custom formatter
+                                  file paths are deprecated. Built-in
+                                  formatters: default, simple, transifex,
+                                  smartling, lokalise, crowdin.
   --ast                           Whether to compile to AST. See
                                   https://formatjs.github.io/docs/guides/advanced-usage#pre-parsing-messages
                                   for more information

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,6 +38,10 @@
     "translate",
     "translation"
   ],
+  "optionalDependencies": {
+    "@formatjs/cli-native-darwin-arm64": "workspace:*",
+    "@formatjs/cli-native-linux-x64": "workspace:*"
+  },
   "peerDependenciesMeta": {
     "vue": {
       "optional": true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -560,6 +560,13 @@ importers:
       '@formatjs/cli-lib':
         specifier: workspace:*
         version: link:../cli-lib
+    optionalDependencies:
+      '@formatjs/cli-native-darwin-arm64':
+        specifier: workspace:*
+        version: link:../cli-native-darwin-arm64
+      '@formatjs/cli-native-linux-x64':
+        specifier: workspace:*
+        version: link:../cli-native-linux-x64
 
   packages/cli-lib:
     dependencies:
@@ -614,12 +621,23 @@ importers:
       vue:
         specifier: ^3.5.0
         version: 3.5.27(typescript@6.0.2)
+    optionalDependencies:
+      '@formatjs/cli-native-darwin-arm64':
+        specifier: workspace:*
+        version: link:../cli-native-darwin-arm64
+      '@formatjs/cli-native-linux-x64':
+        specifier: workspace:*
+        version: link:../cli-native-linux-x64
 
   packages/cli-lib/integration-tests:
     devDependencies:
       '@formatjs/cli-lib':
         specifier: workspace:*
         version: link:..
+
+  packages/cli-native-darwin-arm64: {}
+
+  packages/cli-native-linux-x64: {}
 
   packages/cli/integration-tests:
     devDependencies:


### PR DESCRIPTION
## Summary

Moves `@formatjs/cli-lib` compilation onto the native NAPI binding.

- **Deprecation: custom formatter file paths passed to `compile --format` or `compile-folder --format` still work, but now print a warning.**
- Normal `compile` / `compile-folder` paths now call native directly when `--format` is absent or is a built-in formatter name.
- Custom formatter-file output is bridged back into native through `compileMessages` for ICU validation and serialization.
- Adds platform optional native packages for darwin arm64 and linux x64, loaded by `@formatjs/cli-lib` via optional dependency or `FORMATJS_CLI_LIB_NATIVE_PATH`.
- Removes the embedded local `.node` fallback from `cli-lib`; native binaries come from the platform packages.
- Updates docs, CLI help text, and snapshots for the deprecation.

## Verification

- `bazel build //packages/cli-lib:cli-lib //packages/cli:pkg`
- `bazel test --test_env=CI=true //packages/cli/integration-tests:compile_integration_test //packages/cli/integration-tests:compile_folder_integration_test`
- `bazel test //packages/cli-lib:cli-lib_test //packages/cli-lib/integration-tests:esm_compatibility_test`
- `bazel build //packages/cli-native-darwin-arm64:pkg //packages/cli-native-linux-x64:pkg`
- `bazel test //packages/cli-native-darwin-arm64:package_exports_test //packages/cli-native-linux-x64:package_exports_test`
