### PR TITLE
docs: add internationalization best practices

### DIFF
--- a/.github/workflows/verify-hooks.yml
+++ b/.github/workflows/verify-hooks.yml
@@ -34,7 +34,7 @@ jobs:
           JS_BINARY__CHDIR="$PWD" bazel run //:lefthook -- run pre-commit --all-files
           if [ -n "$(git status --porcelain)" ]; then
             echo "Error: Pre-commit hooks would have made changes. Please run the hooks locally and commit the changes."
-            git diff HEAD
+            git diff
             exit 1
           fi
 

--- a/.github/workflows/verify-hooks.yml
+++ b/.github/workflows/verify-hooks.yml
@@ -34,7 +34,7 @@ jobs:
           JS_BINARY__CHDIR="$PWD" bazel run //:lefthook -- run pre-commit --all-files
           if [ -n "$(git status --porcelain)" ]; then
             echo "Error: Pre-commit hooks would have made changes. Please run the hooks locally and commit the changes."
-            git diff
+            git diff HEAD
             exit 1
           fi
 

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -21,6 +21,6 @@
     "packages/*/CHANGELOG.md",
     "packages/cli-lib/tests/extract/typescript/err.tsx",
     "packages/cli/integration-tests/extract/typescript/err.tsx",
-    "target",
+    "target"
   ]
 }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -9,10 +9,13 @@
     "es2026": true,
     "browser": true
   },
-   "rules": {
-    "typescript/consistent-type-imports": ["error", {
-      "fixStyle": "separate-type-imports",
-      "prefer": "type-imports"
-    }]
+  "rules": {
+    "typescript/consistent-type-imports": [
+      "error",
+      {
+        "fixStyle": "separate-type-imports",
+        "prefer": "type-imports"
+      }
+    ]
   }
 }

--- a/docs/public/sitemap.xml
+++ b/docs/public/sitemap.xml
@@ -46,6 +46,11 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://formatjs.io/docs/guides/best-practices</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://formatjs.io/docs/guides/bundler-plugins</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>

--- a/docs/src/docs-metadata.generated.json
+++ b/docs/src/docs-metadata.generated.json
@@ -31,6 +31,10 @@
     "title": "Advanced Usage",
     "description": "react-intl is optimized for both runtime & compile time rendering. Below are a few guidelines you can follow if you have a strict performance budget."
   },
