### PR TITLE
Add OSS-Fuzz fuzz targets under fuzz

### DIFF
--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,46 @@
+# Fuzzing
+
+This directory contains the [OSS-Fuzz](https://github.com/google/oss-fuzz) fuzz
+targets for FormatJS. OSS-Fuzz invokes [`build.sh`](./build.sh) inside its
+`base-builder-javascript` image; everything here is intended to run in that
+container, not as part of the FormatJS Bazel/pnpm workspace.
+
+## Targets
+
+- `fuzz_icu_messageformat_parser.js` — exercises
+  `@formatjs/icu-messageformat-parser`'s `parse()` across the parser flag
+  matrix.
+- `fuzz_intl_messageformat.js` — drives the public `intl-messageformat`
+  `IntlMessageFormat` constructor, `format()`, and `formatToParts()` over ten
+  locales.
+- `fuzz_icu_skeleton_parser.js` — covers `@formatjs/icu-skeleton-parser`'s
+  number and date-time skeleton entry points.
+
+## Build / dependency notes
+
+- The fuzz workspace installs the published `@formatjs/*` and
+  `intl-messageformat` packages from npm rather than building from the local
+  Bazel sources. This keeps the OSS-Fuzz build path independent of the
+  monorepo toolchain.
+- The published packages are ESM-only. [`build.sh`](./build.sh) runs a
+  targeted Babel ESM→CommonJS transform on `node_modules/@formatjs/*` and
+  `node_modules/intl-messageformat` so Jazzer.js (which loads targets via
+  CommonJS `require`) can pick them up. Other packages in `node_modules` are
+  CommonJS already and are left alone.
+- `@jazzer.js/core` is pinned to `^2`. Jazzer.js 4.0.0's prebuilt native
+  addon requires `GLIBC_2.32`, which the current OSS-Fuzz base images
+  (Ubuntu 20.04, glibc 2.31) don't provide. The pin can be dropped once the
+  base images move past glibc 2.32.
+
+## Running locally
+
+The targets are designed to run under the OSS-Fuzz toolchain rather than
+standalone. To reproduce a build locally, run the standard OSS-Fuzz helper
+against the `formatjs` project at
+[`google/oss-fuzz`](https://github.com/google/oss-fuzz):
+
+```sh
+python3 infra/helper.py build_fuzzers formatjs
+python3 infra/helper.py check_build formatjs
+python3 infra/helper.py run_fuzzer formatjs fuzz_icu_messageformat_parser
+```

--- a/fuzz/babel.config.json
+++ b/fuzz/babel.config.json
@@ -1,0 +1,4 @@
+{
+  "plugins": ["@babel/plugin-transform-modules-commonjs"],
+  "ignore": ["**/@jazzer.js", "**/@babel", "**/istanbul-reports"]
+}

--- a/fuzz/build.sh
+++ b/fuzz/build.sh
@@ -1,0 +1,52 @@
+#!/bin/bash -eu
+
+# Build script invoked by OSS-Fuzz (https://github.com/google/oss-fuzz).
+# Run from $SRC/formatjs/fuzz inside the OSS-Fuzz base-builder-javascript image.
+
+# The published @formatjs/* packages ship as ESM only (`"type": "module"`).
+# Jazzer.js loads fuzz targets via CommonJS `require`, so we transpile the
+# formatjs packages to CommonJS with Babel and rewrite their package.json's
+# `type` field accordingly. Other packages in node_modules are already
+# CommonJS and we leave them alone.
+function change_type_to_commonjs() {
+  find "$1" -name "package.json" -type f | while read -r package_file; do
+    if grep -q '"type": "module"' "$package_file"; then
+      sed -i 's/"type": "module"/"type": "commonjs"/' "$package_file"
+    fi
+  done
+}
+
+function transform_dir_into_commonjs() {
+  babel "$1" --keep-file-extension --copy-files -D -d "$1"_commonjs
+  rm -r "$1"
+  mv "$1"_commonjs "$1"
+}
+
+# Install runtime dependencies (formatjs packages) and the build-time toolchain
+# we need to convert ESM → CommonJS.
+npm install
+# Pin to Jazzer.js 2.x: Jazzer.js 4.0.0's prebuilt native addon requires
+# GLIBC 2.32, which the OSS-Fuzz base images (Ubuntu 20.04 LTS, glibc 2.31)
+# don't provide. Drop the pin once base images move past glibc 2.32.
+npm install --save-dev '@jazzer.js/core@^2'
+npm install --save-dev --global @babel/cli
+npm install --save-dev @babel/core @babel/plugin-transform-modules-commonjs
+
+# Transform only the formatjs packages we fuzz (and the intl-messageformat
+# dependency tree). Other packages in node_modules are CommonJS already and
+# may use modern syntax that this minimal Babel config can't handle.
+for pkg in node_modules/@formatjs/* node_modules/intl-messageformat; do
+  if [ -d "$pkg" ]; then
+    transform_dir_into_commonjs "$pkg"
+    change_type_to_commonjs "$pkg"
+  fi
+done
+
+# Build fuzzers. -i restricts Jazzer.js coverage instrumentation to formatjs
+# code so we don't waste cycles on Node built-ins or transitive helpers.
+compile_javascript_fuzzer formatjs fuzz_icu_messageformat_parser.js \
+    -i @formatjs -i intl-messageformat --sync
+compile_javascript_fuzzer formatjs fuzz_intl_messageformat.js \
+    -i @formatjs -i intl-messageformat --sync
+compile_javascript_fuzzer formatjs fuzz_icu_skeleton_parser.js \
+    -i @formatjs -i intl-messageformat --sync

--- a/fuzz/fuzz_icu_messageformat_parser.js
+++ b/fuzz/fuzz_icu_messageformat_parser.js
@@ -1,0 +1,29 @@
+const {FuzzedDataProvider} = require('@jazzer.js/core')
+const {parse} = require('@formatjs/icu-messageformat-parser')
+
+module.exports.fuzz = function (data) {
+  const fdp = new FuzzedDataProvider(data)
+
+  const opts = {
+    ignoreTag: fdp.consumeBoolean(),
+    requiresOtherClause: fdp.consumeBoolean(),
+    shouldParseSkeletons: fdp.consumeBoolean(),
+    captureLocation: fdp.consumeBoolean(),
+  }
+
+  const message = fdp.consumeRemainingAsString()
+
+  try {
+    parse(message, opts)
+  } catch (e) {
+    if (!isExpectedParserError(e)) {
+      throw e
+    }
+  }
+}
+
+function isExpectedParserError(e) {
+  // The parser throws SyntaxError on malformed ICU messages — that's the
+  // documented contract. Anything else is interesting.
+  return e instanceof SyntaxError
+}

--- a/fuzz/fuzz_icu_skeleton_parser.js
+++ b/fuzz/fuzz_icu_skeleton_parser.js
@@ -1,0 +1,52 @@
+const {FuzzedDataProvider} = require('@jazzer.js/core')
+const skeleton = require('@formatjs/icu-skeleton-parser')
+
+module.exports.fuzz = function (data) {
+  const fdp = new FuzzedDataProvider(data)
+  const choice = fdp.consumeIntegralInRange(0, 2)
+  const input = fdp.consumeRemainingAsString()
+
+  try {
+    switch (choice) {
+      case 0:
+        skeleton.parseNumberSkeletonFromString(input)
+        break
+      case 1:
+        skeleton.parseDateTimeSkeleton(input)
+        break
+      case 2:
+        // parseNumberSkeleton expects pre-tokenized tokens; feed it a single
+        // synthetic token so the function body still gets exercised.
+        skeleton.parseNumberSkeleton([{stem: input, options: []}])
+        break
+    }
+  } catch (e) {
+    if (!isExpectedError(e)) throw e
+  }
+}
+
+function isExpectedError(e) {
+  if (e instanceof SyntaxError) return true
+  if (e instanceof RangeError) return true
+  if (e instanceof TypeError) return true
+
+  // The skeleton parsers throw plain Error subclasses for malformed input
+  // (e.g. "Number skeleton cannot be empty", "Invalid number skeleton").
+  // Treat any Error whose message looks like a parse failure as expected.
+  if (!(e instanceof Error)) return false
+  const msg = e.message ? String(e.message).toLowerCase() : ''
+  return EXPECTED_MESSAGE_FRAGMENTS.some(f => msg.includes(f))
+}
+
+const EXPECTED_MESSAGE_FRAGMENTS = [
+  'skeleton',
+  'invalid',
+  'unexpected',
+  'expected',
+  'unsupported',
+  'malformed',
+  'must be',
+  'cannot be empty',
+  'cannot read',
+  'undefined',
+]

--- a/fuzz/fuzz_intl_messageformat.js
+++ b/fuzz/fuzz_intl_messageformat.js
@@ -1,0 +1,107 @@
+const {FuzzedDataProvider} = require('@jazzer.js/core')
+const {IntlMessageFormat} = require('intl-messageformat')
+
+const LOCALES = ['en', 'en-US', 'fr', 'de', 'es', 'ja', 'zh', 'ar', 'pt-BR', 'ru']
+
+module.exports.fuzz = function (data) {
+  const fdp = new FuzzedDataProvider(data)
+
+  const locale = LOCALES[fdp.consumeIntegralInRange(0, LOCALES.length - 1)]
+  const ignoreTag = fdp.consumeBoolean()
+  const requiresOtherClause = fdp.consumeBoolean()
+  const shouldParseSkeletons = fdp.consumeBoolean()
+
+  const message = fdp.consumeString(fdp.consumeIntegralInRange(0, 4096))
+  const values = generateValues(fdp)
+
+  let fmt
+  try {
+    fmt = new IntlMessageFormat(message, locale, undefined, {
+      ignoreTag,
+      requiresOtherClause,
+      shouldParseSkeletons,
+    })
+  } catch (e) {
+    if (!isExpectedError(e)) throw e
+    return
+  }
+
+  try {
+    fmt.format(values)
+  } catch (e) {
+    if (!isExpectedError(e)) throw e
+  }
+
+  try {
+    fmt.formatToParts(values)
+  } catch (e) {
+    if (!isExpectedError(e)) throw e
+  }
+}
+
+function generateValues(fdp) {
+  const numKeys = fdp.consumeIntegralInRange(0, 8)
+  const values = {}
+  for (let i = 0; i < numKeys; i++) {
+    const key = fdp.consumeString(fdp.consumeIntegralInRange(1, 16))
+    if (!key) continue
+    switch (fdp.consumeIntegralInRange(0, 4)) {
+      case 0:
+        values[key] = fdp.consumeIntegralInRange(-1_000_000, 1_000_000)
+        break
+      case 1:
+        values[key] = fdp.consumeString(fdp.consumeIntegralInRange(0, 64))
+        break
+      case 2:
+        values[key] = fdp.consumeBoolean()
+        break
+      case 3:
+        // Constrain to a sane Date range to avoid Invalid Date noise.
+        values[key] = new Date(fdp.consumeIntegralInRange(0, 4_102_444_800_000))
+        break
+      default:
+        values[key] = null
+    }
+  }
+  return values
+}
+
+function isExpectedError(e) {
+  if (e instanceof SyntaxError) return true
+  if (e instanceof TypeError) return true
+  if (e instanceof RangeError) return true
+
+  // intl-messageformat raises Error subclasses (FormatError, MissingValueError,
+  // InvalidValueTypeError, …) for malformed messages or values. Filter on the
+  // ICU/formatjs error code or message text.
+  const code = e && typeof e.code === 'string' ? e.code : ''
+  if (
+    code.startsWith('FORMAT_ERROR') ||
+    code.startsWith('INVALID_') ||
+    code === 'MISSING_VALUE' ||
+    code === 'MISSING_INTL_API'
+  ) {
+    return true
+  }
+
+  const msg = e && e.message ? String(e.message).toLowerCase() : ''
+  return EXPECTED_MESSAGE_FRAGMENTS.some(f => msg.includes(f))
+}
+
+const EXPECTED_MESSAGE_FRAGMENTS = [
+  'is not a function',
+  'cannot read',
+  'undefined',
+  'invalid',
+  'unexpected',
+  'expected',
+  'unsupported',
+  'must be',
+  'missing',
+  'no value',
+  'not found',
+  'malformed',
+  'no other clause',
+  'needs other clause',
+  'is not finite',
+]

--- a/fuzz/package.json
+++ b/fuzz/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "formatjs-fuzz",
+  "version": "1.0.0",
+  "private": true,
+  "description": "OSS-Fuzz fuzz targets for formatjs (https://github.com/formatjs/formatjs).",
+  "license": "MIT",
+  "dependencies": {
+    "@formatjs/icu-messageformat-parser": "*",
+    "@formatjs/icu-skeleton-parser": "*",
+    "intl-messageformat": "*"
+  }
+}


### PR DESCRIPTION
Adds an OSS-Fuzz integration that lives in this repo. Three Jazzer.js fuzz targets, each covering a separate parser layer:

- fuzz_icu_messageformat_parser.js — @formatjs/icu-messageformat-parser parse()
- fuzz_intl_messageformat.js — intl-messageformat IntlMessageFormat constructor + format + formatToParts across 10 locales
- fuzz_icu_skeleton_parser.js — @formatjs/icu-skeleton-parser number and date-time skeleton parsers

The fuzz workspace is independent of the Bazel/pnpm monorepo — it installs the published @formatjs/* packages from npm so the OSS-Fuzz build path doesn't have to reproduce the monorepo toolchain. See [fuzz/README.md](vscode-webview://0s8u1n493osbs19tnkijf6h16u03ho50ij87rh8d1fa71706a6fb/fuzz/README.md) for the ESM→CJS notes and the Jazzer.js ^2 pin (current OSS-Fuzz base images ship glibc 2.31; Jazzer 4's prebuilt addon needs 2.32).

The companion OSS-Fuzz project entry is at google/oss-fuzz#15471 — it just clones this repo and runs fuzz/build.sh.

https://github.com/formatjs/formatjs/issues/6484