### PR TITLE
feat(@formatjs/intl-collator): implement tailored locale comparison

### DIFF
--- a/packages/generated/cldr-collation/BUILD.bazel
+++ b/packages/generated/cldr-collation/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
+load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("//tools:generated.bzl", "formatjs_generated_package", "generate_package_file")
 
 copy_file(
@@ -7,20 +8,13 @@ copy_file(
     out = "FractionalUCA_SHORT.txt",
 )
 
-COLLATION_LOCALES = [
-    "en",
-    "fr",
-    "zh",
-]
-
-[
-    copy_file(
-        name = "collation_%s" % locale,
-        src = "@cldr_common//:common/collation/%s.xml" % locale,
-        out = "collation/%s.xml" % locale,
-    )
-    for locale in COLLATION_LOCALES
-]
+copy_to_directory(
+    name = "collation_xml",
+    srcs = ["@cldr_common//:collation_xml"],
+    out = "collation_xml",
+    include_external_repositories = ["+http_archive+cldr_common"],
+    root_paths = ["common/collation"],
+)
 
 generate_package_file(
     name = "root_data",
@@ -39,18 +33,12 @@ generate_package_file(
     name = "locale_data",
     src = "locale-data.ts",
     args = [
-        arg
-        for locale in COLLATION_LOCALES
-        for arg in [
-            "--collationPath",
-            "$(rootpath :collation_%s)" % locale,
-        ]
+        "--collationDir",
+        "$(rootpath :collation_xml)",
     ],
     data = [
         "//packages/intl-collator:node_modules/fast-xml-parser",
-    ] + [
-        ":collation_%s" % locale
-        for locale in COLLATION_LOCALES
+        ":collation_xml",
     ],
     tool = "//packages/intl-collator/scripts:generate-locale-data",
 )
@@ -59,18 +47,12 @@ generate_package_file(
     name = "tailoring_data",
     src = "tailoring.ts",
     args = [
-        arg
-        for locale in COLLATION_LOCALES
-        for arg in [
-            "--collationPath",
-            "$(rootpath :collation_%s)" % locale,
-        ]
+        "--collationDir",
+        "$(rootpath :collation_xml)",
     ],
     data = [
         "//packages/intl-collator:node_modules/fast-xml-parser",
-    ] + [
-        ":collation_%s" % locale
-        for locale in COLLATION_LOCALES
+        ":collation_xml",
     ],
     tool = "//packages/intl-collator/scripts:generate-tailoring-data",
 )

--- a/packages/intl-collator/compare.ts
+++ b/packages/intl-collator/compare.ts
@@ -1,4 +1,5 @@
 import type {IntlCollatorInternal} from '#packages/intl-collator/types.js'
+import {collationLocaleData} from '@formatjs_generated/cldr.collation/locale-data.js'
 import {
   rootElements,
   rootPrefixEntries,
@@ -7,10 +8,17 @@ import {
   type PackedPrefixEntry,
   type PackedTrieNode,
 } from '@formatjs_generated/cldr.collation/root.js'
+import {
+  collationTailorings,
+  type PackedLDMLCollation,
+  type PackedLDMLRelation,
+  type PackedLDMLReset,
+  type PackedLDMLRule,
+} from '@formatjs_generated/cldr.collation/tailoring.js'
 
 const COMBINING_MARKS = /[\u0300-\u036f]/g
-const ASCII_PUNCTUATION = /[!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~]/g
 const ASCII_DIGIT_RUN = /[0-9]+/g
+const IMPORT_COLLATION_RE = /^(.+)-u-co-([a-z0-9-]+)$/i
 
 function normalize(input: string): string {
   return typeof input.normalize === 'function' ? input.normalize('NFD') : input
@@ -20,15 +28,8 @@ function stripMarks(input: string): string {
   return input.replace(COMBINING_MARKS, '')
 }
 
-function stripPunctuation(input: string): string {
-  return input.replace(ASCII_PUNCTUATION, '')
-}
-
 function prepare(input: string, slots: IntlCollatorInternal): string {
   let result = normalize(input)
-  if (slots.ignorePunctuation) {
-    result = stripPunctuation(result)
-  }
   if (slots.sensitivity === 'base' || slots.sensitivity === 'case') {
     result = stripMarks(result)
   }
@@ -67,6 +68,62 @@ function stringToCodePoints(input: string): number[] {
 
 function fallbackElement(codePoint: number): PackedCollationElement {
   return [0xff0000 + codePoint, 0, 0, 0, 0]
+}
+
+type TailoringEntry = {
+  readonly codePoints: readonly number[]
+  readonly elements: readonly PackedCollationElement[]
+}
+
+const tailoringCache = new Map<string, readonly TailoringEntry[]>()
+
+function localeBase(locale: string): string {
+  return locale.split('-u-')[0]
+}
+
+function collationForComparison(locale: string, collation: string): string {
+  if (collation !== 'default') {
+    return collation
+  }
+  return (
+    (
+      collationLocaleData as Record<
+        string,
+        {defaultCollation?: string} | undefined
+      >
+    )[locale]?.defaultCollation || collation
+  )
+}
+
+function normalizeTailoringValue(value: string): string {
+  return normalize(value)
+}
+
+function cloneElement(
+  element: PackedCollationElement,
+  level: number,
+  weight: number
+): PackedCollationElement {
+  return [
+    level === 0 ? weight : element[0],
+    level === 1 ? weight : element[1],
+    level === 2 ? weight : element[2],
+    element[3],
+    element[4],
+  ]
+}
+
+function relationLevel(rule: PackedLDMLRelation): number {
+  switch (rule[1]) {
+    case 'primary':
+      return 0
+    case 'secondary':
+      return 1
+    case 'tertiary':
+      return 2
+    default:
+      return 3
+  }
 }
 
 function matchesAt(
@@ -147,11 +204,157 @@ function lookupRootElements(
     : {elements: [fallbackElement(codePoints[start])], length: 1}
 }
 
-function collationElements(input: string): PackedCollationElement[] {
+function rootElementsForString(input: string): PackedCollationElement[] {
   const codePoints = stringToCodePoints(input)
   const elements: PackedCollationElement[] = []
   for (let i = 0; i < codePoints.length; ) {
     const match = lookupRootElements(codePoints, i)
+    elements.push(...match.elements)
+    i += match.length
+  }
+  return elements
+}
+
+function packedCollation(
+  locale: string,
+  collation: string
+): PackedLDMLCollation | undefined {
+  return (
+    collationTailorings as Record<
+      string,
+      Record<string, PackedLDMLCollation> | undefined
+    >
+  )[locale]?.[collation]
+}
+
+function importedTailorings(
+  rule: PackedLDMLRule,
+  visited: Set<string>
+): readonly TailoringEntry[] {
+  if (
+    rule[0] !== 'setting' ||
+    rule[1] !== 'import' ||
+    typeof rule[2] !== 'string'
+  ) {
+    return []
+  }
+  const imported = IMPORT_COLLATION_RE.exec(rule[2])
+  return imported ? tailoringEntries(imported[1], imported[2], visited) : []
+}
+
+function addTailoredRelation(
+  entries: TailoringEntry[],
+  rule: PackedLDMLRelation,
+  element: PackedCollationElement
+) {
+  const value = normalizeTailoringValue(rule[2])
+  entries.push({
+    codePoints: stringToCodePoints(value),
+    elements: [element],
+  })
+}
+
+function addTailoredRelationGroup(
+  entries: TailoringEntry[],
+  resetValue: string,
+  before: 1 | 2 | 3 | undefined,
+  relations: PackedLDMLRelation[]
+) {
+  const anchor = rootElementsForString(normalizeTailoringValue(resetValue))[0]
+  if (!anchor) {
+    return
+  }
+
+  const totalByLevel = [0, 0, 0, 0]
+  for (const relation of relations) {
+    totalByLevel[relationLevel(relation)]++
+  }
+
+  const seenByLevel = [0, 0, 0, 0]
+  let previousElement = anchor
+  for (const relation of relations) {
+    const level = relationLevel(relation)
+    seenByLevel[level]++
+    const baseElement = level === 2 ? previousElement : anchor
+    const anchorWeight = baseElement[level]
+    const offset =
+      before === level + 1
+        ? seenByLevel[level] - totalByLevel[level] - 1
+        : seenByLevel[level]
+    const element = cloneElement(baseElement, level, anchorWeight + offset)
+    previousElement = element
+    addTailoredRelation(entries, relation, element)
+  }
+}
+
+function tailoringEntries(
+  locale: string,
+  collation: string,
+  visited = new Set<string>()
+): readonly TailoringEntry[] {
+  const key = `${locale}|${collation}`
+  if (tailoringCache.has(key)) {
+    return tailoringCache.get(key)!
+  }
+  if (visited.has(key)) {
+    return []
+  }
+  visited.add(key)
+
+  const collationData = packedCollation(locale, collation)
+  const entries: TailoringEntry[] = []
+  const rules = collationData?.rules || []
+  let reset: PackedLDMLReset | undefined
+  let relations: PackedLDMLRelation[] = []
+
+  function flushRelations() {
+    if (reset && relations.length > 0) {
+      addTailoredRelationGroup(entries, reset[1], reset[2], relations)
+    }
+    relations = []
+  }
+
+  for (const rule of rules) {
+    if (rule[0] === 'setting') {
+      flushRelations()
+      entries.push(...importedTailorings(rule, visited))
+    } else if (rule[0] === 'reset') {
+      flushRelations()
+      reset = rule
+    } else if (rule[0] === 'relation') {
+      relations.push(rule)
+    }
+  }
+  flushRelations()
+
+  entries.sort((left, right) => right.codePoints.length - left.codePoints.length)
+  tailoringCache.set(key, entries)
+  return entries
+}
+
+function lookupTailoredElements(
+  entries: readonly TailoringEntry[],
+  codePoints: readonly number[],
+  start: number
+): {elements: readonly PackedCollationElement[]; length: number} | undefined {
+  for (const entry of entries) {
+    if (matchesAt(codePoints, start, entry.codePoints)) {
+      return {elements: entry.elements, length: entry.codePoints.length}
+    }
+  }
+  return undefined
+}
+
+function collationElements(
+  input: string,
+  tailoring: readonly TailoringEntry[]
+): PackedCollationElement[] {
+  const codePoints = stringToCodePoints(input)
+  const elements: PackedCollationElement[] = []
+  for (let i = 0; i < codePoints.length; ) {
+    const match =
+      lookupTailoredElements(tailoring, codePoints, i) ||
+      lookupRootElements(codePoints, i)
     elements.push(...match.elements)
     i += match.length
   }
@@ -174,13 +377,16 @@ function levelCount(slots: IntlCollatorInternal): number {
 function compareCollationElements(
   left: readonly PackedCollationElement[],
   right: readonly PackedCollationElement[],
-  levels: number
+  levels: number,
+  ignoreVariable: boolean
 ): number {
   for (let level = 0; level < levels; level++) {
     const leftWeights = left
+      .filter(element => !ignoreVariable || (element[4] & 1) === 0)
       .map(element => element[level])
       .filter(weight => weight !== 0)
     const rightWeights = right
+      .filter(element => !ignoreVariable || (element[4] & 1) === 0)
       .map(element => element[level])
       .filter(weight => weight !== 0)
     const length = Math.max(leftWeights.length, rightWeights.length)
@@ -199,10 +405,16 @@ function comparePreparedStrings(
   right: string,
   slots: IntlCollatorInternal
 ): number {
+  const locale = localeBase(slots.locale)
+  const tailoring = tailoringEntries(
+    locale,
+    collationForComparison(locale, slots.collation)
+  )
   return compareCollationElements(
-    collationElements(left),
-    collationElements(right),
-    levelCount(slots)
+    collationElements(left, tailoring),
+    collationElements(right, tailoring),
+    levelCount(slots),
+    slots.ignorePunctuation
   )
 }
 

--- a/packages/intl-collator/scripts/generate-locale-data.ts
+++ b/packages/intl-collator/scripts/generate-locale-data.ts
@@ -8,6 +8,7 @@ type GeneratedLocaleData = {
   readonly co: readonly string[]
   readonly kn: readonly ['false', 'true']
   readonly kf: readonly ['false', 'upper', 'lower']
+  readonly defaultCollation: string
   readonly sensitivity: 'variant'
   readonly ignorePunctuation: false
 }
@@ -95,6 +96,7 @@ for (const path of resolvedPaths) {
     co: [...collationTypes].sort(),
     kn: ['false', 'true'],
     kf: ['false', 'upper', 'lower'],
+    defaultCollation: defaultType,
     sensitivity: 'variant',
     ignorePunctuation: false,
   }

--- a/packages/intl-collator/scripts/generate-root-data.ts
+++ b/packages/intl-collator/scripts/generate-root-data.ts
@@ -4,6 +4,7 @@ import {outputFileSync} from 'fs-extra/esm'
 import {
   buildUCATrie,
   parseUCA,
+  parseUCAVariableTop,
   type PackedTrieNode,
   type ParsedUCAEntry,
 } from './parse-uca.ts'
@@ -22,13 +23,21 @@ type PackedPrefixEntry = {
   readonly elements: readonly PackedElement[]
 }
 
-function packElement(entry: ParsedUCAEntry): PackedElement[] {
+function packElement(
+  entry: ParsedUCAEntry,
+  variableTop: number | undefined
+): PackedElement[] {
   return entry.elements.map(element => [
     element.primary,
     element.secondary,
     element.tertiary,
     element.quaternary,
-    element.variable ? 1 : 0,
+    element.variable ||
+    (variableTop !== undefined &&
+      element.primary > 0 &&
+      element.primary <= variableTop)
+      ? 1
+      : 0,
   ])
 }
 
@@ -59,17 +68,18 @@ if (!argv.out) {
 
 const source = readFileSync(argv.ucaPath, 'utf8')
 const entries = parseUCA(source)
+const variableTop = parseUCAVariableTop(source)
 const rootEntries = entries.filter(entry => entry.prefix === undefined)
 const prefixEntries = entries.filter(
   (entry): entry is ParsedUCAEntry & {prefix: number[]} =>
     entry.prefix !== undefined
 )
 const rootTrie = buildUCATrie(rootEntries)
-const rootElements = rootEntries.map(packElement)
+const rootElements = rootEntries.map(entry => packElement(entry, variableTop))
 const rootPrefixEntries: PackedPrefixEntry[] = prefixEntries.map(entry => ({
   prefix: entry.prefix,
   codePoints: entry.codePoints,
-  elements: packElement(entry),
+  elements: packElement(entry, variableTop),
 }))
 
 outputFileSync(
@@ -106,6 +116,7 @@ export const rootDataStats = {
   entries: ${rootEntries.length},
   prefixEntries: ${prefixEntries.length},
   trieNodes: ${countTrieNodes(rootTrie)},
+  variableTop: ${variableTop ?? 'undefined'},
 } as const
 `
 )

--- a/packages/intl-collator/scripts/parse-uca.test.ts
+++ b/packages/intl-collator/scripts/parse-uca.test.ts
@@ -5,6 +5,7 @@ import {
   parseCodePointSequence,
   parseUCA,
   parseUCALine,
+  parseUCAVariableTop,
 } from '#packages/intl-collator/scripts/parse-uca.js'
 
 describe('UCA parser', () => {
@@ -103,6 +104,10 @@ describe('UCA parser', () => {
 0061 ; [.1C47.0020.0002] # LATIN SMALL LETTER A
 `)
     ).toHaveLength(1)
+  })
+
+  it('parses the fractional UCA variable top', () => {
+    expect(parseUCAVariableTop('[variable top = 0B FF FF FF]')).toBe(0x0bffffff)
   })
 
   it('builds a longest-match trie', () => {

--- a/packages/intl-collator/scripts/parse-uca.ts
+++ b/packages/intl-collator/scripts/parse-uca.ts
@@ -19,6 +19,7 @@ export type PackedTrieNode = {
 }
 
 const COLLATION_ELEMENT_RE = /\[([^\]]+)\]/g
+const VARIABLE_TOP_RE = /^\[variable top\s*=\s*([^\]]+)\]/im
 const HEX_BYTE_RE = /^[0-9A-Fa-f]{1,2}$/
 const CODE_POINT_WEIGHT_RE = /^U\+([0-9A-Fa-f]+)$/
 const LEADING_ASTERISK_RE = /^\*/
@@ -124,6 +125,11 @@ export function parseUCA(source: string): ParsedUCAEntry[] {
     .split(LINE_SPLIT_RE)
     .map(parseUCALine)
     .filter((entry): entry is ParsedUCAEntry => entry !== undefined)
+}
+
+export function parseUCAVariableTop(source: string): number | undefined {
+  const match = VARIABLE_TOP_RE.exec(source)
+  return match ? parseWeightComponent(match[1]) : undefined
 }
 
 export function buildUCATrie(entries: ParsedUCAEntry[]): PackedTrieNode {

--- a/packages/intl-collator/tests/index.test.ts
+++ b/packages/intl-collator/tests/index.test.ts
@@ -50,10 +50,16 @@ describe('Intl.Collator', () => {
     ).toBeGreaterThan(0)
   })
 
+  it('ignores UCA variable punctuation when requested', () => {
+    const collator = new Collator('en', {ignorePunctuation: true})
+    expect(collator.compare('a\u2014b', 'ab')).toBe(0)
+  })
+
   it('supports locale filtering', () => {
-    expect(Collator.supportedLocalesOf(['en', 'fr', 'zz'])).toEqual([
+    expect(Collator.supportedLocalesOf(['en', 'fr', 'sv', 'zz'])).toEqual([
       'en',
       'fr',
+      'sv',
     ])
   })
 
@@ -62,5 +68,26 @@ describe('Intl.Collator', () => {
       locale: 'zh-u-co-pinyin',
       collation: 'pinyin',
     })
+  })
+
+  it('applies imported pinyin tone tailorings', () => {
+    const collator = new Collator('zh-u-co-pinyin')
+    expect(collator.compare('\u0101', '\u00e1')).toBeLessThan(0)
+    expect(collator.compare('\u00e1', '\u01ce')).toBeLessThan(0)
+    expect(collator.compare('\u01ce', '\u00e0')).toBeLessThan(0)
+    expect(collator.compare('\u00e0', 'a')).toBeLessThan(0)
+  })
+
+  it('uses generated CLDR default collation for comparison', () => {
+    const collator = new Collator('zh')
+    expect(collator.resolvedOptions().collation).toBe('default')
+    expect(collator.compare('\u00e0', 'a')).toBeLessThan(0)
+  })
+
+  it('applies locale primary tailorings from generated CLDR data', () => {
+    const collator = new Collator('sv')
+    expect(collator.compare('z', '\u00e5')).toBeLessThan(0)
+    expect(collator.compare('\u00e5', '\u00e4')).toBeLessThan(0)
+    expect(collator.compare('\u00e4', '\u00f6')).toBeLessThan(0)
   })
 })

--- a/packages/intl-collator/types.ts
+++ b/packages/intl-collator/types.ts
@@ -56,6 +56,7 @@ export interface CollatorLocaleData {
   co: string[]
   kn: string[]
   kf: string[]
+  defaultCollation?: string
   sensitivity: CollatorSensitivity
   ignorePunctuation: boolean
 }


### PR DESCRIPTION
## Summary
- apply generated LDML tailoring rules during Intl.Collator comparison
- honor locale default collation data and variable collation weights
- expand generated collation data to all CLDR locale collation XML and cover pinyin tone ordering

Folded from: #6561, #6562, #6563.

## Spec / Data
- ECMA-402 Collator compare functions: https://tc39.es/ecma402/#sec-collator-comparefunctions
- ECMA-402 Intl.Collator internal slots: https://tc39.es/ecma402/#sec-properties-of-intl-collator-instances
- UTS #10 variable weighting: https://www.unicode.org/reports/tr10/#Variable_Weighting
- LDML collation tailorings and default collation data: https://www.unicode.org/reports/tr35/tr35-collation.html#Collation

## Test Plan
- bazel build //packages/generated/cldr-collation:pkg //packages/intl-collator //packages/intl-collator/scripts:generate-tailoring-data //packages/intl-collator/scripts:generate-locale-data //packages/intl-collator/scripts:generate-root-data
- bazel test //packages/intl-collator:intl-collator_test //packages/intl-collator/scripts:parsers_test //conformance-tests/icu4j:intl_collator_conformance_test