### PR TITLE
fix(@formatjs/intl-durationformat): align fractional unit style

### DIFF
--- a/packages/ecma402-abstract/DurationFormat/GetDurationUnitOptions.ts
+++ b/packages/ecma402-abstract/DurationFormat/GetDurationUnitOptions.ts
@@ -6,7 +6,8 @@ export function GetDurationUnitOptions<T extends object>(
   baseStyle: Exclude<T[keyof T], undefined>,
   stylesList: readonly T[keyof T][],
   digitalBase: Exclude<T[keyof T], undefined>,
-  prevStyle: string
+  prevStyle: string,
+  twoDigitHours = false
 ): {
   style: Exclude<T[keyof T], undefined>
   display: string | Exclude<T[keyof T], undefined>
@@ -37,6 +38,10 @@ export function GetDurationUnitOptions<T extends object>(
     displayDefault
   )
 
+  if (twoDigitHours && unit === 'hours' && style === 'numeric') {
+    style = '2-digit' as Exclude<T[keyof T], undefined>
+  }
+
   if (prevStyle === 'numeric' || prevStyle === '2-digit') {
     if (style !== 'numeric' && style !== '2-digit') {
       throw new RangeError("Can't mix numeric and non-numeric styles")
@@ -45,14 +50,16 @@ export function GetDurationUnitOptions<T extends object>(
     }
     if (
       style === 'numeric' &&
-      display === 'always' &&
       (unit === 'milliseconds' ||
         unit === 'microseconds' ||
         unit === 'nanoseconds')
     ) {
-      throw new RangeError(
-        "Can't display milliseconds, microseconds, or nanoseconds in numeric format"
-      )
+      if (display === 'always') {
+        throw new RangeError(
+          "Can't display milliseconds, microseconds, or nanoseconds in numeric format"
+        )
+      }
+      style = 'fractional' as Exclude<T[keyof T], undefined>
     }
   }
   return {

--- a/packages/intl-durationformat/abstract/PartitionDurationFormatPattern.ts
+++ b/packages/intl-durationformat/abstract/PartitionDurationFormatPattern.ts
@@ -54,7 +54,7 @@ export function PartitionDurationFormatPattern(
       } else {
         nextStyle = internalSlots.nanoseconds
       }
-      if (nextStyle === 'numeric') {
+      if (nextStyle === 'numeric' || nextStyle === 'fractional') {
         if (unit === 'seconds') {
           value = value
             .plus(new BigDecimal(duration.milliseconds).div(1000))

--- a/packages/intl-durationformat/abstract/PartitionDurationFormatPattern.ts
+++ b/packages/intl-durationformat/abstract/PartitionDurationFormatPattern.ts
@@ -83,7 +83,7 @@ export function PartitionDurationFormatPattern(
       if (style === '2-digit') {
         nfOpts.minimumIntegerDigits = 2
       }
-      if (style !== '2-digit' && style !== 'numeric') {
+      if (style !== '2-digit' && style !== 'numeric' && style !== 'fractional') {
         nfOpts.style = 'unit'
         nfOpts.unit = numberFormatUnit
         nfOpts.unitDisplay = style

--- a/packages/intl-durationformat/core.ts
+++ b/packages/intl-durationformat/core.ts
@@ -268,6 +268,8 @@ export class DurationFormat implements DurationFormatType {
         if (v !== undefined) {
           v = Number(v)
         }
+      } else if (v === 'fractional') {
+        v = 'numeric'
       } else {
         invariant(v !== undefined, `Missing internal slot ${key}`)
       }

--- a/packages/intl-durationformat/tests/index.test.ts
+++ b/packages/intl-durationformat/tests/index.test.ts
@@ -84,6 +84,12 @@ test('Intl.DurationFormat format digital', function () {
     new DurationFormat('en', customFormatterOptions).resolvedOptions()
       .milliseconds
   ).toBe('numeric')
+  expect(
+    new DurationFormat('en', customFormatterOptions).format({
+      seconds: 1,
+      milliseconds: 234,
+    })
+  ).toBe('0:00:01.234')
 })
 
 test('Intl.DurationFormat sub-second rollup is exact (#6462)', function () {

--- a/packages/intl-durationformat/tests/index.test.ts
+++ b/packages/intl-durationformat/tests/index.test.ts
@@ -80,6 +80,10 @@ test('Intl.DurationFormat format digital', function () {
   expect(
     new DurationFormat('en', customFormatterOptions).format({years: 1})
   ).toBe('1 yr, 0:00:00')
+  expect(
+    new DurationFormat('en', customFormatterOptions).resolvedOptions()
+      .milliseconds
+  ).toBe('numeric')
 })
 
 test('Intl.DurationFormat sub-second rollup is exact (#6462)', function () {

--- a/packages/intl-durationformat/types.ts
+++ b/packages/intl-durationformat/types.ts
@@ -80,11 +80,11 @@ export interface IntlDurationFormatInternal {
   minutesDisplay: 'always' | 'auto'
   seconds: 'long' | 'short' | 'narrow' | 'numeric' | '2-digit'
   secondsDisplay: 'always' | 'auto'
-  milliseconds: 'long' | 'short' | 'narrow' | 'numeric'
+  milliseconds: 'long' | 'short' | 'narrow' | 'numeric' | 'fractional'
   millisecondsDisplay: 'always' | 'auto'
-  microseconds: 'long' | 'short' | 'narrow' | 'numeric'
+  microseconds: 'long' | 'short' | 'narrow' | 'numeric' | 'fractional'
   microsecondsDisplay: 'always' | 'auto'
-  nanoseconds: 'long' | 'short' | 'narrow' | 'numeric'
+  nanoseconds: 'long' | 'short' | 'narrow' | 'numeric' | 'fractional'
   nanosecondsDisplay: 'always' | 'auto'
 }
 


### PR DESCRIPTION
## Summary
- add the current GetDurationUnitOptions twoDigitHours parameter shape
- use an internal fractional style for sub-second units rolled into a preceding numeric unit
- keep resolvedOptions reporting public numeric values for fractional sub-second slots

## Spec
- ECMA-402: [GetDurationUnitOptions](https://tc39.es/ecma402/#sec-getdurationunitoptions)
- ECMA-402: [PartitionDurationFormatPattern](https://tc39.es/ecma402/#sec-partitiondurationformatpattern)

## Test
- bazel test //packages/intl-durationformat:intl-durationformat_test