### PR TITLE
fix(@formatjs/intl-datetimeformat): apply Date method defaults

### DIFF
--- a/docs/src/docs/polyfills/intl-datetimeformat.mdx
+++ b/docs/src/docs/polyfills/intl-datetimeformat.mdx
@@ -148,6 +148,10 @@ import '@formatjs/intl-datetimeformat/locale-data/en.js' // locale-data for en
 import '@formatjs/intl-datetimeformat/add-all-tz.js' // Add ALL tz data
 ```
 
+The polyfill also replaces `Date.prototype.toLocaleString`,
+`toLocaleDateString`, and `toLocaleTimeString` with their ECMA-402 behavior,
+including the standard date and time defaults when only `timeZone` is set.
+
 ### Dynamic import + capability detection
 
 ```tsx

--- a/knowledge-base/007b-polyfill-intl-datetimeformat.md
+++ b/knowledge-base/007b-polyfill-intl-datetimeformat.md
@@ -130,6 +130,9 @@ Stage 4: supported-locales.generated.ts
 - `DateTimeFormat.__addTZData()` registers timezone data (unpacks base-36 encoding)
 - Timezone offset lookup uses binary search through transition array
 - Buffered via `globalThis.__FORMATJS_DATETIMEFORMAT_DATA__`
+- Date prototype ponyfills pass options through `ToDateTimeOptions` with the
+  ECMA-402 `required` and `defaults` values for each method. In particular,
+  `toLocaleString({timeZone})` defaults to both date and time fields.
 
 ## Key Design Decisions
 

