### PR TITLE
fix(react-intl): support react 18 peer range

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -48,7 +48,16 @@ npm.npm_translate_lock(
     patch_args = {"*": ["-p1"]},
     pnpm_lock = "//:pnpm-lock.yaml",
 )
-use_repo(npm, "npm")
+npm.npm_translate_lock(
+    name = "react18_npm",
+    data = [
+        "//packages/react-intl/tests/react18-typecheck:package.json",
+        "//packages/react-intl/tests/react18-typecheck:pnpm-workspace.yaml",
+    ],
+    npmrc = "//:.npmrc",
+    pnpm_lock = "//packages/react-intl/tests/react18-typecheck:pnpm-lock.yaml",
+)
+use_repo(npm, "npm", "react18_npm")
 
 pnpm = use_extension("@aspect_rules_js//npm:extensions.bzl", "pnpm")
 

--- a/packages/react-intl/BUILD.bazel
+++ b/packages/react-intl/BUILD.bazel
@@ -151,6 +151,10 @@ formatjs_library(
     ],
     license = "BSD-3-Clause",
     npm_package_name = PACKAGE_NAME,
+    package_dependency_version_overrides = {
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+    },
     package_peer_deps = [
         "//:node_modules/@types/react",
         "//:node_modules/react",

--- a/packages/react-intl/index.ts
+++ b/packages/react-intl/index.ts
@@ -102,7 +102,7 @@ export const FormattedNumber: React.FC<
 > = createFormattedComponent('formatNumber')
 export const FormattedList: React.FC<
   Intl.ListFormatOptions & {
-    value: readonly React.ReactNode[]
+    value: Parameters<IntlShape['formatList']>[0]
   }
 > = createFormattedComponent('formatList')
 export const FormattedDisplayName: React.FC<

--- a/packages/react-intl/tests/react18-typecheck/BUILD.bazel
+++ b/packages/react-intl/tests/react18-typecheck/BUILD.bazel
@@ -1,0 +1,32 @@
+# gazelle:ignore
+
+load("@aspect_rules_js//npm:defs.bzl", "npm_link_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@react18_npm//:defs.bzl", react18_npm_link_all_packages = "npm_link_all_packages")
+
+react18_npm_link_all_packages()
+
+npm_link_package(
+    name = "node_modules/react-intl",
+    src = "//packages/react-intl:pkg",
+)
+
+COMMON_DEPS = [
+    ":node_modules/@formatjs/icu-messageformat-parser",
+    ":node_modules/@formatjs/intl",
+    ":node_modules/@types/react",
+    ":node_modules/@types/react-dom",
+    ":node_modules/intl-messageformat",
+    ":node_modules/react",
+    ":node_modules/react-dom",
+    ":node_modules/react-intl",
+]
+
+ts_project(
+    name = "typecheck",
+    srcs = ["src/index.tsx"],
+    no_emit = True,
+    resolve_json_module = True,
+    tsconfig = "tsconfig.bazel.json",
+    deps = COMMON_DEPS,
+)

--- a/packages/react-intl/tests/react18-typecheck/package.json
+++ b/packages/react-intl/tests/react18-typecheck/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@formatjs-example/react18-typecheck",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "tsc": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@formatjs/icu-messageformat-parser": "3.5.11",
+    "@formatjs/intl": "4.1.13",
+    "intl-messageformat": "11.2.8",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "18.3.23",
+    "@types/react-dom": "18.3.7",
+    "typescript": "6.0.3"
+  },
+  "packageManager": "pnpm@10.4.1"
+}

