### PR TITLE
fix: repair release please cli handoff

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,8 +22,8 @@ jobs:
       npm_release_created: ${{ steps.npm-release-paths.outputs.npm_release_created }}
 
     steps:
-      # Release Please owns version/changelog PRs, GitHub release notes, and
-      # the release-created signal used for npm publication below.
+      # Release Please owns version/changelog PRs, GitHub releases, and the
+      # release-created signal used for npm publication below.
       - name: Run Release Please
         id: release
         uses: googleapis/release-please-action@v5
@@ -39,8 +39,31 @@ jobs:
         run: |
           node <<'JS'
           const fs = require('node:fs')
+
           const paths = JSON.parse(process.env.PATHS_RELEASED || '[]')
-          const npmPaths = paths.filter(path => path.startsWith('packages/'))
+          const cliRustReleasePaths = ['crates/formatjs_cli']
+          const cliNpmReleasePaths = [
+            'packages/cli-native-darwin-arm64',
+            'packages/cli-native-linux-arm64',
+            'packages/cli-native-linux-x64',
+            'packages/cli-native-win32-x64',
+            'packages/cli-lib',
+            'packages/cli',
+          ]
+          const npmPathSet = new Set(
+            paths.filter(path => path.startsWith('packages/'))
+          )
+
+          // Release Please cannot infer that the Rust CLI crate is shipped
+          // through these npm packages, so bridge that cross-ecosystem release
+          // edge here. release.yml sorts selected packages topologically.
+          if (paths.some(path => cliRustReleasePaths.includes(path))) {
+            for (const path of cliNpmReleasePaths) {
+              npmPathSet.add(path)
+            }
+          }
+
+          const npmPaths = [...npmPathSet]
           fs.appendFileSync(
             process.env.GITHUB_OUTPUT,
             `npm_paths=${JSON.stringify(npmPaths)}\n`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,67 @@ jobs:
           NPM_RELEASE_PATHS: ${{ inputs.npm_paths }}
         run: |
           mapfile -t package_paths < <(
-            node -e 'JSON.parse(process.env.NPM_RELEASE_PATHS || "[]").forEach(path => console.log(path))'
+          node <<'JS'
+          const fs = require('node:fs')
+          const path = require('node:path')
+
+          const packagePaths = [
+            ...new Set(JSON.parse(process.env.NPM_RELEASE_PATHS || '[]')),
+          ]
+          const packagesByPath = new Map()
+          const packagesByName = new Map()
+          const dependencyFields = [
+            'dependencies',
+            'devDependencies',
+            'peerDependencies',
+            'optionalDependencies',
+          ]
+
+          for (const packagePath of packagePaths) {
+            const packageJsonPath = path.join(packagePath, 'package.json')
+            const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
+            const entry = {path: packagePath, pkg}
+            packagesByPath.set(packagePath, entry)
+            packagesByName.set(pkg.name, entry)
+          }
+
+          const visiting = new Set()
+          const visited = new Set()
+          const sortedPackagePaths = []
+
+          function visit(entry) {
+            if (visited.has(entry.path)) {
+              return
+            }
+
+            if (visiting.has(entry.path)) {
+              throw new Error(`Cycle in selected npm release paths at ${entry.path}`)
+            }
+
+            visiting.add(entry.path)
+
+            for (const field of dependencyFields) {
+              for (const depName of Object.keys(entry.pkg[field] ?? {})) {
+                const dep = packagesByName.get(depName)
+                if (dep) {
+                  visit(dep)
+                }
+              }
+            }
+
+            visiting.delete(entry.path)
+            visited.add(entry.path)
+            sortedPackagePaths.push(entry.path)
+          }
+
+          for (const packagePath of packagePaths) {
+            visit(packagesByPath.get(packagePath))
+          }
+
+          for (const packagePath of sortedPackagePaths) {
+            console.log(packagePath)
+          }
+          JS
           )
 
           if [ "${#package_paths[@]}" -eq 0 ]; then
@@ -134,6 +194,14 @@ jobs:
               exit 1
             fi
 
-            echo "Publishing $package_path"
+            package_name=$(cd "$package_path" && node -p "require('./package.json').name")
+            package_version=$(cd "$package_path" && node -p "require('./package.json').version")
+
+            if npm view "$package_name@$package_version" version >/dev/null 2>&1; then
+              echo "$package_name@$package_version is already published; skipping."
+              continue
+            fi
+
+            echo "Publishing $package_name@$package_version from $package_path"
             (cd "$package_path" && pnpm publish --access public --no-git-checks)
           done

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,21 +88,23 @@ This separation allows both operations to run in parallel, dramatically improvin
 The repository uses `verbatimModuleSyntax: true` in `tsconfig.json`. This means:
 
 - **Type-only imports must use `import type`**:
+
   ```typescript
   // ✅ Correct
-  import type { MyType } from './types.js'
+  import type {MyType} from './types.js'
 
   // ❌ Wrong - will cause build errors
-  import { MyType } from './types.js'
+  import {MyType} from './types.js'
   ```
 
 - **Type-only exports must use `export type`**:
+
   ```typescript
   // ✅ Correct
-  export type { MyType } from './types.js'
+  export type {MyType} from './types.js'
 
   // ❌ Wrong - will cause runtime errors
-  export { MyType } from './types.js'
+  export {MyType} from './types.js'
   ```
 
 This ensures compatibility with fast transpilers that operate in isolated mode without full type information.
@@ -121,13 +123,17 @@ The transpiler infrastructure is located in:
 Releases are automated via GitHub Actions:
 
 1. The **Release Please** workflow runs on `main` and maintains release PRs for
-   npm packages and Rust crates. Release notes use GitHub-generated changelogs
-   so entries include PR titles, PR links, and contributors.
+   npm packages and Rust crates. Release notes use Release Please's built-in
+   changelog builder so release PR generation does not depend on every
+   historical manifest version having a matching GitHub release.
 
 2. Merge the release PR when it is ready. Release Please creates the package
    tags and GitHub releases from the merged release PR, then calls the
    **Release** workflow with the released npm package paths. That workflow
-   publishes from the Bazel-built distribution using Trusted Publishing (OIDC).
+   publishes from the Bazel-built distribution using Trusted Publishing (OIDC)
+   and orders selected package paths by local package dependencies. A
+   `crates/formatjs_cli` release also queues the CLI and CLI native npm package
+   paths because those packages publish the native Rust binding.
 
 3. The **Crates Release** workflow publishes Rust crates to crates.io from
    `formatjs_icu_skeleton_parser_v*`, `formatjs_icu_messageformat_parser_v*`,

--- a/crates/formatjs_cli/RELEASE.md
+++ b/crates/formatjs_cli/RELEASE.md
@@ -63,8 +63,8 @@ Before publishing `formatjs_cli`, ensure any workspace dependencies are already 
 The normal repository workflow handles this ordering automatically:
 
 1. Release Please opens and maintains release PRs for the Rust crates.
-2. Merging the release PR creates GitHub releases with generated changelog
-   notes that include PR titles, PR links, and contributors.
+2. Merging the release PR creates GitHub releases with Release Please-generated
+   changelog notes.
 3. The `crates-release.yml` workflow publishes matching crate releases to
    crates.io with trusted publishing and waits for workspace dependencies before
    publishing dependents.
@@ -79,12 +79,12 @@ path = "src/main.rs"
 
 ## Platform Support
 
-| Platform | Architecture  | Target Triple                | Status                           |
-| -------- | ------------- | ---------------------------- | -------------------------------- |
-| macOS    | Apple Silicon | aarch64-apple-darwin         | ✅ LLVM cross target             |
-| Linux    | ARM64         | aarch64-unknown-linux-musl   | ✅ LLVM cross target             |
-| Linux    | x86_64        | x86_64-unknown-linux-musl    | ✅ LLVM cross target             |
-| Windows  | x86_64        | x86_64-pc-windows-gnullvm    | ✅ LLVM cross target             |
+| Platform | Architecture  | Target Triple              | Status               |
+| -------- | ------------- | -------------------------- | -------------------- |
+| macOS    | Apple Silicon | aarch64-apple-darwin       | ✅ LLVM cross target |
+| Linux    | ARM64         | aarch64-unknown-linux-musl | ✅ LLVM cross target |
+| Linux    | x86_64        | x86_64-unknown-linux-musl  | ✅ LLVM cross target |
+| Windows  | x86_64        | x86_64-pc-windows-gnullvm  | ✅ LLVM cross target |
 
 **Note**: The GitHub Actions workflow builds release artifacts through Bazel targets on Linux BuildBuddy RBE when credentials are available. Linux release binaries use musl targets for static artifacts; the standalone Windows CLI uses the LLVM gnullvm target and is smoke-tested on a Windows runner.
 
@@ -235,8 +235,10 @@ binary artifact process:
 2. **npm package publish runs automatically**:
 
    The `release-please.yml` workflow calls `release.yml` with the npm package
-   paths released by Release Please. `release.yml` builds the Bazel `:dist`
-   output and publishes those packages through npm Trusted Publishing.
+   paths released by Release Please. A `crates/formatjs_cli` release also queues
+   the CLI and CLI native npm package paths because those packages publish the
+   native Rust binding. `release.yml` builds the Bazel `:dist` output and
+   publishes unpublished package versions through npm Trusted Publishing.
 
 3. **Crates.io publish runs automatically**:
 

--- a/knowledge-base/001-repo-layout.md
+++ b/knowledge-base/001-repo-layout.md
@@ -92,22 +92,27 @@ Commit-msg hook: `commitlint` validates Conventional Commits format.
 
 ## CI/CD (GitHub Actions)
 
-| Workflow               | Trigger               | What it does                             |
-| ---------------------- | --------------------- | ---------------------------------------- |
-| `test.yml`             | PR, push to main      | `bazel test //...` on Ubuntu + macOS     |
+| Workflow               | Trigger               | What it does                                                |
+| ---------------------- | --------------------- | ----------------------------------------------------------- |
+| `test.yml`             | PR, push to main      | `bazel test //...` on Ubuntu + macOS                        |
 | `release-please.yml`   | Push to main/manual   | Version/changelog PRs, GitHub releases, npm publish handoff |
-| `release.yml`          | Release Please/manual | `bazel build :dist` then npm Trusted Publishing |
-| `crates-release.yml`   | Crate releases/manual | Publish Rust crates through crates.io OIDC |
-| `rust-cli-release.yml` | Tag `formatjs_cli_v*` | Cross-platform Rust binary artifacts     |
-| `website.yml`          | Manual/push           | Deploy docs site                         |
-| `verify-hooks.yml`     | PR                    | Verify lefthook hooks + commitlint       |
+| `release.yml`          | Release Please/manual | `bazel build :dist` then npm Trusted Publishing             |
+| `crates-release.yml`   | Crate releases/manual | Publish Rust crates through crates.io OIDC                  |
+| `rust-cli-release.yml` | Tag `formatjs_cli_v*` | Cross-platform Rust binary artifacts                        |
+| `website.yml`          | Manual/push           | Deploy docs site                                            |
+| `verify-hooks.yml`     | PR                    | Verify lefthook hooks + commitlint                          |
 
-Release Please owns version/changelog PRs and GitHub release creation. Its
-GitHub-generated changelog notes include PR titles, PR links, and contributors.
-When Release Please creates npm package releases, it passes those released
-package paths to `release.yml`. The npm publish workflow builds the Bazel
-`:dist` output and uses npm Trusted Publishing, then publishes only the package
-paths Release Please released. Rust crate publishing happens in
+Release Please owns version/changelog PRs and GitHub release creation. It uses
+Release Please's built-in changelog builder instead of GitHub-generated
+changelogs so release PR generation does not depend on historical GitHub
+releases existing for every manifest version. When Release Please creates npm
+package releases, it passes those released package paths to `release.yml`. A
+`crates/formatjs_cli` release also queues the CLI and CLI native npm package
+paths because those packages publish the native Rust binding. The npm publish
+workflow builds the Bazel `:dist` output, sorts selected package paths by local
+package dependencies, and uses npm Trusted Publishing. It skips any package
+version that is already on npm so release workflow re-runs stay idempotent.
+Rust crate publishing happens in
 `crates-release.yml` from crate GitHub releases using crates.io trusted
 publishing. The Rust CLI binary artifacts remain Bazel-owned in
 `rust-cli-release.yml`. Its release build job runs on Linux, uses BuildBuddy RBE

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,6 @@
   "include-v-in-tag": false,
   "include-v-in-release-name": false,
   "tag-separator": "@",
-  "changelog-type": "github",
   "bootstrap-sha": "482c8e224b2582b554e3f4b0718fe2332c4b5cff",
   "sequential-calls": true,
   "exclude-paths": ["**/tests/**", "**/*.md"],


### PR DESCRIPTION
## Summary
- remove the explicit GitHub-generated changelog mode so Release Please uses its built-in default changelog builder and does not trip GitHub's generated-notes previous_tag validation when historical tags/releases are missing
- expand the npm release handoff so a crates/formatjs_cli release also queues the CLI and CLI native npm package paths
- sort selected npm package paths in release.yml by their local package.json dependency graph instead of hardcoding publish order
- make npm publishing skip versions that are already present on npm so release workflow reruns stay idempotent
- update the release docs/knowledge base to match the workflow

## Verification
- ./node_modules/.bin/oxfmt --check .github/workflows/release-please.yml .github/workflows/release.yml release-please-config.json CONTRIBUTING.md knowledge-base/001-repo-layout.md crates/formatjs_cli/RELEASE.md
- git diff --check
- ruby YAML parse for release-please.yml and release.yml
- node JSON parse for release-please-config.json
- simulated PATHS_RELEASED=["crates/formatjs_cli"] expands to CLI/native npm paths
- simulated NPM_RELEASE_PATHS sort puts native packages before cli-lib/cli from package.json dependencies
- npm view @formatjs/cli@6.16.6 version
- commit hooks ran format-oxfmt, bazel run //:gazelle, and commitlint