### PR TITLE
perf(formatjs_cli): reduce parser and extract allocations

### DIFF
--- a/crates/formatjs_cli/src/extract.rs
+++ b/crates/formatjs_cli/src/extract.rs
@@ -8,7 +8,7 @@ use walkdir::WalkDir;
 
 use crate::extractor::{MessageDescriptor, determine_source_type, extract_messages_from_source};
 use crate::formatters::Formatter;
-use crate::id_generator::generate_id;
+use crate::id_generator::IdGenerator;
 
 /// Extract string messages from React components that use react-intl
 #[allow(clippy::too_many_arguments)]
@@ -42,6 +42,7 @@ pub fn extract(
 
     let component_names = build_component_names(additional_component_names);
     let function_names = build_function_names(additional_function_names);
+    let id_generator = IdGenerator::new(id_interpolation_pattern)?;
 
     let mut extracted_files: Vec<_> = file_list
         .par_iter()
@@ -75,12 +76,7 @@ pub fn extract(
                         id
                     } else {
                         // Hash the (possibly flattened) message
-                        generate_id(
-                            id_interpolation_pattern,
-                            msg.default_message.as_deref(),
-                            &msg.description,
-                            file_path.to_str(),
-                        )?
+                        id_generator.generate(msg.default_message.as_deref(), &msg.description)?
                     };
 
                     msg.id = Some(id.clone());

--- a/crates/formatjs_cli/src/id_generator.rs
+++ b/crates/formatjs_cli/src/id_generator.rs
@@ -2,7 +2,6 @@
 ///
 /// This module handles generating message IDs based on content hashing with
 /// configurable patterns like `[sha512:contenthash:base64:6]`.
-
 use anyhow::{Context, Result};
 use base64::Engine;
 use serde_json::Value;
@@ -10,6 +9,24 @@ use sha2::{Digest, Sha512};
 
 /// Base62 character set: 0-9, A-Z, a-z
 const BASE62_CHARS: &[u8] = b"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum HashAlgorithm {
+    Sha512,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DigestType {
+    ContentHash,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Encoding {
+    Base64,
+    Base64Url,
+    Base62,
+    Hex,
+}
 
 /// Encode bytes to base62 string
 fn encode_base62(bytes: &[u8]) -> String {
@@ -71,74 +88,104 @@ pub fn generate_id(
     description: &Option<Value>,
     _file_path: Option<&str>,
 ) -> Result<String> {
-    // Parse pattern: [hash:digest:encoding:length]
-    // Default: [sha512:contenthash:base64:6]
+    IdGenerator::new(pattern)?.generate(default_message, description)
+}
 
-    if !pattern.starts_with('[') || !pattern.ends_with(']') {
-        anyhow::bail!("Invalid ID interpolation pattern: {}", pattern);
-    }
+/// Parsed ID interpolation pattern for repeated message ID generation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct IdGenerator {
+    hash_algorithm: HashAlgorithm,
+    digest_type: DigestType,
+    encoding: Encoding,
+    length: usize,
+}
 
-    let inner = &pattern[1..pattern.len() - 1];
-    let parts: Vec<&str> = inner.split(':').collect();
+impl IdGenerator {
+    pub fn new(pattern: &str) -> Result<Self> {
+        // Parse pattern: [hash:digest:encoding:length]
+        // Default: [sha512:contenthash:base64:6]
 
-    if parts.len() < 4 {
-        anyhow::bail!(
-            "Invalid ID interpolation pattern format: {}. Expected [hash:digest:encoding:length]",
-            pattern
-        );
-    }
-
-    let hash_algo = parts[0];
-    let digest_type = parts[1];
-    let encoding = parts[2];
-    let length: usize = parts[3]
-        .parse()
-        .context("Invalid length in ID interpolation pattern")?;
-
-    // Build content hash input
-    let mut content = String::new();
-    if let Some(msg) = default_message {
-        content.push_str(msg);
-    }
-    if let Some(desc) = description {
-        content.push('#');
-        // Extract string value for string types to match TypeScript CLI behavior
-        // TypeScript uses: typeof description === 'string' ? description : stringify(description)
-        match desc {
-            Value::String(s) => content.push_str(s),
-            _ => content.push_str(&desc.to_string()),
+        if !pattern.starts_with('[') || !pattern.ends_with(']') {
+            anyhow::bail!("Invalid ID interpolation pattern: {}", pattern);
         }
+
+        let inner = &pattern[1..pattern.len() - 1];
+        let parts: Vec<&str> = inner.split(':').collect();
+
+        if parts.len() < 4 {
+            anyhow::bail!(
+                "Invalid ID interpolation pattern format: {}. Expected [hash:digest:encoding:length]",
+                pattern
+            );
+        }
+
+        let hash_algorithm = match parts[0] {
+            "sha512" => HashAlgorithm::Sha512,
+            _ => anyhow::bail!("Unsupported hash algorithm: {}", parts[0]),
+        };
+        let digest_type = match parts[1] {
+            "contenthash" => DigestType::ContentHash,
+            _ => anyhow::bail!("Unsupported digest type: {}", parts[1]),
+        };
+        let encoding = match parts[2] {
+            "base64" => Encoding::Base64,
+            "base64url" => Encoding::Base64Url,
+            "base62" => Encoding::Base62,
+            "hex" => Encoding::Hex,
+            _ => anyhow::bail!("Unsupported encoding: {}", parts[2]),
+        };
+        let length: usize = parts[3]
+            .parse()
+            .context("Invalid length in ID interpolation pattern")?;
+
+        Ok(Self {
+            hash_algorithm,
+            digest_type,
+            encoding,
+            length,
+        })
     }
 
-    // Generate hash
-    let hash = match (hash_algo, digest_type) {
-        ("sha512", "contenthash") => {
-            let mut hasher = Sha512::new();
-            hasher.update(content.as_bytes());
-            let result = hasher.finalize();
-            match encoding {
-                "base64" => {
-                    // Standard base64 (matches Node's crypto.digest('base64'))
-                    base64::engine::general_purpose::STANDARD.encode(&result)
+    pub fn generate(
+        &self,
+        default_message: Option<&str>,
+        description: &Option<Value>,
+    ) -> Result<String> {
+        // Generate hash
+        let hash = match (self.hash_algorithm, self.digest_type) {
+            (HashAlgorithm::Sha512, DigestType::ContentHash) => {
+                let mut hasher = Sha512::new();
+                if let Some(msg) = default_message {
+                    hasher.update(msg.as_bytes());
                 }
-                "base64url" => {
-                    // URL-safe base64 without padding (matches Node's crypto.digest('base64url'))
-                    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&result)
+                if let Some(desc) = description {
+                    hasher.update(b"#");
+                    // Extract string value for string types to match TypeScript CLI behavior
+                    // TypeScript uses: typeof description === 'string' ? description : stringify(description)
+                    match desc {
+                        Value::String(s) => hasher.update(s.as_bytes()),
+                        _ => hasher.update(desc.to_string().as_bytes()),
+                    }
                 }
-                "base62" => encode_base62(&result),
-                "hex" => hex::encode(result),
-                _ => anyhow::bail!("Unsupported encoding: {}", encoding),
+                let result = hasher.finalize();
+                match self.encoding {
+                    Encoding::Base64 => {
+                        // Standard base64 (matches Node's crypto.digest('base64'))
+                        base64::engine::general_purpose::STANDARD.encode(&result)
+                    }
+                    Encoding::Base64Url => {
+                        // URL-safe base64 without padding (matches Node's crypto.digest('base64url'))
+                        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&result)
+                    }
+                    Encoding::Base62 => encode_base62(&result),
+                    Encoding::Hex => hex::encode(result),
+                }
             }
-        }
-        _ => anyhow::bail!(
-            "Unsupported hash algorithm or digest type: {}:{}",
-            hash_algo,
-            digest_type
-        ),
-    };
+        };
 
-    // Truncate to specified length
-    Ok(hash.chars().take(length).collect())
+        // Truncate to specified length
+        Ok(hash.chars().take(self.length).collect())
+    }
 }
 
 #[cfg(test)]
@@ -254,13 +301,8 @@ mod tests {
     #[test]
     fn test_generate_id_with_description_affects_hash() {
         let desc = serde_json::Value::String("Description".to_string());
-        let id1 = generate_id(
-            "[sha512:contenthash:base64:10]",
-            Some("Hello"),
-            &None,
-            None,
-        )
-        .unwrap();
+        let id1 =
+            generate_id("[sha512:contenthash:base64:10]", Some("Hello"), &None, None).unwrap();
         let id2 = generate_id(
             "[sha512:contenthash:base64:10]",
             Some("Hello"),
@@ -290,10 +332,20 @@ mod tests {
 
     #[test]
     fn test_generate_id_base64_vs_base64url() {
-        let id_base64 =
-            generate_id("[sha512:contenthash:base64:10]", Some("Hello World"), &None, None).unwrap();
-        let id_base64url =
-            generate_id("[sha512:contenthash:base64url:10]", Some("Hello World"), &None, None).unwrap();
+        let id_base64 = generate_id(
+            "[sha512:contenthash:base64:10]",
+            Some("Hello World"),
+            &None,
+            None,
+        )
+        .unwrap();
+        let id_base64url = generate_id(
+            "[sha512:contenthash:base64url:10]",
+            Some("Hello World"),
+            &None,
+            None,
+        )
+        .unwrap();
 
         assert_eq!(id_base64, "LHT9F+2v2A");
         assert_eq!(id_base64url, "LHT9F-2v2A");
@@ -301,8 +353,13 @@ mod tests {
 
     #[test]
     fn test_generate_id_base62() {
-        let id =
-            generate_id("[sha512:contenthash:base62:10]", Some("Test message"), &None, None).unwrap();
+        let id = generate_id(
+            "[sha512:contenthash:base62:10]",
+            Some("Test message"),
+            &None,
+            None,
+        )
+        .unwrap();
         assert_eq!(id, "Gm8I0LBX6B");
     }
 
@@ -349,12 +406,7 @@ mod tests {
 
     #[test]
     fn test_generate_id_invalid_encoding() {
-        let result = generate_id(
-            "[sha512:contenthash:base32:10]",
-            Some("Test"),
-            &None,
-            None,
-        );
+        let result = generate_id("[sha512:contenthash:base32:10]", Some("Test"), &None, None);
         assert!(result.is_err());
         assert!(result
             .unwrap_err()

--- a/crates/icu_messageformat_parser/lib.rs
+++ b/crates/icu_messageformat_parser/lib.rs
@@ -26,7 +26,7 @@ pub use manipulator::{
 };
 
 // Re-export parser types and functions
-pub use parser::{Parser, ParserOptions, Position};
+pub use parser::{IntoParserMessage, Parser, ParserOptions, Position};
 
 // Re-export icu::locale::Locale for convenience
 pub use icu::locale::Locale;

--- a/crates/icu_messageformat_parser/parser.rs
+++ b/crates/icu_messageformat_parser/parser.rs
@@ -9,6 +9,7 @@ use crate::types::*;
 use formatjs_icu_skeleton_parser::{parse_date_time_skeleton, parse_number_skeleton};
 use icu::locale::Locale;
 use indexmap::IndexMap;
+use std::borrow::Cow;
 use std::collections::HashSet;
 
 /// Position in the source message string.
@@ -69,6 +70,35 @@ pub struct ParserOptions {
 /// Result type for parser operations.
 pub type Result<T> = std::result::Result<T, ParserError>;
 
+/// Input accepted by [`Parser::new`].
+pub trait IntoParserMessage<'a> {
+    fn into_parser_message(self) -> Cow<'a, str>;
+}
+
+impl<'a> IntoParserMessage<'a> for &'a str {
+    fn into_parser_message(self) -> Cow<'a, str> {
+        Cow::Borrowed(self)
+    }
+}
+
+impl<'a> IntoParserMessage<'a> for &'a String {
+    fn into_parser_message(self) -> Cow<'a, str> {
+        Cow::Borrowed(self.as_str())
+    }
+}
+
+impl<'a> IntoParserMessage<'a> for String {
+    fn into_parser_message(self) -> Cow<'a, str> {
+        Cow::Owned(self)
+    }
+}
+
+impl<'a> IntoParserMessage<'a> for Cow<'a, str> {
+    fn into_parser_message(self) -> Cow<'a, str> {
+        self
+    }
+}
+
 /// Argument type being parsed (used for context-sensitive parsing).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ArgType {
@@ -95,12 +125,6 @@ impl ArgType {
         }
     }
 }
-
-/// Static string constants for common single-character literals.
-/// OPTIMIZATION: Avoids allocating new Strings for commonly-used single characters.
-/// These are used in the parsing hot path (literal text parsing).
-const LEFT_ANGLE_BRACKET: &str = "<";
-const APOSTROPHE: &str = "'";
 
 /// Matches an identifier at a specific byte index in the string.
 ///
@@ -289,9 +313,9 @@ fn cold_panic_fmt(args: std::fmt::Arguments) -> ! {
 /// let result = parser.parse();
 /// assert!(result.is_ok());
 /// ```
-pub struct Parser {
+pub struct Parser<'a> {
     /// The message string being parsed
-    message: String,
+    message: Cow<'a, str>,
     /// Current position in the message
     position: Position,
     /// Locale for resolving locale-dependent skeletons
@@ -306,16 +330,16 @@ pub struct Parser {
     capture_location: bool,
 }
 
-impl Parser {
+impl<'a> Parser<'a> {
     /// Creates a new Parser for the given message string.
     ///
     /// # Arguments
     ///
     /// * `message` - The ICU MessageFormat string to parse
     /// * `options` - Parser configuration options
-    pub fn new(message: impl Into<String>, options: ParserOptions) -> Self {
+    pub fn new(message: impl IntoParserMessage<'a>, options: ParserOptions) -> Self {
         Parser {
-            message: message.into(),
+            message: message.into_parser_message(),
             position: Position::new(),
             locale: options.locale,
             ignore_tag: options.ignore_tag,
@@ -369,7 +393,7 @@ impl Parser {
     #[inline(always)]
     fn is_eof(&self) -> bool {
         // FIX: Check byte_offset against byte length, not character offset
-        self.byte_offset() >= self.message.len()
+        self.byte_offset() >= self.message.as_ref().len()
     }
 
     /// Returns the current Unicode codepoint.
@@ -384,12 +408,12 @@ impl Parser {
         // FIX: Use byte_offset for string indexing, not character offset
         // Character offset counts Unicode code points, byte_offset is the actual position in the UTF-8 string
         let byte_offset = self.position.byte_offset;
-        if byte_offset >= self.message.len() {
+        if byte_offset >= self.message.as_ref().len() {
             cold_panic("out of bound");
         }
 
         // Get the character at this byte offset
-        let remaining = &self.message[byte_offset..];
+        let remaining = &self.message.as_ref()[byte_offset..];
         let ch = remaining
             .chars()
             .next()
@@ -429,7 +453,7 @@ impl Parser {
 
         Err(ParserError {
             kind,
-            message: self.message.clone(),
+            message: self.message.to_string(),
             location: loc,
         })
     }
@@ -470,7 +494,7 @@ impl Parser {
     /// Returns true if the prefix was matched and consumed, false otherwise.
     fn bump_if(&mut self, prefix: &str) -> bool {
         // FIX: Use byte_offset for string slicing
-        if self.message[self.byte_offset()..].starts_with(prefix) {
+        if self.message.as_ref()[self.byte_offset()..].starts_with(prefix) {
             for _ in 0..prefix.chars().count() {
                 self.bump();
             }
@@ -485,7 +509,7 @@ impl Parser {
     /// Returns true if the pattern was found, false if EOF was reached.
     fn bump_until(&mut self, pattern: &str) -> bool {
         let current_offset = self.offset();
-        if let Some(index) = self.message[current_offset..].find(pattern) {
+        if let Some(index) = self.message.as_ref()[current_offset..].find(pattern) {
             self.bump_to(current_offset + index);
             true
         } else {
@@ -508,7 +532,7 @@ impl Parser {
             ));
         }
 
-        let target_offset = target_offset.min(self.message.len());
+        let target_offset = target_offset.min(self.message.as_ref().len());
 
         while self.offset() < target_offset {
             self.bump();
@@ -517,7 +541,7 @@ impl Parser {
             }
         }
 
-        if self.offset() != target_offset && target_offset < self.message.len() {
+        if self.offset() != target_offset && target_offset < self.message.as_ref().len() {
             cold_panic_fmt(format_args!(
                 "targetOffset {} is at invalid UTF-8 boundary",
                 target_offset
@@ -546,10 +570,10 @@ impl Parser {
         let char_len = std::char::from_u32(ch).unwrap().len_utf8();
         let next_byte_offset = byte_offset + char_len;
 
-        if next_byte_offset >= self.message.len() {
+        if next_byte_offset >= self.message.as_ref().len() {
             None
         } else {
-            let remaining = &self.message[next_byte_offset..];
+            let remaining = &self.message.as_ref()[next_byte_offset..];
             remaining.chars().next().map(|c| c as u32)
         }
     }
@@ -566,7 +590,8 @@ impl Parser {
         let start_byte_offset = self.byte_offset();
 
         // OPTIMIZATION: Get both slice and character count in one pass
-        let (value, char_count) = match_identifier_at_index(&self.message, start_byte_offset);
+        let (value, char_count) =
+            match_identifier_at_index(self.message.as_ref(), start_byte_offset);
 
         // Convert to String immediately to avoid borrowing issues
         // This is still better than regex because we avoid the regex overhead!
@@ -590,16 +615,16 @@ impl Parser {
     /// Attempts to parse a left angle bracket if it appears as literal text.
     ///
     /// Returns Some('<') if the bracket should be treated as literal, None otherwise.
-    fn try_parse_left_angle_bracket(&mut self) -> Option<String> {
+    fn try_parse_left_angle_bracket(&mut self, buffer: &mut String) -> bool {
         if !self.is_eof()
             && self.char() == 60  // '<'
             && (self.ignore_tag || !is_alpha_or_slash(self.peek().unwrap_or(0)))
         {
             self.bump();
-            // OPTIMIZATION: Use static string constant instead of allocating
-            Some(LEFT_ANGLE_BRACKET.to_string())
+            buffer.push('<');
+            true
         } else {
-            None
+            false
         }
     }
 
@@ -609,25 +634,27 @@ impl Parser {
     /// immediately precedes a character that requires quoting ("only where needed").
     ///
     /// Returns the unquoted content, or None if no quote sequence is found.
-    fn try_parse_quote(&mut self, parent_arg_type: ArgType) -> Option<String> {
+    fn try_parse_quote(&mut self, parent_arg_type: ArgType, buffer: &mut String) -> bool {
         if self.is_eof() || self.char() != 39 {
             // '\''
-            return None;
+            return false;
         }
 
         // Check what character follows the apostrophe
-        let next_char = self.peek()?;
+        let Some(next_char) = self.peek() else {
+            return false;
+        };
 
         match next_char {
             39 => {
                 // Double apostrophe '' -> single apostrophe
                 self.bump(); // First '
                 self.bump(); // Second '
-                // OPTIMIZATION: Use static string constant instead of allocating
-                return Some(APOSTROPHE.to_string());
+                buffer.push('\'');
+                return true;
             }
-            123 | 60 | 62 | 125 => { // '{', '<', '>', '}'
-                // These need escaping
+            123 | 60 | 62 | 125 => {
+                // '{', '<', '>', '}' need escaping.
             }
             35 => {
                 // '#'
@@ -635,16 +662,16 @@ impl Parser {
                 if parent_arg_type == ArgType::Plural || parent_arg_type == ArgType::SelectOrdinal {
                     // Continue to escape
                 } else {
-                    return None;
+                    return false;
                 }
             }
-            _ => return None,
+            _ => return false,
         }
 
         // We have a valid escape sequence
         self.bump(); // Consume the opening apostrophe
 
-        let mut code_points = vec![self.char()]; // The escaped character
+        buffer.push(std::char::from_u32(self.char()).unwrap()); // The escaped character
         self.bump();
 
         // Read characters until optional closing apostrophe
@@ -654,7 +681,7 @@ impl Parser {
                 // '\''
                 if self.peek() == Some(39) {
                     // Double apostrophe inside quoted text
-                    code_points.push(39);
+                    buffer.push('\'');
                     self.bump(); // Skip one of the apostrophes
                 } else {
                     // Closing apostrophe
@@ -662,17 +689,12 @@ impl Parser {
                     break;
                 }
             } else {
-                code_points.push(ch);
+                buffer.push(std::char::from_u32(ch).unwrap());
             }
             self.bump();
         }
 
-        Some(
-            code_points
-                .into_iter()
-                .map(|cp| std::char::from_u32(cp).unwrap())
-                .collect(),
-        )
+        true
     }
 
     /// Attempts to parse an unquoted character and append it to the buffer.
@@ -722,8 +744,7 @@ impl Parser {
 
         loop {
             // Try parsing quoted sequence
-            if let Some(quoted) = self.try_parse_quote(parent_arg_type) {
-                value.push_str(&quoted);
+            if self.try_parse_quote(parent_arg_type, &mut value) {
                 continue;
             }
 
@@ -733,8 +754,7 @@ impl Parser {
             }
 
             // Try parsing literal angle bracket
-            if let Some(bracket) = self.try_parse_left_angle_bracket() {
-                value.push_str(&bracket);
+            if self.try_parse_left_angle_bracket(&mut value) {
                 continue;
             }
 
@@ -769,7 +789,7 @@ impl Parser {
             self.bump();
         }
 
-        self.message[start_byte_offset..self.byte_offset()].to_string()
+        self.message.as_ref()[start_byte_offset..self.byte_offset()].to_string()
     }
 
     /// Parses an HTML/XML-like tag element.
@@ -997,7 +1017,7 @@ impl Parser {
         }
 
         // FIX: Use byte_offset for string slicing
-        Ok(self.message[start_position.byte_offset..self.byte_offset()].to_string())
+        Ok(self.message.as_ref()[start_position.byte_offset..self.byte_offset()].to_string())
     }
 
     /// Parses the main message content recursively.
@@ -1023,7 +1043,7 @@ impl Parser {
         // Heuristic: Estimate ~1 element per 20 characters, bounded between 4-16 for top level.
         // Nested messages (inside plural/select) tend to be smaller.
         let estimated_capacity = if nesting_level == 0 {
-            let remaining_len = self.message.len() - self.byte_offset();
+            let remaining_len = self.message.as_ref().len() - self.byte_offset();
             ((remaining_len / 20) + 1).clamp(4, 16)
         } else {
             // Nested contexts: be conservative
@@ -1223,7 +1243,7 @@ impl Parser {
                 } else {
                     ErrorKind::InvalidArgumentType
                 },
-                message: self.message.clone(),
+                message: self.message.to_string(),
                 location: loc,
             }
         })?;
@@ -1716,7 +1736,11 @@ mod tests {
         let parser = Parser::new("ही किंमत <span>जास्त</span>", ParserOptions::default());
         let result = parser.parse();
 
-        assert!(result.is_ok(), "Failed to parse Hindi text with tags: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "Failed to parse Hindi text with tags: {:?}",
+            result.err()
+        );
 
         let elements = result.unwrap();
         assert_eq!(elements.len(), 2, "Expected 2 elements (literal + tag)");

--- a/crates/icu_messageformat_parser/printer.rs
+++ b/crates/icu_messageformat_parser/printer.rs
@@ -4,6 +4,7 @@
 //! back into their string representation, following the ICU MessageFormat syntax.
 
 use crate::types::*;
+use std::fmt::Write;
 
 /// Prints a MessageFormat AST to its string representation.
 ///
@@ -27,47 +28,31 @@ use crate::types::*;
 /// assert_eq!(print_ast(&ast), "Hello");
 /// ```
 pub fn print_ast(ast: &[MessageFormatElement]) -> String {
-    do_print_ast(ast, false)
+    let mut result = String::new();
+    write_ast(&mut result, ast, false);
+    result
 }
 
-/// Internal function to print AST with plural context tracking.
-///
-/// This function handles the recursive printing of AST nodes, keeping track
-/// of whether we're currently inside a plural element (which affects how
-/// the '#' character is escaped).
-///
-/// # Arguments
-///
-/// * `ast` - The AST nodes to print
-/// * `is_in_plural` - Whether we're currently inside a plural element (affects '#' escaping)
-///
-/// # Returns
-///
-/// The printed string representation
-fn do_print_ast(ast: &[MessageFormatElement], is_in_plural: bool) -> String {
-    ast.iter()
-        .enumerate()
-        .filter_map(|(i, el)| {
-            // Track position to handle special quote escaping at boundaries
-            let is_first = i == 0;
-            let is_last = i == ast.len() - 1;
+fn write_ast(out: &mut String, ast: &[MessageFormatElement], is_in_plural: bool) {
+    for (i, el) in ast.iter().enumerate() {
+        // Track position to handle special quote escaping at boundaries
+        let is_first = i == 0;
+        let is_last = i == ast.len() - 1;
 
-            match el {
-                MessageFormatElement::Literal(lit) => {
-                    Some(print_literal_element(lit, is_in_plural, is_first, is_last))
-                }
-                MessageFormatElement::Argument(arg) => Some(print_argument_element(arg)),
-                MessageFormatElement::Number(num) => Some(print_number_element(num)),
-                MessageFormatElement::Date(date) => Some(print_date_element(date)),
-                MessageFormatElement::Time(time) => Some(print_time_element(time)),
-                MessageFormatElement::Plural(plural) => Some(print_plural_element(plural)),
-                MessageFormatElement::Select(select) => Some(print_select_element(select)),
-                MessageFormatElement::Pound(_) => Some("#".to_string()),
-                MessageFormatElement::Tag(tag) => Some(print_tag_element(tag)),
+        match el {
+            MessageFormatElement::Literal(lit) => {
+                write_literal_element(out, lit, is_in_plural, is_first, is_last)
             }
-        })
-        .collect::<Vec<_>>()
-        .join("")
+            MessageFormatElement::Argument(arg) => write_argument_element(out, arg),
+            MessageFormatElement::Number(num) => write_number_element(out, num),
+            MessageFormatElement::Date(date) => write_date_element(out, date),
+            MessageFormatElement::Time(time) => write_time_element(out, time),
+            MessageFormatElement::Plural(plural) => write_plural_element(out, plural),
+            MessageFormatElement::Select(select) => write_select_element(out, select),
+            MessageFormatElement::Pound(_) => out.push('#'),
+            MessageFormatElement::Tag(tag) => write_tag_element(out, tag),
+        }
+    }
 }
 
 /// Prints an XML-like tag element with its children.
@@ -81,13 +66,27 @@ fn do_print_ast(ast: &[MessageFormatElement], is_in_plural: bool) -> String {
 /// # Returns
 ///
 /// A string like `<b>text</b>`
-fn print_tag_element(el: &TagElement) -> String {
-    format!("<{}>{}</{}>", el.value, print_ast(&el.children), el.value)
+fn write_tag_element(out: &mut String, el: &TagElement) {
+    out.push('<');
+    out.push_str(&el.value);
+    out.push('>');
+    write_ast(out, &el.children, false);
+    out.push_str("</");
+    out.push_str(&el.value);
+    out.push('>');
 }
 
 /// Wraps one ICU syntax token in apostrophe quotes.
-fn quote_syntax_token(token: &str) -> String {
-    format!("'{}'", token.replace('\'', "''"))
+fn write_quoted_syntax_token(out: &mut String, token: &str) {
+    out.push('\'');
+    for ch in token.chars() {
+        if ch == '\'' {
+            out.push_str("''");
+        } else {
+            out.push(ch);
+        }
+    }
+    out.push('\'');
 }
 
 fn is_tag_syntax_start(bytes: &[u8], index: usize) -> bool {
@@ -123,9 +122,8 @@ fn find_brace_syntax_end(bytes: &[u8], index: usize) -> usize {
 }
 
 /// Escapes ICU syntax tokens in a literal message string.
-fn print_escaped_message(message: &str, is_in_plural: bool) -> String {
+fn write_escaped_message(out: &mut String, message: &str, is_in_plural: bool) {
     let bytes = message.as_bytes();
-    let mut result = String::new();
     let mut literal_start = 0;
     let mut i = 0;
 
@@ -139,8 +137,8 @@ fn print_escaped_message(message: &str, is_in_plural: bool) -> String {
         };
 
         if let Some(end) = end {
-            result.push_str(&message[literal_start..i]);
-            result.push_str(&quote_syntax_token(&message[i..end]));
+            out.push_str(&message[literal_start..i]);
+            write_quoted_syntax_token(out, &message[i..end]);
             literal_start = end;
             i = end;
         } else {
@@ -148,8 +146,7 @@ fn print_escaped_message(message: &str, is_in_plural: bool) -> String {
         }
     }
 
-    result.push_str(&message[literal_start..]);
-    result
+    out.push_str(&message[literal_start..]);
 }
 
 /// Prints a literal text element with appropriate escaping.
@@ -167,26 +164,33 @@ fn print_escaped_message(message: &str, is_in_plural: bool) -> String {
 /// # Returns
 ///
 /// The properly escaped literal text
-fn print_literal_element(
+fn write_literal_element(
+    out: &mut String,
     el: &LiteralElement,
     is_in_plural: bool,
     is_first_el: bool,
     is_last_el: bool,
-) -> String {
-    let mut escaped = el.value.clone();
-
+) {
     // If this literal starts with a ' and it's not the 1st node, this means the node before it is non-literal
     // and the `'` needs to be unescaped (doubled) to preserve it
-    if !is_first_el && escaped.starts_with('\'') {
-        escaped = format!("''{}", &escaped[1..]);
-    }
+    let needs_leading_quote_escape = !is_first_el && el.value.starts_with('\'');
+    let needs_trailing_quote_escape = !is_last_el && el.value.ends_with('\'');
 
-    // Same logic but for the last element - preserve trailing quotes
-    if !is_last_el && escaped.ends_with('\'') {
-        escaped = format!("{}''", &escaped[..escaped.len() - 1]);
-    }
+    if needs_leading_quote_escape || needs_trailing_quote_escape {
+        let mut escaped = el.value.clone();
+        if needs_leading_quote_escape {
+            escaped = format!("''{}", &escaped[1..]);
+        }
 
-    print_escaped_message(&escaped, is_in_plural)
+        // Same logic but for the last element - preserve trailing quotes
+        if !is_last_el && escaped.ends_with('\'') {
+            escaped = format!("{}''", &escaped[..escaped.len() - 1]);
+        }
+
+        write_escaped_message(out, &escaped, is_in_plural);
+    } else {
+        write_escaped_message(out, &el.value, is_in_plural);
+    }
 }
 
 /// Prints a simple argument reference.
@@ -200,8 +204,8 @@ fn print_literal_element(
 /// # Returns
 ///
 /// A string like `{count}`
-fn print_argument_element(el: &ArgumentElement) -> String {
-    format!("{{{}}}", el.value)
+fn write_argument_element(out: &mut String, el: &ArgumentElement) {
+    let _ = write!(out, "{{{}}}", el.value);
 }
 
 /// Prints a number format element.
@@ -215,12 +219,13 @@ fn print_argument_element(el: &ArgumentElement) -> String {
 /// # Returns
 ///
 /// A string like `{count, number, percent}`
-fn print_number_element(el: &NumberElement) -> String {
-    let style_str = match &el.style {
-        Some(s) => format!(", {}", print_argument_style_number(s)),
-        None => String::new(),
-    };
-    format!("{{{}, number{}}}", el.value, style_str)
+fn write_number_element(out: &mut String, el: &NumberElement) {
+    let _ = write!(out, "{{{}, number", el.value);
+    if let Some(style) = &el.style {
+        out.push_str(", ");
+        write_argument_style_number(out, style);
+    }
+    out.push('}');
 }
 
 /// Prints a date format element.
@@ -234,12 +239,13 @@ fn print_number_element(el: &NumberElement) -> String {
 /// # Returns
 ///
 /// A string like `{today, date, short}`
-fn print_date_element(el: &DateElement) -> String {
-    let style_str = match &el.style {
-        Some(s) => format!(", {}", print_argument_style_datetime(s)),
-        None => String::new(),
-    };
-    format!("{{{}, date{}}}", el.value, style_str)
+fn write_date_element(out: &mut String, el: &DateElement) {
+    let _ = write!(out, "{{{}, date", el.value);
+    if let Some(style) = &el.style {
+        out.push_str(", ");
+        write_argument_style_datetime(out, style);
+    }
+    out.push('}');
 }
 
 /// Prints a time format element.
@@ -253,12 +259,13 @@ fn print_date_element(el: &DateElement) -> String {
 /// # Returns
 ///
 /// A string like `{now, time, ::jmm}`
-fn print_time_element(el: &TimeElement) -> String {
-    let style_str = match &el.style {
-        Some(s) => format!(", {}", print_argument_style_datetime(s)),
-        None => String::new(),
-    };
-    format!("{{{}, time{}}}", el.value, style_str)
+fn write_time_element(out: &mut String, el: &TimeElement) {
+    let _ = write!(out, "{{{}, time", el.value);
+    if let Some(style) = &el.style {
+        out.push_str(", ");
+        write_argument_style_datetime(out, style);
+    }
+    out.push('}');
 }
 
 /// Prints a number skeleton token.
@@ -273,20 +280,11 @@ fn print_time_element(el: &TimeElement) -> String {
 /// # Returns
 ///
 /// A string like `currency/USD` or `percent`
-fn print_number_skeleton_token(token: &NumberSkeletonToken) -> String {
-    if token.options.is_empty() {
-        token.stem.clone()
-    } else {
-        format!(
-            "{}{}",
-            token.stem,
-            token
-                .options
-                .iter()
-                .map(|o| format!("/{}", o))
-                .collect::<Vec<_>>()
-                .join("")
-        )
+fn write_number_skeleton_token(out: &mut String, token: &NumberSkeletonToken) {
+    out.push_str(&token.stem);
+    for option in &token.options {
+        out.push('/');
+        out.push_str(option);
     }
 }
 
@@ -302,18 +300,18 @@ fn print_number_skeleton_token(token: &NumberSkeletonToken) -> String {
 /// # Returns
 ///
 /// A string like `percent` or `::currency/USD`
-fn print_argument_style_number(style: &NumberSkeletonOrStyle) -> String {
+fn write_argument_style_number(out: &mut String, style: &NumberSkeletonOrStyle) {
     match style {
-        NumberSkeletonOrStyle::String(s) => print_escaped_message(s, false),
-        NumberSkeletonOrStyle::Skeleton(skeleton) => format!(
-            "::{}",
-            skeleton
-                .tokens
-                .iter()
-                .map(print_number_skeleton_token)
-                .collect::<Vec<_>>()
-                .join(" ")
-        ),
+        NumberSkeletonOrStyle::String(s) => write_escaped_message(out, s, false),
+        NumberSkeletonOrStyle::Skeleton(skeleton) => {
+            out.push_str("::");
+            for (index, token) in skeleton.tokens.iter().enumerate() {
+                if index > 0 {
+                    out.push(' ');
+                }
+                write_number_skeleton_token(out, token);
+            }
+        }
     }
 }
 
@@ -329,11 +327,12 @@ fn print_argument_style_number(style: &NumberSkeletonOrStyle) -> String {
 /// # Returns
 ///
 /// A string like `short` or `::yMMMd`
-fn print_argument_style_datetime(style: &DateTimeSkeletonOrStyle) -> String {
+fn write_argument_style_datetime(out: &mut String, style: &DateTimeSkeletonOrStyle) {
     match style {
-        DateTimeSkeletonOrStyle::String(s) => print_escaped_message(s, false),
+        DateTimeSkeletonOrStyle::String(s) => write_escaped_message(out, s, false),
         DateTimeSkeletonOrStyle::Skeleton(skeleton) => {
-            format!("::{}", print_date_time_skeleton(skeleton))
+            out.push_str("::");
+            out.push_str(&skeleton.pattern);
         }
     }
 }
@@ -368,21 +367,23 @@ pub fn print_date_time_skeleton(style: &DateTimeSkeleton) -> String {
 /// # Returns
 ///
 /// A string like `{gender,select,female{She} male{He} other{They}}`
-fn print_select_element(el: &SelectElement) -> String {
+fn write_select_element(out: &mut String, el: &SelectElement) {
     // Sort keys alphabetically for consistent output
     let mut keys: Vec<_> = el.options.keys().collect();
     keys.sort();
 
-    let options_str = keys
-        .iter()
-        .map(|id| {
-            let option = &el.options[id.as_str()];
-            format!("{}{{{}}}", id, do_print_ast(&option.value, false))
-        })
-        .collect::<Vec<_>>()
-        .join(" ");
-
-    format!("{{{},select,{}}}", el.value, options_str)
+    let _ = write!(out, "{{{},select,", el.value);
+    for (index, id) in keys.iter().enumerate() {
+        if index > 0 {
+            out.push(' ');
+        }
+        let option = el.options.get(*id).expect("select key should exist");
+        out.push_str(id);
+        out.push('{');
+        write_ast(out, &option.value, false);
+        out.push('}');
+    }
+    out.push('}');
 }
 
 /// Returns the LDML sort order for a plural rule.
@@ -428,18 +429,20 @@ fn get_plural_rule_sort_order(rule: &ValidPluralRule) -> (u8, i32) {
 /// # Returns
 ///
 /// A string like `{count,plural,offset:1 one{# item} other{# items}}`
-fn print_plural_element(el: &PluralElement) -> String {
+fn write_plural_element(out: &mut String, el: &PluralElement) {
     // Determine the type keyword (plural vs selectordinal)
     let type_name = match el.plural_type {
         PluralType::Cardinal => "plural",
         PluralType::Ordinal => "selectordinal",
     };
 
-    let mut parts = Vec::new();
+    let _ = write!(out, "{{{},{},", el.value, type_name);
+    let mut wrote_part = false;
 
     // Add offset if non-zero
     if el.offset != 0 {
-        parts.push(format!("offset:{}", el.offset));
+        let _ = write!(out, "offset:{}", el.offset);
+        wrote_part = true;
     }
 
     // Sort keys in LDML order: zero, one, two, few, many, other, then exact matches
@@ -448,17 +451,18 @@ fn print_plural_element(el: &PluralElement) -> String {
 
     // Add each option with its message in sorted order
     for id in keys {
+        if wrote_part {
+            out.push(' ');
+        }
+        wrote_part = true;
         let option = &el.options[id];
-        parts.push(format!(
-            "{}{{{}}}",
-            id.as_str(),
-            do_print_ast(&option.value, true) // true = we're in a plural context
-        ));
+        out.push_str(id.as_str());
+        out.push('{');
+        write_ast(out, &option.value, true); // true = we're in a plural context
+        out.push('}');
     }
 
-    let options_str = parts.join(" ");
-
-    format!("{{{},{},{}}}", el.value, type_name, options_str)
+    out.push('}');
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Let the Rust ICU MessageFormat parser borrow input strings via `Cow`, avoiding one message copy on borrowed inputs.
- Write `print_ast` output into one recursive `String` buffer instead of allocating per node and joining.
- Parse `extract` ID interpolation patterns once per run and hash generated-ID inputs directly instead of staging them in a temporary `String`.

## Benchmarks

Before -> after:

| Probe | Before | After | Result |
| --- | ---: | ---: | ---: |
| parser `complex_msg` | 9.2882 us | 9.1780 us | ~1.2% faster |
| parser `normal_msg` | 1.1798 us | 1.1475 us | ~2.7% faster |
| parser `simple_msg` | 165.68 ns | 146.80 ns | ~11.4% faster |
| parser `string_msg` | 116.63 ns | 97.337 ns | ~16.5% faster |
| Rust CLI extract median, 9,406 messages | 27.15 ms | 26.52 ms | modestly faster |
| Rust CLI extract --flatten median | 27.92 ms | 26.76 ms | modestly faster |
| Rust CLI extract with generated IDs, 9,507 messages | 23.59 ms | 22.09 ms | ~6.4% faster |

Notes:
- Parser numbers came from `bazel run -c opt //crates/icu_messageformat_parser:parser_bench -- --bench`.
- CLI numbers used the checked-in `benchmarks/cli-comparison` generated fixture plus a generated no-explicit-id fixture, with `RAYON_NUM_THREADS=8`.
- One plain extract after-run had a large scheduler outlier, so CLI comparisons use medians.

## Memory

Peak RSS did not materially move at the process level. These are medians from 10 interleaved runs using `/usr/bin/time -l` with `RAYON_NUM_THREADS=8`:

| Workload | Before | After | Result |
| --- | ---: | ---: | ---: |
| Rust CLI extract, 9,406 messages | 20.60 MiB | 20.82 MiB | unchanged (+0.22 MiB) |
| Rust CLI extract --flatten | 21.73 MiB | 22.18 MiB | unchanged (+0.45 MiB) |
| Rust CLI extract with generated IDs, 9,507 messages | 20.49 MiB | 20.47 MiB | unchanged (-0.02 MiB) |

## Validation

- `bazel test //crates/icu_messageformat_parser:icu_messageformat_parser_test //crates/formatjs_cli:formatjs_cli_test //packages/icu-messageformat-parser/integration-tests:integration_tests`
- `git diff --check`