+  "guides/best-practices": {
+    "title": "Best Practices",
+    "description": "Good messages give translators enough context to express the same meaning naturally in every locale. Keep complete thoughts together, format values with..."
+  },
   "guides/bundler-plugins": {
     "title": "Bundler Plugins",
     "description": "Now that you've had a working pipeline. It's time to dive deeper on how to optimize the build with formatjs. From Message Extraction guide, we explicitl..."

--- a/docs/src/docs/core-concepts/basic-internationalization-principles.mdx
+++ b/docs/src/docs/core-concepts/basic-internationalization-principles.mdx
@@ -58,3 +58,5 @@ The actual formatting and presentation of data and translated strings typically 
    - translated strings for that locale
    - optionally, any custom formats
 3. Call the template engine, passing the data that needs formatting.
+
+For practical guidance on writing translation-friendly messages, see [Internationalization Best Practices](/docs/guides/best-practices).

--- a/docs/src/docs/getting-started/message-declaration.mdx
+++ b/docs/src/docs/getting-started/message-declaration.mdx
@@ -5,6 +5,8 @@ While you can declare your messages using only `id`s, we highly recommend declar
 3. Text styling is also dependent on the message itself. Things like truncation, capitalization... certainly affect the messages themselves.
 4. Better integrations with toolchains. Most toolchains cannot verify cross-file references to validate syntax/usage.
 
+See [Internationalization Best Practices](/docs/guides/best-practices) for guidance on complete messages, locale-aware formatting, brand names, and terminology.
+
 At a high level, formatjs messages use [ICU Syntax](/docs/core-concepts/icu-syntax) with a couple of enhancements common in other message format such as [Fluent](https://github.com/projectfluent/fluent.js/). This section focuses on the actual supported ways of calling `formatjs` APIs so messages can be extracted.
 
 ## Using imperative API `intl.formatMessage`

--- a/docs/src/docs/guides/best-practices.mdx
+++ b/docs/src/docs/guides/best-practices.mdx
@@ -1,0 +1,113 @@
+# Internationalization Best Practices
+
+Good messages give translators enough context to express the same meaning naturally in every locale. Keep complete thoughts together, format values with locale-aware APIs, and treat terminology as part of your product.
+
+## Keep messages inline and complete
+
+Declare each message next to its use with a `defaultMessage` and a useful `description`. Colocation preserves UI context for both developers and translators, and lets extraction tools remove messages when their usages disappear.
+
+```tsx
+<FormattedMessage
+  defaultMessage="Delete {fileName}?"
+  description="Confirmation dialog title shown before deleting a file"
+  values={{fileName}}
+/>
+```
+
+Do not concatenate fragments or assemble sentences from multiple messages. Translators may need to reorder words, change inflection, or translate the same English word differently based on its role.
+
+```tsx
+// Avoid: translators only see disconnected fragments.
+const label = intl.formatMessage({defaultMessage: 'Last updated'})
+return `${label}: ${intl.formatRelativeTime(days, 'day')}`
+
+// Prefer: translators see and can reorder the complete thought.
+return intl.formatMessage(
+  {
+    defaultMessage:
+      'Last updated {days, plural, =0 {today} one {# day ago} other {# days ago}}',
+  },
+  {days}
+)
+```
+
+For the same reason, do not reuse one message for a button, page title, and status label only because their English text matches. Give each usage its own message and description.
+
+## Put grammar and formatting in the message
+
+Use ICU `plural` and `select` arguments instead of branching in application code. This keeps every grammatical variant together and allows each locale to define the variants it needs.
+
+```tsx
+intl.formatMessage(
+  {
+    defaultMessage:
+      '{count, plural, =0 {No results} one {# result} other {# results}}',
+  },
+  {count}
+)
+```
+
+Prefer ICU number and date skeletons when formatting is part of a sentence. Skeletons make intent visible to translators while preserving locale-appropriate output.
+
+```tsx
+intl.formatMessage(
+  {
+    defaultMessage:
+      'Your total is {total, number, ::currency/USD}. Delivery is {date, date, ::yyyyMMdd}.',
+  },
+  {total, date}
+)
+```
+
+Skeletons describe formatting, not sentence structure. Keep surrounding punctuation and words inside the message so translators can move them. See [ICU Message Syntax](/docs/core-concepts/icu-syntax) for supported skeletons.
+
+When a value is not part of a message, use FormatJS or the equivalent built-in `Intl` API instead of constructing locale-sensitive text yourself:
+
+- `formatNumber` or `<FormattedNumber>` for numbers and currencies
+- `formatDate`, `formatTime`, or their component equivalents for dates and times
+- `formatDateTimeRange` or `<FormattedDateTimeRange>` for ranges
+- `formatList` or `<FormattedList>` for lists
+- `formatRelativeTime` or `<FormattedRelativeTime>` for relative time
+
+Do not use spaces, non-breaking spaces, or newlines for layout. Different writing systems use whitespace differently. Use CSS for visual spacing.
+
+## Keep brand names translatable
+
+Do not hide a brand behind a placeholder such as `{brand}`. Brands may stay unchanged in one locale but be transliterated or use an established local name in another. The translator also needs the full sentence to place the brand naturally.
+
+```tsx
+// Avoid: the brand cannot be transliterated, and sentence context is weaker.
+intl.formatMessage(
+  {defaultMessage: '{brand} helps you find a place to stay.'},
+  {brand: 'Airbnb'}
+)
+
+// Prefer: the translator controls the complete message, including the brand.
+intl.formatMessage({
+  defaultMessage: 'Airbnb helps you find a place to stay.',
+  description: 'Product introduction; Airbnb is a brand name',
+})
+```
+
+For example, a Japanese translation may render “Google” as “グーグル”, while a Simplified Chinese translation may use Coca-Cola's established local name “可口可乐”. Product and legal requirements still apply: record whether each brand should be translated, transliterated, or kept unchanged in your glossary.
+
+## Maintain a glossary
+
+A shared glossary keeps important terms consistent across translators, teams, and releases. Add an entry when a term is product-specific, ambiguous, legally sensitive, or intentionally left untranslated.
+
+Each entry should include:
+
+- source term and meaning
+- usage context and an example sentence
+- approved translation for each locale, when one exists
+- terms or translations to avoid
+- capitalization, pluralization, and do-not-translate rules
+- owner and last review date
+
+Treat meanings separately. For example, “workspace” as a product container may need a different translation from “workspace” as a physical desk area. Review the glossary with translators as product language changes; do not use it to force one translation into every context.
+
+## Review messages in context
+
+Before shipping, review translated UI with realistic data. Check long text, plurals, gender or select variants, right-to-left layouts, narrow screens, and accessibility labels. Pseudolocalization can expose hard-coded strings and layout assumptions, but native-speaker review remains necessary for meaning and tone.
+
+See [Message Declaration](/docs/getting-started/message-declaration) for extractable message patterns and [Application Workflow](/docs/getting-started/application-workflow) for the translation lifecycle.

--- a/docs/src/docs/guides/best-practices.mdx
+++ b/docs/src/docs/guides/best-practices.mdx
@@ -22,10 +22,7 @@ const greeting = intl.formatMessage({defaultMessage: 'Welcome'})
 return `${greeting}, ${name}!`
 
 // Prefer: translators see and can reorder the complete thought.
-return intl.formatMessage(
-  {defaultMessage: 'Welcome, {name}!'},
-  {name}
-)
+return intl.formatMessage({defaultMessage: 'Welcome, {name}!'}, {name})
 ```
 
 For the same reason, do not reuse one message for a button, page title, and status label only because their English text matches. Give each usage its own message and description.

--- a/docs/src/docs/guides/best-practices.mdx
+++ b/docs/src/docs/guides/best-practices.mdx
@@ -18,16 +18,13 @@ Do not concatenate fragments or assemble sentences from multiple messages. Trans
 
 ```tsx
 // Avoid: translators only see disconnected fragments.
-const label = intl.formatMessage({defaultMessage: 'Last updated'})
-return `${label}: ${intl.formatRelativeTime(days, 'day')}`
+const greeting = intl.formatMessage({defaultMessage: 'Welcome'})
+return `${greeting}, ${name}!`
 
 // Prefer: translators see and can reorder the complete thought.
 return intl.formatMessage(
-  {
-    defaultMessage:
-      'Last updated {days, plural, =0 {today} one {# day ago} other {# days ago}}',
-  },
-  {days}
+  {defaultMessage: 'Welcome, {name}!'},
+  {name}
 )
 ```
 
@@ -68,6 +65,12 @@ When a value is not part of a message, use FormatJS or the equivalent built-in `
 - `formatDateTimeRange` or `<FormattedDateTimeRange>` for ranges
 - `formatList` or `<FormattedList>` for lists
 - `formatRelativeTime` or `<FormattedRelativeTime>` for relative time
+
+Prefer these APIs when ICU skeletons do not cover the format. For example, relative time has no message skeleton; let `formatRelativeTime` produce the complete locale-aware phrase instead of recreating it with plural rules:
+
+```tsx
+intl.formatRelativeTime(-1, 'day') // "yesterday" in English
+```
 
 Do not use spaces, non-breaking spaces, or newlines for layout. Different writing systems use whitespace differently. Use CSS for visual spacing.
 

--- a/docs/src/docs/guides/best-practices.mdx
+++ b/docs/src/docs/guides/best-practices.mdx
@@ -66,11 +66,25 @@ When a value is not part of a message, use FormatJS or the equivalent built-in `
 - `formatList` or `<FormattedList>` for lists
 - `formatRelativeTime` or `<FormattedRelativeTime>` for relative time
 
-Prefer these APIs when ICU skeletons do not cover the format. For example, relative time has no message skeleton; let `formatRelativeTime` produce the complete locale-aware phrase instead of recreating it with plural rules:
+Prefer these APIs when ICU skeletons do not cover the format. For example, relative time has no message skeleton; let `formatRelativeTime` produce the locale-aware phrase instead of recreating it with plural rules.
+
+Separating text is appropriate when the UI presents a semantic label and an independently formatted value rather than one sentence. Keep the label translatable, format the value with its native API, and use layout instead of string concatenation:
 
 ```tsx
-intl.formatRelativeTime(-1, 'day') // "yesterday" in English
+<dl className="metadata-row">
+  <dt>
+    <FormattedMessage
+      defaultMessage="Last updated:"
+      description="Label before a relative time"
+    />
+  </dt>
+  <dd>
+    <FormattedRelativeTime value={-1} unit="day" />
+  </dd>
+</dl>
 ```
+
+This can render as “Last updated: 1 day ago” while allowing the label and relative-time phrase to adapt independently.
 
 Do not use spaces, non-breaking spaces, or newlines for layout. Different writing systems use whitespace differently. Use CSS for visual spacing.
 

--- a/docs/src/utils/navigation.ts
+++ b/docs/src/utils/navigation.ts
@@ -118,6 +118,7 @@ export function getNavigationTree(): NavSection[] {
       title: 'Guides',
       order: 6,
       items: [
+        {title: 'Best Practices', path: 'guides/best-practices'},
         {
           title: 'Testing with React Intl',
           path: 'guides/testing-with-react-intl',


### PR DESCRIPTION
## Summary

- add an internationalization best practices guide covering inline messages, ICU formatting, brand transliteration, glossaries, and contextual review
- link the guide from navigation, Message Declaration, and Basic Internationalization Principles
- regenerate docs metadata and sitemap

## Testing

- `bazel test //docs:sitemap_test //docs:docs_metadata_test //docs:typecheck_typecheck_test`
- `bazel build //docs:dist`

Both passed before rebasing onto latest `main`; affected docs sources did not change across the rebase. Latest-main reruns and commit hooks were blocked by npm registry DNS while fetching Vite, oxfmt, and oxlint: `Unknown host: registry.npmjs.org`.
