### PR TITLE
build: include native packages in release dist

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -79,6 +79,8 @@ PACKAGES_TO_DIST = [
     "//packages/babel-plugin-formatjs",
     "//packages/bigdecimal",
     "//packages/cli-lib",
+    "//packages/cli-native-darwin-arm64",
+    "//packages/cli-native-linux-x64",
     "//packages/cli",
     "//packages/ecma376",
     "//packages/eslint-plugin-formatjs",


### PR DESCRIPTION
## Summary

- Include `@formatjs/cli-native-darwin-arm64` and `@formatjs/cli-native-linux-x64` in the Bazel release dist.
- Fix release publish workspaces so `@formatjs/cli` and `@formatjs/cli-lib` can resolve their native `workspace:*` optional dependencies.

## Verification

- `bazel build :dist`
- Confirmed `bazel-bin/formatjs_dist/packages/cli-native-{darwin-arm64,linux-x64}` contains `package.json` and `formatjs_cli_napi.node`.
