### PR TITLE
feat(@formatjs/intl-collator): honor prefixed UCA entries

### DIFF
--- a/packages/intl-collator/compare.ts
+++ b/packages/intl-collator/compare.ts
@@ -1,8 +1,10 @@
 import type {IntlCollatorInternal} from '#packages/intl-collator/types.js'
 import {
   rootElements,
+  rootPrefixEntries,
   rootTrie,
   type PackedCollationElement,
+  type PackedPrefixEntry,
   type PackedTrieNode,
 } from '@formatjs_generated/cldr.collation/root.js'
 
@@ -67,10 +69,64 @@ function fallbackElement(codePoint: number): PackedCollationElement {
   return [0xff0000 + codePoint, 0, 0, 0, 0]
 }
 
+function matchesAt(
+  codePoints: readonly number[],
+  start: number,
+  expected: readonly number[]
+): boolean {
+  if (start + expected.length > codePoints.length) {
+    return false
+  }
+  return expected.every(
+    (codePoint, index) => codePoints[start + index] === codePoint
+  )
+}
+
+function matchesBefore(
+  codePoints: readonly number[],
+  start: number,
+  expected: readonly number[]
+): boolean {
+  if (start < expected.length) {
+    return false
+  }
+  return expected.every(
+    (codePoint, index) =>
+      codePoints[start - expected.length + index] === codePoint
+  )
+}
+
+function lookupPrefixElements(
+  codePoints: readonly number[],
+  start: number
+): {elements: readonly PackedCollationElement[]; length: number} | undefined {
+  let bestEntry: PackedPrefixEntry | undefined
+  for (const entry of rootPrefixEntries) {
+    if (
+      matchesBefore(codePoints, start, entry.prefix) &&
+      matchesAt(codePoints, start, entry.codePoints) &&
+      (!bestEntry ||
+        entry.prefix.length + entry.codePoints.length >
+          bestEntry.prefix.length + bestEntry.codePoints.length)
+    ) {
+      bestEntry = entry
+    }
+  }
+
+  return bestEntry
+    ? {elements: bestEntry.elements, length: bestEntry.codePoints.length}
+    : undefined
+}
+
 function lookupRootElements(
   codePoints: readonly number[],
   start: number
 ): {elements: readonly PackedCollationElement[]; length: number} {
+  const prefixMatch = lookupPrefixElements(codePoints, start)
+  if (prefixMatch) {
+    return prefixMatch
+  }
+
   let node: PackedTrieNode | undefined = rootTrie
   let matchedElements: readonly PackedCollationElement[] | undefined
   let matchedLength = 0

--- a/packages/intl-collator/scripts/generate-root-data.ts
+++ b/packages/intl-collator/scripts/generate-root-data.ts
@@ -16,6 +16,12 @@ type PackedElement = readonly [
   flags: number,
 ]
 
+type PackedPrefixEntry = {
+  readonly prefix: readonly number[]
+  readonly codePoints: readonly number[]
+  readonly elements: readonly PackedElement[]
+}
+
 function packElement(entry: ParsedUCAEntry): PackedElement[] {
   return entry.elements.map(element => [
     element.primary,
@@ -53,8 +59,18 @@ if (!argv.out) {
 
 const source = readFileSync(argv.ucaPath, 'utf8')
 const entries = parseUCA(source)
-const rootTrie = buildUCATrie(entries)
-const rootElements = entries.map(packElement)
+const rootEntries = entries.filter(entry => entry.prefix === undefined)
+const prefixEntries = entries.filter(
+  (entry): entry is ParsedUCAEntry & {prefix: number[]} =>
+    entry.prefix !== undefined
+)
+const rootTrie = buildUCATrie(rootEntries)
+const rootElements = rootEntries.map(packElement)
+const rootPrefixEntries: PackedPrefixEntry[] = prefixEntries.map(entry => ({
+  prefix: entry.prefix,
+  codePoints: entry.codePoints,
+  elements: packElement(entry),
+}))
 
 outputFileSync(
   argv.out,
@@ -74,12 +90,21 @@ export type PackedTrieNode = {
   next?: Record<number, PackedTrieNode>
 }
 
+export type PackedPrefixEntry = {
+  readonly prefix: readonly number[]
+  readonly codePoints: readonly number[]
+  readonly elements: readonly PackedCollationElement[]
+}
+
 export const rootTrie: PackedTrieNode = ${serialize(rootTrie)}
 
 export const rootElements: readonly (readonly PackedCollationElement[])[] = ${serialize(rootElements)}
 
+export const rootPrefixEntries: readonly PackedPrefixEntry[] = ${serialize(rootPrefixEntries)}
+
 export const rootDataStats = {
-  entries: ${entries.length},
+  entries: ${rootEntries.length},
+  prefixEntries: ${prefixEntries.length},
   trieNodes: ${countTrieNodes(rootTrie)},
 } as const
 `

--- a/packages/intl-collator/scripts/parse-uca.test.ts
+++ b/packages/intl-collator/scripts/parse-uca.test.ts
@@ -83,6 +83,7 @@ describe('UCA parser', () => {
 
   it('parses prefixed UCA data lines by indexing the target sequence', () => {
     expect(parseUCALine('004C | 00B7; [, FB B6, 05]')).toMatchObject({
+      prefix: [0x004c],
       codePoints: [0x00b7],
       elements: [
         {

--- a/packages/intl-collator/scripts/parse-uca.ts
+++ b/packages/intl-collator/scripts/parse-uca.ts
@@ -7,6 +7,7 @@ export type ParsedCollationElement = {
 }
 
 export type ParsedUCAEntry = {
+  prefix?: number[]
   codePoints: number[]
   elements: ParsedCollationElement[]
   comment?: string
@@ -96,9 +97,9 @@ export function parseUCALine(line: string): ParsedUCAEntry | undefined {
   }
 
   const [codePointPart, elementPart] = trimmed.split(';', 2)
-  const relevantCodePointPart = codePointPart.includes('|')
-    ? codePointPart.split('|', 2)[1]
-    : codePointPart
+  const [prefixPart, relevantCodePointPart] = codePointPart.includes('|')
+    ? codePointPart.split('|', 2)
+    : [undefined, codePointPart]
   COLLATION_ELEMENT_RE.lastIndex = 0
   const elements: ParsedCollationElement[] = []
   let match: RegExpExecArray | null
@@ -110,6 +111,8 @@ export function parseUCALine(line: string): ParsedUCAEntry | undefined {
   }
 
   return {
+    prefix:
+      prefixPart === undefined ? undefined : parseCodePointSequence(prefixPart),
     codePoints: parseCodePointSequence(relevantCodePointPart),
     elements,
     comment: comment?.trim(),

--- a/packages/intl-collator/tests/index.test.ts
+++ b/packages/intl-collator/tests/index.test.ts
@@ -31,6 +31,11 @@ describe('Intl.Collator', () => {
     expect(collator.compare('resume', 'résumé')).toBeLessThan(0)
   })
 
+  it('uses prefixed root collation entries', () => {
+    const collator = new Collator('en')
+    expect(collator.compare('l\u00b7', 'lz')).toBeLessThan(0)
+  })
+
   it('compares numeric digit runs', () => {
     const collator = new Collator('en', {numeric: true})
     expect(collator.compare('item2', 'item10')).toBeLessThan(0)


### PR DESCRIPTION
## Summary
- preserve UCA prefix/context rows separately from the root trie
- generate `rootPrefixEntries` so context-sensitive rows no longer overwrite plain root entries
- apply prefixed entries during root collation lookup when preceding code points match

## Spec / Data
- ECMA-402 `CompareStrings`: https://tc39.es/ecma402/#sec-collator-comparestrings
- UTS #10 contractions/context-sensitive mappings: https://www.unicode.org/reports/tr10/#Context_Sensitive_Mappings
- CLDR `FractionalUCA` file format: https://www.unicode.org/reports/tr35/tr35-collation.html#Root_Collation_Data_File_Formats

## Test Plan
- `bazel build //packages/generated/cldr-collation:pkg`
- `bazel test //packages/intl-collator:intl-collator_test`
- `bazel build //packages/intl-collator`