### PR TITLE
fix(formatjs_cli): implement pseudo-locale transforms

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -77,6 +77,7 @@ PACKAGES_TO_DIST = [
     "//packages/bigdecimal",
     "//packages/cli-lib",
     "//packages/cli-native-darwin-arm64",
+    "//packages/cli-native-linux-arm64",
     "//packages/cli-native-linux-x64",
     "//packages/cli",
     "//packages/ecma376",

--- a/crates/formatjs_cli/README.md
+++ b/crates/formatjs_cli/README.md
@@ -240,7 +240,7 @@ formatjs compile "lang/*.json" \
 - `--out-file <PATH>` - Output file path (prints to stdout if not provided)
 - `--ast` - Compile to AST instead of strings
 - `--skip-errors` - Continue compiling after errors (excludes keys with errors)
-- `--pseudo-locale <LOCALE>` - Accept pseudo-locale selection with `--ast`; pseudo-locale transformations are not yet implemented in the Rust CLI
+- `--pseudo-locale <LOCALE>` - Generate pseudo-locale AST output; requires `--ast`
   - Values: `xx-LS`, `xx-AC`, `xx-HA`, `en-XA`, `en-XB`
 - `--ignore-tag` - Treat HTML/XML tags as string literals
 
@@ -298,7 +298,6 @@ formatjs verify "lang/*.json" \
 
 - `--format` accepts built-in formatter names only. The Node.js CLI can also load custom JavaScript formatter files.
 - Extraction currently targets JavaScript and TypeScript source files. Framework template extraction for Vue, Svelte, Handlebars, Glimmer, GTS, and GJS is handled by the Node.js CLI.
-- Pseudo-locale options are accepted for CLI compatibility, but pseudo-locale AST transformations are not yet implemented.
 
 ## Development
 

--- a/crates/formatjs_cli/src/compile.rs
+++ b/crates/formatjs_cli/src/compile.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use formatjs_icu_messageformat_parser::MessageFormatElement;
 use serde_json::{Map, Value, json};
 use std::collections::BTreeMap;
 use std::path::PathBuf;
@@ -22,6 +23,33 @@ pub enum PseudoLocale {
     /// English expansion (east-to-west)
     EnXb,
 }
+
+const XX_LS_SUFFIX: &str = "SSSSSSSSSSSSSSSSSSSSSSSSS";
+const XX_HA_PREFIX: &str = "[javascript]";
+const EN_XA_PREFIX: &str = "[";
+const EN_XA_SUFFIX: &str = "]";
+const EN_XB_PREFIX: &str = "\u{202e}";
+const EN_XB_SUFFIX: &str = "\u{202c}";
+
+const ACCENTED_CAPS: [u32; 26] = [
+    550, 385, 391, 7698, 7702, 401, 403, 294, 298, 308, 310, 319, 7742, 544, 510, 420, 586, 344,
+    350, 358, 364, 7804, 7814, 7818, 7822, 7824,
+];
+
+const ACCENTED_SMALL: [u32; 26] = [
+    551, 384, 392, 7699, 7703, 402, 608, 295, 299, 309, 311, 320, 7743, 414, 511, 421, 587, 345,
+    351, 359, 365, 7805, 7815, 7819, 7823, 7825,
+];
+
+const FLIPPED_CAPS: [u32; 26] = [
+    8704, 1296, 8579, 5601, 398, 8498, 8513, 72, 73, 383, 1276, 8514, 87, 78, 79, 1280, 210, 7450,
+    83, 8869, 8745, 581, 77, 88, 8516, 90,
+];
+
+const FLIPPED_SMALL: [u32; 26] = [
+    592, 113, 596, 112, 477, 607, 387, 613, 305, 638, 670, 645, 623, 117, 111, 100, 98, 633, 115,
+    647, 110, 652, 653, 120, 654, 122,
+];
 
 /// Compile extracted translation files into react-intl consumable JSON.
 ///
@@ -129,7 +157,11 @@ pub fn compile_to_string(
 
         let base_dir = crate::extract::extract_base_dir(pattern_str);
         if base_dir.exists() {
-            for entry in WalkDir::new(&base_dir).follow_links(follow_links).into_iter().filter_map(|e| e.ok()) {
+            for entry in WalkDir::new(&base_dir)
+                .follow_links(follow_links)
+                .into_iter()
+                .filter_map(|e| e.ok())
+            {
                 if entry.path().is_file() {
                     let path_str = entry.path().to_string_lossy();
                     if fast_glob::glob_match(pattern_str, path_str.as_ref()) {
@@ -198,11 +230,6 @@ pub fn compile_messages_to_string(
         anyhow::bail!("Pseudo-locale generation requires --ast flag");
     }
 
-    // Warn about unimplemented features
-    if pseudo_locale.is_some() {
-        eprintln!("Warning: Pseudo-locale transformations not yet implemented");
-    }
-
     // Parse and validate ICU MessageFormat, compile to output format
     let mut compiled_messages: Map<String, Value> = Map::new();
     let mut error_count = 0;
@@ -217,11 +244,12 @@ pub fn compile_messages_to_string(
     for (id, (message, source_file)) in &messages {
         let parser = Parser::new(message.as_str(), parser_options.clone());
         match parser.parse() {
-            Ok(msg_ast) => {
-                // TODO: Apply pseudo-locale transformations to AST if specified
-                // This would modify literal elements in the AST
-
+            Ok(mut msg_ast) => {
                 if ast {
+                    if let Some(locale) = pseudo_locale {
+                        msg_ast = apply_pseudo_locale(msg_ast, locale);
+                    }
+
                     // Serialize AST to JSON for output
                     let ast_json = serde_json::to_value(&msg_ast)
                         .with_context(|| format!("Failed to serialize AST for message '{}'", id))?;
@@ -260,12 +288,168 @@ pub fn compile_messages_to_string(
     Ok(output)
 }
 
+fn apply_pseudo_locale(
+    mut ast: Vec<MessageFormatElement>,
+    pseudo_locale: PseudoLocale,
+) -> Vec<MessageFormatElement> {
+    match pseudo_locale {
+        PseudoLocale::XxLs => {
+            if let Some(MessageFormatElement::Literal(last)) = ast.last_mut() {
+                last.value.push_str(XX_LS_SUFFIX);
+            } else {
+                ast.push(MessageFormatElement::literal(XX_LS_SUFFIX.to_string()));
+            }
+            ast
+        }
+        PseudoLocale::XxAc => {
+            transform_literal_elements(&mut ast, &|value| value.to_uppercase());
+            ast
+        }
+        PseudoLocale::XxHa => {
+            if let Some(MessageFormatElement::Literal(first)) = ast.first_mut() {
+                first.value.insert_str(0, XX_HA_PREFIX);
+            } else {
+                ast.insert(0, MessageFormatElement::literal(XX_HA_PREFIX.to_string()));
+            }
+            ast
+        }
+        PseudoLocale::EnXa => {
+            transform_literal_elements(&mut ast, &|value| {
+                transform_ascii(value, &ACCENTED_SMALL, &ACCENTED_CAPS, true)
+            });
+
+            let mut wrapped = Vec::with_capacity(ast.len() + 2);
+            wrapped.push(MessageFormatElement::literal(EN_XA_PREFIX.to_string()));
+            wrapped.extend(ast);
+            wrapped.push(MessageFormatElement::literal(EN_XA_SUFFIX.to_string()));
+            wrapped
+        }
+        PseudoLocale::EnXb => {
+            transform_literal_elements(&mut ast, &|value| {
+                transform_ascii(value, &FLIPPED_SMALL, &FLIPPED_CAPS, false)
+            });
+
+            let mut wrapped = Vec::with_capacity(ast.len() + 2);
+            wrapped.push(MessageFormatElement::literal(EN_XB_PREFIX.to_string()));
+            wrapped.extend(ast);
+            wrapped.push(MessageFormatElement::literal(EN_XB_SUFFIX.to_string()));
+            wrapped
+        }
+    }
+}
+
+fn transform_literal_elements(
+    ast: &mut [MessageFormatElement],
+    transform: &impl Fn(&str) -> String,
+) {
+    for element in ast {
+        match element {
+            MessageFormatElement::Literal(literal) => {
+                literal.value = transform(&literal.value);
+            }
+            MessageFormatElement::Plural(plural) => {
+                for option in plural.options.values_mut() {
+                    transform_literal_elements(&mut option.value, transform);
+                }
+            }
+            MessageFormatElement::Select(select) => {
+                for option in select.options.values_mut() {
+                    transform_literal_elements(&mut option.value, transform);
+                }
+            }
+            MessageFormatElement::Tag(tag) => {
+                transform_literal_elements(&mut tag.children, transform);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn transform_ascii(
+    message: &str,
+    small_map: &[u32; 26],
+    caps_map: &[u32; 26],
+    elongate: bool,
+) -> String {
+    let mut result = String::with_capacity(message.len());
+
+    for ch in message.chars() {
+        if ch.is_ascii_lowercase() {
+            let index = (ch as u8 - b'a') as usize;
+            let mapped = char::from_u32(small_map[index]).expect("valid pseudo-locale codepoint");
+            result.push(mapped);
+            if elongate && matches!(ch, 'a' | 'e' | 'o' | 'u') {
+                result.push(mapped);
+            }
+        } else if ch.is_ascii_uppercase() {
+            let index = (ch as u8 - b'A') as usize;
+            result.push(char::from_u32(caps_map[index]).expect("valid pseudo-locale codepoint"));
+        } else {
+            result.push(ch);
+        }
+    }
+
+    result
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
     use std::fs;
     use tempfile::tempdir;
+
+    fn compile_message_to_ast(message: &str, pseudo_locale: PseudoLocale) -> Value {
+        let mut messages = BTreeMap::new();
+        messages.insert(
+            "msg".to_string(),
+            (message.to_string(), PathBuf::from("messages.json")),
+        );
+
+        let output =
+            compile_messages_to_string(messages, true, false, Some(pseudo_locale), false).unwrap();
+
+        serde_json::from_str::<Value>(&output).unwrap()["msg"].clone()
+    }
+
+    fn collect_literal_values(value: &Value, values: &mut Vec<String>) {
+        match value {
+            Value::Array(elements) => {
+                for element in elements {
+                    collect_literal_values(element, values);
+                }
+            }
+            Value::Object(map) => {
+                if map.get("type").and_then(Value::as_u64) == Some(0) {
+                    values.push(
+                        map.get("value")
+                            .and_then(Value::as_str)
+                            .unwrap_or_default()
+                            .to_string(),
+                    );
+                }
+
+                if let Some(children) = map.get("children") {
+                    collect_literal_values(children, values);
+                }
+
+                if let Some(options) = map.get("options").and_then(Value::as_object) {
+                    for option in options.values() {
+                        if let Some(value) = option.get("value") {
+                            collect_literal_values(value, values);
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn literal_values(value: &Value) -> Vec<String> {
+        let mut values = Vec::new();
+        collect_literal_values(value, &mut values);
+        values
+    }
 
     #[test]
     fn test_compile_simple_messages() {
@@ -333,7 +517,7 @@ mod tests {
             false,
             None,
             false,
-            true,  // follow links
+            true, // follow links
         )
         .unwrap();
 
@@ -371,7 +555,7 @@ mod tests {
             false,
             None,
             false,
-            true,  // follow links
+            true, // follow links
         )
         .unwrap();
 
@@ -410,7 +594,7 @@ mod tests {
             false, // don't skip errors
             None,
             false,
-            true,  // follow links
+            true, // follow links
         );
 
         assert!(result.is_err());
@@ -446,7 +630,7 @@ mod tests {
             true, // skip errors
             None,
             false,
-            true,  // follow links
+            true, // follow links
         )
         .unwrap();
 
@@ -486,7 +670,7 @@ mod tests {
             false,
             None,
             false,
-            true,  // follow links
+            true, // follow links
         )
         .unwrap();
 
@@ -526,7 +710,7 @@ mod tests {
             false,
             None,
             false,
-            true,  // follow links
+            true, // follow links
         );
 
         assert!(result.is_err());
@@ -561,7 +745,7 @@ mod tests {
             false,
             None,
             false,
-            true,  // follow links
+            true, // follow links
         )
         .unwrap();
 
@@ -600,7 +784,7 @@ mod tests {
             false,
             None,
             false,
-            true,  // follow links
+            true, // follow links
         )
         .unwrap();
 
@@ -642,7 +826,7 @@ mod tests {
             false,
             None,
             false,
-            true,  // follow links
+            true, // follow links
         )
         .unwrap();
 
@@ -670,7 +854,7 @@ mod tests {
             false,
             Some(PseudoLocale::EnXa), // pseudo-locale specified
             false,
-            true,  // follow links
+            true, // follow links
         );
 
         assert!(result.is_err());
@@ -680,6 +864,59 @@ mod tests {
                 .to_string()
                 .contains("requires --ast flag")
         );
+    }
+
+    #[test]
+    fn test_compile_pseudo_locale_transforms_literal_elements() {
+        let ast = compile_message_to_ast(
+            "foo {bar, plural, one {<b>a dog</b>} other {many dogs}}",
+            PseudoLocale::XxAc,
+        );
+
+        assert_eq!(
+            literal_values(&ast),
+            vec![
+                "FOO ".to_string(),
+                "A DOG".to_string(),
+                "MANY DOGS".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn test_compile_pseudo_locale_top_level_insertions() {
+        let xx_ls = compile_message_to_ast("my name is {name}", PseudoLocale::XxLs);
+        assert_eq!(
+            literal_values(&xx_ls),
+            vec!["my name is ".to_string(), XX_LS_SUFFIX.to_string()]
+        );
+
+        let xx_ha = compile_message_to_ast("{name} has help", PseudoLocale::XxHa);
+        assert_eq!(
+            literal_values(&xx_ha),
+            vec![XX_HA_PREFIX.to_string(), " has help".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_compile_pseudo_locale_en_xa_and_en_xb_wrappers() {
+        let en_xa_values = literal_values(&compile_message_to_ast(
+            "my name is {name}",
+            PseudoLocale::EnXa,
+        ));
+        assert_eq!(en_xa_values.first().unwrap(), EN_XA_PREFIX);
+        assert_eq!(en_xa_values.last().unwrap(), EN_XA_SUFFIX);
+        assert_ne!(en_xa_values[1], "my name is ");
+        assert!(en_xa_values[1].contains('\u{1e3f}'));
+
+        let en_xb_values = literal_values(&compile_message_to_ast(
+            "my name is {name}",
+            PseudoLocale::EnXb,
+        ));
+        assert_eq!(en_xb_values.first().unwrap(), EN_XB_PREFIX);
+        assert_eq!(en_xb_values.last().unwrap(), EN_XB_SUFFIX);
+        assert_ne!(en_xb_values[1], "my name is ");
+        assert!(en_xb_values[1].contains('\u{026f}'));
     }
 
     #[test]
@@ -718,7 +955,7 @@ mod tests {
             false,
             None,
             false,
-            true,  // follow links
+            true, // follow links
         )
         .unwrap();
 
@@ -777,7 +1014,7 @@ mod tests {
             false,
             None,
             false,
-            true,  // follow links
+            true, // follow links
         )
         .unwrap();
 
@@ -826,7 +1063,7 @@ mod tests {
             false,
             None,
             false,
-            true,  // follow links
+            true, // follow links
         )
         .unwrap();
 
@@ -878,7 +1115,7 @@ mod tests {
             false,
             None,
             false,
-            true,  // follow links
+            true, // follow links
         )
         .unwrap();
 
@@ -918,7 +1155,7 @@ mod tests {
             false,
             None,
             false,
-            true,  // follow links
+            true, // follow links
         )
         .unwrap();
 
@@ -965,7 +1202,7 @@ mod tests {
             false,
             None,
             false,
-            true,  // follow links
+            true, // follow links
         )
         .unwrap();
 
@@ -1005,7 +1242,7 @@ mod tests {
             false,
             None,
             false,
-            true,  // follow links
+            true, // follow links
         )
         .unwrap();
 
@@ -1047,7 +1284,7 @@ mod tests {
             false,
             None,
             false,
-            true,  // follow links
+            true, // follow links
         )
         .unwrap();
 
@@ -1098,7 +1335,7 @@ mod tests {
             false,
             None,
             false,
-            true,  // follow links
+            true, // follow links
         )
         .unwrap();
 
@@ -1141,7 +1378,7 @@ mod tests {
             false,
             None,
             false,
-            true,  // follow links
+            true, // follow links
         )
         .unwrap();
 
@@ -1182,7 +1419,7 @@ mod tests {
             false,
             None,
             false,
-            true,  // follow links
+            true, // follow links
         )
         .unwrap();
 
@@ -1214,7 +1451,7 @@ mod tests {
             false,
             None,
             false,
-            true,  // follow links
+            true, // follow links
         )
         .unwrap();
 
@@ -1252,7 +1489,7 @@ mod tests {
             false,
             None,
             false,
-            true,  // follow links
+            true, // follow links
         )
         .unwrap();
 

--- a/docs/src/docs/tooling/cli.mdx
+++ b/docs/src/docs/tooling/cli.mdx
@@ -140,7 +140,6 @@ Most common extraction, compilation, and verification options work with the nati
 - `--format` accepts built-in formatter names only: `default`, `simple`, `transifex`, `smartling`, `lokalise`, or `crowdin`.
 - Custom JavaScript formatter files for `compile` and `compile-folder` are deprecated in the Node.js CLI and are not supported by the standalone native CLI.
 - Framework template extraction for Vue, Svelte, Handlebars, Glimmer, GTS, and GJS is only supported by the Node.js CLI.
-- Pseudo-locale options are accepted by the Rust CLI for CLI compatibility, but pseudo-locale AST transformations are not yet implemented there.
 
 ---
 

--- a/packages/cli/integration-tests/compile/__snapshots__/integration.test.ts.snap
+++ b/packages/cli/integration-tests/compile/__snapshots__/integration.test.ts.snap
@@ -218,13 +218,16 @@ exports[`'Rust' CLI > compile glob 1`] = `
 
 exports[`'Rust' CLI > en-XA json 1`] = `
 {
-  "stderr": "Warning: Pseudo-locale transformations not yet implemented
-",
+  "stderr": "",
   "stdout": "{
   "a1d12": [
     {
       "type": 0,
-      "value": "I have "
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ī ħȧȧṽḗḗ "
     },
     {
       "type": 6,
@@ -234,7 +237,7 @@ exports[`'Rust' CLI > en-XA json 1`] = `
           "value": [
             {
               "type": 0,
-              "value": "a dog"
+              "value": "ȧȧ ḓǿǿɠ"
             }
           ]
         },
@@ -242,19 +245,27 @@ exports[`'Rust' CLI > en-XA json 1`] = `
           "value": [
             {
               "type": 0,
-              "value": "many dogs"
+              "value": "ḿȧȧƞẏ ḓǿǿɠş"
             }
           ]
         }
       },
       "offset": 0,
       "pluralType": "cardinal"
+    },
+    {
+      "type": 0,
+      "value": "]"
     }
   ],
   "a1d13": [
     {
       "type": 0,
-      "value": "I have "
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ī ħȧȧṽḗḗ "
     },
     {
       "type": 6,
@@ -268,7 +279,7 @@ exports[`'Rust' CLI > en-XA json 1`] = `
               "children": [
                 {
                   "type": 0,
-                  "value": "a dog"
+                  "value": "ȧȧ ḓǿǿɠ"
                 }
               ]
             }
@@ -278,19 +289,27 @@ exports[`'Rust' CLI > en-XA json 1`] = `
           "value": [
             {
               "type": 0,
-              "value": "many dogs"
+              "value": "ḿȧȧƞẏ ḓǿǿɠş"
             }
           ]
         }
       },
       "offset": 0,
       "pluralType": "cardinal"
+    },
+    {
+      "type": 0,
+      "value": "]"
     }
   ],
   "a1d14": [
     {
       "type": 0,
-      "value": "I have "
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ī ħȧȧṽḗḗ "
     },
     {
       "type": 6,
@@ -304,7 +323,7 @@ exports[`'Rust' CLI > en-XA json 1`] = `
               "children": [
                 {
                   "type": 0,
-                  "value": "a "
+                  "value": "ȧȧ "
                 },
                 {
                   "type": 8,
@@ -312,7 +331,7 @@ exports[`'Rust' CLI > en-XA json 1`] = `
                   "children": [
                     {
                       "type": 0,
-                      "value": "dog"
+                      "value": "ḓǿǿɠ"
                     }
                   ]
                 }
@@ -324,29 +343,49 @@ exports[`'Rust' CLI > en-XA json 1`] = `
           "value": [
             {
               "type": 0,
-              "value": "many dogs"
+              "value": "ḿȧȧƞẏ ḓǿǿɠş"
             }
           ]
         }
       },
       "offset": 0,
       "pluralType": "cardinal"
+    },
+    {
+      "type": 0,
+      "value": "]"
     }
   ],
   "a1dd2": [
     {
       "type": 0,
-      "value": "my name is "
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "ḿẏ ƞȧȧḿḗḗ īş "
     },
     {
       "type": 1,
       "value": "name"
+    },
+    {
+      "type": 0,
+      "value": "]"
     }
   ],
   "ashd2": [
     {
       "type": 0,
-      "value": "a message"
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "ȧȧ ḿḗḗşşȧȧɠḗḗ"
+    },
+    {
+      "type": 0,
+      "value": "]"
     }
   ]
 }
@@ -356,13 +395,16 @@ exports[`'Rust' CLI > en-XA json 1`] = `
 
 exports[`'Rust' CLI > en-XB json 1`] = `
 {
-  "stderr": "Warning: Pseudo-locale transformations not yet implemented
-",
+  "stderr": "",
   "stdout": "{
   "a1d12": [
     {
       "type": 0,
-      "value": "I have "
+      "value": "‮"
+    },
+    {
+      "type": 0,
+      "value": "I ɥɐʌǝ "
     },
     {
       "type": 6,
@@ -372,7 +414,7 @@ exports[`'Rust' CLI > en-XB json 1`] = `
           "value": [
             {
               "type": 0,
-              "value": "a dog"
+              "value": "ɐ poƃ"
             }
           ]
         },
@@ -380,19 +422,27 @@ exports[`'Rust' CLI > en-XB json 1`] = `
           "value": [
             {
               "type": 0,
-              "value": "many dogs"
+              "value": "ɯɐuʎ poƃs"
             }
           ]
         }
       },
       "offset": 0,
       "pluralType": "cardinal"
+    },
+    {
+      "type": 0,
+      "value": "‬"
     }
   ],
   "a1d13": [
     {
       "type": 0,
-      "value": "I have "
+      "value": "‮"
+    },
+    {
+      "type": 0,
+      "value": "I ɥɐʌǝ "
     },
     {
       "type": 6,
@@ -406,7 +456,7 @@ exports[`'Rust' CLI > en-XB json 1`] = `
               "children": [
                 {
                   "type": 0,
-                  "value": "a dog"
+                  "value": "ɐ poƃ"
                 }
               ]
             }
@@ -416,19 +466,27 @@ exports[`'Rust' CLI > en-XB json 1`] = `
           "value": [
             {
               "type": 0,
-              "value": "many dogs"
+              "value": "ɯɐuʎ poƃs"
             }
           ]
         }
       },
       "offset": 0,
       "pluralType": "cardinal"
+    },
+    {
+      "type": 0,
+      "value": "‬"
     }
   ],
   "a1d14": [
     {
       "type": 0,
-      "value": "I have "
+      "value": "‮"
+    },
+    {
+      "type": 0,
+      "value": "I ɥɐʌǝ "
     },
     {
       "type": 6,
@@ -442,7 +500,7 @@ exports[`'Rust' CLI > en-XB json 1`] = `
               "children": [
                 {
                   "type": 0,
-                  "value": "a "
+                  "value": "ɐ "
                 },
                 {
                   "type": 8,
@@ -450,7 +508,7 @@ exports[`'Rust' CLI > en-XB json 1`] = `
                   "children": [
                     {
                       "type": 0,
-                      "value": "dog"
+                      "value": "poƃ"
                     }
                   ]
                 }
@@ -462,29 +520,49 @@ exports[`'Rust' CLI > en-XB json 1`] = `
           "value": [
             {
               "type": 0,
-              "value": "many dogs"
+              "value": "ɯɐuʎ poƃs"
             }
           ]
         }
       },
       "offset": 0,
       "pluralType": "cardinal"
+    },
+    {
+      "type": 0,
+      "value": "‬"
     }
   ],
   "a1dd2": [
     {
       "type": 0,
-      "value": "my name is "
+      "value": "‮"
+    },
+    {
+      "type": 0,
+      "value": "ɯʎ uɐɯǝ ıs "
     },
     {
       "type": 1,
       "value": "name"
+    },
+    {
+      "type": 0,
+      "value": "‬"
     }
   ],
   "ashd2": [
     {
       "type": 0,
-      "value": "a message"
+      "value": "‮"
+    },
+    {
+      "type": 0,
+      "value": "ɐ ɯǝssɐƃǝ"
+    },
+    {
+      "type": 0,
+      "value": "‬"
     }
   ]
 }
@@ -747,13 +825,12 @@ exports[`'Rust' CLI > skipped malformed ICU message json 1`] = `
 
 exports[`'Rust' CLI > xx-AC json 1`] = `
 {
-  "stderr": "Warning: Pseudo-locale transformations not yet implemented
-",
+  "stderr": "",
   "stdout": "{
   "a1d12": [
     {
       "type": 0,
-      "value": "I have "
+      "value": "I HAVE "
     },
     {
       "type": 6,
@@ -763,7 +840,7 @@ exports[`'Rust' CLI > xx-AC json 1`] = `
           "value": [
             {
               "type": 0,
-              "value": "a dog"
+              "value": "A DOG"
             }
           ]
         },
@@ -771,7 +848,7 @@ exports[`'Rust' CLI > xx-AC json 1`] = `
           "value": [
             {
               "type": 0,
-              "value": "many dogs"
+              "value": "MANY DOGS"
             }
           ]
         }
@@ -783,7 +860,7 @@ exports[`'Rust' CLI > xx-AC json 1`] = `
   "a1d13": [
     {
       "type": 0,
-      "value": "I have "
+      "value": "I HAVE "
     },
     {
       "type": 6,
@@ -797,7 +874,7 @@ exports[`'Rust' CLI > xx-AC json 1`] = `
               "children": [
                 {
                   "type": 0,
-                  "value": "a dog"
+                  "value": "A DOG"
                 }
               ]
             }
@@ -807,7 +884,7 @@ exports[`'Rust' CLI > xx-AC json 1`] = `
           "value": [
             {
               "type": 0,
-              "value": "many dogs"
+              "value": "MANY DOGS"
             }
           ]
         }
@@ -819,7 +896,7 @@ exports[`'Rust' CLI > xx-AC json 1`] = `
   "a1d14": [
     {
       "type": 0,
-      "value": "I have "
+      "value": "I HAVE "
     },
     {
       "type": 6,
@@ -833,7 +910,7 @@ exports[`'Rust' CLI > xx-AC json 1`] = `
               "children": [
                 {
                   "type": 0,
-                  "value": "a "
+                  "value": "A "
                 },
                 {
                   "type": 8,
@@ -841,7 +918,7 @@ exports[`'Rust' CLI > xx-AC json 1`] = `
                   "children": [
                     {
                       "type": 0,
-                      "value": "dog"
+                      "value": "DOG"
                     }
                   ]
                 }
@@ -853,7 +930,7 @@ exports[`'Rust' CLI > xx-AC json 1`] = `
           "value": [
             {
               "type": 0,
-              "value": "many dogs"
+              "value": "MANY DOGS"
             }
           ]
         }
@@ -865,7 +942,7 @@ exports[`'Rust' CLI > xx-AC json 1`] = `
   "a1dd2": [
     {
       "type": 0,
-      "value": "my name is "
+      "value": "MY NAME IS "
     },
     {
       "type": 1,
@@ -875,7 +952,7 @@ exports[`'Rust' CLI > xx-AC json 1`] = `
   "ashd2": [
     {
       "type": 0,
-      "value": "a message"
+      "value": "A MESSAGE"
     }
   ]
 }
@@ -885,13 +962,12 @@ exports[`'Rust' CLI > xx-AC json 1`] = `
 
 exports[`'Rust' CLI > xx-HA json 1`] = `
 {
-  "stderr": "Warning: Pseudo-locale transformations not yet implemented
-",
+  "stderr": "",
   "stdout": "{
   "a1d12": [
     {
       "type": 0,
-      "value": "I have "
+      "value": "[javascript]I have "
     },
     {
       "type": 6,
@@ -921,7 +997,7 @@ exports[`'Rust' CLI > xx-HA json 1`] = `
   "a1d13": [
     {
       "type": 0,
-      "value": "I have "
+      "value": "[javascript]I have "
     },
     {
       "type": 6,
@@ -957,7 +1033,7 @@ exports[`'Rust' CLI > xx-HA json 1`] = `
   "a1d14": [
     {
       "type": 0,
-      "value": "I have "
+      "value": "[javascript]I have "
     },
     {
       "type": 6,
@@ -1003,7 +1079,7 @@ exports[`'Rust' CLI > xx-HA json 1`] = `
   "a1dd2": [
     {
       "type": 0,
-      "value": "my name is "
+      "value": "[javascript]my name is "
     },
     {
       "type": 1,
@@ -1013,7 +1089,7 @@ exports[`'Rust' CLI > xx-HA json 1`] = `
   "ashd2": [
     {
       "type": 0,
-      "value": "a message"
+      "value": "[javascript]a message"
     }
   ]
 }
@@ -1023,8 +1099,7 @@ exports[`'Rust' CLI > xx-HA json 1`] = `
 
 exports[`'Rust' CLI > xx-LS json 1`] = `
 {
-  "stderr": "Warning: Pseudo-locale transformations not yet implemented
-",
+  "stderr": "",
   "stdout": "{
   "a1d12": [
     {
@@ -1054,6 +1129,10 @@ exports[`'Rust' CLI > xx-LS json 1`] = `
       },
       "offset": 0,
       "pluralType": "cardinal"
+    },
+    {
+      "type": 0,
+      "value": "SSSSSSSSSSSSSSSSSSSSSSSSS"
     }
   ],
   "a1d13": [
@@ -1090,6 +1169,10 @@ exports[`'Rust' CLI > xx-LS json 1`] = `
       },
       "offset": 0,
       "pluralType": "cardinal"
+    },
+    {
+      "type": 0,
+      "value": "SSSSSSSSSSSSSSSSSSSSSSSSS"
     }
   ],
   "a1d14": [
@@ -1136,6 +1219,10 @@ exports[`'Rust' CLI > xx-LS json 1`] = `
       },
       "offset": 0,
       "pluralType": "cardinal"
+    },
+    {
+      "type": 0,
+      "value": "SSSSSSSSSSSSSSSSSSSSSSSSS"
     }
   ],
   "a1dd2": [
@@ -1146,12 +1233,16 @@ exports[`'Rust' CLI > xx-LS json 1`] = `
     {
       "type": 1,
       "value": "name"
+    },
+    {
+      "type": 0,
+      "value": "SSSSSSSSSSSSSSSSSSSSSSSSS"
     }
   ],
   "ashd2": [
     {
       "type": 0,
-      "value": "a message"
+      "value": "a messageSSSSSSSSSSSSSSSSSSSSSSSSS"
     }
   ]
 }
@@ -1364,13 +1455,16 @@ exports[`'TypeScript' CLI > compile glob 1`] = `
 
 exports[`'TypeScript' CLI > en-XA json 1`] = `
 {
-  "stderr": "Warning: Pseudo-locale transformations not yet implemented
-",
+  "stderr": "",
   "stdout": "{
   "a1d12": [
     {
       "type": 0,
-      "value": "I have "
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ī ħȧȧṽḗḗ "
     },
     {
       "type": 6,
@@ -1380,7 +1474,7 @@ exports[`'TypeScript' CLI > en-XA json 1`] = `
           "value": [
             {
               "type": 0,
-              "value": "a dog"
+              "value": "ȧȧ ḓǿǿɠ"
             }
           ]
         },
@@ -1388,19 +1482,27 @@ exports[`'TypeScript' CLI > en-XA json 1`] = `
           "value": [
             {
               "type": 0,
-              "value": "many dogs"
+              "value": "ḿȧȧƞẏ ḓǿǿɠş"
             }
           ]
         }
       },
       "offset": 0,
       "pluralType": "cardinal"
+    },
+    {
+      "type": 0,
+      "value": "]"
     }
   ],
   "a1d13": [
     {
       "type": 0,
-      "value": "I have "
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ī ħȧȧṽḗḗ "
     },
     {
       "type": 6,
@@ -1414,7 +1516,7 @@ exports[`'TypeScript' CLI > en-XA json 1`] = `
               "children": [
                 {
                   "type": 0,
-                  "value": "a dog"
+                  "value": "ȧȧ ḓǿǿɠ"
                 }
               ]
             }
@@ -1424,19 +1526,27 @@ exports[`'TypeScript' CLI > en-XA json 1`] = `
           "value": [
             {
               "type": 0,
-              "value": "many dogs"
+              "value": "ḿȧȧƞẏ ḓǿǿɠş"
             }
           ]
         }
       },
       "offset": 0,
       "pluralType": "cardinal"
+    },
+    {
+      "type": 0,
+      "value": "]"
     }
   ],
   "a1d14": [
     {
       "type": 0,
-      "value": "I have "
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ī ħȧȧṽḗḗ "
     },
     {
       "type": 6,
@@ -1450,7 +1560,7 @@ exports[`'TypeScript' CLI > en-XA json 1`] = `
               "children": [
                 {
                   "type": 0,
-                  "value": "a "
+                  "value": "ȧȧ "
                 },
                 {
                   "type": 8,
@@ -1458,7 +1568,7 @@ exports[`'TypeScript' CLI > en-XA json 1`] = `
                   "children": [
                     {
                       "type": 0,
-                      "value": "dog"
+                      "value": "ḓǿǿɠ"
                     }
                   ]
                 }
@@ -1470,29 +1580,49 @@ exports[`'TypeScript' CLI > en-XA json 1`] = `
           "value": [
             {
               "type": 0,
-              "value": "many dogs"
+              "value": "ḿȧȧƞẏ ḓǿǿɠş"
             }
           ]
         }
       },
       "offset": 0,
       "pluralType": "cardinal"
+    },
+    {
+      "type": 0,
+      "value": "]"
     }
   ],
   "a1dd2": [
     {
       "type": 0,
-      "value": "my name is "
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "ḿẏ ƞȧȧḿḗḗ īş "
     },
     {
       "type": 1,
       "value": "name"
+    },
+    {
+      "type": 0,
+      "value": "]"
     }
   ],
   "ashd2": [
     {
       "type": 0,
-      "value": "a message"
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "ȧȧ ḿḗḗşşȧȧɠḗḗ"
+    },
+    {
+      "type": 0,
+      "value": "]"
     }
   ]
 }
@@ -1502,13 +1632,16 @@ exports[`'TypeScript' CLI > en-XA json 1`] = `
 
 exports[`'TypeScript' CLI > en-XB json 1`] = `
 {
-  "stderr": "Warning: Pseudo-locale transformations not yet implemented
-",
+  "stderr": "",
   "stdout": "{
   "a1d12": [
     {
       "type": 0,
-      "value": "I have "
+      "value": "‮"
+    },
+    {
+      "type": 0,
+      "value": "I ɥɐʌǝ "
     },
     {
       "type": 6,
@@ -1518,7 +1651,7 @@ exports[`'TypeScript' CLI > en-XB json 1`] = `
           "value": [
             {
               "type": 0,
-              "value": "a dog"
+              "value": "ɐ poƃ"
             }
           ]
         },
@@ -1526,19 +1659,27 @@ exports[`'TypeScript' CLI > en-XB json 1`] = `
           "value": [
             {
               "type": 0,
-              "value": "many dogs"
+              "value": "ɯɐuʎ poƃs"
             }
           ]
         }
       },
       "offset": 0,
       "pluralType": "cardinal"
+    },
+    {
+      "type": 0,
+      "value": "‬"
     }
   ],
   "a1d13": [
     {
       "type": 0,
-      "value": "I have "
+      "value": "‮"
+    },
+    {
+      "type": 0,
+      "value": "I ɥɐʌǝ "
     },
     {
       "type": 6,
@@ -1552,7 +1693,7 @@ exports[`'TypeScript' CLI > en-XB json 1`] = `
               "children": [
                 {
                   "type": 0,
-                  "value": "a dog"
+                  "value": "ɐ poƃ"
                 }
               ]
             }
@@ -1562,19 +1703,27 @@ exports[`'TypeScript' CLI > en-XB json 1`] = `
           "value": [
             {
               "type": 0,
-              "value": "many dogs"
+              "value": "ɯɐuʎ poƃs"
             }
           ]
         }
       },
       "offset": 0,
       "pluralType": "cardinal"
+    },
+    {
+      "type": 0,
+      "value": "‬"
     }
   ],
   "a1d14": [
     {
       "type": 0,
-      "value": "I have "
+      "value": "‮"
+    },
+    {
+      "type": 0,
+      "value": "I ɥɐʌǝ "
     },
     {
       "type": 6,
@@ -1588,7 +1737,7 @@ exports[`'TypeScript' CLI > en-XB json 1`] = `
               "children": [
                 {
                   "type": 0,
-                  "value": "a "
+                  "value": "ɐ "
                 },
                 {
                   "type": 8,
@@ -1596,7 +1745,7 @@ exports[`'TypeScript' CLI > en-XB json 1`] = `
                   "children": [
                     {
                       "type": 0,
-                      "value": "dog"
+                      "value": "poƃ"
                     }
                   ]
                 }
@@ -1608,29 +1757,49 @@ exports[`'TypeScript' CLI > en-XB json 1`] = `
           "value": [
             {
               "type": 0,
-              "value": "many dogs"
+              "value": "ɯɐuʎ poƃs"
             }
           ]
         }
       },
       "offset": 0,
       "pluralType": "cardinal"
+    },
+    {
+      "type": 0,
+      "value": "‬"
     }
   ],
   "a1dd2": [
     {
       "type": 0,
-      "value": "my name is "
+      "value": "‮"
+    },
+    {
+      "type": 0,
+      "value": "ɯʎ uɐɯǝ ıs "
     },
     {
       "type": 1,
       "value": "name"
+    },
+    {
+      "type": 0,
+      "value": "‬"
     }
   ],
   "ashd2": [
     {
       "type": 0,
-      "value": "a message"
+      "value": "‮"
+    },
+    {
+      "type": 0,
+      "value": "ɐ ɯǝssɐƃǝ"
+    },
+    {
+      "type": 0,
+      "value": "‬"
     }
   ]
 }
@@ -1906,13 +2075,12 @@ exports[`'TypeScript' CLI > skipped malformed ICU message json 1`] = `
 
 exports[`'TypeScript' CLI > xx-AC json 1`] = `
 {
-  "stderr": "Warning: Pseudo-locale transformations not yet implemented
-",
+  "stderr": "",
   "stdout": "{
   "a1d12": [
     {
       "type": 0,
-      "value": "I have "
+      "value": "I HAVE "
     },
     {
       "type": 6,
@@ -1922,7 +2090,7 @@ exports[`'TypeScript' CLI > xx-AC json 1`] = `
           "value": [
             {
               "type": 0,
-              "value": "a dog"
+              "value": "A DOG"
             }
           ]
         },
@@ -1930,7 +2098,7 @@ exports[`'TypeScript' CLI > xx-AC json 1`] = `
           "value": [
             {
               "type": 0,
-              "value": "many dogs"
+              "value": "MANY DOGS"
             }
           ]
         }
@@ -1942,7 +2110,7 @@ exports[`'TypeScript' CLI > xx-AC json 1`] = `
   "a1d13": [
     {
       "type": 0,
-      "value": "I have "
+      "value": "I HAVE "
     },
     {
       "type": 6,
@@ -1956,7 +2124,7 @@ exports[`'TypeScript' CLI > xx-AC json 1`] = `
               "children": [
                 {
                   "type": 0,
-                  "value": "a dog"
+                  "value": "A DOG"
                 }
               ]
             }
@@ -1966,7 +2134,7 @@ exports[`'TypeScript' CLI > xx-AC json 1`] = `
           "value": [
             {
               "type": 0,
-              "value": "many dogs"
+              "value": "MANY DOGS"
             }
           ]
         }
@@ -1978,7 +2146,7 @@ exports[`'TypeScript' CLI > xx-AC json 1`] = `
   "a1d14": [
     {
       "type": 0,
-      "value": "I have "
+      "value": "I HAVE "
     },
     {
       "type": 6,
@@ -1992,7 +2160,7 @@ exports[`'TypeScript' CLI > xx-AC json 1`] = `
               "children": [
                 {
                   "type": 0,
-                  "value": "a "
+                  "value": "A "
                 },
                 {
                   "type": 8,
@@ -2000,7 +2168,7 @@ exports[`'TypeScript' CLI > xx-AC json 1`] = `
                   "children": [
                     {
                       "type": 0,
-                      "value": "dog"
+                      "value": "DOG"
                     }
                   ]
                 }
@@ -2012,7 +2180,7 @@ exports[`'TypeScript' CLI > xx-AC json 1`] = `
           "value": [
             {
               "type": 0,
-              "value": "many dogs"
+              "value": "MANY DOGS"
             }
           ]
         }
@@ -2024,7 +2192,7 @@ exports[`'TypeScript' CLI > xx-AC json 1`] = `
   "a1dd2": [
     {
       "type": 0,
-      "value": "my name is "
+      "value": "MY NAME IS "
     },
     {
       "type": 1,
@@ -2034,7 +2202,7 @@ exports[`'TypeScript' CLI > xx-AC json 1`] = `
   "ashd2": [
     {
       "type": 0,
-      "value": "a message"
+      "value": "A MESSAGE"
     }
   ]
 }
@@ -2044,13 +2212,12 @@ exports[`'TypeScript' CLI > xx-AC json 1`] = `
 
 exports[`'TypeScript' CLI > xx-HA json 1`] = `
 {
-  "stderr": "Warning: Pseudo-locale transformations not yet implemented
-",
+  "stderr": "",
   "stdout": "{
   "a1d12": [
     {
       "type": 0,
-      "value": "I have "
+      "value": "[javascript]I have "
     },
     {
       "type": 6,
@@ -2080,7 +2247,7 @@ exports[`'TypeScript' CLI > xx-HA json 1`] = `
   "a1d13": [
     {
       "type": 0,
-      "value": "I have "
+      "value": "[javascript]I have "
     },
     {
       "type": 6,
@@ -2116,7 +2283,7 @@ exports[`'TypeScript' CLI > xx-HA json 1`] = `
   "a1d14": [
     {
       "type": 0,
-      "value": "I have "
+      "value": "[javascript]I have "
     },
     {
       "type": 6,
@@ -2162,7 +2329,7 @@ exports[`'TypeScript' CLI > xx-HA json 1`] = `
   "a1dd2": [
     {
       "type": 0,
-      "value": "my name is "
+      "value": "[javascript]my name is "
     },
     {
       "type": 1,
@@ -2172,7 +2339,7 @@ exports[`'TypeScript' CLI > xx-HA json 1`] = `
   "ashd2": [
     {
       "type": 0,
-      "value": "a message"
+      "value": "[javascript]a message"
     }
   ]
 }
@@ -2182,8 +2349,7 @@ exports[`'TypeScript' CLI > xx-HA json 1`] = `
 
 exports[`'TypeScript' CLI > xx-LS json 1`] = `
 {
-  "stderr": "Warning: Pseudo-locale transformations not yet implemented
-",
+  "stderr": "",
   "stdout": "{
   "a1d12": [
     {
@@ -2213,6 +2379,10 @@ exports[`'TypeScript' CLI > xx-LS json 1`] = `
       },
       "offset": 0,
       "pluralType": "cardinal"
+    },
+    {
+      "type": 0,
+      "value": "SSSSSSSSSSSSSSSSSSSSSSSSS"
     }
   ],
   "a1d13": [
@@ -2249,6 +2419,10 @@ exports[`'TypeScript' CLI > xx-LS json 1`] = `
       },
       "offset": 0,
       "pluralType": "cardinal"
+    },
+    {
+      "type": 0,
+      "value": "SSSSSSSSSSSSSSSSSSSSSSSSS"
     }
   ],
   "a1d14": [
@@ -2295,6 +2469,10 @@ exports[`'TypeScript' CLI > xx-LS json 1`] = `
       },
       "offset": 0,
       "pluralType": "cardinal"
+    },
+    {
+      "type": 0,
+      "value": "SSSSSSSSSSSSSSSSSSSSSSSSS"
     }
   ],
   "a1dd2": [
@@ -2305,12 +2483,16 @@ exports[`'TypeScript' CLI > xx-LS json 1`] = `
     {
       "type": 1,
       "value": "name"
+    },
+    {
+      "type": 0,
+      "value": "SSSSSSSSSSSSSSSSSSSSSSSSS"
     }
   ],
   "ashd2": [
     {
       "type": 0,
-      "value": "a message"
+      "value": "a messageSSSSSSSSSSSSSSSSSSSSSSSSS"
     }
   ]
 }

--- a/packages/cli/integration-tests/conformance-tests/SUMMARY.md
+++ b/packages/cli/integration-tests/conformance-tests/SUMMARY.md
@@ -181,8 +181,7 @@ To broaden parity:
 1. Add conformance coverage for CLI semantics: stdin, `--in-file`, glob ordering, no-match behavior, output files, and duplicate IDs.
 2. Decide whether standalone Rust should support custom JavaScript formatter files. Today Rust supports built-in formatter names only.
 3. Add or explicitly scope framework-file extraction for Vue, Svelte, Handlebars, Glimmer, GTS, and GJS.
-4. Port pseudo-locale transformations to Rust or document them as unsupported in the standalone binary.
-5. Add compile, compile-folder, and verify conformance cases that compare stdout, stderr, output files, and exit status.
+4. Add compile, compile-folder, and verify conformance cases that compare stdout, stderr, output files, and exit status.
 
 ## Benefits
 


### PR DESCRIPTION
## Summary
- implement Rust/native pseudo-locale AST transformations for xx-LS, xx-AC, xx-HA, en-XA, and en-XB
- refresh compile integration snapshots so native output matches transformed pseudo-locale behavior
- remove docs/conformance notes that described pseudo-locales as unsupported in the native CLI

## Test plan
- bazel test //crates/formatjs_cli:formatjs_cli_test //packages/cli/integration-tests:compile_integration_test //packages/cli/integration-tests:compile_folder_integration_test
- git diff --check