### PR TITLE
build: fix release-please multiline outputs

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -359,7 +359,7 @@
         "recordedInputs": [
           "REPO_MAPPING:aspect_rules_ts+,aspect_rules_ts aspect_rules_ts+",
           "REPO_MAPPING:aspect_rules_ts+,bazel_tools bazel_tools",
-          "FILE:@@//package.json 59e684debd0db07feb0ee2c7a6ecdffe96134d12fbcc1e7bf17ed59e080998ff"
+          "FILE:@@//package.json a9b32ad44044d414606192cd549fd597ab1b8a1b2e26ca30a17de218ceab8e30"
         ],
         "generatedRepoSpecs": {
           "npm_typescript": {

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -58,7 +58,10 @@ ts_binary(
 js_test(
     name = "release_please_npm_workspace_test",
     size = "small",
-    data = ["release-please/npm-workspace-graph.ts"],
+    data = [
+        "release-please/github-output.ts",
+        "release-please/npm-workspace-graph.ts",
+    ],
     entry_point = "release-please/npm-workspace-graph.test.ts",
     node_options = ["--disable-warning=MODULE_TYPELESS_PACKAGE_JSON"],
 )

--- a/tools/release-please/github-output.ts
+++ b/tools/release-please/github-output.ts
@@ -1,0 +1,24 @@
+function outputDelimiter(key: string, value: string): string {
+  const normalizedKey = key.replace(/[^A-Za-z0-9_]/g, '_')
+  const baseDelimiter = `FORMATJS_${normalizedKey}_EOF`
+  const lines = new Set(value.split(/\r?\n/))
+  let delimiter = baseDelimiter
+  let suffix = 0
+
+  while (lines.has(delimiter)) {
+    suffix++
+    delimiter = `${baseDelimiter}_${suffix}`
+  }
+
+  return delimiter
+}
+
+export function githubOutputRecord(key: string, value): string {
+  const serialized = typeof value === 'string' ? value : JSON.stringify(value)
+  if (!serialized.includes('\n') && !serialized.includes('\r')) {
+    return `${key}=${serialized}\n`
+  }
+
+  const delimiter = outputDelimiter(key, serialized)
+  return `${key}<<${delimiter}\n${serialized}\n${delimiter}\n`
+}

--- a/tools/release-please/npm-workspace-graph.test.ts
+++ b/tools/release-please/npm-workspace-graph.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
 
+import {githubOutputRecord} from './github-output.ts'
 import {
   buildDependencyGraph,
   dependencyNames,
@@ -105,3 +106,21 @@ assert.throws(() => {
   ])
   dependentPackageOrder(cycleGraph, ['a'])
 }, /found cycle in dependency graph: a -> b -> a/)
+
+assert.equal(
+  githubOutputRecord('release_created', true),
+  'release_created=true\n'
+)
+
+assert.equal(
+  githubOutputRecord('packages/cli--body', "## What's Changed\n* release note"),
+  "packages/cli--body<<FORMATJS_packages_cli__body_EOF\n## What's Changed\n* release note\nFORMATJS_packages_cli__body_EOF\n"
+)
+
+assert.equal(
+  githubOutputRecord(
+    'body',
+    'FORMATJS_body_EOF\n## What changed\nFORMATJS_body_EOF_1'
+  ),
+  'body<<FORMATJS_body_EOF_2\nFORMATJS_body_EOF\n## What changed\nFORMATJS_body_EOF_1\nFORMATJS_body_EOF_2\n'
+)

--- a/tools/release-please/run.ts
+++ b/tools/release-please/run.ts
@@ -1,6 +1,7 @@
 import {appendFileSync} from 'node:fs'
 import {createRequire} from 'node:module'
 
+import {githubOutputRecord} from './github-output.ts'
 import {BazelNpmWorkspace} from './npm-workspace-plugin.ts'
 
 const require = createRequire(import.meta.url)
@@ -28,11 +29,10 @@ function boolEnv(name: string): boolean | undefined {
 }
 
 function setOutput(key: string, value) {
-  const serialized = typeof value === 'string' ? value : JSON.stringify(value)
   if (process.env.GITHUB_OUTPUT) {
-    appendFileSync(process.env.GITHUB_OUTPUT, `${key}=${serialized}\n`)
+    appendFileSync(process.env.GITHUB_OUTPUT, githubOutputRecord(key, value))
   } else {
-    console.log(`${key}=${serialized}`)
+    process.stdout.write(githubOutputRecord(key, value))
   }
 }
 


### PR DESCRIPTION
## Summary
- fix the local Release Please runner to write multiline GitHub outputs with the documented delimiter format
- add coverage for release notes beginning with `## What's Changed`, which caused the failed job output parser error
- refresh the Bazel lock root package.json hash after the release commit

## Root Cause
The failed job wrote a release `notes` string directly as `key=value` in `GITHUB_OUTPUT`. GitHub treats the next line, `## What's Changed`, as a malformed output command and fails with `Invalid format '## What's Changed'`.

Failed job: https://github.com/formatjs/formatjs/actions/runs/26887273143/job/79302961795

## Validation
- bazel test //tools:release_please_npm_workspace_test
- bazel build :release_please_npm_workspace_graph
- NODE_PATH=/private/tmp/formatjs-release-please-runner/node_modules node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON -e "import('./tools/release-please/run.ts').then(() => console.log('run loaded'))"