### PR TITLE
fix(icu-messageformat-parser): preserve plural context in tags

### DIFF
--- a/crates/icu_messageformat_parser/printer.rs
+++ b/crates/icu_messageformat_parser/printer.rs
@@ -50,7 +50,7 @@ fn write_ast(out: &mut String, ast: &[MessageFormatElement], is_in_plural: bool)
             MessageFormatElement::Plural(plural) => write_plural_element(out, plural),
             MessageFormatElement::Select(select) => write_select_element(out, select),
             MessageFormatElement::Pound(_) => out.push('#'),
-            MessageFormatElement::Tag(tag) => write_tag_element(out, tag),
+            MessageFormatElement::Tag(tag) => write_tag_element(out, tag, is_in_plural),
         }
     }
 }
@@ -62,15 +62,16 @@ fn write_ast(out: &mut String, ast: &[MessageFormatElement], is_in_plural: bool)
 /// # Arguments
 ///
 /// * `el` - The tag element to print
+/// * `is_in_plural` - Whether the tag is inside a plural submessage
 ///
 /// # Returns
 ///
 /// A string like `<b>text</b>`
-fn write_tag_element(out: &mut String, el: &TagElement) {
+fn write_tag_element(out: &mut String, el: &TagElement, is_in_plural: bool) {
     out.push('<');
     out.push_str(&el.value);
     out.push('>');
-    write_ast(out, &el.children, false);
+    write_ast(out, &el.children, is_in_plural);
     out.push_str("</");
     out.push_str(&el.value);
     out.push('>');
@@ -582,6 +583,15 @@ mod tests {
         let ast = parse_message("a '''}' b");
         let output = print_ast(&ast);
 
+        assert_eq!(parse_message(&output), ast);
+    }
+
+    #[test]
+    fn test_print_literal_pounds_inside_plural_tag_round_trip() {
+        let ast = parse_message("{count, plural, other {<b>'##'</b>}}");
+        let output = print_ast(&ast);
+
+        assert_eq!(output, "{count,plural,other{<b>'##'</b>}}");
         assert_eq!(parse_message(&output), ast);
     }
 

--- a/packages/babel-plugin-formatjs/tests/fixtures/flattenLiteralPoundsInPluralTag.js
+++ b/packages/babel-plugin-formatjs/tests/fixtures/flattenLiteralPoundsInPluralTag.js
@@ -1,0 +1,5 @@
+import {defineMessage} from 'react-intl'
+
+defineMessage({
+  defaultMessage: "{count, plural, other {<b>'##'</b>}}",
+})

--- a/packages/babel-plugin-formatjs/tests/index.test.ts
+++ b/packages/babel-plugin-formatjs/tests/index.test.ts
@@ -424,3 +424,13 @@ test('GH #3537: flatten with overrideIdFn', function () {
   // ID should be based on flattened message length (249 chars)
   expect(result.data.messages[1].id).toBe('msg_249')
 })
+
+test('flatten preserves literal pounds inside tags nested in plurals', () => {
+  const result = transformAndCheck('flattenLiteralPoundsInPluralTag', {
+    flatten: true,
+  })
+
+  expect(result.data.messages[0].defaultMessage).toBe(
+    "{count,plural,other{<b>'##'</b>}}"
+  )
+})

--- a/packages/icu-messageformat-parser/printer.ts
+++ b/packages/icu-messageformat-parser/printer.ts
@@ -56,15 +56,15 @@ export function doPrintAST(
       return '#'
     }
     if (isTagElement(el)) {
-      return printTagElement(el)
+      return printTagElement(el, isInPlural)
     }
   })
 
   return printedNodes.join('')
 }
 
-function printTagElement(el: TagElement): string {
-  return `<${el.value}>${printAST(el.children)}</${el.value}>`
+function printTagElement(el: TagElement, isInPlural: boolean): string {
+  return `<${el.value}>${doPrintAST(el.children, isInPlural)}</${el.value}>`
 }
 
 function quoteSyntaxToken(token: string): string {

--- a/packages/icu-messageformat-parser/tests/printer.test.ts
+++ b/packages/icu-messageformat-parser/tests/printer.test.ts
@@ -88,6 +88,14 @@ test('escapes pound signs inside plural literals', function () {
   expect(parse(output)).toEqual(parse(input))
 })
 
+test('escapes literal pound signs inside tags nested in plurals', function () {
+  const input = "{count, plural, other {<b>'##'</b>}}"
+  const output = printAST(parse(input))
+
+  expect(output).toBe("{count,plural,other{<b>'##'</b>}}")
+  expect(parse(output)).toEqual(parse(input))
+})
+
 test('coalesces adjacent syntax characters into one quoted span', function () {
   const input = 'Use }} to close'
   const output = printAST(parse(input, {requiresOtherClause: false}))


### PR DESCRIPTION
## Summary

- preserve plural context while printing rich-text tag children in the TypeScript and Rust ICU message printers
- keep apostrophe-quoted literal `#` characters literal after parse/print round trips and Babel `flatten: true`
- add matching TypeScript, Rust, and public Babel-plugin regressions

Fixes #6907.

## Testing

- `npx -y @bazel/bazelisk test //packages/icu-messageformat-parser:icu-messageformat-parser_test //crates/icu_messageformat_parser:icu_messageformat_parser_test //packages/babel-plugin-formatjs:babel-plugin-formatjs_test --test_output=errors` — passed
- `npx -y @bazel/bazelisk test //packages/unplugin:unplugin_test //packages/ts-transformer:ts-transformer_test //packages/unplugin:conformance_test --test_output=errors` — passed
- `npx -y @bazel/bazelisk run //:oxfmt -- --check <changed TypeScript and JavaScript files>` — passed
- `rustfmt --check --edition 2024 crates/icu_messageformat_parser/printer.rs` — passed
- `git diff --check` — passed
- Full `bazel test //...` was not run; validation was focused on both printer implementations and their downstream flattening consumers.

## Notes

- No changeset is required; this repository uses Release Please.
- `cargo fmt --all --check` reports existing formatting differences in unrelated Rust files with the locally installed rustfmt; the changed Rust file passes its focused formatting check.
