### PR TITLE
build: trigger BuildBuddy workflows for PRs

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -77,6 +77,9 @@ build:ci --build_metadata=ROLE=CI
 build:ci --build_metadata=VISIBILITY=PUBLIC
 build:ci --config=rbe
 build:ci --remote_upload_local_results
+build:bb-workflow --build_metadata=ROLE=BB_WORKFLOW
+build:bb-workflow --build_metadata=VISIBILITY=PUBLIC
+build:bb-workflow --config=rbe
 build:rbe --bes_backend=grpcs://formatjs.buildbuddy.io
 build:rbe --bes_results_url=https://formatjs.buildbuddy.io/invocation/
 build:rbe --define=EXECUTOR=rbe

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -6,9 +6,12 @@ actions:
         branches:
           - 'main'
           - 'gh-readonly-queue/*'
+      pull_request:
+        branches:
+          - 'main'
     resource_requests:
       memory: 10GB
       disk: 16GB
     bazel_commands:
-      - 'test --config=ci --remote_download_minimal //...'
-      - 'build --config=ci --remote_download_minimal --compilation_mode=opt //crates/formatjs_cli'
+      - 'test --config=bb-workflow --remote_download_minimal //...'
+      - 'build --config=bb-workflow --remote_download_minimal --compilation_mode=opt //crates/formatjs_cli'


### PR DESCRIPTION
## Summary
- add a BuildBuddy Workflow pull_request trigger for PRs targeting main
- add a dedicated bb-workflow Bazel config that selects the shared RBE settings without relying on GitHub Actions secrets
- switch buildbuddy.yaml commands from --config=ci to --config=bb-workflow

## Context
BuildBuddy Workflows can run on pull_request events and report a GitHub status. This gives OSS PRs a BuildBuddy path without exposing BUILDBUDDY_ORG_API_KEY through GitHub Actions.

## Verification
- ruby -e 'require "yaml"; YAML.load_file("buildbuddy.yaml"); puts "buildbuddy.yaml ok"'
- git diff --check
- bazel --output_user_root=/private/tmp/formatjs-bb-workflow-bazel-output --nosystem_rc --nohome_rc --noworkspace_rc --bazelrc=/private/tmp/formatjs-bb-workflow-no-user.bazelrc info --config=bb-workflow