### PR TITLE
feat(formatjs_icu_messageformat): add Rust message formatter

### DIFF
--- a/.github/workflows/crates-release.yml
+++ b/.github/workflows/crates-release.yml
@@ -20,6 +20,7 @@ on:
           - all
           - formatjs_icu_skeleton_parser
           - formatjs_icu_messageformat_parser
+          - formatjs_icu_messageformat
           - formatjs_cli
 
 concurrency:
@@ -70,6 +71,9 @@ jobs:
                 formatjs_icu_messageformat_parser_v*|icu_messageformat_parser_v*|crates/icu_messageformat_parser_v*)
                   crates=(formatjs_icu_messageformat_parser)
                   ;;
+                formatjs_icu_messageformat_v*|icu_messageformat_v*|crates/icu_messageformat_v*)
+                  crates=(formatjs_icu_messageformat)
+                  ;;
                 formatjs_cli_v*|crates/formatjs_cli_v*)
                   crates=(formatjs_cli)
                   ;;
@@ -84,10 +88,11 @@ jobs:
                   crates=(
                     formatjs_icu_skeleton_parser
                     formatjs_icu_messageformat_parser
+                    formatjs_icu_messageformat
                     formatjs_cli
                   )
                   ;;
-                formatjs_icu_skeleton_parser|formatjs_icu_messageformat_parser|formatjs_cli)
+                formatjs_icu_skeleton_parser|formatjs_icu_messageformat_parser|formatjs_icu_messageformat|formatjs_cli)
                   crates=("$INPUT_CRATE")
                   ;;
                 *)
@@ -125,6 +130,7 @@ jobs:
           targets=(
             //crates/icu_skeleton_parser:icu_skeleton_parser_test
             //crates/icu_messageformat_parser:icu_messageformat_parser_test
+            //crates/icu_messageformat:icu_messageformat_test
             //crates/formatjs_cli:formatjs_cli_test
           )
 
@@ -220,6 +226,14 @@ jobs:
                 wait_if_published_by_this_run \
                   formatjs_icu_skeleton_parser \
                   "$(dependency_version crates/icu_messageformat_parser/Cargo.toml formatjs_icu_skeleton_parser)"
+                ;;
+              formatjs_icu_messageformat)
+                wait_if_published_by_this_run \
+                  formatjs_icu_skeleton_parser \
+                  "$(dependency_version crates/icu_messageformat/Cargo.toml formatjs_icu_skeleton_parser)"
+                wait_if_published_by_this_run \
+                  formatjs_icu_messageformat_parser \
+                  "$(dependency_version crates/icu_messageformat/Cargo.toml formatjs_icu_messageformat_parser)"
                 ;;
               formatjs_cli)
                 wait_if_published_by_this_run \

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -37,6 +37,7 @@
   "packages/vue-intl": "7.2.15",
   "crates/icu_skeleton_parser": "0.1.2",
   "crates/icu_messageformat_parser": "0.2.7",
+  "crates/icu_messageformat": "0.1.0",
   "crates/formatjs_cli": "1.1.22",
   "crates/formatjs_cli_napi": "0.0.13",
   "packages/icu-messageformat-parser/integration-tests": "0.1.3"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,6 +528,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "formatjs_icu_messageformat"
+version = "0.1.0"
+dependencies = [
+ "fixed_decimal",
+ "formatjs_icu_messageformat_parser",
+ "formatjs_icu_skeleton_parser",
+ "icu",
+]
+
+[[package]]
 name = "formatjs_icu_skeleton_parser"
 version = "0.1.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
   "crates/icu_skeleton_parser",
   "crates/icu_messageformat_parser",
+  "crates/icu_messageformat",
   "crates/formatjs_cli",
   "crates/formatjs_cli_napi",
   "packages/icu-messageformat-parser/integration-tests",

