### PR TITLE
build: require Renovate updates to be 7 days old

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "semanticCommitType": "build",
+  "minimumReleaseAge": "7 days",
+  "internalChecksFilter": "strict",
   "ignorePaths": [
     "**/node_modules/**",
     "packages/react-intl/example-sandboxes/**"


### PR DESCRIPTION
## Summary
- configure Renovate to wait 7 days before proposing package version bumps
- require internal checks to pass before creating update branches/PRs

## Test
- node -e "JSON.parse(require('fs').readFileSync('renovate.json','utf8')); console.log('renovate.json is valid JSON')"