### PR TITLE
fix: harden polyfill installation

### DIFF
--- a/packages/ecma402-abstract/BUILD.bazel
+++ b/packages/ecma402-abstract/BUILD.bazel
@@ -51,6 +51,7 @@ formatjs_test(
         "tests/SetNumberFormatDigitOptions.test.ts",
         "tests/ToRawFixed.test.tsx",
         "tests/ToRawPrecision.test.tsx",
+        "tests/utils.test.ts",
         "tests/utils.ts",
     ],
     deps = [

--- a/packages/ecma402-abstract/tests/utils.test.ts
+++ b/packages/ecma402-abstract/tests/utils.test.ts
@@ -1,0 +1,45 @@
+import {defineProperty, ensureIntl} from '#packages/ecma402-abstract/utils.js'
+import {afterEach, beforeEach, describe, expect, it} from 'vitest'
+
+describe('polyfill utilities', () => {
+  let intlDescriptor: PropertyDescriptor | undefined
+
+  beforeEach(() => {
+    intlDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'Intl')
+  })
+
+  afterEach(() => {
+    if (intlDescriptor) {
+      Object.defineProperty(globalThis, 'Intl', intlDescriptor)
+    } else {
+      Reflect.deleteProperty(globalThis, 'Intl')
+    }
+  })
+
+  it('creates a native-shaped Intl global when one is absent', () => {
+    Reflect.deleteProperty(globalThis, 'Intl')
+
+    const intl = ensureIntl()
+
+    expect(intl).toBe(globalThis.Intl)
+    expect(Object.getOwnPropertyDescriptor(globalThis, 'Intl')).toMatchObject({
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    })
+  })
+
+  it('defines polyfill exports with native-compatible descriptors', () => {
+    const intl = {}
+    const Example = function Example() {}
+
+    defineProperty(intl, 'Example', {value: Example})
+
+    expect(Object.getOwnPropertyDescriptor(intl, 'Example')).toEqual({
+      value: Example,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    })
+  })
+})

--- a/packages/ecma402-abstract/utils.ts
+++ b/packages/ecma402-abstract/utils.ts
@@ -111,6 +111,18 @@ export function defineProperty<T extends object>(
   })
 }
 
