### PR TITLE
fix(@formatjs/cli-lib): handle literal Windows compile paths

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,4 +113,43 @@ jobs:
 
           bazel build @bazelWindowsFlags //packages/cli-native-win32-x64:pkg
           $pkgPath = Resolve-Path (bazel cquery @bazelWindowsFlags --output=files //packages/cli-native-win32-x64:pkg | Select-Object -Last 1)
-          node -e 'const native = require(process.argv[1]); const formatters = native.supportedBuiltinFormatters(); if (!formatters.includes("default")) throw new Error("Missing default formatter"); const output = native.compileMessages([{id: "hello", message: "Hello {name}", sourceFile: "smoke.json"}], {}); if (!output.includes("\"hello\"")) throw new Error(output); console.log(output);' $pkgPath
+          $script = @'
+          const fs = require('node:fs')
+          const os = require('node:os')
+          const path = require('node:path')
+          const native = require(process.argv[2])
+
+          const formatters = native.supportedBuiltinFormatters()
+          if (!formatters.includes('default')) {
+            throw new Error('Missing default formatter')
+          }
+
+          const messageDir = fs.mkdtempSync(path.join(os.tmpdir(), 'formatjs-cli-lib-'))
+          const messageSubdir = path.join(messageDir, 'messages[prod]')
+          fs.mkdirSync(messageSubdir)
+          const messageFile = path.join(messageSubdir, 'primary.json')
+          fs.writeFileSync(
+            messageFile,
+            JSON.stringify({
+              hello: {
+                message: 'Hello {name}',
+                description: 'Smoke test message',
+              },
+            })
+          )
+
+          if (!messageFile.includes('\\')) {
+            throw new Error(`Expected a native Windows path, got ${messageFile}`)
+          }
+
+          const output = native.compile([messageFile], {
+            ast: true,
+            format: 'crowdin',
+          })
+          const compiled = JSON.parse(output)
+          if (!Array.isArray(compiled.hello)) {
+            throw new Error(output)
+          }
+          console.log(output)
+          '@
+          $script | node - $pkgPath

--- a/crates/formatjs_cli/src/compile.rs
+++ b/crates/formatjs_cli/src/compile.rs
@@ -151,6 +151,11 @@ pub fn compile_to_string(
     // Step 1: Expand glob patterns to actual file paths
     let mut expanded_files = Vec::new();
     for pattern in translation_files {
+        if pattern.is_file() {
+            expanded_files.push(pattern.clone());
+            continue;
+        }
+
         let pattern_str = pattern
             .to_str()
             .context("Pattern path contains invalid UTF-8")?;
@@ -1435,6 +1440,39 @@ mod tests {
         // Ensure literal (non-glob) paths still work
         let dir = tempdir().unwrap();
         let input_file = dir.path().join("messages.json");
+        let output_file = dir.path().join("compiled.json");
+
+        fs::write(
+            &input_file,
+            json!({"msg": {"defaultMessage": "Literal path"}}).to_string(),
+        )
+        .unwrap();
+
+        compile(
+            &[input_file],
+            None,
+            Some(&output_file),
+            false,
+            false,
+            None,
+            false,
+            true, // follow links
+        )
+        .unwrap();
+
+        let output_content = fs::read_to_string(&output_file).unwrap();
+        let output_json: serde_json::Value = serde_json::from_str(&output_content).unwrap();
+
+        assert_eq!(output_json["msg"], "Literal path");
+    }
+
+    #[test]
+    fn test_compile_with_literal_file_path_containing_glob_metacharacters() {
+        let dir = tempdir().unwrap();
+        let subdir = dir.path().join("messages[prod]");
+        fs::create_dir_all(&subdir).unwrap();
+
+        let input_file = subdir.join("primary.json");
         let output_file = dir.path().join("compiled.json");
 
         fs::write(


### PR DESCRIPTION
## Summary
- treat existing translation file inputs as literal files before glob expansion in the Rust compile path
- cover literal file paths that include glob metacharacters
- extend the Windows native binding smoke test to call compile() with a native Windows path

Fixes #6603

## Test Plan
- bazel test //crates/formatjs_cli:formatjs_cli_test
- bazel build //packages/cli-native-darwin-arm64:pkg
- node smoke test against bazel-bin/packages/cli-native-darwin-arm64/pkg
- git diff --check

Note: local pre-commit was bypassed because format-oxfmt could not load @oxfmt/binding-darwin-arm64 from the local pnpm install.