### PR TITLE
build: include linux arm64 native package in dist

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -77,6 +77,7 @@ PACKAGES_TO_DIST = [
     "//packages/bigdecimal",
     "//packages/cli-lib",
     "//packages/cli-native-darwin-arm64",
+    "//packages/cli-native-linux-arm64",
     "//packages/cli-native-linux-x64",
     "//packages/cli",
     "//packages/ecma376",


### PR DESCRIPTION
## Summary
- include @formatjs/cli-native-linux-arm64 in the root Bazel dist package list
- fixes release publish failures resolving @formatjs/cli's workspace optionalDependency

## Verification
- bazel build :dist
- verified formatjs_dist includes cli-native-linux-arm64 alongside the other native packages
- ran pnpm install in a chmodded temp copy of formatjs_dist with npmjs registry
- packed @formatjs/cli and confirmed workspace dependencies resolve to concrete versions
- packed @formatjs/intl-numberformat and confirmed locale-data is present in the tarball