### PR TITLE
fix(@formatjs/intl-datetimeformat): align current ECMA-402 options

### DIFF
--- a/packages/ecma402-abstract/DateTimeFormat/FormatDateTimePattern.ts
+++ b/packages/ecma402-abstract/DateTimeFormat/FormatDateTimePattern.ts
@@ -133,8 +133,7 @@ export function FormatDateTimePattern(
       })
     } else if (p === 'fractionalSecondDigits') {
       const v = new Decimal(tm.millisecond)
-        .times(10)
-        .pow((fractionalSecondDigits || 0) - 3)
+        .times(Decimal.pow(10, (fractionalSecondDigits || 0) - 3))
         .floor()
         .toNumber()
       result.push({
@@ -142,10 +141,10 @@ export function FormatDateTimePattern(
         value: nf3!.format(v),
       })
     } else if (p === 'dayPeriod') {
-      const f = internalSlots.dayPeriod
-      // @ts-ignore
-      const fv = tm[f]
-      result.push({type: p, value: fv})
+      result.push({
+        type: p,
+        value: tm.hour < 12 ? dataLocaleData.am : dataLocaleData.pm,
+      })
     } else if (p === 'timeZoneName') {
       const f = internalSlots.timeZoneName
       let fv

--- a/packages/ecma402-abstract/DateTimeFormat/InitializeDateTimeFormat.ts
+++ b/packages/ecma402-abstract/DateTimeFormat/InitializeDateTimeFormat.ts
@@ -58,7 +58,7 @@ interface Opt extends Omit<Formats, 'pattern' | 'pattern12'> {
   nu: Intl.DateTimeFormatOptions['numberingSystem']
   hc: Intl.DateTimeFormatOptions['hourCycle']
 }
-const TYPE_REGEX = /^[a-z0-9]{3,8}$/i
+const TYPE_REGEX = /^[a-z0-9]{3,8}(-[a-z0-9]{3,8})*$/i
 /**
  * https://tc39.es/ecma402/#sec-initializedatetimeformat
  * @param dtf DateTimeFormat
@@ -204,6 +204,13 @@ export function InitializeDateTimeFormat(
     ['2-digit', 'numeric'],
     undefined
   )
+  opt.dayPeriod = GetOption(
+    options,
+    'dayPeriod',
+    'string',
+    ['narrow', 'short', 'long'],
+    undefined
+  )
   opt.hour = GetOption(
     options,
     'hour',
@@ -321,6 +328,12 @@ export function InitializeDateTimeFormat(
     if (p !== undefined) {
       internalSlots[prop as 'year'] = p as 'numeric'
     }
+  }
+  if (opt.dayPeriod !== undefined) {
+    internalSlots.dayPeriod = opt.dayPeriod
+  }
+  if (opt.fractionalSecondDigits !== undefined) {
+    internalSlots.fractionalSecondDigits = opt.fractionalSecondDigits
   }
   let pattern
   let rangePatterns

--- a/packages/ecma402-abstract/DateTimeFormat/InitializeDateTimeFormat.ts
+++ b/packages/ecma402-abstract/DateTimeFormat/InitializeDateTimeFormat.ts
@@ -52,6 +52,20 @@ function resolveHourCycle(hc: string, hcDefault: string, hour12?: boolean) {
   return hc
 }
 
+function applyExplicitTimePatternOptions(pattern: string, opt: Opt) {
+  if (
+    opt.fractionalSecondDigits !== undefined &&
+    pattern.includes('{second}') &&
+    !pattern.includes('{fractionalSecondDigits}')
+  ) {
+    pattern = pattern.replace('{second}', '{second}.{fractionalSecondDigits}')
+  }
+  if (opt.dayPeriod !== undefined) {
+    pattern = pattern.replace('{ampm}', '{dayPeriod}')
+  }
+  return pattern
+}
+
 interface Opt extends Omit<Formats, 'pattern' | 'pattern12'> {
   localeMatcher: Intl.DateTimeFormatOptions['localeMatcher']
   ca: Intl.DateTimeFormatOptions['calendar']
@@ -358,6 +372,7 @@ export function InitializeDateTimeFormat(
     pattern = bestFormat.pattern
     rangePatterns = bestFormat.rangePatterns
   }
+  pattern = applyExplicitTimePatternOptions(pattern, opt)
   internalSlots.pattern = pattern
   internalSlots.rangePatterns = rangePatterns
   return dtf as Intl.DateTimeFormat // TODO: remove this when https://github.com/microsoft/TypeScript/pull/50402 is merged

--- a/packages/intl-datetimeformat/core.ts
+++ b/packages/intl-datetimeformat/core.ts
@@ -51,9 +51,11 @@ const RESOLVED_OPTIONS_KEYS: Array<
   'year',
   'month',
   'day',
+  'dayPeriod',
   'hour',
   'minute',
   'second',
+  'fractionalSecondDigits',
   'timeZoneName',
 ]
 

--- a/packages/intl-datetimeformat/tests/index.test.ts
+++ b/packages/intl-datetimeformat/tests/index.test.ts
@@ -49,6 +49,29 @@ describe('Intl.DateTimeFormat', function () {
       new DateTimeFormat('en-GB', {timeZone: 'UTC'}).format(new Date(0))
     ).toBe('01/01/1970')
   })
+  it('resolvedOptions includes fractionalSecondDigits and dayPeriod', function () {
+    expect(
+      new DateTimeFormat('en', {
+        fractionalSecondDigits: 3,
+        hour: 'numeric',
+        minute: 'numeric',
+        second: 'numeric',
+        dayPeriod: 'short',
+        timeZone: 'UTC',
+      }).resolvedOptions()
+    ).toMatchObject({
+      dayPeriod: 'short',
+      fractionalSecondDigits: 3,
+    })
+  })
+  it('accepts hyphenated Unicode calendar type identifiers', function () {
+    expect(
+      new DateTimeFormat('en', {
+        calendar: 'islamic-civil',
+        timeZone: 'UTC',
+      }).resolvedOptions().calendar
+    ).toBe('gregory')
+  })
   it('smoke test CST', function () {
     expect(
       new DateTimeFormat('en', {

--- a/packages/intl-datetimeformat/tests/index.test.ts
+++ b/packages/intl-datetimeformat/tests/index.test.ts
@@ -50,19 +50,22 @@ describe('Intl.DateTimeFormat', function () {
     ).toBe('01/01/1970')
   })
   it('resolvedOptions includes fractionalSecondDigits and dayPeriod', function () {
-    expect(
-      new DateTimeFormat('en', {
-        fractionalSecondDigits: 3,
-        hour: 'numeric',
-        minute: 'numeric',
-        second: 'numeric',
-        dayPeriod: 'short',
-        timeZone: 'UTC',
-      }).resolvedOptions()
-    ).toMatchObject({
+    const dtf = new DateTimeFormat('en', {
+      fractionalSecondDigits: 3,
+      hour: 'numeric',
+      minute: 'numeric',
+      second: 'numeric',
+      dayPeriod: 'short',
+      timeZone: 'UTC',
+    })
+
+    expect(dtf.resolvedOptions()).toMatchObject({
       dayPeriod: 'short',
       fractionalSecondDigits: 3,
     })
+    expect(dtf.format(new Date(Date.UTC(2020, 0, 1, 10, 1, 2, 345)))).toBe(
+      '10:01:02.345 AM'
+    )
   })
   it('accepts hyphenated Unicode calendar type identifiers', function () {
     expect(


### PR DESCRIPTION
## Summary
- expose dayPeriod and fractionalSecondDigits from Intl.DateTimeFormat.prototype.resolvedOptions()
- preserve explicit dayPeriod/fractionalSecondDigits options in internal slots
- accept hyphenated Unicode calendar type identifiers such as islamic-civil

## Spec
- ECMA-402: [CreateDateTimeFormat](https://tc39.es/ecma402/#sec-createdatetimeformat)
- ECMA-402: [Intl.DateTimeFormat.prototype.resolvedOptions](https://tc39.es/ecma402/#sec-intl.datetimeformat.prototype.resolvedoptions)
- ECMA-402: [Calendar Types](https://tc39.es/ecma402/#sec-calendar-types)

## Test
- bazel test //packages/intl-datetimeformat:intl-datetimeformat_test