### PR TITLE
fix(@formatjs/intl-datetimeformat): honor numberingSystem option

### DIFF
--- a/packages/ecma402-abstract/DateTimeFormat/FormatDateTimePattern.ts
+++ b/packages/ecma402-abstract/DateTimeFormat/FormatDateTimePattern.ts
@@ -89,11 +89,13 @@ export function FormatDateTimePattern(
 
   const locale = internalSlots.locale
   const nfOptions = Object.create(null)
+  nfOptions.numberingSystem = internalSlots.numberingSystem
   nfOptions.useGrouping = false
 
   const nf = createMemoizedNumberFormat(locale, nfOptions)
   const nf2Options = Object.create(null)
   nf2Options.minimumIntegerDigits = 2
+  nf2Options.numberingSystem = internalSlots.numberingSystem
   nf2Options.useGrouping = false
   const nf2 = createMemoizedNumberFormat(locale, nf2Options)
   const fractionalSecondDigits = internalSlots.fractionalSecondDigits
@@ -101,6 +103,7 @@ export function FormatDateTimePattern(
   if (fractionalSecondDigits !== undefined) {
     const nf3Options = Object.create(null)
     nf3Options.minimumIntegerDigits = fractionalSecondDigits
+    nf3Options.numberingSystem = internalSlots.numberingSystem
     nf3Options.useGrouping = false
     nf3 = createMemoizedNumberFormat(locale, nf3Options)
   }

--- a/packages/intl-datetimeformat/BUILD.bazel
+++ b/packages/intl-datetimeformat/BUILD.bazel
@@ -17,6 +17,7 @@ PACKAGE_NAME = "intl-datetimeformat"
 
 TEST_LOCALES = [
     "ar",
+    "bn",
     "bs",
     "de",
     "en",
@@ -24,6 +25,8 @@ TEST_LOCALES = [
     "en-CA",
     "ja",
     "ko",
+    "my",
+    "ne",
     "pl",
     "ru",
     "zh-Hans",
@@ -125,6 +128,7 @@ formatjs_test(
         "tests/index.test.ts",
         "tests/offset-timezone.test.ts",
         ":tests-locale-data-ar",  # keep: generated locale data imported by tests
+        ":tests-locale-data-bn",  # keep: generated locale data imported by tests
         ":tests-locale-data-bs",  # keep: generated locale data imported by tests
         ":tests-locale-data-de",  # keep: generated locale data imported by tests
         ":tests-locale-data-en",  # keep: generated locale data imported by tests
@@ -133,6 +137,8 @@ formatjs_test(
         ":tests-locale-data-fa",  # keep: generated locale data imported by tests
         ":tests-locale-data-ja",  # keep: generated locale data imported by tests
         ":tests-locale-data-ko",  # keep: generated locale data imported by tests
+        ":tests-locale-data-my",  # keep: generated locale data imported by tests
+        ":tests-locale-data-ne",  # keep: generated locale data imported by tests
         ":tests-locale-data-nl",  # keep: generated locale data imported by tests
         ":tests-locale-data-pl",  # keep: generated locale data imported by tests
         ":tests-locale-data-ru",  # keep: generated locale data imported by tests

--- a/packages/intl-datetimeformat/scripts/extract-dates.ts
+++ b/packages/intl-datetimeformat/scripts/extract-dates.ts
@@ -184,8 +184,12 @@ async function loadDatesFields(
     caGregorianImport.default.main[locale as 'en'].dates.calendars.gregorian
   const timeZoneNames =
     tznImport.default.main[locale as 'en'].dates.timeZoneNames
-  const nu =
-    numbersImport?.default.main[locale as 'en'].numbers.defaultNumberingSystem
+  const numbers = numbersImport?.default.main[locale as 'en'].numbers
+  const nu = numbers
+    ? numbers.defaultNumberingSystem === 'latn'
+      ? ['latn']
+      : [numbers.defaultNumberingSystem, 'latn']
+    : []
 
   let hc: string[] = []
   let region: string | undefined
@@ -489,7 +493,7 @@ async function loadDatesFields(
     // @ts-ignore
     intervalFormats,
     hourCycle: hc[0],
-    nu: nu ? [nu] : [],
+    nu,
     ca: (
       calendarPreferenceData[region as keyof typeof calendarPreferenceData] ||
       calendarPreferenceData['001']

--- a/packages/intl-datetimeformat/tests/index.test.ts
+++ b/packages/intl-datetimeformat/tests/index.test.ts
@@ -2,15 +2,18 @@ import '@formatjs/intl-getcanonicallocales/polyfill.js'
 import '@formatjs/intl-locale/polyfill.js'
 import {DateTimeFormat} from '#packages/intl-datetimeformat/core'
 import allData from '@formatjs_generated/tz/all-tz.js'
+import bn from '#packages/intl-datetimeformat/tests/locale-data/bn.json' with {type: 'json'}
 import enCA from '#packages/intl-datetimeformat/tests/locale-data/en-CA.json' with {type: 'json'}
 import enGB from '#packages/intl-datetimeformat/tests/locale-data/en-GB.json' with {type: 'json'}
 import en from '#packages/intl-datetimeformat/tests/locale-data/en.json' with {type: 'json'}
 import fa from '#packages/intl-datetimeformat/tests/locale-data/fa.json' with {type: 'json'}
 import ja from '#packages/intl-datetimeformat/tests/locale-data/ja.json' with {type: 'json'}
+import my from '#packages/intl-datetimeformat/tests/locale-data/my.json' with {type: 'json'}
+import ne from '#packages/intl-datetimeformat/tests/locale-data/ne.json' with {type: 'json'}
 import zhHans from '#packages/intl-datetimeformat/tests/locale-data/zh-Hans.json' with {type: 'json'}
 import {describe, expect, it, afterEach} from 'vitest'
 // @ts-ignore
-DateTimeFormat.__addLocaleData(en, enGB, enCA, ja, zhHans, fa)
+DateTimeFormat.__addLocaleData(en, enGB, enCA, ja, zhHans, fa, bn, my, ne)
 DateTimeFormat.__addTZData(allData)
 const DEFAULT_TIMEZONE = DateTimeFormat.getDefaultTimeZone()
 describe('Intl.DateTimeFormat', function () {
@@ -223,6 +226,24 @@ describe('Intl.DateTimeFormat', function () {
         second: 'numeric',
       }).format(Date.UTC(2020, 0, 1, 12, 0, 0))
     ).toBe('1/1/2020, 2:00:00 PM')
+  })
+  it('respects numberingSystem with locales that default to non-latn digits, GH #6767', function () {
+    for (const locale of ['my-MM', 'bn-BD', 'ne-NP']) {
+      const formatter = new DateTimeFormat(locale, {
+        numberingSystem: 'latn',
+        timeZone: 'UTC',
+        year: 'numeric',
+        month: 'numeric',
+        day: 'numeric',
+      })
+      const formatted = formatter.format(Date.UTC(2020, 0, 2))
+
+      expect(formatter.resolvedOptions().numberingSystem).toBe('latn')
+      expect(formatted).toMatch(/[0-9]/)
+      expect(formatted).not.toMatch(
+        /[\u1040-\u1049\u09e6-\u09ef\u0966-\u096f]/u
+      )
+    }
   })
   it('test #2170', function () {
     const formatter = new DateTimeFormat('en-GB', {


### PR DESCRIPTION
Fixes #6767.

## Summary
- allow DateTimeFormat locale data to include latn alongside non-latn defaults
- pass the resolved numberingSystem to internal NumberFormat instances for date parts
- add regression coverage for my-MM, bn-BD, and ne-NP

## Test
- bazel test //packages/intl-datetimeformat:intl-datetimeformat_test --test_output=errors --nocache_test_results