### PR TITLE
fix(@formatjs/intl-durationformat): respect numberingSystem option

### DIFF
--- a/knowledge-base/007g-polyfill-intl-durationformat.md
+++ b/knowledge-base/007g-polyfill-intl-durationformat.md
@@ -25,6 +25,8 @@ Extracts time separator characters per locale and numbering system:
 - Default separator is `:` (colon)
 - Script only includes locales/systems where the separator differs from default
 - Resolves default numbering system per locale
+- Runtime locale data keeps the locale default numbering system first, and adds
+  `latn` when needed for explicit `numberingSystem` overrides.
 
 ### Build Pipeline
 
@@ -56,3 +58,6 @@ export const TIME_SEPARATORS = {
 - **No dynamic locale loading** — data compiled into the main bundle
 - Static import: `import {TIME_SEPARATORS} from './time-separators.generated.js'`
 - Lookup at runtime: `TIME_SEPARATORS.localeData[locale]?.separator[nu] ?? TIME_SEPARATORS.default`
+- `TIME_SEPARATORS.localeData[locale].nu` is the default/alternate set needed
+  by the generator. `core.ts` ensures `latn` is present before calling
+  `ResolveLocale`.

--- a/packages/intl-durationformat/abstract/PartitionDurationFormatPattern.ts
+++ b/packages/intl-durationformat/abstract/PartitionDurationFormatPattern.ts
@@ -27,7 +27,9 @@ export function PartitionDurationFormatPattern(
     throw new TypeError('Invalid locale')
   }
   const numberingSystem = internalSlots.numberingSystem
-  const separator = dataLocaleData.digitalFormat[numberingSystem]
+  const separator =
+    dataLocaleData.digitalFormat[numberingSystem] ??
+    dataLocaleData.digitalFormat.default
 
   for (let i = 0; i < TABLE_2.length && !done; i++) {
     const row = TABLE_2[i]
@@ -83,7 +85,11 @@ export function PartitionDurationFormatPattern(
       if (style === '2-digit') {
         nfOpts.minimumIntegerDigits = 2
       }
-      if (style !== '2-digit' && style !== 'numeric' && style !== 'fractional') {
+      if (
+        style !== '2-digit' &&
+        style !== 'numeric' &&
+        style !== 'fractional'
+      ) {
         nfOpts.style = 'unit'
         nfOpts.unit = numberFormatUnit
         nfOpts.unitDisplay = style

--- a/packages/intl-durationformat/core.ts
+++ b/packages/intl-durationformat/core.ts
@@ -331,15 +331,20 @@ export class DurationFormat implements DurationFormatType {
   ).reduce<Record<string, DurationFormatLocaleInternalData | undefined>>(
     (all, locale) => {
       DurationFormat.availableLocales.add(locale)
-      const nu: readonly string[] = TIME_SEPARATORS.localeData[locale].nu
+      const nu = [...TIME_SEPARATORS.localeData[locale].nu]
+      // ECMA-402 DurationFormat resolves `numberingSystem` through the
+      // locale-data [[nu]] list. Keep the locale default first, but allow the
+      // spec-visible `latn` override even when CLDR only needs the default
+      // numbering system for time-separator data.
+      if (!nu.includes('latn')) {
+        nu.push('latn')
+      }
       all[locale] = {
         nu,
-        digitalFormat:
-          TIME_SEPARATORS.localeData[locale as 'da'].separator ||
-          nu.reduce<Record<string, string>>((separators, n) => {
-            separators[n] = TIME_SEPARATORS.default
-            return separators
-          }, {}),
+        digitalFormat: {
+          default: TIME_SEPARATORS.default,
+          ...TIME_SEPARATORS.localeData[locale as 'da'].separator,
+        },
       }
       return all
     },

--- a/packages/intl-durationformat/tests/index.test.ts
+++ b/packages/intl-durationformat/tests/index.test.ts
@@ -118,6 +118,29 @@ test('Intl.DurationFormat sub-second rollup is exact (#6462)', function () {
   ).toBe('1.473μs')
 })
 
+test('Intl.DurationFormat respects numberingSystem option (#6794)', function () {
+  for (const locale of ['my-MM', 'bn-BD', 'ne-NP']) {
+    const df = new DurationFormat(locale, {numberingSystem: 'latn'})
+    expect(df.resolvedOptions().numberingSystem).toBe('latn')
+    expect(
+      df.formatToParts({years: 1}).find(part => part.type === 'integer')?.value
+    ).toBe('1')
+  }
+  expect(
+    new DurationFormat('my-MM', {
+      hours: 'numeric',
+      minutes: '2-digit',
+      numberingSystem: 'latn',
+      seconds: '2-digit',
+      style: 'digital',
+    }).format({
+      hours: 1,
+      minutes: 2,
+      seconds: 3,
+    })
+  ).toBe('1:02:03')
+})
+
 test('Intl.DurationFormat hours with 2-digit', function () {
   expect(
     new DurationFormat('en', {


### PR DESCRIPTION
Fixes #6794.

DurationFormat resolves the `numberingSystem` option through `ResolveLocale`, so locale data needs to expose `latn` as an allowed `nu` override for locales whose default digits are non-latn. This keeps the locale default first, adds `latn` only when missing, and lets digital formatting fall back to the default `:` separator when the selected numbering system has no locale-specific separator.

Tested:
- bazel test //packages/intl-durationformat:intl-durationformat_test --test_output=errors
- pre-commit hook via git commit
