### PR TITLE
feat(@formatjs/intl-collator): add package skeleton

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -87,6 +87,7 @@ PACKAGES_TO_DIST = [
     "//packages/fast-memoize",
     "//packages/icu-messageformat-parser",
     "//packages/icu-skeleton-parser",
+    "//packages/intl-collator",
     "//packages/intl-datetimeformat",
     "//packages/intl-displaynames",
     "//packages/intl-durationformat",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -312,7 +312,7 @@
         "recordedInputs": [
           "REPO_MAPPING:aspect_rules_ts+,aspect_rules_ts aspect_rules_ts+",
           "REPO_MAPPING:aspect_rules_ts+,bazel_tools bazel_tools",
-          "FILE:@@//package.json 687fdd1645ec2fbe6ac5bb2169e2527c99ff1bdec8f6e471f6e606a94ee61723"
+          "FILE:@@//package.json f1ba6ab2a6c17853e1e39c2363ab2f387ffcf35e5184eebe25a452f09074875f"
         ],
         "generatedRepoSpecs": {
           "npm_typescript": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@formatjs/icu-messageformat-parser": "workspace:*",
     "@formatjs/icu-skeleton-parser": "workspace:*",
     "@formatjs/intl": "workspace:*",
+    "@formatjs/intl-collator": "workspace:*",
     "@formatjs/intl-datetimeformat": "workspace:*",
     "@formatjs/intl-displaynames": "workspace:*",
     "@formatjs/intl-durationformat": "workspace:*",

--- a/packages/intl-collator/BUILD.bazel
+++ b/packages/intl-collator/BUILD.bazel
@@ -1,0 +1,49 @@
+load("@npm//:defs.bzl", "npm_link_all_packages")
+load("//tools:compile.bzl", "formatjs_library")
+load("//tools:test.bzl", "formatjs_test")
+load("//tools:tsconfig.bzl", "ESNEXT_TSCONFIG", "packages_tsconfig")
+
+npm_link_all_packages()
+
+ENTRY_POINTS = [
+    "index.ts",
+    "polyfill.ts",
+    "polyfill-force.ts",
+    "should-polyfill.ts",
+]
+
+formatjs_library(
+    name = "intl-collator",
+    srcs = [
+        "compare.ts",
+        "core.ts",
+        "get_internal_slots.ts",
+        "index.ts",
+        "polyfill.ts",
+        "polyfill-force.ts",
+        "should-polyfill.ts",
+        "types.ts",
+    ],
+    entry_points = ENTRY_POINTS,
+    types = True,
+    visibility = ["//visibility:public"],
+    deps = [
+        "//:node_modules/@formatjs/intl-localematcher",
+        "//packages/ecma262-abstract",
+        "//packages/ecma402-abstract",
+    ],
+)
+
+formatjs_test(
+    name = "intl-collator_test",
+    data = [
+        "tests/index.test.ts",
+        ":intl-collator",
+        "//:node_modules/@formatjs/intl-localematcher",
+        "//:node_modules/vitest",
+        "//packages/ecma262-abstract",
+        "//packages/ecma402-abstract",
+    ],
+    no_copy_to_bin = ["//:package.json"],
+    tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
+)

--- a/packages/intl-collator/LICENSE.md
+++ b/packages/intl-collator/LICENSE.md
@@ -1,0 +1,18 @@
+Copyright 2026 FormatJS
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/intl-collator/README.md
+++ b/packages/intl-collator/README.md
@@ -1,14 +1,7 @@
-# Intl.Collator
+# `@formatjs/intl-collator`
 
-`Intl.Collator` is part of the current ECMA-402 surface, but FormatJS does not
-currently ship a data-backed collator polyfill.
+Intl.Collator polyfill.
 
-This package directory tracks that gap explicitly. A complete implementation
-needs locale-sensitive collation data and comparison semantics for:
-
-- `Intl.Collator`
-- `Intl.Collator.supportedLocalesOf`
-- `Intl.Collator.prototype.compare`
-- `Intl.Collator.prototype.resolvedOptions`
-- `String.prototype.localeCompare`
-
+The initial implementation provides the ECMA-402 constructor/prototype surface
+and a deterministic baseline comparator. Full CLDR/UCA collation data
+compilation is tracked in `knowledge-base/007l-polyfill-intl-collator.md`.

--- a/packages/intl-collator/compare.ts
+++ b/packages/intl-collator/compare.ts
@@ -1,0 +1,121 @@
+import type {IntlCollatorInternal} from '#packages/intl-collator/types.js'
+
+const COMBINING_MARKS = /[\u0300-\u036f]/g
+const ASCII_PUNCTUATION = /[!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~]/g
+const ASCII_DIGIT_RUN = /[0-9]+/g
+
+function normalize(input: string): string {
+  return typeof input.normalize === 'function' ? input.normalize('NFD') : input
+}
+
+function stripMarks(input: string): string {
+  return input.replace(COMBINING_MARKS, '')
+}
+
+function stripPunctuation(input: string): string {
+  return input.replace(ASCII_PUNCTUATION, '')
+}
+
+function prepare(input: string, slots: IntlCollatorInternal): string {
+  let result = normalize(input)
+  if (slots.ignorePunctuation) {
+    result = stripPunctuation(result)
+  }
+  if (slots.sensitivity === 'base' || slots.sensitivity === 'case') {
+    result = stripMarks(result)
+  }
+  if (
+    slots.sensitivity === 'base' ||
+    slots.sensitivity === 'accent' ||
+    slots.caseFirst !== 'false'
+  ) {
+    result = result.toLocaleLowerCase(slots.locale)
+  }
+  return result
+}
+
+function compareStrings(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0
+}
+
+function compareNumeric(left: string, right: string): number {
+  const leftParts = left.split(ASCII_DIGIT_RUN)
+  const rightParts = right.split(ASCII_DIGIT_RUN)
+  const leftDigits = left.match(ASCII_DIGIT_RUN) || []
+  const rightDigits = right.match(ASCII_DIGIT_RUN) || []
+  const length = Math.max(leftParts.length, rightParts.length)
+
+  for (let i = 0; i < length; i++) {
+    const partResult = compareStrings(leftParts[i] || '', rightParts[i] || '')
+    if (partResult) {
+      return partResult
+    }
+
+    const leftNumber = leftDigits[i]
+    const rightNumber = rightDigits[i]
+    if (leftNumber === undefined || rightNumber === undefined) {
+      continue
+    }
+
+    const normalizedLeftNumber = leftNumber.replace(/^0+/, '') || '0'
+    const normalizedRightNumber = rightNumber.replace(/^0+/, '') || '0'
+    const lengthResult =
+      normalizedLeftNumber.length - normalizedRightNumber.length
+    if (lengthResult) {
+      return lengthResult < 0 ? -1 : 1
+    }
+    const digitResult = compareStrings(
+      normalizedLeftNumber,
+      normalizedRightNumber
+    )
+    if (digitResult) {
+      return digitResult
+    }
+  }
+
+  return 0
+}
+
+function compareCaseFirst(
+  left: string,
+  right: string,
+  locale: string,
+  caseFirst: IntlCollatorInternal['caseFirst']
+): number {
+  if (caseFirst === 'false') {
+    return 0
+  }
+  const length = Math.min(left.length, right.length)
+  for (let i = 0; i < length; i++) {
+    const leftChar = left.charAt(i)
+    const rightChar = right.charAt(i)
+    const lowerLeft = leftChar.toLocaleLowerCase(locale)
+    const lowerRight = rightChar.toLocaleLowerCase(locale)
+    if (lowerLeft !== lowerRight) {
+      continue
+    }
+    const leftIsUpper = leftChar !== lowerLeft
+    const rightIsUpper = rightChar !== lowerRight
+    if (leftIsUpper !== rightIsUpper) {
+      const upperResult = leftIsUpper ? -1 : 1
+      return caseFirst === 'upper' ? upperResult : -upperResult
+    }
+  }
+  return 0
+}
+
+export function compareCollatorStrings(
+  slots: IntlCollatorInternal,
+  x: string,
+  y: string
+): number {
+  const left = prepare(x, slots)
+  const right = prepare(y, slots)
+  const result = slots.numeric
+    ? compareNumeric(left, right)
+    : compareStrings(left, right)
+  if (result) {
+    return result
+  }
+  return compareCaseFirst(x, y, slots.locale, slots.caseFirst)
+}

--- a/packages/intl-collator/core.ts
+++ b/packages/intl-collator/core.ts
@@ -1,0 +1,228 @@
+import {OrdinaryHasInstance} from '#packages/ecma262-abstract/OrdinaryHasInstance.js'
+import {ToObject} from '#packages/ecma262-abstract/ToObject.js'
+import {CanonicalizeLocaleList} from '#packages/ecma402-abstract/CanonicalizeLocaleList.js'
+import {GetOption} from '#packages/ecma402-abstract/GetOption.js'
+import {SupportedLocales} from '#packages/ecma402-abstract/SupportedLocales.js'
+import {invariant} from '#packages/ecma402-abstract/utils.js'
+import {ResolveLocale} from '@formatjs/intl-localematcher'
+import {compareCollatorStrings} from '#packages/intl-collator/compare.js'
+import {getInternalSlots} from '#packages/intl-collator/get_internal_slots.js'
+import type {
+  Collator as CollatorType,
+  CollatorConstructor,
+  CollatorLocaleData,
+  CollatorOptions,
+  IntlCollatorInternal,
+  ResolvedCollatorOptions,
+} from '#packages/intl-collator/types.js'
+
+const RESOLVED_OPTIONS_KEYS: Array<
+  keyof Omit<IntlCollatorInternal, 'boundCompare' | 'initializedCollator'>
+> = [
+  'locale',
+  'usage',
+  'sensitivity',
+  'ignorePunctuation',
+  'collation',
+  'numeric',
+  'caseFirst',
+]
+
+const DEFAULT_LOCALE_DATA: CollatorLocaleData = {
+  co: ['default'],
+  kn: ['false', 'true'],
+  kf: ['false', 'upper', 'lower'],
+  sensitivity: 'variant',
+  ignorePunctuation: false,
+}
+
+function ensureIntl() {
+  if (typeof Intl === 'undefined') {
+    if (typeof window !== 'undefined') {
+      Object.defineProperty(window, 'Intl', {
+        value: {},
+      })
+      // @ts-ignore we don't include @types/node so global isn't a thing
+    } else if (typeof global !== 'undefined') {
+      // @ts-ignore we don't include @types/node so global isn't a thing
+      Object.defineProperty(global, 'Intl', {
+        value: {},
+      })
+    }
+  }
+}
+
+function getCollationOption(options: Record<string, unknown>): string {
+  const collation = GetOption(
+    options,
+    'collation',
+    'string',
+    undefined,
+    undefined
+  )
+  return typeof collation === 'string' ? collation : 'default'
+}
+
+export const Collator = function (
+  this: CollatorType,
+  locales?: string | string[],
+  options?: CollatorOptions
+) {
+  if (!this || !OrdinaryHasInstance(Collator, this)) {
+    return new Collator(locales, options)
+  }
+
+  const requestedLocales = CanonicalizeLocaleList(locales)
+  const opts = options === undefined ? Object.create(null) : ToObject(options)
+  const usage = GetOption(
+    opts,
+    'usage',
+    'string',
+    ['sort', 'search'],
+    'sort'
+  )
+  const matcher = GetOption(
+    opts,
+    'localeMatcher',
+    'string',
+    ['lookup', 'best fit'],
+    'best fit'
+  )
+  const numeric = GetOption(opts, 'numeric', 'boolean', undefined, undefined)
+  const caseFirst = GetOption(
+    opts,
+    'caseFirst',
+    'string',
+    ['upper', 'lower', 'false'],
+    undefined
+  )
+  const opt = Object.create(null)
+  opt.localeMatcher = matcher
+  opt.co = getCollationOption(opts)
+  if (numeric !== undefined) {
+    opt.kn = String(numeric)
+  }
+  if (caseFirst !== undefined) {
+    opt.kf = caseFirst
+  }
+
+  const r = ResolveLocale(
+    Collator.availableLocales,
+    requestedLocales,
+    opt,
+    Collator.relevantExtensionKeys,
+    Collator.localeData,
+    Collator.getDefaultLocale
+  )
+  const resolvedLocaleData = Collator.localeData[r.dataLocale]
+  invariant(!!resolvedLocaleData, `Missing locale data for ${r.dataLocale}`)
+
+  const sensitivity = GetOption(
+    opts,
+    'sensitivity',
+    'string',
+    ['base', 'accent', 'case', 'variant'],
+    usage === 'sort' ? 'variant' : resolvedLocaleData.sensitivity
+  )
+  const ignorePunctuation = GetOption(
+    opts,
+    'ignorePunctuation',
+    'boolean',
+    undefined,
+    resolvedLocaleData.ignorePunctuation
+  )
+
+  const internalSlots = getInternalSlots(this)
+  internalSlots.initializedCollator = true
+  internalSlots.locale = r.locale
+  internalSlots.usage = usage
+  internalSlots.collation = r.co === undefined ? 'default' : r.co
+  internalSlots.numeric = r.kn === 'true'
+  internalSlots.caseFirst = r.kf || 'false'
+  internalSlots.sensitivity = sensitivity
+  internalSlots.ignorePunctuation = ignorePunctuation
+} as CollatorConstructor
+
+Object.defineProperty(Collator, 'supportedLocalesOf', {
+  value: function supportedLocalesOf(
+    locales?: string | string[],
+    options?: Pick<CollatorOptions, 'localeMatcher'>
+  ) {
+    return SupportedLocales(
+      Collator.availableLocales,
+      CanonicalizeLocaleList(locales),
+      options
+    )
+  },
+})
+
+Object.defineProperty(Collator.prototype, 'compare', {
+  configurable: true,
+  get(this: CollatorType) {
+    if (
+      typeof this !== 'object' ||
+      !OrdinaryHasInstance(Collator, this)
+    ) {
+      throw TypeError(
+        'Intl.Collator compare property accessor called on incompatible receiver'
+      )
+    }
+    const collator = this
+    const internalSlots = getInternalSlots(collator)
+    let boundCompare = internalSlots.boundCompare
+    if (boundCompare === undefined) {
+      boundCompare = (x: string, y: string) =>
+        compareCollatorStrings(internalSlots, String(x), String(y))
+      internalSlots.boundCompare = boundCompare
+    }
+    return boundCompare
+  },
+})
+
+Object.defineProperty(Collator.prototype, 'resolvedOptions', {
+  value: function resolvedOptions(this: CollatorType): ResolvedCollatorOptions {
+    if (
+      typeof this !== 'object' ||
+      !OrdinaryHasInstance(Collator, this)
+    ) {
+      throw TypeError(
+        'Method Intl.Collator.prototype.resolvedOptions called on incompatible receiver'
+      )
+    }
+    const internalSlots = getInternalSlots(this)
+    const result: Record<string, unknown> = {}
+    for (const key of RESOLVED_OPTIONS_KEYS) {
+      result[key] = internalSlots[key]
+    }
+    return result as unknown as ResolvedCollatorOptions
+  },
+})
+
+Collator.availableLocales = new Set(['en'])
+Collator.relevantExtensionKeys = ['co', 'kn', 'kf']
+Collator.getDefaultLocale = () => 'en'
+Collator.localeData = {
+  en: DEFAULT_LOCALE_DATA,
+}
+Collator.polyfilled = true
+
+try {
+  if (typeof Symbol !== 'undefined') {
+    Object.defineProperty(Collator.prototype, Symbol.toStringTag, {
+      value: 'Intl.Collator',
+      writable: false,
+      enumerable: false,
+      configurable: true,
+    })
+  }
+
+  Object.defineProperty(Collator.prototype.constructor, 'length', {
+    value: 0,
+    writable: false,
+    enumerable: false,
+    configurable: true,
+  })
+} catch {
+}
+
+ensureIntl()

--- a/packages/intl-collator/get_internal_slots.ts
+++ b/packages/intl-collator/get_internal_slots.ts
@@ -1,0 +1,16 @@
+import type {
+  Collator,
+  IntlCollatorInternal,
+} from '#packages/intl-collator/types.js'
+
+const internalSlotMap = new WeakMap<Collator, IntlCollatorInternal>()
+
+export function getInternalSlots(collator: Collator): IntlCollatorInternal {
+  const internalSlots = internalSlotMap.get(collator)
+  if (internalSlots) {
+    return internalSlots
+  }
+  const newInternalSlots: IntlCollatorInternal = Object.create(null)
+  internalSlotMap.set(collator, newInternalSlots)
+  return newInternalSlots
+}

--- a/packages/intl-collator/index.ts
+++ b/packages/intl-collator/index.ts
@@ -1,0 +1,11 @@
+export * from '#packages/intl-collator/core.js'
+export type {
+  CollatorCaseFirst,
+  CollatorConstructor,
+  CollatorLocaleData,
+  CollatorOptions,
+  CollatorSensitivity,
+  CollatorUsage,
+  IntlCollatorInternal,
+  ResolvedCollatorOptions,
+} from '#packages/intl-collator/types.js'

--- a/packages/intl-collator/package.json
+++ b/packages/intl-collator/package.json
@@ -1,18 +1,30 @@
 {
   "name": "@formatjs/intl-collator",
-  "description": "Tracking package for the Intl.Collator polyfill gap",
-  "version": "0.0.0",
+  "description": "Intl.Collator polyfill",
+  "version": "0.1.0",
   "license": "MIT",
+  "author": "Long Ho <holevietlong@gmail.com>",
   "type": "module",
-  "private": true,
+  "types": "index.d.ts",
+  "exports": {
+    ".": "./index.js",
+    "./polyfill.js": "./polyfill.js",
+    "./polyfill-force.js": "./polyfill-force.js",
+    "./should-polyfill.js": "./should-polyfill.js"
+  },
+  "dependencies": {
+    "@formatjs/intl-localematcher": "workspace:*"
+  },
   "bugs": "https://github.com/formatjs/formatjs/issues",
-  "homepage": "https://github.com/formatjs/formatjs",
+  "homepage": "https://github.com/formatjs/formatjs#readme",
   "keywords": [
+    "collator",
+    "ecma402",
+    "formatjs",
     "i18n",
     "intl",
-    "Intl.Collator",
-    "collator",
-    "polyfill"
+    "react-intl",
+    "tc39"
   ],
   "repository": "formatjs/formatjs.git"
 }

--- a/packages/intl-collator/polyfill-force.ts
+++ b/packages/intl-collator/polyfill-force.ts
@@ -1,0 +1,19 @@
+import {Collator} from '#packages/intl-collator/index.js'
+
+if (typeof Intl === 'undefined') {
+  if (typeof window !== 'undefined') {
+    Object.defineProperty(window, 'Intl', {
+      value: {},
+    })
+    // @ts-ignore we don't include @types/node so global isn't a thing
+  } else if (typeof global !== 'undefined') {
+    // @ts-ignore we don't include @types/node so global isn't a thing
+    Object.defineProperty(global, 'Intl', {
+      value: {},
+    })
+  }
+}
+
+Object.defineProperty(Intl, 'Collator', {
+  value: Collator,
+})

--- a/packages/intl-collator/polyfill.ts
+++ b/packages/intl-collator/polyfill.ts
@@ -1,0 +1,22 @@
+import {Collator} from '#packages/intl-collator/index.js'
+import {shouldPolyfill} from '#packages/intl-collator/should-polyfill.js'
+
+if (typeof Intl === 'undefined') {
+  if (typeof window !== 'undefined') {
+    Object.defineProperty(window, 'Intl', {
+      value: {},
+    })
+    // @ts-ignore we don't include @types/node so global isn't a thing
+  } else if (typeof global !== 'undefined') {
+    // @ts-ignore we don't include @types/node so global isn't a thing
+    Object.defineProperty(global, 'Intl', {
+      value: {},
+    })
+  }
+}
+
+if (shouldPolyfill()) {
+  Object.defineProperty(Intl, 'Collator', {
+    value: Collator,
+  })
+}

--- a/packages/intl-collator/should-polyfill.ts
+++ b/packages/intl-collator/should-polyfill.ts
@@ -1,0 +1,3 @@
+export function shouldPolyfill(): boolean {
+  return typeof Intl === 'undefined' || !('Collator' in Intl)
+}

--- a/packages/intl-collator/tests/index.test.ts
+++ b/packages/intl-collator/tests/index.test.ts
@@ -1,0 +1,46 @@
+import {describe, expect, it} from 'vitest'
+import {Collator} from '#packages/intl-collator/index.js'
+
+describe('Intl.Collator', () => {
+  it('exposes resolved options', () => {
+    expect(
+      new Collator('en-u-kn-true-kf-upper', {
+        sensitivity: 'base',
+        ignorePunctuation: true,
+      }).resolvedOptions()
+    ).toMatchObject({
+      locale: 'en-u-kf-upper-kn',
+      usage: 'sort',
+      sensitivity: 'base',
+      ignorePunctuation: true,
+      collation: 'default',
+      numeric: true,
+      caseFirst: 'upper',
+    })
+  })
+
+  it('compares strings with base sensitivity', () => {
+    const collator = new Collator('en', {sensitivity: 'base'})
+    expect(collator.compare('resume', 'resume')).toBe(0)
+    expect(collator.compare('resume', 'résumé')).toBe(0)
+    expect(collator.compare('a', 'b')).toBeLessThan(0)
+  })
+
+  it('compares numeric digit runs', () => {
+    const collator = new Collator('en', {numeric: true})
+    expect(collator.compare('item2', 'item10')).toBeLessThan(0)
+  })
+
+  it('applies caseFirst as a tie breaker', () => {
+    expect(
+      new Collator('en', {caseFirst: 'upper'}).compare('A', 'a')
+    ).toBeLessThan(0)
+    expect(
+      new Collator('en', {caseFirst: 'lower'}).compare('A', 'a')
+    ).toBeGreaterThan(0)
+  })
+
+  it('supports locale filtering', () => {
+    expect(Collator.supportedLocalesOf(['en', 'fr'])).toEqual(['en'])
+  })
+})

--- a/packages/intl-collator/types.ts
+++ b/packages/intl-collator/types.ts
@@ -1,0 +1,61 @@
+export type CollatorUsage = 'sort' | 'search'
+export type CollatorSensitivity = 'base' | 'accent' | 'case' | 'variant'
+export type CollatorCaseFirst = 'upper' | 'lower' | 'false'
+
+export interface CollatorOptions {
+  usage?: CollatorUsage
+  localeMatcher?: 'lookup' | 'best fit'
+  collation?: string
+  numeric?: boolean
+  caseFirst?: CollatorCaseFirst
+  sensitivity?: CollatorSensitivity
+  ignorePunctuation?: boolean
+}
+
+export interface ResolvedCollatorOptions {
+  locale: string
+  usage: CollatorUsage
+  sensitivity: CollatorSensitivity
+  ignorePunctuation: boolean
+  collation: string
+  numeric: boolean
+  caseFirst: CollatorCaseFirst
+}
+
+export interface IntlCollatorInternal {
+  initializedCollator?: boolean
+  locale: string
+  usage: CollatorUsage
+  collation: string
+  numeric: boolean
+  caseFirst: CollatorCaseFirst
+  sensitivity: CollatorSensitivity
+  ignorePunctuation: boolean
+  boundCompare?: (x: string, y: string) => number
+}
+
+export interface Collator extends Intl.Collator {
+  resolvedOptions(): ResolvedCollatorOptions
+}
+
+export interface CollatorConstructor {
+  new (locales?: string | string[], options?: CollatorOptions): Collator
+  (locales?: string | string[], options?: CollatorOptions): Collator
+  supportedLocalesOf(
+    locales?: string | string[],
+    options?: Pick<CollatorOptions, 'localeMatcher'>
+  ): string[]
+  availableLocales: Set<string>
+  relevantExtensionKeys: string[]
+  getDefaultLocale(): string
+  localeData: Record<string, CollatorLocaleData | undefined>
+  polyfilled: boolean
+}
+
+export interface CollatorLocaleData {
+  co: string[]
+  kn: string[]
+  kf: string[]
+  sensitivity: CollatorSensitivity
+  ignorePunctuation: boolean
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       '@formatjs/intl':
         specifier: workspace:*
         version: link:packages/intl
+      '@formatjs/intl-collator':
+        specifier: workspace:*
+        version: link:packages/intl-collator
       '@formatjs/intl-datetimeformat':
         specifier: workspace:*
         version: link:packages/intl-datetimeformat
@@ -717,7 +720,11 @@ importers:
         specifier: workspace:*
         version: link:../intl-messageformat
 
-  packages/intl-collator: {}
+  packages/intl-collator:
+    dependencies:
+      '@formatjs/intl-localematcher':
+        specifier: workspace:*
+        version: link:../intl-localematcher
 
   packages/intl-datetimeformat:
     dependencies:


### PR DESCRIPTION
## Summary
- add the @formatjs/intl-collator package skeleton, exports, polyfill hooks, and build wiring
- implement ECMA-402 option resolution/internal slots for usage, sensitivity, ignorePunctuation, collation, numeric, and caseFirst
- add a deterministic baseline comparator and tests while the CLDR/UCA compiler lands in follow-up stacked PRs

## Spec / Plan References
- ECMA-402: [Intl.Collator constructor](https://tc39.es/ecma402/#sec-intl.collator)
- ECMA-402: [Intl.Collator.prototype.compare](https://tc39.es/ecma402/#sec-intl.collator.prototype.compare)
- Downstack plan: #6550

## Test
- bazel test //packages/intl-collator:intl-collator_test
- bazel build //packages/intl-collator