### PR TITLE
fix(react-intl): set FormattedListParts displayName

### DIFF
--- a/packages/react-intl/components/createFormattedComponent.tsx
+++ b/packages/react-intl/components/createFormattedComponent.tsx
@@ -59,7 +59,7 @@ export const FormattedListParts: React.FC<
   const {value, children, ...formatProps} = props
   return children(intl.formatListToParts(value, formatProps))
 }
-FormattedNumberParts.displayName = 'FormattedNumberParts'
+FormattedListParts.displayName = 'FormattedListParts'
 
 export function createFormattedDateTimePartsComponent<
   Name extends 'formatDate' | 'formatTime',

--- a/packages/react-intl/tests/unit/react-intl.test.tsx
+++ b/packages/react-intl/tests/unit/react-intl.test.tsx
@@ -44,6 +44,16 @@ describe('react-intl', () => {
         expect(typeof ReactIntl.FormattedNumberParts).toBe('function')
       })
 
+      it('exports `FormattedListParts`', () => {
+        expect(typeof ReactIntl.FormattedListParts).toBe('function')
+      })
+
+      it('sets `FormattedListParts.displayName`', () => {
+        expect(ReactIntl.FormattedListParts.displayName).toBe(
+          'FormattedListParts'
+        )
+      })
+
       it('exports `FormattedRelativeTime`', () => {
         expect(typeof ReactIntl.FormattedRelativeTime).toBe('function')
       })


### PR DESCRIPTION
## Summary
- assign `FormattedListParts.displayName` instead of repeating `FormattedNumberParts.displayName`
- add export/displayName regression coverage

## Test plan
- bazel test //packages/react-intl:react-intl_test
- git diff --check