### PR TITLE
fix(@formatjs/intl-relativetimeformat): honor numberingSystem option

### DIFF
--- a/packages/ecma402-abstract/RelativeTimeFormat/InitializeRelativeTimeFormat.ts
+++ b/packages/ecma402-abstract/RelativeTimeFormat/InitializeRelativeTimeFormat.ts
@@ -86,7 +86,9 @@ export function InitializeRelativeTimeFormat(
   const fields = localeData[r.dataLocale]
   invariant(!!fields, `Missing locale data for ${r.dataLocale}`)
   internalSlots.fields = fields
-  internalSlots.numberFormat = createMemoizedNumberFormat(locales)
+  internalSlots.numberFormat = createMemoizedNumberFormat(locales, {
+    numberingSystem: nu,
+  })
   internalSlots.pluralRules = createMemoizedPluralRules(locales)
   internalSlots.numberingSystem = nu
   return rtf

--- a/packages/intl-relativetimeformat/BUILD.bazel
+++ b/packages/intl-relativetimeformat/BUILD.bazel
@@ -18,6 +18,9 @@ TEST_LOCALES = [
     "zh",
     "zh-Hant",
     "zh-Hans",
+    "bn",
+    "my",
+    "ne",
 ]
 
 ENTRY_POINTS = [
@@ -90,6 +93,9 @@ formatjs_test(
         ":tests-locale-data-zh",  # keep: generated locale data imported by tests
         ":tests-locale-data-zh-Hans",  # keep: generated locale data imported by tests
         ":tests-locale-data-zh-Hant",  # keep: generated locale data imported by tests
+        ":tests-locale-data-bn",  # keep: generated locale data imported by tests
+        ":tests-locale-data-my",  # keep: generated locale data imported by tests
+        ":tests-locale-data-ne",  # keep: generated locale data imported by tests
     ],
     no_copy_to_bin = ["//:package.json"],
     tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),

--- a/packages/intl-relativetimeformat/scripts/extract-relative.ts
+++ b/packages/intl-relativetimeformat/scripts/extract-relative.ts
@@ -79,7 +79,17 @@ async function loadRelativeFields(locale: string): Promise<LocaleFieldsData> {
   const dateFileds = dateFiledsImport.default
   const numbers = numbersImport?.default
   const fields = dateFileds.main[locale as 'en'].dates.fields
-  const nu = numbers?.main[locale as 'en'].numbers.defaultNumberingSystem
+  const defaultNumberingSystem =
+    numbers?.main[locale as 'en'].numbers.defaultNumberingSystem
+  // RelativeTimeFormat resolves the `numberingSystem` option through the
+  // locale-data [[nu]] list. Keep the locale default first, but also expose
+  // `latn` so an explicit `numberingSystem: 'latn'` override is honored for
+  // locales whose default digits are non-latn.
+  const nu = defaultNumberingSystem
+    ? defaultNumberingSystem === 'latn'
+      ? ['latn']
+      : [defaultNumberingSystem, 'latn']
+    : []
 
   // Reduce the date fields data down to allowlist of fields needed in the
   // FormatJS libs.
@@ -92,7 +102,7 @@ async function loadRelativeFields(locale: string): Promise<LocaleFieldsData> {
       return relative
     },
     {
-      nu: [nu],
+      nu,
     } as LocaleFieldsData
   )
 }

--- a/packages/intl-relativetimeformat/tests/index.test.ts
+++ b/packages/intl-relativetimeformat/tests/index.test.ts
@@ -8,9 +8,12 @@ import zhHant from '#packages/intl-relativetimeformat/tests/locale-data/zh-Hant.
 import zhHans from '#packages/intl-relativetimeformat/tests/locale-data/zh-Hans.json' with {type: 'json'}
 import en from '#packages/intl-relativetimeformat/tests/locale-data/en.json' with {type: 'json'}
 import enAI from '#packages/intl-relativetimeformat/tests/locale-data/en-AI.json' with {type: 'json'}
