### PR TITLE
feat(vue-intl): add t helper

### DIFF
--- a/docs/src/docs/vue-intl.mdx
+++ b/docs/src/docs/vue-intl.mdx
@@ -102,12 +102,14 @@ You can also use our formatters in Vue template by prepending `$` like below:
 
 ```vue
 <template>
+  <p>{{ $t('cart.itemCount', {count}) }}</p>
   <p>{{ $formatNumber(3, {style: 'currency', currency: 'USD'}) }}</p>
 </template>
 ```
 
 We currently support:
 
+- `$t`
 - `$formatMessage`
 - `$formatDate`
 - `$formatTime`

--- a/packages/cli-lib/tests/unit/__snapshots__/vue_extractor.test.ts.snap
+++ b/packages/cli-lib/tests/unit/__snapshots__/vue_extractor.test.ts.snap
@@ -8,9 +8,15 @@ exports[`vue_extractor 1`] = `
     "id": "f6d14",
   },
   {
+    "id": "in.template.id",
+  },
+  {
     "defaultMessage": "in script",
     "description": "in script desc",
     "id": "1ebd4",
+  },
+  {
+    "id": "in.script.id",
   },
 ]
 `;

--- a/packages/cli-lib/tests/unit/extract.test.ts
+++ b/packages/cli-lib/tests/unit/extract.test.ts
@@ -55,6 +55,36 @@ defineMessage({
     })
   })
 
+  it('extracts vue-intl $t calls from Vue SFCs', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'formatjs-cli-lib-'))
+    const filePath = join(tempDir, 'App.vue')
+    await writeFile(
+      filePath,
+      `
+<template>
+  <p>{{ $t('template.title') }}</p>
+  <button :title="$t('button.title')" />
+</template>
+
+<script>
+export default {
+  mounted() {
+    this.$t('script.ready')
+  },
+}
+</script>
+`
+    )
+
+    const result = JSON.parse(await extract([filePath], {throws: true}))
+
+    expect(result).toEqual({
+      'button.title': {},
+      'script.ready': {},
+      'template.title': {},
+    })
+  })
+
   it('uses the native binding for supported extraction options', async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'formatjs-cli-lib-'))
     const filePath = join(tempDir, 'native.ts')

--- a/packages/cli-lib/tests/unit/fixtures/comp.vue
+++ b/packages/cli-lib/tests/unit/fixtures/comp.vue
@@ -7,6 +7,7 @@
       })
     }}
   </p>
+  <p>{{ $t('in.template.id') }}</p>
 </template>
 
 <script>
@@ -14,4 +15,5 @@ intl.formatMessage({
   defaultMessage: 'in script',
   description: 'in script desc',
 })
+this.$t('in.script.id')
 </script>

