### PR TITLE
docs(@formatjs/intl-collator): document collator polyfill

### DIFF
--- a/docs/public/sitemap.xml
+++ b/docs/public/sitemap.xml
@@ -121,6 +121,11 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://formatjs.io/docs/polyfills/intl-collator</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://formatjs.io/docs/polyfills/intl-datetimeformat</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>

--- a/docs/src/docs-metadata.generated.json
+++ b/docs/src/docs-metadata.generated.json
@@ -91,6 +91,10 @@
     "title": "Polyfills",
     "description": "One of our goals is to provide developers with access to newest ECMA-402 Intl APIs. Therefore, FormatJS suite also provide multiple high quality polyfil..."
   },
+  "polyfills/intl-collator": {
+    "title": "Intl Collator",
+    "description": "A spec-compliant polyfill/ponyfill for Intl.Collator."
+  },
   "polyfills/intl-datetimeformat": {
     "title": "Intl Datetimeformat",
     "description": "A spec-compliant polyfill for Intl.DateTimeFormat fully tested by the official ECMAScript Conformance test suite"

--- a/docs/src/docs/polyfills.mdx
+++ b/docs/src/docs/polyfills.mdx
@@ -7,6 +7,7 @@ Our current list of polyfills includes:
 - [Intl.ListFormat](/docs/polyfills/intl-listformat)
 - [Intl.DisplayNames](/docs/polyfills/intl-displaynames)
 - [Intl.NumberFormat](/docs/polyfills/intl-numberformat) (ES2020)
+- [Intl.Collator](/docs/polyfills/intl-collator)
 - [Intl.Locale](/docs/polyfills/intl-locale)
 - [Intl.LocaleMatcher](/docs/polyfills/intl-localematcher)
 - [Intl.getCanonicalLocales](/docs/polyfills/intl-getcanonicallocales)

--- a/docs/src/docs/polyfills/intl-collator.mdx
+++ b/docs/src/docs/polyfills/intl-collator.mdx
@@ -1,0 +1,91 @@
+A spec-compliant polyfill/ponyfill for `Intl.Collator`.
+
+[![npm Version](https://img.shields.io/npm/v/@formatjs/intl-collator.svg?style=flat-square)](https://www.npmjs.org/package/@formatjs/intl-collator)
+![size](https://badgen.net/bundlephobia/minzip/@formatjs/intl-collator)
+
+`Intl.Collator` provides locale-aware string comparison for sorting and
+searching. The FormatJS polyfill implements the ECMA-402 API surface and uses
+generated Unicode Collation Algorithm (UCA) and CLDR collation data for
+runtime comparison.
+
+## Installation
+
+<Tabs
+groupId="npm"
+defaultValue="npm"
+values={[
+{label: 'npm', value: 'npm'},
+{label: 'yarn', value: 'yarn'},
+{label: 'pnpm', value: 'pnpm'},
+]}>
+<TabItem value="npm">
+
+```sh
+npm i @formatjs/intl-collator
+```
+
+</TabItem>
+<TabItem value="yarn">
+
+```sh
+yarn add @formatjs/intl-collator
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```sh
+pnpm add @formatjs/intl-collator
+```
+
+</TabItem>
+</Tabs>
+
+## Usage
+
+### Global polyfill
+
+```tsx
+import '@formatjs/intl-collator/polyfill.js'
+
+const collator = new Intl.Collator('sv')
+const sorted = ['ä', 'z', 'å'].sort(collator.compare)
+```
+
+### Force polyfill
+
+```tsx
+import '@formatjs/intl-collator/polyfill-force.js'
+```
+
+### ES modules
+
+```tsx
+import {Collator} from '@formatjs/intl-collator'
+
+const collator = new Collator('zh-u-co-pinyin', {
+  sensitivity: 'variant',
+})
+```
+
+## Supported Features
+
+- `Intl.Collator(locales, options)`
+- `Intl.Collator.supportedLocalesOf(locales, options)`
+- `Intl.Collator.prototype.compare`
+- `Intl.Collator.prototype.resolvedOptions()`
+- Unicode extension keys `co`, `kn`, and `kf`
+- `numeric`, `caseFirst`, `sensitivity`, `usage`, and `ignorePunctuation`
+- Root CLDR collation data plus generated locale collation metadata and
+  tailorings
+
+## Data Model
+
+The package consumes generated CLDR collation data from
+`@formatjs_generated/cldr.collation`. Build-time scripts parse CLDR common UCA
+data and LDML collation XML so applications do not parse XML at runtime.
+
+## Tests
+
+This package is tested against FormatJS unit tests, parser tests, and
+conformance data generated from ICU4J and native `Intl.Collator`.

--- a/docs/src/utils/navigation.ts
+++ b/docs/src/utils/navigation.ts
@@ -69,6 +69,7 @@ export function getNavigationTree(): NavSection[] {
       order: 4,
       items: [
         {title: 'Overview', path: 'polyfills'},
+        {title: 'Intl.Collator', path: 'polyfills/intl-collator'},
         {title: 'Intl.DateTimeFormat', path: 'polyfills/intl-datetimeformat'},
         {title: 'Intl.DisplayNames', path: 'polyfills/intl-displaynames'},
         {title: 'Intl.DurationFormat', path: 'polyfills/intl-durationformat'},

--- a/knowledge-base/007-package-intl-polyfills.md
+++ b/knowledge-base/007-package-intl-polyfills.md
@@ -1,6 +1,6 @@
 # Intl Polyfill Packages — Shared Architecture
 
-All 11 polyfill packages share a common architecture. See individual docs (007a-007k) for per-polyfill CLDR data pipeline details.
+All 12 polyfill packages share a common architecture. See individual docs (007a-007l) for per-polyfill CLDR data pipeline details.
 
 ## Polyfill Strategy
 
@@ -32,9 +32,9 @@ Each polyfill uses `rolldown_bundle` with `dts = True` to produce bundled output
 - Buffered via `globalThis.__FORMATJS_{API}_DATA__` if polyfill not yet loaded
 - Two-stage build: `cldr-raw` (extraction) → `locale-data` (distribution)
 
-### Static compilation (durationformat, segmenter, locale, getcanonicallocales, supportedvaluesof)
+### Static compilation (durationformat, segmenter, locale, getcanonicallocales, supportedvaluesof, collator)
 
-- Data compiled directly into the main bundle as `.generated.ts` files
+- Data compiled directly into the main bundle or generated package as `.ts` files
 - No per-locale dynamic loading needed
 - Single-stage build via `generate_src_file` targets
 
@@ -71,7 +71,4 @@ All polyfills depend on `@formatjs/ecma402-abstract` and `@formatjs/intl-localem
 - [007i — intl-locale](./007i-polyfill-intl-locale.md) — ECMA-402 §14 (6 CLDR data sources)
 - [007j — intl-getcanonicallocales](./007j-polyfill-intl-getcanonicallocales.md) — ECMA-402 §8.2.1
 - [007k — intl-supportedvaluesof](./007k-polyfill-intl-supportedvaluesof.md) — ECMA-402 §8.3.2
-
-## Planned Polyfill Docs
-
-- [007l — intl-collator](./007l-polyfill-intl-collator.md) — ECMA-402 §10 (CLDR collation compiler plan)
+- [007l — intl-collator](./007l-polyfill-intl-collator.md) — ECMA-402 §10 (CLDR collation compiler)

--- a/knowledge-base/007l-polyfill-intl-collator.md
+++ b/knowledge-base/007l-polyfill-intl-collator.md
@@ -1,304 +1,120 @@
-# @formatjs/intl-collator Plan
+# @formatjs/intl-collator
 
 **ECMA-402 Section 10** - `Intl.Collator`
 
-## Purpose
+## Current Status
 
-Plan for a full `Intl.Collator` polyfill that supports locale-aware string comparison for sorting and searching.
+`@formatjs/intl-collator` has landed as the FormatJS `Intl.Collator` polyfill.
+The stack was consolidated before merge into:
 
-`Intl.Collator` is different from the formatter polyfills: the hard part is not display data, but compiling the Unicode Collation Algorithm plus CLDR locale tailorings into compact data that can produce stable sort keys at runtime.
+- `feat(@formatjs/intl-collator): add locale collation data pipeline`
+- `feat(@formatjs/intl-collator): implement tailored locale comparison`
+- `test(@formatjs/intl-collator): add collator conformance tests`
 
-## Spec Surface
+The npm package name was bootstrapped with a tiny `0.0.0` placeholder package
+so npm trusted publishing/OIDC can be configured before the first real release.
 
-The package should implement:
+## Public Surface
+
+The package follows the standard FormatJS polyfill entrypoint shape:
+
+- `index.ts`
+- `polyfill.ts`
+- `polyfill-force.ts`
+- `should-polyfill.ts`
+
+It implements:
 
 - `Intl.Collator(locales, options)`
 - `Intl.Collator.supportedLocalesOf(locales, options)`
 - `Intl.Collator.prototype.compare`
 - `Intl.Collator.prototype.resolvedOptions()`
 
-Required internal behavior:
+Supported option plumbing includes:
 
 - `usage`: `"sort"` and `"search"`
-- `locale` resolution with the `co`, `kn`, and `kf` Unicode extension keys
-- `collation`: requested/default collation type, exposed as `"default"` when no explicit type resolves
-- `numeric`: numeric collation via `kn` / `options.numeric`
-- `caseFirst`: `"upper"`, `"lower"`, `"false"` via `kf` / `options.caseFirst`
-- `sensitivity`: `"base"`, `"accent"`, `"case"`, `"variant"`
+- Unicode extension keys: `co`, `kn`, and `kf`
+- `numeric`
+- `caseFirst`
+- `sensitivity`
 - `ignorePunctuation`
-- Bound compare function caching
-
-Primary spec references:
-
-- [Intl.Collator constructor](https://tc39.es/ecma402/#sec-intl.collator)
-- [Initialize Collator options and locale data](https://tc39.es/ecma402/#sec-intl.collator)
-- [CompareStrings](https://tc39.es/ecma402/#sec-comparestrings)
-- [Resolved Collator options](https://tc39.es/ecma402/#table-intl-collator-resolvedoptions)
+- cached bound compare functions
 
 ## Data Sources
 
-### Required
+The collator data pipeline uses CLDR common data rather than CLDR JSON packages:
 
-| Source | Why we need it | How to consume |
-| ------ | -------------- | -------------- |
-| CLDR common `common/uca/FractionalUCA_SHORT.txt` or `allkeys_CLDR_SHORT.txt` | Root CLDR collation element table. This is the base table for untailored collation and all locale tailorings. | Add a pinned CLDR common archive in Bazel, matching the repo's CLDR version. Prefer the `_SHORT` file for generator input. |
-| CLDR common `common/collation/*.xml` | Locale-specific collation tailorings, collation types (`standard`, `search`, `phonebook`, `stroke`, `pinyin`, etc.), aliases, and default settings. | Parse XML during codegen. Do not parse XML at runtime. |
-| `cldr-bcp47/bcp47/collation.json` | BCP 47 collation keyword metadata: valid `co` values, aliases, deprecations, and `Intl.supportedValuesOf("collation")` alignment. | Reuse the existing `cldr-bcp47` dependency already consumed by `intl-supportedvaluesof`. |
-| Unicode decimal digit data | Needed for `numeric: true` / `kn=true` comparison of decimal digit runs across numbering systems. | Reuse the existing Unicode generated digit mapping from `@formatjs_generated/unicode/ecma402-abstract/digit-mapping.js` where possible. |
-| Unicode normalization | UCA assumes canonical-equivalent input compares correctly. | Use `String.prototype.normalize("NFD")` in runtime when the generated collation settings require normalization. Document that environments without `normalize` need a separate dependency or reduced support. |
+- `common/uca/FractionalUCA_SHORT.txt` for root CLDR collation elements
+- `common/collation/*.xml` for locale collation metadata and LDML tailorings
+- generated CLDR collation package `@formatjs_generated/cldr.collation`
 
-### Test Data
+CLDR common is provided to Bazel through the pinned `cldr_common` archive. Keep
+that archive aligned with the rest of the repo's CLDR version family when
+updating CLDR data.
 
-| Source | Why we need it |
-| ------ | -------------- |
-| CLDR common `common/uca/CollationTest_CLDR_NON_IGNORABLE_SHORT.txt` | Root non-ignorable conformance smoke tests. |
-| CLDR common `common/uca/CollationTest_CLDR_SHIFTED_SHORT.txt` | Root shifted/ignore-punctuation conformance smoke tests. |
-| Test262 `intl402/Collator` | ECMA-402 constructor, option, `resolvedOptions`, and compare behavior. |
-| ICU reference snapshots | Locale-tailoring spot checks for languages with important tailorings: `de-u-co-phonebk`, `sv`, `da`, `es`, `zh-u-co-pinyin`, `zh-u-co-stroke`, `ja`, `ko`, `fr`, `th`, `tr`, `lt`. |
+## Build-Time Pipeline
 
-## Why CLDR Common, Not CLDR JSON
+The build-time scripts live in `packages/intl-collator/scripts/`, which is its
+own Bazel package. Keep script-only parser sources, generator binaries, and
+parser tests out of the parent runtime target. This avoids mixing build-time XML
+parsing dependencies with published runtime code.
 
-The repo currently consumes CLDR through npm packages such as `cldr-core`, `cldr-bcp47`, `cldr-numbers-full`, and `cldr-misc-full`. The current CLDR JSON package list does not include a `cldr-collation-full` package. Collation tailorings live in CLDR's LDML/XML data under `common/collation`, and root UCA data lives under `common/uca`.
+Important script targets:
 
-So the Collator pipeline should add a pinned CLDR common archive or CLDR source-tree archive to Bazel, then extract only:
+- `//packages/intl-collator/scripts:parsers`
+- `//packages/intl-collator/scripts:parsers_test`
+- `//packages/intl-collator/scripts:generate-root-data`
+- `//packages/intl-collator/scripts:generate-locale-data`
+- `//packages/intl-collator/scripts:generate-tailoring-data`
 
-- `common/uca/*_SHORT.txt`
-- `common/collation/*.xml`
-- optionally `common/supplemental/supplementalMetadata.xml` / parent locale data if locale inheritance cannot be derived from existing `cldr-core`
+Important generated package targets:
 
-## Preprocessing Strategy
+- `//packages/generated/cldr-collation:root_data`
+- `//packages/generated/cldr-collation:locale_data`
+- `//packages/generated/cldr-collation:tailoring_data`
+- `//packages/generated/cldr-collation:pkg`
 
-### Stage 1: Parse Root Collation Data
+## Parser Notes
 
-Generate a root collation table from CLDR root data:
+- UCA parsing is purpose-built for `FractionalUCA_SHORT.txt`.
+- LDML collation XML parsing uses `fast-xml-parser`; do not replace it with
+  ad hoc XML string parsing.
+- The LDML rule grammar inside collation rule strings is still purpose-built.
+- Keep parser regexes hoisted to module-level constants for performance and to
+  avoid recompiling expressions in hot loops.
+- `generate_package_file` actions must include runtime parser package inputs
+  such as `//packages/intl-collator:node_modules/fast-xml-parser` in `data`
+  when the generator imports a parser that imports that package. Adding the npm
+  package only to the `ts_binary(data = ...)` can pass locally but fail on Linux
+  action runfiles.
 
-1. Parse code point sequences and collation elements.
-2. Store collation weights by level: primary, secondary, tertiary, quaternary/variable.
-3. Build a longest-match trie for contractions and multi-code-point mappings.
-4. Preserve expansions, where one input sequence maps to multiple collation elements.
-5. Mark variable elements so `alternate=shifted` and `ignorePunctuation` can suppress or move them correctly.
-6. Implement implicit weights for code points not explicitly present in the root table, especially Han/unassigned code points.
+## Runtime Model
 
-Preferred generated shape:
+Runtime comparison consumes generated root and locale collation data:
 
-```typescript
-export type CollationElement = readonly [
-  primary: number,
-  secondary: number,
-  tertiary: number,
-  flags: number,
-]
+- root collation data is stored as packed elements and a longest-match trie
+- locale metadata exposes supported collation types and default collation
+- tailoring data applies locale-specific LDML rule effects
+- comparison preserves existing `numeric`, `caseFirst`, and sensitivity behavior
 
-export const rootTrie: PackedTrie
-export const rootElements: readonly CollationElement[]
+Fallback implicit weights are used for code points not present in the root data.
+
+## Tests
+
+Primary validation targets:
+
+```sh
+bazel build //packages/generated/cldr-collation:pkg //packages/intl-collator //packages/intl-collator/scripts:generate-tailoring-data //packages/intl-collator/scripts:generate-locale-data //packages/intl-collator/scripts:generate-root-data
+bazel test //packages/intl-collator:intl-collator_test //packages/intl-collator/scripts:parsers_test //conformance-tests/icu4j:intl_collator_conformance_test
 ```
 
-The runtime should never scan a flat root table. It should walk a trie and emit collation elements.
+The conformance test data compares the polyfill against ICU4J and native Node
+`Intl.Collator`. Keep that test broad when changing generated data or comparison
+behavior.
 
-### Stage 2: Parse LDML Collation Tailorings
+## Release Notes
 
-Parse each `common/collation/*.xml` file into locale collation records:
-
-```typescript
-type RawCollation = {
-  locale: string
-  type: string
-  rules: string
-  settings: CollationSettings
-  alias?: string
-}
-```
-
-The parser needs to understand at least:
-
-- resets: `&`
-- relations: `<`, `<<`, `<<<`, `=`
-- before resets: `[before 1]`, `[before 2]`, `[before 3]`
-- expansions: `/`
-- prefixes/context: `|`
-- imports: `[import und-u-co-emoji]`
-- settings: `[strength]`, `[alternate]`, `[backwards 2]`, `[caseFirst]`, `[numericOrdering]`, `[normalization]`, `[reorder]`
-- XML aliases between locales/types
-
-This parser should live under `packages/intl-collator/scripts/`, not in `ecma402-abstract`, because it is build-time only. `scripts/` should also be its own Bazel package: keep parser sources and parser tests in `//packages/intl-collator/scripts:*` targets instead of adding them to the parent runtime package target.
-
-Use a real XML parser, currently `fast-xml-parser`, for the LDML XML layer. The rule grammar inside `<cr>` is not XML and can stay as a purpose-built parser, but any regexes in that parser should be module-level constants rather than recreated inside hot loops.
-
-### Stage 3: Compile Tailorings Against Root
-
-For each locale/type:
-
-1. Resolve locale inheritance and collation type fallback.
-2. Start from the root order plus inherited parent tailoring.
-3. Apply LDML rules into a mutable order graph.
-4. Allocate synthetic weights in gaps between existing root weights.
-5. Emit only the delta from root:
-   - added contractions
-   - added expansions
-   - replaced weights
-   - settings overrides
-   - alias target
-
-Generated locale data should be compact:
-
-```typescript
-export default {
-  locale: "de",
-  collations: {
-    default: "standard",
-    standard: {settings, trieDelta, elementsDelta},
-    phonebook: {settings, trieDelta, elementsDelta},
-    search: {settings, trieDelta, elementsDelta},
-  },
-}
-```
-
-Do not duplicate the root trie in every locale file.
-
-### Stage 4: Runtime Sort Key Generation
-
-Runtime comparison should be:
-
-1. Convert input with `String(x)`.
-2. Normalize if required by settings.
-3. Tokenize via longest-match trie.
-4. Emit collation elements, including expansions and context-sensitive mappings.
-5. If `numeric` is true, detect decimal digit runs and emit numeric primary weights.
-6. Build or stream-compare level keys according to the resolved sensitivity:
-   - `base`: primary
-   - `accent`: primary + secondary
-   - `case`: primary + case level / case tertiary handling
-   - `variant`: primary + secondary + tertiary
-7. Apply settings:
-   - `caseFirst`: reorder case weights at case/tertiary level
-   - `ignorePunctuation`: use shifted alternate handling for variable punctuation
-   - French backwards secondary when `[backwards 2]` applies
-8. Return `-1`, `0`, or `1`.
-
-Prefer streaming level comparison over allocating full sort keys for every compare call. Add an internal `getSortKey()` helper only for tests and debugging.
-
-## Package Architecture
-
-### Files
-
-```text
-packages/intl-collator/
-  index.ts
-  polyfill.ts
-  polyfill-force.ts
-  should-polyfill.ts
-  core.ts
-  compare.ts
-  sort-key.ts
-  get_internal_slots.ts
-  types.ts
-  scripts/
-    parse-uca.ts
-    parse-ldml-collation.ts
-    compile-collations.ts
-    cldr-raw.ts
-    locale-data.ts
-  tests/
-    index.test.ts
-    compare.test.ts
-    options.test.ts
-    conformance-root.test.ts
-```
-
-### Generated Data
-
-Use a hybrid data-loading model:
-
-- Static root data in `@formatjs_generated/cldr.collation/root.js`
-- Static metadata in `@formatjs_generated/cldr.collation/meta.js`
-- Per-locale tree-shakeable files under `packages/intl-collator/locale-data/{locale}.js`
-
-This keeps the base algorithm usable without loading every locale tailoring and matches the existing dynamic-locale pattern for large data polyfills.
-
-### Public Loading API
-
-Match the other polyfills:
-
-```typescript
-Intl.Collator.__addLocaleData(localeData)
-```
-
-Also support buffered locale data:
-
-```typescript
-globalThis.__FORMATJS_COLLATOR_DATA__
-```
-
-## Build Plan
-
-1. Add `@formatjs/intl-collator` package skeleton.
-2. Add CLDR common archive inputs to Bazel, pinned to the same CLDR family as the repo's npm CLDR dependencies.
-3. Add generated package `@formatjs_generated/cldr.collation` for root data and metadata.
-4. Add `cldr-raw` generation for per-locale collation deltas.
-5. Add `locale-data` generation for tree-shakeable locale registration files.
-6. Add `supported-locales` generation for Collator.
-7. Add package build, `no_internal_imports_test`, and `package_exports_test`.
-8. Add docs entry and website polyfill docs.
-
-## Implementation Milestones
-
-### Milestone 1: Root Sort MVP
-
-- Root CLDR table only.
-- `usage: "sort"` only.
-- `sensitivity: "base" | "accent" | "variant"`.
-- No locale tailorings yet.
-- Tests: root CLDR non-ignorable short conformance, basic Test262 constructor/resolvedOptions.
-
-### Milestone 2: Options
-
-- `numeric`
-- `caseFirst`
-- `ignorePunctuation`
-- `usage: "search"` default sensitivity plumbing
-- Tests for each option against native ICU in Node where stable.
-
-### Milestone 3: Locale Tailorings
-
-- Parse and compile `standard` tailorings.
-- Add locale-data loading.
-- Cover high-signal locales: German phonebook, Swedish, Danish, Spanish traditional, Turkish, Lithuanian, French backwards secondary.
-
-### Milestone 4: Collation Types
-
-- Resolve `co` extension and `options.collation`.
-- Add non-default types: `phonebk`, `dict`, `trad`, `pinyin`, `stroke`, `emoji`, `eor` where CLDR provides them.
-- Align supported collation values with `intl-supportedvaluesof`.
-
-### Milestone 5: Search
-
-- Use `search` tailorings when available.
-- Implement locale default search sensitivity.
-- Add tests that compare search equivalence behavior separately from sort ordering.
-
-### Milestone 6: Conformance and Size Work
-
-- Add Test262 Collator shard.
-- Add CLDR root short conformance tests.
-- Add a small ICU snapshot suite for selected locales/types.
-- Measure root data and top locale-data sizes.
-- Tune packing format before publishing.
-
-## Risks and Open Questions
-
-- **Tailoring compiler complexity**: LDML collation rules are a small language. The first production risk is rule parsing and weight allocation, not the ECMA-402 wrapper.
-- **Bundle size**: Root collation data is large. The generated format must be trie-based and delta-based from the start.
-- **Search semantics**: `usage: "search"` is not just a sort with a different default sensitivity for all locales. CLDR `search` tailorings need to be represented separately.
-- **Normalization**: Runtime normalization is required for correctness in some locales. Decide whether `String.prototype.normalize` is a hard dependency.
-- **Implicit weights**: CJK/unassigned code points cannot rely only on explicit table entries.
-- **Parity target**: Native engines use ICU, but exact output can vary by ICU/CLDR version. Tests should pin to the CLDR version used by our generator, not whatever Node happens to ship.
-
-## Recommendation
-
-Build this as a data compiler first, not a runtime-first polyfill. The runtime should consume a compact precompiled collation model:
-
-- root trie + root element table
-- per-locale/type deltas
-- settings metadata
-
-The first PR should not try to support all locale tailorings. It should land the package skeleton, root data generator, root sort-key runtime, and root conformance tests. Once the root model is stable, locale tailorings become incremental data/compiler work instead of rewrites to the comparison engine.
+- The package name exists on npm as `@formatjs/intl-collator@0.0.0`.
+- The placeholder exists only to enable npm trusted publishing setup.
+- The first real release should come from the normal prerelease/release
+  automation after npm OIDC is configured.


### PR DESCRIPTION
## Summary
- add the public docs page for the Intl.Collator polyfill
- link Intl.Collator from the polyfills overview, sidebar, and docs metadata
- update the knowledge-base collator notes from implementation plan to landed architecture/release notes

## Test Plan
- bazel build //docs:docs_metadata //docs:typecheck
- bazel build //docs:dist