### PR TITLE
fix(@formatjs/icu-messageformat-parser): coalesce adjacent syntax chars when escaping

### DIFF
--- a/conformance-tests/icu4j/BUILD.bazel
+++ b/conformance-tests/icu4j/BUILD.bazel
@@ -17,6 +17,15 @@ java_binary(
 )
 
 java_test(
+    name = "messageformat_escaping_conformance_test",
+    size = "small",
+    srcs = ["MessageFormatEscapingConformanceTest.java"],
+    main_class = "MessageFormatEscapingConformanceTest",
+    test_class = "MessageFormatEscapingConformanceTest",
+    deps = [":icu4j"],
+)
+
+java_test(
     name = "intl_collator_conformance_test",
     size = "small",
     srcs = ["IntlCollatorConformanceTest.java"],

--- a/conformance-tests/icu4j/MessageFormatEscapingConformanceTest.java
+++ b/conformance-tests/icu4j/MessageFormatEscapingConformanceTest.java
@@ -1,0 +1,29 @@
+import com.ibm.icu.text.MessageFormat;
+import com.ibm.icu.util.ULocale;
+import java.text.FieldPosition;
+
+public class MessageFormatEscapingConformanceTest {
+    public static void main(String[] args) {
+        assertFormatsTo("Use '}}' to close", "Use }} to close");
+        assertFormatsTo("Use '}''}' to close", "Use }'} to close");
+    }
+
+    private static void assertFormatsTo(String pattern, String expected) {
+        MessageFormat formatter = new MessageFormat(pattern, ULocale.ENGLISH);
+        String actual = formatter
+            .format(new Object[0], new StringBuffer(), new FieldPosition(0))
+            .toString();
+
+        if (!actual.equals(expected)) {
+            throw new AssertionError(
+                "Expected pattern \""
+                    + pattern
+                    + "\" to format as \""
+                    + expected
+                    + "\", got \""
+                    + actual
+                    + "\""
+            );
+        }
+    }
+}

--- a/crates/icu_messageformat_parser/printer.rs
+++ b/crates/icu_messageformat_parser/printer.rs
@@ -121,10 +121,33 @@ fn find_brace_syntax_end(bytes: &[u8], index: usize) -> usize {
     }
 }
 
+fn flush_quoted_syntax_token(
+    out: &mut String,
+    message: &str,
+    literal_start: &mut usize,
+    quoted_start: &mut Option<usize>,
+    quoted_end: usize,
+) {
+    let Some(start) = *quoted_start else {
+        return;
+    };
+
+    let literal = &message[*literal_start..start];
+    out.push_str(literal);
+    if literal.ends_with('\'') {
+        out.push('\'');
+    }
+    write_quoted_syntax_token(out, &message[start..quoted_end]);
+    *literal_start = quoted_end;
+    *quoted_start = None;
+}
+
 /// Escapes ICU syntax tokens in a literal message string.
 fn write_escaped_message(out: &mut String, message: &str, is_in_plural: bool) {
     let bytes = message.as_bytes();
     let mut literal_start = 0;
+    let mut quoted_start = None;
+    let mut quoted_end = 0;
     let mut i = 0;
 
     while i < bytes.len() {
@@ -137,15 +160,32 @@ fn write_escaped_message(out: &mut String, message: &str, is_in_plural: bool) {
         };
 
         if let Some(end) = end {
-            out.push_str(&message[literal_start..i]);
-            write_quoted_syntax_token(out, &message[i..end]);
-            literal_start = end;
+            if quoted_start.is_some() && i == quoted_end {
+                quoted_end = end;
+            } else {
+                flush_quoted_syntax_token(
+                    out,
+                    message,
+                    &mut literal_start,
+                    &mut quoted_start,
+                    quoted_end,
+                );
+                quoted_start = Some(i);
+                quoted_end = end;
+            }
             i = end;
         } else {
             i += 1;
         }
     }
 
+    flush_quoted_syntax_token(
+        out,
+        message,
+        &mut literal_start,
+        &mut quoted_start,
+        quoted_end,
+    );
     out.push_str(&message[literal_start..]);
 }
 
