### PR TITLE
fix(formatjs_cli): support loader-utils id templates

### DIFF
--- a/crates/formatjs_cli/src/extract.rs
+++ b/crates/formatjs_cli/src/extract.rs
@@ -129,7 +129,11 @@ pub fn extract_to_string(
                         id
                     } else {
                         // Hash the (possibly flattened) message
-                        id_generator.generate(msg.default_message.as_deref(), &msg.description)?
+                        id_generator.generate(
+                            msg.default_message.as_deref(),
+                            &msg.description,
+                            Some(file_path.as_path()),
+                        )?
                     };
 
                     msg.id = Some(id.clone());
@@ -907,6 +911,50 @@ const greeting = defineMessage({
 
         // Verify message content
         assert_eq!(message["defaultMessage"].as_str().unwrap(), "Hello World");
+    }
+
+    #[test]
+    fn test_extract_with_loader_utils_id_interpolation_template() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let test_file = temp_dir.path().join("a.ts");
+        let output_file = temp_dir.path().join("output.json");
+
+        let test_content = r#"
+import { defineMessages } from 'react-intl';
+
+export const messages = defineMessages({
+  hello: {
+    defaultMessage: 'Hello',
+  },
+});
+"#;
+        std::fs::write(&test_file, test_content).unwrap();
+
+        extract(
+            &[test_file],
+            None,
+            None,
+            Some(&output_file),
+            "[name].[ext]_[sha512:contenthash:base64:6]",
+            false,
+            &[],
+            &[],
+            &[],
+            false,
+            None,
+            false,
+            false,
+            true,
+        )
+        .unwrap();
+
+        let output_content = std::fs::read_to_string(&output_file).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&output_content).unwrap();
+        assert!(json.get("a.ts_NhX4DJ").is_some());
+        assert_eq!(
+            json["a.ts_NhX4DJ"]["defaultMessage"].as_str().unwrap(),
+            "Hello"
+        );
     }
 
     #[test]

--- a/crates/formatjs_cli/src/id_generator.rs
+++ b/crates/formatjs_cli/src/id_generator.rs
@@ -8,6 +8,7 @@ use md5::{Digest, Md5};
 use serde_json::Value;
 use sha1::Sha1;
 use sha2::{Sha224, Sha256, Sha384, Sha512};
+use std::path::Path;
 
 /// Base62 character set: 0-9, A-Z, a-z
 const BASE62_CHARS: &[u8] = b"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
