### PR TITLE
build: minimize BuildBuddy workflow downloads

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -10,5 +10,5 @@ actions:
       memory: 10GB
       disk: 16GB
     bazel_commands:
-      - 'test --config=ci //...'
-      - 'build --config=ci --compilation_mode=opt //crates/formatjs_cli'
+      - 'test --config=ci --remote_download_minimal //...'
+      - 'build --config=ci --remote_download_minimal --compilation_mode=opt //crates/formatjs_cli'


### PR DESCRIPTION
## Summary
- add --remote_download_minimal to BuildBuddy workflow Bazel commands
- scope the flag to buildbuddy.yaml so GitHub Actions release/dist flows are unaffected

## Context
- latest BuildBuddy logs still fail with No space left on device under /home/buildbuddy/workspace/output-base
- the failures happen while materializing runfiles, npm package outputs, and repository/toolchain state on the workflow runner

## Verification
- ruby -e 'require "yaml"; YAML.load_file("buildbuddy.yaml"); puts "buildbuddy.yaml ok"'
- git diff --check