### PR TITLE
fix(@formatjs/intl-numberformat): polyfill BigInt toLocaleString

### DIFF
--- a/packages/intl-numberformat/polyfill-force.ts
+++ b/packages/intl-numberformat/polyfill-force.ts
@@ -12,6 +12,16 @@ defineProperty(Number.prototype, 'toLocaleString', {
     return _toLocaleString(this, locales, options)
   },
 })
+if (typeof BigInt !== 'undefined') {
+  defineProperty(BigInt.prototype, 'toLocaleString', {
+    value: function toLocaleString(
+      locales?: string | string[],
+      options?: NumberFormatOptions
+    ) {
+      return _toLocaleString(this, locales, options)
+    },
+  })
+}
 
 // Drain any locale data that was buffered before polyfill loaded
 const buf = (globalThis as Record<string, unknown>)

--- a/packages/intl-numberformat/polyfill.ts
+++ b/packages/intl-numberformat/polyfill.ts
@@ -14,6 +14,16 @@ if (shouldPolyfill()) {
       return _toLocaleString(this, locales, options)
     },
   })
+  if (typeof BigInt !== 'undefined') {
+    defineProperty(BigInt.prototype, 'toLocaleString', {
+      value: function toLocaleString(
+        locales?: string | string[],
+        options?: NumberFormatOptions
+      ) {
+        return _toLocaleString(this, locales, options)
+      },
+    })
+  }
 
   // Drain any locale data that was buffered before polyfill loaded
   const buf = (globalThis as Record<string, unknown>)

--- a/packages/intl-numberformat/tests/misc.test.ts
+++ b/packages/intl-numberformat/tests/misc.test.ts
@@ -21,6 +21,7 @@ import '@formatjs/intl-pluralrules/locale-data/tr.js'
 import '@formatjs/intl-pluralrules/locale-data/uk.js'
 import '@formatjs/intl-pluralrules/locale-data/zh.js'
 import {NumberFormat} from '#packages/intl-numberformat/core'
+import {toLocaleString} from '#packages/intl-numberformat/to_locale_string.js'
 
 const LOCALES = [
   'en',
@@ -96,6 +97,12 @@ it('supportedLocalesOf should return correct result based on data loaded', funct
 })
 it('should not crash if unit is not specified', function () {
   expect(new NumberFormat().resolvedOptions().unit).toBeUndefined()
+})
+
+it('formats BigInt values through toLocaleString ponyfill', function () {
+  expect(toLocaleString(1234567890123456789n, 'en')).toBe(
+    '1,234,567,890,123,456,789'
+  )
 })
 
 // Some test262

--- a/packages/intl-numberformat/to_locale_string.ts
+++ b/packages/intl-numberformat/to_locale_string.ts
@@ -3,11 +3,11 @@ import {NumberFormat} from '#packages/intl-numberformat/core.js'
 import {type NumberFormatOptions} from '#packages/ecma402-abstract/types/number.js'
 
 /**
- * Number.prototype.toLocaleString ponyfill
+ * Number.prototype.toLocaleString and BigInt.prototype.toLocaleString ponyfill
  * https://tc39.es/ecma402/#sup-number.prototype.tolocalestring
  */
 export function toLocaleString(
-  x: number,
+  x: number | bigint,
   locales?: string | string[],
   options?: NumberFormatOptions
 ): string {


### PR DESCRIPTION
## Summary
- patch BigInt.prototype.toLocaleString from the NumberFormat polyfill when BigInt exists
- allow the shared toLocaleString helper to format bigint values
- add bigint ponyfill coverage

## Spec
- ECMA-402: [BigInt.prototype.toLocaleString](https://tc39.es/ecma402/#sup-bigint.prototype.tolocalestring)
- ECMA-402: [FormatNumeric](https://tc39.es/ecma402/#sec-formatnumeric)

## Test
- bazel test //packages/intl-numberformat:misc_tests