--- a/packages/intl-datetimeformat/polyfill-force.ts
+++ b/packages/intl-datetimeformat/polyfill-force.ts
@@ -12,10 +12,7 @@ defineProperty(intl, 'DateTimeFormat', {value: DateTimeFormat})
 defineProperty(Date.prototype, 'toLocaleString', {
   value: function toLocaleString(
     locales?: string | string[],
-    options: Intl.DateTimeFormatOptions = {
-      dateStyle: 'short',
-      timeStyle: 'medium',
-    }
+    options?: Intl.DateTimeFormatOptions
   ) {
     try {
       return _toLocaleString(this, locales, options)
@@ -27,9 +24,7 @@ defineProperty(Date.prototype, 'toLocaleString', {
 defineProperty(Date.prototype, 'toLocaleDateString', {
   value: function toLocaleDateString(
     locales?: string | string[],
-    options: Intl.DateTimeFormatOptions = {
-      dateStyle: 'short',
-    }
+    options?: Intl.DateTimeFormatOptions
   ) {
     try {
       return _toLocaleDateString(this, locales, options)
@@ -41,9 +36,7 @@ defineProperty(Date.prototype, 'toLocaleDateString', {
 defineProperty(Date.prototype, 'toLocaleTimeString', {
   value: function toLocaleTimeString(
     locales?: string | string[],
-    options: Intl.DateTimeFormatOptions = {
-      timeStyle: 'medium',
-    }
+    options?: Intl.DateTimeFormatOptions
   ) {
     try {
       return _toLocaleTimeString(this, locales, options)

--- a/packages/intl-datetimeformat/polyfill.ts
+++ b/packages/intl-datetimeformat/polyfill.ts
@@ -14,10 +14,7 @@ if (shouldPolyfill()) {
   defineProperty(Date.prototype, 'toLocaleString', {
     value: function toLocaleString(
       locales?: string | string[],
-      options: Intl.DateTimeFormatOptions = {
-        dateStyle: 'short',
-        timeStyle: 'medium',
-      }
+      options?: Intl.DateTimeFormatOptions
     ) {
       try {
         return _toLocaleString(this, locales, options)
@@ -29,9 +26,7 @@ if (shouldPolyfill()) {
   defineProperty(Date.prototype, 'toLocaleDateString', {
     value: function toLocaleDateString(
       locales?: string | string[],
-      options: Intl.DateTimeFormatOptions = {
-        dateStyle: 'short',
-      }
+      options?: Intl.DateTimeFormatOptions
     ) {
       try {
         return _toLocaleDateString(this, locales, options)
@@ -43,9 +38,7 @@ if (shouldPolyfill()) {
   defineProperty(Date.prototype, 'toLocaleTimeString', {
     value: function toLocaleTimeString(
       locales?: string | string[],
-      options: Intl.DateTimeFormatOptions = {
-        timeStyle: 'medium',
-      }
+      options?: Intl.DateTimeFormatOptions
     ) {
       try {
         return _toLocaleTimeString(this, locales, options)

--- a/packages/intl-datetimeformat/tests/format.test.ts
+++ b/packages/intl-datetimeformat/tests/format.test.ts
@@ -319,6 +319,13 @@ describe('toLocaleString', function () {
       expect(toLocaleString(new Date(TS), 'en', options)).toBe(en)
     })
   })
+
+  it('defaults to date and time when only timeZone is set, GH #6891', function () {
+    const date = new Date('2077-01-02T09:15:25Z')
+    expect(toLocaleString(date, 'en-US', {timeZone: 'Europe/Warsaw'})).toMatch(
+      /^1\/2\/2077, 10:15:25/
+    )
+  })
 })
 
 describe('toLocaleDateString', function () {

--- a/packages/intl-datetimeformat/to_locale_string.ts
+++ b/packages/intl-datetimeformat/to_locale_string.ts
@@ -3,18 +3,23 @@ import {DateTimeFormat} from '#packages/intl-datetimeformat/core.js'
 import {ToDateTimeOptions} from '#packages/ecma402-abstract/DateTimeFormat/ToDateTimeOptions.js'
 
 /**
- * Number.prototype.toLocaleString ponyfill
- * https://tc39.es/ecma402/#sup-number.prototype.tolocalestring
+ * https://tc39.es/ecma402/#sup-date.prototype.tolocalestring
  */
 export function toLocaleString(
   x?: Date | number,
   locales?: string | string[],
   options?: Intl.DateTimeFormatOptions
 ): string {
-  const dtf = new DateTimeFormat(locales, options)
+  const dtf = new DateTimeFormat(
+    locales,
+    ToDateTimeOptions(options, 'any', 'all')
+  )
   return dtf.format(x)
 }
 
+/**
+ * https://tc39.es/ecma402/#sup-date.prototype.tolocaledatestring
+ */
 export function toLocaleDateString(
   x?: Date | number,
   locales?: string | string[],
@@ -27,6 +32,9 @@ export function toLocaleDateString(
   return dtf.format(x)
 }
 
+/**
+ * https://tc39.es/ecma402/#sup-date.prototype.tolocaletimestring
+ */
 export function toLocaleTimeString(
   x?: Date | number,
   locales?: string | string[],


### PR DESCRIPTION
Fixes #6891

## What changed

- Apply the ECMA-402 `required=any, defaults=all` behavior in the `toLocaleString` ponyfill.
- Let the three Date ponyfills own their defaults instead of hardcoding styles in the wrappers.
- Add a timezone-only regression and document the Date prototype behavior.
- Link each Date method implementation to its ECMA-402 section.

## Why

`Date.prototype.toLocaleString` defaults to date and time fields, while the plain `Intl.DateTimeFormat` constructor defaults to date fields. Passing `{timeZone}` directly to the constructor therefore dropped the time and broke consumers such as Day.js timezone handling.

## Validation

- `bazel build //packages/intl-datetimeformat:pkg`
- Built package repro returns `1/2/2077, 10:15:25 AM` for `Europe/Warsaw`
- Pre-commit hooks: oxfmt, Gazelle, ast-grep, Codescythe, oxlint, commitlint

`bazel test //packages/intl-datetimeformat:intl-datetimeformat_test --test_output=errors` is locally blocked before execution because the environment cannot resolve three uncached packages from `registry.npmjs.org`; CI should exercise the added regression.
