### PR TITLE
test(@formatjs/intl-collator): add collator conformance tests

### DIFF
--- a/conformance-tests/icu4j/BUILD.bazel
+++ b/conformance-tests/icu4j/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_java//java:defs.bzl", "java_binary", "java_import")
+load("@rules_java//java:defs.bzl", "java_binary", "java_import", "java_test")
 
 java_import(
     name = "icu4j",
@@ -13,5 +13,18 @@ java_binary(
         "LOCALE_MATCH_FIXTURES": "$(rootpath //packages/intl-localematcher:tests/locale-match-fixtures.json)",
     },
     main_class = "ICUConformanceTest",
+    deps = [":icu4j"],
+)
+
+java_test(
+    name = "intl_collator_conformance_test",
+    size = "small",
+    srcs = ["IntlCollatorConformanceTest.java"],
+    data = ["//packages/intl-collator:tests/collator-conformance.tsv"],
+    env = {
+        "COLLATOR_CONFORMANCE_FIXTURES": "$(rootpath //packages/intl-collator:tests/collator-conformance.tsv)",
+    },
+    main_class = "IntlCollatorConformanceTest",
+    test_class = "IntlCollatorConformanceTest",
     deps = [":icu4j"],
 )

--- a/conformance-tests/icu4j/IntlCollatorConformanceTest.java
+++ b/conformance-tests/icu4j/IntlCollatorConformanceTest.java
@@ -1,0 +1,139 @@
+import com.ibm.icu.text.Collator;
+import com.ibm.icu.text.RuleBasedCollator;
+import com.ibm.icu.util.ULocale;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+public class IntlCollatorConformanceTest {
+    private static final class TestCase {
+        final String description;
+        final String locale;
+        final String sensitivity;
+        final String numeric;
+        final String caseFirst;
+        final String ignorePunctuation;
+        final String left;
+        final String right;
+        final int expected;
+
+        TestCase(String line) {
+            String[] parts = line.split("\t", -1);
+            if (parts.length != 9) {
+                throw new IllegalArgumentException("Invalid fixture row: " + line);
+            }
+            description = parts[0];
+            locale = parts[1];
+            sensitivity = parts[2];
+            numeric = parts[3];
+            caseFirst = parts[4];
+            ignorePunctuation = parts[5];
+            left = parts[6];
+            right = parts[7];
+            expected = Integer.parseInt(parts[8]);
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        List<TestCase> cases = readCases();
+        List<String> failures = new ArrayList<>();
+        for (TestCase testCase : cases) {
+            int actual = sign(
+                collator(testCase).compare(testCase.left, testCase.right)
+            );
+            if (actual != testCase.expected) {
+                failures.add(
+                    testCase.description +
+                    ": expected " +
+                    testCase.expected +
+                    ", got " +
+                    actual
+                );
+            }
+        }
+
+        if (!failures.isEmpty()) {
+            for (String failure : failures) {
+                System.err.println(failure);
+            }
+            throw new AssertionError(failures.size() + " ICU4J collator checks failed");
+        }
+        System.out.println(cases.size() + " ICU4J collator conformance checks passed");
+    }
+
+    private static List<TestCase> readCases() throws IOException {
+        String fixturePath = System.getenv("COLLATOR_CONFORMANCE_FIXTURES");
+        if (fixturePath == null || fixturePath.isEmpty()) {
+            throw new IllegalStateException("COLLATOR_CONFORMANCE_FIXTURES is required");
+        }
+        List<String> lines = Files.readAllLines(
+            Paths.get(fixturePath),
+            StandardCharsets.UTF_8
+        );
+        List<TestCase> cases = new ArrayList<>();
+        for (int i = 1; i < lines.size(); i++) {
+            String line = lines.get(i);
+            if (!line.isEmpty()) {
+                cases.add(new TestCase(line));
+            }
+        }
+        return cases;
+    }
+
+    private static RuleBasedCollator collator(TestCase testCase) {
+        RuleBasedCollator collator = (RuleBasedCollator) Collator.getInstance(
+            ULocale.forLanguageTag(testCase.locale)
+        );
+        if (!testCase.sensitivity.equals("-")) {
+            // ECMA-402 sensitivity maps onto UCA comparison levels. ICU4J's
+            // case level is the closest reference behavior for sensitivity
+            // "case": primary differences plus case, but not accents.
+            // https://tc39.es/ecma402/#sec-properties-of-intl-collator-instances
+            if (testCase.sensitivity.equals("case")) {
+                collator.setStrength(Collator.PRIMARY);
+                collator.setCaseLevel(true);
+            } else {
+                collator.setStrength(strength(testCase.sensitivity));
+            }
+        }
+        if (!testCase.numeric.equals("-")) {
+            // ECMA-402 numeric / Unicode kn=true is ICU numeric collation.
+            // https://tc39.es/ecma402/#sec-initializecollator
+            collator.setNumericCollation(Boolean.parseBoolean(testCase.numeric));
+        }
+        if (testCase.caseFirst.equals("upper")) {
+            // ECMA-402 caseFirst / Unicode kf maps to ICU upper/lower first.
+            // https://tc39.es/ecma402/#sec-initializecollator
+            collator.setUpperCaseFirst(true);
+        } else if (testCase.caseFirst.equals("lower")) {
+            collator.setLowerCaseFirst(true);
+        }
+        if (testCase.ignorePunctuation.equals("true")) {
+            // ECMA-402 ignorePunctuation corresponds to shifted alternate
+            // handling for variable UCA elements in the ICU reference.
+            // https://www.unicode.org/reports/tr10/#Variable_Weighting
+            collator.setAlternateHandlingShifted(true);
+        }
+        return collator;
+    }
+
+    private static int strength(String sensitivity) {
+        switch (sensitivity) {
+            case "base":
+                return Collator.PRIMARY;
+            case "accent":
+                return Collator.SECONDARY;
+            case "variant":
+                return Collator.TERTIARY;
+            default:
+                throw new IllegalArgumentException("Unsupported sensitivity: " + sensitivity);
+        }
+    }
+
+    private static int sign(int value) {
+        return value < 0 ? -1 : value > 0 ? 1 : 0;
+    }
+}

--- a/packages/intl-collator/BUILD.bazel
+++ b/packages/intl-collator/BUILD.bazel
@@ -12,6 +12,8 @@ ENTRY_POINTS = [
     "should-polyfill.ts",
 ]
 
+exports_files(["tests/collator-conformance.tsv"])
+
 formatjs_library(
     name = "intl-collator",
     srcs = [
@@ -28,8 +30,8 @@ formatjs_library(
     types = True,
     visibility = ["//visibility:public"],
     deps = [
-        "//:node_modules/@formatjs_generated/cldr.collation",
         "//:node_modules/@formatjs/intl-localematcher",
+        "//:node_modules/@formatjs_generated/cldr.collation",
         "//packages/ecma262-abstract",
         "//packages/ecma402-abstract",
     ],
@@ -38,10 +40,13 @@ formatjs_library(
 formatjs_test(
     name = "intl-collator_test",
     data = [
+        "tests/collator-conformance.tsv",
+        "tests/conformance.test.ts",
         "tests/index.test.ts",
         ":intl-collator",
-        "//:node_modules/@formatjs_generated/cldr.collation",
         "//:node_modules/@formatjs/intl-localematcher",
+        "//:node_modules/@formatjs_generated/cldr.collation",
+        "//:node_modules/@types/node",
         "//:node_modules/vitest",
         "//packages/ecma262-abstract",
         "//packages/ecma402-abstract",

--- a/packages/intl-collator/compare.ts
+++ b/packages/intl-collator/compare.ts
@@ -19,6 +19,12 @@ import {
 const COMBINING_MARKS = /[\u0300-\u036f]/g
 const ASCII_DIGIT_RUN = /[0-9]+/g
 const IMPORT_COLLATION_RE = /^(.+)-u-co-([a-z0-9-]+)$/i
+const LEADING_ZERO_RE = /^0+/
+
+// ECMA-402 leaves CompareStrings locale-sensitive ordering
+// implementation-defined; this implementation maps the resolved Collator
+// options onto UCA/CLDR collation element levels.
+// https://tc39.es/ecma402/#sec-comparestrings
 
 function normalize(input: string): string {
   return typeof input.normalize === 'function' ? input.normalize('NFD') : input
@@ -28,6 +34,10 @@ function stripMarks(input: string): string {
   return input.replace(COMBINING_MARKS, '')
 }
 
+// Implements ECMA-402 sensitivity by dropping marks/case before UCA lookup:
+// base ignores marks and case, accent ignores case, case ignores marks, and
+// variant keeps all levels. caseFirst keeps original case for its tie-breaker.
+// https://tc39.es/ecma402/#sec-properties-of-intl-collator-instances
 function prepare(input: string, slots: IntlCollatorInternal): string {
   let result = normalize(input)
   if (slots.sensitivity === 'base' || slots.sensitivity === 'case') {
@@ -67,6 +77,10 @@ function stringToCodePoints(input: string): number[] {
 }
 
 function fallbackElement(codePoint: number): PackedCollationElement {
+  // UCA requires an order for code points not in the explicit root table; this
+  // compact fallback gives unassigned/unknown code points deterministic primary
+  // weights until full implicit weighting is implemented.
+  // https://www.unicode.org/reports/tr10/#Implicit_Weights
   return [0xff0000 + codePoint, 0, 0, 0, 0]
 }
 
@@ -85,6 +99,9 @@ function collationForComparison(locale: string, collation: string): string {
   if (collation !== 'default') {
     return collation
   }
+  // LDML Collation Type Fallback uses the locale's <defaultCollation> when
+  // ECMA-402 resolvedOptions exposes "default" for the collation slot.
+  // https://www.unicode.org/reports/tr35/tr35-collation.html#Collation_Type_Fallback
   return (
     (
       collationLocaleData as Record<
@@ -114,6 +131,9 @@ function cloneElement(
 }
 
 function relationLevel(rule: PackedLDMLRelation): number {
+  // LDML relation operators map to UCA strength levels: < primary, <<
+  // secondary, <<< tertiary, and = identical.
+  // https://www.unicode.org/reports/tr35/tr35-collation.html#Orderings
   switch (rule[1]) {
     case 'primary':
       return 0
@@ -157,6 +177,10 @@ function lookupPrefixElements(
   codePoints: readonly number[],
   start: number
 ): {elements: readonly PackedCollationElement[]; length: number} | undefined {
+  // UCA supports context-sensitive mappings. CLDR FractionalUCA encodes these
+  // as prefix + code point sequences, so choose the longest applicable prefix
+  // match before falling back to the root trie.
+  // https://www.unicode.org/reports/tr10/#Contextual_Sensitive_Mappings
   let bestEntry: PackedPrefixEntry | undefined
   for (const entry of rootPrefixEntries) {
     if (
@@ -188,6 +212,9 @@ function lookupRootElements(
   let matchedElements: readonly PackedCollationElement[] | undefined
   let matchedLength = 0
 
+  // UCA collation element lookup is longest-match so contractions such as
+  // multi-code-point sequences beat their shorter prefixes.
+  // https://www.unicode.org/reports/tr10/#Contractions
   for (let i = start; i < codePoints.length; i++) {
     node = node.next?.[codePoints[i]]
     if (!node) {
@@ -238,6 +265,9 @@ function importedTailorings(
   ) {
     return []
   }
+  // LDML [import] pulls rules from another language tag / collation type.
+  // The visited set prevents recursive imports from looping.
+  // https://www.unicode.org/reports/tr35/tr35-collation.html#Special_Purpose_Commands
   const imported = IMPORT_COLLATION_RE.exec(rule[2])
   return imported ? tailoringEntries(imported[1], imported[2], visited) : []
 }
@@ -260,6 +290,10 @@ function addTailoredRelationGroup(
   before: 1 | 2 | 3 | undefined,
   relations: PackedLDMLRelation[]
 ) {
+  // LDML rule chains are a reset (&) followed by relations. [before n] inserts
+  // relations before the reset at the requested strength; otherwise each
+  // relation is assigned weights after the reset anchor.
+  // https://www.unicode.org/reports/tr35/tr35-collation.html#Orderings
   const anchor = rootElementsForString(normalizeTailoringValue(resetValue))[0]
   if (!anchor) {
     return
@@ -316,6 +350,9 @@ function tailoringEntries(
 
   for (const rule of rules) {
     if (rule[0] === 'setting') {
+      // Settings break the current LDML rule chain. Imports contribute their
+      // compiled tailoring entries at this point in rule order.
+      // https://www.unicode.org/reports/tr35/tr35-collation.html#Collation_Settings
       flushRelations()
       entries.push(...importedTailorings(rule, visited))
     } else if (rule[0] === 'reset') {
@@ -362,6 +399,10 @@ function collationElements(
 }
 
 function levelCount(slots: IntlCollatorInternal): number {
+  // ECMA-402 sensitivity selects how many UCA levels participate in
+  // CompareStrings: base=primary, accent=primary+secondary,
+  // case/variant include tertiary handling in this compact implementation.
+  // https://tc39.es/ecma402/#sec-properties-of-intl-collator-instances
   switch (slots.sensitivity) {
     case 'base':
       return 1
@@ -380,6 +421,10 @@ function compareCollationElements(
   levels: number,
   ignoreVariable: boolean
 ): number {
+  // UCA compares level by level. ignorePunctuation maps to shifted handling for
+  // variable elements, approximated here by filtering variable weights.
+  // https://www.unicode.org/reports/tr10/#Multi_Level_Comparison
+  // https://www.unicode.org/reports/tr35/tr35-collation.html#Setting_Options
   for (let level = 0; level < levels; level++) {
     const leftWeights = left
       .filter(element => !ignoreVariable || (element[4] & 1) === 0)
@@ -423,6 +468,9 @@ function compareNumeric(
   right: string,
   slots: IntlCollatorInternal
 ): number {
+  // ECMA-402 numeric=true / Unicode extension kn=true compares digit runs by
+  // numeric value instead of lexical code unit order.
+  // https://tc39.es/ecma402/#sec-initializecollator
   const leftParts = left.split(ASCII_DIGIT_RUN)
   const rightParts = right.split(ASCII_DIGIT_RUN)
   const leftDigits = left.match(ASCII_DIGIT_RUN) || []
@@ -445,8 +493,9 @@ function compareNumeric(
       continue
     }
 
-    const normalizedLeftNumber = leftNumber.replace(/^0+/, '') || '0'
-    const normalizedRightNumber = rightNumber.replace(/^0+/, '') || '0'
+    const normalizedLeftNumber = leftNumber.replace(LEADING_ZERO_RE, '') || '0'
+    const normalizedRightNumber =
+      rightNumber.replace(LEADING_ZERO_RE, '') || '0'
     const lengthResult =
       normalizedLeftNumber.length - normalizedRightNumber.length
     if (lengthResult) {
@@ -485,6 +534,9 @@ function compareCaseFirst(
     const leftIsUpper = leftChar !== lowerLeft
     const rightIsUpper = rightChar !== lowerRight
     if (leftIsUpper !== rightIsUpper) {
+      // ECMA-402 caseFirst / Unicode extension kf determines whether upper or
+      // lower case sorts first once base collation weights compare equal.
+      // https://tc39.es/ecma402/#sec-initializecollator
       const upperResult = leftIsUpper ? -1 : 1
       return caseFirst === 'upper' ? upperResult : -upperResult
     }
@@ -497,6 +549,9 @@ export function compareCollatorStrings(
   x: string,
   y: string
 ): number {
+  // CompareStrings receives already-ToString-converted values from the
+  // bound compare function and returns a negative/zero/positive Number.
+  // https://tc39.es/ecma402/#sec-comparestrings
   const left = prepare(x, slots)
   const right = prepare(y, slots)
   const result = slots.numeric

--- a/packages/intl-collator/core.ts
+++ b/packages/intl-collator/core.ts
@@ -32,6 +32,9 @@ const RESOLVED_OPTIONS_KEYS: Array<
   'caseFirst',
 ]
 
+// ECMA-402 Intl.Collator is installed on Intl, so force-polyfill entry points
+// need a safe Intl object before they define Intl.Collator.
+// https://tc39.es/ecma402/#sec-intl.collator
 function ensureIntl() {
   if (typeof Intl === 'undefined') {
     if (typeof window !== 'undefined') {
@@ -57,6 +60,9 @@ export const Collator = function (
     return new Collator(locales, options)
   }
 
+  // InitializeCollator canonicalizes locales, reads options, and resolves the
+  // locale-sensitive extension keys before writing internal slots.
+  // https://tc39.es/ecma402/#sec-initializecollator
   const requestedLocales = CanonicalizeLocaleList(locales)
   const opts = options === undefined ? Object.create(null) : ToObject(options)
   const usage = GetOption(
@@ -100,6 +106,9 @@ export const Collator = function (
     opt.kf = caseFirst
   }
 
+  // ECMA-402 Collator has relevant extension keys "co", "kn", and "kf";
+  // ResolveLocale negotiates them against generated locale collation data.
+  // https://tc39.es/ecma402/#sec-intl.collator-internal-slots
   const r = ResolveLocale(
     Collator.availableLocales,
     requestedLocales,
@@ -111,6 +120,9 @@ export const Collator = function (
   const resolvedLocaleData = Collator.localeData[r.dataLocale]
   invariant(!!resolvedLocaleData, `Missing locale data for ${r.dataLocale}`)
 
+  // "sort" defaults sensitivity to "variant"; "search" takes its locale data
+  // default. ignorePunctuation likewise comes from locale data when omitted.
+  // https://tc39.es/ecma402/#sec-initializecollator
   const sensitivity = GetOption(
     opts,
     'sensitivity',
@@ -142,6 +154,9 @@ Object.defineProperty(Collator, 'supportedLocalesOf', {
     locales?: string | string[],
     options?: Pick<CollatorOptions, 'localeMatcher'>
   ) {
+    // Intl.Collator.supportedLocalesOf delegates to SupportedLocales with the
+    // constructor's available locale set.
+    // https://tc39.es/ecma402/#sec-intl.collator.supportedlocalesof
     return SupportedLocales(
       Collator.availableLocales,
       CanonicalizeLocaleList(locales),
@@ -165,6 +180,10 @@ Object.defineProperty(Collator.prototype, 'compare', {
     const internalSlots = getInternalSlots(collator)
     let boundCompare = internalSlots.boundCompare
     if (boundCompare === undefined) {
+      // Collator Compare Functions convert both arguments with ToString and
+      // then call CompareStrings. The getter caches the bound compare function
+      // in the collator internal slots.
+      // https://tc39.es/ecma402/#sec-collator-comparefunctions
       boundCompare = (x: string, y: string) =>
         compareCollatorStrings(internalSlots, String(x), String(y))
       internalSlots.boundCompare = boundCompare
@@ -185,6 +204,9 @@ Object.defineProperty(Collator.prototype, 'resolvedOptions', {
     }
     const internalSlots = getInternalSlots(this)
     const result: Record<string, unknown> = {}
+    // resolvedOptions returns the locale and computed collation option slots
+    // listed in ECMA-402 Table: Intl.Collator Resolved Options.
+    // https://tc39.es/ecma402/#table-intl-collator-resolvedoptions
     for (const key of RESOLVED_OPTIONS_KEYS) {
       result[key] = internalSlots[key]
     }
@@ -193,6 +215,9 @@ Object.defineProperty(Collator.prototype, 'resolvedOptions', {
 })
 
 Collator.availableLocales = new Set(availableCollationLocales)
+// ECMA-402 defines these as the Collator relevant extension keys: collation
+// ("co"), numeric collation ("kn"), and caseFirst ("kf").
+// https://tc39.es/ecma402/#sec-intl.collator-internal-slots
 Collator.relevantExtensionKeys = ['co', 'kn', 'kf']
 Collator.getDefaultLocale = () => 'en'
 Collator.localeData = collationLocaleData as unknown as Record<

--- a/packages/intl-collator/scripts/BUILD.bazel
+++ b/packages/intl-collator/scripts/BUILD.bazel
@@ -46,12 +46,13 @@ ts_binary(
 ts_binary(
     name = "generate-locale-data",
     data = [
+        ":parsers",
         "//:node_modules/@types/fs-extra",
         "//:node_modules/@types/minimist",
         "//:node_modules/@types/node",
         "//:node_modules/fs-extra",
+        "//packages/intl-collator:node_modules/fast-xml-parser",
         "//:node_modules/minimist",
-        "parse-ldml-collation.ts",
     ],
     entry_point = "generate-locale-data.ts",
     visibility = [
@@ -62,12 +63,13 @@ ts_binary(
 ts_binary(
     name = "generate-tailoring-data",
     data = [
+        ":parsers",
         "//:node_modules/@types/fs-extra",
         "//:node_modules/@types/minimist",
         "//:node_modules/@types/node",
         "//:node_modules/fs-extra",
+        "//packages/intl-collator:node_modules/fast-xml-parser",
         "//:node_modules/minimist",
-        "parse-ldml-collation.ts",
     ],
     entry_point = "generate-tailoring-data.ts",
     visibility = [

--- a/packages/intl-collator/scripts/generate-locale-data.ts
+++ b/packages/intl-collator/scripts/generate-locale-data.ts
@@ -2,7 +2,7 @@ import {basename} from 'node:path'
 import minimist from 'minimist'
 import {readdirSync, readFileSync, statSync} from 'node:fs'
 import {outputFileSync} from 'fs-extra/esm'
-import {parseLDMLCollations} from './parse-ldml-collation.ts'
+import {parseLDMLCollations} from './parse-ldml-collation.js'
 
 type GeneratedLocaleData = {
   readonly co: readonly string[]
@@ -14,6 +14,13 @@ type GeneratedLocaleData = {
 }
 
 const DEFAULT_COLLATION_RE = /<defaultCollation\b[^>]*>([^<]+)<\/defaultCollation>/i
+const UNDERSCORE_RE = /_/g
+const WHITESPACE_RE = /\s+/g
+
+// Emits the ECMA-402 locale data shape consumed by ResolveLocale for
+// Intl.Collator relevant extension keys co/kn/kf.
+// https://tc39.es/ecma402/#sec-initializecollator
+// https://tc39.es/ecma402/#sec-intl.collator-internal-slots
 
 function collationPaths(dir: string): string[] {
   const entries = readdirSync(dir).flatMap(entry => {
@@ -25,7 +32,7 @@ function collationPaths(dir: string): string[] {
 
 function collationPathList(input: string | string[] | undefined): string[] {
   return (Array.isArray(input) ? input.join(' ') : input || '')
-    .split(/\s+/)
+    .split(WHITESPACE_RE)
     .filter(path => path.endsWith('.xml'))
     .sort()
 }
@@ -39,10 +46,13 @@ function collationPathsFromCopyConfig(dir: string): string[] {
 }
 
 function localeFromPath(path: string): string {
-  return basename(path, '.xml').replace(/_/g, '-')
+  return basename(path, '.xml').replace(UNDERSCORE_RE, '-')
 }
 
 function defaultCollation(source: string): string {
+  // LDML <defaultCollation> defines the locale default collation type used by
+  // type fallback when the requested ECMA-402 collation is "default".
+  // https://www.unicode.org/reports/tr35/tr35-collation.html#Collation_Type_Fallback
   return DEFAULT_COLLATION_RE.exec(source)?.[1].trim() || 'standard'
 }
 
@@ -80,6 +90,9 @@ for (const path of resolvedPaths) {
   const defaultType = defaultCollation(source)
   const collations = parseLDMLCollations(locale, source)
   const collationTypes = new Set<string>(['default'])
+  // ECMA-402 exposes supported "co" values through locale data. Keep
+  // non-standard/search LDML types plus the locale default type.
+  // https://www.unicode.org/reports/tr35/tr35-collation.html#Collation_Types
   for (const collation of collations) {
     if (
       collation.type !== 'standard' &&

--- a/packages/intl-collator/scripts/generate-root-data.ts
+++ b/packages/intl-collator/scripts/generate-root-data.ts
@@ -7,7 +7,7 @@ import {
   parseUCAVariableTop,
   type PackedTrieNode,
   type ParsedUCAEntry,
-} from './parse-uca.ts'
+} from './parse-uca.js'
 
 type PackedElement = readonly [
   primary: number,
@@ -27,6 +27,10 @@ function packElement(
   entry: ParsedUCAEntry,
   variableTop: number | undefined
 ): PackedElement[] {
+  // UCA elements carry comparison weights by level. The flags slot marks
+  // variable elements so alternate shifted / ignorePunctuation can filter them.
+  // https://www.unicode.org/reports/tr10/#Multi_Level_Comparison
+  // https://www.unicode.org/reports/tr10/#Variable_Weighting
   return entry.elements.map(element => [
     element.primary,
     element.secondary,
@@ -69,6 +73,10 @@ if (!argv.out) {
 const source = readFileSync(argv.ucaPath, 'utf8')
 const entries = parseUCA(source)
 const variableTop = parseUCAVariableTop(source)
+// UCA root mappings without prefixes go into the longest-match trie; prefixed
+// mappings are emitted separately for context-sensitive lookup.
+// https://www.unicode.org/reports/tr10/#Contractions
+// https://www.unicode.org/reports/tr10/#Contextual_Sensitive_Mappings
 const rootEntries = entries.filter(entry => entry.prefix === undefined)
 const prefixEntries = entries.filter(
   (entry): entry is ParsedUCAEntry & {prefix: number[]} =>

--- a/packages/intl-collator/scripts/generate-tailoring-data.ts
+++ b/packages/intl-collator/scripts/generate-tailoring-data.ts
@@ -6,7 +6,7 @@ import {
   parseLDMLCollations,
   type CollationRule,
   type ParsedLDMLCollation,
-} from './parse-ldml-collation.ts'
+} from './parse-ldml-collation.js'
 
 type PackedSetting = readonly [
   type: 'setting',
@@ -35,6 +35,13 @@ type PackedCollation = {
   readonly rules?: readonly PackedRule[]
 }
 
+const UNDERSCORE_RE = /_/g
+const WHITESPACE_RE = /\s+/g
+
+// Packs LDML collation tailorings into generated data consumed by runtime
+// CompareStrings. The XML/rule parser follows LDML Part 5 Collation.
+// https://www.unicode.org/reports/tr35/tr35-collation.html#Collation_Tailorings
+
 function collationPaths(dir: string): string[] {
   const entries = readdirSync(dir).flatMap(entry => {
     const path = `${dir}/${entry}`
@@ -48,16 +55,19 @@ function collationPathList(input: string | string[] | undefined): string[] {
     return input.filter(path => path.endsWith('.xml')).sort()
   }
   return (input || '')
-    .split(/\s+/)
+    .split(WHITESPACE_RE)
     .filter(path => path.endsWith('.xml'))
     .sort()
 }
 
 function localeFromPath(path: string): string {
-  return basename(path, '.xml').replace(/_/g, '-')
+  return basename(path, '.xml').replace(UNDERSCORE_RE, '-')
 }
 
 function packRule(rule: CollationRule): PackedRule {
+  // Preserve LDML reset/relation/setting order. Runtime compilation applies
+  // each reset chain in sequence against root UCA weights.
+  // https://www.unicode.org/reports/tr35/tr35-collation.html#Orderings
   switch (rule.type) {
     case 'reset':
       return rule.before
@@ -76,6 +86,8 @@ function packRule(rule: CollationRule): PackedRule {
 
 function packCollation(collation: ParsedLDMLCollation): PackedCollation {
   if (collation.alias) {
+    // LDML aliases redirect one locale/type collation to another.
+    // https://www.unicode.org/reports/tr35/tr35-collation.html#Collation_Types
     return {alias: collation.alias}
   }
   return {rules: collation.rules.map(packRule)}

--- a/packages/intl-collator/scripts/parse-ldml-collation.ts
+++ b/packages/intl-collator/scripts/parse-ldml-collation.ts
@@ -46,6 +46,9 @@ const LEADING_WHITESPACE_RE = /^\s+/
 const SETTING_RE = /^\[([^\]\s]+)(?:\s+([^\]]+))?\]/
 const WHITESPACE_RE = /\s+/g
 
+// LDML Part 5 defines collation XML as <collations> containing one or more
+// typed <collation> elements, each with <cr> rule text or an <alias>.
+// https://www.unicode.org/reports/tr35/tr35-collation.html#Collation_Tailorings
 const xmlParser = new XMLParser({
   attributeNamePrefix: '',
   ignoreAttributes: false,
@@ -62,6 +65,9 @@ function trimStart(input: string): string {
 }
 
 function readRelationStrength(input: string): CollationRelationStrength | undefined {
+  // LDML relation operators encode strength: < primary, << secondary,
+  // <<< tertiary, and = identical.
+  // https://www.unicode.org/reports/tr35/tr35-collation.html#Orderings
   if (input.startsWith('<<<')) {
     return 'tertiary'
   }
@@ -86,6 +92,8 @@ function relationTokenLength(strength: CollationRelationStrength): number {
 }
 
 function starredRelationValues(input: string): string[] {
+  // LDML starred relations expand a sequence into one relation per code point.
+  // https://www.unicode.org/reports/tr35/tr35-collation.html#Orderings
   return Array.from(input.replace(WHITESPACE_RE, ''))
 }
 
@@ -114,6 +122,9 @@ function readToken(input: string): [string, string] {
 
 function parseSetting(key: string, rawValue = ''): CollationSetting {
   const value = rawValue.trim()
+  // LDML collation settings appear in square brackets in the <cr> rule stream.
+  // Unknown settings are preserved so generation can decide how to handle them.
+  // https://www.unicode.org/reports/tr35/tr35-collation.html#Collation_Settings
   switch (key) {
     case 'alternate':
     case 'backwards':
@@ -135,6 +146,9 @@ function parseSetting(key: string, rawValue = ''): CollationSetting {
 }
 
 function parseReset(rawValue: string): CollationReset {
+  // A rule chain starts with a reset (&). [before 1|2|3] changes insertion
+  // position relative to the reset anchor at primary/secondary/tertiary level.
+  // https://www.unicode.org/reports/tr35/tr35-collation.html#Orderings
   const before = BEFORE_RESET_RE.exec(rawValue)
   if (before) {
     return {
@@ -153,6 +167,10 @@ function parseRelation(
   strength: CollationRelationStrength,
   rawValue: string
 ): CollationRelation {
+  // LDML relation strings can carry a prefix/context with "|" and an expansion
+  // with "/"; keep both so tailoring compilation can assign context mappings.
+  // https://www.unicode.org/reports/tr35/tr35-collation.html#Context_Before
+  // https://www.unicode.org/reports/tr35/tr35-collation.html#Expansions
   const [prefixAndValue, expansion] = rawValue.split('/', 2)
   const [prefix, value] = prefixAndValue.split('|', 2)
   return {
@@ -166,6 +184,9 @@ function parseRelation(
 
 export function parseCollationRules(source: string): CollationRule[] {
   const rules: CollationRule[] = []
+  // Parse the LDML <cr> rule language: settings, resets, relation chains,
+  // starred relations, comments, prefixes, and expansions.
+  // https://www.unicode.org/reports/tr35/tr35-collation.html#Orderings
   let input = source.replace(COMMENT_RE, '').replace(WHITESPACE_RE, ' ').trim()
 
   while (input) {
@@ -239,6 +260,10 @@ export function parseLDMLCollations(
   source: string
 ): ParsedLDMLCollation[] {
   const collations: ParsedLDMLCollation[] = []
+  // Read the LDML XML layer with a real XML parser, then hand only <cr> rule
+  // text to the rule parser above. Aliases represent LDML collation fallback
+  // links between locale/type records.
+  // https://www.unicode.org/reports/tr35/tr35-collation.html#Collation_Types
   const parsed = xmlParser.parse(source) as XMLNode
   const collationNodes = rootCollations(parsed)?.collation
   if (!Array.isArray(collationNodes)) {

--- a/packages/intl-collator/scripts/parse-uca.ts
+++ b/packages/intl-collator/scripts/parse-uca.ts
@@ -27,6 +27,10 @@ const LEADING_DOT_RE = /^\./
 const LINE_SPLIT_RE = /\r?\n/
 const WHITESPACE_RE = /\s+/
 
+// Parses CLDR FractionalUCA/allkeys-style root entries into the collation
+// elements used by UCA's multi-level comparison algorithm.
+// https://www.unicode.org/reports/tr10/#Default_Unicode_Collation_Element_Table
+
 function parseHex(input: string): number {
   const value = parseInt(input, 16)
   if (!Number.isFinite(value)) {
@@ -36,6 +40,9 @@ function parseHex(input: string): number {
 }
 
 function parseWeightComponent(input: string): number {
+  // FractionalUCA weights can be raw hexadecimal bytes or symbolic U+NNNN
+  // weights; both become numeric UCA level weights.
+  // https://www.unicode.org/reports/tr10/#Default_Unicode_Collation_Element_Table
   const codePointWeight = input.trim().match(CODE_POINT_WEIGHT_RE)
   if (codePointWeight) {
     return parseHex(codePointWeight[1])
@@ -57,6 +64,9 @@ function parseDottedWeightComponent(input: string): number {
 }
 
 export function parseCodePointSequence(input: string): number[] {
+  // UCA mappings are keyed by one or more code points. Multiple code points
+  // form contractions that must be matched as a sequence at runtime.
+  // https://www.unicode.org/reports/tr10/#Contractions
   const codePoints = input
     .trim()
     .split(WHITESPACE_RE)
@@ -71,6 +81,10 @@ export function parseCodePointSequence(input: string): number[] {
 export function parseCollationElement(
   input: string
 ): ParsedCollationElement {
+  // Collation elements expose primary, secondary, tertiary, and quaternary
+  // weights. A leading "*" marks variable elements for shifted handling.
+  // https://www.unicode.org/reports/tr10/#Multi_Level_Comparison
+  // https://www.unicode.org/reports/tr10/#Variable_Weighting
   const normalized = input.trim().replace(LEADING_ASTERISK_RE, '')
   const variable = input.trim().startsWith('*')
   const weights = normalized.includes(',')
@@ -91,6 +105,9 @@ export function parseCollationElement(
 }
 
 export function parseUCALine(line: string): ParsedUCAEntry | undefined {
+  // Lines may include a prefix before "|" for context-sensitive mappings and
+  // one or more bracketed collation elements after ";".
+  // https://www.unicode.org/reports/tr10/#Contextual_Sensitive_Mappings
   const [withoutComment, comment] = line.split('#', 2)
   const trimmed = withoutComment.trim()
   if (!trimmed || trimmed.startsWith('@') || !trimmed.includes(';')) {
@@ -128,11 +145,17 @@ export function parseUCA(source: string): ParsedUCAEntry[] {
 }
 
 export function parseUCAVariableTop(source: string): number | undefined {
+  // The UCA variable top separates variable elements used by alternate shifted
+  // handling, which ECMA-402 exposes through ignorePunctuation.
+  // https://www.unicode.org/reports/tr10/#Variable_Weighting
   const match = VARIABLE_TOP_RE.exec(source)
   return match ? parseWeightComponent(match[1]) : undefined
 }
 
 export function buildUCATrie(entries: ParsedUCAEntry[]): PackedTrieNode {
+  // Runtime lookup needs longest-match contraction search, so generated root
+  // data stores root mappings in a trie instead of scanning UCA lines.
+  // https://www.unicode.org/reports/tr10/#Contractions
   const root: PackedTrieNode = {}
   entries.forEach((entry, index) => {
     let node = root

--- a/packages/intl-collator/tests/collator-conformance.tsv
+++ b/packages/intl-collator/tests/collator-conformance.tsv
@@ -1,0 +1,28 @@
+description	locale	sensitivity	numeric	caseFirst	ignorePunctuation	left	right	expected
+English base sensitivity ignores accents	en	base	-	-	-	resume	résumé	0
+English accent sensitivity orders plain before accented	en	accent	-	-	-	resume	résumé	-1
+English accent sensitivity ignores case	en	accent	-	-	-	a	A	0
+English case sensitivity ignores accents	en	case	-	-	-	a	á	0
+English case sensitivity distinguishes lowercase and uppercase	en	case	-	-	-	a	A	-1
+English variant sensitivity distinguishes accents	en	variant	-	-	-	resume	résumé	-1
+English numeric ordering sorts digit runs numerically	en	variant	true	-	-	item2	item10	-1
+English numeric ordering treats leading zeros as equal	en	variant	true	-	-	item02	item2	0
+English default ordering sorts digit runs lexically	en	variant	false	-	-	item2	item10	1
+English locale numeric extension sorts digit runs numerically	en-u-kn-true	variant	-	-	-	item2	item10	-1
+English upper caseFirst orders uppercase first	en	variant	-	upper	-	A	a	-1
+English lower caseFirst orders lowercase first	en	variant	-	lower	-	A	a	1
+English locale upper caseFirst extension orders uppercase first	en-u-kf-upper	variant	-	-	-	A	a	-1
+English ignorePunctuation ignores em dash	en	variant	-	-	true	a—b	ab	0
+French accent sensitivity orders multi-accent words	fr	accent	-	-	-	cote	côté	-1
+German variant sensitivity keeps umlaut before z	de	variant	-	-	-	ä	z	-1
+Spanish sorts n before ñ	es	variant	-	-	-	n	ñ	-1
+Chinese pinyin tone one before tone two	zh-u-co-pinyin	variant	-	-	-	ā	á	-1
+Chinese pinyin tone two before tone three	zh-u-co-pinyin	variant	-	-	-	á	ǎ	-1
+Chinese pinyin tone three before tone four	zh-u-co-pinyin	variant	-	-	-	ǎ	à	-1
+Chinese default collation uses pinyin tone order	zh	variant	-	-	-	à	a	-1
+Swedish sorts z before å	sv	variant	-	-	-	z	å	-1
+Swedish sorts å before ä	sv	variant	-	-	-	å	ä	-1
+Swedish sorts ä before ö	sv	variant	-	-	-	ä	ö	-1
+Danish sorts z before æ	da	variant	-	-	-	z	æ	-1
+Danish sorts æ before ø	da	variant	-	-	-	æ	ø	-1
+Danish sorts ø before å	da	variant	-	-	-	ø	å	-1

--- a/packages/intl-collator/tests/conformance.test.ts
+++ b/packages/intl-collator/tests/conformance.test.ts
@@ -1,0 +1,97 @@
+import {readFileSync} from 'node:fs'
+import {dirname, join} from 'node:path'
+import {Collator as FormatJSCollator} from '#packages/intl-collator/index.js'
+import {describe, expect, it} from 'vitest'
+
+type ConformanceCase = {
+  readonly description: string
+  readonly locale: string
+  readonly options: Intl.CollatorOptions
+  readonly left: string
+  readonly right: string
+  readonly expected: number
+}
+
+function parseOptionalBoolean(value: string): boolean | undefined {
+  return value === '-' ? undefined : value === 'true'
+}
+
+function parseCase(line: string): ConformanceCase {
+  const parts = line.split('\t')
+  if (parts.length !== 9) {
+    throw new Error(
+      `Invalid fixture row (expected 9 columns, got ${parts.length}): ${line}`
+    )
+  }
+  const [
+    description,
+    locale,
+    sensitivity,
+    numeric,
+    caseFirst,
+    ignorePunctuation,
+    left,
+    right,
+    expected,
+  ] = parts
+  const options: Intl.CollatorOptions = {}
+  // Fixture columns cover the ECMA-402 Collator options that feed
+  // InitializeCollator and CompareStrings: sensitivity, numeric (kn),
+  // caseFirst (kf), and ignorePunctuation.
+  // https://tc39.es/ecma402/#sec-initializecollator
+  if (sensitivity !== '-') {
+    options.sensitivity = sensitivity as Intl.CollatorOptions['sensitivity']
+  }
+  const numericValue = parseOptionalBoolean(numeric)
+  if (numericValue !== undefined) {
+    options.numeric = numericValue
+  }
+  if (caseFirst !== '-') {
+    options.caseFirst = caseFirst as Intl.CollatorOptions['caseFirst']
+  }
+  const ignorePunctuationValue = parseOptionalBoolean(ignorePunctuation)
+  if (ignorePunctuationValue !== undefined) {
+    options.ignorePunctuation = ignorePunctuationValue
+  }
+  return {
+    description,
+    locale,
+    options,
+    left,
+    right,
+    expected: Number(expected),
+  }
+}
+
+function sign(value: number): number {
+  return value < 0 ? -1 : value > 0 ? 1 : 0
+}
+
+const cases = readFileSync(
+  join(dirname(import.meta.filename), 'collator-conformance.tsv'),
+  'utf8'
+)
+  .trim()
+  .split(/\r?\n/)
+  .slice(1)
+  .map(parseCase)
+
+describe('Intl.Collator conformance with native Node Intl.Collator', () => {
+  for (const testCase of cases) {
+    it(testCase.description, () => {
+      const formatjs = new FormatJSCollator(testCase.locale, testCase.options)
+      const native = new Intl.Collator(testCase.locale, testCase.options)
+      // CompareStrings only promises a negative/zero/positive Number, so
+      // conformance compares signs rather than engine-specific magnitudes.
+      // https://tc39.es/ecma402/#sec-comparestrings
+      const formatjsResult = sign(
+        formatjs.compare(testCase.left, testCase.right)
+      )
+      const nativeResult = sign(native.compare(testCase.left, testCase.right))
+
+      expect(formatjsResult).toBe(testCase.expected)
+      expect(nativeResult).toBe(testCase.expected)
+      expect(formatjsResult).toBe(nativeResult)
+    })
+  }
+})


### PR DESCRIPTION
## Summary
- add a shared Intl.Collator conformance fixture that compares @formatjs/intl-collator against native Node Intl.Collator
- add an ICU4J conformance runner over the same fixture
- keep parser scripts/tests in their own Bazel package and document that convention

## Spec / reference links
- ECMA-402 Intl.Collator: https://tc39.es/ecma402/#sec-intl.collator
- ECMA-402 CompareStrings: https://tc39.es/ecma402/#sec-comparestrings
- ECMA-402 Collator resolved options: https://tc39.es/ecma402/#table-intl-collator-resolvedoptions
- Unicode Collation Algorithm: https://www.unicode.org/reports/tr10/

## Verification
- bazel test //packages/intl-collator:intl-collator_test //packages/intl-collator/scripts:parsers_test //conformance-tests/icu4j:intl_collator_conformance_test
- bazel build //packages/intl-collator //packages/intl-collator/scripts:generate-locale-data //packages/intl-collator/scripts:generate-tailoring-data //packages/intl-collator/scripts:generate-root-data
- bazel test //packages/intl-collator:types_typecheck_test //packages/intl-collator:typecheck_typecheck_test //packages/intl-collator:intl-collator_test_typecheck_typecheck_test