### PR TITLE
ci: fix crates release dependency polling

### DIFF
--- a/.github/workflows/crates-release.yml
+++ b/.github/workflows/crates-release.yml
@@ -164,7 +164,13 @@ jobs:
             local url="https://crates.io/api/v1/crates/$crate/$version"
 
             for attempt in $(seq 1 30); do
-              if curl --fail --silent --show-error "$url" > /dev/null; then
+              if curl \
+                --fail \
+                --silent \
+                --show-error \
+                --header "Accept: application/json" \
+                --user-agent "formatjs-crates-release (https://github.com/formatjs/formatjs)" \
+                "$url" > /dev/null; then
                 echo "$crate $version is available on crates.io"
                 return 0
               fi
@@ -178,6 +184,29 @@ jobs:
             return 1
           }
 
+          publishes_crate() {
+            local crate="$1"
+
+            while IFS= read -r selected_crate; do
+              if [ "$selected_crate" = "$crate" ]; then
+                return 0
+              fi
+            done <<< "${{ steps.crates.outputs.names }}"
+
+            return 1
+          }
+
+          wait_if_published_by_this_run() {
+            local crate="$1"
+            local version="$2"
+
+            if publishes_crate "$crate"; then
+              wait_for_crate "$crate" "$version"
+            else
+              echo "$crate is not selected in this run; skipping crates.io availability wait"
+            fi
+          }
+
           dependency_version() {
             local manifest="$1"
             local crate="$2"
@@ -187,15 +216,15 @@ jobs:
           while IFS= read -r crate; do
             case "$crate" in
               formatjs_icu_messageformat_parser)
-                wait_for_crate \
+                wait_if_published_by_this_run \
                   formatjs_icu_skeleton_parser \
                   "$(dependency_version crates/icu_messageformat_parser/Cargo.toml formatjs_icu_skeleton_parser)"
                 ;;
               formatjs_cli)
-                wait_for_crate \
+                wait_if_published_by_this_run \
                   formatjs_icu_skeleton_parser \
                   "$(dependency_version crates/formatjs_cli/Cargo.toml formatjs_icu_skeleton_parser)"
-                wait_for_crate \
+                wait_if_published_by_this_run \
                   formatjs_icu_messageformat_parser \
                   "$(dependency_version crates/formatjs_cli/Cargo.toml formatjs_icu_messageformat_parser)"
                 ;;


### PR DESCRIPTION
## Summary

- avoid waiting on parser crates unless the current workflow run is publishing them
- add an identifying `User-Agent` and JSON `Accept` header to the remaining crates.io availability poll
- keep the `cargo publish --locked -p <crate>` path unchanged

## Validation

- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/crates-release.yml')"`
- extracted `Publish Crates` shell block passes `bash -n` after substituting sample GitHub output
- `git diff --check`
- crates.io API checks with the workflow User-Agent return `200` for:
  - `formatjs_icu_skeleton_parser/0.1.1`
  - `formatjs_icu_messageformat_parser/0.2.4`

Note: local pre-commit failed on the existing `oxfmt` native binding install issue (`@oxfmt/binding-darwin-arm64` missing), so the commit was created with `LEFTHOOK=0` after the focused validations above.
