### PR TITLE
fix: preserve release-please workspace candidates

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -143,10 +143,12 @@
   "plugins": [
     {
       "type": "node-workspace",
+      "merge": false,
       "updatePeerDependencies": true
     },
     {
-      "type": "cargo-workspace"
+      "type": "cargo-workspace",
+      "merge": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- disable internal candidate merging in the node-workspace and cargo-workspace Release Please plugins
- lets the final manifest merge keep npm and Rust release candidates together instead of cargo-workspace replacing the npm candidate set

## Testing
- `node -e 'JSON.parse(require("node:fs").readFileSync("release-please-config.json", "utf8")); console.log("json ok")'`
- `git diff --cached --check`
- checked Release Please schema: `merge` is supported on both workspace plugin configs