@@ -468,6 +508,13 @@ fn write_plural_element(out: &mut String, el: &PluralElement) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parser::{Parser, ParserOptions};
+
+    fn parse_message(message: &str) -> Vec<MessageFormatElement> {
+        Parser::new(message, ParserOptions::default())
+            .parse()
+            .expect("message should parse")
+    }
 
     #[test]
     fn test_print_literal() {
@@ -511,6 +558,31 @@ mod tests {
             print_ast(&ast),
             "This is '<b>'HTML'</b>' and '<i>'XML'</i>'."
         );
+    }
+
+    #[test]
+    fn test_print_adjacent_syntax_as_one_quoted_span() {
+        let ast = parse_message("Use }} to close");
+
+        assert_eq!(print_ast(&ast), "Use '}}' to close");
+    }
+
+    #[test]
+    fn test_print_literal_syntax_runs_round_trip() {
+        for input in ["Use }} to close", "a }}< b", "}}}", "<}}", "'{a}{b}'"] {
+            let ast = parse_message(input);
+            let output = print_ast(&ast);
+
+            assert_eq!(parse_message(&output), ast, "printed message: {output}");
+        }
+    }
+
+    #[test]
+    fn test_print_apostrophe_before_quoted_span_round_trip() {
+        let ast = parse_message("a '''}' b");
+        let output = print_ast(&ast);
+
+        assert_eq!(parse_message(&output), ast);
     }
 
     #[test]

