### PR TITLE
build: configure BuildBuddy RBE

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -67,22 +67,25 @@ run --incompatible_strict_action_env
 build --define=NODE_OPTIONS=--max-old-space-size=4096
 build --build_metadata=REPO_URL=https://github.com/formatjs/formatjs.git
 
-# BuildBuddy GH Actions Config
+# BuildBuddy RBE GH Actions Config
 # https://www.buildbuddy.io/docs/rbe-github-actions
 build:ci --build_metadata=ROLE=CI
 build:ci --build_metadata=VISIBILITY=PUBLIC
-build:ci --config=remote
-build:remote --bes_backend=grpcs://formatjs.buildbuddy.io
-build:remote --bes_results_url=https://formatjs.buildbuddy.io/invocation/
-build:remote --define=EXECUTOR=remote
-build:remote --extra_execution_platforms=//platforms:buildbuddy_linux_x86_64_gnu
-build:remote --jobs=50
-build:remote --platforms=//platforms:buildbuddy_linux_x86_64_gnu
-build:remote --remote_cache=grpcs://formatjs.buildbuddy.io
-build:remote --remote_executor=grpcs://formatjs.buildbuddy.io
-build:remote --remote_timeout=10m
+build:ci --config=rbe
+build:rbe --bes_backend=grpcs://formatjs.buildbuddy.io
+build:rbe --bes_results_url=https://formatjs.buildbuddy.io/invocation/
+build:rbe --define=EXECUTOR=rbe
+build:rbe --extra_execution_platforms=//platforms:buildbuddy_linux_x86_64_gnu
+build:rbe --jobs=50
+build:rbe --platforms=//platforms:buildbuddy_linux_x86_64_gnu
+build:rbe --remote_cache=grpcs://formatjs.buildbuddy.io
+build:rbe --remote_executor=grpcs://formatjs.buildbuddy.io
+build:rbe --remote_timeout=10m
 
-# BuildBuddy config for macOS CI - remote cache only, no remote execution
+# Keep the old config name as an alias for existing local workflows.
+build:remote --config=rbe
+
+# BuildBuddy config for macOS CI - remote cache only, no RBE
 build:ci-darwin --build_metadata=ROLE=CI
 build:ci-darwin --build_metadata=VISIBILITY=PUBLIC
 build:ci-darwin --bes_backend=grpcs://formatjs.buildbuddy.io

--- a/knowledge-base/001a-bazel-toolchain.md
+++ b/knowledge-base/001a-bazel-toolchain.md
@@ -30,7 +30,7 @@ actions so they can cache and run independently across the monorepo.
 | `rules_rs`              | 0.0.61 + archive override | Rust compilation, crates, wasm                    |
 | `llvm`                  | 0.7.5                     | LLVM toolchain support for Rust/wasm paths        |
 | `rules_java`            | 9.6.1                     | Java toolchain for ICU4J conformance tests        |
-| `toolchains_buildbuddy` | 0.0.4                     | Remote execution C/C++ toolchain                  |
+| `toolchains_buildbuddy` | 0.0.4                     | BuildBuddy RBE C/C++ toolchain                    |
 
 `gazelle_ts` is overridden to commit
 `e3579a043d2639b85877c051f3fedd2095a4b1a2` for the post-0.3.3 abstract-kind
@@ -47,11 +47,11 @@ to the v0.0.61 GitHub release because it is not available from BCR yet.
 - Go SDK is pinned to **1.24.12**.
 - Rust is pinned to **1.95.0**, edition **2024**, through `rules_rs`.
 
-## Remote Cache & Execution
+## Remote Cache & RBE
 
 - **Remote cache:** `grpcs://formatjs.buildbuddy.io`
-- **Linux CI:** `--config=ci` expands to `--config=remote`, enabling remote
-  execution and remote cache.
+- **Linux CI:** `--config=ci` expands to `--config=rbe`, enabling BuildBuddy RBE
+  and remote cache.
 - **macOS CI:** `--config=ci-darwin` uses BuildBuddy BES and remote cache only.
 - **Remote platform:** `//platforms:buildbuddy_linux_x86_64_gnu` with
   `@toolchains_buildbuddy//toolchains/cc:ubuntu_gcc_x86_64`.


### PR DESCRIPTION
## Summary
- rename the BuildBuddy CI config from remote to rbe
- set EXECUTOR=rbe while keeping the old remote config as an alias
- update the Bazel toolchain docs to describe BuildBuddy RBE

## Test
- bazel --output_user_root=/private/tmp/formatjs-pr-bazel-output info --config=ci