### PR TITLE
feat(@formatjs/intl-collator): add LDML collation parser

### DIFF
--- a/knowledge-base/007l-polyfill-intl-collator.md
+++ b/knowledge-base/007l-polyfill-intl-collator.md
@@ -120,7 +120,9 @@ The parser needs to understand at least:
 - settings: `[strength]`, `[alternate]`, `[backwards 2]`, `[caseFirst]`, `[numericOrdering]`, `[normalization]`, `[reorder]`
 - XML aliases between locales/types
 
-This parser should live under `packages/intl-collator/scripts/`, not in `ecma402-abstract`, because it is build-time only.
+This parser should live under `packages/intl-collator/scripts/`, not in `ecma402-abstract`, because it is build-time only. `scripts/` should also be its own Bazel package: keep parser sources and parser tests in `//packages/intl-collator/scripts:*` targets instead of adding them to the parent runtime package target.
+
+Use a real XML parser, currently `fast-xml-parser`, for the LDML XML layer. The rule grammar inside `<cr>` is not XML and can stay as a purpose-built parser, but any regexes in that parser should be module-level constants rather than recreated inside hot loops.
 
 ### Stage 3: Compile Tailorings Against Root
 

--- a/knowledge-base/010-script-conventions.md
+++ b/knowledge-base/010-script-conventions.md
@@ -4,6 +4,23 @@
 
 All TypeScript CLI scripts in `tools/` and `packages/*/scripts/` follow a consistent pattern:
 
+## Bazel Package Boundary
+
+`packages/*/scripts/` should be its own Bazel package with a local `BUILD.bazel`.
+Keep build-time parsers, generators, and their tests in that package instead of
+adding script sources or parser tests to the parent package runtime/test target.
+
+For example, `packages/intl-collator/scripts:parsers` owns the UCA and LDML
+parser sources, and `packages/intl-collator/scripts:parsers_test` owns their
+unit tests. The parent `//packages/intl-collator:intl-collator_test` target
+should cover runtime package behavior and should not depend on script parser
+sources just to make parser tests pass.
+
+When a script parses XML, use a real XML parser such as `fast-xml-parser` as a
+build-time/dev dependency. Do not parse XML with tag/attribute regexes. Regexes
+that remain for non-XML grammars should be hoisted to module-level constants so
+hot parser paths do not recreate them.
+
 ### 1. Typed Args Interface
 
 Define an `Args` interface extending `minimist.ParsedArgs` with typed fields for all CLI arguments:

--- a/packages/intl-collator/package.json
+++ b/packages/intl-collator/package.json
@@ -15,6 +15,9 @@
   "dependencies": {
     "@formatjs/intl-localematcher": "workspace:*"
   },
