### PR TITLE
feat(@formatjs/intl-collator): mark variable collation weights

### DIFF
--- a/packages/intl-collator/compare.ts
+++ b/packages/intl-collator/compare.ts
@@ -17,7 +17,6 @@ import {
 } from '@formatjs_generated/cldr.collation/tailoring.js'
 
 const COMBINING_MARKS = /[\u0300-\u036f]/g
-const ASCII_PUNCTUATION = /[!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~]/g
 const ASCII_DIGIT_RUN = /[0-9]+/g
 const IMPORT_COLLATION_RE = /^(.+)-u-co-([a-z0-9-]+)$/i
 
@@ -29,15 +28,8 @@ function stripMarks(input: string): string {
   return input.replace(COMBINING_MARKS, '')
 }
 
-function stripPunctuation(input: string): string {
-  return input.replace(ASCII_PUNCTUATION, '')
-}
-
 function prepare(input: string, slots: IntlCollatorInternal): string {
   let result = normalize(input)
-  if (slots.ignorePunctuation) {
-    result = stripPunctuation(result)
-  }
   if (slots.sensitivity === 'base' || slots.sensitivity === 'case') {
     result = stripMarks(result)
   }
@@ -385,13 +377,16 @@ function levelCount(slots: IntlCollatorInternal): number {
 function compareCollationElements(
   left: readonly PackedCollationElement[],
   right: readonly PackedCollationElement[],
-  levels: number
+  levels: number,
+  ignoreVariable: boolean
 ): number {
   for (let level = 0; level < levels; level++) {
     const leftWeights = left
+      .filter(element => !ignoreVariable || (element[4] & 1) === 0)
       .map(element => element[level])
       .filter(weight => weight !== 0)
     const rightWeights = right
+      .filter(element => !ignoreVariable || (element[4] & 1) === 0)
       .map(element => element[level])
       .filter(weight => weight !== 0)
     const length = Math.max(leftWeights.length, rightWeights.length)
@@ -418,7 +413,8 @@ function comparePreparedStrings(
   return compareCollationElements(
     collationElements(left, tailoring),
     collationElements(right, tailoring),
-    levelCount(slots)
+    levelCount(slots),
+    slots.ignorePunctuation
   )
 }
 

--- a/packages/intl-collator/scripts/generate-root-data.ts
+++ b/packages/intl-collator/scripts/generate-root-data.ts
@@ -4,6 +4,7 @@ import {outputFileSync} from 'fs-extra/esm'
 import {
   buildUCATrie,
   parseUCA,
+  parseUCAVariableTop,
   type PackedTrieNode,
   type ParsedUCAEntry,
 } from './parse-uca.ts'
@@ -22,13 +23,21 @@ type PackedPrefixEntry = {
   readonly elements: readonly PackedElement[]
 }
 
-function packElement(entry: ParsedUCAEntry): PackedElement[] {
+function packElement(
+  entry: ParsedUCAEntry,
+  variableTop: number | undefined
+): PackedElement[] {
   return entry.elements.map(element => [
     element.primary,
     element.secondary,
     element.tertiary,
     element.quaternary,
-    element.variable ? 1 : 0,
+    element.variable ||
+    (variableTop !== undefined &&
+      element.primary > 0 &&
+      element.primary <= variableTop)
+      ? 1
+      : 0,
   ])
 }
 
@@ -59,17 +68,18 @@ if (!argv.out) {
 
 const source = readFileSync(argv.ucaPath, 'utf8')
 const entries = parseUCA(source)
+const variableTop = parseUCAVariableTop(source)
 const rootEntries = entries.filter(entry => entry.prefix === undefined)
 const prefixEntries = entries.filter(
   (entry): entry is ParsedUCAEntry & {prefix: number[]} =>
     entry.prefix !== undefined
 )
 const rootTrie = buildUCATrie(rootEntries)
-const rootElements = rootEntries.map(packElement)
+const rootElements = rootEntries.map(entry => packElement(entry, variableTop))
 const rootPrefixEntries: PackedPrefixEntry[] = prefixEntries.map(entry => ({
   prefix: entry.prefix,
   codePoints: entry.codePoints,
-  elements: packElement(entry),
+  elements: packElement(entry, variableTop),
 }))
 
 outputFileSync(
@@ -106,6 +116,7 @@ export const rootDataStats = {
   entries: ${rootEntries.length},
   prefixEntries: ${prefixEntries.length},
   trieNodes: ${countTrieNodes(rootTrie)},
+  variableTop: ${variableTop ?? 'undefined'},
 } as const
 `
 )

--- a/packages/intl-collator/scripts/parse-uca.test.ts
+++ b/packages/intl-collator/scripts/parse-uca.test.ts
@@ -5,6 +5,7 @@ import {
   parseCodePointSequence,
   parseUCA,
   parseUCALine,
+  parseUCAVariableTop,
 } from '#packages/intl-collator/scripts/parse-uca.js'
 
 describe('UCA parser', () => {
@@ -103,6 +104,10 @@ describe('UCA parser', () => {
 0061 ; [.1C47.0020.0002] # LATIN SMALL LETTER A
 `)
     ).toHaveLength(1)
+  })
+
+  it('parses the fractional UCA variable top', () => {
+    expect(parseUCAVariableTop('[variable top = 0B FF FF FF]')).toBe(0x0bffffff)
   })
 
   it('builds a longest-match trie', () => {

--- a/packages/intl-collator/scripts/parse-uca.ts
+++ b/packages/intl-collator/scripts/parse-uca.ts
@@ -19,6 +19,7 @@ export type PackedTrieNode = {
 }
 
 const COLLATION_ELEMENT_RE = /\[([^\]]+)\]/g
+const VARIABLE_TOP_RE = /^\[variable top\s*=\s*([^\]]+)\]/im
 const HEX_BYTE_RE = /^[0-9A-Fa-f]{1,2}$/
 const CODE_POINT_WEIGHT_RE = /^U\+([0-9A-Fa-f]+)$/
 const LEADING_ASTERISK_RE = /^\*/
@@ -124,6 +125,11 @@ export function parseUCA(source: string): ParsedUCAEntry[] {
     .split(LINE_SPLIT_RE)
     .map(parseUCALine)
     .filter((entry): entry is ParsedUCAEntry => entry !== undefined)
+}
+
+export function parseUCAVariableTop(source: string): number | undefined {
+  const match = VARIABLE_TOP_RE.exec(source)
+  return match ? parseWeightComponent(match[1]) : undefined
 }
 
 export function buildUCATrie(entries: ParsedUCAEntry[]): PackedTrieNode {

--- a/packages/intl-collator/tests/index.test.ts
+++ b/packages/intl-collator/tests/index.test.ts
@@ -50,6 +50,11 @@ describe('Intl.Collator', () => {
     ).toBeGreaterThan(0)
   })
 
+  it('ignores UCA variable punctuation when requested', () => {
+    const collator = new Collator('en', {ignorePunctuation: true})
+    expect(collator.compare('a\u2014b', 'ab')).toBe(0)
+  })
+
   it('supports locale filtering', () => {
     expect(Collator.supportedLocalesOf(['en', 'fr', 'zz'])).toEqual([
       'en',


### PR DESCRIPTION
## Summary
- parse the UCA variable top metadata from FractionalUCA_SHORT.txt
- mark generated root collation elements as variable when their primary weight is in the CLDR variable range
- make ignorePunctuation ignore variable-weight elements, covering non-ASCII punctuation

## Spec / Data
- ECMA-402 [[IgnorePunctuation]] slot for Intl.Collator: https://tc39.es/ecma402/#sec-properties-of-intl-collator-instances
- ECMA-402 Collator compare function: https://tc39.es/ecma402/#sec-collator-comparefunctions
- UTS #10 variable weighting / alternate handling: https://www.unicode.org/reports/tr10/#Variable_Weighting

## Test Plan
- bazel build //packages/generated/cldr-collation:pkg
- bazel test //packages/intl-collator:intl-collator_test
- bazel build //packages/intl-collator
