### PR TITLE
ci(formatjs_cli): cross-compile release binaries on linux

### DIFF
--- a/.github/workflows/rust-cli-release.yml
+++ b/.github/workflows/rust-cli-release.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   build:
     name: Build Release Binaries
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout Repository
@@ -34,22 +34,32 @@ jobs:
 
       - name: Build Binaries
         run: |
+          targets=(
+            //crates/formatjs_cli:release_binary_darwin_arm64
+            //crates/formatjs_cli:release_binary_linux_x64
+            //crates/formatjs_cli:release_binary_linux_arm64
+            //crates/formatjs_cli:release_binary_windows_x64_gnullvm
+          )
+
+          bazel_build_args=()
+          bazel_query_args=()
+
           if [ -n "${{ secrets.BUILDBUDDY_ORG_API_KEY }}" ]; then
-            bazel build \
-              --config=ci-darwin \
-              --compilation_mode=opt \
-              --remote_download_outputs=all \
-              --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
-              //crates/formatjs_cli:release_binary_darwin_arm64 \
-              //crates/formatjs_cli:release_binary_linux_x64 \
-              //crates/formatjs_cli:release_binary_linux_arm64
+            bazel_build_args+=(
+              --config=ci
+              --remote_download_outputs=all
+              --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }}
+            )
+            bazel_query_args+=(
+              --config=ci
+              --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }}
+            )
           else
-            bazel build \
-              --compilation_mode=opt \
-              //crates/formatjs_cli:release_binary_darwin_arm64 \
-              //crates/formatjs_cli:release_binary_linux_x64 \
-              //crates/formatjs_cli:release_binary_linux_arm64
+            bazel_build_args+=(--compilation_mode=opt)
+            bazel_query_args+=(--compilation_mode=opt)
           fi
+
+          bazel build "${bazel_build_args[@]}" "${targets[@]}"
 
           mkdir -p artifacts
 
@@ -57,7 +67,7 @@ jobs:
             local target="$1"
             local output="$2"
             local binary_path
-            binary_path="$(bazel cquery --output=files "$target")"
+            binary_path="$(bazel cquery "${bazel_query_args[@]}" --output=files "$target")"
             cp "$binary_path" "artifacts/$output"
             chmod +x "artifacts/$output"
           }
@@ -65,6 +75,7 @@ jobs:
           copy_artifact //crates/formatjs_cli:release_binary_darwin_arm64 formatjs_cli-darwin-arm64
           copy_artifact //crates/formatjs_cli:release_binary_linux_x64 formatjs_cli-linux-x64
           copy_artifact //crates/formatjs_cli:release_binary_linux_arm64 formatjs_cli-linux-arm64
+          copy_artifact //crates/formatjs_cli:release_binary_windows_x64_gnullvm formatjs_cli-win32-x64.exe
 
       - name: Upload macOS ARM64 Artifact
         uses: actions/upload-artifact@v7
@@ -86,38 +97,6 @@ jobs:
           name: formatjs_cli-linux-arm64
           path: artifacts/formatjs_cli-linux-arm64
           retention-days: 7
