### PR TITLE
ci: pass repository to release workflow dispatch

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -112,5 +112,6 @@ jobs:
           # Keep npm Trusted Publishing bound to release.yml by dispatching it
           # as the top-level workflow, not as a reusable workflow call.
           gh workflow run release.yml \
+            --repo "$GITHUB_REPOSITORY" \
             --ref "$GITHUB_REF_NAME" \
             --raw-field "npm_paths=$NPM_RELEASE_PATHS"


### PR DESCRIPTION
## Summary

- pass `--repo "$GITHUB_REPOSITORY"` to the Release Please npm dispatch job
- keep the release workflow as a top-level `workflow_dispatch` so npm Trusted Publishing remains bound to `release.yml`

## Debugging

The failed `Dispatch npm Package Release` job had no checkout step, then ran `gh workflow run release.yml` without an explicit repository. GitHub CLI tried to infer the repository from `.git` and failed with:

```text
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

## Validation

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-please.yml"); puts "ok"'`
- `gh workflow view release.yml --repo formatjs/formatjs` from `/private/tmp`
- commit hooks: Bazel-backed `format-oxfmt`, `gazelle`, and `commitlint`

