### PR TITLE
fix(@formatjs/cli-lib): handle fast-glob esm import

### DIFF
--- a/packages/cli-lib/BUILD.bazel
+++ b/packages/cli-lib/BUILD.bazel
@@ -141,6 +141,7 @@ formatjs_test(
     name = "cli-lib_test",
     srcs = [
         "tests/unit/abort_signal.test.ts",
+        "tests/unit/compile.test.ts",
         "tests/unit/extract.test.ts",
         "tests/unit/gts_extractor.test.ts",
         "tests/unit/hbs_extractor.test.ts",

--- a/packages/cli-lib/cli.ts
+++ b/packages/cli-lib/cli.ts
@@ -1,5 +1,5 @@
 import {program} from 'commander'
-import * as glob from 'fast-glob'
+import glob from 'fast-glob'
 const globSync = glob.sync
 import loudRejection from 'loud-rejection'
 import compile, {

--- a/packages/cli-lib/compile.ts
+++ b/packages/cli-lib/compile.ts
@@ -1,6 +1,6 @@
 import {outputFile} from 'fs-extra/esm'
 import {readFile} from 'fs/promises'
-import * as glob from 'fast-glob'
+import glob from 'fast-glob'
 import * as stringifyNs from 'json-stable-stringify'
 import {resolve} from 'path'
 import {pathToFileURL} from 'url'

--- a/packages/cli-lib/integration-tests/test_esm_imports.mjs
+++ b/packages/cli-lib/integration-tests/test_esm_imports.mjs
@@ -124,6 +124,38 @@ async function testCompileWithAST() {
   console.log('✓ Compile function with AST works correctly')
 }
 
+async function testCompileWithCustomFormatter() {
+  console.log('Testing compile function with custom formatter...')
+
+  const testMessagesFile = join(testDir, 'custom-messages.json')
+  const formatterFile = join(testDir, 'formatter.mjs')
+
+  await writeFile(
+    testMessagesFile,
+    JSON.stringify({
+      hello: 'Hello World',
+    }),
+    'utf8'
+  )
+  await writeFile(
+    formatterFile,
+    `export function compile(messages) {
+  return messages
+}
+`,
+    'utf8'
+  )
+
+  const result = await compile([testMessagesFile], {format: formatterFile})
+  const parsed = JSON.parse(result)
+
+  if (parsed['hello'] !== 'Hello World') {
+    throw new Error('Custom formatter compile result has incorrect value')
+  }
+
+  console.log('✓ Compile function with custom formatter works correctly')
+}
+
 async function main() {
   let exitCode = 0
 
@@ -138,6 +170,9 @@ async function main() {
 
     // Test compile with AST option
     await testCompileWithAST()
+
+    // Test custom formatter path, which resolves glob patterns in ESM
+    await testCompileWithCustomFormatter()
 
     console.log('\n✅ All ESM compatibility tests passed!')
   } catch (error) {

--- a/packages/cli-lib/tests/unit/compile.test.ts
+++ b/packages/cli-lib/tests/unit/compile.test.ts
@@ -1,0 +1,66 @@
+import {mkdtemp, rm, writeFile} from 'fs/promises'
+import {tmpdir} from 'os'
+import {join} from 'path'
+import {afterEach, describe, expect, it, vi} from 'vitest'
+import {compile} from '#packages/cli-lib/compile'
+import {
+  compileMessagesWithNative,
+  type NativeCompileMessage,
+} from '#packages/cli-lib/native.js'
+
+vi.mock('#packages/cli-lib/native.js', () => ({
+  compileMessagesWithNative: vi.fn((messages: NativeCompileMessage[]) =>
+    JSON.stringify(
+      Object.fromEntries(messages.map(({id, message}) => [id, message]))
+    )
+  ),
+  compileWithNative: vi.fn(),
+}))
+
+describe('compile()', () => {
+  let testDir: string | undefined
+
+  afterEach(async () => {
+    vi.clearAllMocks()
+    if (testDir) {
+      await rm(testDir, {force: true, recursive: true})
+      testDir = undefined
+    }
+  })
+
+  it('resolves globbed files for custom formatters', async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'formatjs-cli-lib-'))
+    await writeFile(
+      join(testDir, 'messages.json'),
+      JSON.stringify({hello: 'Hello World'})
+    )
+
+    const result = await compile([join(testDir, '*.json')], {
+      format: {
+        format(messages: unknown) {
+          return messages
+        },
+        compile(messages: unknown) {
+          return messages as Record<string, string>
+        },
+      },
+    })
+
+    expect(JSON.parse(result)).toEqual({hello: 'Hello World'})
+    expect(compileMessagesWithNative).toHaveBeenCalledWith(
+      [
+        {
+          id: 'hello',
+          message: 'Hello World',
+          sourceFile: join(testDir, 'messages.json'),
+        },
+      ],
+      {
+        ast: undefined,
+        ignoreTag: undefined,
+        pseudoLocale: undefined,
+        skipErrors: undefined,
+      }
+    )
+  })
+})


### PR DESCRIPTION
Fixes #6843.

## Summary
- import fast-glob through its default export so the ESM bundle can access sync
- add regression coverage for compile() with custom formatters and globbed files

## Test Plan
- bazel test //packages/cli-lib:cli-lib_test
- bazel build //packages/cli-lib:pkg
- bazel run //:gazelle
- direct Node smoke against bazel-bin/packages/cli-lib/pkg/index.js with FORMATJS_CLI_LIB_NATIVE_PATH