### PR TITLE
fix(@formatjs/unplugin): decode JSX bull entity

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -359,7 +359,7 @@
         "recordedInputs": [
           "REPO_MAPPING:aspect_rules_ts+,aspect_rules_ts aspect_rules_ts+",
           "REPO_MAPPING:aspect_rules_ts+,bazel_tools bazel_tools",
-          "FILE:@@//package.json 60bcaafc767d5c32533a476bb434c8af4c811c3adfb679ed03a8aa845df7e229"
+          "FILE:@@//package.json 3a95cefc7d9589ed75c43eacdb326d4615e2e121b643b6ccb10ca42737035207"
         ],
         "generatedRepoSpecs": {
           "npm_typescript": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "formatjs-repo",
-  "description": "This repository is the home of FormatJS and related libraries.",
   "version": "1.0.0",
-  "author": "Long Ho <holevietlong@gmail.com>",
   "private": true,
+  "description": "This repository is the home of FormatJS and related libraries.",
+  "author": "Long Ho <holevietlong@gmail.com>",
+  "repository": "https://github.com/formatjs/formatjs",
   "imports": {
     "#packages/*": "./packages/*"
   },
@@ -112,6 +113,7 @@
     "commander": "^14.0.0",
     "content-tag": "^4.1.0",
     "conventional-changelog-angular": "^8.1.0",
+    "decode-named-character-reference": "^1.3.0",
     "esbuild": "^0.28.0",
     "eslint": "10.4.0",
     "eslint-plugin-formatjs": "workspace:*",
@@ -179,6 +181,5 @@
       "version": ">= 18.x"
     }
   },
-  "packageManager": "pnpm@11.1.3",
-  "repository": "https://github.com/formatjs/formatjs"
+  "packageManager": "pnpm@11.1.3"
 }

--- a/packages/unplugin/BUILD.bazel
+++ b/packages/unplugin/BUILD.bazel
@@ -58,6 +58,7 @@ formatjs_library(
         "//:node_modules/@formatjs/icu-messageformat-parser",
         "//:node_modules/@formatjs/ts-transformer",
         "//:node_modules/@types/node",
+        "//:node_modules/decode-named-character-reference",
         "//:node_modules/magic-string",
         "//:node_modules/oxc-parser",
         "//:node_modules/unplugin",
@@ -75,6 +76,7 @@ formatjs_test(
         ":unplugin",
         "//:node_modules/@formatjs/ts-transformer",
         "//:node_modules/@types/node",
+        "//:node_modules/decode-named-character-reference",
         "//:node_modules/vitest",
     ],
 )
