### PR TITLE
fix(@formatjs/icu-messageformat-parser): print plural/select branches in canonical order

### DIFF
--- a/packages/icu-messageformat-parser/printer.ts
+++ b/packages/icu-messageformat-parser/printer.ts
@@ -180,26 +180,63 @@ export function printDateTimeSkeleton(style: DateTimeSkeleton): string {
 }
 
 function printSelectElement(el: SelectElement) {
+  // Sort keys alphabetically for consistent output.
+  // Mirrors write_select_element in crates/icu_messageformat_parser/printer.rs.
+  const keys = Object.keys(el.options).sort()
   const msg = [
     el.value,
     'select',
-    Object.keys(el.options)
-      .map(id => `${id}{${doPrintAST(el.options[id].value, false)}}`)
-      .join(' '),
+    keys.map(id => `${id}{${doPrintAST(el.options[id].value, false)}}`).join(' '),
   ].join(',')
   return `{${msg}}`
 }
 
+/**
+ * Returns the LDML sort order for a plural rule.
+ *
+ * LDML order is: zero, one, two, few, many, other, then =N exact matches sorted
+ * numerically. Returns a [primary, secondary] tuple for sorting.
+ *
+ * Mirrors get_plural_rule_sort_order in crates/icu_messageformat_parser/printer.rs.
+ */
+function getPluralRuleSortOrder(rule: string): [number, number] {
+  switch (rule) {
+    case 'zero':
+      return [0, 0]
+    case 'one':
+      return [1, 0]
+    case 'two':
+      return [2, 0]
+    case 'few':
+      return [3, 0]
+    case 'many':
+      return [4, 0]
+    case 'other':
+      return [5, 0]
+    default: {
+      // Extract the numeric value from exact matches like "=0", "=1".
+      const num = parseInt(rule.replace(/^=+/, ''), 10)
+      // Exact matches come after 'other', sorted numerically.
+      return [6, Number.isNaN(num) ? 0 : num]
+    }
+  }
+}
+
 function printPluralElement(el: PluralElement) {
   const type = el.pluralType === 'cardinal' ? 'plural' : 'selectordinal'
+  // Sort keys in LDML order: zero, one, two, few, many, other, then exact matches.
+  // Mirrors write_plural_element in crates/icu_messageformat_parser/printer.rs.
+  const keys = Object.keys(el.options).sort((a, b) => {
+    const [pa, sa] = getPluralRuleSortOrder(a)
+    const [pb, sb] = getPluralRuleSortOrder(b)
+    return pa - pb || sa - sb
+  })
   const msg = [
     el.value,
     type,
     [
       el.offset ? `offset:${el.offset}` : '',
-      ...Object.keys(el.options).map(
-        id => `${id}{${doPrintAST(el.options[id].value, true)}}`
-      ),
+      ...keys.map(id => `${id}{${doPrintAST(el.options[id].value, true)}}`),
     ]
       .filter(Boolean)
       .join(' '),

--- a/packages/icu-messageformat-parser/printer.ts
+++ b/packages/icu-messageformat-parser/printer.ts
@@ -179,53 +179,59 @@ export function printDateTimeSkeleton(style: DateTimeSkeleton): string {
   return style.pattern
 }
 
-function printSelectElement(el: SelectElement) {
-  // Sort keys alphabetically for consistent output.
-  // Mirrors write_select_element in crates/icu_messageformat_parser/printer.rs.
-  const keys = Object.keys(el.options).sort()
-  const msg = [
-    el.value,
-    'select',
-    keys.map(id => `${id}{${doPrintAST(el.options[id].value, false)}}`).join(' '),
-  ].join(',')
-  return `{${msg}}`
-}
+// Rust string ordering is UTF-8 lexicographic, which matches code point order.
+function compareCodePoints(a: string, b: string): number {
+  const aIter = a[Symbol.iterator]()
+  const bIter = b[Symbol.iterator]()
 
-/**
- * Returns the LDML sort order for a plural rule.
- *
- * LDML order is: zero, one, two, few, many, other, then =N exact matches sorted
- * numerically. Returns a [primary, secondary] tuple for sorting.
- *
- * Mirrors get_plural_rule_sort_order in crates/icu_messageformat_parser/printer.rs.
- */
-function getPluralRuleSortOrder(rule: string): [number, number] {
-  switch (rule) {
-    case 'zero':
-      return [0, 0]
-    case 'one':
-      return [1, 0]
-    case 'two':
-      return [2, 0]
-    case 'few':
-      return [3, 0]
-    case 'many':
-      return [4, 0]
-    case 'other':
-      return [5, 0]
-    default: {
-      // Extract the numeric value from exact matches like "=0", "=1".
-      const num = parseInt(rule.replace(/^=+/, ''), 10)
-      // Exact matches come after 'other', sorted numerically.
-      return [6, Number.isNaN(num) ? 0 : num]
+  while (true) {
+    const aNext = aIter.next()
+    const bNext = bIter.next()
+    if (aNext.done || bNext.done) {
+      return aNext.done === bNext.done ? 0 : aNext.done ? -1 : 1
+    }
+
+    const diff = aNext.value.codePointAt(0)! - bNext.value.codePointAt(0)!
+    if (diff !== 0) {
+      return diff
     }
   }
 }
 
+function printSelectElement(el: SelectElement) {
+  const keys = Object.keys(el.options).sort(compareCodePoints)
+  const msg = [
+    el.value,
+    'select',
+    keys
+      .map(id => `${id}{${doPrintAST(el.options[id].value, false)}}`)
+      .join(' '),
+  ].join(',')
+  return `{${msg}}`
+}
+
+const PLURAL_RULE_ORDER: Record<string, number> = {
+  zero: 0,
+  one: 1,
+  two: 2,
+  few: 3,
+  many: 4,
+  other: 5,
+}
+
+function getPluralRuleSortOrder(rule: string): [number, number] {
+  const categoryOrder = PLURAL_RULE_ORDER[rule]
+  if (categoryOrder !== undefined) {
+    return [categoryOrder, 0]
+  }
+
+  const exactRule = rule.replace(/^=+/, '')
+  const exactValue = /^[+-]?\d+$/.test(exactRule) ? Number(exactRule) : 0
+  return [6, exactValue]
+}
+
 function printPluralElement(el: PluralElement) {
   const type = el.pluralType === 'cardinal' ? 'plural' : 'selectordinal'
-  // Sort keys in LDML order: zero, one, two, few, many, other, then exact matches.
-  // Mirrors write_plural_element in crates/icu_messageformat_parser/printer.rs.
   const keys = Object.keys(el.options).sort((a, b) => {
     const [pa, sa] = getPluralRuleSortOrder(a)
     const [pb, sb] = getPluralRuleSortOrder(b)

--- a/packages/icu-messageformat-parser/tests/__snapshots__/manipulator.test.ts.snap
+++ b/packages/icu-messageformat-parser/tests/__snapshots__/manipulator.test.ts.snap
@@ -1,29 +1,29 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`should hoist plural & select and tag 1`] = `
-"{count,plural,one{{gender,select,male{{count,plural,one{{gender,select,male{I have a male <b>dog</b>
-             and a male <strong>cat</strong>
-                } female{I have a male <b>dog</b>
+"{count,plural,one{{gender,select,female{{count,plural,one{{gender,select,female{I have a female <b>dog</b>
              and a female <strong>cat</strong>
-                } other{I have a male <b>dog</b>
+                } male{I have a female <b>dog</b>
              and a male <strong>cat</strong>
-                }}} other{I have a male <b>dog</b>
-             and many cats}}} female{{count,plural,one{{gender,select,male{I have a female <b>dog</b>
-             and a male <strong>cat</strong>
-                } female{I have a female <b>dog</b>
-             and a female <strong>cat</strong>
                 } other{I have a female <b>dog</b>
              and a male <strong>cat</strong>
                 }}} other{I have a female <b>dog</b>
-             and many cats}}} other{{count,plural,one{{gender,select,male{I have a male <b>dog</b>
-             and a male <strong>cat</strong>
-                } female{I have a male <b>dog</b>
+             and many cats}}} male{{count,plural,one{{gender,select,female{I have a male <b>dog</b>
              and a female <strong>cat</strong>
+                } male{I have a male <b>dog</b>
+             and a male <strong>cat</strong>
                 } other{I have a male <b>dog</b>
              and a male <strong>cat</strong>
                 }}} other{I have a male <b>dog</b>
-             and many cats}}}}} other{{count,plural,one{{gender,select,male{I have many dogs and a male <strong>cat</strong>
-                } female{I have many dogs and a female <strong>cat</strong>
+             and many cats}}} other{{count,plural,one{{gender,select,female{I have a male <b>dog</b>
+             and a female <strong>cat</strong>
+                } male{I have a male <b>dog</b>
+             and a male <strong>cat</strong>
+                } other{I have a male <b>dog</b>
+             and a male <strong>cat</strong>
+                }}} other{I have a male <b>dog</b>
+             and many cats}}}}} other{{count,plural,one{{gender,select,female{I have many dogs and a female <strong>cat</strong>
+                } male{I have many dogs and a male <strong>cat</strong>
                 } other{I have many dogs and a male <strong>cat</strong>
                 }}} other{I have many dogs and many cats}}}}"
 `;

--- a/packages/icu-messageformat-parser/tests/printer.test.ts
+++ b/packages/icu-messageformat-parser/tests/printer.test.ts
@@ -87,3 +87,40 @@ test('escapes pound signs inside plural literals', function () {
   expect(output).toBe("{count,plural,one{'#' item} other{'#' items}}")
   expect(parse(output)).toEqual(parse(input))
 })
+
+// printAST must emit plural/select branches in a deterministic, source-order-
+// independent order so that auto-generated message ids match the Rust extractor
+// (formatjs_cli) regardless of how branches were authored. See printer.rs:
+// plural -> LDML order (zero, one, two, few, many, other) then =N ascending;
+// select -> keys sorted alphabetically.
+test('sorts plural branches in LDML order with exact matches last', function () {
+  expect(
+    printAST(parse('{count, plural, =0 {No items} one {# item} other {# items}}'))
+  ).toBe('{count,plural,one{# item} other{# items} =0{No items}}')
+})
+
+test('sorts every plural category in LDML order then =N numerically', function () {
+  const input =
+    '{n, plural, other {O} =5 {F5} many {M} =0 {Z0} few {W} two {T} one {N1} zero {ZZ} =2 {E2}}'
+  expect(printAST(parse(input))).toBe(
+    '{n,plural,zero{ZZ} one{N1} two{T} few{W} many{M} other{O} =0{Z0} =2{E2} =5{F5}}'
+  )
+})
+
+test('sorts selectordinal branches in LDML order too', function () {
+  expect(
+    printAST(parse('{n, selectordinal, other {#th} one {#st} two {#nd} few {#rd}}'))
+  ).toBe('{n,selectordinal,one{#st} two{#nd} few{#rd} other{#th}}')
+})
+
+test('sorts select branches alphabetically by key', function () {
+  expect(
+    printAST(parse('{gender, select, male {He} female {She} other {They}}'))
+  ).toBe('{gender,select,female{She} male{He} other{They}}')
+})
+
+test('branch order does not affect printed output (id stability)', function () {
+  const a = '{count, plural, =0 {none} one {one} other {many}}'
+  const b = '{count, plural, other {many} one {one} =0 {none}}'
+  expect(printAST(parse(a))).toBe(printAST(parse(b)))
+})

--- a/packages/icu-messageformat-parser/tests/printer.test.ts
+++ b/packages/icu-messageformat-parser/tests/printer.test.ts
@@ -95,7 +95,9 @@ test('escapes pound signs inside plural literals', function () {
 // select -> keys sorted alphabetically.
 test('sorts plural branches in LDML order with exact matches last', function () {
   expect(
-    printAST(parse('{count, plural, =0 {No items} one {# item} other {# items}}'))
+    printAST(
+      parse('{count, plural, =0 {No items} one {# item} other {# items}}')
+    )
   ).toBe('{count,plural,one{# item} other{# items} =0{No items}}')
 })
 
@@ -109,7 +111,9 @@ test('sorts every plural category in LDML order then =N numerically', function (
 
 test('sorts selectordinal branches in LDML order too', function () {
   expect(
-    printAST(parse('{n, selectordinal, other {#th} one {#st} two {#nd} few {#rd}}'))
+    printAST(
+      parse('{n, selectordinal, other {#th} one {#st} two {#nd} few {#rd}}')
+    )
   ).toBe('{n,selectordinal,one{#st} two{#nd} few{#rd} other{#th}}')
 })
 
@@ -117,6 +121,19 @@ test('sorts select branches alphabetically by key', function () {
   expect(
     printAST(parse('{gender, select, male {He} female {She} other {They}}'))
   ).toBe('{gender,select,female{She} male{He} other{They}}')
+})
+
+test('sorts select branches by Unicode code point order', function () {
+  const privateUse = '\uE000'
+  const astral = '\u{10000}'
+
+  expect(
+    printAST(
+      parse(
+        `{kind, select, ${astral} {Astral} ${privateUse} {Private} other {Other}}`
+      )
+    )
+  ).toBe(`{kind,select,other{Other} ${privateUse}{Private} ${astral}{Astral}}`)
 })
 
 test('branch order does not affect printed output (id stability)', function () {

--- a/packages/unplugin/conformance-tests/cli-unplugin-conformance.test.ts
+++ b/packages/unplugin/conformance-tests/cli-unplugin-conformance.test.ts
@@ -100,6 +100,20 @@ describe('formatjs_cli vs @formatjs/unplugin conformance', () => {
     )
   })
 
+  test('plural with =N exact selector — branches ordered LDML, exact last', async () => {
+    await assertConformance(
+      `intl.formatMessage({defaultMessage: '{count, plural, =0 {No items} one {# item} other {# items}}'})`,
+      'plural-exact-selector.tsx'
+    )
+  })
+
+  test('select with non-alphabetical branches — keys sorted', async () => {
+    await assertConformance(
+      `intl.formatMessage({defaultMessage: '{gender, select, male {He} female {She} other {They}}'})`,
+      'select-unsorted.tsx'
+    )
+  })
+
   test('JSX FormattedMessage with description', async () => {
     await assertConformance(
       `<FormattedMessage defaultMessage="Hello World" description="greeting" />`,

--- a/packages/unplugin/conformance-tests/cli-unplugin-conformance.test.ts
+++ b/packages/unplugin/conformance-tests/cli-unplugin-conformance.test.ts
@@ -114,6 +114,15 @@ describe('formatjs_cli vs @formatjs/unplugin conformance', () => {
     )
   })
 
+  test('select with astral branch key — keys sorted like Rust', async () => {
+    const message =
+      '{kind, select, \u{10000} {Astral} \uE000 {Private} other {Other}}'
+    await assertConformance(
+      `intl.formatMessage({defaultMessage: ${JSON.stringify(message)}})`,
+      'select-astral-key.tsx'
+    )
+  })
+
   test('JSX FormattedMessage with description', async () => {
     await assertConformance(
       `<FormattedMessage defaultMessage="Hello World" description="greeting" />`,


### PR DESCRIPTION
## Summary

`@formatjs/icu-messageformat-parser`'s JS printer emitted plural/select option branches in **source order**, while the Rust extractor (`formatjs_cli`) **sorts** them. With `flatten: true` this made `printAST()` and `print_ast()` produce different strings for the same message, so the content-hash IDs generated by `@formatjs/unplugin` / `babel-plugin-formatjs` diverged from the catalog produced by `formatjs extract` — and the app silently fell back to the source locale for the affected messages.

This makes the JS printer sort branches exactly as the Rust printer does, so IDs match across extract and build regardless of how branches are authored.

Fixes #6801

## Root cause

The Rust printer sorts at print time, in `crates/icu_messageformat_parser/printer.rs`:

- [`write_select_element` → `keys.sort()`](https://github.com/formatjs/formatjs/blob/be289acda0804bd517eca95c6ba04ecfce7dc735/crates/icu_messageformat_parser/printer.rs#L370-L387) — select keys alphabetical;
- [`get_plural_rule_sort_order`](https://github.com/formatjs/formatjs/blob/be289acda0804bd517eca95c6ba04ecfce7dc735/crates/icu_messageformat_parser/printer.rs#L389-L414) + [`write_plural_element`](https://github.com/formatjs/formatjs/blob/be289acda0804bd517eca95c6ba04ecfce7dc735/crates/icu_messageformat_parser/printer.rs#L432-L463) — plural keys in LDML order (`zero, one, two, few, many, other`) then `=N` exact matches numerically.

The JS printer in `packages/icu-messageformat-parser/printer.ts` did not sort — it printed options in source/insertion order. This is the same class as #6177 (whitespace/hoisting, fixed in #6178) and #6593 (escaping, fixed in #6599); branch ordering is the remaining facet of the `printAST` ↔ `print_ast` round-trip that still diverged.

## What changed

- **`printer.ts`** — `printSelectElement` / `printPluralElement` now sort option keys, as a near line-for-line port of `printer.rs` (`getPluralRuleSortOrder` mirrors the Rust `match`). JS-only: the Rust printer already produces this order, so there's no Rust change.
- **Tests** — printer unit tests (LDML plural order, `=N` numeric ordering, `selectordinal`, alphabetical `select`, and a branch-order-independence/ID-stability test), plus two `cli-unplugin-conformance` cases (a plural with an `=N` exact selector, and a `select` with non-alphabetical branches) that **fail before** this change and **pass after**.
- One existing hoist snapshot updated — a pure reorder, identical content.

Same approach as #6599: fix it in the printer, keep the TS and Rust printers aligned, and cover it with a CLI↔unplugin conformance case.

## Is it breaking?

- **Runtime: no.** Branch order never affects ICU evaluation (`=N` exact still wins over keyword categories; lookup is by key). `react-intl` output is unchanged.
- **Generated IDs: change only** for `flatten: true` messages whose branches weren't already in canonical order. For the common "build with a JS plugin + extract the catalog with `formatjs_cli`" setup this is a **fix** — the build's IDs realign to the catalog the CLI already emits. For setups that flatten on **both** sides via JS (e.g. extract + build both via `babel-plugin-formatjs`), affected IDs shift and a re-extract is needed. So it warrants a "re-run extraction" note in the changelog; it is not runtime-breaking.

## Test plan

- `bazel test //packages/icu-messageformat-parser:icu-messageformat-parser_test`
- `bazel test //packages/unplugin:conformance_test` — the two new cases are red before this change, green after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
