### PR TITLE
feat(@formatjs/intl-datetimeformat): update IANA timezone database to 2026c

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -188,7 +188,7 @@ register_toolchains(
 
 http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-IANA_TZ_VERSION = "2026b"
+IANA_TZ_VERSION = "2026c"
 
 CLDR_COMMON_VERSION = "48.1"
 
@@ -202,14 +202,14 @@ http_archive(
 http_archive(
     name = "iana_tzcode",
     build_file = "@//packages/intl-datetimeformat:tzcode.BUILD.bazel",
-    sha256 = "37e9ed8427f5d3521c22fc58e293cbfb043d70eedf1003870b33f363f61ca344",
+    sha256 = "b1cffc3ace4c4c7cd0efba2f7add86ec3d0b79da48bcf03582671fd3c8feace8",
     urls = ["https://data.iana.org/time-zones/releases/tzcode%s.tar.gz" % IANA_TZ_VERSION],
 )
 
 http_archive(
     name = "iana_tzdata",
     build_file = "@//packages/intl-datetimeformat:tzdata.BUILD.bazel",
-    sha256 = "114543d9f19a6bfeb5bca43686aea173d38755a3db1f2eec112647ae92c6f544",
+    sha256 = "e4a178a4477f3d0ea77cc31828ff72aa38feff8d61aa13e7e99e142e9d902be4",
     urls = ["https://data.iana.org/time-zones/releases/tzdata%s.tar.gz" % IANA_TZ_VERSION],
 )
 

--- a/knowledge-base/007b-polyfill-intl-datetimeformat.md
+++ b/knowledge-base/007b-polyfill-intl-datetimeformat.md
@@ -20,7 +20,7 @@ Full polyfill for `Intl.DateTimeFormat` with timezone, calendar, and skeleton su
 | `cldr-numbers-full`  | Number formatting for date components                           |
 | `cldr-core`          | Hour cycle preferences, calendar preferences, metazone mappings |
 | `cldr-bcp47`         | Locale validation                                               |
-| IANA tzdata (v2026b) | Timezone transitions, links/aliases                             |
+| IANA tzdata (v2026c) | Timezone transitions, links/aliases                             |
 
 ### Date/Time Extraction (`scripts/extract-dates.ts`)
 
@@ -42,7 +42,7 @@ Pinned IANA tzdata/tzcode archives from MODULE.bazel
     ↓
 Bazel builds zic/zdump from tzcode with rules_cc
     ↓
-generate_tz_data: run zic, then zdump -c 2100 -v for 418 zones
+generate_tz_data: run zic, then zdump -c 2100 -v for 427 zones
     ↓
 zdump files (raw transition dumps)
     ↓
@@ -52,7 +52,7 @@ process-zdump.ts: parse transitions, pack with base-36 encoding
 @formatjs_generated/tz/links.js (timezone aliases)
 ```
 
-**418 IANA zones** organized by continent, with transitions from historical LMT through year 2100.
+**427 IANA zones** organized by continent, with transitions from historical LMT through year 2100.
 
 **Packing format:**
 
@@ -62,8 +62,8 @@ process-zdump.ts: parse transitions, pack with base-36 encoding
 
 **Two distribution sizes:**
 
-- `add-all-tz.js` — Full 418 zones
-- `add-golden-tz.js` — 121 exemplar zones (smaller bundle)
+- `add-all-tz.js` — Full 427 zones
+- `add-golden-tz.js` — 251 exemplar zones (smaller bundle)
 
 ### Timezone Links (`scripts/link.ts`)
 

--- a/packages/intl-datetimeformat/tests/index.test.ts
+++ b/packages/intl-datetimeformat/tests/index.test.ts
@@ -260,6 +260,19 @@ describe('Intl.DateTimeFormat', function () {
     expect(formatter.format(new Date('2019-10-27T01:00:00.000Z'))).toBe('02')
     expect(formatter.format(new Date('2019-10-27T01:00:00.001Z'))).toBe('02')
   })
+  it.each([
+    ['America/Edmonton', '2026-11-01T09:00:00Z', '03:00'],
+    ['Africa/Casablanca', '2026-09-20T02:00:00Z', '02:00'],
+  ])('uses tzdb 2026c rules for %s, GH #6851', (timeZone, date, expected) => {
+    const formatter = new DateTimeFormat('en-GB', {
+      hour: '2-digit',
+      minute: '2-digit',
+      hourCycle: 'h23',
+      timeZone,
+    })
+
+    expect(formatter.format(new Date(date))).toBe(expected)
+  })
   it('test #2236', function () {
     const date = new Date('2020-09-16T11:55:32.491+02:00')
     const formatter = new DateTimeFormat('en-US', {


### PR DESCRIPTION
## Summary

- update the pinned IANA `tzcode` and `tzdata` archives from 2026b to 2026c
- add coverage for Alberta's permanent UTC-06 and Morocco's permanent UTC
- refresh the timezone pipeline documentation and zone counts

Closes #6851

## Test plan

- [x] `bazel build //packages/intl-datetimeformat:tz_all_tz //packages/intl-datetimeformat:tz_links`
- [x] `bazel test //packages/intl-datetimeformat:intl-datetimeformat_test --test_output=errors`
- [x] `bazel build //packages/intl-datetimeformat:pkg`
- [x] `pnpm t`
