### PR TITLE
fix(@formatjs/unplugin): parse module ids with queries

### DIFF
--- a/packages/unplugin/tests/transform.test.ts
+++ b/packages/unplugin/tests/transform.test.ts
@@ -12,6 +12,23 @@ function t(
 }
 
 describe('@formatjs/unplugin transform', () => {
+  test('parses JSX when the module id has a query or hash (#6895)', () => {
+    const input = `export const x = <div>{intl.formatMessage({defaultMessage: "Hello world"})}</div>`
+    const options = {
+      idInterpolationPattern: '[sha512:contenthash:base64:6]',
+      ast: true,
+    }
+    const expected = transform(input, '/src/route.tsx', options)
+
+    expect(expected).toBeDefined()
+    expect(
+      transform(input, '/src/route.tsx?tsr-split=component', options)
+    ).toEqual(expected)
+    expect(transform(input, '/src/route.tsx#route-chunk', options)).toEqual(
+      expected
+    )
+  })
+
   describe('id generation', () => {
     test('inserts generated id into formatMessage call', () => {
       const input = `intl.formatMessage({defaultMessage: 'Hello World', description: 'greeting'})`

--- a/packages/unplugin/transform.ts
+++ b/packages/unplugin/transform.ts
@@ -107,7 +107,8 @@ export function transform(
     'createElement',
   ])
 
-  const result = parseSync(id, code, {sourceType: 'module'})
+  const filename = id.replace(/[?#].*$/, '')
+  const result = parseSync(filename, code, {sourceType: 'module'})
   const program = result.program
 
   let s: MagicString | undefined


### PR DESCRIPTION
## Summary

- strip query strings and hashes before passing module IDs to `oxc-parser`
- keep the original ID for interpolation and `overrideIdFn`
- cover React Router and TanStack Router-style virtual module IDs

`oxc-parser` uses the filename to detect JSX/TSX. IDs such as `route.tsx?tsr-split=component` were accepted by the unplugin filter but parsed as a non-TSX filename, so the transform returned `undefined`.

Fixes #6895

## Checks

- pre-commit hooks: oxfmt, Gazelle, ast-grep, Codescythe, oxlint
- commitlint
- `bazel test //packages/unplugin:unplugin_test --test_output=errors` (blocked locally because `registry.npmjs.org` DNS failed while Bazel fetched missing npm externals; CI should run it)
