### PR TITLE
feat(@formatjs/intl-collator): honor default collation data

### DIFF
--- a/packages/intl-collator/compare.ts
+++ b/packages/intl-collator/compare.ts
@@ -1,4 +1,5 @@
 import type {IntlCollatorInternal} from '#packages/intl-collator/types.js'
+import {collationLocaleData} from '@formatjs_generated/cldr.collation/locale-data.js'
 import {
   rootElements,
   rootPrefixEntries,
@@ -86,6 +87,20 @@ const tailoringCache = new Map<string, readonly TailoringEntry[]>()
 
 function localeBase(locale: string): string {
   return locale.split('-u-')[0]
+}
+
+function collationForComparison(locale: string, collation: string): string {
+  if (collation !== 'default') {
+    return collation
+  }
+  return (
+    (
+      collationLocaleData as Record<
+        string,
+        {defaultCollation?: string} | undefined
+      >
+    )[locale]?.defaultCollation || collation
+  )
 }
 
 function normalizeTailoringValue(value: string): string {
@@ -395,7 +410,11 @@ function comparePreparedStrings(
   right: string,
   slots: IntlCollatorInternal
 ): number {
-  const tailoring = tailoringEntries(localeBase(slots.locale), slots.collation)
+  const locale = localeBase(slots.locale)
+  const tailoring = tailoringEntries(
+    locale,
+    collationForComparison(locale, slots.collation)
+  )
   return compareCollationElements(
     collationElements(left, tailoring),
     collationElements(right, tailoring),

--- a/packages/intl-collator/scripts/generate-locale-data.ts
+++ b/packages/intl-collator/scripts/generate-locale-data.ts
@@ -8,6 +8,7 @@ type GeneratedLocaleData = {
   readonly co: readonly string[]
   readonly kn: readonly ['false', 'true']
   readonly kf: readonly ['false', 'upper', 'lower']
+  readonly defaultCollation: string
   readonly sensitivity: 'variant'
   readonly ignorePunctuation: false
 }
@@ -95,6 +96,7 @@ for (const path of resolvedPaths) {
     co: [...collationTypes].sort(),
     kn: ['false', 'true'],
     kf: ['false', 'upper', 'lower'],
+    defaultCollation: defaultType,
     sensitivity: 'variant',
     ignorePunctuation: false,
   }

--- a/packages/intl-collator/tests/index.test.ts
+++ b/packages/intl-collator/tests/index.test.ts
@@ -71,4 +71,10 @@ describe('Intl.Collator', () => {
     expect(collator.compare('\u01ce', '\u00e0')).toBeLessThan(0)
     expect(collator.compare('\u00e0', 'a')).toBeLessThan(0)
   })
+
+  it('uses generated CLDR default collation for comparison', () => {
+    const collator = new Collator('zh')
+    expect(collator.resolvedOptions().collation).toBe('default')
+    expect(collator.compare('\u00e0', 'a')).toBeLessThan(0)
+  })
 })

--- a/packages/intl-collator/types.ts
+++ b/packages/intl-collator/types.ts
@@ -56,6 +56,7 @@ export interface CollatorLocaleData {
   co: string[]
   kn: string[]
   kf: string[]
+  defaultCollation?: string
   sensitivity: CollatorSensitivity
   ignorePunctuation: boolean
 }


### PR DESCRIPTION
## Summary
- include CLDR defaultCollation in generated Intl.Collator locale metadata
- use that default collation when comparing default-collation locales such as zh
- keep resolvedOptions().collation as default while comparison uses the locale data

## Spec / Data
- ECMA-402 InitializeCollator resolves [[Collation]] independently from locale data defaults: https://tc39.es/ecma402/#sec-initializecollator
- ECMA-402 Collator compare function consumes implementation locale collation data: https://tc39.es/ecma402/#sec-collator-comparefunctions
- CLDR defaultCollation data: https://www.unicode.org/reports/tr35/tr35-collation.html#Collation_Element_Table

## Test Plan
- bazel build //packages/generated/cldr-collation:pkg
- bazel test //packages/intl-collator:intl-collator_test
- bazel build //packages/intl-collator
