### PR TITLE
fix(formatjs_cli): extract id-only messages

### DIFF
--- a/crates/formatjs_cli/src/extractor.rs
+++ b/crates/formatjs_cli/src/extractor.rs
@@ -380,6 +380,7 @@ impl<'a> MessageExtractor<'a> {
             start: None,
             end: None,
         };
+        let mut extraction_error = false;
 
         // Extract source location if requested
         if self.extract_source_location {
@@ -423,6 +424,7 @@ impl<'a> MessageExtractor<'a> {
                                         "id" => {
                                             descriptor.id = self.extract_string_literal(expr, None);
                                             if descriptor.id.is_none() {
+                                                extraction_error = true;
                                                 let loc = self.format_location(jsx_attr.span.start);
                                                 if self.throws {
                                                     panic!(
@@ -440,6 +442,7 @@ impl<'a> MessageExtractor<'a> {
                                             descriptor.default_message =
                                                 self.extract_string_literal(expr, None);
                                             if descriptor.default_message.is_none() {
+                                                extraction_error = true;
                                                 let loc = self.format_location(jsx_attr.span.start);
                                                 if self.throws {
                                                     panic!(
@@ -467,8 +470,7 @@ impl<'a> MessageExtractor<'a> {
             }
         }
 
-        // Only add if we have at least a defaultMessage
-        if descriptor.default_message.is_some() {
+        if !extraction_error && (descriptor.id.is_some() || descriptor.default_message.is_some()) {
             self.messages.push(descriptor);
         }
     }
@@ -541,6 +543,7 @@ impl<'a> MessageExtractor<'a> {
             start: None,
             end: None,
         };
+        let mut extraction_error = false;
 
         if self.extract_source_location {
             descriptor.file = Some(self.file_path.to_string_lossy().to_string());
@@ -554,6 +557,7 @@ impl<'a> MessageExtractor<'a> {
                         "id" => {
                             descriptor.id = self.extract_string_literal(&p.value, None);
                             if descriptor.id.is_none() {
+                                extraction_error = true;
                                 let loc = self.format_location(p.span.start);
                                 if self.throws {
                                     panic!(
@@ -571,6 +575,7 @@ impl<'a> MessageExtractor<'a> {
                             descriptor.default_message =
                                 self.extract_string_literal(&p.value, None);
                             if descriptor.default_message.is_none() {
+                                extraction_error = true;
                                 let loc = self.format_location(p.span.start);
                                 if self.throws {
                                     panic!(
@@ -593,8 +598,7 @@ impl<'a> MessageExtractor<'a> {
             }
         }
 
-        // Only return if we have at least defaultMessage
-        if descriptor.default_message.is_some() {
+        if !extraction_error && (descriptor.id.is_some() || descriptor.default_message.is_some()) {
             Some(descriptor)
         } else {
             None
@@ -1099,15 +1103,16 @@ mod tests {
     }
 
     #[test]
-    fn test_no_defaultmessage_skips() {
+    fn test_extracts_id_only_messages() {
         let source = r#"
-            <FormattedMessage id="no-default" description="Has no default message" />
+            const label = intl.formatMessage({id: "call-only"});
+            <FormattedMessage id="jsx-only" />
         "#;
 
         let file_path = PathBuf::from("test.tsx");
         let source_type = SourceType::default().with_typescript(true).with_jsx(true);
         let component_names = vec!["FormattedMessage".to_string()];
-        let function_names = vec![];
+        let function_names = vec!["formatMessage".to_string()];
 
         let messages = extract_messages_from_source(
             source,
@@ -1123,8 +1128,13 @@ mod tests {
         )
         .unwrap();
 
-        // Should not extract messages without defaultMessage
-        assert_eq!(messages.len(), 0);
+        assert_eq!(messages.len(), 2);
+        assert!(messages.iter().any(|message| {
+            message.id.as_deref() == Some("call-only") && message.default_message.is_none()
+        }));
+        assert!(messages.iter().any(|message| {
+            message.id.as_deref() == Some("jsx-only") && message.default_message.is_none()
+        }));
     }
 
     // Fixture-based tests (matching ts-transformer test suite)

--- a/crates/formatjs_cli/src/extractor.rs
+++ b/crates/formatjs_cli/src/extractor.rs
@@ -422,7 +422,8 @@ impl<'a> MessageExtractor<'a> {
                                 if let Some(expr) = container.expression.as_expression() {
                                     match attr_name {
                                         "id" => {
-                                            descriptor.id = self.extract_string_literal(expr, None);
+                                            descriptor.id =
+                                                self.extract_string_literal(expr, Some(true));
                                             if descriptor.id.is_none() {
                                                 extraction_error = true;
                                                 let loc = self.format_location(jsx_attr.span.start);
@@ -555,7 +556,8 @@ impl<'a> MessageExtractor<'a> {
                 if let PropertyKey::StaticIdentifier(key) = &p.key {
                     match key.name.as_str() {
                         "id" => {
-                            descriptor.id = self.extract_string_literal(&p.value, None);
+                            descriptor.id =
+                                self.extract_string_literal(&p.value, Some(true));
                             if descriptor.id.is_none() {
                                 extraction_error = true;
                                 let loc = self.format_location(p.span.start);
@@ -1105,8 +1107,8 @@ mod tests {
     #[test]
     fn test_extracts_id_only_messages() {
         let source = r#"
-            const label = intl.formatMessage({id: "call-only"});
-            <FormattedMessage id="jsx-only" />
+            const label = intl.formatMessage({id: "call  only"});
+            <FormattedMessage id={"jsx  only"} />
         "#;
 
         let file_path = PathBuf::from("test.tsx");
@@ -1130,10 +1132,10 @@ mod tests {
 
         assert_eq!(messages.len(), 2);
         assert!(messages.iter().any(|message| {
-            message.id.as_deref() == Some("call-only") && message.default_message.is_none()
+            message.id.as_deref() == Some("call  only") && message.default_message.is_none()
         }));
         assert!(messages.iter().any(|message| {
-            message.id.as_deref() == Some("jsx-only") && message.default_message.is_none()
+            message.id.as_deref() == Some("jsx  only") && message.default_message.is_none()
         }));
     }
 

--- a/packages/cli/integration-tests/conformance-tests/test_cases/25_id_only_messages.txt
+++ b/packages/cli/integration-tests/conformance-tests/test_cases/25_id_only_messages.txt
@@ -1,7 +1,7 @@
 import {FormattedMessage} from 'react-intl';
 
-const label = intl.formatMessage({id: 'Call-only message'});
-const element = <FormattedMessage id="JSX-only message" />;
+const label = intl.formatMessage({id: 'Call-only  message'});
+const element = <FormattedMessage id={'JSX-only  message'} />;
 ---
 {
   "command": "extract",
@@ -10,6 +10,6 @@ const element = <FormattedMessage id="JSX-only message" />;
 }
 ---
 {
-  "Call-only message": {},
-  "JSX-only message": {}
+  "Call-only  message": {},
+  "JSX-only  message": {}
 }

--- a/packages/cli/integration-tests/conformance-tests/test_cases/25_id_only_messages.txt
+++ b/packages/cli/integration-tests/conformance-tests/test_cases/25_id_only_messages.txt
@@ -1,0 +1,15 @@
+import {FormattedMessage} from 'react-intl';
+
+const label = intl.formatMessage({id: 'Call-only message'});
+const element = <FormattedMessage id="JSX-only message" />;
+---
+{
+  "command": "extract",
+  "args": ["--throws"],
+  "fileType": "tsx"
+}
+---
+{
+  "Call-only message": {},
+  "JSX-only message": {}
+}


### PR DESCRIPTION
## Summary

- extract descriptors containing only a static `id` in native JSX and call paths
- keep skipping descriptors with non-static extraction errors
- add Rust unit and TypeScript/Rust CLI conformance coverage

Fixes #6961.

## Testing

- `bazel test //crates/formatjs_cli:formatjs_cli_test --test_output=errors`
- `bazel run //crates/formatjs_cli -- extract /private/tmp/formatjs-6961-id-only.tsx --throws`

The conformance target was blocked locally before execution because Bazel could not resolve `registry.npmjs.org` while fetching `oxfmt@0.60.0`; CI will run it.
