### PR TITLE
fix(@formatjs/cli): guard native ABI releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,44 @@ jobs:
 
       - name: Smoke Test Package
         run: |
-          node -e 'const native = require(process.argv[1]); const formatters = native.supportedBuiltinFormatters(); if (!formatters.includes("default")) throw new Error("Missing default formatter"); const output = native.compileMessages([{id: "hello", message: "Hello {name}", sourceFile: "smoke.json"}], {}); if (!output.includes("\"hello\"")) throw new Error(output); console.log(output);' ./artifacts/cli-native-win32-x64
+          $script = @'
+          const fs = require('node:fs')
+          const os = require('node:os')
+          const path = require('node:path')
+          const native = require(process.argv[2])
+
+          const formatters = native.supportedBuiltinFormatters()
+          if (!formatters.includes('default')) {
+            throw new Error('Missing default formatter')
+          }
+
+          const compiled = native.compileMessages(
+            [{id: 'hello', message: 'Hello {name}', sourceFile: 'smoke.json'}],
+            {}
+          )
+          if (!compiled.includes('"hello"')) {
+            throw new Error(compiled)
+          }
+
+          const sourceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'formatjs-cli-native-'))
+          const sourceFile = path.join(sourceDir, 'source.ts')
+          fs.writeFileSync(
+            sourceFile,
+            "defineMessage({id: 'native.extract', defaultMessage: 'Native extract'})"
+          )
+          const extracted = JSON.parse(
+            native.extract([sourceFile], {
+              idInterpolationPattern: '[sha512:contenthash:base64:6]',
+              throws: true,
+            })
+          )
+          if (extracted['native.extract']?.defaultMessage !== 'Native extract') {
+            throw new Error(JSON.stringify(extracted))
+          }
+
+          console.log(compiled)
+          '@
+          $script | node - ./artifacts/cli-native-win32-x64
 
       - name: Upload Package
         uses: actions/upload-artifact@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,6 +150,22 @@ jobs:
           if (!Array.isArray(compiled.hello)) {
             throw new Error(output)
           }
+
+          const sourceFile = path.join(messageSubdir, 'source.ts')
+          fs.writeFileSync(
+            sourceFile,
+            "defineMessage({id: 'native.extract', defaultMessage: 'Native extract'})"
+          )
+          const extracted = JSON.parse(
+            native.extract([sourceFile], {
+              idInterpolationPattern: '[sha512:contenthash:base64:6]',
+              throws: true,
+            })
+          )
+          if (extracted['native.extract']?.defaultMessage !== 'Native extract') {
+            throw new Error(JSON.stringify(extracted))
+          }
+
           console.log(output)
           '@
           $script | node - $pkgPath

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -25,7 +25,10 @@ load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
 # Exported for Node subpath import resolution (#packages/*) in tests.
 # Node walks up to find package.json with "imports" field.
 exports_files(
-    ["package.json"],
+    [
+        "package.json",
+        "release-please-config.json",
+    ],
     visibility = ["//visibility:public"],
 )
 