@@ -33,6 +34,25 @@ enum Encoding {
     Base64Url,
     Base62,
     Hex,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct HashInterpolation {
+    hash_algorithm: HashAlgorithm,
+    digest_type: DigestType,
+    encoding: Encoding,
+    length: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum InterpolationPart {
+    Literal(String),
+    Hash(HashInterpolation),
+    Ext,
+    Name,
+    Path,
+    Folder,
+    Query,
 }
 
 /// Encode bytes to base62 string
@@ -70,7 +90,9 @@ fn encode_base62(bytes: &[u8]) -> String {
 
 /// Generate message ID using interpolation pattern.
 ///
-/// Supports patterns in the format: `[hash:digest:encoding:length]`
+/// Supports loader-utils style interpolation templates, including hash
+/// placeholders in the format `[hash:digest:encoding:length]` and file-name
+/// placeholders such as `[name]` and `[ext]`.
 ///
 /// # Supported formats:
 /// - **Hash algorithms**: `md5`, `sha1`, `sha224`, `sha256`, `sha384`, `sha512`
@@ -90,101 +112,26 @@ fn encode_base62(bytes: &[u8]) -> String {
 /// * `pattern` - The interpolation pattern string
 /// * `default_message` - The message text to hash
 /// * `description` - Optional description that affects the hash
-/// * `_file_path` - File path (currently unused, reserved for future use)
+/// * `file_path` - File path for loader-utils file-name placeholders
 pub fn generate_id(
     pattern: &str,
     default_message: Option<&str>,
     description: &Option<Value>,
-    _file_path: Option<&str>,
+    file_path: Option<&str>,
 ) -> Result<String> {
-    IdGenerator::new(pattern)?.generate(default_message, description)
+    IdGenerator::new(pattern)?.generate(default_message, description, file_path.map(Path::new))
 }
 
 /// Parsed ID interpolation pattern for repeated message ID generation.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct IdGenerator {
-    hash_algorithm: HashAlgorithm,
-    digest_type: DigestType,
-    encoding: Encoding,
-    length: usize,
+    parts: Vec<InterpolationPart>,
 }
 
 impl IdGenerator {
     pub fn new(pattern: &str) -> Result<Self> {
-        if !pattern.starts_with('[') || !pattern.ends_with(']') {
-            anyhow::bail!("Invalid ID interpolation pattern: {}", pattern);
-        }
-
-        let inner = &pattern[1..pattern.len() - 1];
-        let parts: Vec<&str> = inner.split(':').collect();
-
-        if parts.is_empty() || parts.iter().any(|part| part.is_empty()) {
-            anyhow::bail!("Invalid ID interpolation pattern: {}", pattern);
-        }
-
-        let normalized_parts: Vec<String> = parts.iter().map(|part| part.to_lowercase()).collect();
-        let mut index = 0;
-        let hash_algorithm = if is_digest_type(&normalized_parts[index]) {
-            // loader-utils compatibility: `[contenthash:5]` means md5 + hex + length 5.
-            HashAlgorithm::Md5
-        } else {
-            let algorithm = parse_hash_algorithm(&normalized_parts[index])?;
-            index += 1;
-            algorithm
-        };
-
-        if index >= normalized_parts.len() {
-            anyhow::bail!(
-                "Invalid ID interpolation pattern format: {}. Expected [hash:digest:encoding:length]",
-                pattern
-            );
-        }
-
-        let digest_type = match normalized_parts[index].as_str() {
-            "contenthash" | "hash" => DigestType::ContentHash,
-            _ => anyhow::bail!("Unsupported digest type: {}", parts[index]),
-        };
-        index += 1;
-
-        let encoding = if index < normalized_parts.len()
-            && !normalized_parts[index]
-                .chars()
-                .all(|ch| ch.is_ascii_digit())
-        {
-            let encoding = parse_encoding(&normalized_parts[index], parts[index])?;
-            index += 1;
-            encoding
-        } else {
-            Encoding::Hex
-        };
-
-        if index >= normalized_parts.len() {
-            anyhow::bail!(
-                "Invalid ID interpolation pattern format: {}. Expected [hash:digest:encoding:length]",
-                pattern
-            );
-        }
-
-        let length: usize = parts[index]
-            .parse()
-            .context("Invalid length in ID interpolation pattern")?;
-        if length == 0 {
-            anyhow::bail!(
-                "Invalid length in ID interpolation pattern: {}",
-                parts[index]
-            );
-        }
-        index += 1;
-
-        if index != normalized_parts.len() {
-            anyhow::bail!("Invalid ID interpolation pattern: {}", pattern);
-        }
-
         Ok(Self {
-            hash_algorithm,
-            digest_type,
-            encoding,
-            length,
+            parts: parse_interpolation_pattern(pattern)?,
         })
     }
 
@@ -192,22 +139,238 @@ impl IdGenerator {
         &self,
         default_message: Option<&str>,
         description: &Option<Value>,
+        file_path: Option<&Path>,
     ) -> Result<String> {
         let content = hash_content(default_message, description);
+        let resource_path_parts = ResourcePathParts::from_path(file_path);
+        let mut id = String::new();
+
+        for part in &self.parts {
+            match part {
+                InterpolationPart::Literal(value) => id.push_str(value),
+                InterpolationPart::Hash(hash) => id.push_str(&hash.generate(&content)),
+                InterpolationPart::Ext => id.push_str(&resource_path_parts.ext),
+                InterpolationPart::Name => id.push_str(&resource_path_parts.name),
+                InterpolationPart::Path => id.push_str(&resource_path_parts.path),
+                InterpolationPart::Folder => id.push_str(&resource_path_parts.folder),
+                InterpolationPart::Query => id.push_str(&resource_path_parts.query),
+            }
+        }
+
+        Ok(id)
+    }
+}
+
+impl HashInterpolation {
+    fn generate(&self, content: &[u8]) -> String {
         let digest = match (self.hash_algorithm, self.digest_type) {
-            (HashAlgorithm::Md5, DigestType::ContentHash) => hash_with::<Md5>(&content),
-            (HashAlgorithm::Sha1, DigestType::ContentHash) => hash_with::<Sha1>(&content),
-            (HashAlgorithm::Sha224, DigestType::ContentHash) => hash_with::<Sha224>(&content),
-            (HashAlgorithm::Sha256, DigestType::ContentHash) => hash_with::<Sha256>(&content),
-            (HashAlgorithm::Sha384, DigestType::ContentHash) => hash_with::<Sha384>(&content),
-            (HashAlgorithm::Sha512, DigestType::ContentHash) => hash_with::<Sha512>(&content),
+            (HashAlgorithm::Md5, DigestType::ContentHash) => hash_with::<Md5>(content),
+            (HashAlgorithm::Sha1, DigestType::ContentHash) => hash_with::<Sha1>(content),
+            (HashAlgorithm::Sha224, DigestType::ContentHash) => hash_with::<Sha224>(content),
+            (HashAlgorithm::Sha256, DigestType::ContentHash) => hash_with::<Sha256>(content),
+            (HashAlgorithm::Sha384, DigestType::ContentHash) => hash_with::<Sha384>(content),
+            (HashAlgorithm::Sha512, DigestType::ContentHash) => hash_with::<Sha512>(content),
         };
 
-        Ok(encode_digest(&digest, self.encoding)
+        encode_digest(&digest, self.encoding)
             .chars()
             .take(self.length)
-            .collect())
+            .collect()
     }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ResourcePathParts {
+    ext: String,
+    name: String,
+    path: String,
+    folder: String,
+    query: String,
+}
+
+impl ResourcePathParts {
+    fn from_path(path: Option<&Path>) -> Self {
+        let Some(path) = path else {
+            return Self::default();
+        };
+
+        let ext = path
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .unwrap_or("bin")
+            .to_string();
+        let name = path
+            .file_stem()
+            .and_then(|name| name.to_str())
+            .unwrap_or("file")
+            .to_string();
+
+        let parent = path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty() && *parent != Path::new("."));
+        let mut path = parent
+            .map(|parent| normalize_path_separators(&parent.to_string_lossy()))
+            .unwrap_or_default();
+        if !path.is_empty() && !path.ends_with('/') {
+            path.push('/');
+        }
+        let folder = parent
+            .and_then(|parent| parent.file_name())
+            .and_then(|folder| folder.to_str())
+            .unwrap_or_default()
+            .to_string();
+
+        Self {
+            ext,
+            name,
+            path,
+            folder,
+            query: String::new(),
+        }
+    }
+}
+
+impl Default for ResourcePathParts {
+    fn default() -> Self {
+        Self {
+            ext: "bin".to_string(),
+            name: "file".to_string(),
+            path: String::new(),
+            folder: String::new(),
+            query: String::new(),
+        }
+    }
+}
+
+fn normalize_path_separators(path: &str) -> String {
+    path.replace('\\', "/").replace("../", "_/")
+}
+
+fn parse_interpolation_pattern(pattern: &str) -> Result<Vec<InterpolationPart>> {
+    let mut parts = Vec::new();
+    let mut rest = pattern;
+    let mut has_interpolation = false;
+
+    while let Some(start) = rest.find('[') {
+        if start > 0 {
+            parts.push(InterpolationPart::Literal(rest[..start].to_string()));
+        }
+
+        let after_open = &rest[start + 1..];
+        let Some(end) = after_open.find(']') else {
+            anyhow::bail!("Invalid ID interpolation pattern: {}", pattern);
+        };
+
+        let token = &after_open[..end];
+        let (part, is_interpolation) = parse_interpolation_part(token)?;
+        has_interpolation |= is_interpolation;
+        parts.push(part);
+        rest = &after_open[end + 1..];
+    }
+
+    if !rest.is_empty() {
+        parts.push(InterpolationPart::Literal(rest.to_string()));
+    }
+
+    if !has_interpolation {
+        anyhow::bail!("Invalid ID interpolation pattern: {}", pattern);
+    }
+
+    Ok(parts)
+}
+
+fn parse_interpolation_part(token: &str) -> Result<(InterpolationPart, bool)> {
+    match token.to_lowercase().as_str() {
+        "ext" => Ok((InterpolationPart::Ext, true)),
+        "name" => Ok((InterpolationPart::Name, true)),
+        "path" => Ok((InterpolationPart::Path, true)),
+        "folder" => Ok((InterpolationPart::Folder, true)),
+        "query" => Ok((InterpolationPart::Query, true)),
+        _ if is_hash_interpolation(token) => {
+            Ok((InterpolationPart::Hash(parse_hash_interpolation(token)?), true))
+        }
+        _ => Ok((InterpolationPart::Literal(format!("[{}]", token)), false)),
+    }
+}
+
+fn is_hash_interpolation(token: &str) -> bool {
+    token
+        .split(':')
+        .map(|part| part.to_lowercase())
+        .any(|part| is_digest_type(&part))
+}
+
+fn parse_hash_interpolation(token: &str) -> Result<HashInterpolation> {
+    let parts: Vec<&str> = token.split(':').collect();
+
+    if parts.is_empty() || parts.iter().any(|part| part.is_empty()) {
+        anyhow::bail!("Invalid ID interpolation pattern: [{}]", token);
+    }
+
+    let normalized_parts: Vec<String> = parts.iter().map(|part| part.to_lowercase()).collect();
+    let mut index = 0;
+    let hash_algorithm = if is_digest_type(&normalized_parts[index]) {
+        // loader-utils compatibility: `[contenthash:5]` means md5 + hex + length 5.
+        HashAlgorithm::Md5
+    } else {
+        let algorithm = parse_hash_algorithm(&normalized_parts[index])?;
+        index += 1;
+        algorithm
+    };
+
+    if index >= normalized_parts.len() {
+        anyhow::bail!(
+            "Invalid ID interpolation pattern format: [{}]. Expected [hash:digest:encoding:length]",
+            token
+        );
+    }
+
+    let digest_type = match normalized_parts[index].as_str() {
+        "contenthash" | "hash" => DigestType::ContentHash,
+        _ => anyhow::bail!("Unsupported digest type: {}", parts[index]),
+    };
+    index += 1;
+
+    let encoding = if index < normalized_parts.len()
+        && !normalized_parts[index]
+            .chars()
+            .all(|ch| ch.is_ascii_digit())
+    {
+        let encoding = parse_encoding(&normalized_parts[index], parts[index])?;
+        index += 1;
+        encoding
+    } else {
+        Encoding::Hex
+    };
+
+    if index >= normalized_parts.len() {
+        anyhow::bail!(
+            "Invalid ID interpolation pattern format: [{}]. Expected [hash:digest:encoding:length]",
+            token
+        );
+    }
+
+    let length: usize = parts[index]
+        .parse()
+        .context("Invalid length in ID interpolation pattern")?;
+    if length == 0 {
+        anyhow::bail!(
+            "Invalid length in ID interpolation pattern: {}",
+            parts[index]
+        );
+    }
+    index += 1;
+
+    if index != normalized_parts.len() {
+        anyhow::bail!("Invalid ID interpolation pattern: [{}]", token);
+    }
+
+    Ok(HashInterpolation {
+        hash_algorithm,
+        digest_type,
+        encoding,
+        length,
+    })
 }
 
 fn is_digest_type(part: &str) -> bool {
@@ -322,6 +485,18 @@ mod tests {
     fn test_generate_id_hex() {
         let id = generate_id("[sha512:contenthash:hex:10]", Some("Test"), &None, None).unwrap();
         assert_eq!(id, "c6ee9e33cf");
+    }
+
+    #[test]
+    fn test_generate_id_loader_utils_file_placeholders() {
+        let id = generate_id(
+            "[name].[ext]_[sha512:contenthash:base64:6]",
+            Some("Hello"),
+            &None,
+            Some("a.ts"),
+        )
+        .unwrap();
+        assert_eq!(id, "a.ts_NhX4DJ");
     }
 
     #[test]

--- a/packages/cli/integration-tests/conformance-tests/README.md
+++ b/packages/cli/integration-tests/conformance-tests/README.md
@@ -69,6 +69,7 @@ The test suite covers:
 - `05_additional_function_names.txt` - `--additional-function-names` flag
 - `06_extract_source_location.txt` - `--extract-source-location` flag
 - `17_pragma.txt` - `--pragma` flag for file filtering
+- `23_loader_utils_id_template.txt` - `--id-interpolation-pattern` with loader-utils file placeholders
 
 ### Output Formats
 

--- a/packages/cli/integration-tests/conformance-tests/SUMMARY.md
+++ b/packages/cli/integration-tests/conformance-tests/SUMMARY.md
@@ -20,7 +20,7 @@ Created a conformance test suite to ensure the Rust CLI (`crates/formatjs_cli`) 
 - [BUILD.bazel](../BUILD.bazel) - Bazel test configuration
 - [README.md](./README.md) - Documentation and usage guide
 
-### Test Cases (22 total)
+### Test Cases (23 total)
 
 Located in [test_cases/](./test_cases/):
 
@@ -33,13 +33,14 @@ Located in [test_cases/](./test_cases/):
 - `18_optional_chaining.txt` - Optional chaining in code
 - `21_formatmessage_any_object.txt` - formatMessage on arbitrary member chains
 
-#### CLI Options & Flags (5 tests)
+#### CLI Options & Flags (6 tests)
 
 - `03_flatten_option.txt` - `--flatten` flag
 - `04_content_hash_id.txt` - `--id-interpolation-pattern` with content hashing
 - `05_additional_function_names.txt` - `--additional-function-names` flag
 - `06_extract_source_location.txt` - `--extract-source-location` flag
 - `17_pragma.txt` - `--pragma` flag for file filtering
+- `23_loader_utils_id_template.txt` - `--id-interpolation-pattern` with loader-utils file placeholders
 
 #### Output Formats (5 tests)
 

--- a/packages/cli/integration-tests/conformance-tests/test_cases/23_loader_utils_id_template.txt
+++ b/packages/cli/integration-tests/conformance-tests/test_cases/23_loader_utils_id_template.txt
@@ -1,0 +1,19 @@
+import {defineMessages} from 'react-intl';
+
+export const messages = defineMessages({
+  hello: {
+    defaultMessage: 'Hello'
+  }
+});
+---
+{
+  "command": "extract",
+  "args": ["--throws", "--id-interpolation-pattern", "[name].[ext]_[sha512:contenthash:base64:6]"],
+  "fileType": "ts"
+}
+---
+{
+  "input.ts_NhX4DJ": {
+    "defaultMessage": "Hello"
+  }
+}


### PR DESCRIPTION
## Summary

- parse native id interpolation patterns as loader-utils-style templates instead of one whole hash descriptor
- pass the source path into native id generation so `[name]`, `[ext]`, `[path]`, `[folder]`, and `[query]` placeholders can resolve
- add Rust extractor coverage plus a CLI conformance fixture for the reported template

Fixes #6730

## Test plan

- `bazel test //crates/formatjs_cli:formatjs_cli_test --nocache_test_results`
- `bazel build //crates/formatjs_cli_napi:formatjs_cli_napi`
- `git diff --check`

Note: `bazel test //packages/cli/integration-tests:conformance_test` currently fails during Bazel analysis on macOS before running tests because `@formatjs/cli` pulls the existing incompatible `@formatjs/cli-native-win32-x64` optional package target.
