### PR TITLE
build(@formatjs/intl-collator): add CLDR common archive

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -187,6 +187,15 @@ http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "ht
 
 IANA_TZ_VERSION = "2026b"
 
+CLDR_COMMON_VERSION = "48.1"
+
+http_archive(
+    name = "cldr_common",
+    build_file = "@//packages/intl-collator:cldr-common.BUILD.bazel",
+    sha256 = "c691e94f217486fed259871429ae71cc4855e8a7f22b1586eb6eb52262c9c307",
+    urls = ["https://www.unicode.org/Public/cldr/%s/cldr-common-%s.zip" % (CLDR_COMMON_VERSION, CLDR_COMMON_VERSION)],
+)
+
 http_archive(
     name = "iana_tzcode",
     build_file = "@//packages/intl-datetimeformat:tzcode.BUILD.bazel",

--- a/packages/intl-collator/cldr-common.BUILD.bazel
+++ b/packages/intl-collator/cldr-common.BUILD.bazel
@@ -1,0 +1,12 @@
+package(default_visibility = ["//visibility:public"])
+
+exports_files([
+    "common/uca/FractionalUCA_SHORT.txt",
+    "common/uca/CollationTest_CLDR_NON_IGNORABLE_SHORT.txt",
+    "common/uca/CollationTest_CLDR_SHIFTED_SHORT.txt",
+])
+
+filegroup(
+    name = "collation_xml",
+    srcs = glob(["common/collation/*.xml"]),
+)


### PR DESCRIPTION
## Summary
- add a pinned CLDR 48.1 common archive for Intl.Collator data generation
- expose the root UCA short table, CLDR short collation tests, and common/collation XML through Bazel targets
- verify Bazel can resolve the archive file and collation XML filegroup

## Data Reference
- Unicode CLDR 48.1 common production data: https://www.unicode.org/Public/cldr/48.1/
- Downstack LDML parser: #6553

## Test
- bazel build @cldr_common//:common/uca/FractionalUCA_SHORT.txt
- bazel build @cldr_common//:collation_xml