### PR TITLE
fix(formatjs_cli_napi): build musl packages with bazel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,28 +93,19 @@ jobs:
 
       - name: Build Package
         run: |
-          bazel build //packages/${{ matrix.package }}:generated_package_json
-          package_json=$(bazel cquery --output=files //packages/${{ matrix.package }}:generated_package_json | tail -n 1)
+          bazel build //packages/${{ matrix.package }}:pkg
+          package_dir=$(bazel cquery --output=files //packages/${{ matrix.package }}:pkg | tail -n 1)
           mkdir -p artifacts/${{ matrix.package }}
-          cp "$package_json" artifacts/${{ matrix.package }}/package.json
+          cp -R "$package_dir"/. artifacts/${{ matrix.package }}/
 
-          docker run --rm \
-            -v "$PWD:/repo" \
-            -w /repo \
-            rust:1.95-alpine \
-            sh -euxc '
-              apk add --no-cache build-base file
-              RUSTFLAGS="-C target-feature=-crt-static" cargo build --release -p formatjs_cli_napi
-              cp target/release/libformatjs_cli_napi.so artifacts/${{ matrix.package }}/formatjs_cli_napi.node
-              artifact_info=$(file artifacts/${{ matrix.package }}/formatjs_cli_napi.node)
-              echo "$artifact_info"
-              case "$artifact_info" in
-                *"static-pie linked"*)
-                  echo "musl Node addon must not statically link libc"
-                  exit 1
-                  ;;
-              esac
-            '
+          artifact_info=$(file artifacts/${{ matrix.package }}/formatjs_cli_napi.node)
+          echo "$artifact_info"
+          case "$artifact_info" in
+            *"static-pie linked"*)
+              echo "musl Node addon must not statically link libc"
+              exit 1
+              ;;
+          esac
 
       - name: Smoke Test Package
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,28 +123,19 @@ jobs:
 
       - name: Build Linux musl Native Package
         run: |
-          bazel build //packages/${{ matrix.package }}:generated_package_json
-          package_json=$(bazel cquery --output=files //packages/${{ matrix.package }}:generated_package_json | tail -n 1)
+          bazel build //packages/${{ matrix.package }}:pkg
+          package_dir=$(bazel cquery --output=files //packages/${{ matrix.package }}:pkg | tail -n 1)
           mkdir -p artifacts/${{ matrix.package }}
-          cp "$package_json" artifacts/${{ matrix.package }}/package.json
+          cp -R "$package_dir"/. artifacts/${{ matrix.package }}/
 
-          docker run --rm \
-            -v "$PWD:/repo" \
-            -w /repo \
-            rust:1.95-alpine \
-            sh -euxc '
-              apk add --no-cache build-base file
-              RUSTFLAGS="-C target-feature=-crt-static" cargo build --release -p formatjs_cli_napi
-              cp target/release/libformatjs_cli_napi.so artifacts/${{ matrix.package }}/formatjs_cli_napi.node
-              artifact_info=$(file artifacts/${{ matrix.package }}/formatjs_cli_napi.node)
-              echo "$artifact_info"
-              case "$artifact_info" in
-                *"static-pie linked"*)
-                  echo "musl Node addon must not statically link libc"
-                  exit 1
-                  ;;
-              esac
-            '
+          artifact_info=$(file artifacts/${{ matrix.package }}/formatjs_cli_napi.node)
+          echo "$artifact_info"
+          case "$artifact_info" in
+            *"static-pie linked"*)
+              echo "musl Node addon must not statically link libc"
+              exit 1
+              ;;
+          esac
 
       - name: Smoke Test Package In Alpine
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,9 +106,11 @@ jobs:
           - arch: x64
             runner: ubuntu-latest
             package: cli-native-linux-x64-musl
+            cli-target: //crates/formatjs_cli:release_binary_linux_x64
           - arch: arm64
             runner: ubuntu-24.04-arm
             package: cli-native-linux-arm64-musl
+            cli-target: //crates/formatjs_cli:release_binary_linux_arm64
 
     steps:
       - name: Checkout Repository
@@ -143,6 +145,23 @@ jobs:
             -v "$PWD/artifacts/${{ matrix.package }}:/native:ro" \
             node:24-alpine \
             node -e 'const native = require("/native"); const formatters = native.supportedBuiltinFormatters(); if (!formatters.includes("default")) throw new Error("Missing default formatter"); const output = native.compileMessages([{id: "hello", message: "Hello {name}", sourceFile: "smoke.json"}], {}); if (!output.includes("\"hello\"")) throw new Error(output); console.log(output);'
