### PR TITLE
fix(formatjs_cli_napi): package musl runtime library

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,11 +101,15 @@ jobs:
           artifact_info=$(file artifacts/${{ matrix.package }}/formatjs_cli_napi.node)
           echo "$artifact_info"
           case "$artifact_info" in
-            *"static-pie linked"*)
-              echo "musl Node addon must not statically link libc"
+            *"static-pie linked"* | *"statically linked"*)
+              echo "musl Node addon must dynamically link libc"
               exit 1
               ;;
           esac
+          if nm -a artifacts/${{ matrix.package }}/formatjs_cli_napi.node | grep 'init_have_lse_atomics' >/dev/null; then
+            echo "musl Node addon must not run compiler-rt outline atomics init during dlopen"
+            exit 1
+          fi
 
       - name: Smoke Test Package
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,18 +133,15 @@ jobs:
           artifact_info=$(file artifacts/${{ matrix.package }}/formatjs_cli_napi.node)
           echo "$artifact_info"
           case "$artifact_info" in
-            *"static-pie linked"*)
-              echo "musl Node addon must not statically link libc"
+            *"static-pie linked"* | *"statically linked"*)
+              echo "musl Node addon must dynamically link libc"
               exit 1
               ;;
           esac
-
-      - name: Smoke Test Package In Alpine
-        run: |
-          docker run --rm \
-            -v "$PWD/artifacts/${{ matrix.package }}:/native:ro" \
-            node:24-alpine \
-            node -e 'const native = require("/native"); const formatters = native.supportedBuiltinFormatters(); if (!formatters.includes("default")) throw new Error("Missing default formatter"); const output = native.compileMessages([{id: "hello", message: "Hello {name}", sourceFile: "smoke.json"}], {}); if (!output.includes("\"hello\"")) throw new Error(output); console.log(output);'
+          if nm -a artifacts/${{ matrix.package }}/formatjs_cli_napi.node | grep 'init_have_lse_atomics' >/dev/null; then
+            echo "musl Node addon must not run compiler-rt outline atomics init during dlopen"
+            exit 1
+          fi
 
       - name: Smoke Test Static musl CLI On GNU
         run: |
@@ -153,7 +150,7 @@ jobs:
           artifact_info=$(file "$binary_path")
           echo "$artifact_info"
           case "$artifact_info" in
-            *"static-pie linked"*)
+            *"static-pie linked"* | *"statically linked"*)
               ;;
             *)
               echo "linux release CLI should be a static musl binary"
@@ -162,6 +159,13 @@ jobs:
           esac
           "$binary_path" --version
           "$binary_path" --help
+
+      - name: Smoke Test Package In Alpine
+        run: |
+          docker run --rm \
+            -v "$PWD/artifacts/${{ matrix.package }}:/native:ro" \
+            node:24-alpine \
+            node -e 'const native = require("/native"); const formatters = native.supportedBuiltinFormatters(); if (!formatters.includes("default")) throw new Error("Missing default formatter"); const output = native.compileMessages([{id: "hello", message: "Hello {name}", sourceFile: "smoke.json"}], {}); if (!output.includes("\"hello\"")) throw new Error(output); console.log(output);'
 
   windows_smoke:
     name: Windows Smoke Tests

