### PR TITLE
fix(babel-plugin-formatjs): respect throws false for extraction errors

### DIFF
--- a/docs/src/docs/tooling/babel-plugin.mdx
+++ b/docs/src/docs/tooling/babel-plugin.mdx
@@ -191,6 +191,11 @@ Pre-parse `defaultMessage` into AST for faster runtime perf. This flag doesn't d
 
 When set to true, message trimming is disabled.
 
+### **`throws`**
+
+Defaults to `true`. Set to `false` to skip message descriptors that fail
+extraction. Skipped descriptors are left unchanged.
+
 ### **`flatten`**
 
 Whether to hoist selectors & flatten sentences as much as possible. For example:

--- a/packages/babel-plugin-formatjs/tests/fixtures/throwsFalse.js
+++ b/packages/babel-plugin-formatjs/tests/fixtures/throwsFalse.js
@@ -1,0 +1,46 @@
+import React from 'react'
+import {FormattedMessage, defineMessages, useIntl} from 'react-intl'
+
+defineMessages({
+  staticMessage: {
+    defaultMessage: 'Static defineMessages message',
+    description: 'Static defineMessages description',
+  },
+  dynamicId: {
+    id: window.location.hash,
+    defaultMessage: 'Dynamic defineMessages id',
+  },
+})
+
+export function Example({status}) {
+  const intl = useIntl()
+
+  return (
+    <div>
+      {intl.formatMessage({
+        defaultMessage: 'Static formatMessage message',
+        description: 'Static formatMessage description',
+      })}
+      {intl.formatMessage({
+        id: status,
+      })}
+      {intl.formatMessage({
+        defaultMessage: getDynamicMessage(),
+      })}
+      {intl.formatMessage({
+        defaultMessage: intl.formatMessage({
+          defaultMessage: 'Nested static formatMessage message',
+          description: 'Nested static formatMessage description',
+        }),
+      })}
+      <FormattedMessage
+        defaultMessage="Static JSX message"
+        description="Static JSX description"
+      />
+      <FormattedMessage
+        id={`Agent.Details.Status.${status}`}
+        defaultMessage="Dynamic JSX id"
+      />
+    </div>
+  )
+}

--- a/packages/babel-plugin-formatjs/tests/index.test.ts
+++ b/packages/babel-plugin-formatjs/tests/index.test.ts
@@ -221,6 +221,35 @@ test('skipExtractionFormattedMessage', function () {
   transformAndCheck('skipExtractionFormattedMessage')
 })
 