--- a/crates/icu_messageformat/BUILD.bazel
+++ b/crates/icu_messageformat/BUILD.bazel
@@ -1,0 +1,38 @@
+load("@rules_rs//rs:rust_library.bzl", "rust_library")
+load("@rules_rs//rs:rust_test.bzl", "rust_test")
+
+exports_files(
+    [
+        "Cargo.toml",
+        "README.md",
+        "error.rs",
+        "formatter.rs",
+        "lib.rs",
+        "value.rs",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+rust_library(
+    name = "icu_messageformat",
+    srcs = [
+        "error.rs",
+        "formatter.rs",
+        "lib.rs",
+        "value.rs",
+    ],
+    crate_name = "formatjs_icu_messageformat",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//crates/icu_messageformat_parser",
+        "//crates/icu_skeleton_parser",
+        "@crates//:fixed_decimal",
+        "@crates//:icu",
+    ],
+)
+
+rust_test(
+    name = "icu_messageformat_test",
+    size = "small",
+    crate = ":icu_messageformat",
+)

--- a/crates/icu_messageformat/Cargo.toml
+++ b/crates/icu_messageformat/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "formatjs_icu_messageformat"
+version = "0.1.0"
+edition = "2024"
+authors = ["FormatJS Team", "Long Ho <holevietlong@gmail.com>"]
+description = "ICU MessageFormat runtime implementation in Rust"
+license = "BSD-3-Clause"
+repository = "https://github.com/formatjs/formatjs"
+homepage = "https://formatjs.io/"
+documentation = "https://docs.rs/formatjs_icu_messageformat"
+keywords = ["icu", "i18n", "internationalization", "messageformat", "intl"]
+categories = ["internationalization", "localization"]
+readme = "README.md"
+rust-version = "1.95"
+
+[dependencies]
+fixed_decimal = "0.7"
+formatjs_icu_messageformat_parser = { path = "../icu_messageformat_parser", version = "0.2.7" }
+formatjs_icu_skeleton_parser = { path = "../icu_skeleton_parser", version = "0.1.2" }
+icu = "2.1"
+
+[lib]
+path = "lib.rs"
+crate-type = ["rlib"]

--- a/crates/icu_messageformat/README.md
+++ b/crates/icu_messageformat/README.md
@@ -1,0 +1,31 @@
+# formatjs_icu_messageformat
+
+Rust runtime for ICU MessageFormat. Mirrors `intl-messageformat` around the
+existing `formatjs_icu_messageformat_parser` AST and uses ICU4X for locale-aware
+number, date/time, and plural formatting.
+
+```rust
+use formatjs_icu_messageformat::{IcuMessageFormat, Value};
+use std::collections::HashMap;
+
+let message = IcuMessageFormat::try_new(
+    "Hello, {name}. You have {count, plural, one {# task} other {# tasks}}.",
+)?;
+let values = HashMap::from([
+    ("name".to_owned(), Value::from("Ada")),
+    ("count".to_owned(), Value::from(2_i64)),
+]);
+assert_eq!(
+    message.format_to_string("en-US", &values)?,
+    "Hello, Ada. You have 2 tasks."
+);
+# Ok::<(), formatjs_icu_messageformat::Error>(())
+```
+
+Messages are parsed once without a locale. Pass each request's locale to
+`format`, `format_to_parts`, or `format_to_string`; one compiled message can be
+shared across requests with different locales.
+
+Unix epoch millisecond values are formatted in UTC. ICU4X currently lacks full
+ECMA-402 currency, unit, and time-zone formatting parity; custom implementations
+can be supplied through the `Formatters` trait.

--- a/crates/icu_messageformat/error.rs
+++ b/crates/icu_messageformat/error.rs
@@ -1,0 +1,119 @@
+use std::error::Error as StdError;
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ErrorCode {
+    MissingValue,
+    InvalidValue,
+    InvalidValueType,
+    Parse,
+    Formatter,
+}
+
+impl ErrorCode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::MissingValue => "MISSING_VALUE",
+            Self::InvalidValue => "INVALID_VALUE",
+            Self::InvalidValueType => "INVALID_VALUE",
+            Self::Parse => "PARSE_ERROR",
+            Self::Formatter => "FORMAT_ERROR",
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Error {
+    pub code: ErrorCode,
+    pub message: String,
+    pub original_message: Option<String>,
+    source: Option<Box<dyn StdError + Send + Sync>>,
+}
+
+impl Error {
+    pub fn new(code: ErrorCode, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            original_message: None,
+            source: None,
+        }
+    }
+
+    pub fn with_original_message(mut self, original_message: Option<&str>) -> Self {
+        self.original_message = original_message.map(str::to_owned);
+        self
+    }
+
+    pub fn with_source(
+        mut self,
+        source: impl StdError + Send + Sync + 'static,
+    ) -> Self {
+        self.source = Some(Box::new(source));
+        self
+    }
+
+    pub fn missing_value(variable: &str, original_message: Option<&str>) -> Self {
+        Self::new(
+            ErrorCode::MissingValue,
+            format!(
+                "The intl string context variable \"{variable}\" was not provided to the string \"{}\"",
+                original_message.unwrap_or("undefined")
+            ),
+        )
+        .with_original_message(original_message)
+    }
+
+    pub fn invalid_value(
+        variable: &str,
+        value: &str,
+        options: impl IntoIterator<Item = impl AsRef<str>>,
+        original_message: Option<&str>,
+    ) -> Self {
+        let options = options
+            .into_iter()
+            .map(|option| option.as_ref().to_owned())
+            .collect::<Vec<_>>()
+            .join("\", \"");
+        Self::new(
+            ErrorCode::InvalidValue,
+            format!(
+                "Invalid value for \"{variable}\": \"{value}\". Options are \"{options}\""
+            ),
+        )
+        .with_original_message(original_message)
+    }
+
+    pub fn invalid_value_type(
+        variable: &str,
+        expected: &str,
+        original_message: Option<&str>,
+    ) -> Self {
+        Self::new(
+            ErrorCode::InvalidValueType,
+            format!("Value for \"{variable}\" must be of type {expected}"),
+        )
+        .with_original_message(original_message)
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "[formatjs Error: {}] {}",
+            self.code.as_str(),
+            self.message
+        )
+    }
+}
+
+impl StdError for Error {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        self.source
+            .as_deref()
+            .map(|source| source as &(dyn StdError + 'static))
+    }
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/icu_messageformat/formatter.rs
+++ b/crates/icu_messageformat/formatter.rs
@@ -1,0 +1,266 @@
+use crate::error::{Error, ErrorCode, Result};
+use crate::value::{DateTimeValue, NumericValue};
+use fixed_decimal::{SignedRoundingMode, UnsignedRoundingMode};
+use formatjs_icu_messageformat_parser::types::PluralType;
+use formatjs_icu_skeleton_parser::{DateTimeFormatOptions, ExtendedNumberFormatOptions};
+use icu::datetime::fieldsets::{T, YMD, YMDE};
+use icu::datetime::input::{Date, Time};
+use icu::datetime::DateTimeFormatter;
+use icu::decimal::input::Decimal;
+use icu::decimal::options::{DecimalFormatterOptions, GroupingStrategy};
+use icu::decimal::DecimalFormatter;
+use icu::locale::Locale;
+use icu::plurals::{PluralCategory, PluralOperands, PluralRules};
+use std::str::FromStr;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DateTimeKind {
+    Date,
+    Time,
+}
+
+pub trait Formatters: Send + Sync {
+    fn format_number(
+        &self,
+        locale: &Locale,
+        value: NumericValue,
+        options: &ExtendedNumberFormatOptions,
+    ) -> Result<String>;
+
+    fn format_datetime(
+        &self,
+        locale: &Locale,
+        value: DateTimeValue,
+        kind: DateTimeKind,
+        options: &DateTimeFormatOptions,
+    ) -> Result<String>;
+
+    fn plural_category(
+        &self,
+        locale: &Locale,
+        value: NumericValue,
+        plural_type: PluralType,
+    ) -> Result<PluralCategory>;
+}
+
+#[derive(Debug, Default)]
+pub struct DefaultFormatters;
+
+impl DefaultFormatters {
+    fn formatter_error(error: impl std::fmt::Display) -> Error {
+        Error::new(ErrorCode::Formatter, error.to_string())
+    }
+}
+
+impl Formatters for DefaultFormatters {
+    fn format_number(
+        &self,
+        locale: &Locale,
+        value: NumericValue,
+        options: &ExtendedNumberFormatOptions,
+    ) -> Result<String> {
+        use formatjs_icu_skeleton_parser::{
+            NumberFormatOptionsStyle, RoundingModeType, TrailingZeroDisplay, UseGroupingString,
+            UseGroupingType,
+        };
+
+        let percent = matches!(options.style(), Some(NumberFormatOptionsStyle::Percent));
+        let value = if percent { value.scaled(100.0) } else { value };
+        let mut decimal = Decimal::from_str(&value.decimal_string()?)
+            .map_err(Self::formatter_error)?;
+
+        let default_minimum_fraction_digits = match options.style() {
+            Some(NumberFormatOptionsStyle::Currency) => 2,
+            _ => 0,
+        };
+        let minimum_fraction_digits = options
+            .minimum_fraction_digits()
+            .unwrap_or(default_minimum_fraction_digits);
+        let default_maximum_fraction_digits = match options.style() {
+            Some(NumberFormatOptionsStyle::Percent) => 0,
+            Some(NumberFormatOptionsStyle::Currency) => 2,
+            _ => 3,
+        };
+        let maximum_fraction_digits = options
+            .maximum_fraction_digits()
+            .unwrap_or(default_maximum_fraction_digits.max(minimum_fraction_digits));
+        {
+            let rounding_mode = match options.rounding_mode() {
+                Some(RoundingModeType::Ceil) => SignedRoundingMode::Ceil,
+                Some(RoundingModeType::Floor) => SignedRoundingMode::Floor,
+                Some(RoundingModeType::Expand) => {
+                    SignedRoundingMode::Unsigned(UnsignedRoundingMode::Expand)
+                }
+                Some(RoundingModeType::Trunc) => {
+                    SignedRoundingMode::Unsigned(UnsignedRoundingMode::Trunc)
+                }
+                Some(RoundingModeType::HalfCeil) => SignedRoundingMode::HalfCeil,
+                Some(RoundingModeType::HalfFloor) => SignedRoundingMode::HalfFloor,
+                Some(RoundingModeType::HalfTrunc) => {
+                    SignedRoundingMode::Unsigned(UnsignedRoundingMode::HalfTrunc)
+                }
+                Some(RoundingModeType::HalfEven) => {
+                    SignedRoundingMode::Unsigned(UnsignedRoundingMode::HalfEven)
+                }
+                Some(RoundingModeType::HalfExpand) | None => {
+                    SignedRoundingMode::Unsigned(UnsignedRoundingMode::HalfExpand)
+                }
+            };
+            decimal.round_with_mode(-(maximum_fraction_digits as i16), rounding_mode);
+            decimal.absolute.trim_end();
+        }
+        if minimum_fraction_digits > 0 {
+            decimal.absolute.pad_end(-(minimum_fraction_digits as i16));
+        }
+        if let Some(minimum_integer_digits) = options.minimum_integer_digits() {
+            decimal
+                .absolute
+                .pad_start(minimum_integer_digits.saturating_sub(1) as i16);
+        }
+        if matches!(
+            options.trailing_zero_display(),
+            Some(TrailingZeroDisplay::StripIfInteger)
+        ) {
+            decimal.absolute.trim_end_if_integer();
+        }
+
+        let mut formatter_options = DecimalFormatterOptions::default();
+        formatter_options.grouping_strategy = options.use_grouping().map(|grouping| match grouping {
+            UseGroupingType::Bool(false) => GroupingStrategy::Never,
+            UseGroupingType::Bool(true) | UseGroupingType::String(UseGroupingString::Always) => {
+                GroupingStrategy::Always
+            }
+            UseGroupingType::String(UseGroupingString::Min2) => GroupingStrategy::Min2,
+            UseGroupingType::String(UseGroupingString::Auto) => GroupingStrategy::Auto,
+        });
+
+        let formatter = DecimalFormatter::try_new(locale.clone().into(), formatter_options)
+            .map_err(Self::formatter_error)?;
+        let mut formatted = formatter.format_to_string(&decimal);
+
+        match options.style() {
+            Some(NumberFormatOptionsStyle::Percent) => formatted.push('%'),
+            Some(NumberFormatOptionsStyle::Currency) => {
+                let currency = options.currency().ok_or_else(|| {
+                    Error::new(
+                        ErrorCode::InvalidValue,
+                        "Currency number format requires a currency code",
+                    )
+                })?;
+                formatted = format!("{currency}\u{a0}{formatted}");
+            }
+            Some(NumberFormatOptionsStyle::Unit) => {
+                let unit = options.unit().ok_or_else(|| {
+                    Error::new(
+                        ErrorCode::InvalidValue,
+                        "Unit number format requires a unit identifier",
+                    )
+                })?;
+                formatted = format!("{formatted} {unit}");
+            }
+            _ => {}
+        }
+
+        Ok(formatted)
+    }
+
+    fn format_datetime(
+        &self,
+        locale: &Locale,
+        value: DateTimeValue,
+        kind: DateTimeKind,
+        options: &DateTimeFormatOptions,
+    ) -> Result<String> {
+        use formatjs_icu_skeleton_parser::{DateTimeFormatMonth, DateTimeFormatWeekday};
+
+        match kind {
+            DateTimeKind::Date => {
+                let date = Date::try_new_iso(value.year, value.month, value.day)
+                    .map_err(Self::formatter_error)?;
+                let length = match options.month() {
+                    Some(DateTimeFormatMonth::Long) => 2,
+                    Some(DateTimeFormatMonth::Short) => 1,
+                    _ => 0,
+                };
+                let has_weekday = matches!(
+                    options.weekday(),
+                    Some(
+                        DateTimeFormatWeekday::Long
+                            | DateTimeFormatWeekday::Short
+                            | DateTimeFormatWeekday::Narrow
+                    )
+                );
+
+                let formatted = if has_weekday {
+                    match length {
+                        0 => DateTimeFormatter::try_new(locale.clone().into(), YMDE::short())
+                            .map_err(Self::formatter_error)?
+                            .format(&date)
+                            .to_string(),
+                        1 => DateTimeFormatter::try_new(locale.clone().into(), YMDE::medium())
+                            .map_err(Self::formatter_error)?
+                            .format(&date)
+                            .to_string(),
+                        _ => DateTimeFormatter::try_new(locale.clone().into(), YMDE::long())
+                            .map_err(Self::formatter_error)?
+                            .format(&date)
+                            .to_string(),
+                    }
+                } else {
+                    match length {
+                        0 => DateTimeFormatter::try_new(locale.clone().into(), YMD::short())
+                            .map_err(Self::formatter_error)?
+                            .format(&date)
+                            .to_string(),
+                        1 => DateTimeFormatter::try_new(locale.clone().into(), YMD::medium())
+                            .map_err(Self::formatter_error)?
+                            .format(&date)
+                            .to_string(),
+                        _ => DateTimeFormatter::try_new(locale.clone().into(), YMD::long())
+                            .map_err(Self::formatter_error)?
+                            .format(&date)
+                            .to_string(),
+                    }
+                };
+                Ok(formatted)
+            }
+            DateTimeKind::Time => {
+                let time = Time::try_new(
+                    value.hour,
+                    value.minute,
+                    value.second,
+                    value.nanosecond,
+                )
+                .map_err(Self::formatter_error)?;
+                if options.second().is_some() {
+                    Ok(DateTimeFormatter::try_new(locale.clone().into(), T::hms())
+                        .map_err(Self::formatter_error)?
+                        .format(&time)
+                        .to_string())
+                } else {
+                    Ok(DateTimeFormatter::try_new(locale.clone().into(), T::hm())
+                        .map_err(Self::formatter_error)?
+                        .format(&time)
+                        .to_string())
+                }
+            }
+        }
+    }
+
+    fn plural_category(
+        &self,
+        locale: &Locale,
+        value: NumericValue,
+        plural_type: PluralType,
+    ) -> Result<PluralCategory> {
+        let rules = match plural_type {
+            PluralType::Cardinal => PluralRules::try_new_cardinal(locale.clone().into()),
+            PluralType::Ordinal => PluralRules::try_new_ordinal(locale.clone().into()),
+        }
+        .map_err(Self::formatter_error)?;
+        let decimal = Decimal::from_str(&value.decimal_string()?)
+            .map_err(Self::formatter_error)?;
+        let operands = PluralOperands::from(&decimal);
+        Ok(rules.category_for(operands))
+    }
+}

--- a/crates/icu_messageformat/lib.rs
+++ b/crates/icu_messageformat/lib.rs
@@ -1,0 +1,757 @@
+mod error;
+mod formatter;
+mod value;
+
+pub use error::{Error, ErrorCode, Result};
+pub use formatter::{DateTimeKind, DefaultFormatters, Formatters};
+pub use formatjs_icu_messageformat_parser::{
+    ParserOptions,
+    types::{MessageFormatElement, PluralType},
+};
+pub use formatjs_icu_skeleton_parser::{DateTimeFormatOptions, ExtendedNumberFormatOptions};
+pub use icu::locale::Locale;
+pub use icu::plurals::PluralCategory;
+pub use value::{
+    DateTimeValue, FormattedMessage, NumericValue, Part, TagFunction, Value,
+};
+
+use formatjs_icu_messageformat_parser::types::{
+    DateTimeSkeletonOrStyle, NumberSkeletonOrStyle, PluralElement, PluralOrSelectOption,
+    ValidPluralRule,
+};
+use formatjs_icu_messageformat_parser::{Parser, get_best_pattern};
+use formatjs_icu_skeleton_parser::{
+    DateTimeFormatDay, DateTimeFormatHour, DateTimeFormatMinute, DateTimeFormatMonth,
+    DateTimeFormatSecond, DateTimeFormatTimeZoneName, DateTimeFormatWeekday,
+    DateTimeFormatYear, NumberFormatOptionsStyle, parse_date_time_skeleton,
+};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+pub type Values<T = String> = HashMap<String, Value<T>>;
+
+#[derive(Debug, Clone)]
+pub struct Formats {
+    pub number: HashMap<String, ExtendedNumberFormatOptions>,
+    pub date: HashMap<String, DateTimeFormatOptions>,
+    pub time: HashMap<String, DateTimeFormatOptions>,
+}
+
+impl Default for Formats {
+    fn default() -> Self {
+        let number = HashMap::from([
+            (
+                "integer".to_owned(),
+                ExtendedNumberFormatOptions {
+                    base: formatjs_icu_skeleton_parser::NumberFormatOptions {
+                        maximum_fraction_digits: Some(0),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            ),
+            (
+                "currency".to_owned(),
+                ExtendedNumberFormatOptions::new().with_style(NumberFormatOptionsStyle::Currency),
+            ),
+            (
+                "percent".to_owned(),
+                ExtendedNumberFormatOptions::new().with_style(NumberFormatOptionsStyle::Percent),
+            ),
+        ]);
+        let date = HashMap::from([
+            (
+                "short".to_owned(),
+                DateTimeFormatOptions::new()
+                    .with_month(DateTimeFormatMonth::Numeric)
+                    .with_day(DateTimeFormatDay::Numeric)
+                    .with_year(DateTimeFormatYear::TwoDigit),
+            ),
+            (
+                "medium".to_owned(),
+                DateTimeFormatOptions::new()
+                    .with_month(DateTimeFormatMonth::Short)
+                    .with_day(DateTimeFormatDay::Numeric)
+                    .with_year(DateTimeFormatYear::Numeric),
+            ),
+            (
+                "long".to_owned(),
+                DateTimeFormatOptions::new()
+                    .with_month(DateTimeFormatMonth::Long)
+                    .with_day(DateTimeFormatDay::Numeric)
+                    .with_year(DateTimeFormatYear::Numeric),
+            ),
+            (
+                "full".to_owned(),
+                DateTimeFormatOptions::new()
+                    .with_weekday(DateTimeFormatWeekday::Long)
+                    .with_month(DateTimeFormatMonth::Long)
+                    .with_day(DateTimeFormatDay::Numeric)
+                    .with_year(DateTimeFormatYear::Numeric),
+            ),
+        ]);
+        let time = HashMap::from([
+            (
+                "short".to_owned(),
+                DateTimeFormatOptions::new()
+                    .with_hour(DateTimeFormatHour::Numeric)
+                    .with_minute(DateTimeFormatMinute::Numeric),
+            ),
+            (
+                "medium".to_owned(),
+                DateTimeFormatOptions::new()
+                    .with_hour(DateTimeFormatHour::Numeric)
+                    .with_minute(DateTimeFormatMinute::Numeric)
+                    .with_second(DateTimeFormatSecond::Numeric),
+            ),
+            (
+                "long".to_owned(),
+                DateTimeFormatOptions::new()
+                    .with_hour(DateTimeFormatHour::Numeric)
+                    .with_minute(DateTimeFormatMinute::Numeric)
+                    .with_second(DateTimeFormatSecond::Numeric)
+                    .with_time_zone_name(DateTimeFormatTimeZoneName::Short),
+            ),
+            (
+                "full".to_owned(),
+                DateTimeFormatOptions::new()
+                    .with_hour(DateTimeFormatHour::Numeric)
+                    .with_minute(DateTimeFormatMinute::Numeric)
+                    .with_second(DateTimeFormatSecond::Numeric)
+                    .with_time_zone_name(DateTimeFormatTimeZoneName::Short),
+            ),
+        ]);
+        Self { number, date, time }
+    }
+}
+
+pub struct Options {
+    pub parser: ParserOptions,
+    pub formats: Formats,
+    pub formatters: Arc<dyn Formatters>,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            parser: ParserOptions {
+                requires_other_clause: true,
+                should_parse_skeletons: true,
+                ..Default::default()
+            },
+            formats: Formats::default(),
+            formatters: Arc::new(DefaultFormatters),
+        }
+    }
+}
+
+pub struct IcuMessageFormat {
+    ast: Vec<MessageFormatElement>,
+    message: Option<String>,
+    formats: Formats,
+    formatters: Arc<dyn Formatters>,
+}
+
+impl IcuMessageFormat {
+    pub fn new(message: impl AsRef<str>) -> Result<Self> {
+        Self::try_new(message)
+    }
+
+    pub fn try_new(message: impl AsRef<str>) -> Result<Self> {
+        Self::try_new_with_options(message, Options::default())
+    }
+
+    pub fn try_new_with_options(
+        message: impl AsRef<str>,
+        mut options: Options,
+    ) -> Result<Self> {
+        options.parser.locale = None;
+        let message = message.as_ref();
+        let ast = Parser::new(message, options.parser)
+            .parse()
+            .map_err(|error| {
+                Error::new(ErrorCode::Parse, error.to_string())
+                    .with_original_message(Some(message))
+            })?;
+        Ok(Self {
+            ast,
+            message: Some(message.to_owned()),
+            formats: options.formats,
+            formatters: options.formatters,
+        })
+    }
+
+    pub fn from_ast(ast: Vec<MessageFormatElement>) -> Self {
+        Self::from_ast_with_options(ast, Options::default())
+    }
+
+    pub fn from_ast_with_options(
+        ast: Vec<MessageFormatElement>,
+        options: Options,
+    ) -> Self {
+        Self {
+            ast,
+            message: None,
+            formats: options.formats,
+            formatters: options.formatters,
+        }
+    }
+
+    pub fn format<T: Clone>(
+        &self,
+        locale: impl AsRef<str>,
+        values: &Values<T>,
+    ) -> Result<FormattedMessage<T>> {
+        let parts = self.format_to_parts(locale, values)?;
+        if parts.len() == 1 {
+            return Ok(match parts.into_iter().next().expect("one part") {
+                Part::Literal(value) => FormattedMessage::Literal(value),
+                Part::Object(value) => FormattedMessage::Object(value),
+            });
+        }
+        Ok(FormattedMessage::Parts(parts))
+    }
+
+    pub fn format_to_parts<T: Clone>(
+        &self,
+        locale: impl AsRef<str>,
+        values: &Values<T>,
+    ) -> Result<Vec<Part<T>>> {
+        let locale = resolve_locale([locale.as_ref()])?;
+        self.format_elements(&locale, &self.ast, values, None)
+    }
+
+    pub fn format_to_string(
+        &self,
+        locale: impl AsRef<str>,
+        values: &Values<String>,
+    ) -> Result<String> {
+        let parts = self.format_to_parts(locale, values)?;
+        let mut output = String::new();
+        for part in parts {
+            match part {
+                Part::Literal(value) => output.push_str(&value),
+                Part::Object(_) => {
+                    return Err(Error::new(
+                        ErrorCode::InvalidValueType,
+                        "Cannot convert rich object part to string",
+                    ))
+                }
+            }
+        }
+        Ok(output)
+    }
+
+    pub fn get_ast(&self) -> &[MessageFormatElement] {
+        &self.ast
+    }
+
+    fn format_elements<T: Clone>(
+        &self,
+        locale: &Locale,
+        elements: &[MessageFormatElement],
+        values: &Values<T>,
+        current_plural_value: Option<NumericValue>,
+    ) -> Result<Vec<Part<T>>> {
+        if let [MessageFormatElement::Literal(literal)] = elements {
+            return Ok(vec![Part::Literal(literal.value.clone())]);
+        }
+
+        let mut result = Vec::new();
+        for element in elements {
+            match element {
+                MessageFormatElement::Literal(literal) => {
+                    result.push(Part::Literal(literal.value.clone()));
+                }
+                MessageFormatElement::Pound(_) => {
+                    if let Some(value) = current_plural_value {
+                        result.push(Part::Literal(self.formatters.format_number(
+                            locale,
+                            value,
+                            &ExtendedNumberFormatOptions::default(),
+                        )?));
+                    }
+                }
+                MessageFormatElement::Argument(argument) => {
+                    let value = self.required_value(values, &argument.value)?;
+                    result.push(match value {
+                        Value::String(value) => Part::Literal(value.clone()),
+                        Value::Number(value) => Part::Literal(value.to_string()),
+                        Value::Integer(value) => Part::Literal(value.to_string()),
+                        Value::Unsigned(value) => Part::Literal(value.to_string()),
+                        Value::Boolean(false) => Part::Literal(String::new()),
+                        Value::Boolean(true) => Part::Literal("true".to_owned()),
+                        Value::Null => Part::Literal(String::new()),
+                        Value::Object(value) => Part::Object(value.clone()),
+                        Value::DateTime(_) => {
+                            return Err(Error::invalid_value_type(
+                                &argument.value,
+                                "string, number, boolean, null, or object",
+                                self.message.as_deref(),
+                            ))
+                        }
+                        Value::Tag(_) => {
+                            return Err(Error::invalid_value_type(
+                                &argument.value,
+                                "non-function value",
+                                self.message.as_deref(),
+                            ))
+                        }
+                    });
+                }
+                MessageFormatElement::Number(number) => {
+                    let value = self
+                        .required_value(values, &number.value)?
+                        .numeric()
+                        .ok_or_else(|| {
+                            Error::invalid_value_type(
+                                &number.value,
+                                "number",
+                                self.message.as_deref(),
+                            )
+                        })?;
+                    let style = match number.style.as_ref() {
+                        Some(NumberSkeletonOrStyle::String(name)) => self
+                            .formats
+                            .number
+                            .get(name)
+                            .cloned()
+                            .unwrap_or_default(),
+                        Some(NumberSkeletonOrStyle::Skeleton(skeleton)) => {
+                            skeleton.parsed_options.clone()
+                        }
+                        None => ExtendedNumberFormatOptions::default(),
+                    };
+                    let value = value.scaled(style.scale().unwrap_or(1.0));
+                    result.push(Part::Literal(self.formatters.format_number(
+                        locale,
+                        value,
+                        &style,
+                    )?));
+                }
+                MessageFormatElement::Date(date) => {
+                    let value = self
+                        .required_value(values, &date.value)?
+                        .datetime()
+                        .ok_or_else(|| {
+                            Error::invalid_value_type(
+                                &date.value,
+                                "date/time or Unix epoch milliseconds",
+                                self.message.as_deref(),
+                            )
+                        })?;
+                    let style = self.datetime_style(
+                        locale,
+                        date.style.as_ref(),
+                        DateTimeKind::Date,
+                    )?;
+                    result.push(Part::Literal(self.formatters.format_datetime(
+                        locale,
+                        value,
+                        DateTimeKind::Date,
+                        &style,
+                    )?));
+                }
+                MessageFormatElement::Time(time) => {
+                    let value = self
+                        .required_value(values, &time.value)?
+                        .datetime()
+                        .ok_or_else(|| {
+                            Error::invalid_value_type(
+                                &time.value,
+                                "date/time or Unix epoch milliseconds",
+                                self.message.as_deref(),
+                            )
+                        })?;
+                    let style = self.datetime_style(
+                        locale,
+                        time.style.as_ref(),
+                        DateTimeKind::Time,
+                    )?;
+                    result.push(Part::Literal(self.formatters.format_datetime(
+                        locale,
+                        value,
+                        DateTimeKind::Time,
+                        &style,
+                    )?));
+                }
+                MessageFormatElement::Select(select) => {
+                    let value = self.required_value(values, &select.value)?;
+                    let key = value.selector().ok_or_else(|| {
+                        Error::invalid_value_type(
+                            &select.value,
+                            "string-compatible selector",
+                            self.message.as_deref(),
+                        )
+                    })?;
+                    let option = select
+                        .options
+                        .get(&key)
+                        .or_else(|| select.options.get("other"))
+                        .ok_or_else(|| {
+                            Error::invalid_value(
+                                &select.value,
+                                &key,
+                                select.options.keys(),
+                                self.message.as_deref(),
+                            )
+                        })?;
+                    result.extend(self.format_elements(locale, &option.value, values, None)?);
+                }
+                MessageFormatElement::Plural(plural) => {
+                    let value = self
+                        .required_value(values, &plural.value)?
+                        .numeric()
+                        .ok_or_else(|| {
+                            Error::invalid_value_type(
+                                &plural.value,
+                                "number",
+                                self.message.as_deref(),
+                            )
+                        })?;
+                    let option = self.plural_option(locale, plural, value)?.ok_or_else(|| {
+                        Error::invalid_value(
+                            &plural.value,
+                            &value.as_f64().to_string(),
+                            plural.options.keys().map(ValidPluralRule::as_str),
+                            self.message.as_deref(),
+                        )
+                    })?;
+                    let adjusted = NumericValue::Float(value.as_f64() - f64::from(plural.offset));
+                    result.extend(self.format_elements(
+                        locale,
+                        &option.value,
+                        values,
+                        Some(adjusted),
+                    )?);
+                }
+                MessageFormatElement::Tag(tag) => {
+                    let value = self.required_value(values, &tag.value)?;
+                    let Value::Tag(function) = value else {
+                        return Err(Error::invalid_value_type(
+                            &tag.value,
+                            "function",
+                            self.message.as_deref(),
+                        ));
+                    };
+                    let children = self.format_elements(
+                        locale,
+                        &tag.children,
+                        values,
+                        current_plural_value,
+                    )?;
+                    result.extend(function(children)?);
+                }
+            }
+        }
+        Ok(merge_literals(result))
+    }
+
+    fn required_value<'a, T>(
+        &self,
+        values: &'a Values<T>,
+        variable: &str,
+    ) -> Result<&'a Value<T>> {
+        values
+            .get(variable)
+            .ok_or_else(|| Error::missing_value(variable, self.message.as_deref()))
+    }
+
+    fn datetime_style(
+        &self,
+        locale: &Locale,
+        style: Option<&DateTimeSkeletonOrStyle>,
+        kind: DateTimeKind,
+    ) -> Result<DateTimeFormatOptions> {
+        Ok(match style {
+            Some(DateTimeSkeletonOrStyle::String(name)) => match kind {
+                DateTimeKind::Date => self.formats.date.get(name),
+                DateTimeKind::Time => self.formats.time.get(name),
+            }
+            .cloned()
+            .unwrap_or_default(),
+            Some(DateTimeSkeletonOrStyle::Skeleton(skeleton))
+                if skeleton.pattern.chars().any(|symbol| matches!(symbol, 'j' | 'J')) =>
+            {
+                let pattern = get_best_pattern(&skeleton.pattern, locale);
+                parse_date_time_skeleton(&pattern)
+                    .map_err(|error| Error::new(ErrorCode::Formatter, error))?
+            }
+            Some(DateTimeSkeletonOrStyle::Skeleton(skeleton)) => skeleton.parsed_options.clone(),
+            None if kind == DateTimeKind::Time => self
+                .formats
+                .time
+                .get("medium")
+                .cloned()
+                .unwrap_or_default(),
+            None => DateTimeFormatOptions::default(),
+        })
+    }
+
+    fn plural_option<'a>(
+        &self,
+        locale: &Locale,
+        plural: &'a PluralElement,
+        value: NumericValue,
+    ) -> Result<Option<&'a PluralOrSelectOption>> {
+        let numeric = value.as_f64();
+        if let Some(option) = plural.options.iter().find_map(|(key, option)| match key {
+            ValidPluralRule::Exact(exact) => exact
+                .strip_prefix('=')
+                .and_then(|exact| exact.parse::<f64>().ok())
+                .filter(|exact| *exact == numeric)
+                .map(|_| option),
+            _ => None,
+        }) {
+            return Ok(Some(option));
+        }
+
+        let adjusted = NumericValue::Float(numeric - f64::from(plural.offset));
+        let category = self.formatters.plural_category(
+            locale,
+            adjusted,
+            plural.plural_type,
+        )?;
+        Ok(plural
+            .options
+            .get(&plural_rule(category))
+            .or_else(|| plural.options.get(&ValidPluralRule::Other)))
+    }
+}
+
+fn resolve_locale<I, S>(locales: I) -> Result<Locale>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let mut invalid = Vec::new();
+    for locale in locales {
+        let locale = locale.as_ref();
+        match locale.parse() {
+            Ok(locale) => return Ok(locale),
+            Err(_) => invalid.push(locale.to_owned()),
+        }
+    }
+    Err(Error::new(
+        ErrorCode::InvalidValue,
+        format!("No valid locale in [{}]", invalid.join(", ")),
+    ))
+}
+
+fn plural_rule(category: PluralCategory) -> ValidPluralRule {
+    match category {
+        PluralCategory::Zero => ValidPluralRule::Zero,
+        PluralCategory::One => ValidPluralRule::One,
+        PluralCategory::Two => ValidPluralRule::Two,
+        PluralCategory::Few => ValidPluralRule::Few,
+        PluralCategory::Many => ValidPluralRule::Many,
+        PluralCategory::Other => ValidPluralRule::Other,
+    }
+}
+
+fn merge_literals<T>(parts: Vec<Part<T>>) -> Vec<Part<T>> {
+    let mut merged: Vec<Part<T>> = Vec::with_capacity(parts.len());
+    for part in parts {
+        match (merged.last_mut(), part) {
+            (Some(Part::Literal(previous)), Part::Literal(value)) => previous.push_str(&value),
+            (_, part) => merged.push(part),
+        }
+    }
+    merged
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn formats_arguments_selects_and_plurals() {
+        let formatter = IcuMessageFormat::try_new(
+            "{name} has {count, plural, =0 {no tasks} one {# task} other {# tasks}}.",
+        )
+        .unwrap();
+        let values: Values<String> = HashMap::from([
+            ("name".to_owned(), Value::from("Ada")),
+            ("count".to_owned(), Value::from(2_i64)),
+        ]);
+
+        assert_eq!(
+            formatter.format_to_string("en-US", &values).unwrap(),
+            "Ada has 2 tasks."
+        );
+    }
+
+    #[test]
+    fn selects_locale_specific_plural_category() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<IcuMessageFormat>();
+
+        let formatter = IcuMessageFormat::try_new(
+            "{count, plural, one {one} few {few} many {many} other {other}}",
+        )
+        .unwrap();
+        let values: Values<String> =
+            HashMap::from([("count".to_owned(), Value::from(2_i64))]);
+        assert_eq!(formatter.format_to_string("pl", &values).unwrap(), "few");
+
+        assert_eq!(formatter.format_to_string("en", &values).unwrap(), "other");
+        assert_eq!(
+            formatter
+                .format_to_string("", &values)
+                .unwrap_err()
+                .code,
+            ErrorCode::InvalidValue
+        );
+    }
+
+    #[test]
+    fn resolves_locale_dependent_skeleton_at_format_time() {
+        use formatjs_icu_skeleton_parser::DateTimeFormatHourCycle;
+
+        let formatter = IcuMessageFormat::try_new("{value, time, ::jmm}").unwrap();
+        let MessageFormatElement::Time(time) = &formatter.ast[0] else {
+            panic!("expected time element");
+        };
+        let en_us: Locale = "en-US".parse().unwrap();
+        let h23: Locale = "en-US-u-hc-h23".parse().unwrap();
+
+        assert_eq!(
+            formatter
+                .datetime_style(&en_us, time.style.as_ref(), DateTimeKind::Time)
+                .unwrap()
+                .hour_cycle(),
+            Some(&DateTimeFormatHourCycle::H12)
+        );
+        assert_eq!(
+            formatter
+                .datetime_style(&h23, time.style.as_ref(), DateTimeKind::Time)
+                .unwrap()
+                .hour_cycle(),
+            Some(&DateTimeFormatHourCycle::H23)
+        );
+    }
+
+    #[test]
+    fn formats_ordinals_and_plural_offsets() {
+        let ordinal = IcuMessageFormat::try_new(
+            "{place, selectordinal, one {#st} two {#nd} few {#rd} other {#th}}",
+        )
+        .unwrap();
+        for (place, expected) in [
+            (1_i64, "1st"),
+            (2_i64, "2nd"),
+            (3_i64, "3rd"),
+            (11_i64, "11th"),
+        ] {
+            let values = HashMap::from([("place".to_owned(), Value::from(place))]);
+            assert_eq!(
+                ordinal.format_to_string("en-US", &values).unwrap(),
+                expected
+            );
+        }
+
+        let offset = IcuMessageFormat::try_new(
+            "{count, plural, offset:1 =1 {one guest} other {# other guests}}",
+        )
+        .unwrap();
+        let values = HashMap::from([("count".to_owned(), Value::from(3_i64))]);
+        assert_eq!(
+            offset.format_to_string("en-US", &values).unwrap(),
+            "2 other guests"
+        );
+    }
+
+    #[test]
+    fn formats_numbers_and_dates_with_icu4x() {
+        let number = IcuMessageFormat::try_new("{value, number}").unwrap();
+        let number_values = HashMap::from([("value".to_owned(), Value::from(1234.5))]);
+        assert_eq!(
+            number.format_to_string("en-US", &number_values).unwrap(),
+            "1,234.5"
+        );
+
+        let date = IcuMessageFormat::try_new("{value, date, medium}").unwrap();
+        let date_values = HashMap::from([("value".to_owned(), Value::from(0_i64))]);
+        assert_eq!(
+            date.format_to_string("en-US", &date_values).unwrap(),
+            "Jan 1, 1970"
+        );
+
+        let integer = IcuMessageFormat::try_new("{value, number, integer}").unwrap();
+        let integer_values = HashMap::from([("value".to_owned(), Value::from(2.5))]);
+        assert_eq!(
+            integer
+                .format_to_string("en-US", &integer_values)
+                .unwrap(),
+            "3"
+        );
+
+        let percent =
+            IcuMessageFormat::try_new("{value, number, ::percent scale/0.01}").unwrap();
+        let percent_values = HashMap::from([("value".to_owned(), Value::from(12.3))]);
+        assert_eq!(
+            percent
+                .format_to_string("en-US", &percent_values)
+                .unwrap(),
+            "12%"
+        );
+    }
+
+    #[test]
+    fn reports_missing_values_with_formatjs_error_code() {
+        let formatter = IcuMessageFormat::try_new("Hello, {name}!").unwrap();
+        let error = formatter
+            .format_to_string("en", &Values::default())
+            .unwrap_err();
+        assert_eq!(error.code, ErrorCode::MissingValue);
+        assert!(error.message.contains("name"));
+    }
+
+    #[test]
+    fn requires_other_clause_by_default_but_can_disable_it() {
+        let message = "{value, select, a {A} b {B}}";
+        assert!(IcuMessageFormat::try_new(message).is_err());
+
+        let mut options = Options::default();
+        options.parser.requires_other_clause = false;
+        assert!(IcuMessageFormat::try_new_with_options(message, options).is_ok());
+    }
+
+    #[test]
+    fn formats_rich_tags_to_parts() {
+        let formatter = IcuMessageFormat::try_new("Hello, <b>{name}</b>!").unwrap();
+        let values: Values<String> = HashMap::from([
+            ("name".to_owned(), Value::from("Ada")),
+            (
+                "b".to_owned(),
+                Value::tag(|parts: Vec<Part<String>>| {
+                    Ok(vec![
+                        Part::Literal("<strong>".to_owned()),
+                        parts.into_iter().next().unwrap(),
+                        Part::Literal("</strong>".to_owned()),
+                    ])
+                }),
+            ),
+        ]);
+        assert_eq!(
+            formatter.format_to_string("en", &values).unwrap(),
+            "Hello, <strong>Ada</strong>!"
+        );
+    }
+
+    #[test]
+    fn converts_epoch_milliseconds_to_utc() {
+        assert_eq!(
+            DateTimeValue::from_unix_millis(0),
+            DateTimeValue {
+                year: 1970,
+                month: 1,
+                day: 1,
+                hour: 0,
+                minute: 0,
+                second: 0,
+                nanosecond: 0,
+            }
+        );
+    }
+}