--- a/packages/react-intl/tests/react18-typecheck/pnpm-lock.yaml
+++ b/packages/react-intl/tests/react18-typecheck/pnpm-lock.yaml
@@ -1,0 +1,146 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@formatjs/icu-messageformat-parser':
+        specifier: 3.5.11
+        version: 3.5.11
+      '@formatjs/intl':
+        specifier: 4.1.13
+        version: 4.1.13
+      intl-messageformat:
+        specifier: 11.2.8
+        version: 11.2.8
+      react:
+        specifier: 18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: 18.3.1
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      '@types/react':
+        specifier: 18.3.23
+        version: 18.3.23
+      '@types/react-dom':
+        specifier: 18.3.7
+        version: 18.3.7(@types/react@18.3.23)
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+
+packages:
+
+  '@formatjs/fast-memoize@3.1.6':
+    resolution: {integrity: sha512-H5aexk1Le7T9TPmscacZ+1pR6CTa2n1wq+HDVGXhH8TzUlQQpeXzZs91dRtmFHrbeNbjPFPfQujUqm7MHgVoXQ==}
+
+  '@formatjs/icu-messageformat-parser@3.5.11':
+    resolution: {integrity: sha512-NVsuNsc2dUVG9+4HBJ/srScxtA/18LqGgwtop/tuN/OIBjVl6QA+0KhfZQddDD9sEh2LeVjLFPGVU3ixa3blcA==}
+
+  '@formatjs/icu-skeleton-parser@2.1.10':
+    resolution: {integrity: sha512-XuSva+8ZGawk8VnD5VD6UeH8KarQ/Z022zgjHDoHmlNiAewstXuuzXc0Hk5pGFSdG+nNw5bfJKXqj1ZXHn9yUA==}
+
+  '@formatjs/intl@4.1.13':
+    resolution: {integrity: sha512-dufOl09iREq8V+laVdlGuyoqNmuzqDvyeA3O3k+0XQfvKJgK8bBWFKqYYWejFMKeOij/4LuPKJA+LsshpXQ4sw==}
+
+  '@types/prop-types@15.7.15':
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
+  '@types/react-dom@18.3.7':
+    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
+    peerDependencies:
+      '@types/react': ^18.0.0
+
+  '@types/react@18.3.23':
+    resolution: {integrity: sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  intl-messageformat@11.2.8:
+    resolution: {integrity: sha512-l323RCl3qJDVQ8U9j74ut/hVMdg3VPsOHpVMDvFfz9qiq4dPO5ooVYFNVUzzrpgG39a+RLzcXyJb8VFgIU+tUA==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+snapshots:
+
+  '@formatjs/fast-memoize@3.1.6': {}
+
+  '@formatjs/icu-messageformat-parser@3.5.11':
+    dependencies:
+      '@formatjs/icu-skeleton-parser': 2.1.10
+
+  '@formatjs/icu-skeleton-parser@2.1.10': {}
+
+  '@formatjs/intl@4.1.13':
+    dependencies:
+      '@formatjs/fast-memoize': 3.1.6
+      '@formatjs/icu-messageformat-parser': 3.5.11
+      intl-messageformat: 11.2.8
+
+  '@types/prop-types@15.7.15': {}
+
+  '@types/react-dom@18.3.7(@types/react@18.3.23)':
+    dependencies:
+      '@types/react': 18.3.23
+
+  '@types/react@18.3.23':
+    dependencies:
+      '@types/prop-types': 15.7.15
+      csstype: 3.2.3
+
+  csstype@3.2.3: {}
+
+  intl-messageformat@11.2.8:
+    dependencies:
+      '@formatjs/fast-memoize': 3.1.6
+      '@formatjs/icu-messageformat-parser': 3.5.11
+
+  js-tokens@4.0.0: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
+  react-dom@18.3.1(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
+
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
+
+  typescript@6.0.3: {}

--- a/packages/react-intl/tests/react18-typecheck/pnpm-workspace.yaml
+++ b/packages/react-intl/tests/react18-typecheck/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+allowBuilds: {}

--- a/packages/react-intl/tests/react18-typecheck/src/index.tsx
+++ b/packages/react-intl/tests/react18-typecheck/src/index.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react'
+import {
+  FormattedDate,
+  FormattedMessage,
+  IntlProvider,
+  createIntl,
+  createIntlCache,
+  defineMessage,
+  useIntl,
+} from 'react-intl'
+import {createIntl as createServerIntl} from 'react-intl/server'
+
+const messages = {
+  title: 'Hello React 18',
+  today: 'Today is {value, date, ::yyyyMMdd}',
+}
+
+declare global {
+  namespace FormatjsIntl {
+    interface Message {
+      ids: keyof typeof messages
+    }
+  }
+}
+
+function Child() {
+  const intl = useIntl()
+  const message = defineMessage({id: 'title', defaultMessage: 'Hello'})
+  return <p>{intl.formatMessage(message)}</p>
+}
+
+function App() {
+  const intl = createIntl({locale: 'en', messages}, createIntlCache())
+  createServerIntl({locale: 'en', messages}, createIntlCache())
+
+  return (
+    <IntlProvider locale="en" messages={messages}>
+      <h1>
+        <FormattedMessage id="title" />
+      </h1>
+      <FormattedDate value={new Date()} />
+      <p>{intl.formatMessage({id: 'today'}, {value: new Date()})}</p>
+      <Child />
+    </IntlProvider>
+  )
+}
+
+;<App />

--- a/packages/react-intl/tests/react18-typecheck/tsconfig.bazel.json
+++ b/packages/react-intl/tests/react18-typecheck/tsconfig.bazel.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": ".",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "ignoreDeprecations": "6.0",
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "lib": ["DOM", "ES2020", "ES2020.Intl", "ES2021.Intl", "ES2022.Intl"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "noFallthroughCasesInSwitch": true,
+    "paths": {
+      "react": ["node_modules/@types/react/index.d.ts"],
+      "react-dom/client": ["node_modules/@types/react-dom/client.d.ts"],
+      "react/jsx-runtime": ["node_modules/@types/react/jsx-runtime.d.ts"]
+    },
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2020",
+    "types": ["react", "react-dom"],
+    "typeRoots": ["node_modules/@types"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- widen react-intl peer deps to allow React 18 or 19
- type FormattedList.value from IntlShape['formatList'] so React 18 types accept it
- add a React 18 Bzlmod ts_project typecheck example and run it in the examples GHA matrix

Fixes #6799

## Test
- cd examples/react18-typecheck && bazel build //...
- cd examples/react18-typecheck && bazel test //... --test_output=errors
- bazel build //packages/react-intl:typecheck_typecheck
- bazel test //packages/react-intl:react-intl_test --test_output=errors
- bazel build //packages/react-intl:package_json //packages/react-intl:pkg