### PR TITLE
fix(babel-plugin-formatjs): stop enabling JSX syntax implicitly

### DIFF
--- a/docs/src/docs/tooling/babel-plugin.mdx
+++ b/docs/src/docs/tooling/babel-plugin.mdx
@@ -44,6 +44,8 @@ pnpm add babel-plugin-formatjs
 
 The default message descriptors for the app's default language will be processed from: `defineMessages()`, `defineMessage()`, `intl.formatMessage` and `<FormattedMessage>`; all of which are named exports of the React Intl package.
 
+This plugin does not enable any syntax on its own. To extract messages from `<FormattedMessage>` elements, JSX parsing must be enabled by your own Babel configuration (e.g. `@babel/preset-react`, `@babel/preset-typescript` for `.tsx` files, or `@babel/plugin-syntax-jsx`), as it normally already is in projects that use JSX.
+
 ### Via `babel.config.json` (Recommended)
 
 **babel.config.json**

--- a/packages/babel-plugin-formatjs/BUILD.bazel
+++ b/packages/babel-plugin-formatjs/BUILD.bazel
@@ -5,7 +5,6 @@ formatjs_library(
     name = "babel-plugin-formatjs",
     package_name = "babel-plugin-formatjs",
     srcs = [
-        "global.d.ts",
         "index.ts",
         "types.ts",
         "utils.ts",
@@ -34,7 +33,6 @@ formatjs_library(
     deps = [
         "//:node_modules/@babel/core",
         "//:node_modules/@babel/helper-plugin-utils",
-        "//:node_modules/@babel/plugin-syntax-jsx",
         "//:node_modules/@babel/types",
         "//:node_modules/@formatjs/icu-messageformat-parser",
         "//:node_modules/@formatjs/ts-transformer",

--- a/packages/babel-plugin-formatjs/global.d.ts
+++ b/packages/babel-plugin-formatjs/global.d.ts
@@ -1,1 +1,0 @@
-declare module '@babel/plugin-syntax-jsx'

--- a/packages/babel-plugin-formatjs/index.ts
+++ b/packages/babel-plugin-formatjs/index.ts
@@ -1,6 +1,5 @@
 import {type PluginPass, type PluginTarget} from '@babel/core'
 import {declare} from '@babel/helper-plugin-utils'
-import babelPluginSyntaxJsxNs from '@babel/plugin-syntax-jsx'
 import {
   type ExtractedMessageDescriptor,
   type Options,
@@ -11,9 +10,6 @@ import {
   visitor as CallExpression,
 } from '#packages/babel-plugin-formatjs/visitors/call-expression.js'
 import {visitor as JSXOpeningElement} from '#packages/babel-plugin-formatjs/visitors/jsx-opening-element.js'
-
-const babelPluginSyntaxJsx =
-  (babelPluginSyntaxJsxNs as any).default || babelPluginSyntaxJsxNs
 
 export type ExtractionResult<M = Record<string, string>> = {
   messages: ExtractedMessageDescriptor[]
@@ -40,7 +36,6 @@ const plugin: FormatJSPlugin = declare<State, Options>((api, options) => {
   // Vue
   functionNames.add('$formatMessage')
   return {
-    inherits: babelPluginSyntaxJsx,
     pre() {
       this.componentNames = Array.from(componentNames)
       this.functionNames = Array.from(functionNames)

--- a/packages/babel-plugin-formatjs/package.json
+++ b/packages/babel-plugin-formatjs/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@babel/core": "8",
     "@babel/helper-plugin-utils": "8",
-    "@babel/plugin-syntax-jsx": "8",
     "@babel/types": "8",
     "@formatjs/icu-messageformat-parser": "workspace:*",
     "@formatjs/ts-transformer": "workspace:*",

--- a/packages/babel-plugin-formatjs/tests/fixtures/6928.ts
+++ b/packages/babel-plugin-formatjs/tests/fixtures/6928.ts
@@ -1,0 +1,10 @@
+import {defineMessage} from 'react-intl'
+
+export const msg = defineMessage({
+  id: 'foo.bar.baz',
+  defaultMessage: 'Hello World!',
+  description: 'The default message.',
+})
+
+// This parses as plain TypeScript but not as TSX
+export const f = <T>(x: T): T => x

--- a/packages/babel-plugin-formatjs/tests/fixtures/6928.tsx
+++ b/packages/babel-plugin-formatjs/tests/fixtures/6928.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import {FormattedMessage} from 'react-intl'
+
+export default () => (
+  <FormattedMessage
+    id="foo.bar.baz"
+    defaultMessage="Hello World!"
+    description="The default message."
+  />
+)

--- a/packages/babel-plugin-formatjs/tests/fixtures/BUILD.bazel
+++ b/packages/babel-plugin-formatjs/tests/fixtures/BUILD.bazel
@@ -2,7 +2,11 @@ load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 
 filegroup(
     name = "files",
-    srcs = glob(["*.js"]),
+    srcs = glob([
+        "*.js",
+        "*.ts",
+        "*.tsx",
+    ]),
     visibility = [
         "//packages/babel-plugin-formatjs:__subpackages__",
     ],

--- a/packages/babel-plugin-formatjs/tests/index.test.ts
+++ b/packages/babel-plugin-formatjs/tests/index.test.ts
@@ -140,6 +140,74 @@ test('GH #2663', function () {
   }).toMatchSnapshot()
 })
 
+test('GH #6928 - does not force JSX parsing onto plain .ts files', function () {
+  const filePath = path.join(import.meta.dirname, 'fixtures', '6928.ts')
+  const messages: ExtractedMessageDescriptor[] = []
+
+  const {code} = transformFileSync(filePath, {
+    parserOpts: {plugins: ['typescript']},
+    plugins: [
+      [
+        plugin,
+        {
+          onMsgExtracted(_, msgs) {
+            messages.push(...msgs)
+          },
+        } as Options,
+        Date.now() + '' + ++cacheBust,
+      ],
+    ],
+  })!
+
+  expect(code).toMatch(/<T,?>\(x: T\): T => x/)
+  expect(messages).toEqual([
+    {
+      defaultMessage: 'Hello World!',
+      description: 'The default message.',
+      id: 'foo.bar.baz',
+    },
+  ])
+})
+
+test('GH #6928 - extracts from .tsx when the user enables JSX', function () {
+  const filePath = path.join(import.meta.dirname, 'fixtures', '6928.tsx')
+  const messages: ExtractedMessageDescriptor[] = []
+
+  transformFileSync(filePath, {
+    parserOpts: {plugins: ['typescript', 'jsx']},
+    plugins: [
+      [
+        plugin,
+        {
+          onMsgExtracted(_, msgs) {
+            messages.push(...msgs)
+          },
+        } as Options,
+        Date.now() + '' + ++cacheBust,
+      ],
+    ],
+  })!
+
+  expect(messages).toEqual([
+    {
+      defaultMessage: 'Hello World!',
+      description: 'The default message.',
+      id: 'foo.bar.baz',
+    },
+  ])
+})
+
+test('GH #6928 - does not enable JSX syntax on its own', function () {
+  const filePath = path.join(import.meta.dirname, 'fixtures', '6928.tsx')
+
+  expect(() =>
+    transformFileSync(filePath, {
+      parserOpts: {plugins: ['typescript']},
+      plugins: [[plugin, {} as Options, Date.now() + '' + ++cacheBust]],
+    })
+  ).toThrow(/Unexpected token/)
+})
+
 test('overrideIdFn', function () {
   transformAndCheck('overrideIdFn', {
     overrideIdFn: (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -512,9 +512,6 @@ importers:
       '@babel/helper-plugin-utils':
         specifier: '8'
         version: 8.0.1(@babel/core@8.0.1)
-      '@babel/plugin-syntax-jsx':
-        specifier: '8'
-        version: 8.0.1(@babel/core@8.0.1)
       '@babel/types':
         specifier: '8'
         version: 8.0.4


### PR DESCRIPTION
The plugin unconditionally inherited `@babel/plugin-syntax-jsx`, forcing JSX parsing onto every file. In plain `.ts` files, `<T>(x: T) => x` is a generic arrow function, which the jsx parser plugin rejects, so enabling the plugin broke valid TypeScript.

The plugin only observes `JSXOpeningElement` nodes; it does not need to enable any syntax itself. Whether JSX is parsed is now entirely up to the user's Babel configuration.

BREAKING CHANGE: `babel-plugin-formatjs` no longer enables JSX parsing itself. If you extract messages from `<FormattedMessage>` elements, ensure your own Babel config enables JSX (e.g. `@babel/preset-react`, `@babel/preset-typescript` for `.tsx` files, or `@babel/plugin-syntax-jsx`).

- Fixes #6928.