--- a/packages/eslint-plugin-formatjs/rules/enforce-id.ts
+++ b/packages/eslint-plugin-formatjs/rules/enforce-id.ts
@@ -45,12 +45,13 @@ function checkNode(
     {
       message: {defaultMessage, description, id},
       idPropNode,
+      idValueNode,
       descriptionNode,
       messagePropNode,
       messageDescriptorNode,
     },
   ] of msgs) {
-    if (!idInterpolationPattern && !idPropNode) {
+    if (!idInterpolationPattern && !idPropNode && !idValueNode) {
       context.report({
         node: messageDescriptorNode ?? node,
         messageId: 'enforceId',

--- a/packages/eslint-plugin-formatjs/tests/enforce-default-message.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/enforce-default-message.test.ts
@@ -255,6 +255,14 @@ vueRuleTester.run(`vue-${name}`, rule, {
   ],
   invalid: [
     {
+      code: `<template><p>{{ $t('cart.itemCount') }}</p></template>`,
+      errors: [
+        {
+          messageId: 'defaultMessage',
+        },
+      ],
+    },
+    {
       code: `
       <template>
       <p>{{$formatMessage({

--- a/packages/eslint-plugin-formatjs/tests/enforce-id.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/enforce-id.test.ts
@@ -319,6 +319,18 @@ defineMessages({ example: { defaultMessage: 'example', id: "O7Eu2j" } })`,
 vueRuleTester.run(`vue-${name}`, rule, {
   valid: [
     {
+      code: `<template><p>{{ $t('cart.itemCount') }}</p></template>`,
+    },
+    {
+      code: `<script>
+export default {
+  mounted() {
+    this.$t('script.ready')
+  },
+}
+</script>`,
+    },
+    {
       options,
       code: `<template>
 <p>{{$formatMessage({

--- a/packages/eslint-plugin-formatjs/util.ts
+++ b/packages/eslint-plugin-formatjs/util.ts
@@ -2,13 +2,14 @@ import type {MessageFormatElement} from '@formatjs/icu-messageformat-parser'
 import type {Rule} from 'eslint'
 import type {
   BinaryExpression,
+  CallExpression,
   Expression,
   Node,
   ObjectExpression,
   Property,
   TemplateLiteral,
+  JSXOpeningElement,
 } from 'estree-jsx'
-import type {JSXAttribute, JSXOpeningElement} from 'estree-jsx'
 
 export interface MessageDescriptor {
   id?: string
@@ -28,12 +29,12 @@ export interface Settings {
 }
 export interface MessageDescriptorNodeInfo {
   message: MessageDescriptor
-  messageDescriptorNode: ObjectExpression | JSXOpeningElement
-  messageNode?: Property['value'] | JSXAttribute['value']
-  messagePropNode?: Property | JSXAttribute
-  descriptionNode?: Property['value'] | JSXAttribute['value']
-  idValueNode?: Property['value'] | JSXAttribute['value']
-  idPropNode?: Property | JSXAttribute
+  messageDescriptorNode: Node
+  messageNode?: Node
+  messagePropNode?: Node
+  descriptionNode?: Node
+  idValueNode?: Node
+  idPropNode?: Node
 }
 
 export function getSettings({settings}: Rule.RuleContext): Settings {
@@ -201,6 +202,46 @@ function isMultipleMessageDescriptorDeclaration(node: Node) {
   )
 }
 
+function isShorthandTCall(node: CallExpression) {
+  if (node.callee.type === 'Identifier') {
+    return node.callee.name === '$t'
+  }
+  return (
+    node.callee.type === 'MemberExpression' &&
+    node.callee.property.type === 'Identifier' &&
+    node.callee.property.name === '$t'
+  )
+}
+
+function extractShorthandTDescriptor(
+  node: CallExpression
+): [MessageDescriptorNodeInfo, Expression | undefined] | undefined {
+  const [idArg, values] = node.arguments
+  if (!idArg || idArg.type === 'SpreadElement') {
+    return
+  }
+  if (!isStaticMessageExpression(idArg)) {
+    return
+  }
+  const id = getStaticStringFromMessageExpression(idArg)
+  if (!id) {
+    return
+  }
+  const result: MessageDescriptorNodeInfo = {
+    messageDescriptorNode: node,
+    message: {id},
+    messageNode: undefined,
+    messagePropNode: undefined,
+    descriptionNode: undefined,
+    idValueNode: idArg,
+    idPropNode: undefined,
+  }
+  return [
+    result,
+    values && values.type !== 'SpreadElement' ? values : undefined,
+  ]
+}
+
 export function extractMessageDescriptor(
   node?: Expression
 ): MessageDescriptorNodeInfo | undefined {
@@ -308,19 +349,19 @@ function extractMessageDescriptorFromJSXElement(
     switch (keyName) {
       case 'defaultMessage':
         result.messagePropNode = prop
-        result.messageNode = valueNode
+        result.messageNode = valueNode ?? undefined
         if (value) {
           result.message.defaultMessage = value
         }
         break
       case 'description':
-        result.descriptionNode = valueNode
+        result.descriptionNode = valueNode ?? undefined
         if (value) {
           result.message.description = value
         }
         break
       case 'id':
-        result.idValueNode = valueNode
+        result.idValueNode = valueNode ?? undefined
         result.idPropNode = prop
         if (value) {
           result.message.id = value
@@ -391,6 +432,12 @@ export function extractMessages(
     // We can't really analyze spread element
     if (!args0 || args0.type === 'SpreadElement') {
       return []
+    }
+    const shorthandTDescriptor = isShorthandTCall(node)
+      ? extractShorthandTDescriptor(node)
+      : undefined
+    if (shorthandTDescriptor) {
+      return [shorthandTDescriptor]
     }
     if (
       (!excludeMessageDeclCalls &&

--- a/packages/ts-transformer/BUILD.bazel
+++ b/packages/ts-transformer/BUILD.bazel
@@ -103,6 +103,7 @@ formatjs_test(
         "tests/fixtures/removeDefaultMessage.tsx",
         "tests/fixtures/removeDescription.tsx",
         "tests/fixtures/resourcePath.tsx",
+        "tests/fixtures/shorthandT.tsx",
         "tests/fixtures/stringConcat.tsx",
         "tests/fixtures/templateLiteral.tsx",
         "tests/fixtures/typeAssertions.tsx",

--- a/packages/ts-transformer/tests/fixtures/shorthandT.tsx
+++ b/packages/ts-transformer/tests/fixtures/shorthandT.tsx
@@ -1,0 +1,4 @@
+$t('template.title')
+this.$t(`script.ready`)
+$t('literal.' + 'concat')
+$t(dynamicId)

--- a/packages/ts-transformer/tests/index.test.ts
+++ b/packages/ts-transformer/tests/index.test.ts
@@ -59,6 +59,15 @@ describe('emit asserts for', function () {
     ])
   })
 
+  it('shorthandT', async function () {
+    const output = await compile(join(FIXTURES_DIR, 'shorthandT.tsx'), {})
+    expect(output.msgs).toEqual([
+      {id: 'template.title'},
+      {id: 'script.ready'},
+      {id: 'literal.concat'},
+    ])
+  })
+
   it('defineMessages', async function () {
     const output = await compile(join(FIXTURES_DIR, 'defineMessages.tsx'), {
       pragma: 'react-intl',

--- a/packages/ts-transformer/transform.ts
+++ b/packages/ts-transformer/transform.ts
@@ -678,6 +678,68 @@ function isMemberMethodFormatMessageCall(
   return ts.isIdentifier(method) && fnNames.has(method.text)
 }
 
+function isShorthandTCall(ts: TypeScript, node: typescript.CallExpression) {
+  const method = node.expression
+  if (ts.isIdentifier(method)) {
+    return method.text === '$t'
+  }
+  if (ts.isPropertyAccessExpression(method)) {
+    return method.name.text === '$t'
+  }
+  if (
+    ts.isExpressionWithTypeArguments &&
+    ts.isExpressionWithTypeArguments(method)
+  ) {
+    const expr = method.expression
+    return ts.isPropertyAccessExpression(expr) && expr.name.text === '$t'
+  }
+  return false
+}
+
+function getStaticStringFromExpression(
+  ts: TypeScript,
+  node: typescript.Expression
+): string | undefined {
+  const expression = unwrapTransparentTypeScriptExpression(ts, node)
+  if (
+    ts.isStringLiteral(expression) ||
+    ts.isNoSubstitutionTemplateLiteral(expression)
+  ) {
+    return expression.text
+  }
+  if (ts.isBinaryExpression(expression)) {
+    const [result, isStatic] = evaluateStringConcat(ts, expression)
+    return isStatic ? result : undefined
+  }
+  return undefined
+}
+
+function extractShorthandTDescriptor(
+  ts: TypeScript,
+  node: typescript.CallExpression,
+  {extractSourceLocation}: Opts,
+  sf: typescript.SourceFile
+): MessageDescriptor | undefined {
+  const [idArg] = node.arguments
+  if (!idArg || ts.isSpreadElement(idArg)) {
+    return
+  }
+  const id = getStaticStringFromExpression(ts, idArg)
+  if (!id) {
+    return
+  }
+  const msg = {id}
+  if (extractSourceLocation) {
+    return {
+      ...msg,
+      file: sf.fileName,
+      start: idArg.pos,
+      end: idArg.end,
+    }
+  }
+  return msg
+}
+
 function extractMessageFromJsxComponent(
   ts: TypeScript,
   factory: typescript.NodeFactory,
@@ -828,7 +890,12 @@ function extractMessagesFromCallExpression(
   sf: typescript.SourceFile
 ): typescript.VisitResult<typescript.CallExpression> {
   const {onMsgExtracted, additionalFunctionNames} = opts
-  if (isMultipleMessageDecl(ts, node)) {
+  if (isShorthandTCall(ts, node)) {
+    const msg = extractShorthandTDescriptor(ts, node, opts, sf)
+    if (msg && typeof onMsgExtracted === 'function') {
+      onMsgExtracted(sf.fileName, [msg])
+    }
+  } else if (isMultipleMessageDecl(ts, node)) {
     const [arg, ...restArgs] = node.arguments
     const descriptorsObj = unwrapObjectLiteralExpression(ts, arg)
     if (descriptorsObj) {

--- a/packages/vue-intl/plugin.ts
+++ b/packages/vue-intl/plugin.ts
@@ -3,13 +3,21 @@ import {
   type IntlConfig,
   type IntlFormatters,
   type IntlShape,
+  type MessageDescriptor,
 } from '@formatjs/intl'
 import type {Plugin} from 'vue'
 import {intlKey} from '#packages/vue-intl/injection-key.js'
 
+export type Translate = (
+  id: NonNullable<MessageDescriptor['id']>,
+  values?: Parameters<IntlFormatters['formatMessage']>[1],
+  opts?: Parameters<IntlFormatters['formatMessage']>[2]
+) => ReturnType<IntlFormatters['formatMessage']>
+
 declare module 'vue' {
   interface ComponentCustomProperties {
     $intl: IntlShape
+    $t: Translate
     $formatMessage: IntlFormatters['formatMessage']
     $formatDate: IntlFormatters['formatDate']
     $formatTime: IntlFormatters['formatTime']
@@ -29,6 +37,8 @@ export const createIntl = (options: IntlConfig): Plugin => ({
     const intl = _createIntl(options)
 
     app.config.globalProperties.$intl = intl
+    app.config.globalProperties.$t = (id, values, opts) =>
+      intl.formatMessage({id}, values as never, opts)
     app.config.globalProperties.$formatMessage = intl.formatMessage
     app.config.globalProperties.$formatDate = intl.formatDate
     app.config.globalProperties.$formatTime = intl.formatTime

--- a/packages/vue-intl/tests/index.test.ts
+++ b/packages/vue-intl/tests/index.test.ts
@@ -14,12 +14,10 @@ const Translations = defineComponent({
   <div>
     <h2>
       {{
-        $formatMessage({
-          id: 'foo',
-          defaultMessage: 'Hello',
-        })
+        $t('foo')
       }}
     </h2>
+    <h3>{{ $t('welcome', {name: 'Vue'}) }}</h3>
     <p>
       {{
         $formatNumber(123, {
@@ -88,13 +86,14 @@ test('basic', function () {
           defaultLocale: 'en',
           messages: {
             foo: 'Foo',
+            welcome: 'Hello {name}',
           },
         }),
       ],
     },
   })
 
-  expect(wrapper.text()).toBe('Foo€123.00')
+  expect(wrapper.text()).toBe('FooHello Vue€123.00')
 })
 
 test('injected', function () {


### PR DESCRIPTION
Fixes #3444.

## Summary
- add $t(id, values, opts) to the Vue plugin global properties
- type the helper as a string-id wrapper around formatMessage
- update Vue docs and template coverage

## Test Plan
- bazel test //packages/vue-intl:vue-intl_test --test_output=errors
- bazel build //packages/vue-intl:pkg
- bazel build //docs:docs_metadata
- bazel run //:gazelle