### PR TITLE
fix(@formatjs/unplugin): preserve escaped tag literals when flattening

### DIFF
--- a/crates/icu_messageformat_parser/printer.rs
+++ b/crates/icu_messageformat_parser/printer.rs
@@ -4,14 +4,6 @@
 //! back into their string representation, following the ICU MessageFormat syntax.
 
 use crate::types::*;
-use once_cell::sync::Lazy;
-use regex::Regex;
-
-/// Regex for escaping braces that could be interpreted as argument delimiters.
-/// Matches curly braces that contain content.
-static ESCAPE_BRACES_REGEX: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"([{}](?:[\s\S]*[{}])?)").expect("Failed to compile ESCAPE_BRACES_REGEX")
-});
 
 /// Prints a MessageFormat AST to its string representation.
 ///
@@ -93,21 +85,71 @@ fn print_tag_element(el: &TagElement) -> String {
     format!("<{}>{}</{}>", el.value, print_ast(&el.children), el.value)
 }
 
-/// Escapes curly braces in a message string.
-///
-/// According to ICU MessageFormat syntax, curly braces that could be
-/// interpreted as argument delimiters need to be quoted.
-///
-/// # Arguments
-///
-/// * `message` - The message string to escape
-///
-/// # Returns
-///
-/// The escaped message with braces wrapped in quotes where necessary
-fn print_escaped_message(message: &str) -> String {
-    // Replace braces that contain content with quoted versions using the static regex
-    ESCAPE_BRACES_REGEX.replace_all(message, "'$1'").to_string()
+/// Wraps one ICU syntax token in apostrophe quotes.
+fn quote_syntax_token(token: &str) -> String {
+    format!("'{}'", token.replace('\'', "''"))
+}
+
+fn is_tag_syntax_start(bytes: &[u8], index: usize) -> bool {
+    bytes[index] == b'<'
+        && matches!(
+            bytes.get(index + 1),
+            Some(b'/') | Some(b'a'..=b'z') | Some(b'A'..=b'Z')
+        )
+}
+
+fn find_tag_syntax_end(bytes: &[u8], index: usize) -> usize {
+    let mut end = index + 1;
+    while end < bytes.len() && bytes[end] != b'>' {
+        end += 1;
+    }
+    if end < bytes.len() {
+        end + 1
+    } else {
+        bytes.len()
+    }
+}
+
+fn find_brace_syntax_end(bytes: &[u8], index: usize) -> usize {
+    let mut end = index + 1;
+    while end < bytes.len() && bytes[end] != b'}' {
+        end += 1;
+    }
+    if end < bytes.len() {
+        end + 1
+    } else {
+        index + 1
+    }
+}
+
+/// Escapes ICU syntax tokens in a literal message string.
+fn print_escaped_message(message: &str, is_in_plural: bool) -> String {
+    let bytes = message.as_bytes();
+    let mut result = String::new();
+    let mut literal_start = 0;
+    let mut i = 0;
+
+    while i < bytes.len() {
+        let end = match bytes[i] {
+            b'{' => Some(find_brace_syntax_end(bytes, i)),
+            b'}' => Some(i + 1),
+            b'<' if is_tag_syntax_start(bytes, i) => Some(find_tag_syntax_end(bytes, i)),
+            b'#' if is_in_plural => Some(i + 1),
+            _ => None,
+        };
+
+        if let Some(end) = end {
+            result.push_str(&message[literal_start..i]);
+            result.push_str(&quote_syntax_token(&message[i..end]));
+            literal_start = end;
+            i = end;
+        } else {
+            i += 1;
+        }
+    }
+
+    result.push_str(&message[literal_start..]);
+    result
 }
 
 /// Prints a literal text element with appropriate escaping.
@@ -144,15 +186,7 @@ fn print_literal_element(
         escaped = format!("{}''", &escaped[..escaped.len() - 1]);
     }
 
-    // Escape any curly braces in the message
-    escaped = print_escaped_message(&escaped);
-
-    // Inside plural elements, '#' represents the count and must be quoted to be literal
-    if is_in_plural {
-        escaped.replace('#', "'#'")
-    } else {
-        escaped
-    }
+    print_escaped_message(&escaped, is_in_plural)
 }
 
 /// Prints a simple argument reference.