+import bn from '#packages/intl-relativetimeformat/tests/locale-data/bn.json' with {type: 'json'}
+import my from '#packages/intl-relativetimeformat/tests/locale-data/my.json' with {type: 'json'}
+import ne from '#packages/intl-relativetimeformat/tests/locale-data/ne.json' with {type: 'json'}
 import RelativeTimeFormat from '#packages/intl-relativetimeformat/index.js'
 import {describe, expect, it} from 'vitest'
-RelativeTimeFormat.__addLocaleData(en, enAI, zh, zhHans, zhHant)
+RelativeTimeFormat.__addLocaleData(en, enAI, zh, zhHans, zhHant, bn, my, ne)
 
 describe('Intl.RelativeTimeFormat', function () {
   it('should lookup zh-CN', function () {
@@ -29,5 +32,18 @@ describe('Intl.RelativeTimeFormat', function () {
     expect(new RelativeTimeFormat('en-AI').format(-1, 'second')).toBe(
       '1 second ago'
     )
+  })
+  it('honors the numberingSystem option for locales that default to non-latn digits', function () {
+    for (const locale of ['my-MM', 'bn-BD', 'ne-NP']) {
+      const rtf = new RelativeTimeFormat(locale, {
+        numberingSystem: 'latn',
+      } as Intl.RelativeTimeFormatOptions)
+      expect(rtf.resolvedOptions().numberingSystem).toBe('latn')
+      const formatted = rtf.format(1, 'day')
+      expect(formatted).toMatch(/[0-9]/)
+      expect(formatted).not.toMatch(
+        /[\u1040-\u1049\u09e6-\u09ef\u0966-\u096f]/u
+      )
+    }
   })
 })


### PR DESCRIPTION
`Intl.RelativeTimeFormat` ignores the `numberingSystem` option for locales whose default digits are non-latn. This is the same gap that was just fixed for `intl-datetimeformat` (#6767 / #6775) and `intl-durationformat` (#6794 / #6795); `intl-relativetimeformat` was left behind.

### Reproduction

```js
new Intl.RelativeTimeFormat('my-MM', {numberingSystem: 'latn'}).format(1, 'day')
```

| | `resolvedOptions().numberingSystem` | `format(1, 'day')` |
|---|---|---|
| native Intl | `latn` | `1 ရက်အတွင်း` |
| polyfill (12.3.10) | `mymr` | `၁ ရက်အတွင်း` |

Same for `bn-BD` (beng) and `ne-NP` (deva): the requested `latn` is silently dropped and the locale's default non-latn digits are used instead.

### Cause

Two parts, matching the datetimeformat/durationformat fixes:

1. `scripts/extract-relative.ts` emits `nu: [defaultNumberingSystem]`, so the generated locale data only advertises the default numbering system. `ResolveLocale` (with `relevantExtensionKeys` `['nu']`) then rejects a requested `numberingSystem: 'latn'` because it is not in the list and falls back to the default, so `resolvedOptions().numberingSystem` ends up wrong.
2. `InitializeRelativeTimeFormat` builds the internal `NumberFormat` with `createMemoizedNumberFormat(locales)` and never passes the resolved numbering system, so even once `nu` resolves correctly the digits stay on the locale default.

### Fix

1. `extract-relative.ts`: keep the locale default first and add `latn` when it is not already present (same shape `extract-dates.ts` got in #6775).
2. `InitializeRelativeTimeFormat`: pass the resolved `nu` to the internal `NumberFormat`.

Both halves are required. With only the data change, `resolvedOptions()` reports `latn` but the digits stay non-latn; with only the runtime change, `latn` is still rejected by `ResolveLocale`. For locales whose default is already `latn`, and for the no-option case, the resolved `nu` equals the locale default, so this is a no-op for existing behavior.

### Test

Added a regression test that loads bn/my/ne data and asserts that an explicit `numberingSystem: 'latn'` gives `resolvedOptions().numberingSystem === 'latn'` and latin digits in the output, mirroring the datetimeformat test. I verified the behavior against the published 12.3.10 polyfill (each half independently reverts to the bug; both together match native `Intl`), but I was not able to run the full bazel suite locally.

This is the `intl-relativetimeformat` counterpart of #6767 and #6794.
