### PR TITLE
fix(@formatjs/intl-numberformat): expose rounding resolved options

### DIFF
--- a/packages/intl-numberformat/core.ts
+++ b/packages/intl-numberformat/core.ts
@@ -47,6 +47,9 @@ const RESOLVED_OPTIONS_KEYS = [
   'notation',
   'compactDisplay',
   'signDisplay',
+  'roundingIncrement',
+  'roundingMode',
+  'trailingZeroDisplay',
 ] as const
 
 /**

--- a/packages/intl-numberformat/tests/misc.test.ts
+++ b/packages/intl-numberformat/tests/misc.test.ts
@@ -334,9 +334,12 @@ it('correctly set default options', () => {
     minimumIntegerDigits: 1,
     notation: 'standard',
     numberingSystem: 'latn',
+    roundingIncrement: 1,
+    roundingMode: 'halfExpand',
     roundingPriority: 'auto',
     signDisplay: 'auto',
     style: 'decimal',
+    trailingZeroDisplay: 'auto',
     useGrouping: 'auto',
   })
 })
@@ -436,6 +439,21 @@ test('#4359 roundingIncrement with fraction digits', () => {
   expect(nf.format(1.234)).toBe('1.25')
   expect(nf.format(1.222)).toBe('1.20')
   expect(nf.format(1.227)).toBe('1.25')
+})
+
+test('resolvedOptions includes rounding options', () => {
+  const resolved = new NumberFormat('en-US', {
+    roundingIncrement: 5,
+    roundingMode: 'ceil',
+    trailingZeroDisplay: 'stripIfInteger',
+    maximumFractionDigits: 2,
+    minimumFractionDigits: 2,
+  }).resolvedOptions()
+
+  expect(resolved.roundingIncrement).toBe(5)
+  expect(resolved.roundingMode).toBe('ceil')
+  expect(resolved.roundingPriority).toBe('auto')
+  expect(resolved.trailingZeroDisplay).toBe('stripIfInteger')
 })
 
 // https://github.com/formatjs/formatjs/issues/4236

--- a/packages/intl-numberformat/tests/misc.test.ts
+++ b/packages/intl-numberformat/tests/misc.test.ts
@@ -442,18 +442,21 @@ test('#4359 roundingIncrement with fraction digits', () => {
 })
 
 test('resolvedOptions includes rounding options', () => {
-  const resolved = new NumberFormat('en-US', {
+  const nf = new NumberFormat('en-US', {
     roundingIncrement: 5,
     roundingMode: 'ceil',
     trailingZeroDisplay: 'stripIfInteger',
     maximumFractionDigits: 2,
     minimumFractionDigits: 2,
-  }).resolvedOptions()
+  })
+  const resolved = nf.resolvedOptions()
 
   expect(resolved.roundingIncrement).toBe(5)
   expect(resolved.roundingMode).toBe('ceil')
   expect(resolved.roundingPriority).toBe('auto')
   expect(resolved.trailingZeroDisplay).toBe('stripIfInteger')
+  expect(nf.format(1.221)).toBe('1.25')
+  expect(nf.format(1)).toBe('1')
 })
 
 // https://github.com/formatjs/formatjs/issues/4236


### PR DESCRIPTION
## Summary
- include roundingIncrement, roundingMode, and trailingZeroDisplay in Intl.NumberFormat.prototype.resolvedOptions()
- add coverage for explicit and default rounding resolved options

## Spec
- ECMA-402: [Intl.NumberFormat.prototype.resolvedOptions](https://tc39.es/ecma402/#sec-intl.numberformat.prototype.resolvedoptions)
- ECMA-402: [Resolved Options of NumberFormat Instances](https://tc39.es/ecma402/#table-intl-numberformat-resolvedoptions)

## Test
- bazel test //packages/intl-numberformat:misc_tests