--- a/packages/icu-messageformat-parser/printer.ts
+++ b/packages/icu-messageformat-parser/printer.ts
@@ -100,11 +100,42 @@ function findBraceSyntaxEnd(message: string, index: number): number {
 function printEscapedMessage(message: string, isInPlural = false): string {
   let result = ''
   let literalStart = 0
+  // Boundaries of the run of consecutive syntax characters currently being
+  // coalesced, or -1 if no run is open.
+  let runStart = -1
+  let runEnd = -1
+
+  // Adjacent syntax characters must be wrapped in a single `'...'` span. ICU
+  // parses the `''` between two separate spans as an escaped literal
+  // apostrophe, so emitting one span per character (e.g. `'}''}'` for `}}`)
+  // re-parses to a different string. A maximal run of consecutive syntax
+  // characters is quoted once (e.g. `'}}'`).
+  function flushRun() {
+    if (runStart === -1) {
+      return
+    }
+    let prefix = message.slice(literalStart, runStart)
+    // A literal apostrophe immediately before the quoted span would otherwise
+    // pair up with the span's opening apostrophe and be read as an escaped
+    // literal apostrophe, so double it.
+    if (prefix[prefix.length - 1] === "'") {
+      prefix += "'"
+    }
+    result += prefix
+    result += quoteSyntaxToken(message.slice(runStart, runEnd))
+    literalStart = runEnd
+    runStart = -1
+    runEnd = -1
+  }
 
   function quoteToken(start: number, end: number) {
-    result += message.slice(literalStart, start)
-    result += quoteSyntaxToken(message.slice(start, end))
-    literalStart = end
+    // Extend the open run if this token is adjacent to it, otherwise flush the
+    // previous run and start a new one.
+    if (runStart === -1 || start !== runEnd) {
+      flushRun()
+      runStart = start
+    }
+    runEnd = end
   }
 
   for (let i = 0; i < message.length; i++) {
@@ -124,6 +155,7 @@ function printEscapedMessage(message: string, isInPlural = false): string {
     }
   }
 
+  flushRun()
   return result + message.slice(literalStart)
 }
 

--- a/packages/icu-messageformat-parser/printer.ts
+++ b/packages/icu-messageformat-parser/printer.ts
@@ -100,42 +100,33 @@ function findBraceSyntaxEnd(message: string, index: number): number {
 function printEscapedMessage(message: string, isInPlural = false): string {
   let result = ''
   let literalStart = 0
-  // Boundaries of the run of consecutive syntax characters currently being
-  // coalesced, or -1 if no run is open.
-  let runStart = -1
-  let runEnd = -1
+  let quotedStart = -1
+  let quotedEnd = -1
 
-  // Adjacent syntax characters must be wrapped in a single `'...'` span. ICU
-  // parses the `''` between two separate spans as an escaped literal
-  // apostrophe, so emitting one span per character (e.g. `'}''}'` for `}}`)
-  // re-parses to a different string. A maximal run of consecutive syntax
-  // characters is quoted once (e.g. `'}}'`).
-  function flushRun() {
-    if (runStart === -1) {
+  function flushQuotedToken() {
+    if (quotedStart === -1) {
       return
     }
-    let prefix = message.slice(literalStart, runStart)
-    // A literal apostrophe immediately before the quoted span would otherwise
-    // pair up with the span's opening apostrophe and be read as an escaped
-    // literal apostrophe, so double it.
-    if (prefix[prefix.length - 1] === "'") {
-      prefix += "'"
+
+    const literal = message.slice(literalStart, quotedStart)
+    result += literal
+    if (literal.endsWith("'")) {
+      result += "'"
     }
-    result += prefix
-    result += quoteSyntaxToken(message.slice(runStart, runEnd))
-    literalStart = runEnd
-    runStart = -1
-    runEnd = -1
+    result += quoteSyntaxToken(message.slice(quotedStart, quotedEnd))
+    literalStart = quotedEnd
+    quotedStart = -1
   }
 
   function quoteToken(start: number, end: number) {
-    // Extend the open run if this token is adjacent to it, otherwise flush the
-    // previous run and start a new one.
-    if (runStart === -1 || start !== runEnd) {
-      flushRun()
-      runStart = start
+    if (quotedStart !== -1 && start === quotedEnd) {
+      quotedEnd = end
+      return
     }
-    runEnd = end
+
+    flushQuotedToken()
+    quotedStart = start
+    quotedEnd = end
   }
 
   for (let i = 0; i < message.length; i++) {
@@ -155,7 +146,7 @@ function printEscapedMessage(message: string, isInPlural = false): string {
     }
   }
 
-  flushRun()
+  flushQuotedToken()
   return result + message.slice(literalStart)
 }
 

--- a/packages/icu-messageformat-parser/tests/printer.test.ts
+++ b/packages/icu-messageformat-parser/tests/printer.test.ts
@@ -88,6 +88,38 @@ test('escapes pound signs inside plural literals', function () {
   expect(parse(output)).toEqual(parse(input))
 })
 
+// Adjacent syntax characters must be coalesced into a single quoted span.
+// Quoting each one separately (e.g. `'}''}'` for `}}`) is wrong because ICU
+// reads the `''` between the two spans as an escaped literal apostrophe, so the
+// printed message re-parses to a different string.
+test('coalesces adjacent syntax characters into one quoted span', function () {
+  const input = 'Use }} to close'
+  const output = printAST(parse(input, {requiresOtherClause: false}))
+
+  expect(output).toBe("Use '}}' to close")
+  expect(parse(output, {requiresOtherClause: false})).toEqual(
+    parse(input, {requiresOtherClause: false})
+  )
+})
+
+test('round-trips literal runs of syntax characters', function () {
+  for (const input of ['Use }} to close', 'a }}< b', '}}}', '<}}']) {
+    const output = printAST(parse(input, {requiresOtherClause: false}))
+    expect(parse(output, {requiresOtherClause: false})).toEqual(
+      parse(input, {requiresOtherClause: false})
+    )
+  }
+})
+
+test('doubles a literal apostrophe abutting a quoted span', function () {
+  const input = "a '''}' b"
+  const output = printAST(parse(input, {requiresOtherClause: false}))
+
+  expect(parse(output, {requiresOtherClause: false})).toEqual(
+    parse(input, {requiresOtherClause: false})
+  )
+})
+
 // printAST must emit plural/select branches in a deterministic, source-order-
 // independent order so that auto-generated message ids match the Rust extractor
 // (formatjs_cli) regardless of how branches were authored. See printer.rs:

--- a/packages/icu-messageformat-parser/tests/printer.test.ts
+++ b/packages/icu-messageformat-parser/tests/printer.test.ts
@@ -88,10 +88,6 @@ test('escapes pound signs inside plural literals', function () {
   expect(parse(output)).toEqual(parse(input))
 })
 
-// Adjacent syntax characters must be coalesced into a single quoted span.
-// Quoting each one separately (e.g. `'}''}'` for `}}`) is wrong because ICU
-// reads the `''` between the two spans as an escaped literal apostrophe, so the
-// printed message re-parses to a different string.
 test('coalesces adjacent syntax characters into one quoted span', function () {
   const input = 'Use }} to close'
   const output = printAST(parse(input, {requiresOtherClause: false}))
@@ -103,7 +99,13 @@ test('coalesces adjacent syntax characters into one quoted span', function () {
 })
 
 test('round-trips literal runs of syntax characters', function () {
-  for (const input of ['Use }} to close', 'a }}< b', '}}}', '<}}']) {
+  for (const input of [
+    'Use }} to close',
+    'a }}< b',
+    '}}}',
+    '<}}',
+    "'{a}{b}'",
+  ]) {
     const output = printAST(parse(input, {requiresOtherClause: false}))
     expect(parse(output, {requiresOtherClause: false})).toEqual(
       parse(input, {requiresOtherClause: false})

--- a/packages/unplugin/conformance-tests/cli-unplugin-conformance.test.ts
+++ b/packages/unplugin/conformance-tests/cli-unplugin-conformance.test.ts
@@ -165,6 +165,17 @@ describe('formatjs_cli vs @formatjs/unplugin conformance', () => {
     )
   })
 
+  test('adjacent literal syntax stays parseable after flattening', async () => {
+    await assertConformance(
+      `defineMessages({
+  example: {
+    defaultMessage: 'Use }} to close',
+  },
+})`,
+      'adjacent-literal-syntax.tsx'
+    )
+  })
+
   test('TypeScript satisfies expressions are transparent for extraction', async () => {
     await assertConformance(
       `type DefaultMessage = string


### PR DESCRIPTION
## Problem

`printAST` is not round-trip-safe for literal text that contains adjacent syntax characters. `printEscapedMessage` quotes each special character in its own `'...'` span, so two adjacent specials such as `}}` print as `'}''}'`. ICU parses the `''` between the two spans as an escaped literal apostrophe, so the printed string re-parses to a different literal.

```js
import {parse} from '@formatjs/icu-messageformat-parser'
import {printAST} from '@formatjs/icu-messageformat-parser/printer.js'

const src = 'Use }} to close'
const printed = printAST(parse(src, {requiresOtherClause: false}))
// printed === "Use '}''}' to close"
parse(printed, {requiresOtherClause: false})
// literal value === "Use }'} to close"   <- spurious apostrophe, not "Use }} to close"
```

The same happens for any run of adjacent specials (`a }}< b`, `}}}`, `<}}`, two adjacent literal brace groups `{a}{b}`), and for a literal apostrophe sitting directly before a quoted span, which silently pairs with the span's opening apostrophe.

The ICU-correct escaping of `}}` is a single span `'}}'`, which re-parses to `}}`:

```js
parse("'}}'",   {requiresOtherClause: false}) // -> "}}"
parse("'}''}'", {requiresOtherClause: false}) // -> "}'}"
```

## Fix

In `printEscapedMessage`, coalesce a maximal run of consecutive syntax characters into a single `'...'` span instead of emitting one span per character (`}}` -> `'}}'`). A literal apostrophe immediately before a quoted span is doubled so it is not misread as the start of an escape pair. Non-adjacent specials separated by ordinary text are still quoted independently, so existing output like `'<b>'HTML'</b>'` is unchanged.

The invariant restored: for any literal text, `parse(printAST(parse(src)))` yields the same literal value as `parse(src)`.

## Tests

Added cases in `tests/printer.test.ts` asserting the round-trip invariant for `Use }} to close`, `a }}< b`, `}}}`, `<}}`, and a literal apostrophe abutting a quoted span, plus the exact corrected output `Use '}}' to close`. All existing printer tests still pass unchanged.

Diff is limited to `printer.ts` (escaping logic) and `tests/printer.test.ts`. The AST and parser are untouched. Note the Rust mirror in `crates/icu_messageformat_parser/src/printer.rs` has the same per-character quoting and is not covered here.