--- a/crates/formatjs_cli/release_binary.bzl
+++ b/crates/formatjs_cli/release_binary.bzl
@@ -70,7 +70,14 @@ release_node_linux_x64_musl, _release_node_linux_x64_musl_internal = _release_bi
 release_node_linux_arm64_musl, _release_node_linux_arm64_musl_internal = _release_binary(
     "//crates/formatjs_cli/platforms:linux_aarch64_musl",
     "linux_aarch64",
-    extra_rustc_flags = ["-Cprefer-dynamic"],
+    # The aarch64 compiler-rt outline atomics initializer calls getauxval from
+    # the statically linked musl archive during dlopen, before Node loads the
+    # addon. Alpine arm64 segfaults there, so keep outline atomics out of the
+    # N-API shared object.
+    extra_rustc_flags = [
+        "-Cprefer-dynamic",
+        "-Ctarget-feature=-outline-atomics",
+    ],
 )
 
 release_binary_linux_x64_gnu, _release_binary_linux_x64_gnu_internal = _release_binary(

--- a/crates/formatjs_cli_napi/BUILD.bazel
+++ b/crates/formatjs_cli_napi/BUILD.bazel
@@ -29,6 +29,14 @@ rust_shared_library(
     srcs = [
         "src/lib.rs",
     ],
+    # The LLVM musl toolchain defaults to a static libc search directory. Node
+    # addons must use Alpine's loaded musl runtime instead of embedding libc.
+    compile_data = select({
+        ":linux_musl": [
+            "@llvm//runtimes/musl:musl_libc.so",
+        ],
+        "//conditions:default": [],
+    }),
     crate_name = "formatjs_cli_napi",
     edition = "2024",
     proc_macro_deps = [
@@ -39,7 +47,10 @@ rust_shared_library(
             "-Clink-arg=-Wl,-undefined,dynamic_lookup",
         ],
         ":linux_musl": [
+            "-Clink-arg=-Wl,-rpath,$$ORIGIN",
             "-Ctarget-feature=-crt-static",
+            "-Clink-arg=-Wl,-Bdynamic",
+            "-Clink-arg=$(location @llvm//runtimes/musl:musl_libc.so)",
         ],
         "//conditions:default": [],
     }),

--- a/crates/formatjs_cli_napi/rust_stdlib.bzl
+++ b/crates/formatjs_cli_napi/rust_stdlib.bzl
@@ -1,0 +1,33 @@
+"""Helpers for packaging Rust runtime libraries with Node addons."""
+
+def _rust_stdlib_shared_library_impl(ctx):
+    stdlibs = [
+        src
+        for src in ctx.files.srcs
+        if src.basename.startswith("libstd-") and src.basename.endswith(".so")
+    ]
+    if len(stdlibs) != 1:
+        fail("expected exactly one libstd-*.so in srcs, got %d" % len(stdlibs))
+
+    stdlib = stdlibs[0]
+    output = ctx.actions.declare_file(stdlib.basename)
+    ctx.actions.run_shell(
+        arguments = [
+            stdlib.path,
+            output.path,
+        ],
+        command = "cp \"$1\" \"$2\"",
+        inputs = [stdlib],
+        outputs = [output],
+    )
+    return [DefaultInfo(files = depset([output]))]
+
+rust_stdlib_shared_library = rule(
+    implementation = _rust_stdlib_shared_library_impl,
+    attrs = {
+        "srcs": attr.label_list(
+            allow_files = True,
+            mandatory = True,
+        ),
+    },
+)

--- a/packages/cli-native-linux-arm64-musl/BUILD.bazel
+++ b/packages/cli-native-linux-arm64-musl/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("//crates/formatjs_cli_napi:rust_stdlib.bzl", "rust_stdlib_shared_library")
 load("//tools:index.bzl", "package_exports_test")
 load("//tools:package_json.bzl", "generate_package_json")
 
@@ -13,6 +14,7 @@ generate_package_json(
     description = "Native FormatJS CLI binding for Linux arm64 musl.",
     files = [
         "formatjs_cli_napi.node",
+        "libstd-*.so",
     ],
     homepage = "https://github.com/formatjs/formatjs",
     libc = [
@@ -36,11 +38,19 @@ copy_file(
     out = "formatjs_cli_napi.node",
 )
 
+rust_stdlib_shared_library(
+    name = "rust_std_lib",
+    srcs = [
+        "@@rules_rs++toolchains+rust_stdlib_aarch64_unknown_linux_musl_1_95_0//:rust_std-aarch64-unknown-linux-musl",
+    ],
+)
+
 npm_package(
     name = "pkg",
     srcs = [
         ":formatjs_cli_napi_node",
         ":generated_package_json",
+        ":rust_std_lib",
     ],
     package = "@formatjs/cli-native-linux-arm64-musl",
     visibility = ["//visibility:public"],

--- a/packages/cli-native-linux-x64-musl/BUILD.bazel
+++ b/packages/cli-native-linux-x64-musl/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("//crates/formatjs_cli_napi:rust_stdlib.bzl", "rust_stdlib_shared_library")
 load("//tools:index.bzl", "package_exports_test")
 load("//tools:package_json.bzl", "generate_package_json")
 
@@ -13,6 +14,7 @@ generate_package_json(
     description = "Native FormatJS CLI binding for Linux x64 musl.",
     files = [
         "formatjs_cli_napi.node",
+        "libstd-*.so",
     ],
     homepage = "https://github.com/formatjs/formatjs",
     libc = [
@@ -36,11 +38,19 @@ copy_file(
     out = "formatjs_cli_napi.node",
 )
 
+rust_stdlib_shared_library(
+    name = "rust_std_lib",
+    srcs = [
+        "@@rules_rs++toolchains+rust_stdlib_x86_64_unknown_linux_musl_1_95_0//:rust_std-x86_64-unknown-linux-musl",
+    ],
+)
+
 npm_package(
     name = "pkg",
     srcs = [
         ":formatjs_cli_napi_node",
         ":generated_package_json",
+        ":rust_std_lib",
     ],
     package = "@formatjs/cli-native-linux-x64-musl",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
Summary:
- package Rust libstd next to the musl .node artifacts introduced by -Cprefer-dynamic
- add an $ORIGIN rpath for musl N-API builds so Alpine can resolve the colocated libstd
- run the static musl standalone CLI smoke before the Alpine package smoke so GNU compatibility is checked independently

Test:
- bazel build //packages/cli-native-linux-x64-musl:pkg //packages/cli-native-linux-arm64-musl:pkg
- bazel test //packages/cli-native-linux-x64-musl:package_exports_test //packages/cli-native-linux-arm64-musl:package_exports_test
- pre-commit hook: bazel-lock-regen, oxfmt, buildifier, gazelle, generated-dist-packages
- commit-msg hook: commitlint