### PR TITLE
fix(formatjs_cli): build native packages in opt mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
           $ErrorActionPreference = 'Stop'
           $PSNativeCommandUseErrorActionPreference = $true
           $bazelWindowsFlags = @(
+            '--compilation_mode=opt',
             '--repo_env==BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN',
             '--extra_toolchains=@local_config_cc//:cc-toolchain-x64_windows'
           )
@@ -97,9 +98,10 @@ jobs:
         run: |
           bazel build \
             --config=ci \
+            --compilation_mode=opt \
             --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
             :dist
-          DIST_PATH=$(bazel cquery --config=ci --output=files :dist)
+          DIST_PATH=$(bazel cquery --config=ci --compilation_mode=opt --output=files :dist)
           echo "Distribution path: $DIST_PATH"
           cp -rf "$DIST_PATH" release/
           chmod -R +w release/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,7 +97,6 @@ jobs:
 
   windows_smoke:
     name: Windows Smoke Tests
-    if: github.event_name != 'pull_request'
     runs-on: windows-latest
 
     steps:
@@ -124,6 +123,7 @@ jobs:
           $ErrorActionPreference = 'Stop'
           $PSNativeCommandUseErrorActionPreference = $true
           $bazelWindowsFlags = @(
+            '--compilation_mode=opt',
             '--repo_env==BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN',
             '--extra_toolchains=@local_config_cc//:cc-toolchain-x64_windows'
           )
@@ -138,6 +138,7 @@ jobs:
           $ErrorActionPreference = 'Stop'
           $PSNativeCommandUseErrorActionPreference = $true
           $bazelWindowsFlags = @(
+            '--compilation_mode=opt',
             '--repo_env==BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN',
             '--extra_toolchains=@local_config_cc//:cc-toolchain-x64_windows'
           )
@@ -182,5 +183,37 @@ jobs:
             throw new Error(output)
           }
           console.log(output)
+
+          const sourceSubdir = path.join(messageDir, 'src[prod]')
+          fs.mkdirSync(sourceSubdir)
+          const sourceFile = path.join(sourceSubdir, 'component.tsx')
+          fs.writeFileSync(
+            sourceFile,
+            `
+          import {defineMessage} from 'react-intl'
+
+          defineMessage({
+            id: 'native.extract',
+            defaultMessage: 'Native extract smoke',
+          })
+          `
+          )
+
+          if (!sourceFile.includes('\\')) {
+            throw new Error(`Expected a native Windows path, got ${sourceFile}`)
+          }
+
+          const extractedOutput = native.extract([sourceFile], {
+            idInterpolationPattern: '[sha512:contenthash:base64:6]',
+            throws: true,
+          })
+          const extracted = JSON.parse(extractedOutput)
+          if (
+            extracted['native.extract']?.defaultMessage !==
+            'Native extract smoke'
+          ) {
+            throw new Error(extractedOutput)
+          }
+          console.log(extractedOutput)
           '@
           $script | node - $pkgPath

--- a/crates/formatjs_cli/src/extract.rs
+++ b/crates/formatjs_cli/src/extract.rs
@@ -215,11 +215,16 @@ pub fn extract_base_dir(pattern: &str) -> PathBuf {
 
     let prefix = &pattern[..wildcard_pos];
 
-    // Find the last path separator in the prefix
-    if let Some(sep_pos) = prefix.rfind('/') {
-        let dir = &pattern[..sep_pos];
+    // Find the last path separator in the prefix. Windows accepts both `\` and
+    // `/`, and native callers pass real Windows paths through this helper.
+    if let Some(sep_pos) = prefix.rfind(|c| c == '/' || c == '\\') {
+        let dir = if sep_pos == 2 && prefix.as_bytes().get(1) == Some(&b':') {
+            &pattern[..=sep_pos]
+        } else {
+            &pattern[..sep_pos]
+        };
         if dir.is_empty() {
-            PathBuf::from("/")
+            PathBuf::from(&pattern[..=sep_pos])
         } else {
             PathBuf::from(dir)
         }
@@ -238,6 +243,13 @@ fn resolve_files_from_globs(
     let mut files = Vec::new();
 
     for glob_path in globs {
+        if glob_path.is_file() {
+            if !should_ignore(glob_path, ignore) && is_supported_file(glob_path) {
+                files.push(glob_path.to_path_buf());
+            }
+            continue;
+        }
+
         let glob_str = glob_path
             .to_str()
             .context("Invalid UTF-8 in glob pattern")?;
@@ -633,6 +645,15 @@ const msg = defineMessage({
         assert_eq!(extract_base_dir("src/**/*.{ts,tsx}"), PathBuf::from("src"));
         // Literal path (no wildcards) returns parent dir
         assert_eq!(extract_base_dir("src/app.ts"), PathBuf::from("src"));
+        assert_eq!(
+            extract_base_dir(r"src\components\*.tsx"),
+            PathBuf::from(r"src\components")
+        );
+        assert_eq!(
+            extract_base_dir(r"C:\repo\src\*.tsx"),
+            PathBuf::from(r"C:\repo\src")
+        );
+        assert_eq!(extract_base_dir(r"C:\*.tsx"), PathBuf::from(r"C:\"));
         // Question mark wildcard
         assert_eq!(extract_base_dir("src/?.ts"), PathBuf::from("src"));
         // Bracket wildcard
@@ -695,6 +716,21 @@ const msg = defineMessage({
         // Literal file paths (no glob characters) should also resolve
         let temp_dir = tempfile::tempdir().unwrap();
         let file = temp_dir.path().join("app.ts");
+        fs::write(&file, "// app").unwrap();
+
+        let globs = vec![file.clone()];
+        let files = resolve_files_from_globs(&globs, &[], true).unwrap();
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0], file);
+    }
+
+    #[test]
+    fn test_resolve_files_literal_path_containing_glob_metacharacters() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let subdir = temp_dir.path().join("messages[prod]");
+        fs::create_dir_all(&subdir).unwrap();
+        let file = subdir.join("primary.tsx");
         fs::write(&file, "// app").unwrap();
 
         let globs = vec![file.clone()];


### PR DESCRIPTION
Fixes #6706.

## What changed
- Build release `:dist` with `--compilation_mode=opt` so native packages distributed from the Linux release job are optimized.
- Build the separately assembled Windows native package with `--compilation_mode=opt` in release and smoke workflows.
- Add a Windows native extract smoke that uses a real backslash path under a directory with glob metacharacters.
- Fix native extract file resolution for Windows separators and literal paths containing glob metacharacters.

## Validation
- `bazel test //crates/formatjs_cli:formatjs_cli_test --test_output=all`
- `bazel build --compilation_mode=opt //crates/formatjs_cli_napi:formatjs_cli_napi`
- `bazel build --compilation_mode=opt //packages/cli-native-darwin-arm64:pkg //packages/cli-native-linux-x64:pkg //packages/cli-native-linux-arm64:pkg`
- `git diff --check`