@@ -270,7 +304,7 @@ fn print_number_skeleton_token(token: &NumberSkeletonToken) -> String {
 /// A string like `percent` or `::currency/USD`
 fn print_argument_style_number(style: &NumberSkeletonOrStyle) -> String {
     match style {
-        NumberSkeletonOrStyle::String(s) => print_escaped_message(s),
+        NumberSkeletonOrStyle::String(s) => print_escaped_message(s, false),
         NumberSkeletonOrStyle::Skeleton(skeleton) => format!(
             "::{}",
             skeleton
@@ -297,7 +331,7 @@ fn print_argument_style_number(style: &NumberSkeletonOrStyle) -> String {
 /// A string like `short` or `::yMMMd`
 fn print_argument_style_datetime(style: &DateTimeSkeletonOrStyle) -> String {
     match style {
-        DateTimeSkeletonOrStyle::String(s) => print_escaped_message(s),
+        DateTimeSkeletonOrStyle::String(s) => print_escaped_message(s, false),
         DateTimeSkeletonOrStyle::Skeleton(skeleton) => {
             format!("::{}", print_date_time_skeleton(skeleton))
         }
@@ -440,6 +474,42 @@ mod tests {
     }
 
     #[test]
+    fn test_print_tag_like_literal() {
+        let ast = vec![MessageFormatElement::Literal(LiteralElement::new(
+            "The URL is defined as <Issuer URL>/.well-known/openid-configuration.".to_string(),
+        ))];
+
+        assert_eq!(
+            print_ast(&ast),
+            "The URL is defined as '<Issuer URL>'/.well-known/openid-configuration."
+        );
+    }
+
+    #[test]
+    fn test_print_quoted_literals_with_apostrophes() {
+        let ast = vec![MessageFormatElement::Literal(LiteralElement::new(
+            "This {isn't} obvious and <Bob's URL> works.".to_string(),
+        ))];
+
+        assert_eq!(
+            print_ast(&ast),
+            "This '{isn''t}' obvious and '<Bob''s URL>' works."
+        );
+    }
+
+    #[test]
+    fn test_print_tag_syntax_delimiters() {
+        let ast = vec![MessageFormatElement::Literal(LiteralElement::new(
+            "This is <b>HTML</b> and <i>XML</i>.".to_string(),
+        ))];
+
+        assert_eq!(
+            print_ast(&ast),
+            "This is '<b>'HTML'</b>' and '<i>'XML'</i>'."
+        );
+    }
+
+    #[test]
     fn test_print_argument() {
         let ast = vec![MessageFormatElement::Argument(ArgumentElement::new(
             "name".to_string(),
@@ -543,7 +613,7 @@ mod tests {
             ValidPluralRule::One,
             PluralOrSelectOption {
                 value: vec![MessageFormatElement::Literal(LiteralElement::new(
-                    "one item".to_string(),
+                    "# item".to_string(),
                 ))],
                 location: None,
             },
@@ -570,7 +640,7 @@ mod tests {
         let result = print_ast(&ast);
 
         // Keys are sorted in LDML order: one, other
-        assert_eq!(result, "{count,plural,one{one item} other{'#' items}}");
+        assert_eq!(result, "{count,plural,one{'#' item} other{'#' items}}");
     }
 
     #[test]

--- a/packages/icu-messageformat-parser/printer.ts
+++ b/packages/icu-messageformat-parser/printer.ts
@@ -67,8 +67,64 @@ function printTagElement(el: TagElement): string {
   return `<${el.value}>${printAST(el.children)}</${el.value}>`
 }
 
-function printEscapedMessage(message: string): string {
-  return message.replace(/([{}](?:[\s\S]*[{}])?)/, `'$1'`)
+function quoteSyntaxToken(token: string): string {
+  return `'${token.split("'").join("''")}'`
+}
+
+function isAlpha(ch: string | undefined): boolean {
+  if (!ch) {
+    return false
+  }
+  const code = ch.charCodeAt(0)
+  return (code >= 65 && code <= 90) || (code >= 97 && code <= 122)
+}
+
+function isTagSyntaxStart(message: string, index: number): boolean {
+  if (message[index] !== '<') {
+    return false
+  }
+  const next = message[index + 1]
+  return next === '/' || isAlpha(next)
+}
+
+function findTagSyntaxEnd(message: string, index: number): number {
+  const closingIndex = message.indexOf('>', index + 1)
+  return closingIndex === -1 ? message.length : closingIndex + 1
+}
+
+function findBraceSyntaxEnd(message: string, index: number): number {
+  const closingIndex = message.indexOf('}', index + 1)
+  return closingIndex === -1 ? index + 1 : closingIndex + 1
+}
+
+function printEscapedMessage(message: string, isInPlural = false): string {
+  let result = ''
+  let literalStart = 0
+
+  function quoteToken(start: number, end: number) {
+    result += message.slice(literalStart, start)
+    result += quoteSyntaxToken(message.slice(start, end))
+    literalStart = end
+  }
+
+  for (let i = 0; i < message.length; i++) {
+    const ch = message[i]
+    if (ch === '{') {
+      const end = findBraceSyntaxEnd(message, i)
+      quoteToken(i, end)
+      i = end - 1
+    } else if (ch === '}') {
+      quoteToken(i, i + 1)
+    } else if (isTagSyntaxStart(message, i)) {
+      const end = findTagSyntaxEnd(message, i)
+      quoteToken(i, end)
+      i = end - 1
+    } else if (isInPlural && ch === '#') {
+      quoteToken(i, i + 1)
+    }
+  }
+
+  return result + message.slice(literalStart)
 }
 
 function printLiteralElement(
@@ -87,8 +143,7 @@ function printLiteralElement(
   if (!isLastEl && escaped[escaped.length - 1] === `'`) {
     escaped = `${escaped.slice(0, escaped.length - 1)}''`
   }
-  escaped = printEscapedMessage(escaped)
-  return isInPlural ? escaped.replace('#', "'#'") : escaped
+  return printEscapedMessage(escaped, isInPlural)
 }
 
 function printArgumentElement({value}: ArgumentElement) {

--- a/packages/icu-messageformat-parser/tests/printer.test.ts
+++ b/packages/icu-messageformat-parser/tests/printer.test.ts
@@ -14,3 +14,38 @@ test('should escape things properly', function () {
     )
   ).toBe("Peter's brother {name1} is taller than {name} who is Peter's friend.")
 })
+
+test('escapes tag-like literal text so printed messages can be parsed again', function () {
+  const input =
+    "The URL is defined as '<Issuer URL>'/.well-known/openid-configuration."
+  const output = printAST(parse(input))
+
+  expect(output).toBe(
+    "The URL is defined as '<Issuer URL>'/.well-known/openid-configuration."
+  )
+  expect(parse(output)).toEqual(parse(input))
+})
+
+test('doubles apostrophes inside quoted literal syntax', function () {
+  const input = "This '{isn''t}' obvious and '<Bob''s URL>' works."
+  const output = printAST(parse(input))
+
+  expect(output).toBe("This '{isn''t}' obvious and '<Bob''s URL>' works.")
+  expect(parse(output)).toEqual(parse(input))
+})
+
+test('escapes tag syntax delimiters independently', function () {
+  const input = "This is '<b>HTML</b>' and '<i>XML</i>'."
+  const output = printAST(parse(input))
+
+  expect(output).toBe("This is '<b>'HTML'</b>' and '<i>'XML'</i>'.")
+  expect(parse(output)).toEqual(parse(input))
+})
+
+test('escapes pound signs inside plural literals', function () {
+  const input = "{count, plural, one {'# item'} other {'# items'}}"
+  const output = printAST(parse(input))
+
+  expect(output).toBe("{count,plural,one{'#' item} other{'#' items}}")
+  expect(parse(output)).toEqual(parse(input))
+})

--- a/packages/unplugin/conformance-tests/cli-unplugin-conformance.test.ts
+++ b/packages/unplugin/conformance-tests/cli-unplugin-conformance.test.ts
@@ -124,6 +124,17 @@ describe('formatjs_cli vs @formatjs/unplugin conformance', () => {
     )
   })
 
+  test('apostrophe-escaped tag-like literals stay parseable after flattening', async () => {
+    await assertConformance(
+      `defineMessages({
+  example: {
+    defaultMessage: "The URL is defined as '<Issuer URL>'/.well-known/openid-configuration.",
+  },
+})`,
+      'escaped-tag-like-literal.tsx'
+    )
+  })
+
   test('TypeScript satisfies expressions are transparent for extraction', async () => {
     await assertConformance(
       `type DefaultMessage = string

--- a/packages/unplugin/tests/transform.test.ts
+++ b/packages/unplugin/tests/transform.test.ts
@@ -124,6 +124,21 @@ describe('@formatjs/unplugin transform', () => {
         `<FormattedMessage id="test" defaultMessage={[{"type":0,"value":"Hello World"}]} />`
       )
     })
+
+    test('parses apostrophe-escaped tag-like literals after flattening', () => {
+      const input = `defineMessages({example: {defaultMessage: "The URL is defined as '<Issuer URL>'/.well-known/openid-configuration."}})`
+      const flattenedMessage =
+        "The URL is defined as '<Issuer URL>'/.well-known/openid-configuration."
+      const expectedId = interpolateName(
+        {resourcePath: '/path/to/file.tsx'} as any,
+        '[sha512:contenthash:base64:6]',
+        {content: flattenedMessage}
+      )
+
+      expect(t(input, {ast: true})).toBe(
+        `defineMessages({example: {id: "${expectedId}", defaultMessage: [{"type":0,"value":"The URL is defined as <Issuer URL>/.well-known/openid-configuration."}]}})`
+      )
+    })
   })
 
   describe('defineMessages', () => {


### PR DESCRIPTION
## Summary

- Fixes #6593 by preserving literal text that looks like rich-text tag syntax after `@formatjs/unplugin` flattens messages.
- Replaces the escaping regex with a scanner that quotes reparsable ICU syntax tokens in literal output: brace spans, tag-like `<...>` / `</...>` sequences, and plural-literal `#`.
- Keeps the TypeScript and Rust printers aligned, with parser, unplugin AST-mode, and CLI/unplugin conformance regression coverage.

## Why

`@formatjs/unplugin` defaults `flatten: true`, which parses `defaultMessage`, hoists selectors, and prints the AST. For messages like `'<Issuer URL>'`, parsing correctly treats the angle brackets as quoted literal text. If the printer emits `<Issuer URL>` without apostrophe quoting, the later AST-mode parse treats it as rich-text tag syntax and throws `INVALID_TAG`.

The fix belongs in the printer rather than the public AST. The AST should stay semantic: once text has parsed as a literal, the source escape syntax is not part of the message meaning. The printer's job is to emit a parseable representation for that semantic AST, so it now scans literal output for tokens that would change meaning if reparsed and quotes only those tokens. This avoids growing the AST with escape-token nodes just to preserve source spelling, while still producing stable round-trippable output.

## Test plan

- `bazel test //packages/icu-messageformat-parser:icu-messageformat-parser_test //packages/unplugin:unplugin_test //crates/icu_messageformat_parser:icu_messageformat_parser_test`
- `bazel test //packages/icu-messageformat-parser:typecheck_typecheck_test //packages/icu-messageformat-parser:icu-messageformat-parser_test_typecheck_typecheck_test //packages/unplugin:typecheck_typecheck_test //packages/unplugin:unplugin_test_typecheck_typecheck_test`
- `bazel test //packages/unplugin:conformance_test`
- `git diff --check`
