### PR TITLE
test(@formatjs/intl-datetimeformat): cover ar-EG locale data

### DIFF
--- a/packages/intl-datetimeformat/BUILD.bazel
+++ b/packages/intl-datetimeformat/BUILD.bazel
@@ -14,6 +14,7 @@ PACKAGE_NAME = "intl-datetimeformat"
 
 TEST_LOCALES = [
     "ar",
+    "ar-EG",
     "bn",
     "bs",
     "de",
@@ -125,6 +126,7 @@ formatjs_test(
         "tests/index.test.ts",
         "tests/offset-timezone.test.ts",
         ":tests-locale-data-ar",  # keep: generated locale data imported by tests
+        ":tests-locale-data-ar-EG",  # keep: generated locale data imported by tests
         ":tests-locale-data-bn",  # keep: generated locale data imported by tests
         ":tests-locale-data-bs",  # keep: generated locale data imported by tests
         ":tests-locale-data-de",  # keep: generated locale data imported by tests

--- a/packages/intl-datetimeformat/tests/index.test.ts
+++ b/packages/intl-datetimeformat/tests/index.test.ts
@@ -2,6 +2,7 @@ import '@formatjs/intl-getcanonicallocales/polyfill.js'
 import '@formatjs/intl-locale/polyfill.js'
 import {DateTimeFormat} from '#packages/intl-datetimeformat/core'
 import allData from '@formatjs_generated/tz/all-tz.js'
+import arEG from '#packages/intl-datetimeformat/tests/locale-data/ar-EG.json' with {type: 'json'}
 import bn from '#packages/intl-datetimeformat/tests/locale-data/bn.json' with {type: 'json'}
 import enCA from '#packages/intl-datetimeformat/tests/locale-data/en-CA.json' with {type: 'json'}
 import enGB from '#packages/intl-datetimeformat/tests/locale-data/en-GB.json' with {type: 'json'}
@@ -13,7 +14,18 @@ import ne from '#packages/intl-datetimeformat/tests/locale-data/ne.json' with {t
 import zhHans from '#packages/intl-datetimeformat/tests/locale-data/zh-Hans.json' with {type: 'json'}
 import {describe, expect, it, afterEach} from 'vitest'
 // @ts-ignore
-DateTimeFormat.__addLocaleData(en, enGB, enCA, ja, zhHans, fa, bn, my, ne)
+DateTimeFormat.__addLocaleData(
+  en,
+  enGB,
+  enCA,
+  ja,
+  zhHans,
+  fa,
+  arEG,
+  bn,
+  my,
+  ne
+)
 DateTimeFormat.__addTZData(allData)
 const DEFAULT_TIMEZONE = DateTimeFormat.getDefaultTimeZone()
 describe('Intl.DateTimeFormat', function () {
@@ -244,6 +256,22 @@ describe('Intl.DateTimeFormat', function () {
         /[\u1040-\u1049\u09e6-\u09ef\u0966-\u096f]/u
       )
     }
+  })
+  it('uses ar-EG numbering system when ar-EG locale data is loaded, GH #6912', function () {
+    const formatter = new DateTimeFormat('ar-EG', {
+      weekday: 'long',
+      month: 'long',
+      day: 'numeric',
+      timeZone: 'UTC',
+    })
+
+    expect(formatter.resolvedOptions()).toMatchObject({
+      locale: 'ar-EG',
+      numberingSystem: 'arab',
+    })
+    expect(formatter.format(new Date('2007-03-21T21:26:00Z'))).toBe(
+      'الأربعاء، ٢١ مارس'
+    )
   })
   it('test #2170', function () {
     const formatter = new DateTimeFormat('en-GB', {

--- a/packages/intl-datetimeformat/tests/index.test.ts
+++ b/packages/intl-datetimeformat/tests/index.test.ts
@@ -14,18 +14,7 @@ import ne from '#packages/intl-datetimeformat/tests/locale-data/ne.json' with {t
 import zhHans from '#packages/intl-datetimeformat/tests/locale-data/zh-Hans.json' with {type: 'json'}
 import {describe, expect, it, afterEach} from 'vitest'
 // @ts-ignore
-DateTimeFormat.__addLocaleData(
-  en,
-  enGB,
-  enCA,
-  ja,
-  zhHans,
-  fa,
-  arEG,
-  bn,
-  my,
-  ne
-)
+DateTimeFormat.__addLocaleData(en, enGB, enCA, ja, zhHans, fa, arEG, bn, my, ne)
 DateTimeFormat.__addTZData(allData)
 const DEFAULT_TIMEZONE = DateTimeFormat.getDefaultTimeZone()
 describe('Intl.DateTimeFormat', function () {


### PR DESCRIPTION
## Summary

- load generated `ar-EG` DateTimeFormat locale data in tests
- verify it resolves `numberingSystem: 'arab'`
- verify formatting uses Eastern Arabic digits

Issue #6912 loads `locale-data/ar.js` while requesting `ar-EG`. The base `ar` data defaults to `latn`; loading `locale-data/ar-EG.js` produces the expected digits.

## Test

- `buildifier -mode=check packages/intl-datetimeformat/BUILD.bazel`
- direct reproduction with `@formatjs/intl-datetimeformat@7.5.2` and `locale-data/ar-EG.js`
- focused Bazel test blocked locally: `Unknown host: registry.npmjs.org`

Refs #6912
