### PR TITLE
fix(@formatjs/intl): include context in missing id errors

### DIFF
--- a/packages/intl/message.ts
+++ b/packages/intl/message.ts
@@ -20,7 +20,6 @@ import {
   MessageFormatError,
   MissingTranslationError,
 } from '#packages/intl/error.js'
-import {invariant} from '#packages/intl/utils.js'
 
 function setTimeZoneInOptions(
   opts: Record<string, Intl.DateTimeFormatOptions>,
@@ -102,6 +101,23 @@ export type FormatMessageFn<T> = (
   opts?: Options
 ) => T extends string ? string : Array<T | string> | string | T
 
+function getMessageDescriptorContext(
+  messageDescriptor: MessageDescriptor
+): string {
+  const {defaultMessage} = messageDescriptor
+  try {
+    return defaultMessage !== undefined
+      ? `\nDefault Message: ${
+          typeof defaultMessage === 'string'
+            ? defaultMessage
+            : JSON.stringify(defaultMessage)
+        }`
+      : `\nMessage Descriptor: ${JSON.stringify(messageDescriptor)}`
+  } catch {
+    return ''
+  }
+}
+
 export const formatMessage: FormatMessageFn<any> = (
   {
     locale,
@@ -123,21 +139,12 @@ export const formatMessage: FormatMessageFn<any> = (
 
   // `id` is a required field of a Message Descriptor.
   if (!msgId) {
-    let descriptorContext = ''
-    if (defaultMessage !== undefined) {
-      descriptorContext = `\nDefault Message: ${defaultMessage}`
-    } else {
-      try {
-        descriptorContext = `\nMessage Descriptor: ${JSON.stringify(messageDescriptor)}`
-      } catch {}
-    }
-    invariant(
-      !!msgId,
+    throw new Error(
       `[@formatjs/intl] An \`id\` must be provided to format a message. You can either:
 1. Configure your build toolchain with [babel-plugin-formatjs](https://formatjs.github.io/docs/tooling/babel-plugin)
 or [@formatjs/ts-transformer](https://formatjs.github.io/docs/tooling/ts-transformer) OR
 2. Configure your \`eslint\` config to include [eslint-plugin-formatjs](https://formatjs.github.io/docs/tooling/linter#enforce-id)
-to autofix this issue${descriptorContext}`
+to autofix this issue${getMessageDescriptorContext(messageDescriptor)}`
     )
   }
   const id = String(msgId)

--- a/packages/intl/message.ts
+++ b/packages/intl/message.ts
@@ -122,14 +122,24 @@ export const formatMessage: FormatMessageFn<any> = (
   const {id: msgId, defaultMessage} = messageDescriptor
 
   // `id` is a required field of a Message Descriptor.
-  invariant(
-    !!msgId,
-    `[@formatjs/intl] An \`id\` must be provided to format a message. You can either:
+  if (!msgId) {
+    let descriptorContext = ''
+    if (defaultMessage !== undefined) {
+      descriptorContext = `\nDefault Message: ${defaultMessage}`
+    } else {
+      try {
+        descriptorContext = `\nMessage Descriptor: ${JSON.stringify(messageDescriptor)}`
+      } catch {}
+    }
+    invariant(
+      !!msgId,
+      `[@formatjs/intl] An \`id\` must be provided to format a message. You can either:
 1. Configure your build toolchain with [babel-plugin-formatjs](https://formatjs.github.io/docs/tooling/babel-plugin)
 or [@formatjs/ts-transformer](https://formatjs.github.io/docs/tooling/ts-transformer) OR
 2. Configure your \`eslint\` config to include [eslint-plugin-formatjs](https://formatjs.github.io/docs/tooling/linter#enforce-id)
-to autofix this issue`
-  )
+to autofix this issue${descriptorContext}`
+    )
+  }
   const id = String(msgId)
   const message =
     // In case messages is Object.create(null)

--- a/packages/intl/message.ts
+++ b/packages/intl/message.ts
@@ -20,6 +20,7 @@ import {
   MessageFormatError,
   MissingTranslationError,
 } from '#packages/intl/error.js'
+import {invariant} from '#packages/intl/utils.js'
 
 function setTimeZoneInOptions(
   opts: Record<string, Intl.DateTimeFormatOptions>,
@@ -139,7 +140,8 @@ export const formatMessage: FormatMessageFn<any> = (
 
   // `id` is a required field of a Message Descriptor.
   if (!msgId) {
-    throw new Error(
+    invariant(
+      false,
       `[@formatjs/intl] An \`id\` must be provided to format a message. You can either:
 1. Configure your build toolchain with [babel-plugin-formatjs](https://formatjs.github.io/docs/tooling/babel-plugin)
 or [@formatjs/ts-transformer](https://formatjs.github.io/docs/tooling/ts-transformer) OR

--- a/packages/intl/tests/formatMessage.test.ts
+++ b/packages/intl/tests/formatMessage.test.ts
@@ -168,6 +168,30 @@ describe('format API', () => {
       })
     })
 
+    it('includes Message Descriptor context when `id` is missing', () => {
+      expect(() =>
+        formatMessage({
+          defaultMessage: 'Hello, World!',
+          description: 'Greeting',
+        })
+      ).toThrow('Default Message: Hello, World!')
+
+      expect(() =>
+        formatMessage({
+          description: 'Greeting',
+        })
+      ).toThrow('Message Descriptor: {"description":"Greeting"}')
+    })
+
+    it('does not mask the missing `id` error for circular descriptors', () => {
+      const descriptor: any = {}
+      descriptor.self = descriptor
+
+      expect(() => formatMessage(descriptor)).toThrow(
+        '[@formatjs/intl] An `id` must be provided to format a message.'
+      )
+    })
+
     it('formats basic messages', () => {
       const {locale, messages} = config
       const mf = new IntlMessageFormat(messages!.no_args, locale)

--- a/packages/intl/tests/formatMessage.test.ts
+++ b/packages/intl/tests/formatMessage.test.ts
@@ -181,6 +181,12 @@ describe('format API', () => {
           description: 'Greeting',
         })
       ).toThrow('Message Descriptor: {"description":"Greeting"}')
+
+      expect(() =>
+        formatMessage({
+          defaultMessage: [{type: 0, value: 'Hello, World!'}],
+        })
+      ).toThrow('Default Message: [{"type":0,"value":"Hello, World!"}]')
     })
 
     it('does not mask the missing `id` error for circular descriptors', () => {

--- a/packages/intl/utils.ts
+++ b/packages/intl/utils.ts
@@ -11,16 +11,6 @@ import {
   type ResolvedIntlConfig,
 } from '#packages/intl/types.js'
 
-export function invariant(
-  condition: boolean,
-  message: string,
-  Err: any = Error
-): asserts condition {
-  if (!condition) {
-    throw new Err(message)
-  }
-}
-
 export function filterProps<T extends Record<string, any>, K extends string>(
   props: T,
   allowlist: Array<K>,

--- a/packages/intl/utils.ts
+++ b/packages/intl/utils.ts
@@ -11,6 +11,16 @@ import {
   type ResolvedIntlConfig,
 } from '#packages/intl/types.js'
 
+export function invariant(
+  condition: boolean,
+  message: string,
+  Err: any = Error
+): asserts condition {
+  if (!condition) {
+    throw new Err(message)
+  }
+}
+
 export function filterProps<T extends Record<string, any>, K extends string>(
   props: T,
   allowlist: Array<K>,


### PR DESCRIPTION
Fixes #6921

## Summary

- include `defaultMessage` in missing-id errors
- fall back to serialized Message Descriptor context
- preserve original error when descriptor cannot be serialized

## Test

- `oxfmt --check packages/intl/message.ts packages/intl/tests/formatMessage.test.ts`
- `ast-grep scan packages/intl/message.ts packages/intl/tests/formatMessage.test.ts`
- `bazel test //packages/intl:intl_test --test_output=errors` (local dependency fetch blocked by DNS)
