### PR TITLE
build: use public BuildBuddy workflow config

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -77,9 +77,11 @@ build:ci --build_metadata=ROLE=CI
 build:ci --build_metadata=VISIBILITY=PUBLIC
 build:ci --config=rbe
 build:ci --remote_upload_local_results
+
+# BuildBuddy Workflows can be triggered by public fork PRs where org secrets are
+# unavailable, so keep this config off authenticated remote cache / RBE.
 build:bb-workflow --build_metadata=ROLE=BB_WORKFLOW
 build:bb-workflow --build_metadata=VISIBILITY=PUBLIC
-build:bb-workflow --config=rbe
 build:rbe --bes_backend=grpcs://formatjs.buildbuddy.io
 build:rbe --bes_results_url=https://formatjs.buildbuddy.io/invocation/
 build:rbe --define=EXECUTOR=rbe

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -11,7 +11,7 @@ actions:
           - 'main'
     resource_requests:
       memory: 10GB
-      disk: 16GB
+      disk: 64GB
     bazel_commands:
-      - 'test --config=bb-workflow --remote_download_minimal //...'
-      - 'build --config=bb-workflow --remote_download_minimal --compilation_mode=opt //crates/formatjs_cli'
+      - 'test --config=bb-workflow //...'
+      - 'build --config=bb-workflow --compilation_mode=opt //crates/formatjs_cli'


### PR DESCRIPTION
## Summary
- keep BuildBuddy workflow PR runs off authenticated RBE/remote cache
- remove remote download minimal from workflow commands since public PR workflows now run locally
- raise BuildBuddy workflow disk to 64GB for local execution headroom

## Test plan
- ruby -e 'require "yaml"; YAML.load_file("buildbuddy.yaml"); puts "buildbuddy.yaml ok"'
- git diff --check
- bazel --output_user_root=/private/tmp/formatjs-bb-public-bazel-output --nosystem_rc --nohome_rc --noworkspace_rc --bazelrc=/private/tmp/formatjs-bb-public.bazelrc info --config=bb-workflow