### PR TITLE
chore(deps): fix pnpm install warnings

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -487,8 +487,6 @@ importers:
 
   benchmarks/cli-comparison: {}
 
-  docs: {}
-
   docs:
     devDependencies:
       intl-messageformat:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,8 +9,11 @@ packages:
   - 'benchmarks/*'
   - '!packages/editor'
 
+catalog:
+  vite: ^8.0.0
+
 overrides:
-  '@tailwindcss/vite>vite': $vite
+  '@tailwindcss/vite>vite': 'catalog:'
 
 packageExtensions:
   '@vue/compiler-core':


### PR DESCRIPTION
## Summary
- move the Tailwind/Vite override to pnpm catalog syntax
- remove the duplicate docs importer from pnpm-lock.yaml

## Test
- pnpm i --frozen-lockfile
- bazel build //:node_modules/vite //:node_modules/@tailwindcss/vite