### PR TITLE
test(react-intl): add React 17 typecheck fixture

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -49,6 +49,15 @@ npm.npm_translate_lock(
     pnpm_lock = "//:pnpm-lock.yaml",
 )
 npm.npm_translate_lock(
+    name = "react17_npm",
+    data = [
+        "//packages/react-intl/tests/react17-typecheck:package.json",
+        "//packages/react-intl/tests/react17-typecheck:pnpm-workspace.yaml",
+    ],
+    npmrc = "//:.npmrc",
+    pnpm_lock = "//packages/react-intl/tests/react17-typecheck:pnpm-lock.yaml",
+)
+npm.npm_translate_lock(
     name = "react18_npm",
     data = [
         "//packages/react-intl/tests/react18-typecheck:package.json",
@@ -57,7 +66,7 @@ npm.npm_translate_lock(
     npmrc = "//:.npmrc",
     pnpm_lock = "//packages/react-intl/tests/react18-typecheck:pnpm-lock.yaml",
 )
-use_repo(npm, "npm", "react18_npm")
+use_repo(npm, "npm", "react17_npm", "react18_npm")
 
 pnpm = use_extension("@aspect_rules_js//npm:extensions.bzl", "pnpm")
 

--- a/packages/react-intl/tests/react17-typecheck/BUILD.bazel
+++ b/packages/react-intl/tests/react17-typecheck/BUILD.bazel
@@ -1,0 +1,32 @@
+# gazelle:ignore
+
+load("@aspect_rules_js//npm:defs.bzl", "npm_link_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@react17_npm//:defs.bzl", react17_npm_link_all_packages = "npm_link_all_packages")
+
+react17_npm_link_all_packages()
+
+npm_link_package(
+    name = "node_modules/react-intl",
+    src = "//packages/react-intl:pkg",
+)
+
+COMMON_DEPS = [
+    ":node_modules/@formatjs/icu-messageformat-parser",
+    ":node_modules/@formatjs/intl",
+    ":node_modules/@types/react",
+    ":node_modules/@types/react-dom",
+    ":node_modules/intl-messageformat",
+    ":node_modules/react",
+    ":node_modules/react-dom",
+    ":node_modules/react-intl",
+]
+
+ts_project(
+    name = "typecheck",
+    srcs = ["src/index.tsx"],
+    no_emit = True,
+    resolve_json_module = True,
+    tsconfig = "tsconfig.bazel.json",
+    deps = COMMON_DEPS,
+)

--- a/packages/react-intl/tests/react17-typecheck/package.json
+++ b/packages/react-intl/tests/react17-typecheck/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@formatjs-example/react17-typecheck",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "tsc": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@formatjs/icu-messageformat-parser": "3.5.11",
+    "@formatjs/intl": "4.1.13",
+    "intl-messageformat": "11.2.8",
+    "react": "17.0.2",
+    "react-dom": "17.0.2"
+  },
+  "devDependencies": {
+    "@types/react": "17.0.93",
+    "@types/react-dom": "17.0.26",
+    "typescript": "6.0.3"
+  },
+  "packageManager": "pnpm@10.4.1"
+}

