### PR TITLE
docs(@formatjs/intl-collator): document missing ECMA-402 polyfill

### DIFF
--- a/packages/intl-collator/README.md
+++ b/packages/intl-collator/README.md
@@ -1,0 +1,14 @@
+# Intl.Collator
+
+`Intl.Collator` is part of the current ECMA-402 surface, but FormatJS does not
+currently ship a data-backed collator polyfill.
+
+This package directory tracks that gap explicitly. A complete implementation
+needs locale-sensitive collation data and comparison semantics for:
+
+- `Intl.Collator`
+- `Intl.Collator.supportedLocalesOf`
+- `Intl.Collator.prototype.compare`
+- `Intl.Collator.prototype.resolvedOptions`
+- `String.prototype.localeCompare`
+

--- a/packages/intl-collator/package.json
+++ b/packages/intl-collator/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@formatjs/intl-collator",
+  "description": "Tracking package for the Intl.Collator polyfill gap",
+  "version": "0.0.0",
+  "license": "MIT",
+  "type": "module",
+  "private": true,
+  "bugs": "https://github.com/formatjs/formatjs/issues",
+  "homepage": "https://github.com/formatjs/formatjs",
+  "keywords": [
+    "i18n",
+    "intl",
+    "Intl.Collator",
+    "collator",
+    "polyfill"
+  ],
+  "repository": "formatjs/formatjs.git"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -717,6 +717,8 @@ importers:
         specifier: workspace:*
         version: link:../intl-messageformat
 
+  packages/intl-collator: {}
+
   packages/intl-datetimeformat:
     dependencies:
       '@formatjs/bigdecimal':


### PR DESCRIPTION
## Summary
- add an explicit @formatjs/intl-collator tracking package for the missing ECMA-402 Collator surface
- document the constructor/prototype pieces needed for a complete polyfill

## Spec
- ECMA-402: [Intl.Collator constructor](https://tc39.es/ecma402/#sec-intl.collator)
- ECMA-402: [Intl.Collator prototype methods](https://tc39.es/ecma402/#sec-properties-of-the-intl-collator-prototype-object)

## Test
- not run; documentation/package tracking only