--- a/crates/icu_messageformat/value.rs
+++ b/crates/icu_messageformat/value.rs
@@ -1,0 +1,267 @@
+use crate::error::{Error, Result};
+use std::fmt;
+use std::sync::Arc;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Part<T> {
+    Literal(String),
+    Object(T),
+}
+
+impl<T> Part<T> {
+    pub fn as_literal(&self) -> Option<&str> {
+        match self {
+            Self::Literal(value) => Some(value),
+            Self::Object(_) => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum FormattedMessage<T> {
+    Literal(String),
+    Object(T),
+    Parts(Vec<Part<T>>),
+}
+
+impl<T> FormattedMessage<T> {
+    pub fn into_parts(self) -> Vec<Part<T>> {
+        match self {
+            Self::Literal(value) => vec![Part::Literal(value)],
+            Self::Object(value) => vec![Part::Object(value)],
+            Self::Parts(parts) => parts,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DateTimeValue {
+    pub year: i32,
+    pub month: u8,
+    pub day: u8,
+    pub hour: u8,
+    pub minute: u8,
+    pub second: u8,
+    pub nanosecond: u32,
+}
+
+impl DateTimeValue {
+    pub fn try_new(
+        year: i32,
+        month: u8,
+        day: u8,
+        hour: u8,
+        minute: u8,
+        second: u8,
+        nanosecond: u32,
+    ) -> Result<Self> {
+        if !(-9999..=9999).contains(&year)
+            || !(1..=12).contains(&month)
+            || !(1..=31).contains(&day)
+            || hour > 23
+            || minute > 59
+            || second > 60
+            || nanosecond > 999_999_999
+        {
+            return Err(Error::new(
+                crate::ErrorCode::InvalidValue,
+                "Invalid date/time fields",
+            ));
+        }
+        Ok(Self {
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            second,
+            nanosecond,
+        })
+    }
+
+    /// Converts Unix epoch milliseconds to UTC date/time fields.
+    pub fn from_unix_millis(milliseconds: i64) -> Self {
+        const MILLIS_PER_DAY: i64 = 86_400_000;
+        let days = milliseconds.div_euclid(MILLIS_PER_DAY);
+        let millis = milliseconds.rem_euclid(MILLIS_PER_DAY);
+
+        // Howard Hinnant's civil-from-days algorithm.
+        let z = days + 719_468;
+        let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+        let day_of_era = z - era * 146_097;
+        let year_of_era =
+            (day_of_era - day_of_era / 1_460 + day_of_era / 36_524 - day_of_era / 146_096)
+                / 365;
+        let mut year = year_of_era + era * 400;
+        let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
+        let month_prime = (5 * day_of_year + 2) / 153;
+        let day = day_of_year - (153 * month_prime + 2) / 5 + 1;
+        let month = month_prime + if month_prime < 10 { 3 } else { -9 };
+        year += i64::from(month <= 2);
+
+        let seconds = millis / 1_000;
+        Self {
+            year: year as i32,
+            month: month as u8,
+            day: day as u8,
+            hour: (seconds / 3_600) as u8,
+            minute: ((seconds % 3_600) / 60) as u8,
+            second: (seconds % 60) as u8,
+            nanosecond: ((millis % 1_000) * 1_000_000) as u32,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum NumericValue {
+    Float(f64),
+    Integer(i64),
+    Unsigned(u64),
+}
+
+impl NumericValue {
+    pub fn as_f64(self) -> f64 {
+        match self {
+            Self::Float(value) => value,
+            Self::Integer(value) => value as f64,
+            Self::Unsigned(value) => value as f64,
+        }
+    }
+
+    pub fn scaled(self, scale: f64) -> Self {
+        if scale == 1.0 {
+            self
+        } else {
+            Self::Float(self.as_f64() * scale)
+        }
+    }
+
+    pub fn decimal_string(self) -> Result<String> {
+        match self {
+            Self::Float(value) if value.is_finite() => Ok(value.to_string()),
+            Self::Float(_) => Err(Error::new(
+                crate::ErrorCode::InvalidValue,
+                "Number must be finite",
+            )),
+            Self::Integer(value) => Ok(value.to_string()),
+            Self::Unsigned(value) => Ok(value.to_string()),
+        }
+    }
+}
+
+pub type TagFunction<T> =
+    Arc<dyn Fn(Vec<Part<T>>) -> Result<Vec<Part<T>>> + Send + Sync + 'static>;
+
+#[derive(Clone)]
+pub enum Value<T = String> {
+    String(String),
+    Number(f64),
+    Integer(i64),
+    Unsigned(u64),
+    Boolean(bool),
+    Null,
+    DateTime(DateTimeValue),
+    Object(T),
+    Tag(TagFunction<T>),
+}
+
+impl<T: fmt::Debug> fmt::Debug for Value<T> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::String(value) => formatter.debug_tuple("String").field(value).finish(),
+            Self::Number(value) => formatter.debug_tuple("Number").field(value).finish(),
+            Self::Integer(value) => formatter.debug_tuple("Integer").field(value).finish(),
+            Self::Unsigned(value) => formatter.debug_tuple("Unsigned").field(value).finish(),
+            Self::Boolean(value) => formatter.debug_tuple("Boolean").field(value).finish(),
+            Self::Null => formatter.write_str("Null"),
+            Self::DateTime(value) => formatter.debug_tuple("DateTime").field(value).finish(),
+            Self::Object(value) => formatter.debug_tuple("Object").field(value).finish(),
+            Self::Tag(_) => formatter.write_str("Tag(<function>)"),
+        }
+    }
+}
+
+impl<T> Value<T> {
+    pub fn tag(
+        function: impl Fn(Vec<Part<T>>) -> Result<Vec<Part<T>>> + Send + Sync + 'static,
+    ) -> Self {
+        Self::Tag(Arc::new(function))
+    }
+
+    pub(crate) fn numeric(&self) -> Option<NumericValue> {
+        match self {
+            Self::Number(value) => Some(NumericValue::Float(*value)),
+            Self::Integer(value) => Some(NumericValue::Integer(*value)),
+            Self::Unsigned(value) => Some(NumericValue::Unsigned(*value)),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn selector(&self) -> Option<String> {
+        match self {
+            Self::String(value) => Some(value.clone()),
+            Self::Number(value) => Some(value.to_string()),
+            Self::Integer(value) => Some(value.to_string()),
+            Self::Unsigned(value) => Some(value.to_string()),
+            Self::Boolean(value) => Some(value.to_string()),
+            Self::Null => Some("null".to_owned()),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn datetime(&self) -> Option<DateTimeValue> {
+        match self {
+            Self::DateTime(value) => Some(*value),
+            Self::Integer(value) => Some(DateTimeValue::from_unix_millis(*value)),
+            Self::Unsigned(value) => i64::try_from(*value)
+                .ok()
+                .map(DateTimeValue::from_unix_millis),
+            Self::Number(value) if value.is_finite() => {
+                Some(DateTimeValue::from_unix_millis(*value as i64))
+            }
+            _ => None,
+        }
+    }
+}
+
+impl<T> From<String> for Value<T> {
+    fn from(value: String) -> Self {
+        Self::String(value)
+    }
+}
+
+impl<T> From<&str> for Value<T> {
+    fn from(value: &str) -> Self {
+        Self::String(value.to_owned())
+    }
+}
+
+impl<T> From<f64> for Value<T> {
+    fn from(value: f64) -> Self {
+        Self::Number(value)
+    }
+}
+
+impl<T> From<i64> for Value<T> {
+    fn from(value: i64) -> Self {
+        Self::Integer(value)
+    }
+}
+
+impl<T> From<u64> for Value<T> {
+    fn from(value: u64) -> Self {
+        Self::Unsigned(value)
+    }
+}
+
+impl<T> From<bool> for Value<T> {
+    fn from(value: bool) -> Self {
+        Self::Boolean(value)
+    }
+}
+
+impl<T> From<DateTimeValue> for Value<T> {
+    fn from(value: DateTimeValue) -> Self {
+        Self::DateTime(value)
+    }
+}

--- a/knowledge-base/001-repo-layout.md
+++ b/knowledge-base/001-repo-layout.md
@@ -5,7 +5,7 @@
 ```
 formatjs/
   packages/           # 33 npm packages (polyfills, parsers, integrations, tools)
-  crates/             # 3 Rust crates (CLI, parser, skeleton parser)
+  crates/             # Rust crates (CLI, formatter, parser, skeleton parser, N-API)
   tools/              # Custom Bazel macros (ts_compile, vitest, oxc_transpiler, etc.)
   docs/               # Documentation site (Vike + React + MDX)
   benchmarks/         # Cross-tool benchmarks (Rust CLI vs TS CLI)

--- a/knowledge-base/003-rust-crate-dependency-hierarchy.md
+++ b/knowledge-base/003-rust-crate-dependency-hierarchy.md
@@ -8,6 +8,7 @@ The Rust workspace (`Cargo.toml`) contains 4 members:
 crates/
   icu_skeleton_parser/         # Number/date skeleton parser
   icu_messageformat_parser/    # ICU MessageFormat parser (+ WASM target)
+  icu_messageformat/           # ICU MessageFormat runtime formatter
   formatjs_cli/                # CLI binary (extract, compile, verify)
 packages/
   icu-messageformat-parser/integration-tests/   # Cross-language integration tests
@@ -36,6 +37,11 @@ formatjs_cli (v0.1.14)
 ├── fast-glob 1.0, walkdir 2 (file discovery)
 ├── anyhow (error handling)
 └── regex 1.12
+
+formatjs_icu_messageformat (v0.1.0)
+├── formatjs_icu_messageformat_parser
+├── formatjs_icu_skeleton_parser
+└── icu 2.1 (number, date/time, and plural formatting)
 ```
 
 ## Crate Details
@@ -107,12 +113,22 @@ formatjs_cli (v0.1.14)
 
 **176 unit tests.** Integration tests via `packages/cli/integration-tests/` ensure 100% conformance with the TypeScript CLI (60/60 tests passing).
 
+### `formatjs_icu_messageformat` (v0.1.0)
+
+**Purpose:** Low-level ICU MessageFormat runtime.
+
+- Reuses the Rust ICU MessageFormat parser AST.
+- Formats arguments, selects, plurals, pound tokens, numbers, dates, times, and rich-text tags.
+- Uses ICU4X by default and accepts custom formatters through a trait.
+- Parses messages once; locale is supplied per formatting call.
+
 ## Connection to TypeScript Packages
 
 | Rust Crate                 | TypeScript Package                   | Relationship                        |
 | -------------------------- | ------------------------------------ | ----------------------------------- |
 | `icu_skeleton_parser`      | `@formatjs/icu-skeleton-parser`      | Rust mirror of TS implementation    |
 | `icu_messageformat_parser` | `@formatjs/icu-messageformat-parser` | Rust mirror, also compiled to WASM  |
+| `icu_messageformat`        | `intl-messageformat`                 | Low-level Rust runtime              |
 | `formatjs_cli`             | `@formatjs/cli`                      | Drop-in replacement for Node.js CLI |
 
 **Data flow:** TypeScript scripts in `packages/icu-messageformat-parser/tools/` generate Rust source files (`time_data_generated.rs`, `regex_generated.rs`) from CLDR data. These are checked in and used by the Rust crate at compile time.

--- a/knowledge-base/008-package-intl-and-framework-integrations.md
+++ b/knowledge-base/008-package-intl-and-framework-integrations.md
@@ -10,6 +10,10 @@
 - Ships an IIFE bundle (`intl-messageformat.iife.js`) for browser `<script>` tag usage
 - BSD-3-Clause licensed (not `@formatjs` scoped for historical reasons)
 
+The low-level Rust runtime lives at `crates/icu_messageformat` as
+`formatjs_icu_messageformat`. It reuses the Rust parser AST and ICU4X. Messages
+are parsed without a locale, then formatted with a request locale.
+
 ## @formatjs/intl
 
 **Purpose:** Main FormatJS package aggregating all formatting APIs into a single coherent interface.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -456,6 +456,13 @@
       "include-v-in-release-name": false,
       "tag-separator": "_v"
     },
+    "crates/icu_messageformat": {
+      "release-type": "rust",
+      "include-component-in-tag": true,
+      "include-v-in-tag": false,
+      "include-v-in-release-name": false,
+      "tag-separator": "_v"
+    },
     "crates/formatjs_cli": {
       "release-type": "rust",
       "include-component-in-tag": true,


### PR DESCRIPTION
## Summary

- add low-level `formatjs_icu_messageformat`, backed by the existing Rust ICU parser and ICU4X
- parse each message once, then supply locale per formatting call
- format arguments, selects, plurals, numbers, dates, times, and rich-text parts
- resolve locale-dependent date/time skeletons during formatting
- expose custom formatter hooks
- wire Cargo, Bazel, crate releases, docs, and knowledge base

Descriptors, extraction, catalog loading, locale negotiation, and shared cache stay in the higher-level follow-up crate.

Full ECMA-402 currency, unit, and time-zone parity remains available through custom formatter overrides rather than built-in ICU4X formatting.

## Validation

- `bazel test //crates/icu_messageformat:icu_messageformat_test --test_output=errors`
- `cargo metadata --locked --no-deps --format-version 1`
- repository Rust formatting
- `git diff --check`
