### PR TITLE
fix(@formatjs/intl-datetimeformat): honor hour12 with timeStyle

### DIFF
--- a/packages/ecma402-abstract/DateTimeFormat/DateTimeStyleFormat.ts
+++ b/packages/ecma402-abstract/DateTimeFormat/DateTimeStyleFormat.ts
@@ -3,23 +3,56 @@ import {
   type Formats,
 } from '#packages/ecma402-abstract/types/date-time.js'
 import {invariant} from '#packages/ecma402-abstract/utils.js'
+import {BestFitFormatMatcher} from '#packages/ecma402-abstract/DateTimeFormat/BestFitFormatMatcher.js'
+import {DATE_TIME_PROPS} from '#packages/ecma402-abstract/DateTimeFormat/utils.js'
+
+function getTimeStyleFormat(
+  timeStyle: Intl.DateTimeFormatOptions['timeStyle'],
+  dataLocaleData: DateTimeFormatLocaleInternalData,
+  formats: Formats[],
+  hour12: boolean | undefined
+): Formats | undefined {
+  if (timeStyle === undefined) {
+    return undefined
+  }
+  invariant(
+    timeStyle === 'full' ||
+      timeStyle === 'long' ||
+      timeStyle === 'medium' ||
+      timeStyle === 'short',
+    'invalid timeStyle'
+  )
+  const timeFormat = dataLocaleData.timeFormat[timeStyle]
+  const formatHour12 = timeFormat.hour12 === true
+  if (hour12 === undefined || hour12 === formatHour12) {
+    return timeFormat
+  }
+
+  // Spec: ECMA-402 11.5.1 DateTimeStyleFormat selects the locale style record.
+  // FormatJS impl detail: our data has separate 12/24-hour format records, so
+  // use the implementation-defined matcher from 11.5.3 when 11.1.2 resolves
+  // hour12 to the opposite hc from the default timeStyle pattern.
+  const matcherOptions = {
+    hour12,
+  } as Intl.DateTimeFormatOptions
+  for (const prop of DATE_TIME_PROPS) {
+    const value = timeFormat[prop]
+    if (value !== undefined) {
+      matcherOptions[prop] = value as never
+    }
+  }
+  return BestFitFormatMatcher(matcherOptions, formats)
+}
 
 export function DateTimeStyleFormat(
   dateStyle: Intl.DateTimeFormatOptions['dateStyle'],
   timeStyle: Intl.DateTimeFormatOptions['timeStyle'],
-  dataLocaleData: DateTimeFormatLocaleInternalData
+  dataLocaleData: DateTimeFormatLocaleInternalData,
+  formats: Formats[],
+  hour12?: boolean
 ): Formats {
   let dateFormat: Formats | undefined, timeFormat: Formats | undefined
-  if (timeStyle !== undefined) {
-    invariant(
-      timeStyle === 'full' ||
-        timeStyle === 'long' ||
-        timeStyle === 'medium' ||
-        timeStyle === 'short',
-      'invalid timeStyle'
-    )
-    timeFormat = dataLocaleData.timeFormat[timeStyle]
-  }
+  timeFormat = getTimeStyleFormat(timeStyle, dataLocaleData, formats, hour12)
   if (dateStyle !== undefined) {
     invariant(
       dateStyle === 'full' ||

--- a/packages/ecma402-abstract/DateTimeFormat/InitializeDateTimeFormat.ts
+++ b/packages/ecma402-abstract/DateTimeFormat/InitializeDateTimeFormat.ts
@@ -74,7 +74,7 @@ interface Opt extends Omit<Formats, 'pattern' | 'pattern12'> {
 }
 const TYPE_REGEX = /^[a-z0-9]{3,8}(-[a-z0-9]{3,8})*$/i
 /**
- * https://tc39.es/ecma402/#sec-initializedatetimeformat
+ * https://tc39.es/ecma402/#sec-createdatetimeformat
  * @param dtf DateTimeFormat
  * @param locales locales
  * @param opts options
@@ -331,7 +331,26 @@ export function InitializeDateTimeFormat(
         )
       }
     }
-    bestFormat = DateTimeStyleFormat(dateStyle, timeStyle, dataLocaleData)
+    // Spec: ECMA-402 11.1.2 CreateDateTimeFormat steps 12-14 resolve
+    // hour12 to hc; step 30.5 picks the style format; step 33 stores
+    // [[HourCycle]] when the selected format has [[hour]].
+    // FormatJS impl detail: pass that resolved 12/24 preference through
+    // because our style data is represented as concrete 12/24 patterns.
+    const hc =
+      timeStyle !== undefined
+        ? resolveHourCycle(
+            internalSlots.hourCycle,
+            dataLocaleData.hourCycle,
+            hour12
+          )
+        : undefined
+    bestFormat = DateTimeStyleFormat(
+      dateStyle,
+      timeStyle,
+      dataLocaleData,
+      formats,
+      hc !== undefined ? hc === 'h11' || hc === 'h12' : undefined
+    )
   }
   // IMPL DETAIL START
   // For debugging

--- a/packages/intl-datetimeformat/tests/index.test.ts
+++ b/packages/intl-datetimeformat/tests/index.test.ts
@@ -773,6 +773,53 @@ describe('Intl.DateTimeFormat', function () {
     // 12:00 UTC = 09:00 in Coyhaique (-03:00)
     expect(result).toBe('04/01/2025, 09:00')
   })
+
+  it('honors hour12 with timeStyle, GH #6842', function () {
+    const morning = new Date(Date.UTC(2000, 4, 31, 3, 0))
+    const evening = new Date(Date.UTC(2000, 4, 31, 21, 0))
+
+    expect(
+      new DateTimeFormat('en-US', {
+        timeStyle: 'short',
+        hour12: false,
+        timeZone: 'UTC',
+      }).format(morning)
+    ).toBe('03:00')
+
+    expect(
+      new DateTimeFormat('en-US', {
+        timeStyle: 'short',
+        hour12: false,
+        timeZone: 'UTC',
+      }).format(evening)
+    ).toBe('21:00')
+
+    expect(
+      new DateTimeFormat('en-US', {
+        dateStyle: 'short',
+        timeStyle: 'short',
+        hour12: false,
+        timeZone: 'UTC',
+      }).format(evening)
+    ).toBe('5/31/00, 21:00')
+
+    expect(
+      new DateTimeFormat('en-GB', {
+        timeStyle: 'short',
+        hour12: true,
+        timeZone: 'Europe/London',
+      }).format(evening)
+    ).toBe('10:00 pm')
+
+    expect(
+      new DateTimeFormat('en-GB', {
+        dateStyle: 'short',
+        timeStyle: 'short',
+        hour12: true,
+        timeZone: 'Europe/London',
+      }).format(evening)
+    ).toBe('31/05/2000, 10:00 pm')
+  })
 })
 
 // https://github.com/formatjs/formatjs/issues/6020


### PR DESCRIPTION
Fixes #6842.

## Summary
- pick a timeStyle-compatible alternate skeleton when hour12 asks for the opposite hour cycle
- keep dateStyle/timeStyle connector behavior intact
- add regression coverage for en-US 24-hour style output and en-GB 12-hour style output

## Test Plan
- bazel test //packages/intl-datetimeformat:intl-datetimeformat_test --test_output=errors
- bazel build //packages/intl-datetimeformat:pkg
- bazel run //:gazelle
- direct Node smoke against bazel-bin/packages/intl-datetimeformat/pkg/index.js