### PR TITLE
fix: repair corrupted `patches/typescript@7.0.2.patch`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -292,3 +292,22 @@ jobs:
           console.log(extractedOutput)
           '@
           $script | node - $pkgPath
+
+  validate-pnpm-lock:
+    name: Validate pnpm-lock.yaml
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Install dependencies with pnpm
+        run: pnpm install --frozen-lockfile

--- a/patches/typescript@7.0.2.patch
+++ b/patches/typescript@7.0.2.patch
@@ -1,23 +1,24 @@
 diff --git a/lib/compat.cjs b/lib/compat.cjs
 new file mode 100644
-index 0000000000000000000000000000000000000000..2e6efb14f38ce8eed84ab8efba9520e06aaa3be1
+index 0000000000000000000000000000000000000000..b32f62fad3890b80b5d68291dda88d7799f97dd3
 --- /dev/null
 +++ b/lib/compat.cjs
 @@ -0,0 +1 @@
 +module.exports = require("@typescript/typescript6");
 diff --git a/lib/compat.d.cts b/lib/compat.d.cts
 new file mode 100644
-index 0000000000000000000000000000000000000000..66ce9b3a5d3239c618a7e48bb04488837c34f4ea
+index 0000000000000000000000000000000000000000..5e978dee1da2b60eabca0520ae4aac2c28829dbf
 --- /dev/null
 +++ b/lib/compat.d.cts
 @@ -0,0 +1,2 @@
 +import ts = require("@typescript/typescript6");
 +export = ts;
 diff --git a/package.json b/package.json
-index 99c84c7689b9fb5a9a6af2c93ed98fc7cfbf567e..ad5f85446461a89c16f5300db77f3fe37ad5a3d2 100644
+index f4242a69df961fcaf5210ac08ace176ced18c6a4..5302e15bc1ac890e04d4e2420bd462a86ae7cf54 100644
 --- a/package.json
 +++ b/package.json
-@@ -29,7 +29,7 @@
+@@ -36,7 +36,7 @@
+     },
      "exports": {
          "./package.json": "./package.json",
 -        ".": "./lib/version.cjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,7 @@ packageExtensionsChecksum: sha256-XwiwrN19quNXNpdYpaW6Z5iaYXGoLbpVA6wSutY9I+A=
 patchedDependencies:
   '@types/mdx': b756d39279264f32f80885062fc3b65e334db17a9aa2c8cd9ce7f88ed3065a0b
   '@vue/compiler-sfc': c5ac0bf7b3e706836efc86993f694d3d8c2dd6b1a967fdd4ba17e0e3134ef2de
-  typescript@7.0.2: 11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9
+  typescript@7.0.2: e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0
   unicode-match-property-ecmascript@2.0.0: eeab7906cd33963f15843106ed5415de9a8fef9ac46cc589ec84c257e9f0385e
   unicode-match-property-value-ecmascript@2.2.1: 3f2e10f2afffb197cc2f9c5fc8f72f9e4c03d60cec0cbcf366f0365f1d2e5734
 
@@ -60,7 +60,7 @@ importers:
         version: 6.5.0
       '@commitlint/cli':
         specifier: ^21.0.0
-        version: 21.2.1(@types/node@24.13.3)(conventional-commits-parser@7.0.1)(typescript@7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9))
+        version: 21.2.1(@types/node@24.13.3)(conventional-commits-parser@7.0.1)(typescript@7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0))
       '@formatjs/bigdecimal':
         specifier: workspace:*
         version: link:packages/bigdecimal
@@ -264,10 +264,10 @@ importers:
         version: 3.5.39
       '@vue/server-renderer':
         specifier: ^3.5.26
-        version: 3.5.39(vue@3.5.39(typescript@7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9)))
+        version: 3.5.39(vue@3.5.39(typescript@7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0)))
       '@vue/test-utils':
         specifier: ^2.4.6
-        version: 2.4.11(@vue/compiler-dom@3.5.39)(@vue/server-renderer@3.5.39(vue@3.5.39(typescript@7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9))))(vue@3.5.39(typescript@7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9)))
+        version: 2.4.11(@vue/compiler-dom@3.5.39)(@vue/server-renderer@3.5.39(vue@3.5.39(typescript@7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0))))(vue@3.5.39(typescript@7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0)))
       babel-loader:
         specifier: ^10.0.0
         version: 10.1.1(@babel/core@8.0.1)(@rspack/core@2.1.4)(webpack@5.108.4(esbuild@0.28.1))