+
+      - name: Smoke Test Static musl CLI On GNU
+        run: |
+          bazel build ${{ matrix.cli-target }}
+          binary_path=$(bazel cquery --output=files ${{ matrix.cli-target }} | tail -n 1)
+          artifact_info=$(file "$binary_path")
+          echo "$artifact_info"
+          case "$artifact_info" in
+            *"static-pie linked"*)
+              ;;
+            *)
+              echo "linux release CLI should be a static musl binary"
+              exit 1
+              ;;
+          esac
+          "$binary_path" --version
+          "$binary_path" --help
 
   windows_smoke:
     name: Windows Smoke Tests

--- a/crates/formatjs_cli/release_binary.bzl
+++ b/crates/formatjs_cli/release_binary.bzl
@@ -18,7 +18,7 @@ def _llvm_toolchains(target):
         for host in _HOSTS
     ]
 
-def _release_binary(platform, llvm_target = None):
+def _release_binary(platform, llvm_target = None, extra_rustc_flags = []):
     builder = with_cfg(
         native.genrule,
     ).set(
@@ -39,6 +39,11 @@ def _release_binary(platform, llvm_target = None):
             Label("@llvm//config/bootstrap:experimental_stub_libgcc_s"),
             True,
         )
+    if extra_rustc_flags:
+        builder = builder.extend(
+            Label("@rules_rust//rust/settings:extra_rustc_flag"),
+            extra_rustc_flags,
+        )
     return builder.build()
 
 release_binary_darwin_arm64, _release_binary_darwin_arm64_internal = _release_binary(
@@ -54,6 +59,18 @@ release_binary_linux_x64, _release_binary_linux_x64_internal = _release_binary(
 release_binary_linux_arm64, _release_binary_linux_arm64_internal = _release_binary(
     "//crates/formatjs_cli/platforms:linux_aarch64_musl",
     "linux_aarch64",
+)
+
+release_node_linux_x64_musl, _release_node_linux_x64_musl_internal = _release_binary(
+    "//crates/formatjs_cli/platforms:linux_x86_64_musl",
+    "linux_x86_64",
+    extra_rustc_flags = ["-Cprefer-dynamic"],
+)
+
+release_node_linux_arm64_musl, _release_node_linux_arm64_musl_internal = _release_binary(
+    "//crates/formatjs_cli/platforms:linux_aarch64_musl",
+    "linux_aarch64",
+    extra_rustc_flags = ["-Cprefer-dynamic"],
 )
 
 release_binary_linux_x64_gnu, _release_binary_linux_x64_gnu_internal = _release_binary(

--- a/crates/formatjs_cli_napi/release_node.bzl
+++ b/crates/formatjs_cli_napi/release_node.bzl
@@ -6,11 +6,13 @@ load(
     "release_binary_linux_x64",
     "release_binary_linux_x64_gnu",
     "release_binary_windows_x64",
+    _release_node_linux_arm64_musl = "release_node_linux_arm64_musl",
+    _release_node_linux_x64_musl = "release_node_linux_x64_musl",
 )
 
 release_node_darwin_arm64 = release_binary_darwin_arm64
 release_node_linux_arm64 = release_binary_linux_arm64_gnu
-release_node_linux_arm64_musl = release_binary_linux_arm64
+release_node_linux_arm64_musl = _release_node_linux_arm64_musl
 release_node_linux_x64 = release_binary_linux_x64_gnu
-release_node_linux_x64_musl = release_binary_linux_x64
+release_node_linux_x64_musl = _release_node_linux_x64_musl
 release_node_win32_x64 = release_binary_windows_x64


### PR DESCRIPTION
Summary:
- build linux musl native packages through Bazel instead of a raw rust:alpine Docker build
- add node-specific musl release transitions with -Cprefer-dynamic while keeping standalone musl CLI binaries static
- package the musl Rust libstd shared object next to the .node artifact and link with an $ORIGIN rpath so Alpine can load it
- keep the Alpine Docker runtime smoke and reject static-pie .node artifacts
- smoke the static musl standalone CLI on Ubuntu/GNU runners to prove the generic Linux artifact executes there

Test:
- bazel build //packages/cli-native-linux-x64-musl:pkg //packages/cli-native-linux-arm64-musl:pkg //crates/formatjs_cli:release_binary_linux_x64
- bazel test //packages/cli-native-linux-x64-musl:package_exports_test //packages/cli-native-linux-arm64-musl:package_exports_test
- bazel build //crates/formatjs_cli:release_binary_linux_x64
- pre-commit hook: bazel-lock-regen, oxfmt, buildifier, gazelle, generated-dist-packages
- commit-msg hook: commitlint