### PR TITLE
build: enable RBE for BuildBuddy workflows

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -10,5 +10,5 @@ actions:
       memory: 10GB
       disk: 16GB
     bazel_commands:
-      - 'test //...'
-      - 'build --compilation_mode=opt //crates/formatjs_cli'
+      - 'test --config=ci //...'
+      - 'build --config=ci --compilation_mode=opt //crates/formatjs_cli'


### PR DESCRIPTION
## Summary
- pass --config=ci in buildbuddy.yaml workflow bazel commands
- ensure BuildBuddy Workflows load the .bazelrc RBE config with --remote_executor

## Debugging
- latest main already has --config=ci -> --config=rbe and --remote_executor in .bazelrc
- buildbuddy.yaml still ran plain `test //...` and `build --compilation_mode=opt ...`, bypassing that config

## Verification
- ruby -e 'require "yaml"; YAML.load_file("buildbuddy.yaml"); puts "buildbuddy.yaml ok"'
- git diff --check
- bazel --output_user_root=/private/tmp/formatjs-buildbuddy-yaml-bazel-output --nosystem_rc --nohome_rc --noworkspace_rc --bazelrc=/private/tmp/formatjs-main-no-user.bazelrc info --config=ci