@@ -426,7 +426,7 @@ importers:
         version: 1.1.5
       rolldown-plugin-dts:
         specifier: ^0.27.0
-        version: 0.27.11(rolldown@1.1.5)(typescript@7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9))
+        version: 0.27.11(rolldown@1.1.5)(typescript@7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0))
       rollup:
         specifier: ^4.40.0
         version: 4.62.2
@@ -453,16 +453,16 @@ importers:
         version: 6.0.2
       ts-jest:
         specifier: ^29
-        version: 29.4.11(@babel/core@8.0.1)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@8.0.1))(esbuild@0.28.1)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.13.3))(typescript@7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9))
+        version: 29.4.11(@babel/core@8.0.1)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@8.0.1))(esbuild@0.28.1)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.13.3))(typescript@7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0))
       ts-loader:
         specifier: ^9.5.4
-        version: 9.6.2(typescript@7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9))(webpack@5.108.4(esbuild@0.28.1))
+        version: 9.6.2(typescript@7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0))(webpack@5.108.4(esbuild@0.28.1))
       tsd:
         specifier: ^0.33.0
         version: 0.33.0
       typescript:
         specifier: 7.0.2
-        version: 7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9)
+        version: 7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0)
       typesense:
         specifier: 3.0.6
         version: 3.0.6(@babel/runtime@7.29.7)
@@ -483,10 +483,10 @@ importers:
         version: 4.1.10(@types/node@24.13.3)(happy-dom@20.10.6)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0))
       vue:
         specifier: ^3.5.0
-        version: 3.5.39(typescript@7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9))
+        version: 3.5.39(typescript@7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0))
       vue-class-component:
         specifier: 8.0.0-rc.1
-        version: 8.0.0-rc.1(vue@3.5.39(typescript@7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9)))
+        version: 8.0.0-rc.1(vue@3.5.39(typescript@7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0)))
       vue-eslint-parser:
         specifier: ^10.4.0
         version: 10.4.1(eslint@10.6.0(jiti@2.7.0))
@@ -495,7 +495,7 @@ importers:
         version: link:packages/vue-intl
       vue-loader:
         specifier: ^17.4.2
-        version: 17.4.2(vue@3.5.39(typescript@7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9)))(webpack@5.108.4(esbuild@0.28.1))
+        version: 17.4.2(vue@3.5.39(typescript@7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0)))(webpack@5.108.4(esbuild@0.28.1))
       webpack:
         specifier: ^5.104.1
         version: 5.108.4(esbuild@0.28.1)
@@ -549,7 +549,7 @@ importers:
         version: 4.2.0
       vue:
         specifier: '3'
-        version: 3.5.39(typescript@7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9))
+        version: 3.5.39(typescript@7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0))
     optionalDependencies:
       '@formatjs/cli-native-darwin-arm64':
         specifier: workspace:*
@@ -910,7 +910,7 @@ importers:
         version: link:../intl
       vue:
         specifier: '3'
-        version: 3.5.39(typescript@7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9))
+        version: 3.5.39(typescript@7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0))
 
 packages:
 
@@ -8619,12 +8619,12 @@ snapshots:
       '@brillout/import': 0.2.6
       '@brillout/picocolors': 1.0.31
 
-  '@commitlint/cli@21.2.1(@types/node@24.13.3)(conventional-commits-parser@7.0.1)(typescript@7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9))':
+  '@commitlint/cli@21.2.1(@types/node@24.13.3)(conventional-commits-parser@7.0.1)(typescript@7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0))':
     dependencies:
       '@commitlint/config-conventional': 21.2.0
       '@commitlint/format': 21.2.0
       '@commitlint/lint': 21.2.0
-      '@commitlint/load': 21.2.0(@types/node@24.13.3)(typescript@7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9))
+      '@commitlint/load': 21.2.0(@types/node@24.13.3)(typescript@7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0))
       '@commitlint/read': 21.2.1(conventional-commits-parser@7.0.1)
       '@commitlint/types': 21.2.0
       tinyexec: 1.2.4
@@ -8669,14 +8669,14 @@ snapshots:
       '@commitlint/rules': 21.2.0
       '@commitlint/types': 21.2.0
 