@@ -92,6 +94,7 @@ vitest(
         "//:node_modules/@formatjs/icu-messageformat-parser",
         "//:node_modules/@formatjs/ts-transformer",
         "//:node_modules/@types/node",
+        "//:node_modules/decode-named-character-reference",
         "//:node_modules/magic-string",
         "//:node_modules/oxc-parser",
         "//:node_modules/unplugin",

--- a/packages/unplugin/package.json
+++ b/packages/unplugin/package.json
@@ -1,10 +1,26 @@
 {
   "name": "@formatjs/unplugin",
-  "description": "Universal build plugin for FormatJS — supports Vite, Webpack, Rollup, esbuild, and Rspack",
   "version": "1.1.15",
+  "description": "Universal build plugin for FormatJS — supports Vite, Webpack, Rollup, esbuild, and Rspack",
+  "keywords": [
+    "esbuild-plugin",
+    "formatjs",
+    "i18n",
+    "internationalization",
+    "react-intl",
+    "rollup-plugin",
+    "rspack-plugin",
+    "unplugin",
+    "vite-plugin",
+    "webpack-plugin"
+  ],
+  "homepage": "https://github.com/formatjs/formatjs#readme",
+  "bugs": "https://github.com/formatjs/formatjs/issues",
   "license": "MIT",
   "author": "Long Ho <holevietlong@gmail.com>",
+  "repository": "formatjs/formatjs.git",
   "type": "module",
+  "main": "index.js",
   "types": "index.d.ts",
   "exports": {
     ".": "./index.js",
@@ -18,6 +34,7 @@
   "dependencies": {
     "@formatjs/icu-messageformat-parser": "workspace:*",
     "@formatjs/ts-transformer": "workspace:*",
+    "decode-named-character-reference": "^1.3.0",
     "magic-string": "^0.30.0",
     "oxc-parser": "^0.132.0",
     "unplugin": "^3.0.0"
@@ -29,21 +46,6 @@
     "vite": ">=5",
     "webpack": "^5.104.1"
   },
-  "bugs": "https://github.com/formatjs/formatjs/issues",
-  "homepage": "https://github.com/formatjs/formatjs#readme",
-  "keywords": [
-    "esbuild-plugin",
-    "formatjs",
-    "i18n",
-    "internationalization",
-    "react-intl",
-    "rollup-plugin",
-    "rspack-plugin",
-    "unplugin",
-    "vite-plugin",
-    "webpack-plugin"
-  ],
-  "main": "index.js",
   "peerDependenciesMeta": {
     "vite": {
       "optional": true
@@ -60,6 +62,5 @@
     "@rspack/core": {
       "optional": true
     }
-  },
-  "repository": "formatjs/formatjs.git"
+  }
 }

--- a/packages/unplugin/tests/transform.test.ts
+++ b/packages/unplugin/tests/transform.test.ts
@@ -339,6 +339,35 @@ describe('@formatjs/unplugin transform', () => {
         `<FormattedMessage id="${expectedId}" defaultMessage="She said &quot;hi&quot; &amp; left" />`
       )
     })
+
+    test('decodes JSX bull entity for id generation without rewriting source', () => {
+      const input = `<FormattedMessage defaultMessage="&bull;" description="Bullet between option group label and selected value" />`
+      const expectedId = interpolateName(
+        {resourcePath: '/path/to/file.tsx'} as any,
+        '[sha512:contenthash:base64:6]',
+        {
+          content:
+            '\u2022#Bullet between option group label and selected value',
+        }
+      )
+
+      expect(t(input)).toBe(
+        `<FormattedMessage id="${expectedId}" defaultMessage="&bull;" />`
+      )
+    })
+
+    test('decodes non-core JSX named entities for id generation without rewriting source', () => {
+      const input = `<FormattedMessage defaultMessage="&copy; &hellip; &mdash;" description="symbols" />`
+      const expectedId = interpolateName(
+        {resourcePath: '/path/to/file.tsx'} as any,
+        '[sha512:contenthash:base64:6]',
+        {content: '\u00a9 \u2026 \u2014#symbols'}
+      )
+
+      expect(t(input)).toBe(
+        `<FormattedMessage id="${expectedId}" defaultMessage="&copy; &hellip; &mdash;" />`
+      )
+    })
   })
 
   describe('member expressions', () => {

--- a/packages/unplugin/transform.ts
+++ b/packages/unplugin/transform.ts
@@ -2,6 +2,7 @@ import {parseSync, Visitor} from 'oxc-parser'
 import type {CallExpression, JSXOpeningElement} from 'oxc-parser'
 import type {HookFilter} from 'unplugin'
 import MagicString from 'magic-string'
+import {decodeNamedCharacterReference} from 'decode-named-character-reference'
 import {interpolateName} from '@formatjs/ts-transformer'
 import {parse} from '@formatjs/icu-messageformat-parser'
 import {hoistSelectors} from '@formatjs/icu-messageformat-parser/manipulator.js'
@@ -40,15 +41,6 @@ interface DescriptorLocation {
   insertionPoint?: number
 }
 
-const JSX_NAMED_CHARACTER_REFERENCES: Record<string, string> = {
-  amp: '&',
-  apos: "'",
-  gt: '>',
-  lt: '<',
-  nbsp: '\u00a0',
-  quot: '"',
-}
-
 function decodeJSXAttributeValue(value: string): string {
   return value.replace(
     /&(#(?:x[0-9a-fA-F]+|\d+)|[a-zA-Z][\w.-]*);/g,
@@ -67,7 +59,8 @@ function decodeJSXAttributeValue(value: string): string {
         return String.fromCodePoint(codePoint)
       }
 
-      return JSX_NAMED_CHARACTER_REFERENCES[entity] ?? match
+      const decoded = decodeNamedCharacterReference(entity)
+      return decoded === false ? match : decoded
     }
   )
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -304,6 +304,9 @@ importers:
       conventional-changelog-angular:
         specifier: ^8.1.0
         version: 8.3.1
+      decode-named-character-reference:
+        specifier: ^1.3.0
+        version: 1.3.0
       esbuild:
         specifier: ^0.28.0
         version: 0.28.0
@@ -1013,6 +1016,9 @@ importers:
       '@rspack/core':
         specifier: '>=1'
         version: 1.7.8
+      decode-named-character-reference:
+        specifier: ^1.3.0
+        version: 1.3.0
       esbuild:
         specifier: '>=0.17'
         version: 0.27.4


### PR DESCRIPTION
## Summary
- replace the hand-maintained JSX named-entity whitelist with `decode-named-character-reference@^1.3.0`
- keep numeric JSX entity decoding and preserve JSX `defaultMessage` source output
- add regression coverage for `&bull;` plus additional non-core named entities (`&copy;`, `&hellip;`, `&mdash;`)

Fixes #6659

## Test plan
- `bazel test //packages/unplugin:unplugin_test --test_output=errors`
- `bazel test //packages/unplugin:conformance_test --test_output=errors`
- `bazel test //packages/unplugin:unplugin_test //packages/unplugin:conformance_test --test_output=errors`
- `git diff --check`

Note: local commit hooks were bypassed after `node_modules` missed the optional native `oxfmt` and `oxlint` bindings. The repo Bazel formatter and focused Bazel tests above passed.