+export function ensureIntl(): typeof Intl {
+  if (typeof Intl === 'undefined') {
+    Object.defineProperty(globalThis, 'Intl', {
+      configurable: true,
+      enumerable: false,
+      writable: true,
+      value: {},
+    })
+  }
+  return Intl
+}
+
 /**
  * 7.3.5 CreateDataProperty
  * @param target

--- a/packages/intl-collator/polyfill-force.ts
+++ b/packages/intl-collator/polyfill-force.ts
@@ -1,19 +1,6 @@
 import {Collator} from '#packages/intl-collator/index.js'
+import {defineProperty, ensureIntl} from '#packages/ecma402-abstract/utils.js'
 
-if (typeof Intl === 'undefined') {
-  if (typeof window !== 'undefined') {
-    Object.defineProperty(window, 'Intl', {
-      value: {},
-    })
-    // @ts-ignore we don't include @types/node so global isn't a thing
-  } else if (typeof global !== 'undefined') {
-    // @ts-ignore we don't include @types/node so global isn't a thing
-    Object.defineProperty(global, 'Intl', {
-      value: {},
-    })
-  }
-}
+const intl = ensureIntl()
 
-Object.defineProperty(Intl, 'Collator', {
-  value: Collator,
-})
+defineProperty(intl, 'Collator', {value: Collator})

--- a/packages/intl-collator/polyfill.ts
+++ b/packages/intl-collator/polyfill.ts
@@ -1,22 +1,9 @@
 import {Collator} from '#packages/intl-collator/index.js'
 import {shouldPolyfill} from '#packages/intl-collator/should-polyfill.js'
+import {defineProperty, ensureIntl} from '#packages/ecma402-abstract/utils.js'
 
-if (typeof Intl === 'undefined') {
-  if (typeof window !== 'undefined') {
-    Object.defineProperty(window, 'Intl', {
-      value: {},
-    })
-    // @ts-ignore we don't include @types/node so global isn't a thing
-  } else if (typeof global !== 'undefined') {
-    // @ts-ignore we don't include @types/node so global isn't a thing
-    Object.defineProperty(global, 'Intl', {
-      value: {},
-    })
-  }
-}
+const intl = ensureIntl()
 
 if (shouldPolyfill()) {
-  Object.defineProperty(Intl, 'Collator', {
-    value: Collator,
-  })
+  defineProperty(intl, 'Collator', {value: Collator})
 }

--- a/packages/intl-datetimeformat/polyfill-force.ts
+++ b/packages/intl-datetimeformat/polyfill-force.ts
@@ -1,4 +1,4 @@
-import {defineProperty} from '#packages/ecma402-abstract/utils.js'
+import {defineProperty, ensureIntl} from '#packages/ecma402-abstract/utils.js'
 import {DateTimeFormat} from '#packages/intl-datetimeformat/index.js'
 import {
   toLocaleDateString as _toLocaleDateString,
@@ -6,7 +6,9 @@ import {
   toLocaleTimeString as _toLocaleTimeString,
 } from '#packages/intl-datetimeformat/to_locale_string.js'
 
-defineProperty(Intl, 'DateTimeFormat', {value: DateTimeFormat})
+const intl = ensureIntl()
+
+defineProperty(intl, 'DateTimeFormat', {value: DateTimeFormat})
 defineProperty(Date.prototype, 'toLocaleString', {
   value: function toLocaleString(
     locales?: string | string[],

--- a/packages/intl-datetimeformat/polyfill.ts
+++ b/packages/intl-datetimeformat/polyfill.ts
@@ -1,5 +1,5 @@
 import {DateTimeFormat} from '#packages/intl-datetimeformat/index.js'
-import {defineProperty} from '#packages/ecma402-abstract/utils.js'
+import {defineProperty, ensureIntl} from '#packages/ecma402-abstract/utils.js'
 import {shouldPolyfill} from '#packages/intl-datetimeformat/should-polyfill.js'
 import {
   toLocaleString as _toLocaleString,
@@ -7,8 +7,10 @@ import {
   toLocaleTimeString as _toLocaleTimeString,
 } from '#packages/intl-datetimeformat/to_locale_string.js'
 
+const intl = ensureIntl()
+
 if (shouldPolyfill()) {
-  defineProperty(Intl, 'DateTimeFormat', {value: DateTimeFormat})
+  defineProperty(intl, 'DateTimeFormat', {value: DateTimeFormat})
   defineProperty(Date.prototype, 'toLocaleString', {
     value: function toLocaleString(
       locales?: string | string[],

--- a/packages/intl-datetimeformat/should-polyfill.ts
+++ b/packages/intl-datetimeformat/should-polyfill.ts
@@ -57,6 +57,7 @@ function supportedLocalesOf(locale?: string | string[]) {
 
 export function shouldPolyfill(locale = 'en'): string | undefined {
   if (
+    typeof Intl === 'undefined' ||
     !('DateTimeFormat' in Intl) ||
     !('formatToParts' in Intl.DateTimeFormat.prototype) ||
     !('formatRange' in Intl.DateTimeFormat.prototype) ||

--- a/packages/intl-displaynames/polyfill-force.ts
+++ b/packages/intl-displaynames/polyfill-force.ts
@@ -1,11 +1,9 @@
 import {DisplayNames} from '#packages/intl-displaynames/index.js'
+import {defineProperty, ensureIntl} from '#packages/ecma402-abstract/utils.js'
 
-Object.defineProperty(Intl, 'DisplayNames', {
-  value: DisplayNames,
-  enumerable: false,
-  writable: true,
-  configurable: true,
-})
+const intl = ensureIntl()
+
+defineProperty(intl, 'DisplayNames', {value: DisplayNames})
 
 // Drain any locale data that was buffered before polyfill loaded
 const buf = (globalThis as Record<string, unknown>)

--- a/packages/intl-displaynames/polyfill.ts
+++ b/packages/intl-displaynames/polyfill.ts
@@ -1,13 +1,11 @@
 import {DisplayNames} from '#packages/intl-displaynames/index.js'
 import {shouldPolyfill} from '#packages/intl-displaynames/should-polyfill.js'
+import {defineProperty, ensureIntl} from '#packages/ecma402-abstract/utils.js'
+
+const intl = ensureIntl()
 
 if (shouldPolyfill()) {
-  Object.defineProperty(Intl, 'DisplayNames', {
-    value: DisplayNames,
-    enumerable: false,
-    writable: true,
-    configurable: true,
-  })
+  defineProperty(intl, 'DisplayNames', {value: DisplayNames})
 
   // Drain any locale data that was buffered before polyfill loaded
   const buf = (globalThis as Record<string, unknown>)

--- a/packages/intl-displaynames/should-polyfill.ts
+++ b/packages/intl-displaynames/should-polyfill.ts
@@ -53,7 +53,12 @@ function supportedLocalesOf(locale?: string | string[]) {
 }
 
 export function _shouldPolyfillWithoutLocale(): boolean {
-  return !(Intl as any).DisplayNames || hasMissingICUBug() || hasScriptBug()
+  return (
+    typeof Intl === 'undefined' ||
+    !(Intl as any).DisplayNames ||
+    hasMissingICUBug() ||
+    hasScriptBug()
+  )
 }
 
 export function shouldPolyfill(locale = 'en'): string | true | undefined {

--- a/packages/intl-durationformat/polyfill-force.ts
+++ b/packages/intl-durationformat/polyfill-force.ts
@@ -1,17 +1,6 @@
 import {DurationFormat} from '#packages/intl-durationformat/index.js'
-if (typeof Intl === 'undefined') {
-  if (typeof window !== 'undefined') {
-    Object.defineProperty(window, 'Intl', {
-      value: {},
-    })
-    // @ts-ignore we don't include @types/node so global isn't a thing
-  } else if (typeof global !== 'undefined') {
-    // @ts-ignore we don't include @types/node so global isn't a thing
-    Object.defineProperty(global, 'Intl', {
-      value: {},
-    })
-  }
-}
-Object.defineProperty(Intl, 'DurationFormat', {
-  value: DurationFormat,
-})
+import {defineProperty, ensureIntl} from '#packages/ecma402-abstract/utils.js'
+
+const intl = ensureIntl()
+
+defineProperty(intl, 'DurationFormat', {value: DurationFormat})

--- a/packages/intl-durationformat/polyfill.ts
+++ b/packages/intl-durationformat/polyfill.ts
@@ -1,20 +1,9 @@
 import {DurationFormat} from '#packages/intl-durationformat/index.js'
 import {shouldPolyfill} from '#packages/intl-durationformat/should-polyfill.js'
-if (typeof Intl === 'undefined') {
-  if (typeof window !== 'undefined') {
-    Object.defineProperty(window, 'Intl', {
-      value: {},
-    })
-    // @ts-ignore we don't include @types/node so global isn't a thing
-  } else if (typeof global !== 'undefined') {
-    // @ts-ignore we don't include @types/node so global isn't a thing
-    Object.defineProperty(global, 'Intl', {
-      value: {},
-    })
-  }
-}
+import {defineProperty, ensureIntl} from '#packages/ecma402-abstract/utils.js'
+
+const intl = ensureIntl()
+
 if (shouldPolyfill()) {
-  Object.defineProperty(Intl, 'DurationFormat', {
-    value: DurationFormat,
-  })
+  defineProperty(intl, 'DurationFormat', {value: DurationFormat})
 }

--- a/packages/intl-getcanonicallocales/BUILD.bazel
+++ b/packages/intl-getcanonicallocales/BUILD.bazel
@@ -34,7 +34,10 @@ formatjs_library(
     entry_points = ENTRY_POINTS,
     extra_npm_srcs = ["polyfill.iife.js"],
     visibility = ["//visibility:public"],
-    deps = ["//:node_modules/@formatjs_generated/cldr.core"],
+    deps = [
+        "//:node_modules/@formatjs_generated/cldr.core",
+        "//packages/ecma402-abstract",
+    ],
 )
 
 formatjs_test(

--- a/packages/intl-getcanonicallocales/polyfill-force.ts
+++ b/packages/intl-getcanonicallocales/polyfill-force.ts
@@ -1,20 +1,6 @@
 import {getCanonicalLocales} from '#packages/intl-getcanonicallocales/index.js'
-if (typeof Intl === 'undefined') {
-  if (typeof window !== 'undefined') {
-    Object.defineProperty(window, 'Intl', {
-      value: {},
-    })
-    // @ts-ignore we don't include @types/node so global isn't a thing
-  } else if (typeof global !== 'undefined') {
-    // @ts-ignore we don't include @types/node so global isn't a thing
-    Object.defineProperty(global, 'Intl', {
-      value: {},
-    })
-  }
-}
-Object.defineProperty(Intl, 'getCanonicalLocales', {
-  value: getCanonicalLocales,
-  writable: true,
-  enumerable: false,
-  configurable: true,
-})
+import {defineProperty, ensureIntl} from '#packages/ecma402-abstract/utils.js'
+
+const intl = ensureIntl()
+
+defineProperty(intl, 'getCanonicalLocales', {value: getCanonicalLocales})

--- a/packages/intl-getcanonicallocales/polyfill.ts
+++ b/packages/intl-getcanonicallocales/polyfill.ts
@@ -1,23 +1,9 @@
 import {getCanonicalLocales} from '#packages/intl-getcanonicallocales/index.js'
 import {shouldPolyfill} from '#packages/intl-getcanonicallocales/should-polyfill.js'
-if (typeof Intl === 'undefined') {
-  if (typeof window !== 'undefined') {
-    Object.defineProperty(window, 'Intl', {
-      value: {},
-    })
-    // @ts-ignore we don't include @types/node so global isn't a thing
-  } else if (typeof global !== 'undefined') {
-    // @ts-ignore we don't include @types/node so global isn't a thing
-    Object.defineProperty(global, 'Intl', {
-      value: {},
-    })
-  }
-}
+import {defineProperty, ensureIntl} from '#packages/ecma402-abstract/utils.js'
+
+const intl = ensureIntl()
+
 if (shouldPolyfill()) {
-  Object.defineProperty(Intl, 'getCanonicalLocales', {
-    value: getCanonicalLocales,
-    writable: true,
-    enumerable: false,
-    configurable: true,
-  })
+  defineProperty(intl, 'getCanonicalLocales', {value: getCanonicalLocales})
 }

--- a/packages/intl-listformat/polyfill-force.ts
+++ b/packages/intl-listformat/polyfill-force.ts
@@ -1,11 +1,9 @@
 import ListFormat from '#packages/intl-listformat/index.js'
+import {defineProperty, ensureIntl} from '#packages/ecma402-abstract/utils.js'
 
-Object.defineProperty(Intl, 'ListFormat', {
-  value: ListFormat,
-  writable: true,
-  enumerable: false,
-  configurable: true,
-})
+const intl = ensureIntl()
+
+defineProperty(intl, 'ListFormat', {value: ListFormat})
 
 // Drain any locale data that was buffered before polyfill loaded
 const buf = (globalThis as Record<string, unknown>)

--- a/packages/intl-listformat/polyfill.ts
+++ b/packages/intl-listformat/polyfill.ts
@@ -1,12 +1,11 @@
 import ListFormat from '#packages/intl-listformat/index.js'
 import {shouldPolyfill} from '#packages/intl-listformat/should-polyfill.js'
+import {defineProperty, ensureIntl} from '#packages/ecma402-abstract/utils.js'
+
+const intl = ensureIntl()
+
 if (shouldPolyfill()) {
-  Object.defineProperty(Intl, 'ListFormat', {
-    value: ListFormat,
-    writable: true,
-    enumerable: false,
-    configurable: true,
-  })
+  defineProperty(intl, 'ListFormat', {value: ListFormat})
 
   // Drain any locale data that was buffered before polyfill loaded
   const buf = (globalThis as Record<string, unknown>)

--- a/packages/intl-listformat/should-polyfill.ts
+++ b/packages/intl-listformat/should-polyfill.ts
@@ -13,7 +13,11 @@ function supportedLocalesOf(locale?: string | string[]) {
 }
 
 export function shouldPolyfill(locale = 'en'): string | undefined {
-  if (!('ListFormat' in Intl) || !supportedLocalesOf(locale)) {
+  if (
+    typeof Intl === 'undefined' ||
+    !('ListFormat' in Intl) ||
+    !supportedLocalesOf(locale)
+  ) {
     return locale ? match([locale], supportedLocales, 'en') : undefined
   }
 }

--- a/packages/intl-locale/polyfill-force.ts
+++ b/packages/intl-locale/polyfill-force.ts
@@ -1,8 +1,6 @@
 import {Locale} from '#packages/intl-locale/index.js'
+import {defineProperty, ensureIntl} from '#packages/ecma402-abstract/utils.js'
 
-Object.defineProperty(Intl, 'Locale', {
-  value: Locale,
-  writable: true,
-  enumerable: false,
-  configurable: true,
-})
+const intl = ensureIntl()
+
+defineProperty(intl, 'Locale', {value: Locale})

--- a/packages/intl-locale/polyfill.ts
+++ b/packages/intl-locale/polyfill.ts
@@ -1,10 +1,9 @@
 import {Locale} from '#packages/intl-locale/index.js'
 import {shouldPolyfill} from '#packages/intl-locale/should-polyfill.js'
+import {defineProperty, ensureIntl} from '#packages/ecma402-abstract/utils.js'
+
+const intl = ensureIntl()
+
 if (shouldPolyfill()) {
-  Object.defineProperty(Intl, 'Locale', {
-    value: Locale,
-    writable: true,
-    enumerable: false,
-    configurable: true,
-  })
+  defineProperty(intl, 'Locale', {value: Locale})
 }

--- a/packages/intl-locale/should-polyfill.ts
+++ b/packages/intl-locale/should-polyfill.ts
@@ -63,6 +63,7 @@ function hasIncompleteLocaleInfo(): boolean {
 
 export function shouldPolyfill(): boolean {
   return (
+    typeof Intl === 'undefined' ||
     !('Locale' in Intl) ||
     hasIntlGetCanonicalLocalesBug() ||
     hasIncompleteLocaleInfo() ||

--- a/packages/intl-numberformat/polyfill-force.ts
+++ b/packages/intl-numberformat/polyfill-force.ts
@@ -1,9 +1,11 @@
 import {NumberFormat} from '#packages/intl-numberformat/core.js'
 import {toLocaleString as _toLocaleString} from '#packages/intl-numberformat/to_locale_string.js'
 import {type NumberFormatOptions} from '#packages/ecma402-abstract/types/number.js'
-import {defineProperty} from '#packages/ecma402-abstract/utils.js'
+import {defineProperty, ensureIntl} from '#packages/ecma402-abstract/utils.js'
 
-defineProperty(Intl, 'NumberFormat', {value: NumberFormat})
+const intl = ensureIntl()
+
+defineProperty(intl, 'NumberFormat', {value: NumberFormat})
 defineProperty(Number.prototype, 'toLocaleString', {
   value: function toLocaleString(
     locales?: string | string[],

--- a/packages/intl-numberformat/polyfill.ts
+++ b/packages/intl-numberformat/polyfill.ts
@@ -1,11 +1,13 @@
 import {NumberFormat} from '#packages/intl-numberformat/core.js'
 import {toLocaleString as _toLocaleString} from '#packages/intl-numberformat/to_locale_string.js'
 import {type NumberFormatOptions} from '#packages/ecma402-abstract/types/number.js'
-import {defineProperty} from '#packages/ecma402-abstract/utils.js'
+import {defineProperty, ensureIntl} from '#packages/ecma402-abstract/utils.js'
 import {shouldPolyfill} from '#packages/intl-numberformat/should-polyfill.js'
 
+const intl = ensureIntl()
+
 if (shouldPolyfill()) {
-  defineProperty(Intl, 'NumberFormat', {value: NumberFormat})
+  defineProperty(intl, 'NumberFormat', {value: NumberFormat})
   defineProperty(Number.prototype, 'toLocaleString', {
     value: function toLocaleString(
       locales?: string | string[],

--- a/packages/intl-pluralrules/polyfill-force.ts
+++ b/packages/intl-pluralrules/polyfill-force.ts
@@ -1,11 +1,9 @@
 import {PluralRules} from '#packages/intl-pluralrules/index.js'
+import {defineProperty, ensureIntl} from '#packages/ecma402-abstract/utils.js'
 
-Object.defineProperty(Intl, 'PluralRules', {
-  value: PluralRules,
-  writable: true,
-  enumerable: false,
-  configurable: true,
-})
+const intl = ensureIntl()
+
+defineProperty(intl, 'PluralRules', {value: PluralRules})
 
 // Drain any locale data that was buffered before polyfill loaded
 const buf = (globalThis as Record<string, unknown>)

--- a/packages/intl-pluralrules/polyfill.ts
+++ b/packages/intl-pluralrules/polyfill.ts
@@ -1,13 +1,11 @@
 import {PluralRules} from '#packages/intl-pluralrules/index.js'
 import {shouldPolyfill} from '#packages/intl-pluralrules/should-polyfill.js'
+import {defineProperty, ensureIntl} from '#packages/ecma402-abstract/utils.js'
+
+const intl = ensureIntl()
 
 if (shouldPolyfill()) {
-  Object.defineProperty(Intl, 'PluralRules', {
-    value: PluralRules,
-    writable: true,
-    enumerable: false,
-    configurable: true,
-  })
+  defineProperty(intl, 'PluralRules', {value: PluralRules})
 
   // Drain any locale data that was buffered before polyfill loaded
   const buf = (globalThis as Record<string, unknown>)

--- a/packages/intl-pluralrules/should-polyfill.ts
+++ b/packages/intl-pluralrules/should-polyfill.ts
@@ -11,6 +11,7 @@ function supportedLocalesOf(locale?: string | string[]) {
 
 export function shouldPolyfill(locale = 'en'): string | undefined {
   if (
+    typeof Intl === 'undefined' ||
     !('PluralRules' in Intl) ||
     new Intl.PluralRules('en', {minimumFractionDigits: 2} as any).select(1) ===
       'one' ||

--- a/packages/intl-relativetimeformat/polyfill-force.ts
+++ b/packages/intl-relativetimeformat/polyfill-force.ts
@@ -1,10 +1,9 @@
 import RelativeTimeFormat from '#packages/intl-relativetimeformat/index.js'
-Object.defineProperty(Intl, 'RelativeTimeFormat', {
-  value: RelativeTimeFormat,
-  writable: true,
-  enumerable: false,
-  configurable: true,
-})
+import {defineProperty, ensureIntl} from '#packages/ecma402-abstract/utils.js'
+
+const intl = ensureIntl()
+
+defineProperty(intl, 'RelativeTimeFormat', {value: RelativeTimeFormat})
 
 // Drain any locale data that was buffered before polyfill loaded
 const buf = (globalThis as Record<string, unknown>)

--- a/packages/intl-relativetimeformat/polyfill.ts
+++ b/packages/intl-relativetimeformat/polyfill.ts
@@ -1,12 +1,11 @@
 import RelativeTimeFormat from '#packages/intl-relativetimeformat/index.js'
 import {shouldPolyfill} from '#packages/intl-relativetimeformat/should-polyfill.js'
+import {defineProperty, ensureIntl} from '#packages/ecma402-abstract/utils.js'
+
+const intl = ensureIntl()
+
 if (shouldPolyfill()) {
-  Object.defineProperty(Intl, 'RelativeTimeFormat', {
-    value: RelativeTimeFormat,
-    writable: true,
-    enumerable: false,
-    configurable: true,
-  })
+  defineProperty(intl, 'RelativeTimeFormat', {value: RelativeTimeFormat})
 
   // Drain any locale data that was buffered before polyfill loaded
   const buf = (globalThis as Record<string, unknown>)

--- a/packages/intl-relativetimeformat/should-polyfill.ts
+++ b/packages/intl-relativetimeformat/should-polyfill.ts
@@ -27,6 +27,7 @@ function hasResolvedOptionsNumberingSystem(locale?: string | string[]) {
 
 export function shouldPolyfill(locale = 'en'): string | undefined {
   if (
+    typeof Intl === 'undefined' ||
     !('RelativeTimeFormat' in Intl) ||
     !supportedLocalesOf(locale) ||
     !hasResolvedOptionsNumberingSystem(locale)

--- a/packages/intl-segmenter/polyfill-force.ts
+++ b/packages/intl-segmenter/polyfill-force.ts
@@ -1,8 +1,6 @@
 import {Segmenter} from '#packages/intl-segmenter/segmenter.js'
+import {defineProperty, ensureIntl} from '#packages/ecma402-abstract/utils.js'
 
-Object.defineProperty(Intl, 'Segmenter', {
-  value: Segmenter,
-  enumerable: false,
-  writable: true,
-  configurable: true,
-})
+const intl = ensureIntl()
+
+defineProperty(intl, 'Segmenter', {value: Segmenter})

--- a/packages/intl-segmenter/polyfill.ts
+++ b/packages/intl-segmenter/polyfill.ts
@@ -1,11 +1,9 @@
 import {Segmenter} from '#packages/intl-segmenter/segmenter.js'
 import {shouldPolyfill} from '#packages/intl-segmenter/should-polyfill.js'
+import {defineProperty, ensureIntl} from '#packages/ecma402-abstract/utils.js'
+
+const intl = ensureIntl()
 
 if (shouldPolyfill()) {
-  Object.defineProperty(Intl, 'Segmenter', {
-    value: Segmenter,
-    enumerable: false,
-    writable: true,
-    configurable: true,
-  })
+  defineProperty(intl, 'Segmenter', {value: Segmenter})
 }

--- a/packages/intl-segmenter/should-polyfill.ts
+++ b/packages/intl-segmenter/should-polyfill.ts
@@ -1,3 +1,3 @@
 export function shouldPolyfill(): boolean {
-  return !(Intl as any).Segmenter
+  return typeof Intl === 'undefined' || !(Intl as any).Segmenter
 }

--- a/packages/intl-supportedvaluesof/BUILD.bazel
+++ b/packages/intl-supportedvaluesof/BUILD.bazel
@@ -46,7 +46,10 @@ formatjs_library(
 
 formatjs_test(
     name = "intl-supportedvaluesof_test",
-    srcs = ["tests/index.test.ts"],
+    srcs = [
+        "tests/index.test.ts",
+        "tests/polyfill-force.test.ts",
+    ],
     no_copy_to_bin = ["//:package.json"],
     tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
     deps = [

--- a/packages/intl-supportedvaluesof/polyfill-force.ts
+++ b/packages/intl-supportedvaluesof/polyfill-force.ts
@@ -1,8 +1,6 @@
 import {supportedValuesOf} from '#packages/intl-supportedvaluesof/index.js'
+import {defineProperty, ensureIntl} from '#packages/ecma402-abstract/utils.js'
 
-Object.defineProperty(Intl, 'supportedValuesOf', {
-  value: supportedValuesOf,
-  enumerable: true,
-  writable: false,
-  configurable: false,
-})
+const intl = ensureIntl()
+
+defineProperty(intl, 'supportedValuesOf', {value: supportedValuesOf})

--- a/packages/intl-supportedvaluesof/polyfill.ts
+++ b/packages/intl-supportedvaluesof/polyfill.ts
@@ -1,11 +1,9 @@
 import {shouldPolyfill} from '#packages/intl-supportedvaluesof/should-polyfill.js'
 import {supportedValuesOf} from '#packages/intl-supportedvaluesof/index.js'
+import {defineProperty, ensureIntl} from '#packages/ecma402-abstract/utils.js'
+
+const intl = ensureIntl()
 
 if (shouldPolyfill()) {
-  Object.defineProperty(Intl, 'supportedValuesOf', {
-    value: supportedValuesOf,
-    enumerable: true,
-    writable: false,
-    configurable: false,
-  })
+  defineProperty(intl, 'supportedValuesOf', {value: supportedValuesOf})
 }

--- a/packages/intl-supportedvaluesof/should-polyfill.ts
+++ b/packages/intl-supportedvaluesof/should-polyfill.ts
@@ -1,3 +1,3 @@
 export function shouldPolyfill(): boolean {
-  return !('supportedValuesOf' in Intl)
+  return typeof Intl === 'undefined' || !('supportedValuesOf' in Intl)
 }

--- a/packages/intl-supportedvaluesof/tests/index.test.ts
+++ b/packages/intl-supportedvaluesof/tests/index.test.ts
@@ -1,7 +1,18 @@
 import {supportedValuesOf} from '#packages/intl-supportedvaluesof/index.js'
+import '#packages/intl-supportedvaluesof/polyfill-force.js'
 import {describe, expect, it} from 'vitest'
 
 describe('Intl.supportedValuesOf', () => {
+  it('installs with native-compatible property descriptors', () => {
+    expect(
+      Object.getOwnPropertyDescriptor(Intl, 'supportedValuesOf')
+    ).toMatchObject({
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    })
+  })
+
   describe('ECMA-402 spec compliance', () => {
     it('should return an array for valid keys', () => {
       // ECMA-402 Spec: Must return an array

--- a/packages/intl-supportedvaluesof/tests/polyfill-force.test.ts
+++ b/packages/intl-supportedvaluesof/tests/polyfill-force.test.ts
@@ -1,0 +1,41 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+describe('Intl.supportedValuesOf polyfill-force', () => {
+  let intlDescriptor: PropertyDescriptor | undefined
+
+  beforeEach(() => {
+    intlDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'Intl')
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+    if (intlDescriptor) {
+      Object.defineProperty(globalThis, 'Intl', intlDescriptor)
+    } else {
+      Reflect.deleteProperty(globalThis, 'Intl')
+    }
+  })
+
+  it('installs into a missing Intl global', async () => {
+    Reflect.deleteProperty(globalThis, 'Intl')
+
+    await import('#packages/intl-supportedvaluesof/polyfill-force.js')
+
+    expect(globalThis.Intl).toBeDefined()
+    expect(
+      Object.getOwnPropertyDescriptor(globalThis.Intl, 'supportedValuesOf')
+    ).toMatchObject({
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    })
+    expect(Array.isArray(globalThis.Intl.supportedValuesOf('calendar'))).toBe(
+      true
+    )
+    // @ts-expect-error exercising runtime key validation
+    expect(() => globalThis.Intl.supportedValuesOf('invalid')).toThrow(
+      RangeError
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- add a shared `ensureIntl()` helper before installing Intl polyfills
- use native-compatible property descriptors through the shared `defineProperty()` helper
- guard `shouldPolyfill()` helpers against runtimes where `Intl` is absent
- add shared helper coverage plus an `Intl.supportedValuesOf` missing-global `polyfill-force` smoke test

## Test plan
- bazel test //packages/ecma402-abstract:ecma402-abstract_test //packages/intl-collator:intl-collator_test //packages/intl-datetimeformat:intl-datetimeformat_test //packages/intl-displaynames:intl-displaynames_test //packages/intl-durationformat:intl-durationformat_test //packages/intl-getcanonicallocales:intl-getcanonicallocales_test //packages/intl-listformat:intl-listformat_test //packages/intl-locale:intl-locale_test //packages/intl-numberformat:intl-numberformat_test //packages/intl-pluralrules:intl-pluralrules_test //packages/intl-relativetimeformat:intl-relativetimeformat_test //packages/intl-segmenter:intl-segmenter_test //packages/intl-supportedvaluesof:intl-supportedvaluesof_test
- git diff --check