### PR TITLE
ci(formatjs_cli): build release artifacts in opt mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,8 +93,8 @@ jobs:
 
       - name: Build Package
         run: |
-          bazel build //packages/${{ matrix.package }}:pkg
-          package_dir=$(bazel cquery --output=files //packages/${{ matrix.package }}:pkg | tail -n 1)
+          bazel build --compilation_mode=opt //packages/${{ matrix.package }}:pkg
+          package_dir=$(bazel cquery --compilation_mode=opt --output=files //packages/${{ matrix.package }}:pkg | tail -n 1)
           mkdir -p artifacts/${{ matrix.package }}
           cp -R "$package_dir"/. artifacts/${{ matrix.package }}/
 

--- a/.github/workflows/rust-cli-release.yml
+++ b/.github/workflows/rust-cli-release.yml
@@ -41,8 +41,8 @@ jobs:
             //crates/formatjs_cli:release_binary_windows_x64_gnullvm
           )
 
-          bazel_build_args=()
-          bazel_query_args=()
+          bazel_build_args=(--compilation_mode=opt)
+          bazel_query_args=(--compilation_mode=opt)
 
           if [ -n "${{ secrets.BUILDBUDDY_ORG_API_KEY }}" ]; then
             bazel_build_args+=(
@@ -54,9 +54,6 @@ jobs:
               --config=ci
               --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }}
             )
-          else
-            bazel_build_args+=(--compilation_mode=opt)
-            bazel_query_args+=(--compilation_mode=opt)
           fi
 
           bazel build "${bazel_build_args[@]}" "${targets[@]}"


### PR DESCRIPTION
## Summary
- build musl native release packages with explicit Bazel opt mode
- make Rust CLI release build/query args always include opt mode, including BuildBuddy-backed runs

## Verification
- JS_BINARY__CHDIR="/Users/longho/src/formatjs" bazel run //:oxfmt -- .github/workflows/release.yml .github/workflows/rust-cli-release.yml
- bazel build --compilation_mode=opt //packages/cli-native-linux-arm64-musl:pkg //packages/cli-native-linux-x64-musl:pkg
- bazel cquery --compilation_mode=opt --output=files 'set(//packages/cli-native-linux-arm64-musl:pkg //packages/cli-native-linux-x64-musl:pkg)'
- bazel cquery --compilation_mode=opt --output=files 'set(//crates/formatjs_cli:release_binary_darwin_arm64 //crates/formatjs_cli:release_binary_linux_x64 //crates/formatjs_cli:release_binary_linux_arm64 //crates/formatjs_cli:release_binary_windows_x64_gnullvm)'