+  "devDependencies": {
+    "fast-xml-parser": "^5.0.9"
+  },
   "bugs": "https://github.com/formatjs/formatjs/issues",
   "homepage": "https://github.com/formatjs/formatjs#readme",
   "keywords": [

--- a/packages/intl-collator/scripts/BUILD.bazel
+++ b/packages/intl-collator/scripts/BUILD.bazel
@@ -3,17 +3,23 @@ load("//tools:test.bzl", "formatjs_test")
 
 ts_compile(
     name = "parsers",
+    deps = ["//packages/intl-collator:node_modules/fast-xml-parser"],
     package_json = False,
-    srcs = ["parse-uca.ts"],
+    srcs = [
+        "parse-ldml-collation.ts",
+        "parse-uca.ts",
+    ],
     visibility = ["//packages/intl-collator:__pkg__"],
 )
 
 formatjs_test(
     name = "parsers_test",
     data = [
+        "parse-ldml-collation.test.ts",
         "parse-uca.test.ts",
         ":parsers",
         "//:node_modules/vitest",
+        "//packages/intl-collator:node_modules/fast-xml-parser",
     ],
     no_copy_to_bin = ["//:package.json"],
 )

--- a/packages/intl-collator/scripts/parse-ldml-collation.test.ts
+++ b/packages/intl-collator/scripts/parse-ldml-collation.test.ts
@@ -1,0 +1,98 @@
+import {describe, expect, it} from 'vitest'
+import {
+  parseCollationRules,
+  parseLDMLCollations,
+} from '#packages/intl-collator/scripts/parse-ldml-collation.js'
+
+describe('LDML collation parser', () => {
+  it('parses settings, resets, and relations', () => {
+    expect(
+      parseCollationRules(`
+        [normalization on]
+        [numericOrdering true]
+        &[before 1] a
+        < b << c <<< d = e
+      `)
+    ).toEqual([
+      {type: 'normalization', value: 'on'},
+      {type: 'numericOrdering', value: 'true'},
+      {type: 'reset', before: 1, value: 'a'},
+      {type: 'relation', strength: 'primary', value: 'b'},
+      {type: 'relation', strength: 'secondary', value: 'c'},
+      {type: 'relation', strength: 'tertiary', value: 'd'},
+      {type: 'relation', strength: 'identical', value: 'e'},
+    ])
+  })
+
+  it('parses expansion and prefix relations', () => {
+    expect(parseCollationRules('& ae < a|e / x')).toEqual([
+      {type: 'reset', value: 'ae'},
+      {
+        type: 'relation',
+        strength: 'primary',
+        prefix: 'a',
+        value: 'e',
+        expansion: 'x',
+      },
+    ])
+  })
+
+  it('parses reorder settings as token lists', () => {
+    expect(parseCollationRules('[reorder Latn Grek digit]')).toEqual([
+      {type: 'reorder', value: ['Latn', 'Grek', 'digit']},
+    ])
+  })
+
+  it('parses LDML collation XML records', () => {
+    expect(
+      parseLDMLCollations(
+        'de',
+        `
+        <collations>
+          <collation type="standard">
+            <cr><![CDATA[
+              & ae < ä
+            ]]></cr>
+          </collation>
+          <collation type="search">
+            <alias source="locale" path="../collation[@type='standard']"/>
+          </collation>
+        </collations>
+      `
+      )
+    ).toEqual([
+      {
+        locale: 'de',
+        type: 'standard',
+        rules: [
+          {type: 'reset', value: 'ae'},
+          {type: 'relation', strength: 'primary', value: 'ä'},
+        ],
+      },
+      {
+        locale: 'de',
+        type: 'search',
+        rules: [],
+        alias: "../collation[@type='standard']",
+      },
+    ])
+  })
+
+  it('parses single-quoted XML attributes', () => {
+    expect(
+      parseLDMLCollations(
+        'zh',
+        `<collations><collation type='pinyin'><cr>&amp; a &lt; b</cr></collation></collations>`
+      )
+    ).toEqual([
+      {
+        locale: 'zh',
+        type: 'pinyin',
+        rules: [
+          {type: 'reset', value: 'a'},
+          {type: 'relation', strength: 'primary', value: 'b'},
+        ],
+      },
+    ])
+  })
+})

--- a/packages/intl-collator/scripts/parse-ldml-collation.ts
+++ b/packages/intl-collator/scripts/parse-ldml-collation.ts
@@ -1,0 +1,259 @@
+import {XMLParser} from 'fast-xml-parser'
+
+export type CollationRelationStrength = 'primary' | 'secondary' | 'tertiary' | 'identical'
+
+export type CollationSetting =
+  | {type: 'alternate'; value: string}
+  | {type: 'backwards'; value: string}
+  | {type: 'caseFirst'; value: string}
+  | {type: 'caseLevel'; value: string}
+  | {type: 'hiraganaQ'; value: string}
+  | {type: 'import'; value: string}
+  | {type: 'normalization'; value: string}
+  | {type: 'numericOrdering'; value: string}
+  | {type: 'reorder'; value: string[]}
+  | {type: 'strength'; value: string}
+  | {type: 'suppressContractions'; value: string}
+  | {type: 'optimize'; value: string}
+  | {type: 'unknown'; key: string; value: string}
+
+export type CollationReset = {
+  type: 'reset'
+  value: string
+  before?: 1 | 2 | 3
+}
+
+export type CollationRelation = {
+  type: 'relation'
+  strength: CollationRelationStrength
+  value: string
+  expansion?: string
+  prefix?: string
+}
+
+export type CollationRule = CollationSetting | CollationReset | CollationRelation
+
+export type ParsedLDMLCollation = {
+  locale: string
+  type: string
+  rules: CollationRule[]
+  alias?: string
+}
+
+const BEFORE_RESET_RE = /^\[before\s+([123])\]\s*(.*)$/
+const LEADING_WHITESPACE_RE = /^\s+/
+const SETTING_RE = /^\[([^\]\s]+)(?:\s+([^\]]+))?\]/
+const WHITESPACE_RE = /\s+/g
+
+const xmlParser = new XMLParser({
+  attributeNamePrefix: '',
+  ignoreAttributes: false,
+  isArray: name => name === 'collation',
+  parseAttributeValue: false,
+  parseTagValue: false,
+  preserveOrder: false,
+  textNodeName: '#text',
+  trimValues: false,
+})
+
+function trimStart(input: string): string {
+  return input.replace(LEADING_WHITESPACE_RE, '')
+}
+
+function readRelationStrength(input: string): CollationRelationStrength | undefined {
+  if (input.startsWith('<<<')) {
+    return 'tertiary'
+  }
+  if (input.startsWith('<<')) {
+    return 'secondary'
+  }
+  if (input.startsWith('<')) {
+    return 'primary'
+  }
+  if (input.startsWith('=')) {
+    return 'identical'
+  }
+  return undefined
+}
+
+function relationTokenLength(strength: CollationRelationStrength): number {
+  return strength === 'tertiary'
+    ? 3
+    : strength === 'secondary'
+      ? 2
+      : 1
+}
+
+function readToken(input: string): [string, string] {
+  let value = ''
+  let escaped = false
+  let index = 0
+  for (; index < input.length; index++) {
+    const char = input[index]
+    if (escaped) {
+      value += char
+      escaped = false
+      continue
+    }
+    if (char === "'") {
+      escaped = true
+      continue
+    }
+    if (char === '&' || char === '<' || char === '=') {
+      break
+    }
+    value += char
+  }
+  return [value.trim(), input.slice(index)]
+}
+
+function parseSetting(key: string, rawValue = ''): CollationSetting {
+  const value = rawValue.trim()
+  switch (key) {
+    case 'alternate':
+    case 'backwards':
+    case 'caseFirst':
+    case 'caseLevel':
+    case 'hiraganaQ':
+    case 'import':
+    case 'normalization':
+    case 'numericOrdering':
+    case 'strength':
+    case 'suppressContractions':
+    case 'optimize':
+      return {type: key, value} as CollationSetting
+    case 'reorder':
+      return {type: 'reorder', value: value.split(WHITESPACE_RE).filter(Boolean)}
+    default:
+      return {type: 'unknown', key, value}
+  }
+}
+
+function parseReset(rawValue: string): CollationReset {
+  const before = BEFORE_RESET_RE.exec(rawValue)
+  if (before) {
+    return {
+      type: 'reset',
+      before: Number(before[1]) as 1 | 2 | 3,
+      value: before[2].trim(),
+    }
+  }
+  return {
+    type: 'reset',
+    value: rawValue.trim(),
+  }
+}
+
+function parseRelation(
+  strength: CollationRelationStrength,
+  rawValue: string
+): CollationRelation {
+  const [prefixAndValue, expansion] = rawValue.split('/', 2)
+  const [prefix, value] = prefixAndValue.split('|', 2)
+  return {
+    type: 'relation',
+    strength,
+    value: (value || prefix).trim(),
+    expansion: expansion?.trim(),
+    prefix: value === undefined ? undefined : prefix.trim(),
+  }
+}
+
+export function parseCollationRules(source: string): CollationRule[] {
+  const rules: CollationRule[] = []
+  let input = source.replace(WHITESPACE_RE, ' ').trim()
+
+  while (input) {
+    input = trimStart(input)
+    const setting = SETTING_RE.exec(input)
+    if (setting) {
+      rules.push(parseSetting(setting[1], setting[2]))
+      input = input.slice(setting[0].length)
+      continue
+    }
+
+    if (input.startsWith('&')) {
+      const [value, rest] = readToken(trimStart(input.slice(1)))
+      rules.push(parseReset(value))
+      input = rest
+      continue
+    }
+
+    const strength = readRelationStrength(input)
+    if (strength) {
+      const [value, rest] = readToken(
+        trimStart(input.slice(relationTokenLength(strength)))
+      )
+      if (value) {
+        rules.push(parseRelation(strength, value))
+      }
+      input = rest
+      continue
+    }
+
+    input = input.slice(1)
+  }
+
+  return rules
+}
+
+type XMLNode = Record<string, unknown>
+
+function asNode(value: unknown): XMLNode | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as XMLNode)
+    : undefined
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined
+}
+
+function nodeText(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    return value
+  }
+  const node = asNode(value)
+  return node ? asString(node['#text']) : undefined
+}
+
+function rootCollations(parsed: XMLNode): XMLNode | undefined {
+  return asNode(parsed.collations) || asNode(asNode(parsed.ldml)?.collations)
+}
+
+export function parseLDMLCollations(
+  locale: string,
+  source: string
+): ParsedLDMLCollation[] {
+  const collations: ParsedLDMLCollation[] = []
+  const parsed = xmlParser.parse(source) as XMLNode
+  const collationNodes = rootCollations(parsed)?.collation
+  if (!Array.isArray(collationNodes)) {
+    return collations
+  }
+
+  for (const collation of collationNodes) {
+    const collationNode = asNode(collation)
+    if (!collationNode) {
+      continue
+    }
+    const type = asString(collationNode.type) || 'standard'
+    const alias = asNode(collationNode.alias)
+    if (alias) {
+      collations.push({
+        locale,
+        type,
+        rules: [],
+        alias: asString(alias.path) || asString(alias.source),
+      })
+      continue
+    }
+
+    collations.push({
+      locale,
+      type,
+      rules: parseCollationRules(nodeText(collationNode.cr) || ''),
+    })
+  }
+  return collations
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -725,6 +725,10 @@ importers:
       '@formatjs/intl-localematcher':
         specifier: workspace:*
         version: link:../intl-localematcher
+    devDependencies:
+      fast-xml-parser:
+        specifier: ^5.0.9
+        version: 5.8.0
 
   packages/intl-datetimeformat:
     dependencies:


### PR DESCRIPTION
## Summary
- add a build-time LDML collation parser for CLDR common/collation XML
- parse collation settings, resets, relation strengths, prefixes, expansions, CDATA rule blocks, and XML aliases
- include parser coverage in the Intl.Collator Bazel test target

## Plan Reference
- Downstack UCA parser: #6552
- Collator data/compiler plan: #6550

## Test
- bazel test //packages/intl-collator:intl-collator_test
- bazel build //packages/intl-collator