### PR TITLE
feat(@formatjs/intl-collator): add UCA parser scaffold

### DIFF
--- a/packages/intl-collator/scripts/BUILD.bazel
+++ b/packages/intl-collator/scripts/BUILD.bazel
@@ -1,0 +1,19 @@
+load("//tools:index.bzl", "ts_compile")
+load("//tools:test.bzl", "formatjs_test")
+
+ts_compile(
+    name = "parsers",
+    package_json = False,
+    srcs = ["parse-uca.ts"],
+    visibility = ["//packages/intl-collator:__pkg__"],
+)
+
+formatjs_test(
+    name = "parsers_test",
+    data = [
+        "parse-uca.test.ts",
+        ":parsers",
+        "//:node_modules/vitest",
+    ],
+    no_copy_to_bin = ["//:package.json"],
+)

--- a/packages/intl-collator/scripts/parse-uca.test.ts
+++ b/packages/intl-collator/scripts/parse-uca.test.ts
@@ -1,0 +1,82 @@
+import {describe, expect, it} from 'vitest'
+import {
+  buildUCATrie,
+  parseCollationElement,
+  parseCodePointSequence,
+  parseUCA,
+  parseUCALine,
+} from '#packages/intl-collator/scripts/parse-uca.js'
+
+describe('UCA parser', () => {
+  it('parses code point sequences', () => {
+    expect(parseCodePointSequence('0063 0068')).toEqual([0x63, 0x68])
+  })
+
+  it('parses collation element weights', () => {
+    expect(parseCollationElement('.1C47.0020.0002')).toEqual({
+      primary: 0x1c47,
+      secondary: 0x20,
+      tertiary: 0x2,
+      quaternary: 0,
+      variable: false,
+    })
+  })
+
+  it('marks variable collation elements', () => {
+    expect(parseCollationElement('*0209.0020.0002')).toMatchObject({
+      primary: 0x209,
+      secondary: 0x20,
+      tertiary: 0x2,
+      variable: true,
+    })
+  })
+
+  it('parses UCA data lines', () => {
+    expect(
+      parseUCALine(
+        '0061 ; [.1C47.0020.0002] # LATIN SMALL LETTER A'
+      )
+    ).toEqual({
+      codePoints: [0x61],
+      elements: [
+        {
+          primary: 0x1c47,
+          secondary: 0x20,
+          tertiary: 0x2,
+          quaternary: 0,
+          variable: false,
+        },
+      ],
+      comment: 'LATIN SMALL LETTER A',
+    })
+  })
+
+  it('skips comments and settings', () => {
+    expect(
+      parseUCA(`
+# comment
+@version 48
+0061 ; [.1C47.0020.0002] # LATIN SMALL LETTER A
+`)
+    ).toHaveLength(1)
+  })
+
+  it('builds a longest-match trie', () => {
+    const entries = parseUCA(`
+0063 ; [.1C50.0020.0002] # LATIN SMALL LETTER C
+0063 0068 ; [.1D00.0020.0002] # CH contraction
+`)
+    expect(buildUCATrie(entries)).toMatchObject({
+      next: {
+        [0x63]: {
+          value: 0,
+          next: {
+            [0x68]: {
+              value: 1,
+            },
+          },
+        },
+      },
+    })
+  })
+})

--- a/packages/intl-collator/scripts/parse-uca.ts
+++ b/packages/intl-collator/scripts/parse-uca.ts
@@ -1,0 +1,107 @@
+export type ParsedCollationElement = {
+  primary: number
+  secondary: number
+  tertiary: number
+  quaternary: number
+  variable: boolean
+}
+
+export type ParsedUCAEntry = {
+  codePoints: number[]
+  elements: ParsedCollationElement[]
+  comment?: string
+}
+
+export type PackedTrieNode = {
+  value?: number
+  next?: Record<number, PackedTrieNode>
+}
+
+const COLLATION_ELEMENT_RE = /\[([^\]]+)\]/g
+const LINE_SPLIT_RE = /\r?\n/
+const LEADING_WEIGHT_MARKER_RE = /^[*.]/
+const WHITESPACE_RE = /\s+/
+
+function parseHex(input: string): number {
+  const value = parseInt(input, 16)
+  if (!Number.isFinite(value)) {
+    throw new RangeError(`Invalid hexadecimal value: ${input}`)
+  }
+  return value
+}
+
+export function parseCodePointSequence(input: string): number[] {
+  const codePoints = input
+    .trim()
+    .split(WHITESPACE_RE)
+    .filter(Boolean)
+    .map(parseHex)
+  if (codePoints.length === 0) {
+    throw new RangeError('UCA entry must contain at least one code point')
+  }
+  return codePoints
+}
+
+export function parseCollationElement(
+  input: string
+): ParsedCollationElement {
+  const variable = input.startsWith('*')
+  const weights = input
+    .replace(LEADING_WEIGHT_MARKER_RE, '')
+    .split('.')
+    .filter(Boolean)
+    .map(parseHex)
+
+  return {
+    primary: weights[0] || 0,
+    secondary: weights[1] || 0,
+    tertiary: weights[2] || 0,
+    quaternary: weights[3] || 0,
+    variable,
+  }
+}
+
+export function parseUCALine(line: string): ParsedUCAEntry | undefined {
+  const [withoutComment, comment] = line.split('#', 2)
+  const trimmed = withoutComment.trim()
+  if (!trimmed || trimmed.startsWith('@') || !trimmed.includes(';')) {
+    return undefined
+  }
+
+  const [codePointPart, elementPart] = trimmed.split(';', 2)
+  COLLATION_ELEMENT_RE.lastIndex = 0
+  const elements: ParsedCollationElement[] = []
+  let match: RegExpExecArray | null
+  while ((match = COLLATION_ELEMENT_RE.exec(elementPart))) {
+    elements.push(parseCollationElement(match[1]))
+  }
+  if (elements.length === 0) {
+    return undefined
+  }
+
+  return {
+    codePoints: parseCodePointSequence(codePointPart),
+    elements,
+    comment: comment?.trim(),
+  }
+}
+
+export function parseUCA(source: string): ParsedUCAEntry[] {
+  return source
+    .split(LINE_SPLIT_RE)
+    .map(parseUCALine)
+    .filter((entry): entry is ParsedUCAEntry => entry !== undefined)
+}
+
+export function buildUCATrie(entries: ParsedUCAEntry[]): PackedTrieNode {
+  const root: PackedTrieNode = {}
+  entries.forEach((entry, index) => {
+    let node = root
+    for (const codePoint of entry.codePoints) {
+      const next = (node.next ||= Object.create(null))
+      node = next[codePoint] ||= {}
+    }
+    node.value = index
+  })
+  return root
+}


### PR DESCRIPTION
## Summary
- add a build-time UCA parser scaffold for Intl.Collator data generation
- parse code point sequences, collation element weights, variable elements, comments/settings, and packed trie entries
- add parser coverage to the Intl.Collator test target

## Plan Reference
- Downstack implementation: #6551
- Collator data/compiler plan: #6550

## Test
- bazel test //packages/intl-collator:intl-collator_test
- bazel build //packages/intl-collator