### PR TITLE
perf(formatjs_cli): parallelize file processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,6 +485,7 @@ dependencies = [
  "oxc_ast",
  "oxc_parser",
  "oxc_span",
+ "rayon",
  "regex",
  "serde",
  "serde_json",

--- a/benchmarks/cli-comparison/BUILD.bazel
+++ b/benchmarks/cli-comparison/BUILD.bazel
@@ -3,16 +3,20 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 
 npm_link_all_packages()
 
-# Generate test files (100K files with mixed message formats)
+js_binary(
+    name = "generate_tool",
+    entry_point = "generate-test-files.mjs",
+)
+
+# Generate test files with mixed message formats
 # Includes defineMessage, defineMessages, formatMessage, and FormattedMessage patterns
 js_run_binary(
     name = "generate",
-    srcs = ["generate-test-files.mjs"],
     chdir = package_name(),
-    env = {"NUM_FILES": "100000"},
+    env = {"NUM_FILES": "1000"},
     out_dirs = ["test-files"],
     tags = ["manual"],
-    tool = "//:node_modules/node",
+    tool = ":generate_tool",
 )
 
 # Benchmark binary

--- a/benchmarks/cli-comparison/README.md
+++ b/benchmarks/cli-comparison/README.md
@@ -6,7 +6,7 @@ This benchmark compares the performance of the Rust CLI implementation against t
 
 The benchmark:
 
-- Generates 100,000 TypeScript/React files with ICU MessageFormat messages
+- Generates 1,000 TypeScript/React files with ICU MessageFormat messages
 - Tests all message extraction patterns:
   - `defineMessage` - individual message definitions
   - `defineMessages` - grouped message definitions
@@ -19,23 +19,24 @@ The benchmark:
 
 ### Test Environment
 
-- **OS**: macOS 25.2.0 (Darwin)
-- **CPU**: Apple Silicon
+- **OS**: macOS 26.2 (Darwin)
+- **CPU**: Apple Silicon (arm64)
 - **Node.js**: v24.12.0
-- **Date**: 2026-01-04
+- **Rayon threads**: default worker count (available logical CPUs)
+- **Date**: 2026-05-22
 
-### Results (1,000 files, 9,656 messages)
+### Results (1,000 files, 9,406 messages)
 
 | Metric                 | TypeScript | Rust     | Speedup   |
 | ---------------------- | ---------- | -------- | --------- |
-| **Mean Time**          | 601.63ms   | 131.77ms | **4.57x** |
-| **Operations/sec**     | 1.66       | 7.59     | **4.57x** |
-| **Messages/sec**       | 16,050     | 73,279   | **4.57x** |
-| **Margin of Error**    | ±31.94ms   | ±2.82ms  | -         |
-| **Samples**            | 9          | 38       | -         |
-| **Messages Extracted** | 9,656      | 9,656    | ✓         |
+| **Mean Time**          | 744.86ms   | 35.65ms  | **20.90x** |
+| **Operations/sec**     | 1.34       | 28.05    | **20.90x** |
+| **Messages/sec**       | 12,628     | 263,876  | **20.90x** |
+| **Margin of Error**    | ±39.47ms   | ±0.56ms  | -         |
+| **Samples**            | 7          | 141      | -         |
+| **Messages Extracted** | 9,406      | 9,406    | ✓         |
 
-**Summary**: The Rust CLI is **4.57x faster** (356.6% faster) than the TypeScript CLI, processing 73,279 messages/second vs 16,050 messages/second.
+**Summary**: The Rust CLI is **20.90x faster** (1,989.6% faster) than the TypeScript CLI, processing 263,876 messages/second vs 12,628 messages/second.
 
 These results include all message extraction patterns: `defineMessage`, `defineMessages`, `intl.formatMessage()`, and `<FormattedMessage />`.
 
@@ -51,7 +52,7 @@ cd benchmarks/cli-comparison
 This script will:
 
 1. Build both TypeScript and Rust CLIs
-2. Generate 100K test files (if not already present)
+2. Generate 1,000 test files (if not already present)
 3. Run the benchmark with statistical analysis
 
 ### Option 2: Manual steps
@@ -59,7 +60,7 @@ This script will:
 ```bash
 # From the repository root
 
-# 1. Generate test files (100K files with mixed message formats)
+# 1. Generate test files (1,000 files with mixed message formats)
 bazel build //benchmarks/cli-comparison:generate
 
 # 2. Build both CLIs
@@ -79,6 +80,15 @@ bazel run //benchmarks/cli-comparison:benchmark
 ```
 
 The benchmark script automatically looks for test files and CLIs in `bazel-bin/` output directories.
+
+### Controlling Rust CLI Threads
+
+The Rust CLI parallelizes per-file work with Rayon. Rayon defaults to the
+available logical CPU count. Set `RAYON_NUM_THREADS` to cap worker threads:
+
+```bash
+RAYON_NUM_THREADS=4 bazel run //benchmarks/cli-comparison:benchmark
+```
 
 ## How It Works
 
@@ -146,19 +156,19 @@ BENCHMARK RESULTS
 ────────────────────────────────────────────────────────────────────────────────
 Metric                                        TypeScript                 Rust           Ratio
 ────────────────────────────────────────────────────────────────────────────────
-Mean Time (ms)                                    601.63               131.77           4.57x
-Operations/sec                                      1.66                 7.59           4.57x
-Messages/sec                                       16,050               73,279           4.57x
-Margin of Error (ms)                              ±31.94                ±2.82               -
-Samples                                                9                   38               -
-Messages Extracted                                 9,656                9,656               -
+Mean Time (ms)                                    744.86                35.65          20.90x
+Operations/sec                                      1.34                28.05          20.90x
+Messages/sec                                       12,628              263,876          20.90x
+Margin of Error (ms)                              ±39.47                ±0.56               -
+Samples                                                7                  141               -
+Messages Extracted                                 9,406                9,406               -
 ────────────────────────────────────────────────────────────────────────────────
 
 ✨ Summary:
-   🚀 Rust is 4.57x faster (356.6% faster)
-   📈 7.59 ops/sec vs 1.66 ops/sec
-   💬 Processes 73,279 msg/s vs 16,050 msg/s
-   ✓ Both extracted 9,656 messages
+   🚀 Rust is 20.90x faster (1989.6% faster)
+   📈 28.05 ops/sec vs 1.34 ops/sec
+   💬 Processes 263,875.72 msg/s vs 12,627.948 msg/s
+   ✓ Both extracted 9,406 messages
 ```
 
 Results are saved to `benchmark-results.json` with detailed statistics.
@@ -190,20 +200,20 @@ cd benchmarks/cli-comparison
 pnpm install
 ```
 
-### Out of memory with 100K files
+### Running a Larger Corpus
 
-Reduce the file count in BUILD.bazel:
+The Bazel target defaults to 1,000 files so routine benchmark runs complete quickly. Increase the file count in BUILD.bazel for larger local stress runs:
 
 ```python
-env = {"NUM_FILES": "10000"},  # Reduce from 100000 to 10000
+env = {"NUM_FILES": "10000"},
 ```
 
 ## System Requirements
 
-- **Node.js**: v18 or later
+- **Node.js**: v20 or later
 - **Bazel**: Latest version
 - **Memory**: At least 4GB available RAM
-- **Disk**: ~2GB for test files (100K files)
+- **Disk**: ~50MB for the default 1,000-file corpus; larger corpora scale with file count
 
 ## License
 

--- a/benchmarks/cli-comparison/benchmark-results.json
+++ b/benchmarks/cli-comparison/benchmark-results.json
@@ -1,28 +1,28 @@
 {
-  "timestamp": "2026-01-04T16:53:38.221Z",
+  "timestamp": "2026-05-22T13:28:38.189Z",
   "testFiles": {
     "count": 1000,
-    "messages": 9656,
+    "messages": 9406,
     "pattern": "/Users/longho/src/formatjs/bazel-bin/benchmarks/cli-comparison/test-files/**/*.tsx"
   },
   "typescript": {
-    "mean": 601.6272822222221,
-    "marginOfError": 31.94,
-    "opsPerSec": 1.6621586645909978,
-    "messagesPerSec": 16049.804065290675,
-    "samples": 9,
-    "rme": 5.30959347502743
+    "mean": 744.8557499999998,
+    "marginOfError": 39.47,
+    "opsPerSec": 1.3425418277297319,
+    "messagesPerSec": 12627.948431625859,
+    "samples": 7,
+    "rme": 5.298639830136275
   },
   "rust": {
-    "mean": 131.77019302631572,
-    "marginOfError": 2.82,
-    "opsPerSec": 7.588969683001761,
-    "messagesPerSec": 73279.091259065,
-    "samples": 38,
-    "rme": 2.143856692003947
+    "mean": 35.64556827659585,
+    "marginOfError": 0.56,
+    "opsPerSec": 28.05397833022007,
+    "messagesPerSec": 263875.72017404996,
+    "samples": 141,
+    "rme": 1.564085410312433
   },
   "comparison": {
-    "speedup": 4.565731205251187,
-    "percentFaster": 356.6
+    "speedup": 20.896167069639812,
+    "percentFaster": 1989.6
   }
 }

--- a/benchmarks/cli-comparison/benchmark-tinybench.mjs
+++ b/benchmarks/cli-comparison/benchmark-tinybench.mjs
@@ -4,15 +4,25 @@
  */
 
 import {Bench} from 'tinybench'
-import {execSync} from 'child_process'
+import {execFileSync} from 'child_process'
 import fs from 'fs'
+import os from 'os'
 import path from 'path'
 import {fileURLToPath} from 'url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const WORKSPACE_DIR =
+  process.env.BUILD_WORKSPACE_DIRECTORY ?? path.join(__dirname, '../..')
 
 // Try to use Bazel runfiles if available, otherwise fall back to bazel-bin
 let TEST_FILES_DIR, TS_CLI, RUST_CLI
+
+function setBazelBinPaths() {
+  const BAZEL_BIN = path.join(WORKSPACE_DIR, 'bazel-bin')
+  TEST_FILES_DIR = path.join(BAZEL_BIN, 'benchmarks/cli-comparison/test-files')
+  TS_CLI = path.join(BAZEL_BIN, 'packages/cli/bin/formatjs')
+  RUST_CLI = path.join(BAZEL_BIN, 'crates/formatjs_cli/formatjs_cli')
+}
 
 try {
   // Try importing @bazel/runfiles for proper Bazel sandbox support
@@ -25,15 +35,22 @@ try {
   )
   TS_CLI = runfiles.resolve('_main/packages/cli/bin/formatjs')
   RUST_CLI = runfiles.resolve('_main/crates/formatjs_cli/formatjs_cli')
+
+  if (
+    !fs.existsSync(TEST_FILES_DIR) ||
+    !fs.existsSync(TS_CLI) ||
+    !fs.existsSync(RUST_CLI)
+  ) {
+    setBazelBinPaths()
+  }
 } catch {
   // Fall back to bazel-bin for manual execution
-  const BAZEL_BIN = path.join(__dirname, '../../bazel-bin')
-  TEST_FILES_DIR = path.join(BAZEL_BIN, 'benchmarks/cli-comparison/test-files')
-  TS_CLI = path.join(BAZEL_BIN, 'packages/cli/bin/formatjs')
-  RUST_CLI = path.join(BAZEL_BIN, 'crates/formatjs_cli/formatjs_cli')
+  setBazelBinPaths()
 }
 
-const OUTPUT_DIR = path.join(__dirname, 'benchmark-output')
+const OUTPUT_DIR = fs.mkdtempSync(
+  path.join(os.tmpdir(), 'formatjs-cli-benchmark-')
+)
 
 // Check if TypeScript CLI is built
 if (!fs.existsSync(TS_CLI)) {
@@ -105,10 +122,8 @@ let rustMessageCount = 0
 // TypeScript CLI benchmark
 bench.add('TypeScript CLI', () => {
   const outputFile = path.join(OUTPUT_DIR, `typescript-${Date.now()}.json`)
-  const command = `"${TS_CLI}" extract "${pattern}" --out-file "${outputFile}"`
-
   try {
-    execSync(command, {
+    execFileSync(TS_CLI, ['extract', pattern, '--out-file', outputFile], {
       stdio: 'pipe',
       maxBuffer: 1024 * 1024 * 100, // 100MB buffer
     })
@@ -130,10 +145,8 @@ bench.add('TypeScript CLI', () => {
 // Rust CLI benchmark
 bench.add('Rust CLI', () => {
   const outputFile = path.join(OUTPUT_DIR, `rust-${Date.now()}.json`)
-  const command = `"${RUST_CLI}" extract "${pattern}" --out-file "${outputFile}"`
-
   try {
-    execSync(command, {
+    execFileSync(RUST_CLI, ['extract', pattern, '--out-file', outputFile], {
       stdio: 'pipe',
       maxBuffer: 1024 * 1024 * 100, // 100MB buffer
     })
@@ -168,9 +181,31 @@ if (!tsResult?.result || !rustResult?.result) {
   process.exit(1)
 }
 
+function getLatency(result) {
+  return result.latency ?? result
+}
+
+function getMean(result) {
+  return getLatency(result).mean
+}
+
+function getRme(result) {
+  return getLatency(result).rme
+}
+
+function getMarginOfError(result) {
+  const latency = getLatency(result)
+  return latency.moe ?? ((latency.rme / 100) * latency.mean)
+}
+
+function getSampleCount(result) {
+  const latency = getLatency(result)
+  return latency.samplesCount ?? latency.samples.length
+}
+
 // Calculate metrics
-const tsMean = tsResult.result.mean // Already in ms
-const rustMean = rustResult.result.mean // Already in ms
+const tsMean = getMean(tsResult.result) // Already in ms
+const rustMean = getMean(rustResult.result) // Already in ms
 const speedup = tsMean / rustMean
 
 const tsMsgPerSec = tsMessageCount / (tsMean / 1000)
@@ -201,15 +236,15 @@ console.log(
 )
 
 // Margin of error
-const tsError = ((tsResult.result.rme / 100) * tsMean).toFixed(2)
-const rustError = ((rustResult.result.rme / 100) * rustMean).toFixed(2)
+const tsError = getMarginOfError(tsResult.result).toFixed(2)
+const rustError = getMarginOfError(rustResult.result).toFixed(2)
 console.log(
   `${'Margin of Error (ms)'.padEnd(35)} ${`±${tsError}`.padStart(20)} ${`±${rustError}`.padStart(20)} ${'-'.padStart(15)}`
 )
 
 // Sample size
 console.log(
-  `${'Samples'.padEnd(35)} ${`${tsResult.result.samples.length}`.padStart(20)} ${`${rustResult.result.samples.length}`.padStart(20)} ${'-'.padStart(15)}`
+  `${'Samples'.padEnd(35)} ${`${getSampleCount(tsResult.result)}`.padStart(20)} ${`${getSampleCount(rustResult.result)}`.padStart(20)} ${'-'.padStart(15)}`
 )
 
 // Messages extracted
@@ -242,7 +277,10 @@ if (Math.abs(tsMessageCount - rustMessageCount) > 0) {
 }
 
 // Save results
-const resultsFile = path.join(__dirname, 'benchmark-results.json')
+const resultsFile = path.join(
+  WORKSPACE_DIR,
+  'benchmarks/cli-comparison/benchmark-results.json'
+)
 const results = {
   timestamp: new Date().toISOString(),
   testFiles: {
@@ -255,16 +293,16 @@ const results = {
     marginOfError: parseFloat(tsError),
     opsPerSec: tsOpsPerSec,
     messagesPerSec: tsMsgPerSec,
-    samples: tsResult.result.samples.length,
-    rme: tsResult.result.rme,
+    samples: getSampleCount(tsResult.result),
+    rme: getRme(tsResult.result),
   },
   rust: {
     mean: rustMean,
     marginOfError: parseFloat(rustError),
     opsPerSec: rustOpsPerSec,
     messagesPerSec: rustMsgPerSec,
-    samples: rustResult.result.samples.length,
-    rme: rustResult.result.rme,
+    samples: getSampleCount(rustResult.result),
+    rme: getRme(rustResult.result),
   },
   comparison: {
     speedup: speedup,

--- a/benchmarks/cli-comparison/run-benchmark.sh
+++ b/benchmarks/cli-comparison/run-benchmark.sh
@@ -28,7 +28,7 @@ echo "📁 Step 2/3: Generating test files..."
 if [ -d "bazel-bin/benchmarks/cli-comparison/test-files" ]; then
   echo "  ✓ Test files already exist, skipping generation"
 else
-  echo "  - Generating 100,000 test files (this may take a few minutes)..."
+  echo "  - Generating 1,000 test files..."
   bazel build //benchmarks/cli-comparison:generate
 fi
 

--- a/crates/formatjs_cli/BUILD.bazel
+++ b/crates/formatjs_cli/BUILD.bazel
@@ -49,6 +49,7 @@ COMMON_DEPS = [
     "@crates//:oxc_ast",
     "@crates//:oxc_parser",
     "@crates//:oxc_span",
+    "@crates//:rayon",
     "@crates//:regex",
     "@crates//:serde",
     "@crates//:serde_json",

--- a/crates/formatjs_cli/Cargo.toml
+++ b/crates/formatjs_cli/Cargo.toml
@@ -34,6 +34,7 @@ oxc_span = "0.130"
 sha2 = "0.11"
 base64 = "0.22"
 hex = "0.4"
+rayon = "1.12"
 regex = "1.12"
 
 [dev-dependencies]

--- a/crates/formatjs_cli/src/compile.rs
+++ b/crates/formatjs_cli/src/compile.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use formatjs_icu_messageformat_parser::MessageFormatElement;
+use rayon::prelude::*;
 use serde_json::{Map, Value, json};
 use std::collections::BTreeMap;
 use std::path::PathBuf;
@@ -185,16 +186,29 @@ pub fn compile_to_string(
     // Store both message and source file for better error reporting
     let mut messages: BTreeMap<String, (String, PathBuf)> = BTreeMap::new();
 
-    for file in &expanded_files {
-        let content = std::fs::read_to_string(file)
-            .with_context(|| format!("Failed to read file: {}", file.display()))?;
+    let mut loaded_files: Vec<_> = expanded_files
+        .par_iter()
+        .enumerate()
+        .map(|(index, file)| {
+            let result = (|| -> Result<_> {
+                let content = std::fs::read_to_string(file)
+                    .with_context(|| format!("Failed to read file: {}", file.display()))?;
 
-        let json: Value = serde_json::from_str(&content)
-            .with_context(|| format!("Failed to parse JSON in file: {}", file.display()))?;
+                let json: Value = serde_json::from_str(&content)
+                    .with_context(|| format!("Failed to parse JSON in file: {}", file.display()))?;
 
-        // Apply formatter to extract messages
-        let file_path_str = file.to_str().unwrap_or("<invalid path>");
-        let file_messages = formatter.apply(&json, file_path_str)?;
+                // Apply formatter to extract messages
+                let file_path_str = file.to_str().unwrap_or("<invalid path>");
+                formatter.apply(&json, file_path_str)
+            })();
+
+            (index, file.clone(), result)
+        })
+        .collect();
+    loaded_files.sort_by_key(|(index, _, _)| *index);
+
+    for (_, file, result) in loaded_files {
+        let file_messages = result?;
 
         // Merge messages, checking for conflicts
         // Convert to BTreeMap for sorted iteration

--- a/crates/formatjs_cli/src/extract.rs
+++ b/crates/formatjs_cli/src/extract.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use rayon::prelude::*;
 use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::io::{self, Write};
@@ -42,18 +43,31 @@ pub fn extract(
     let component_names = build_component_names(additional_component_names);
     let function_names = build_function_names(additional_function_names);
 
-    for file_path in &file_list {
+    let mut extracted_files: Vec<_> = file_list
+        .par_iter()
+        .enumerate()
+        .map(|(index, file_path)| {
+            (
+                index,
+                file_path.clone(),
+                extract_from_file(
+                    file_path,
+                    extract_source_location,
+                    &component_names,
+                    &function_names,
+                    pragma,
+                    preserve_whitespace,
+                    flatten,
+                    throws,
+                ),
+            )
+        })
+        .collect();
+    extracted_files.sort_by_key(|(index, _, _)| *index);
+
+    for (_, file_path, result) in extracted_files {
         // To match TypeScript CLI behavior, we hash the message AFTER flattening
-        match extract_from_file(
-            file_path,
-            extract_source_location,
-            &component_names,
-            &function_names,
-            pragma,
-            preserve_whitespace,
-            flatten,
-            throws,
-        ) {
+        match result {
             Ok(messages) => {
                 for mut msg in messages.into_iter() {
                     // Generate ID if not present

--- a/crates/formatjs_cli/src/verify.rs
+++ b/crates/formatjs_cli/src/verify.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use rayon::prelude::*;
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -89,22 +90,31 @@ pub fn verify(
     // Load all translation files
     let mut locales: HashMap<String, Value> = HashMap::new();
 
-    for file in &expanded_files {
-        // Skip ignored patterns
-        if should_ignore(file, ignore) {
-            continue;
-        }
+    let files_to_load: Vec<_> = expanded_files
+        .iter()
+        .enumerate()
+        .filter(|(_, file)| !should_ignore(file, ignore))
+        .map(|(index, file)| Ok((index, file.clone(), extract_locale_from_path(file)?)))
+        .collect::<Result<_>>()?;
 
-        // Extract locale from filename (e.g., "en.json" -> "en")
-        let locale = extract_locale_from_path(file)?;
+    let mut loaded_files: Vec<_> = files_to_load
+        .par_iter()
+        .map(|(index, file, locale)| {
+            let result = (|| -> Result<_> {
+                let content = std::fs::read_to_string(file)
+                    .with_context(|| format!("Failed to read file: {}", file.display()))?;
 
-        // Read and parse JSON
-        let content = std::fs::read_to_string(file)
-            .with_context(|| format!("Failed to read file: {}", file.display()))?;
+                serde_json::from_str(&content)
+                    .with_context(|| format!("Failed to parse JSON in file: {}", file.display()))
+            })();
 
-        let json: Value = serde_json::from_str(&content)
-            .with_context(|| format!("Failed to parse JSON in file: {}", file.display()))?;
+            (*index, locale.clone(), result)
+        })
+        .collect();
+    loaded_files.sort_by_key(|(index, _, _)| *index);
 
+    for (_, locale, result) in loaded_files {
+        let json = result?;
         locales.insert(locale, json);
     }
 

--- a/docs/src/docs/tooling/bazel.mdx
+++ b/docs/src/docs/tooling/bazel.mdx
@@ -414,11 +414,15 @@ The toolchain is registered automatically when you add the MODULE.bazel dependen
 
 The native Rust CLI is significantly faster than the Node.js-based tools:
 
-- **4-17x faster** message extraction
+- **20.90x faster** message extraction in the checked-in Rust vs TypeScript CLI benchmark
 - **No Node.js runtime required** for supported extraction, compilation, and verification workflows
 - **Minimal memory footprint**
 - **Instant startup** - no JavaScript runtime initialization
 - **CI/CD friendly** - fast builds in continuous integration
+
+The native CLI parallelizes per-file work with Rayon. By default, Rayon uses the
+available logical CPU count. Set `RAYON_NUM_THREADS` to cap worker threads when
+running under constrained CI executors.
 
 The Rust CLI used by these rules covers the native toolchain's supported
 FormatJS workflows. Node.js-only behavior from `@formatjs/cli`, such as

--- a/docs/src/docs/tooling/cli.mdx
+++ b/docs/src/docs/tooling/cli.mdx
@@ -68,8 +68,8 @@ not support non-native compilation.
 
 ## Native CLI (Rust)
 
-<Admonition type="tip" title="4x Faster Performance">
-We provide a high-performance native Rust CLI that's **4-17x faster** than the Node.js version for supported workflows. It is useful for CI/CD pipelines and large JavaScript/TypeScript codebases that do not need Node.js-specific CLI features.
+<Admonition type="tip" title="20x Faster Extraction">
+We provide a high-performance native Rust CLI that's **20.90x faster** than the Node.js version in the checked-in extraction benchmark. It is useful for CI/CD pipelines and large JavaScript/TypeScript codebases that do not need Node.js-specific CLI features.
 
 Install it from Cargo with `cargo install formatjs_cli`, or download a pre-built binary from [GitHub Releases](https://github.com/formatjs/formatjs/releases).
 
@@ -149,7 +149,7 @@ curl.exe -L https://github.com/formatjs/formatjs/releases/download/<version>/for
 
 ### Benefits
 
-- **4-17x Faster**: Dramatically faster extraction and compilation for supported workflows
+- **20.90x Faster Extraction**: Dramatically faster extraction in the checked-in Rust vs TypeScript CLI benchmark
 - **No Node.js Runtime for Supported Features**: Single binary, no Node.js runtime required
 - **Low Memory**: Minimal memory footprint
 - **Instant Startup**: No Node.js initialization overhead
@@ -168,6 +168,14 @@ formatjs compile "lang/*.json" --out-file compiled.json --ast
 
 # Verify translations
 formatjs verify "lang/*.json" --source-locale en --missing-keys
+```
+
+The native CLI parallelizes per-file work with Rayon. By default, Rayon uses the
+available logical CPU count. Set `RAYON_NUM_THREADS` to cap worker threads in
+CPU-constrained environments:
+
+```sh
+RAYON_NUM_THREADS=4 formatjs extract "src/**/*.{ts,tsx}" --out-file messages.json
 ```
 
 Most common extraction, compilation, and verification options work with the native CLI. Notable differences from the Node.js CLI:

--- a/packages/cli/BUILD.bazel
+++ b/packages/cli/BUILD.bazel
@@ -12,6 +12,7 @@ copy_to_directory(
     replace_prefixes = {
         "-lib/formatjs/": "",
     },
+    visibility = ["//benchmarks/cli-comparison:__pkg__"],
 )
 
 npm_package(


### PR DESCRIPTION
## Summary

- Parallelize per-file `extract`, `compile`, and `verify` work in `formatjs_cli` with Rayon while preserving deterministic merge/output order.
- Repair the CLI benchmark Bazel target and Tinybench v6 result parsing, then refresh benchmark results.
- Update native CLI, Bazel, and benchmark docs with the refreshed speedup and `RAYON_NUM_THREADS` thread-cap guidance.
- Limit `//packages/cli:bin` benchmark visibility to `//benchmarks/cli-comparison`.

## Benchmark

`bazel run //benchmarks/cli-comparison:benchmark --compilation_mode=opt`

- Corpus: 1,000 files / 9,406 messages
- TypeScript CLI: 744.86 ms mean, 12,628 messages/sec
- Rust CLI: 35.65 ms mean, 263,876 messages/sec
- Speedup: 20.90x

## Validation

- `bazel build //crates/formatjs_cli --compilation_mode=opt`
- `bazel build //packages/cli:bin --compilation_mode=opt`
- `bazel run //benchmarks/cli-comparison:benchmark --compilation_mode=opt`
- `bazel test //crates/formatjs_cli:formatjs_cli_test`
- `git diff --check`

## Local blockers

- `cargo check -p formatjs_cli --offline` is blocked by the local custom Cargo index cache missing `pretty_assertions`; online `cargo check -p formatjs_cli` is blocked by CodeArtifact DNS resolution.
- `//packages/cli/integration-tests:{compile_integration_test,verify_integration_test,conformance_test}` currently fails during Bazel analysis on macOS because the `@formatjs/cli` dependency chain pulls the Windows native package target.
- Local pre-commit formatting for staged JS/MD/MDX files cannot run because this checkout cannot load optional Darwin native bindings for `oxfmt`; the focused Bazel checks above passed.
