### PR TITLE
docs: update upgrade guide to reflect relaxed React 18 support

### DIFF
--- a/docs/src/docs/react-intl/upgrade-guide-8.x.mdx
+++ b/docs/src/docs/react-intl/upgrade-guide-8.x.mdx
@@ -4,6 +4,12 @@
 
 `react-intl` v8 requires React 19. If you are using React 18 or below, stay on `react-intl` v7.
 
+<Admonition type="warning">
+  Starting in
+  [10.1.14](https://github.com/formatjs/formatjs/releases/tag/react-intl%4010.1.14),
+  `react-intl` supports React 18 again.
+</Admonition>
+
 Before:
 
 ```json


### PR DESCRIPTION
## Summary

Add a warning note to the React Intl v8 upgrade guide that React 18 support was restored in `react-intl` 10.1.14.

## Testing

- Not run; docs-only change.