### PR TITLE
fix(deps): update package manifests in release PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -63,6 +63,13 @@ jobs:
             --prefix "$RUNNER_TEMP/release-please" \
             release-please@17.6.0
 
+      - name: Verify Release Please package manifest updates
+        env:
+          NODE_PATH: ${{ runner.temp }}/release-please/node_modules
+        run: >-
+          node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON
+          tools/release-please/config.test.ts
+
       # Release Please owns version/changelog PRs, GitHub release notes, and
       # the release-created signal used for npm publication below.
       - name: Run Release Please

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
-load("@aspect_rules_js//js:defs.bzl", "js_test")
+load("@aspect_rules_js//js:defs.bzl", "js_library", "js_test")
 load("@gazelle//:def.bzl", "gazelle", "gazelle_binary")
 load("@npm//:@commitlint/cli/package_json.bzl", commitlint = "bin")
 load("@npm//:codescythe/package_json.bzl", codescythe = "bin")
@@ -39,6 +39,12 @@ load("//tools:tsconfig.bzl", "BASE_TSCONFIG")
 exports_files(
     ["package.json"],
     visibility = ["//visibility:public"],
+)
+
+js_library(
+    name = "release_please_config",
+    srcs = ["release-please-config.json"],
+    visibility = ["//tools:__pkg__"],
 )
 
 # Root package.json for Node subpath import resolution (#packages/*).

--- a/knowledge-base/001-repo-layout.md
+++ b/knowledge-base/001-repo-layout.md
@@ -115,9 +115,10 @@ Commit-msg hook: `commitlint` validates Conventional Commits format.
 
 Release Please owns version/changelog PRs and GitHub release creation. Its
 GitHub-generated changelog notes include PR titles, PR links, and contributors.