+test('throws defaults to true for non-static descriptors', function () {
+  expect(() => transformAndCheck('throwsFalse')).toThrow(
+    '[React Intl] Messages must be statically evaluate-able for extraction.'
+  )
+})
+
+test('throws false skips non-static descriptors and keeps extracting static ones', function () {
+  const errors: Error[] = []
+  const result = transformAndCheck('throwsFalse', {
+    throws: false,
+    onMsgError(_, error) {
+      errors.push(error)
+    },
+  })
+
+  expect(errors).toHaveLength(5)
+  expect(errors.every(error => error.message.includes('statically'))).toBe(true)
+  expect(result.data.messages.map(message => message.defaultMessage)).toEqual([
+    'Static defineMessages message',
+    'Static formatMessage message',
+    'Nested static formatMessage message',
+    'Static JSX message',
+  ])
+  expect(result.code).toContain('id: window.location.hash')
+  expect(result.code).toContain('id: status')
+  expect(result.code).toContain('defaultMessage: getDynamicMessage()')
+  expect(result.code).toContain('Agent.Details.Status.')
+})
+
 // See: https://github.com/formatjs/formatjs/issues/3589#issuecomment-1532461569
 test('jsxNestedInCallExpr', () => {
   transformAndCheck('jsxNestedInCallExpr')

--- a/packages/babel-plugin-formatjs/types.ts
+++ b/packages/babel-plugin-formatjs/types.ts
@@ -44,4 +44,6 @@ export interface Options {
   ast?: boolean
   preserveWhitespace?: boolean
   flatten?: boolean
+  throws?: boolean
+  onMsgError?: (filePath: string, error: Error) => void
 }

--- a/packages/babel-plugin-formatjs/visitors/call-expression.ts
+++ b/packages/babel-plugin-formatjs/visitors/call-expression.ts
@@ -1,6 +1,8 @@
 import {type NodePath, type PluginPass} from '@babel/core'
 import * as t from '@babel/types'
 import {
+  type MessageDescriptor,
+  type MessageDescriptorPath,
   type Options,
   type State,
 } from '#packages/babel-plugin-formatjs/types.js'
@@ -75,6 +77,8 @@ export const visitor: VisitNodeFunction<PluginPass & State, t.CallExpression> =
       ast,
       preserveWhitespace,
       flatten,
+      throws,
+      onMsgError,
     } = opts as Options
     if (wasExtracted(path)) {
       return
@@ -96,31 +100,41 @@ export const visitor: VisitNodeFunction<PluginPass & State, t.CallExpression> =
         'properties'
       ) as NodePath<t.ObjectProperty>[]
 
-      const descriptorPath = createMessageDescriptor(
-        properties.map(
-          prop =>
-            [prop.get('key'), prop.get('value')] as [
-              NodePath<t.Identifier>,
-              NodePath<t.StringLiteral>,
-            ]
+      let descriptorPath: MessageDescriptorPath
+      let descriptor: MessageDescriptor
+      try {
+        descriptorPath = createMessageDescriptor(
+          properties.map(
+            prop =>
+              [prop.get('key'), prop.get('value')] as [
+                NodePath<t.Identifier>,
+                NodePath<t.StringLiteral>,
+              ]
+          )
         )
-      )
 
-      // If the message is already compiled, don't re-compile it
-      if (descriptorPath.defaultMessage?.isArrayExpression()) {
-        return
+        // If the message is already compiled, don't re-compile it
+        if (descriptorPath.defaultMessage?.isArrayExpression()) {
+          return
+        }
+
+        descriptor = evaluateMessageDescriptor(
+          descriptorPath,
+          false,
+          filename || undefined,
+          idInterpolationPattern,
+          overrideIdFn,
+          preserveWhitespace,
+          flatten
+        )
+      } catch (e) {
+        if (throws === false) {
+          tagAsExtracted(path)
+          onMsgError?.(filename || '', e as Error)
+          return
+        }
+        throw e
       }
-
-      // Evaluate the Message Descriptor values, then store it.
-      const descriptor = evaluateMessageDescriptor(
-        descriptorPath,
-        false,
-        filename || undefined,
-        idInterpolationPattern,
-        overrideIdFn,
-        preserveWhitespace,
-        flatten
-      )
       storeMessage(
         descriptor,
         messageDescriptor,

--- a/packages/babel-plugin-formatjs/visitors/jsx-opening-element.ts
+++ b/packages/babel-plugin-formatjs/visitors/jsx-opening-element.ts
@@ -1,6 +1,8 @@
 import {type NodePath, type PluginPass} from '@babel/core'
 
 import {
+  type MessageDescriptor,
+  type MessageDescriptorPath,
   type Options,
   type State,
 } from '#packages/babel-plugin-formatjs/types.js'
@@ -35,6 +37,8 @@ export const visitor: VisitNodeFunction<
     ast,
     preserveWhitespace,
     flatten,
+    throws,
+    onMsgError,
   } = opts as Options
 
   const {componentNames, messages} = this
@@ -52,36 +56,45 @@ export const visitor: VisitNodeFunction<
     .get('attributes')
     .filter(attr => attr.isJSXAttribute())
 
-  const descriptorPath = createMessageDescriptor(
-    attributes.map(attr => [
-      attr.get('name') as NodePath<t.JSXIdentifier>,
-      attr.get('value') as
-        | NodePath<t.StringLiteral>
-        | NodePath<t.JSXExpressionContainer>,
-    ])
-  )
+  let descriptorPath: MessageDescriptorPath
+  let descriptor: MessageDescriptor
+  try {
+    descriptorPath = createMessageDescriptor(
+      attributes.map(attr => [
+        attr.get('name') as NodePath<t.JSXIdentifier>,
+        attr.get('value') as
+          | NodePath<t.StringLiteral>
+          | NodePath<t.JSXExpressionContainer>,
+      ])
+    )
 
-  // In order for a default message to be extracted when
-  // declaring a JSX element, it must be done with standard
-  // `key=value` attributes. But it's completely valid to
-  // write `<FormattedMessage {...descriptor} />`, because it will be
-  // skipped here and extracted elsewhere. The descriptor will
-  // be extracted only (storeMessage) if a `defaultMessage` prop.
-  if (!descriptorPath.defaultMessage) {
-    return
+    // In order for a default message to be extracted when
+    // declaring a JSX element, it must be done with standard
+    // `key=value` attributes. But it's completely valid to
+    // write `<FormattedMessage {...descriptor} />`, because it will be
+    // skipped here and extracted elsewhere. The descriptor will
+    // be extracted only (storeMessage) if a `defaultMessage` prop.
+    if (!descriptorPath.defaultMessage) {
+      return
+    }
+
+    descriptor = evaluateMessageDescriptor(
+      descriptorPath,
+      true,
+      filename || undefined,
+      idInterpolationPattern,
+      overrideIdFn,
+      preserveWhitespace,
+      flatten
+    )
+  } catch (e) {
+    if (throws === false) {
+      tagAsExtracted(path)
+      onMsgError?.(filename || '', e as Error)
+      return
+    }
+    throw e
   }
-
-  // Evaluate the Message Descriptor values in a JSX
-  // context, then store it.
-  const descriptor = evaluateMessageDescriptor(
-    descriptorPath,
-    true,
-    filename || undefined,
-    idInterpolationPattern,
-    overrideIdFn,
-    preserveWhitespace,
-    flatten
-  )
 
   storeMessage(
     descriptor,


### PR DESCRIPTION
## Summary
- honor the existing `throws: false` escape hatch in babel-plugin-formatjs descriptor extraction
- skip failed descriptors before mutating the AST and report them through `onMsgError`
- add Babel coverage for default fail-fast behavior and mixed static/non-static descriptors
- document the Babel plugin `throws` option

Refs #6791

## Test plan
- `bazel test //packages/babel-plugin-formatjs:babel-plugin-formatjs_test //packages/ts-transformer:ts-transformer_test //packages/unplugin:unplugin_test --test_output=errors`