--- a/packages/react-intl/tests/react17-typecheck/pnpm-lock.yaml
+++ b/packages/react-intl/tests/react17-typecheck/pnpm-lock.yaml
@@ -1,0 +1,161 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@formatjs/icu-messageformat-parser':
+        specifier: 3.5.11
+        version: 3.5.11
+      '@formatjs/intl':
+        specifier: 4.1.13
+        version: 4.1.13
+      intl-messageformat:
+        specifier: 11.2.8
+        version: 11.2.8
+      react:
+        specifier: 17.0.2
+        version: 17.0.2
+      react-dom:
+        specifier: 17.0.2
+        version: 17.0.2(react@17.0.2)
+    devDependencies:
+      '@types/react':
+        specifier: 17.0.93
+        version: 17.0.93
+      '@types/react-dom':
+        specifier: 17.0.26
+        version: 17.0.26(@types/react@17.0.93)
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+
+packages:
+
+  '@formatjs/fast-memoize@3.1.6':
+    resolution: {integrity: sha512-H5aexk1Le7T9TPmscacZ+1pR6CTa2n1wq+HDVGXhH8TzUlQQpeXzZs91dRtmFHrbeNbjPFPfQujUqm7MHgVoXQ==}
+
+  '@formatjs/icu-messageformat-parser@3.5.11':
+    resolution: {integrity: sha512-NVsuNsc2dUVG9+4HBJ/srScxtA/18LqGgwtop/tuN/OIBjVl6QA+0KhfZQddDD9sEh2LeVjLFPGVU3ixa3blcA==}
+
+  '@formatjs/icu-skeleton-parser@2.1.10':
+    resolution: {integrity: sha512-XuSva+8ZGawk8VnD5VD6UeH8KarQ/Z022zgjHDoHmlNiAewstXuuzXc0Hk5pGFSdG+nNw5bfJKXqj1ZXHn9yUA==}
+
+  '@formatjs/intl@4.1.13':
+    resolution: {integrity: sha512-dufOl09iREq8V+laVdlGuyoqNmuzqDvyeA3O3k+0XQfvKJgK8bBWFKqYYWejFMKeOij/4LuPKJA+LsshpXQ4sw==}
+
+  '@types/prop-types@15.7.15':
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
+  '@types/react-dom@17.0.26':
+    resolution: {integrity: sha512-Z+2VcYXJwOqQ79HreLU/1fyQ88eXSSFh6I3JdrEHQIfYSI0kCQpTGvOrbE6jFGGYXKsHuwY9tBa/w5Uo6KzrEg==}
+    peerDependencies:
+      '@types/react': ^17.0.0
+
+  '@types/react@17.0.93':
+    resolution: {integrity: sha512-KM4Ty/ZTLZupiYxZVAlP+InNJS3De6uBMdq0ePa6/04+eG9Y7ftnWfst1xTLQ5rwAhgHwQ4momt/O4KepdGBTw==}
+
+  '@types/scheduler@0.16.8':
+    resolution: {integrity: sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  intl-messageformat@11.2.8:
+    resolution: {integrity: sha512-l323RCl3qJDVQ8U9j74ut/hVMdg3VPsOHpVMDvFfz9qiq4dPO5ooVYFNVUzzrpgG39a+RLzcXyJb8VFgIU+tUA==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  react-dom@17.0.2:
+    resolution: {integrity: sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==}
+    peerDependencies:
+      react: 17.0.2
+
+  react@17.0.2:
+    resolution: {integrity: sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==}
+    engines: {node: '>=0.10.0'}
+
+  scheduler@0.20.2:
+    resolution: {integrity: sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==}
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+snapshots:
+
+  '@formatjs/fast-memoize@3.1.6': {}
+
+  '@formatjs/icu-messageformat-parser@3.5.11':
+    dependencies:
+      '@formatjs/icu-skeleton-parser': 2.1.10
+
+  '@formatjs/icu-skeleton-parser@2.1.10': {}
+
+  '@formatjs/intl@4.1.13':
+    dependencies:
+      '@formatjs/fast-memoize': 3.1.6
+      '@formatjs/icu-messageformat-parser': 3.5.11
+      intl-messageformat: 11.2.8
+
+  '@types/prop-types@15.7.15': {}
+
+  '@types/react-dom@17.0.26(@types/react@17.0.93)':
+    dependencies:
+      '@types/react': 17.0.93
+
+  '@types/react@17.0.93':
+    dependencies:
+      '@types/prop-types': 15.7.15
+      '@types/scheduler': 0.16.8
+      csstype: 3.2.3
+
+  '@types/scheduler@0.16.8': {}
+
+  csstype@3.2.3: {}
+
+  intl-messageformat@11.2.8:
+    dependencies:
+      '@formatjs/fast-memoize': 3.1.6
+      '@formatjs/icu-messageformat-parser': 3.5.11
+
+  js-tokens@4.0.0: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
+  object-assign@4.1.1: {}
+
+  react-dom@17.0.2(react@17.0.2):
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react: 17.0.2
+      scheduler: 0.20.2
+
+  react@17.0.2:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+
+  scheduler@0.20.2:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+
+  typescript@6.0.3: {}

--- a/packages/react-intl/tests/react17-typecheck/pnpm-workspace.yaml
+++ b/packages/react-intl/tests/react17-typecheck/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+allowBuilds: {}

--- a/packages/react-intl/tests/react17-typecheck/src/index.tsx
+++ b/packages/react-intl/tests/react17-typecheck/src/index.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react'
+import {
+  FormattedDate,
+  FormattedMessage,
+  IntlProvider,
+  createIntl,
+  createIntlCache,
+  defineMessage,
+  useIntl,
+} from 'react-intl'
+import {createIntl as createServerIntl} from 'react-intl/server'
+
+const messages = {
+  title: 'Hello React 17',
+  today: 'Today is {value, date, ::yyyyMMdd}',
+}
+
+declare global {
+  namespace FormatjsIntl {
+    interface Message {
+      ids: keyof typeof messages
+    }
+  }
+}
+
+function Child() {
+  const intl = useIntl()
+  const message = defineMessage({id: 'title', defaultMessage: 'Hello'})
+  return <p>{intl.formatMessage(message)}</p>
+}
+
+function App() {
+  const intl = createIntl({locale: 'en', messages}, createIntlCache())
+  createServerIntl({locale: 'en', messages}, createIntlCache())
+
+  return (
+    <IntlProvider locale="en" messages={messages}>
+      <h1>
+        <FormattedMessage id="title" />
+      </h1>
+      <FormattedDate value={new Date()} />
+      <p>{intl.formatMessage({id: 'today'}, {value: new Date()})}</p>
+      <Child />
+    </IntlProvider>
+  )
+}
+
+;<App />

--- a/packages/react-intl/tests/react17-typecheck/tsconfig.bazel.json
+++ b/packages/react-intl/tests/react17-typecheck/tsconfig.bazel.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": ".",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "ignoreDeprecations": "6.0",
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "lib": ["DOM", "ES2020", "ES2020.Intl", "ES2021.Intl", "ES2022.Intl"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "noFallthroughCasesInSwitch": true,
+    "paths": {
+      "react": ["node_modules/@types/react/index.d.ts"],
+      "react/jsx-runtime": ["node_modules/@types/react/jsx-runtime.d.ts"]
+    },
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2020",
+    "types": ["react", "react-dom"],
+    "typeRoots": ["node_modules/@types"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add a React 17 consumer typecheck workspace for the packaged react-intl artifact
- register the workspace npm lock in bzlmod alongside the React 18 fixture

## Test
- bazel test //packages/react-intl/tests/react17-typecheck/... //packages/react-intl/tests/react18-typecheck/... --test_output=errors --verbose_failures