-For npm packages, Release Please uses package-local Bazel `BUILD.bazel`
-`x-release-please-version` markers and checked-in `package.json` files kept in
-sync by `package_json_sync`. When Release Please creates or updates release PRs,
+For npm packages, Release Please advances versions in both package-local Bazel
+`BUILD.bazel` `x-release-please-version` markers and checked-in `package.json`
+files; `package_json_sync` keeps the rest of each generated manifest in sync.
+When Release Please creates or updates release PRs,
 `.github/workflows/release-please.yml` first builds
 `//:release_please_npm_workspace_graph` from the package manifests and runs the
 local `tools/release-please/run.ts` wrapper. That wrapper registers the

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -13,6 +13,7 @@
     "packages/babel-plugin-formatjs": {
       "component": "babel-plugin-formatjs",
       "extra-files": [
+        "package.json",
         {
           "type": "generic",
           "path": "BUILD.bazel"
@@ -24,6 +25,7 @@
     "packages/bigdecimal": {
       "component": "@formatjs/bigdecimal",
       "extra-files": [
+        "package.json",
         {
           "type": "generic",
           "path": "BUILD.bazel"
@@ -35,6 +37,7 @@
     "packages/cli-lib": {
       "component": "@formatjs/cli-lib",
       "extra-files": [
+        "package.json",
         {
           "type": "generic",
           "path": "BUILD.bazel"
@@ -46,6 +49,7 @@
     "packages/cli-native-darwin-arm64": {
       "component": "@formatjs/cli-native-darwin-arm64",
       "extra-files": [
+        "package.json",
         {
           "type": "generic",
           "path": "BUILD.bazel"
@@ -57,6 +61,7 @@
     "packages/cli-native-linux-arm64": {
       "component": "@formatjs/cli-native-linux-arm64",
       "extra-files": [
+        "package.json",
         {
           "type": "generic",
           "path": "BUILD.bazel"
@@ -68,6 +73,7 @@
     "packages/cli-native-linux-arm64-musl": {
       "component": "@formatjs/cli-native-linux-arm64-musl",
       "extra-files": [
+        "package.json",
         {
           "type": "generic",
           "path": "BUILD.bazel"
@@ -79,6 +85,7 @@
     "packages/cli-native-linux-x64": {
       "component": "@formatjs/cli-native-linux-x64",
       "extra-files": [
+        "package.json",
         {
           "type": "generic",
           "path": "BUILD.bazel"
@@ -90,6 +97,7 @@
     "packages/cli-native-linux-x64-musl": {
       "component": "@formatjs/cli-native-linux-x64-musl",
       "extra-files": [
+        "package.json",
         {
           "type": "generic",
           "path": "BUILD.bazel"
@@ -101,6 +109,7 @@
     "packages/cli-native-win32-x64": {
       "component": "@formatjs/cli-native-win32-x64",
       "extra-files": [
+        "package.json",
         {
           "type": "generic",
           "path": "BUILD.bazel"
@@ -112,6 +121,7 @@
     "packages/cli": {
       "component": "@formatjs/cli",
       "extra-files": [
+        "package.json",
         {
           "type": "generic",
           "path": "BUILD.bazel"
@@ -123,6 +133,7 @@
     "packages/ecma376": {
       "component": "@formatjs/ecma376",
       "extra-files": [
+        "package.json",
         {
           "type": "generic",
           "path": "BUILD.bazel"
@@ -134,6 +145,7 @@
     "packages/eslint-plugin-formatjs": {
       "component": "eslint-plugin-formatjs",
       "extra-files": [
+        "package.json",
         {
           "type": "generic",
           "path": "BUILD.bazel"
@@ -145,6 +157,7 @@
     "packages/fast-memoize": {
       "component": "@formatjs/fast-memoize",
       "extra-files": [
+        "package.json",
         {
           "type": "generic",
           "path": "BUILD.bazel"
@@ -156,6 +169,7 @@
     "packages/icu-messageformat-parser": {
       "component": "@formatjs/icu-messageformat-parser",
       "extra-files": [
+        "package.json",
         {
           "type": "generic",
           "path": "BUILD.bazel"
@@ -167,6 +181,7 @@
     "packages/icu-skeleton-parser": {
       "component": "@formatjs/icu-skeleton-parser",
       "extra-files": [
+        "package.json",
         {
           "type": "generic",
           "path": "BUILD.bazel"
@@ -178,6 +193,7 @@
     "packages/intl-collator": {
       "component": "@formatjs/intl-collator",
       "extra-files": [
+        "package.json",
         {
           "type": "generic",
           "path": "BUILD.bazel"
@@ -189,6 +205,7 @@
     "packages/intl-datetimeformat": {
       "component": "@formatjs/intl-datetimeformat",
       "extra-files": [
+        "package.json",
         {
           "type": "generic",
           "path": "BUILD.bazel"
@@ -200,6 +217,7 @@
     "packages/intl-displaynames": {
       "component": "@formatjs/intl-displaynames",
       "extra-files": [
+        "package.json",
         {
           "type": "generic",
           "path": "BUILD.bazel"
@@ -211,6 +229,7 @@
     "packages/intl-durationformat": {
       "component": "@formatjs/intl-durationformat",
       "extra-files": [
+        "package.json",
         {
           "type": "generic",
           "path": "BUILD.bazel"
@@ -222,6 +241,7 @@
     "packages/intl-supportedvaluesof": {
       "component": "@formatjs/intl-supportedvaluesof",
       "extra-files": [
+        "package.json",
         {
           "type": "generic",
           "path": "BUILD.bazel"
@@ -233,6 +253,7 @@
     "packages/intl-getcanonicallocales": {
       "component": "@formatjs/intl-getcanonicallocales",
       "extra-files": [
+        "package.json",
         {
           "type": "generic",
           "path": "BUILD.bazel"
@@ -244,6 +265,7 @@
     "packages/intl-listformat": {
       "component": "@formatjs/intl-listformat",
       "extra-files": [
+        "package.json",
         {
           "type": "generic",
           "path": "BUILD.bazel"
@@ -255,6 +277,7 @@
     "packages/intl-locale": {
       "component": "@formatjs/intl-locale",
       "extra-files": [
+        "package.json",
         {
           "type": "generic",
           "path": "BUILD.bazel"
@@ -266,6 +289,7 @@
     "packages/intl-localematcher": {
       "component": "@formatjs/intl-localematcher",
       "extra-files": [
+        "package.json",
         {
           "type": "generic",
           "path": "BUILD.bazel"
@@ -277,6 +301,7 @@
     "packages/intl-messageformat": {
       "component": "intl-messageformat",
       "extra-files": [
+        "package.json",
         {
           "type": "generic",
           "path": "BUILD.bazel"
@@ -288,6 +313,7 @@
     "packages/intl-numberformat": {
       "component": "@formatjs/intl-numberformat",
       "extra-files": [
+        "package.json",
         {
           "type": "generic",
           "path": "BUILD.bazel"
@@ -299,6 +325,7 @@
     "packages/intl-pluralrules": {
       "component": "@formatjs/intl-pluralrules",
       "extra-files": [
+        "package.json",
         {
           "type": "generic",
           "path": "BUILD.bazel"
@@ -310,6 +337,7 @@
     "packages/intl-relativetimeformat": {
       "component": "@formatjs/intl-relativetimeformat",
       "extra-files": [
+        "package.json",
         {
           "type": "generic",
           "path": "BUILD.bazel"
@@ -321,6 +349,7 @@
     "packages/intl-segmenter": {
       "component": "@formatjs/intl-segmenter",
       "extra-files": [
+        "package.json",
         {
           "type": "generic",
           "path": "BUILD.bazel"
@@ -332,6 +361,7 @@
     "packages/intl": {
       "component": "@formatjs/intl",
       "extra-files": [
+        "package.json",
         {
           "type": "generic",
           "path": "BUILD.bazel"
@@ -343,6 +373,7 @@
     "packages/react-intl": {
       "component": "react-intl",
       "extra-files": [
+        "package.json",
         {
           "type": "generic",
           "path": "BUILD.bazel"
@@ -354,6 +385,7 @@
     "packages/svelte-intl": {
       "component": "@formatjs/svelte-intl",
       "extra-files": [
+        "package.json",
         {
           "type": "generic",
           "path": "BUILD.bazel"
@@ -365,6 +397,7 @@
     "packages/ts-transformer": {
       "component": "@formatjs/ts-transformer",
       "extra-files": [
+        "package.json",
         {
           "type": "generic",
           "path": "BUILD.bazel"
@@ -376,6 +409,7 @@
     "packages/unplugin": {
       "component": "@formatjs/unplugin",
       "extra-files": [
+        "package.json",
         {
           "type": "generic",
           "path": "BUILD.bazel"
@@ -387,6 +421,7 @@
     "packages/utils": {
       "component": "@formatjs/utils",
       "extra-files": [
+        "package.json",
         {
           "type": "generic",
           "path": "BUILD.bazel"
@@ -398,6 +433,7 @@
     "packages/vue-intl": {
       "component": "vue-intl",
       "extra-files": [
+        "package.json",
         {
           "type": "generic",
           "path": "BUILD.bazel"

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -58,9 +58,11 @@ ts_binary(
 js_test(
     name = "release_please_npm_workspace_test",
     size = "small",
+    args = ["$(rootpath //:release_please_config)"],
     data = [
         "release-please/github-output.ts",
         "release-please/npm-workspace-graph.ts",
+        "//:release_please_config",
     ],
     entry_point = "release-please/npm-workspace-graph.test.ts",
     node_options = ["--disable-warning=MODULE_TYPELESS_PACKAGE_JSON"],

--- a/tools/release-please/config.test.ts
+++ b/tools/release-please/config.test.ts
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict'
+import {readFileSync} from 'node:fs'
+import {createRequire} from 'node:module'
+
+const require = createRequire(import.meta.url)
+
+// Load the public entrypoint first so release-please initializes its built-in
+// strategy graph before the deep imports below.
+const {VERSION} = require('release-please')
+const {Bazel} = require('release-please/build/src/strategies/bazel')
+const {Version} = require('release-please/build/src/version')
+
+const SENTINEL_VERSION = '99.88.77'
+const config = JSON.parse(readFileSync('release-please-config.json', 'utf8'))
+const logger = {
+  debug() {},
+  error() {},
+  info() {},
+  warn() {},
+}
+let checked = 0
+
+assert.equal(VERSION, '17.6.0')
+
+for (const [path, packageConfig] of Object.entries(config.packages)) {
+  if (!path.startsWith('packages/')) {
+    continue
+  }
+
+  const releaseType =
+    packageConfig['release-type'] ?? config['release-type'] ?? 'node'
+  assert.equal(releaseType, 'bazel', `${path} must use the Bazel strategy`)
+
+  const strategy = new Bazel({
+    changelogNotes: {buildNotes: async () => '* fixture'},
+    component: packageConfig.component,
+    extraFiles: packageConfig['extra-files'] ?? config['extra-files'],
+    github: {
+      repository: {
+        defaultBranch: 'main',
+        owner: 'formatjs',
+        repo: 'formatjs',
+      },
+    },
+    logger,
+    packageName: packageConfig['package-name'],
+    path,
+    skipChangelog: true,
+    targetBranch: 'main',
+    versionFile: packageConfig['version-file'] ?? config['version-file'],
+  })
+  const candidate = await strategy.buildReleasePullRequest(
+    [],
+    undefined,
+    false,
+    [],
+    {newVersion: Version.parse(SENTINEL_VERSION)}
+  )
+  assert(candidate, `${path} did not produce a release candidate`)
+
+  const packageJsonPath = `${path}/package.json`
+  const packageJsonUpdate = candidate.updates.find(
+    update => update.path === packageJsonPath
+  )
+  assert(
+    packageJsonUpdate,
+    `${path} did not generate a package.json version update`
+  )
+  assert.equal(packageJsonUpdate.createIfMissing, false)
+
+  const updated = packageJsonUpdate.updater.updateContent(
+    readFileSync(packageJsonPath, 'utf8')
+  )
+  assert.equal(JSON.parse(updated).version, SENTINEL_VERSION)
+  checked++
+}
+
+assert(checked > 0, 'no npm release packages were checked')
+console.log(`Verified ${checked} Release Please package.json updates`)

--- a/tools/release-please/npm-workspace-graph.test.ts
+++ b/tools/release-please/npm-workspace-graph.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import {readFileSync} from 'node:fs'
 
 import {githubOutputRecord} from './github-output.ts'
 import {
@@ -42,6 +43,18 @@ const packages = [
     },
   },
 ]
+
+const configPath = process.argv[2]
+assert.ok(configPath, 'release-please config path is required')
+const releasePleaseConfig = JSON.parse(readFileSync(configPath, 'utf8'))
+const npmReleasePackages = Object.entries(releasePleaseConfig.packages).filter(
+  ([path]) => path.startsWith('packages/')
+)
+assert.ok(npmReleasePackages.length > 0)
+for (const [path, config] of npmReleasePackages) {
+  assert.equal(config['version-file'], 'BUILD.bazel', path)
+  assert.ok(config['extra-files'].includes('package.json'), path)
+}
 
 const graph = buildDependencyGraph(packages)
 assert.deepEqual(graph.get('@formatjs/runtime').deps, ['@formatjs/core'])


### PR DESCRIPTION
## Summary

- have Release Please update checked-in `package.json` versions alongside Bazel version markers
- enforce config coverage in the normal Bazel test suite
- exercise the pinned `release-please@17.6.0` Bazel strategy before the workflow updates a release PR

## Root cause

#6844 made published `package.json` manifests checked-in generated files, but Release Please still advanced only `BUILD.bazel`. #6853 therefore failed all 36 `package_json_sync_test` targets.

After this lands, the push to `main` will rerun Release Please and rebuild #6853 from automation; no manual release-branch edit is needed.

## Test plan

- `pnpm t` — 428 passed, 14 skipped
- `tools/release-please/config.test.ts` against `release-please@17.6.0` — verified 36 package manifest updates