-  '@commitlint/load@21.2.0(@types/node@24.13.3)(typescript@7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9))':
+  '@commitlint/load@21.2.0(@types/node@24.13.3)(typescript@7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0))':
     dependencies:
       '@commitlint/config-validator': 21.2.0
       '@commitlint/execute-rule': 21.0.1
       '@commitlint/resolve-extends': 21.2.0
       '@commitlint/types': 21.2.0
-      cosmiconfig: 9.0.2(typescript@7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9))
-      cosmiconfig-typescript-loader: 6.3.0(@types/node@24.13.3)(cosmiconfig@9.0.2(typescript@7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9)))(typescript@7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9))
+      cosmiconfig: 9.0.2(typescript@7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0))
+      cosmiconfig-typescript-loader: 6.3.0(@types/node@24.13.3)(cosmiconfig@9.0.2(typescript@7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0)))(typescript@7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0))
       es-toolkit: 1.49.0
       is-plain-obj: 4.1.0
       picocolors: 1.1.1
@@ -10564,22 +10564,22 @@ snapshots:
       '@vue/shared': 3.5.39
       vue: 3.5.39(typescript@6.0.3)
 
-  '@vue/server-renderer@3.5.39(vue@3.5.39(typescript@7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9)))':
+  '@vue/server-renderer@3.5.39(vue@3.5.39(typescript@7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0)))':
     dependencies:
       '@vue/compiler-ssr': 3.5.39
       '@vue/shared': 3.5.39
-      vue: 3.5.39(typescript@7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9))
+      vue: 3.5.39(typescript@7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0))
 
   '@vue/shared@3.5.39': {}
 
-  '@vue/test-utils@2.4.11(@vue/compiler-dom@3.5.39)(@vue/server-renderer@3.5.39(vue@3.5.39(typescript@7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9))))(vue@3.5.39(typescript@7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9)))':
+  '@vue/test-utils@2.4.11(@vue/compiler-dom@3.5.39)(@vue/server-renderer@3.5.39(vue@3.5.39(typescript@7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0))))(vue@3.5.39(typescript@7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0)))':
     dependencies:
       '@vue/compiler-dom': 3.5.39
       js-beautify: 1.15.4
-      vue: 3.5.39(typescript@7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9))
+      vue: 3.5.39(typescript@7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0))
       vue-component-type-helpers: 3.3.7
     optionalDependencies:
-      '@vue/server-renderer': 3.5.39(vue@3.5.39(typescript@7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9)))
+      '@vue/server-renderer': 3.5.39(vue@3.5.39(typescript@7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0)))
 
   '@webassemblyjs/ast@1.14.1':
     dependencies:
@@ -11230,21 +11230,21 @@ snapshots:
 
   corser@2.0.1: {}
 
-  cosmiconfig-typescript-loader@6.3.0(@types/node@24.13.3)(cosmiconfig@9.0.2(typescript@7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9)))(typescript@7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9)):
+  cosmiconfig-typescript-loader@6.3.0(@types/node@24.13.3)(cosmiconfig@9.0.2(typescript@7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0)))(typescript@7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0)):
     dependencies:
       '@types/node': 24.13.3
-      cosmiconfig: 9.0.2(typescript@7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9))
+      cosmiconfig: 9.0.2(typescript@7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0))
       jiti: 2.6.1
-      typescript: 7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9)
+      typescript: 7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0)
 
-  cosmiconfig@9.0.2(typescript@7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9)):
+  cosmiconfig@9.0.2(typescript@7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0)):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
       js-yaml: 4.3.0
       parse-json: 5.2.0
     optionalDependencies:
-      typescript: 7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9)
+      typescript: 7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0)
 
   create-jest@29.7.0(@types/node@24.13.3):
     dependencies:
@@ -14025,7 +14025,7 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rolldown-plugin-dts@0.27.11(rolldown@1.1.5)(typescript@7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9)):
+  rolldown-plugin-dts@0.27.11(rolldown@1.1.5)(typescript@7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0)):
     dependencies:
       dts-resolver: 3.0.0
       get-tsconfig: 5.0.0-beta.5
@@ -14035,7 +14035,7 @@ snapshots:
       yuku-codegen: 0.6.12
       yuku-parser: 0.6.12
     optionalDependencies:
-      typescript: 7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9)
+      typescript: 7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0)
     transitivePeerDependencies:
       - oxc-resolver
 
@@ -14552,7 +14552,7 @@ snapshots:
       esbuild: 0.28.1
       jest-util: 29.7.0
 
-  ts-jest@29.4.11(@babel/core@8.0.1)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@8.0.1))(esbuild@0.28.1)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.13.3))(typescript@7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9)):
+  ts-jest@29.4.11(@babel/core@8.0.1)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@8.0.1))(esbuild@0.28.1)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.13.3))(typescript@7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0)):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -14563,7 +14563,7 @@ snapshots:
       make-error: 1.3.6
       semver: 7.8.5
       type-fest: 4.41.0
-      typescript: 7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9)
+      typescript: 7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0)
       yargs-parser: 21.1.1
     optionalDependencies:
       '@babel/core': 8.0.1
@@ -14573,12 +14573,12 @@ snapshots:
       esbuild: 0.28.1
       jest-util: 29.7.0
 
-  ts-loader@9.6.2(typescript@7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9))(webpack@5.108.4(esbuild@0.28.1)):
+  ts-loader@9.6.2(typescript@7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0))(webpack@5.108.4(esbuild@0.28.1)):
     dependencies:
       chalk: 4.1.2
       picomatch: 4.0.5
       source-map: 0.7.6
-      typescript: 7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9)
+      typescript: 7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0)
       webpack: 5.108.4(esbuild@0.28.1)
 
   tsd@0.33.0:
@@ -14613,7 +14613,7 @@ snapshots:
 
   typescript@6.0.3: {}
 
-  typescript@7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9):
+  typescript@7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0):
     dependencies:
       '@typescript/typescript6': 6.0.2
     optionalDependencies:
@@ -14885,9 +14885,9 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vue-class-component@8.0.0-rc.1(vue@3.5.39(typescript@7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9))):
+  vue-class-component@8.0.0-rc.1(vue@3.5.39(typescript@7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0))):
     dependencies:
-      vue: 3.5.39(typescript@7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9))
+      vue: 3.5.39(typescript@7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0))
 
   vue-component-type-helpers@3.3.7: {}
 
@@ -14904,14 +14904,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vue-loader@17.4.2(vue@3.5.39(typescript@7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9)))(webpack@5.108.4(esbuild@0.28.1)):
+  vue-loader@17.4.2(vue@3.5.39(typescript@7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0)))(webpack@5.108.4(esbuild@0.28.1)):
     dependencies:
       chalk: 4.1.2
       hash-sum: 2.0.0
       watchpack: 2.5.2
       webpack: 5.108.4(esbuild@0.28.1)
     optionalDependencies:
-      vue: 3.5.39(typescript@7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9))
+      vue: 3.5.39(typescript@7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0))
 
   vue@3.5.39(typescript@6.0.3):
     dependencies:
@@ -14923,15 +14923,15 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  vue@3.5.39(typescript@7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9)):
+  vue@3.5.39(typescript@7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0)):
     dependencies:
       '@vue/compiler-dom': 3.5.39
       '@vue/compiler-sfc': 3.5.39(patch_hash=c5ac0bf7b3e706836efc86993f694d3d8c2dd6b1a967fdd4ba17e0e3134ef2de)
       '@vue/runtime-dom': 3.5.39
-      '@vue/server-renderer': 3.5.39(vue@3.5.39(typescript@7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9)))
+      '@vue/server-renderer': 3.5.39(vue@3.5.39(typescript@7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0)))
       '@vue/shared': 3.5.39
     optionalDependencies:
-      typescript: 7.0.2(patch_hash=11b4cba8f26df44c28a8ec9dde35fc58966120ded2f71a9c9881575b5ea876b9)
+      typescript: 7.0.2(patch_hash=e8f3253d18aba594ebb6588699219c7533508cf5a9afd35f86b8a2737e7191d0)
 
   walker@1.0.8:
     dependencies:


### PR DESCRIPTION
Fix this error from `pnpm install`:
    
`ERR_PNPM_INVALID_PATCH] Applying patch "/tmp/formatjs/patches/typescript@7.0.2.patch" failed: hunk header integrity check failed`

Verify in CI that `pnpm install --frozen-lockfile` succeeds, because our Bazel tests don’t validate `pnpm-lock.yaml` as strictly as pnpm does.