### PR TITLE
fix(@formatjs/icu-skeleton-parser): map e/c weekday counts 4/5/6 to long/narrow/short

### DIFF
--- a/packages/icu-skeleton-parser/date-time.ts
+++ b/packages/icu-skeleton-parser/date-time.ts
@@ -67,7 +67,7 @@ export function parseDateTimeSkeleton(
           throw new RangeError('`e..eee` (weekday) patterns are not supported')
         }
         result.weekday = ['short', 'long', 'narrow', 'short'][
-          len - 4
+          len - 3
         ] as 'short'
         break
       case 'c':
@@ -75,7 +75,7 @@ export function parseDateTimeSkeleton(
           throw new RangeError('`c..ccc` (weekday) patterns are not supported')
         }
         result.weekday = ['short', 'long', 'narrow', 'short'][
-          len - 4
+          len - 3
         ] as 'short'
         break
 

--- a/packages/icu-skeleton-parser/tests/index.test.ts
+++ b/packages/icu-skeleton-parser/tests/index.test.ts
@@ -35,6 +35,24 @@ const dateTimeSkeletonResults = {
     hourCycle: 'h12',
     minute: '2-digit',
   },
+  eeee: {
+    weekday: 'long',
+  },
+  eeeee: {
+    weekday: 'narrow',
+  },
+  eeeeee: {
+    weekday: 'short',
+  },
+  cccc: {
+    weekday: 'long',
+  },
+  ccccc: {
+    weekday: 'narrow',
+  },
+  cccccc: {
+    weekday: 'short',
+  },
   '': {},
 }
 


### PR DESCRIPTION
`parseDateTimeSkeleton` maps the `e` and `c` (local / stand-alone day-of-week) fields one count off. Per the [LDML date field symbol table](https://unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table), counts 4/5/6 are wide/narrow/short — the same widths `E` already uses at those counts. Both branches index `['short', 'long', 'narrow', 'short']` with `len - 4` instead of `len - 3`, so every result is shifted:

```
parseDateTimeSkeleton('eeee')   // {weekday: 'short'}  — should be 'long'
parseDateTimeSkeleton('eeeee')  // {weekday: 'long'}   — should be 'narrow'
parseDateTimeSkeleton('eeeeee') // {weekday: 'narrow'} — should be 'short'
```

`EEEE` already returns `{weekday: 'long'}`, so `eeee` disagreeing with it is the tell. Indexing with `len - 3` matches the table and the existing `E` branch. Adds regression cases for `e`/`c` at counts 4–6.
