### PR TITLE
fix(@formatjs/cli-native-win32-x64): add native package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,46 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  build_windows_native:
+    name: Build Windows Native Package
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Setup Bazel
+        uses: bazel-contrib/setup-bazel@0.19.0
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}-windows-native
+          repository-cache: true
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Build Package
+        run: |
+          bazel build //packages/cli-native-win32-x64:pkg
+          $pkgPath = (bazel cquery --output=files //packages/cli-native-win32-x64:pkg | Select-Object -Last 1)
+          New-Item -ItemType Directory -Force artifacts\cli-native-win32-x64
+          Copy-Item -Path (Join-Path $pkgPath '*') -Destination artifacts\cli-native-win32-x64 -Recurse -Force
+
+      - name: Smoke Test Package
+        run: |
+          node -e 'const native = require(process.argv[1]); const formatters = native.supportedBuiltinFormatters(); if (!formatters.includes("default")) throw new Error("Missing default formatter"); const output = native.compileMessages([{id: "hello", message: "Hello {name}", sourceFile: "smoke.json"}], {}); if (!output.includes("\"hello\"")) throw new Error(output); console.log(output);' ./artifacts/cli-native-win32-x64
+
+      - name: Upload Package
+        uses: actions/upload-artifact@v7
+        with:
+          name: cli-native-win32-x64
+          path: artifacts/cli-native-win32-x64
+          retention-days: 7
+
   release:
+    needs: build_windows_native
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -49,6 +88,12 @@ jobs:
           echo "Distribution path: $DIST_PATH"
           cp -rf "$DIST_PATH" release/
           chmod -R +w release/
+
+      - name: Download Windows Native Package
+        uses: actions/download-artifact@v8
+        with:
+          name: cli-native-win32-x64
+          path: release/packages/cli-native-win32-x64
 
       - name: Install Dependencies
         working-directory: release

--- a/.github/workflows/rust-cli-release.yml
+++ b/.github/workflows/rust-cli-release.yml
@@ -87,6 +87,35 @@ jobs:
           path: artifacts/formatjs_cli-linux-arm64
           retention-days: 7
 
+  build_windows:
+    name: Build Windows x64 Binary
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Setup Bazel
+        uses: bazel-contrib/setup-bazel@0.19.0
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}-windows-release-binary
+          repository-cache: true
+
+      - name: Build Binary
+        run: |
+          bazel build //crates/formatjs_cli:release_binary_windows_x64
+          $binaryPath = (bazel cquery --output=files //crates/formatjs_cli:release_binary_windows_x64 | Select-Object -Last 1)
+          New-Item -ItemType Directory -Force artifacts
+          Copy-Item $binaryPath artifacts\formatjs_cli-win32-x64.exe
+
+      - name: Upload Windows x64 Artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: formatjs_cli-win32-x64.exe
+          path: artifacts/formatjs_cli-win32-x64.exe
+          retention-days: 7
+
   verify_macos:
     name: Verify macOS ARM64
     needs: build
@@ -146,12 +175,30 @@ jobs:
             fi
           done
 
+  verify_windows:
+    name: Verify Windows x64
+    needs: build_windows
+    runs-on: windows-latest
+
+    steps:
+      - name: Download Windows x64 Artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: formatjs_cli-win32-x64.exe
+          path: artifacts
+
+      - name: Smoke Test
+        run: |
+          .\artifacts\formatjs_cli-win32-x64.exe --version
+          .\artifacts\formatjs_cli-win32-x64.exe --help
+
   release:
     name: Create Release
     needs:
       - build
       - verify_macos
       - verify_linux
+      - verify_windows
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -175,14 +222,16 @@ jobs:
           mv release/formatjs_cli-darwin-arm64/formatjs_cli-darwin-arm64 release/formatjs_cli-darwin-arm64.bin
           mv release/formatjs_cli-linux-arm64/formatjs_cli-linux-arm64 release/formatjs_cli-linux-arm64.bin
           mv release/formatjs_cli-linux-x64/formatjs_cli-linux-x64 release/formatjs_cli-linux-x64.bin
+          mv release/formatjs_cli-win32-x64.exe/formatjs_cli-win32-x64.exe release/formatjs_cli-win32-x64.exe.bin
 
           # Remove empty directories
-          rmdir release/formatjs_cli-darwin-arm64 release/formatjs_cli-linux-arm64 release/formatjs_cli-linux-x64
+          rmdir release/formatjs_cli-darwin-arm64 release/formatjs_cli-linux-arm64 release/formatjs_cli-linux-x64 release/formatjs_cli-win32-x64.exe
 
           # Rename binaries to final names
           mv release/formatjs_cli-darwin-arm64.bin release/formatjs_cli-darwin-arm64
           mv release/formatjs_cli-linux-arm64.bin release/formatjs_cli-linux-arm64
           mv release/formatjs_cli-linux-x64.bin release/formatjs_cli-linux-x64
+          mv release/formatjs_cli-win32-x64.exe.bin release/formatjs_cli-win32-x64.exe
 
       - name: Generate Checksums
         run: |
@@ -205,6 +254,7 @@ jobs:
             release/formatjs_cli-darwin-arm64
             release/formatjs_cli-linux-arm64
             release/formatjs_cli-linux-x64
+            release/formatjs_cli-win32-x64.exe
             release/checksums.txt
           body: |
             ## FormatJS Rust CLI Release
@@ -213,6 +263,7 @@ jobs:
             - **macOS Apple Silicon**: `formatjs_cli-darwin-arm64`
             - **Linux ARM64**: `formatjs_cli-linux-arm64`
             - **Linux x86_64**: `formatjs_cli-linux-x64`
+            - **Windows x64**: `formatjs_cli-win32-x64.exe`
 
             ### Installation
 
@@ -231,6 +282,11 @@ jobs:
             curl -LO https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/formatjs_cli-linux-arm64
             chmod +x formatjs_cli-linux-arm64
             sudo mv formatjs_cli-linux-arm64 /usr/local/bin/formatjs
+            ```
+
+            ```powershell
+            # Windows x64 (PowerShell)
+            curl.exe -LO https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/formatjs_cli-win32-x64.exe
             ```
 
             ### Verification

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,3 +63,37 @@ jobs:
           BINARY_PATH=bazel-bin/crates/formatjs_cli/formatjs_cli
           $BINARY_PATH --version
           $BINARY_PATH --help
+
+  windows_smoke:
+    name: Windows Smoke Tests
+    if: github.event_name != 'pull_request'
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Setup Bazel
+        uses: bazel-contrib/setup-bazel@0.19.0
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}-windows-smoke
+          repository-cache: true
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Rust CLI Smoke Test
+        run: |
+          bazel build //crates/formatjs_cli:release_binary_windows_x64
+          $binaryPath = (bazel cquery --output=files //crates/formatjs_cli:release_binary_windows_x64 | Select-Object -Last 1)
+          & $binaryPath --version
+          & $binaryPath --help
+
+      - name: Native Binding Smoke Test
+        run: |
+          bazel build //packages/cli-native-win32-x64:pkg
+          $pkgPath = Resolve-Path (bazel cquery --output=files //packages/cli-native-win32-x64:pkg | Select-Object -Last 1)
+          node -e 'const native = require(process.argv[1]); const formatters = native.supportedBuiltinFormatters(); if (!formatters.includes("default")) throw new Error("Missing default formatter"); const output = native.compileMessages([{id: "hello", message: "Hello {name}", sourceFile: "smoke.json"}], {}); if (!output.includes("\"hello\"")) throw new Error(output); console.log(output);' $pkgPath

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -143,6 +143,7 @@ crate.from_cargo(
         "aarch64-unknown-linux-gnu",
         "aarch64-unknown-linux-musl",
         "x86_64-apple-darwin",
+        "x86_64-pc-windows-msvc",
         "x86_64-unknown-linux-gnu",
         "x86_64-unknown-linux-musl",
     ],

--- a/crates/formatjs_cli/BUILD.bazel
+++ b/crates/formatjs_cli/BUILD.bazel
@@ -6,6 +6,7 @@ load(
     "release_binary_darwin_arm64",
     "release_binary_linux_arm64",
     "release_binary_linux_x64",
+    "release_binary_windows_x64",
 )
 
 exports_files(
@@ -147,6 +148,18 @@ release_binary_darwin_arm64(
     srcs = [":formatjs_cli"],
     outs = ["formatjs_cli_darwin_arm64"],
     cmd = "cp $< $@ && chmod +x $@",
+    visibility = ["//visibility:public"],
+)
+
+release_binary_windows_x64(
+    name = "release_binary_windows_x64",
+    srcs = [":formatjs_cli"],
+    outs = ["formatjs_cli_win32_x64.exe"],
+    cmd_ps = "Copy-Item -Path '$(location :formatjs_cli)' -Destination '$@'",
+    target_compatible_with = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:windows",
+    ],
     visibility = ["//visibility:public"],
 )
 

--- a/crates/formatjs_cli/release_binary.bzl
+++ b/crates/formatjs_cli/release_binary.bzl
@@ -38,6 +38,14 @@ def _release_binary(platform, llvm_target):
         True,
     ).build()
 
+def _host_release_binary():
+    return with_cfg(
+        native.genrule,
+    ).set(
+        "compilation_mode",
+        "opt",
+    ).build()
+
 release_binary_darwin_arm64, _release_binary_darwin_arm64_internal = _release_binary(
     "//crates/formatjs_cli/platforms:darwin_arm64",
     "macos_aarch64",
@@ -62,3 +70,5 @@ release_binary_linux_arm64_gnu, _release_binary_linux_arm64_gnu_internal = _rele
     "//crates/formatjs_cli/platforms:linux_aarch64",
     "linux_aarch64",
 )
+
+release_binary_windows_x64, _release_binary_windows_x64_internal = _host_release_binary()

--- a/crates/formatjs_cli_napi/BUILD.bazel
+++ b/crates/formatjs_cli_napi/BUILD.bazel
@@ -4,6 +4,7 @@ load(
     "release_node_darwin_arm64",
     "release_node_linux_arm64",
     "release_node_linux_x64",
+    "release_node_win32_x64",
 )
 
 exports_files(
@@ -58,6 +59,27 @@ release_node_linux_arm64(
     srcs = [":formatjs_cli_napi"],
     outs = ["formatjs_cli_napi_linux_arm64.node"],
     cmd = "cp $< $@",
+    visibility = ["//visibility:public"],
+)
+
+release_node_win32_x64(
+    name = "release_node_win32_x64",
+    srcs = [":formatjs_cli_napi"],
+    outs = ["formatjs_cli_napi_win32_x64.node"],
+    cmd_ps = """
+$ErrorActionPreference = 'Stop'
+foreach ($f in '$(locations :formatjs_cli_napi)' -split ' ') {
+  if ($f.EndsWith('.dll')) {
+    Copy-Item -Path $f -Destination '$@'
+    exit 0
+  }
+}
+throw 'Windows native library not found in $(locations :formatjs_cli_napi)'
+""",
+    target_compatible_with = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:windows",
+    ],
     visibility = ["//visibility:public"],
 )
 

--- a/crates/formatjs_cli_napi/release_node.bzl
+++ b/crates/formatjs_cli_napi/release_node.bzl
@@ -1,3 +1,4 @@
+load("@with_cfg.bzl", "with_cfg")
 load(
     "//crates/formatjs_cli:release_binary.bzl",
     "release_binary_darwin_arm64",
@@ -5,6 +6,15 @@ load(
     "release_binary_linux_x64_gnu",
 )
 
+def _host_release_node():
+    return with_cfg(
+        native.genrule,
+    ).set(
+        "compilation_mode",
+        "opt",
+    ).build()
+
 release_node_darwin_arm64 = release_binary_darwin_arm64
 release_node_linux_arm64 = release_binary_linux_arm64_gnu
 release_node_linux_x64 = release_binary_linux_x64_gnu
+release_node_win32_x64, _release_node_win32_x64_internal = _host_release_node()

--- a/packages/cli-lib/native.ts
+++ b/packages/cli-lib/native.ts
@@ -6,6 +6,7 @@ const NATIVE_PACKAGES: Record<string, string> = {
   'darwin-arm64': '@formatjs/cli-native-darwin-arm64',
   'linux-arm64': '@formatjs/cli-native-linux-arm64',
   'linux-x64': '@formatjs/cli-native-linux-x64',
+  'win32-x64': '@formatjs/cli-native-win32-x64',
 }
 
 export interface NativeCompileOptions {

--- a/packages/cli-lib/package.json
+++ b/packages/cli-lib/package.json
@@ -56,7 +56,8 @@
   "optionalDependencies": {
     "@formatjs/cli-native-darwin-arm64": "workspace:*",
     "@formatjs/cli-native-linux-arm64": "workspace:*",
-    "@formatjs/cli-native-linux-x64": "workspace:*"
+    "@formatjs/cli-native-linux-x64": "workspace:*",
+    "@formatjs/cli-native-win32-x64": "workspace:*"
   },
   "peerDependenciesMeta": {
     "vue": {

--- a/packages/cli-native-win32-x64/BUILD.bazel
+++ b/packages/cli-native-win32-x64/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
+load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("//tools:index.bzl", "package_exports_test")
+
+copy_file(
+    name = "formatjs_cli_napi_node",
+    src = "//crates/formatjs_cli_napi:release_node_win32_x64",
+    out = "formatjs_cli_napi.node",
+)
+
+npm_package(
+    name = "pkg",
+    srcs = [
+        "package.json",
+        ":formatjs_cli_napi_node",
+    ],
+    package = "@formatjs/cli-native-win32-x64",
+    visibility = ["//visibility:public"],
+)
+
+package_exports_test(
+    name = "package_exports_test",
+    pkg = ":pkg",
+)

--- a/packages/cli-native-win32-x64/CHANGELOG.md
+++ b/packages/cli-native-win32-x64/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# 1.1.0 (2026-05-19)
+
+### Features
+
+* **@formatjs/cli-native-win32-x64:** add native package for Windows x64 ([#6583](https://github.com/formatjs/formatjs/issues/6583)) - by @longlho

--- a/packages/cli-native-win32-x64/package.json
+++ b/packages/cli-native-win32-x64/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@formatjs/cli-native-win32-x64",
+  "description": "Native FormatJS CLI binding for Windows x64.",
+  "version": "1.1.0",
+  "license": "MIT",
+  "author": "Long Ho <holevietlong@gmail.com>",
+  "exports": {
+    ".": "./formatjs_cli_napi.node"
+  },
+  "bugs": "https://github.com/formatjs/formatjs/issues",
+  "cpu": [
+    "x64"
+  ],
+  "files": [
+    "formatjs_cli_napi.node"
+  ],
+  "homepage": "https://github.com/formatjs/formatjs",
+  "main": "formatjs_cli_napi.node",
+  "os": [
+    "win32"
+  ],
+  "repository": "formatjs/formatjs.git"
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,7 +41,8 @@
   "optionalDependencies": {
     "@formatjs/cli-native-darwin-arm64": "workspace:*",
     "@formatjs/cli-native-linux-arm64": "workspace:*",
-    "@formatjs/cli-native-linux-x64": "workspace:*"
+    "@formatjs/cli-native-linux-x64": "workspace:*",
+    "@formatjs/cli-native-win32-x64": "workspace:*"
   },
   "peerDependenciesMeta": {
     "vue": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -565,6 +565,9 @@ importers:
       '@formatjs/cli-native-linux-x64':
         specifier: workspace:*
         version: link:../cli-native-linux-x64
+      '@formatjs/cli-native-win32-x64':
+        specifier: workspace:*
+        version: link:../cli-native-win32-x64
 
   packages/cli-lib:
     dependencies:
@@ -629,6 +632,9 @@ importers:
       '@formatjs/cli-native-linux-x64':
         specifier: workspace:*
         version: link:../cli-native-linux-x64
+      '@formatjs/cli-native-win32-x64':
+        specifier: workspace:*
+        version: link:../cli-native-win32-x64
 
   packages/cli-lib/integration-tests:
     devDependencies:
@@ -641,6 +647,8 @@ importers:
   packages/cli-native-linux-arm64: {}
 
   packages/cli-native-linux-x64: {}
+
+  packages/cli-native-win32-x64: {}
 
   packages/cli/integration-tests:
     devDependencies:


### PR DESCRIPTION
## Summary
- add @formatjs/cli-native-win32-x64 and wire win32-x64 native loading
- add Windows release targets that carry opt config through with_cfg
- add Windows native/package smoke coverage outside PR runs and include Windows CLI artifacts in the Rust CLI release

Fixes #6583.

## Test plan
- bazel build //:dist //packages/cli-lib:cli-lib //packages/cli:pkg
- bazel test //packages/cli-native-win32-x64:all
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts f }' .github/workflows/release.yml .github/workflows/rust-cli-release.yml .github/workflows/test.yml
- git diff --check origin/main...HEAD