### PR TITLE
build: include linux arm64 native package in dist

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -77,6 +77,7 @@ PACKAGES_TO_DIST = [
     "//packages/bigdecimal",
     "//packages/cli-lib",
     "//packages/cli-native-darwin-arm64",
+    "//packages/cli-native-linux-arm64",
     "//packages/cli-native-linux-x64",
     "//packages/cli",
     "//packages/ecma376",


### PR DESCRIPTION
Adds the new //packages/cli-native-linux-arm64 package to PACKAGES_TO_DIST so dist metadata includes the Linux ARM64 native CLI package. This was generated by the repo's Gazelle pre-commit hook after the formatjs_cli v1.1.5 release commit.