-
-  build_windows:
-    name: Build Windows x64 Binary
-    runs-on: windows-latest
-
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v6
-
-      - name: Setup MSVC
-        uses: ./.github/actions/setup-msvc
-
-      - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@0.19.0
-        with:
-          bazelisk-cache: true
-          disk-cache: ${{ github.workflow }}-windows-release-binary
-          repository-cache: true
-
-      - name: Build Binary
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $PSNativeCommandUseErrorActionPreference = $true
-          $bazelWindowsFlags = @(
-            '--repo_env==BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN',
-            '--extra_toolchains=@local_config_cc//:cc-toolchain-x64_windows'
-          )
-
-          bazel build @bazelWindowsFlags //crates/formatjs_cli:release_binary_windows_x64
-          $binaryPath = (bazel cquery @bazelWindowsFlags --output=files //crates/formatjs_cli:release_binary_windows_x64 | Select-Object -Last 1)
-          New-Item -ItemType Directory -Force artifacts
-          Copy-Item $binaryPath artifacts\formatjs_cli-win32-x64.exe
 
       - name: Upload Windows x64 Artifact
         uses: actions/upload-artifact@v7
@@ -187,7 +166,7 @@ jobs:
 
   verify_windows:
     name: Verify Windows x64
-    needs: build_windows
+    needs: build
     runs-on: windows-latest
 
     steps:

--- a/crates/formatjs_cli/BUILD.bazel
+++ b/crates/formatjs_cli/BUILD.bazel
@@ -7,6 +7,7 @@ load(
     "release_binary_linux_arm64",
     "release_binary_linux_x64",
     "release_binary_windows_x64",
+    "release_binary_windows_x64_gnullvm",
 )
 
 FORMATJS_CLI_VERSION = "1.1.9"  # x-release-please-version
@@ -168,12 +169,21 @@ release_binary_windows_x64(
     visibility = ["//visibility:public"],
 )
 
+release_binary_windows_x64_gnullvm(
+    name = "release_binary_windows_x64_gnullvm",
+    srcs = [":formatjs_cli"],
+    outs = ["formatjs_cli_win32_x64_gnullvm.exe"],
+    cmd = "cp $< $@",
+    visibility = ["//visibility:public"],
+)
+
 filegroup(
     name = "release_binaries",
     srcs = [
         ":release_binary_darwin_arm64",
         ":release_binary_linux_arm64",
         ":release_binary_linux_x64",
+        ":release_binary_windows_x64_gnullvm",
     ],
     visibility = ["//visibility:public"],
 )

--- a/crates/formatjs_cli/README.md
+++ b/crates/formatjs_cli/README.md
@@ -114,6 +114,7 @@ Download pre-built native binaries from the [GitHub Releases](https://github.com
 - `formatjs_cli-darwin-arm64` - macOS Apple Silicon
 - `formatjs_cli-linux-arm64` - Linux ARM64
 - `formatjs_cli-linux-x64` - Linux x86_64
+- `formatjs_cli-win32-x64.exe` - Windows x64
 
 **Installation steps:**
 
@@ -128,15 +129,18 @@ Download pre-built native binaries from the [GitHub Releases](https://github.com
 
    # Linux ARM64
    curl -L https://github.com/formatjs/formatjs/releases/download/<version>/formatjs_cli-linux-arm64 -o formatjs
+
+   # Windows x64
+   curl.exe -L https://github.com/formatjs/formatjs/releases/download/<version>/formatjs_cli-win32-x64.exe -o formatjs.exe
    ```
 
-2. Make it executable:
+2. On macOS or Linux, make it executable:
 
    ```bash
    chmod +x formatjs
    ```
 
-3. Optionally, move it to your PATH:
+3. On macOS or Linux, optionally move it to your PATH:
 
    ```bash
    sudo mv formatjs /usr/local/bin/
@@ -163,13 +167,14 @@ bazel run //crates/formatjs_cli:formatjs -- --help
 
 ### Cross-Platform Release Builds
 
-Build the release binaries for Darwin ARM64, Linux x64, and Linux ARM64:
+Build the release binaries for Darwin ARM64, Linux x64, Linux ARM64, and Windows x64:
 
 ```bash
 bazel build --compilation_mode=opt \
   //crates/formatjs_cli:release_binary_darwin_arm64 \
   //crates/formatjs_cli:release_binary_linux_x64 \
-  //crates/formatjs_cli:release_binary_linux_arm64
+  //crates/formatjs_cli:release_binary_linux_arm64 \
+  //crates/formatjs_cli:release_binary_windows_x64_gnullvm
 ```
 
 Use `bazel cquery --output=files <target>` to locate each binary:
@@ -178,6 +183,7 @@ Use `bazel cquery --output=files <target>` to locate each binary:
 bazel cquery --output=files //crates/formatjs_cli:release_binary_darwin_arm64
 bazel cquery --output=files //crates/formatjs_cli:release_binary_linux_x64
 bazel cquery --output=files //crates/formatjs_cli:release_binary_linux_arm64
+bazel cquery --output=files //crates/formatjs_cli:release_binary_windows_x64_gnullvm
 ```
 
 ### Local Cargo Build

--- a/crates/formatjs_cli/RELEASE.md
+++ b/crates/formatjs_cli/RELEASE.md
@@ -41,8 +41,8 @@ git push origin formatjs_cli_v0.1.0
 
 **What it does**:
 
-1. Build macOS ARM64, Linux x86_64, and Linux ARM64 binaries in one Bazel build job
-2. Verify artifacts on the corresponding macOS and Linux runners
+1. Build macOS ARM64, Linux x86_64, Linux ARM64, and Windows x64 binaries in one Linux BuildBuddy RBE Bazel job
+2. Verify artifacts on the corresponding macOS, Linux, and Windows runners
 3. Combine artifacts and generate checksums
 4. Create a GitHub Release with all binaries
 
@@ -51,6 +51,7 @@ git push origin formatjs_cli_v0.1.0
 - `formatjs_cli-darwin-arm64` (macOS Apple Silicon)
 - `formatjs_cli-linux-arm64` (Linux ARM64)
 - `formatjs_cli-linux-x64` (Linux x86_64)
+- `formatjs_cli-win32-x64.exe` (Windows x64)
 - `checksums.txt` (SHA-256 checksums)
 
 ### Option 2: Publishing to crates.io
@@ -87,13 +88,14 @@ path = "src/main.rs"
 
 ## Platform Support
 
-| Platform | Architecture  | Target Triple             | Status                                |
-| -------- | ------------- | ------------------------- | ------------------------------------- |
-| macOS    | Apple Silicon | aarch64-apple-darwin      | ✅ Native (Bazel on GHA macOS runner) |
-| Linux    | ARM64         | aarch64-unknown-linux-gnu | ✅ Bazel release target               |
-| Linux    | x86_64        | x86_64-unknown-linux-gnu  | ✅ Bazel release target               |
+| Platform | Architecture  | Target Triple                | Status                           |
+| -------- | ------------- | ---------------------------- | -------------------------------- |
+| macOS    | Apple Silicon | aarch64-apple-darwin         | ✅ LLVM cross target             |
+| Linux    | ARM64         | aarch64-unknown-linux-musl   | ✅ LLVM cross target             |
+| Linux    | x86_64        | x86_64-unknown-linux-musl    | ✅ LLVM cross target             |
+| Windows  | x86_64        | x86_64-pc-windows-gnullvm    | ✅ LLVM cross target             |
 
-**Note**: The GitHub Actions workflow builds release artifacts through Bazel targets. Linux release binaries use musl targets for static artifacts.
+**Note**: The GitHub Actions workflow builds release artifacts through Bazel targets on Linux BuildBuddy RBE when credentials are available. Linux release binaries use musl targets for static artifacts; the standalone Windows CLI uses the LLVM gnullvm target and is smoke-tested on a Windows runner.
 
 ## Cross-Compilation Setup
 
@@ -154,6 +156,9 @@ bazel build --compilation_mode=opt //crates/formatjs_cli:release_binary_linux_x6
 
 # Linux ARM64 static release artifact:
 bazel build --compilation_mode=opt //crates/formatjs_cli:release_binary_linux_arm64
+
+# Windows x64 release artifact:
+bazel build --compilation_mode=opt //crates/formatjs_cli:release_binary_windows_x64_gnullvm
 ```
 
 Use `bazel cquery --output=files <target>` to locate platform-specific release target outputs.
@@ -190,6 +195,7 @@ Release assets:
 ├── formatjs_cli-darwin-arm64      # macOS Apple Silicon
 ├── formatjs_cli-linux-arm64       # Linux ARM64
 ├── formatjs_cli-linux-x64         # Linux x86_64
+├── formatjs_cli-win32-x64.exe     # Windows x64
 └── checksums.txt                  # SHA-256 checksums
 ```
 
@@ -241,8 +247,8 @@ binary artifact process:
    trusted publishing after the parser crate dependencies are available.
 
 3. **Rust CLI Release runs automatically**:
-   - Builds macOS, Linux, and Windows binaries through Bazel
-   - Runs smoke tests
+   - Builds macOS, Linux, and Windows binaries through Bazel on Linux BuildBuddy RBE
+   - Runs smoke tests on macOS, Linux, and Windows runners
    - Uploads binaries and checksums to the existing GitHub release
    - Appends binary installation notes without replacing the changelog
 
@@ -328,20 +334,21 @@ build-and-test-linux: # Build and test on Linux runner
 **Jobs**:
 
 ```yaml
-build: # Build release binaries
+build: # Build release binaries on Linux BuildBuddy RBE
 verify-macos: # Smoke-test macOS binary
 verify-linux: # Smoke-test and inspect Linux binaries
+verify-windows: # Smoke-test Windows binary
 release: # Combine, checksum, and create release
 ```
 
 **Features**:
 
-1. **Multi-platform builds**: Bazel builds all release artifacts in one job
+1. **Multi-platform builds**: Bazel cross-compiles all release artifacts in one Linux BuildBuddy RBE job
 2. **Smoke tests**: Platform runners test downloaded artifacts with `--version` and `--help`
 3. **Artifact management**: 7-day retention during workflow, permanent in releases
 4. **Checksum generation**: Automatic SHA-256 checksums
 5. **GitHub Release**: Automatic creation with formatted release notes
-6. **BuildBuddy integration**: Optional remote caching
+6. **BuildBuddy integration**: Remote execution and caching for release builds when credentials are available
 
 ## License
 

--- a/crates/formatjs_cli/platforms/BUILD.bazel
+++ b/crates/formatjs_cli/platforms/BUILD.bazel
@@ -37,16 +37,17 @@ platform(
     visibility = ["//visibility:public"],
 )
 
-# Windows x64 using the native MSVC ABI. Windows release jobs run on a Windows
-# runner, so keep proc macros and build scripts on the native host toolchain.
+# Windows x64 using the native MSVC ABI. Native Windows package jobs run on a
+# Windows runner, so keep proc macros and build scripts on the native host
+# toolchain there.
 platform(
     name = "windows_x86_64_msvc",
     parents = ["@rules_rs//rs/platforms:x86_64-pc-windows-msvc"],
     visibility = ["//visibility:public"],
 )
 
-# Windows x64 with the LLVM GNU ABI. Keep this available for experiments, but
-# release targets use MSVC because proc-macro crates must run on the host.
+# Windows x64 with the LLVM GNU ABI. The standalone CLI release uses this
+# platform for Linux BuildBuddy RBE cross-compilation.
 platform(
     name = "windows_x86_64_gnullvm",
     parents = ["@rules_rs//rs/platforms:x86_64-pc-windows-gnullvm"],

--- a/crates/formatjs_cli/release_binary.bzl
+++ b/crates/formatjs_cli/release_binary.bzl
@@ -69,3 +69,8 @@ release_binary_linux_arm64_gnu, _release_binary_linux_arm64_gnu_internal = _rele
 release_binary_windows_x64, _release_binary_windows_x64_internal = _release_binary(
     "//crates/formatjs_cli/platforms:windows_x86_64_msvc",
 )
+
+release_binary_windows_x64_gnullvm, _release_binary_windows_x64_gnullvm_internal = _release_binary(
+    "//crates/formatjs_cli/platforms:windows_x86_64_gnullvm",
+    "windows_x86_64",
+)

--- a/knowledge-base/001-repo-layout.md
+++ b/knowledge-base/001-repo-layout.md
@@ -108,9 +108,11 @@ GitHub-generated changelog notes include PR titles, PR links, and contributors.
 The npm package publish path remains `release.yml` with Bazel-built packages and
 npm Trusted Publishing. Rust crate publishing happens in `crates-release.yml`
 from crate GitHub releases using crates.io trusted publishing. The Rust CLI
-binary artifacts remain Bazel-owned in `rust-cli-release.yml`, which uploads
-assets and checksums to the `formatjs_cli_v*` release without replacing Release
-Please notes.
+binary artifacts remain Bazel-owned in `rust-cli-release.yml`. Its release build
+job runs on Linux, uses BuildBuddy RBE when credentials are available, and
+cross-compiles the macOS, Linux, and Windows standalone CLI artifacts before
+uploading assets and checksums to the `formatjs_cli_v*` release without
+replacing Release Please notes.
 
 ## Common Commands
 


### PR DESCRIPTION
## Summary
- switch the Rust CLI release build job to Ubuntu and BuildBuddy RBE via `--config=ci`
- add a Windows x64 LLVM gnullvm release target so macOS, Linux, and Windows standalone CLI binaries build in one Bazel job
- keep native smoke-test jobs for downloaded artifacts and update the release docs/knowledge base

## Validation
- `buildifier crates/formatjs_cli/BUILD.bazel crates/formatjs_cli/platforms/BUILD.bazel crates/formatjs_cli/release_binary.bzl`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/rust-cli-release.yml"); puts "ok"'`
- `git diff --check`
- `bazel --output_user_root=/private/tmp/bazel-formatjs-cross-release build //crates/formatjs_cli:release_binary_darwin_arm64 //crates/formatjs_cli:release_binary_linux_x64 //crates/formatjs_cli:release_binary_linux_arm64 //crates/formatjs_cli:release_binary_windows_x64_gnullvm`
- `bazel --output_user_root=/private/tmp/bazel-formatjs-ci-cquery cquery --config=ci --output=files 'set(//crates/formatjs_cli:release_binary_darwin_arm64 //crates/formatjs_cli:release_binary_linux_x64 //crates/formatjs_cli:release_binary_linux_arm64 //crates/formatjs_cli:release_binary_windows_x64_gnullvm)'`
- `file` confirmed Mach-O arm64, Linux x86_64/ARM64 static artifacts, and PE32+ Windows x64 output