--- a/crates/formatjs_cli_napi/BUILD.bazel
+++ b/crates/formatjs_cli_napi/BUILD.bazel
@@ -10,6 +10,7 @@ load(
 exports_files(
     [
         "Cargo.toml",
+        "native_abi.json",
         "src/lib.rs",
     ],
     visibility = ["//visibility:public"],

--- a/crates/formatjs_cli_napi/native_abi.json
+++ b/crates/formatjs_cli_napi/native_abi.json
@@ -1,0 +1,9 @@
+{
+  "version": 2,
+  "exports": [
+    "compile",
+    "compileMessages",
+    "extract",
+    "supportedBuiltinFormatters"
+  ]
+}

--- a/knowledge-base/001-repo-layout.md
+++ b/knowledge-base/001-repo-layout.md
@@ -92,15 +92,15 @@ Commit-msg hook: `commitlint` validates Conventional Commits format.
 
 ## CI/CD (GitHub Actions)
 
-| Workflow               | Trigger               | What it does                             |
-| ---------------------- | --------------------- | ---------------------------------------- |
-| `test.yml`             | PR, push to main      | `bazel test //...` on Ubuntu + macOS     |
+| Workflow               | Trigger               | What it does                                                |
+| ---------------------- | --------------------- | ----------------------------------------------------------- |
+| `test.yml`             | PR, push to main      | `bazel test //...` on Ubuntu + macOS                        |
 | `release-please.yml`   | Push to main/manual   | Version/changelog PRs, GitHub releases, npm publish handoff |
-| `release.yml`          | Release Please/manual | `bazel build :dist` then npm Trusted Publishing |
-| `crates-release.yml`   | Crate releases/manual | Publish Rust crates through crates.io OIDC |
-| `rust-cli-release.yml` | Tag `formatjs_cli_v*` | Cross-platform Rust binary artifacts     |
-| `website.yml`          | Manual/push           | Deploy docs site                         |
-| `verify-hooks.yml`     | PR                    | Verify lefthook hooks + commitlint       |
+| `release.yml`          | Release Please/manual | `bazel build :dist` then npm Trusted Publishing             |
+| `crates-release.yml`   | Crate releases/manual | Publish Rust crates through crates.io OIDC                  |
+| `rust-cli-release.yml` | Tag `formatjs_cli_v*` | Cross-platform Rust binary artifacts                        |
+| `website.yml`          | Manual/push           | Deploy docs site                                            |
+| `verify-hooks.yml`     | PR                    | Verify lefthook hooks + commitlint                          |
 
 Release Please owns version/changelog PRs and GitHub release creation. Its
 GitHub-generated changelog notes include PR titles, PR links, and contributors.
@@ -114,6 +114,13 @@ publishing. The Rust CLI binary artifacts remain Bazel-owned in
 when credentials are available, and cross-compiles the macOS, Linux, and Windows
 standalone CLI artifacts before uploading assets and checksums to the
 `formatjs_cli_v*` release without replacing Release Please notes.
+
+Native `@formatjs/cli-native-*` npm packages carry a checked-in
+`native_abi.json` marker that must match `crates/formatjs_cli_napi` exports. The
+`//tools:cli_native_abi_test` target compares the Rust `#[napi]` export surface,
+the central ABI marker, and every platform package marker. Updating the native
+N-API surface should update all platform markers so Release Please includes all
+native packages in the next npm release.
 
 ## Common Commands
 

--- a/packages/cli-native-darwin-arm64/BUILD.bazel
+++ b/packages/cli-native-darwin-arm64/BUILD.bazel
@@ -2,6 +2,14 @@ load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("//tools:index.bzl", "package_exports_test")
 
+exports_files(
+    [
+        "native_abi.json",
+        "package.json",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 copy_file(
     name = "formatjs_cli_napi_node",
     src = "//crates/formatjs_cli_napi:release_node_darwin_arm64",
@@ -11,6 +19,7 @@ copy_file(
 npm_package(
     name = "pkg",
     srcs = [
+        "native_abi.json",
         "package.json",
         ":formatjs_cli_napi_node",
     ],

--- a/packages/cli-native-darwin-arm64/native_abi.json
+++ b/packages/cli-native-darwin-arm64/native_abi.json
@@ -1,0 +1,9 @@
+{
+  "version": 2,
+  "exports": [
+    "compile",
+    "compileMessages",
+    "extract",
+    "supportedBuiltinFormatters"
+  ]
+}

--- a/packages/cli-native-darwin-arm64/package.json
+++ b/packages/cli-native-darwin-arm64/package.json
@@ -12,7 +12,8 @@
     "arm64"
   ],
   "files": [
-    "formatjs_cli_napi.node"
+    "formatjs_cli_napi.node",
+    "native_abi.json"
   ],
   "homepage": "https://github.com/formatjs/formatjs",
   "main": "formatjs_cli_napi.node",

--- a/packages/cli-native-linux-arm64/BUILD.bazel
+++ b/packages/cli-native-linux-arm64/BUILD.bazel
@@ -2,6 +2,14 @@ load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("//tools:index.bzl", "package_exports_test")
 
+exports_files(
+    [
+        "native_abi.json",
+        "package.json",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 copy_file(
     name = "formatjs_cli_napi_node",
     src = "//crates/formatjs_cli_napi:release_node_linux_arm64",
@@ -11,6 +19,7 @@ copy_file(
 npm_package(
     name = "pkg",
     srcs = [
+        "native_abi.json",
         "package.json",
         ":formatjs_cli_napi_node",
     ],

--- a/packages/cli-native-linux-arm64/native_abi.json
+++ b/packages/cli-native-linux-arm64/native_abi.json
@@ -1,0 +1,9 @@
+{
+  "version": 2,
+  "exports": [
+    "compile",
+    "compileMessages",
+    "extract",
+    "supportedBuiltinFormatters"
+  ]
+}

--- a/packages/cli-native-linux-arm64/package.json
+++ b/packages/cli-native-linux-arm64/package.json
@@ -12,7 +12,8 @@
     "arm64"
   ],
   "files": [
-    "formatjs_cli_napi.node"
+    "formatjs_cli_napi.node",
+    "native_abi.json"
   ],
   "homepage": "https://github.com/formatjs/formatjs",
   "libc": [

--- a/packages/cli-native-linux-x64/BUILD.bazel
+++ b/packages/cli-native-linux-x64/BUILD.bazel
@@ -2,6 +2,14 @@ load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("//tools:index.bzl", "package_exports_test")
 
+exports_files(
+    [
+        "native_abi.json",
+        "package.json",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 copy_file(
     name = "formatjs_cli_napi_node",
     src = "//crates/formatjs_cli_napi:release_node_linux_x64",
@@ -11,6 +19,7 @@ copy_file(
 npm_package(
     name = "pkg",
     srcs = [
+        "native_abi.json",
         "package.json",
         ":formatjs_cli_napi_node",
     ],

--- a/packages/cli-native-linux-x64/native_abi.json
+++ b/packages/cli-native-linux-x64/native_abi.json
@@ -1,0 +1,9 @@
+{
+  "version": 2,
+  "exports": [
+    "compile",
+    "compileMessages",
+    "extract",
+    "supportedBuiltinFormatters"
+  ]
+}

--- a/packages/cli-native-linux-x64/package.json
+++ b/packages/cli-native-linux-x64/package.json
@@ -12,7 +12,8 @@
     "x64"
   ],
   "files": [
-    "formatjs_cli_napi.node"
+    "formatjs_cli_napi.node",
+    "native_abi.json"
   ],
   "homepage": "https://github.com/formatjs/formatjs",
   "libc": [

--- a/packages/cli-native-win32-x64/BUILD.bazel
+++ b/packages/cli-native-win32-x64/BUILD.bazel
@@ -2,6 +2,14 @@ load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("//tools:index.bzl", "package_exports_test")
 
+exports_files(
+    [
+        "native_abi.json",
+        "package.json",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 copy_file(
     name = "formatjs_cli_napi_node",
     src = "//crates/formatjs_cli_napi:release_node_win32_x64",
@@ -11,6 +19,7 @@ copy_file(
 npm_package(
     name = "pkg",
     srcs = [
+        "native_abi.json",
         "package.json",
         ":formatjs_cli_napi_node",
     ],

--- a/packages/cli-native-win32-x64/native_abi.json
+++ b/packages/cli-native-win32-x64/native_abi.json
@@ -1,0 +1,9 @@
+{
+  "version": 2,
+  "exports": [
+    "compile",
+    "compileMessages",
+    "extract",
+    "supportedBuiltinFormatters"
+  ]
+}

--- a/packages/cli-native-win32-x64/package.json
+++ b/packages/cli-native-win32-x64/package.json
@@ -12,7 +12,8 @@
     "x64"
   ],
   "files": [
-    "formatjs_cli_napi.node"
+    "formatjs_cli_napi.node",
+    "native_abi.json"
   ],
   "homepage": "https://github.com/formatjs/formatjs",
   "main": "formatjs_cli_napi.node",

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,5 +1,6 @@
 # gazelle:ignore
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
+load("@aspect_rules_js//js:defs.bzl", "js_test")
 load("//tools:index.bzl", "ts_binary")
 load("//tools:vitest.bzl", "vitest")
 
@@ -42,6 +43,61 @@ copy_to_bin(
     name = "check_package_json",
     srcs = ["check_package_json.ts"],
     visibility = ["//visibility:public"],
+)
+
+copy_to_bin(
+    name = "check_cli_native_abi",
+    srcs = ["check_cli_native_abi.ts"],
+    visibility = ["//visibility:public"],
+)
+
+CLI_NATIVE_ABI_TEST_DATA = [
+    "//:release-please-config.json",
+    "//crates/formatjs_cli_napi:native_abi.json",
+    "//crates/formatjs_cli_napi:src/lib.rs",
+    "//packages/cli-native-darwin-arm64:native_abi.json",
+    "//packages/cli-native-darwin-arm64:package.json",
+    "//packages/cli-native-linux-arm64:native_abi.json",
+    "//packages/cli-native-linux-arm64:package.json",
+    "//packages/cli-native-linux-x64:native_abi.json",
+    "//packages/cli-native-linux-x64:package.json",
+    "//packages/cli-native-win32-x64:native_abi.json",
+    "//packages/cli-native-win32-x64:package.json",
+]
+
+js_test(
+    name = "cli_native_abi_test",
+    size = "small",
+    args = [
+        "--central-abi",
+        "$(rootpath //crates/formatjs_cli_napi:native_abi.json)",
+        "--rust-lib",
+        "$(rootpath //crates/formatjs_cli_napi:src/lib.rs)",
+        "--release-config",
+        "$(rootpath //:release-please-config.json)",
+        "--package-abi",
+        "$(rootpath //packages/cli-native-darwin-arm64:native_abi.json)",
+        "--package-json",
+        "$(rootpath //packages/cli-native-darwin-arm64:package.json)",
+        "--package-abi",
+        "$(rootpath //packages/cli-native-linux-arm64:native_abi.json)",
+        "--package-json",
+        "$(rootpath //packages/cli-native-linux-arm64:package.json)",
+        "--package-abi",
+        "$(rootpath //packages/cli-native-linux-x64:native_abi.json)",
+        "--package-json",
+        "$(rootpath //packages/cli-native-linux-x64:package.json)",
+        "--package-abi",
+        "$(rootpath //packages/cli-native-win32-x64:native_abi.json)",
+        "--package-json",
+        "$(rootpath //packages/cli-native-win32-x64:package.json)",
+    ],
+    data = [
+        "//:node_modules/minimist",
+    ] + CLI_NATIVE_ABI_TEST_DATA,
+    entry_point = ":check_cli_native_abi",
+    no_copy_to_bin = CLI_NATIVE_ABI_TEST_DATA,
+    node_options = ["--experimental-transform-types"],
 )
 
 ts_binary(

--- a/tools/check_cli_native_abi.ts
+++ b/tools/check_cli_native_abi.ts
@@ -1,0 +1,217 @@
+import {existsSync, readFileSync} from 'fs'
+import {basename, dirname, relative} from 'path'
+import minimist from 'minimist'
+
+interface Args extends minimist.ParsedArgs {
+  'central-abi'?: string
+  'rust-lib'?: string
+  'package-abi'?: string | string[]
+  'package-json'?: string | string[]
+  'release-config'?: string
+}
+
+interface NativeAbi {
+  version: number
+  exports: string[]
+}
+
+interface PackageMarker {
+  abiPath: string
+  packageJsonPath: string
+}
+
+interface ValidateNativeAbiOptions {
+  centralAbiPath: string
+  rustLibPath: string
+  packageMarkers: PackageMarker[]
+  releaseConfigPath?: string
+}
+
+function asArray(value: string | string[] | undefined): string[] {
+  if (value === undefined) {
+    return []
+  }
+  return Array.isArray(value) ? value : [value]
+}
+
+function readJson<T>(path: string): T {
+  return JSON.parse(readFileSync(path, 'utf8')) as T
+}
+
+function snakeToCamel(name: string): string {
+  return name.replace(/_([a-z])/g, (_, char: string) => char.toUpperCase())
+}
+
+function normalizeAbi(abi: NativeAbi): NativeAbi {
+  return {
+    version: abi.version,
+    exports: [...abi.exports].sort(),
+  }
+}
+
+function formatList(items: string[]): string {
+  return items.length ? items.join(', ') : '<none>'
+}
+
+function diffLists(expected: string[], actual: string[]): string[] {
+  const expectedSet = new Set(expected)
+  const actualSet = new Set(actual)
+  const missing = expected.filter(item => !actualSet.has(item))
+  const extra = actual.filter(item => !expectedSet.has(item))
+  const errors: string[] = []
+
+  if (missing.length) {
+    errors.push(`missing: ${formatList(missing)}`)
+  }
+  if (extra.length) {
+    errors.push(`extra: ${formatList(extra)}`)
+  }
+
+  return errors
+}
+
+export function collectRustNapiExports(source: string): string[] {
+  const exports = new Set<string>()
+  const napiFnPattern =
+    /#\s*\[\s*napi(?:\([^)]*\))?\s*\]\s*(?:#\s*\[[^\]]+\]\s*)*pub\s+fn\s+([A-Za-z0-9_]+)\s*\(/g
+
+  for (
+    let match = napiFnPattern.exec(source);
+    match;
+    match = napiFnPattern.exec(source)
+  ) {
+    exports.add(snakeToCamel(match[1]))
+  }
+
+  return [...exports].sort()
+}
+
+export function validateNativeAbi({
+  centralAbiPath,
+  rustLibPath,
+  packageMarkers,
+  releaseConfigPath,
+}: ValidateNativeAbiOptions): string[] {
+  const errors: string[] = []
+
+  if (!existsSync(centralAbiPath)) {
+    return [`central native ABI marker not found: ${centralAbiPath}`]
+  }
+  if (!existsSync(rustLibPath)) {
+    return [`Rust N-API source not found: ${rustLibPath}`]
+  }
+
+  const centralAbi = normalizeAbi(readJson<NativeAbi>(centralAbiPath))
+  if (!Number.isInteger(centralAbi.version) || centralAbi.version < 1) {
+    errors.push(`${centralAbiPath} must define a positive integer ABI version`)
+  }
+
+  const duplicateExports = centralAbi.exports.filter(
+    (name, index) => centralAbi.exports.indexOf(name) !== index
+  )
+  if (duplicateExports.length) {
+    errors.push(
+      `${centralAbiPath} has duplicate exports: ${formatList(duplicateExports)}`
+    )
+  }
+
+  const rustExports = collectRustNapiExports(readFileSync(rustLibPath, 'utf8'))
+  const exportDiffs = diffLists(centralAbi.exports, rustExports)
+  if (exportDiffs.length) {
+    errors.push(
+      `${centralAbiPath} does not match Rust #[napi] exports in ${rustLibPath}: ${exportDiffs.join('; ')}`
+    )
+  }
+
+  const releaseConfig = releaseConfigPath
+    ? readJson<{packages?: Record<string, unknown>}>(releaseConfigPath)
+    : undefined
+
+  for (const {abiPath, packageJsonPath} of packageMarkers) {
+    if (!existsSync(abiPath)) {
+      errors.push(`package native ABI marker not found: ${abiPath}`)
+      continue
+    }
+    if (!existsSync(packageJsonPath)) {
+      errors.push(
+        `package.json not found for native ABI marker: ${packageJsonPath}`
+      )
+      continue
+    }
+
+    const packageAbi = normalizeAbi(readJson<NativeAbi>(abiPath))
+    const packageJson = readJson<{name?: string; files?: string[]}>(
+      packageJsonPath
+    )
+    const packageName = packageJson.name ?? packageJsonPath
+    const packageDir = dirname(packageJsonPath)
+    const markerName = basename(abiPath)
+
+    if (JSON.stringify(packageAbi) !== JSON.stringify(centralAbi)) {
+      errors.push(
+        `${packageName} native ABI marker must match ${centralAbiPath}`
+      )
+    }
+
+    if (!packageJson.files?.includes(markerName)) {
+      errors.push(
+        `${packageName} package.json files must include ${markerName}`
+      )
+    }
+
+    if (releaseConfig) {
+      const releasePath = relative(dirname(releaseConfigPath!), packageDir)
+      if (!releaseConfig.packages?.[releasePath]) {
+        errors.push(
+          `${packageName} must be configured as a Release Please package at ${releasePath}`
+        )
+      }
+    }
+  }
+
+  return errors
+}
+
+function main(args: Args): void {
+  const centralAbiPath = args['central-abi']
+  const rustLibPath = args['rust-lib']
+  const packageAbiPaths = asArray(args['package-abi'])
+  const packageJsonPaths = asArray(args['package-json'])
+
+  if (!centralAbiPath || !rustLibPath || packageAbiPaths.length === 0) {
+    console.error(
+      'Usage: check_cli_native_abi --central-abi <path> --rust-lib <path> --package-abi <path> --package-json <path>...'
+    )
+    process.exit(1)
+  }
+
+  if (packageAbiPaths.length !== packageJsonPaths.length) {
+    console.error(
+      `Expected matching --package-abi and --package-json counts, got ${packageAbiPaths.length} and ${packageJsonPaths.length}`
+    )
+    process.exit(1)
+  }
+
+  const errors = validateNativeAbi({
+    centralAbiPath,
+    rustLibPath,
+    releaseConfigPath: args['release-config'],
+    packageMarkers: packageAbiPaths.map((abiPath, index) => ({
+      abiPath,
+      packageJsonPath: packageJsonPaths[index],
+    })),
+  })
+
+  if (errors.length) {
+    for (const error of errors) {
+      console.error(`FAIL: ${error}`)
+    }
+    process.exit(1)
+  }
+
+  console.log('PASS: CLI native ABI markers match Rust exports')
+}
+
+if (import.meta.filename === process.argv[1]) {
+  main(minimist<Args>(process.argv.slice(2)))
+}


### PR DESCRIPTION
Summary:
- add a checked-in CLI native ABI marker for the Rust N-API crate and all platform native packages
- add a Bazel test that keeps Rust #[napi] exports, package markers, package files, and Release Please config in sync
- smoke test native extract in Windows CI and release package build

Validation:
- bazel run //:gazelle
- bazel test --lockfile_mode=off --nocache_test_results //tools:cli_native_abi_test //packages/cli-lib:cli-lib_test
- bazel build --lockfile_mode=off :dist
- git diff --check