### PR TITLE
feat(formatjs_intl): add Rust intl runtime

### DIFF
--- a/.github/workflows/crates-release.yml
+++ b/.github/workflows/crates-release.yml
@@ -21,6 +21,7 @@ on:
           - formatjs_icu_skeleton_parser
           - formatjs_icu_messageformat_parser
           - formatjs_icu_messageformat
+          - formatjs_intl
           - formatjs_cli
 
 concurrency:
@@ -74,6 +75,9 @@ jobs:
                 formatjs_icu_messageformat_v*|icu_messageformat_v*|crates/icu_messageformat_v*)
                   crates=(formatjs_icu_messageformat)
                   ;;
+                formatjs_intl_v*|crates/formatjs_intl_v*)
+                  crates=(formatjs_intl)
+                  ;;
                 formatjs_cli_v*|crates/formatjs_cli_v*)
                   crates=(formatjs_cli)
                   ;;
@@ -89,10 +93,11 @@ jobs:
                     formatjs_icu_skeleton_parser
                     formatjs_icu_messageformat_parser
                     formatjs_icu_messageformat
+                    formatjs_intl
                     formatjs_cli
                   )
                   ;;
-                formatjs_icu_skeleton_parser|formatjs_icu_messageformat_parser|formatjs_icu_messageformat|formatjs_cli)
+                formatjs_icu_skeleton_parser|formatjs_icu_messageformat_parser|formatjs_icu_messageformat|formatjs_intl|formatjs_cli)
                   crates=("$INPUT_CRATE")
                   ;;
                 *)
@@ -131,6 +136,7 @@ jobs:
             //crates/icu_skeleton_parser:icu_skeleton_parser_test
             //crates/icu_messageformat_parser:icu_messageformat_parser_test
             //crates/icu_messageformat:icu_messageformat_test
+            //crates/formatjs_intl:formatjs_intl_test
             //crates/formatjs_cli:formatjs_cli_test
           )
 
@@ -234,6 +240,11 @@ jobs:
                 wait_if_published_by_this_run \
                   formatjs_icu_messageformat_parser \
                   "$(dependency_version crates/icu_messageformat/Cargo.toml formatjs_icu_messageformat_parser)"
+                ;;
+              formatjs_intl)
+                wait_if_published_by_this_run \
+                  formatjs_icu_messageformat \
+                  "$(dependency_version crates/formatjs_intl/Cargo.toml formatjs_icu_messageformat)"
                 ;;
               formatjs_cli)
                 wait_if_published_by_this_run \

--- a/.github/workflows/crates-release.yml
+++ b/.github/workflows/crates-release.yml
@@ -21,6 +21,7 @@ on:
           - formatjs_icu_skeleton_parser
           - formatjs_icu_messageformat_parser
           - formatjs_icu_messageformat
+          - formatjs_intl_macros
           - formatjs_intl
           - formatjs_cli
 
@@ -75,6 +76,9 @@ jobs:
                 formatjs_icu_messageformat_v*|icu_messageformat_v*|crates/icu_messageformat_v*)
                   crates=(formatjs_icu_messageformat)
                   ;;
+                formatjs_intl_macros_v*|crates/formatjs_intl_macros_v*)
+                  crates=(formatjs_intl_macros)
+                  ;;
                 formatjs_intl_v*|crates/formatjs_intl_v*)
                   crates=(formatjs_intl)
                   ;;
@@ -93,11 +97,12 @@ jobs:
                     formatjs_icu_skeleton_parser
                     formatjs_icu_messageformat_parser
                     formatjs_icu_messageformat
+                    formatjs_intl_macros
                     formatjs_intl
                     formatjs_cli
                   )
                   ;;
-                formatjs_icu_skeleton_parser|formatjs_icu_messageformat_parser|formatjs_icu_messageformat|formatjs_intl|formatjs_cli)
+                formatjs_icu_skeleton_parser|formatjs_icu_messageformat_parser|formatjs_icu_messageformat|formatjs_intl_macros|formatjs_intl|formatjs_cli)
                   crates=("$INPUT_CRATE")
                   ;;
                 *)
@@ -242,6 +247,9 @@ jobs:
                   "$(dependency_version crates/icu_messageformat/Cargo.toml formatjs_icu_messageformat_parser)"
                 ;;
               formatjs_intl)
+                wait_if_published_by_this_run \
+                  formatjs_intl_macros \
+                  "$(dependency_version crates/formatjs_intl/Cargo.toml formatjs_intl_macros)"
                 wait_if_published_by_this_run \
                   formatjs_icu_messageformat \
                   "$(dependency_version crates/formatjs_intl/Cargo.toml formatjs_icu_messageformat)"

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -38,6 +38,7 @@
   "crates/icu_skeleton_parser": "0.1.2",
   "crates/icu_messageformat_parser": "0.2.7",
   "crates/icu_messageformat": "0.1.0",
+  "crates/formatjs_intl": "0.1.0",
   "crates/formatjs_cli": "1.1.22",
   "crates/formatjs_cli_napi": "0.0.13",
   "packages/icu-messageformat-parser/integration-tests": "0.1.3"

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -38,6 +38,7 @@
   "crates/icu_skeleton_parser": "0.1.2",
   "crates/icu_messageformat_parser": "0.2.7",
   "crates/icu_messageformat": "0.1.0",
+  "crates/formatjs_intl_macros": "0.1.0",
   "crates/formatjs_intl": "0.1.0",
   "crates/formatjs_cli": "1.1.22",
   "crates/formatjs_cli_napi": "0.0.13",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,7 +544,18 @@ name = "formatjs_intl"
 version = "0.1.0"
 dependencies = [
  "formatjs_icu_messageformat",
+ "formatjs_intl_macros",
  "icu_locale",
+]
+
+[[package]]
+name = "formatjs_intl_macros"
+version = "0.1.0"
+dependencies = [
+ "base64",
+ "quote",
+ "sha2",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,11 +486,13 @@ dependencies = [
  "oxc_data_structures",
  "oxc_parser",
  "oxc_span",
+ "proc-macro2",
  "rayon",
  "serde",
  "serde_json",
  "sha1",
  "sha2",
+ "syn 2.0.117",
  "tempfile",
  "walkdir",
 ]
@@ -535,6 +537,14 @@ dependencies = [
  "formatjs_icu_messageformat_parser",
  "formatjs_icu_skeleton_parser",
  "icu",
+]
+
+[[package]]
+name = "formatjs_intl"
+version = "0.1.0"
+dependencies = [
+ "formatjs_icu_messageformat",
+ "icu_locale",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
   "crates/icu_skeleton_parser",
   "crates/icu_messageformat_parser",
   "crates/icu_messageformat",
+  "crates/formatjs_intl_macros",
   "crates/formatjs_intl",
   "crates/formatjs_cli",
   "crates/formatjs_cli_napi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
   "crates/icu_skeleton_parser",
   "crates/icu_messageformat_parser",
   "crates/icu_messageformat",
+  "crates/formatjs_intl",
   "crates/formatjs_cli",
   "crates/formatjs_cli_napi",
   "packages/icu-messageformat-parser/integration-tests",

--- a/crates/formatjs_cli/BUILD.bazel
+++ b/crates/formatjs_cli/BUILD.bazel
@@ -17,6 +17,7 @@ exports_files(
         "Cargo.toml",
         "src/lib.rs",
         "src/main.rs",
+        "src/rust_extractor.rs",
         "src/extract.rs",
         "src/extractor.rs",
         "src/compile.rs",
@@ -51,11 +52,13 @@ COMMON_DEPS = [
     "@crates//:oxc_data_structures",
     "@crates//:oxc_parser",
     "@crates//:oxc_span",
+    "@crates//:proc-macro2",
     "@crates//:rayon",
     "@crates//:serde",
     "@crates//:serde_json",
     "@crates//:sha1",
     "@crates//:sha2",
+    "@crates//:syn",
 ]
 
 TEST_DEPS = COMMON_DEPS + [
@@ -78,6 +81,7 @@ rust_library(
         "src/formatters/transifex.rs",
         "src/id_generator.rs",
         "src/lib.rs",
+        "src/rust_extractor.rs",
         "src/verify.rs",
     ],
     crate_name = "formatjs_cli",

--- a/crates/formatjs_cli/Cargo.toml
+++ b/crates/formatjs_cli/Cargo.toml
@@ -38,6 +38,8 @@ md-5 = "0.11"
 base64 = "0.22"
 hex = "0.4"
 rayon = "1.12"
+proc-macro2 = { version = "1.0", features = ["span-locations"] }
+syn = { version = "2.0", features = ["full", "parsing", "visit"] }
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/crates/formatjs_cli/README.md
+++ b/crates/formatjs_cli/README.md
@@ -208,11 +208,11 @@ Extract string messages from React components that use react-intl:
 formatjs extract "src/**/*.tsx" --out-file messages.json
 ```
 
-Rust extraction reads `formatjs_intl::message!` descriptors. IDs must be explicit:
+Rust extraction reads `formatjs_intl::message_descriptor!` descriptors. Missing
+IDs use `[sha512:contenthash:base64:10]`:
 
 ```rust
-const GREETING: formatjs_intl::MessageDescriptor = formatjs_intl::message!(
-    id: "greeting",
+const GREETING: formatjs_intl::MessageDescriptor = formatjs_intl::message_descriptor!(
     default_message: "Hello, {name}!",
     description: "Greeting"
 );

--- a/crates/formatjs_cli/README.md
+++ b/crates/formatjs_cli/README.md
@@ -208,6 +208,20 @@ Extract string messages from React components that use react-intl:
 formatjs extract "src/**/*.tsx" --out-file messages.json
 ```
 
+Rust extraction reads `formatjs_intl::message!` descriptors. IDs must be explicit:
+
+```rust
+const GREETING: formatjs_intl::MessageDescriptor = formatjs_intl::message!(
+    id: "greeting",
+    default_message: "Hello, {name}!",
+    description: "Greeting"
+);
+```
+
+```bash
+formatjs extract "src/**/*.rs" --out-file messages.json
+```
+
 **Full example with options:**
 
 ```bash
@@ -221,7 +235,7 @@ formatjs extract "src/**/*.{js,ts,tsx}" \
 
 **Options:**
 
-- `[FILES]...` - File glob patterns to extract from (e.g., `src/**/*.tsx`)
+- `[FILES]...` - JavaScript, TypeScript, or Rust glob patterns (e.g., `src/**/*.tsx`)
 - `--format <FORMATTER>` - Built-in formatter controlling JSON output shape (`default`, `simple`, `transifex`, `smartling`, `lokalise`, or `crowdin`)
 - `--in-file <PATH>` - File containing list of files to extract (one per line)
 - `--out-file <PATH>` - Target file for aggregated .json output

--- a/crates/formatjs_cli/src/extract.rs
+++ b/crates/formatjs_cli/src/extract.rs
@@ -9,8 +9,9 @@ use walkdir::WalkDir;
 use crate::extractor::{determine_source_type, extract_messages_from_source, MessageDescriptor};
 use crate::formatters::Formatter;
 use crate::id_generator::IdGenerator;
+use crate::rust_extractor::extract_messages_from_rust_source;
 
-/// Extract string messages from React components that use react-intl
+/// Extract messages from JavaScript, TypeScript, and Rust source files.
 #[allow(clippy::too_many_arguments)]
 pub fn extract(
     files: &[PathBuf],
@@ -307,7 +308,7 @@ fn is_supported_file(path: &Path) -> bool {
     if let Some(ext) = path.extension() {
         matches!(
             ext.to_string_lossy().as_ref(),
-            "ts" | "tsx" | "js" | "jsx" | "mjs" | "cjs"
+            "ts" | "tsx" | "js" | "jsx" | "mjs" | "cjs" | "rs"
         )
     } else {
         false
@@ -355,10 +356,18 @@ fn extract_from_file(
         HashMap::new()
     };
 
-    // Determine source type from extension
-    let source_type = determine_source_type(path)?;
+    if path.extension().and_then(|extension| extension.to_str()) == Some("rs") {
+        return extract_messages_from_rust_source(
+            &source_text,
+            path,
+            extract_source_location,
+            preserve_whitespace,
+            flatten,
+            throws,
+        );
+    }
 
-    // Use the extractor module to parse and extract messages
+    let source_type = determine_source_type(path)?;
     extract_messages_from_source(
         &source_text,
         path,
@@ -422,6 +431,7 @@ mod tests {
         assert!(is_supported_file(&PathBuf::from("test.jsx")));
         assert!(is_supported_file(&PathBuf::from("test.mjs")));
         assert!(is_supported_file(&PathBuf::from("test.cjs")));
+        assert!(is_supported_file(&PathBuf::from("test.rs")));
         assert!(!is_supported_file(&PathBuf::from("test.py")));
         assert!(!is_supported_file(&PathBuf::from("test.txt")));
     }
@@ -626,6 +636,47 @@ const msg = defineMessage({
             json["native.extract"]["defaultMessage"],
             "Extracted by native binding"
         );
+    }
+
+    #[test]
+    fn test_extract_to_string_reads_rust_message_macro() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let file = temp_dir.path().join("main.rs");
+        fs::write(
+            &file,
+            r#"
+fn main() {
+    let descriptor = message!(
+        id: "rust.hello",
+        default_message: "Hello, {name}!",
+        description: "Greeting"
+    );
+}
+"#,
+        )
+        .unwrap();
+
+        let output = extract_to_string(
+            &[file],
+            None,
+            None,
+            "[sha512:contenthash:base64:6]",
+            false,
+            &[],
+            &[],
+            &[],
+            true,
+            None,
+            false,
+            false,
+            true,
+        )
+        .unwrap();
+        let json: serde_json::Value = serde_json::from_str(&output).unwrap();
+
+        assert_eq!(json["rust.hello"]["defaultMessage"], "Hello, {name}!");
+        assert_eq!(json["rust.hello"]["description"], "Greeting");
+        assert_eq!(json.as_object().unwrap().len(), 1);
     }
 
     #[test]

--- a/crates/formatjs_cli/src/extract.rs
+++ b/crates/formatjs_cli/src/extract.rs
@@ -646,8 +646,7 @@ const msg = defineMessage({
             &file,
             r#"
 fn main() {
-    let descriptor = message!(
-        id: "rust.hello",
+    let descriptor = message_descriptor!(
         default_message: "Hello, {name}!",
         description: "Greeting"
     );
@@ -674,8 +673,8 @@ fn main() {
         .unwrap();
         let json: serde_json::Value = serde_json::from_str(&output).unwrap();
 
-        assert_eq!(json["rust.hello"]["defaultMessage"], "Hello, {name}!");
-        assert_eq!(json["rust.hello"]["description"], "Greeting");
+        assert_eq!(json["EG1xJTTqQy"]["defaultMessage"], "Hello, {name}!");
+        assert_eq!(json["EG1xJTTqQy"]["description"], "Greeting");
         assert_eq!(json.as_object().unwrap().len(), 1);
     }
 

--- a/crates/formatjs_cli/src/extractor.rs
+++ b/crates/formatjs_cli/src/extractor.rs
@@ -36,7 +36,7 @@ pub struct MessageDescriptor {
 /// - Trimming leading and trailing whitespace
 /// Matches TypeScript behavior: Unicode White_Space trim + collapse.
 /// This intentionally differs from JavaScript \s/String#trim for U+0085 and U+FEFF.
-fn normalize_whitespace(s: &str) -> String {
+pub(crate) fn normalize_whitespace(s: &str) -> String {
     let trimmed = s.trim_matches(char::is_whitespace);
     let mut normalized = String::with_capacity(trimmed.len());
     let mut in_whitespace = false;
@@ -107,72 +107,64 @@ pub fn extract_messages_from_source(
     );
 
     visitor.visit_program(&program);
-    let MessageExtractor {
-        messages,
-        source_rope,
-        ..
-    } = visitor;
+    flatten_message_descriptors(visitor.messages, source_text, file_path, flatten)
+}
 
-    // Apply selector hoisting if flatten is enabled
-    let messages = if flatten {
-        messages
-            .into_iter()
-            .map(|mut msg| {
-                if let Some(ref default_message) = msg.default_message {
-                    // Parse the ICU message
-                    let parser = IcuParser::new(
-                        default_message,
-                        ParserOptions {
-                            ignore_tag: false,
-                            ..Default::default()
-                        },
-                    );
+pub(crate) fn flatten_message_descriptors(
+    messages: Vec<MessageDescriptor>,
+    source_text: &str,
+    file_path: &Path,
+    flatten: bool,
+) -> Result<Vec<MessageDescriptor>> {
+    if !flatten {
+        return Ok(messages);
+    }
 
-                    match parser.parse() {
-                        Ok(ast) => {
-                            // Apply selector hoisting
-                            match try_hoist_selectors(ast) {
-                                Ok(hoisted_ast) => {
-                                    // Print back to string
-                                    msg.default_message = Some(print_ast(&hoisted_ast));
-                                }
-                                Err(e) => {
-                                    // Get line and column from start position if available
-                                    let location_str = if let Some(start) = msg.start {
-                                        let line_col = get_line_col(source_text, &source_rope, start);
-                                        format!(" at line {}, column {}", line_col.0, line_col.1)
-                                    } else {
-                                        String::new()
-                                    };
-                                    let id_str = msg
-                                        .id
-                                        .as_ref()
-                                        .map(|id| format!(" with id \"{}\"", id))
-                                        .unwrap_or_default();
-                                    anyhow::bail!(
-                                        "[formatjs] Cannot flatten message in file \"{}\"{}{}: {}\nMessage: {}",
-                                        file_path.display(),
-                                        location_str,
-                                        id_str,
-                                        e,
-                                        default_message
-                                    );
-                                }
-                            }
-                        }
-                        Err(_) => {
-                            // If parsing fails, keep the original message
+    let source_rope = Rope::from_str(source_text);
+    messages
+        .into_iter()
+        .map(|mut message| {
+            if let Some(ref default_message) = message.default_message {
+                let parser = IcuParser::new(
+                    default_message,
+                    ParserOptions {
+                        ignore_tag: false,
+                        ..Default::default()
+                    },
+                );
+
+                if let Ok(ast) = parser.parse() {
+                    match try_hoist_selectors(ast) {
+                        Ok(ast) => message.default_message = Some(print_ast(&ast)),
+                        Err(error) => {
+                            let location = message
+                                .start
+                                .map(|start| {
+                                    let (line, column) =
+                                        get_line_col(source_text, &source_rope, start);
+                                    format!(" at line {line}, column {column}")
+                                })
+                                .unwrap_or_default();
+                            let id = message
+                                .id
+                                .as_ref()
+                                .map(|id| format!(" with id \"{id}\""))
+                                .unwrap_or_default();
+                            anyhow::bail!(
+                                "[formatjs] Cannot flatten message in file \"{}\"{}{}: {}\nMessage: {}",
+                                file_path.display(),
+                                location,
+                                id,
+                                error,
+                                default_message
+                            );
                         }
                     }
                 }
-                Ok(msg)
-            })
-            .collect::<Result<Vec<_>>>()?
-    } else {
-        messages
-    };
-
-    Ok(messages)
+            }
+            Ok(message)
+        })
+        .collect()
 }
 
 /// Determine oxc SourceType from file extension

--- a/crates/formatjs_cli/src/lib.rs
+++ b/crates/formatjs_cli/src/lib.rs
@@ -4,4 +4,5 @@ pub mod extract;
 pub mod extractor;
 pub mod formatters;
 pub mod id_generator;
+pub mod rust_extractor;
 pub mod verify;

--- a/crates/formatjs_cli/src/main.rs
+++ b/crates/formatjs_cli/src/main.rs
@@ -75,8 +75,7 @@ impl From<PseudoLocale> for compile::PseudoLocale {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Extract string messages from React components that use react-intl.
-    /// Extracts messages from TypeScript, JavaScript, Vue, and Handlebars files.
+    /// Extract messages from JavaScript, TypeScript, and Rust source files.
     Extract {
         /// File glob patterns to extract from (e.g., src/**/*.tsx)
         #[arg(value_name = "FILES")]

--- a/crates/formatjs_cli/src/rust_extractor.rs
+++ b/crates/formatjs_cli/src/rust_extractor.rs
@@ -1,0 +1,224 @@
+use crate::extractor::{MessageDescriptor, flatten_message_descriptors, normalize_whitespace};
+use anyhow::{Result, bail};
+use proc_macro2::{LineColumn, Span};
+use serde_json::Value;
+use std::path::Path;
+use syn::parse::{Parse, ParseStream};
+use syn::spanned::Spanned;
+use syn::visit::{self, Visit};
+use syn::{Ident, LitStr, Macro, Token};
+
+pub fn extract_messages_from_rust_source(
+    source_text: &str,
+    file_path: &Path,
+    extract_source_location: bool,
+    preserve_whitespace: bool,
+    flatten: bool,
+    throws: bool,
+) -> Result<Vec<MessageDescriptor>> {
+    let file = syn::parse_file(source_text)?;
+    let mut extractor = RustMessageExtractor {
+        source_text,
+        file_path,
+        extract_source_location,
+        preserve_whitespace,
+        throws,
+        messages: Vec::new(),
+        errors: Vec::new(),
+    };
+    extractor.visit_file(&file);
+    if let Some(error) = extractor.errors.into_iter().next() {
+        bail!(error);
+    }
+    flatten_message_descriptors(extractor.messages, source_text, file_path, flatten)
+}
+
+struct RustMessageExtractor<'a> {
+    source_text: &'a str,
+    file_path: &'a Path,
+    extract_source_location: bool,
+    preserve_whitespace: bool,
+    throws: bool,
+    messages: Vec<MessageDescriptor>,
+    errors: Vec<String>,
+}
+
+impl RustMessageExtractor<'_> {
+    fn descriptor(&self, arguments: MessageArgs, span: Span) -> MessageDescriptor {
+        let (start, end) = if self.extract_source_location {
+            (
+                Some(line_column_to_offset(self.source_text, span.start())),
+                Some(line_column_to_offset(self.source_text, span.end())),
+            )
+        } else {
+            (None, None)
+        };
+        let default_message = if self.preserve_whitespace {
+            arguments.default_message
+        } else {
+            normalize_whitespace(&arguments.default_message)
+        };
+        MessageDescriptor {
+            id: Some(arguments.id),
+            default_message: Some(default_message),
+            description: arguments.description.map(Value::String),
+            file: self
+                .extract_source_location
+                .then(|| self.file_path.to_string_lossy().into_owned()),
+            start,
+            end,
+        }
+    }
+
+    fn error(&mut self, span: Span, message: impl AsRef<str>) {
+        if self.throws {
+            let start = span.start();
+            self.errors.push(format!(
+                "{}:{}:{}: {}",
+                self.file_path.display(),
+                start.line,
+                start.column + 1,
+                message.as_ref()
+            ));
+        }
+    }
+}
+
+impl<'ast> Visit<'ast> for RustMessageExtractor<'_> {
+    fn visit_macro(&mut self, node: &'ast Macro) {
+        let name = node.path.segments.last().map(|segment| &segment.ident);
+        if name.is_some_and(|name| name == "message") {
+            match syn::parse2::<MessageArgs>(node.tokens.clone()) {
+                Ok(arguments) => {
+                    let descriptor = self.descriptor(arguments, node.span());
+                    self.messages.push(descriptor);
+                }
+                Err(error) => self.error(node.span(), error.to_string()),
+            }
+        }
+        visit::visit_macro(self, node);
+    }
+}
+
+fn line_column_to_offset(source: &str, location: LineColumn) -> u32 {
+    let line_offset: usize = source
+        .split_inclusive('\n')
+        .take(location.line.saturating_sub(1))
+        .map(str::len)
+        .sum();
+    line_offset
+        .saturating_add(location.column)
+        .min(source.len()) as u32
+}
+
+struct MessageArgs {
+    id: String,
+    default_message: String,
+    description: Option<String>,
+}
+
+impl Parse for MessageArgs {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let mut id = None;
+        let mut default_message = None;
+        let mut description = None;
+        while !input.is_empty() {
+            let key: Ident = input.parse()?;
+            if input.peek(Token![:]) {
+                input.parse::<Token![:]>()?;
+            } else {
+                input.parse::<Token![=]>()?;
+            }
+            let value: LitStr = input.parse()?;
+            match key.to_string().as_str() {
+                "id" if id.is_none() => id = Some(value.value()),
+                "default_message" if default_message.is_none() => {
+                    default_message = Some(value.value())
+                }
+                "description" if description.is_none() => description = Some(value.value()),
+                "id" | "default_message" | "description" => {
+                    return Err(syn::Error::new(key.span(), "duplicate message field"));
+                }
+                _ => return Err(syn::Error::new(key.span(), "unknown message field")),
+            }
+            if input.peek(Token![,]) {
+                input.parse::<Token![,]>()?;
+            } else if !input.is_empty() {
+                return Err(input.error("expected comma"));
+            }
+        }
+
+        Ok(Self {
+            id: id.ok_or_else(|| syn::Error::new(Span::call_site(), "id is required"))?,
+            default_message: default_message
+                .ok_or_else(|| syn::Error::new(Span::call_site(), "default_message is required"))?,
+            description,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_message_descriptors() {
+        let source = r#"fn main() {
+            let descriptor = message!(
+                id: "hello",
+                default_message: "Hello, {name}!",
+                description: "Greeting"
+            );
+        }"#;
+        let messages = extract_messages_from_rust_source(
+            source,
+            Path::new("src/main.rs"),
+            false,
+            false,
+            false,
+            true,
+        )
+        .unwrap();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].id.as_deref(), Some("hello"));
+        assert_eq!(
+            messages[0].default_message.as_deref(),
+            Some("Hello, {name}!")
+        );
+        assert_eq!(
+            messages[0].description,
+            Some(Value::String("Greeting".to_owned()))
+        );
+    }
+
+    #[test]
+    fn requires_explicit_id() {
+        let error = extract_messages_from_rust_source(
+            r#"fn main() { message!(default_message: "Hello"); }"#,
+            Path::new("src/main.rs"),
+            false,
+            false,
+            false,
+            true,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("id is required"));
+    }
+
+    #[test]
+    fn reports_source_offsets() {
+        let source = "fn main() {\n    message!(id: \"hello\", default_message: \"Hello\");\n}\n";
+        let messages = extract_messages_from_rust_source(
+            source,
+            Path::new("src/main.rs"),
+            true,
+            false,
+            false,
+            true,
+        )
+        .unwrap();
+        assert_eq!(messages[0].file.as_deref(), Some("src/main.rs"));
+        assert_eq!(messages[0].start, Some(16));
+        assert!(messages[0].end.unwrap() > messages[0].start.unwrap());
+    }
+}

--- a/crates/formatjs_cli/src/rust_extractor.rs
+++ b/crates/formatjs_cli/src/rust_extractor.rs
@@ -1,4 +1,5 @@
 use crate::extractor::{MessageDescriptor, flatten_message_descriptors, normalize_whitespace};
+use crate::id_generator::IdGenerator;
 use anyhow::{Result, bail};
 use proc_macro2::{LineColumn, Span};
 use serde_json::Value;
@@ -7,6 +8,8 @@ use syn::parse::{Parse, ParseStream};
 use syn::spanned::Spanned;
 use syn::visit::{self, Visit};
 use syn::{Ident, LitStr, Macro, Token};
+
+const RUST_ID_INTERPOLATION_PATTERN: &str = "[sha512:contenthash:base64:10]";
 
 pub fn extract_messages_from_rust_source(
     source_text: &str,
@@ -17,12 +20,14 @@ pub fn extract_messages_from_rust_source(
     throws: bool,
 ) -> Result<Vec<MessageDescriptor>> {
     let file = syn::parse_file(source_text)?;
+    let id_generator = IdGenerator::new(RUST_ID_INTERPOLATION_PATTERN)?;
     let mut extractor = RustMessageExtractor {
         source_text,
         file_path,
         extract_source_location,
         preserve_whitespace,
         throws,
+        id_generator,
         messages: Vec::new(),
         errors: Vec::new(),
     };
@@ -39,12 +44,13 @@ struct RustMessageExtractor<'a> {
     extract_source_location: bool,
     preserve_whitespace: bool,
     throws: bool,
+    id_generator: IdGenerator,
     messages: Vec<MessageDescriptor>,
     errors: Vec<String>,
 }
 
 impl RustMessageExtractor<'_> {
-    fn descriptor(&self, arguments: MessageArgs, span: Span) -> MessageDescriptor {
+    fn descriptor(&self, arguments: MessageArgs, span: Span) -> Result<MessageDescriptor> {
         let (start, end) = if self.extract_source_location {
             (
                 Some(line_column_to_offset(self.source_text, span.start())),
@@ -53,21 +59,30 @@ impl RustMessageExtractor<'_> {
         } else {
             (None, None)
         };
+        let normalized_default_message = normalize_whitespace(&arguments.default_message);
+        let description = arguments.description.map(Value::String);
+        let id = match arguments.id {
+            Some(id) => id,
+            None => {
+                self.id_generator
+                    .generate(Some(&normalized_default_message), &description, None)?
+            }
+        };
         let default_message = if self.preserve_whitespace {
             arguments.default_message
         } else {
-            normalize_whitespace(&arguments.default_message)
+            normalized_default_message
         };
-        MessageDescriptor {
-            id: Some(arguments.id),
+        Ok(MessageDescriptor {
+            id: Some(id),
             default_message: Some(default_message),
-            description: arguments.description.map(Value::String),
+            description,
             file: self
                 .extract_source_location
                 .then(|| self.file_path.to_string_lossy().into_owned()),
             start,
             end,
-        }
+        })
     }
 
     fn error(&mut self, span: Span, message: impl AsRef<str>) {
@@ -87,12 +102,12 @@ impl RustMessageExtractor<'_> {
 impl<'ast> Visit<'ast> for RustMessageExtractor<'_> {
     fn visit_macro(&mut self, node: &'ast Macro) {
         let name = node.path.segments.last().map(|segment| &segment.ident);
-        if name.is_some_and(|name| name == "message") {
+        if name.is_some_and(|name| name == "message_descriptor") {
             match syn::parse2::<MessageArgs>(node.tokens.clone()) {
-                Ok(arguments) => {
-                    let descriptor = self.descriptor(arguments, node.span());
-                    self.messages.push(descriptor);
-                }
+                Ok(arguments) => match self.descriptor(arguments, node.span()) {
+                    Ok(descriptor) => self.messages.push(descriptor),
+                    Err(error) => self.error(node.span(), error.to_string()),
+                },
                 Err(error) => self.error(node.span(), error.to_string()),
             }
         }
@@ -112,7 +127,7 @@ fn line_column_to_offset(source: &str, location: LineColumn) -> u32 {
 }
 
 struct MessageArgs {
-    id: String,
+    id: Option<String>,
     default_message: String,
     description: Option<String>,
 }
@@ -149,7 +164,7 @@ impl Parse for MessageArgs {
         }
 
         Ok(Self {
-            id: id.ok_or_else(|| syn::Error::new(Span::call_site(), "id is required"))?,
+            id,
             default_message: default_message
                 .ok_or_else(|| syn::Error::new(Span::call_site(), "default_message is required"))?,
             description,
@@ -164,8 +179,7 @@ mod tests {
     #[test]
     fn extracts_message_descriptors() {
         let source = r#"fn main() {
-            let descriptor = message!(
-                id: "hello",
+            let descriptor = message_descriptor!(
                 default_message: "Hello, {name}!",
                 description: "Greeting"
             );
@@ -180,7 +194,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(messages.len(), 1);
-        assert_eq!(messages[0].id.as_deref(), Some("hello"));
+        assert_eq!(messages[0].id.as_deref(), Some("EG1xJTTqQy"));
         assert_eq!(
             messages[0].default_message.as_deref(),
             Some("Hello, {name}!")
@@ -192,22 +206,22 @@ mod tests {
     }
 
     #[test]
-    fn requires_explicit_id() {
-        let error = extract_messages_from_rust_source(
-            r#"fn main() { message!(default_message: "Hello"); }"#,
+    fn preserves_explicit_id() {
+        let messages = extract_messages_from_rust_source(
+            r#"fn main() { message_descriptor!(id: "hello", default_message: "Hello"); }"#,
             Path::new("src/main.rs"),
             false,
             false,
             false,
             true,
         )
-        .unwrap_err();
-        assert!(error.to_string().contains("id is required"));
+        .unwrap();
+        assert_eq!(messages[0].id.as_deref(), Some("hello"));
     }
 
     #[test]
     fn reports_source_offsets() {
-        let source = "fn main() {\n    message!(id: \"hello\", default_message: \"Hello\");\n}\n";
+        let source = "fn main() {\n    message_descriptor!(default_message: \"Hello\");\n}\n";
         let messages = extract_messages_from_rust_source(
             source,
             Path::new("src/main.rs"),

--- a/crates/formatjs_intl/BUILD.bazel
+++ b/crates/formatjs_intl/BUILD.bazel
@@ -16,6 +16,7 @@ rust_library(
     crate_name = "formatjs_intl",
     visibility = ["//visibility:public"],
     deps = [
+        "//crates/formatjs_intl_macros",
         "//crates/icu_messageformat",
         "@crates//:icu_locale",
     ],

--- a/crates/formatjs_intl/BUILD.bazel
+++ b/crates/formatjs_intl/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@rules_rs//rs:rust_library.bzl", "rust_library")
+load("@rules_rs//rs:rust_test.bzl", "rust_test")
+
+exports_files(
+    [
+        "Cargo.toml",
+        "README.md",
+        "lib.rs",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+rust_library(
+    name = "formatjs_intl",
+    srcs = ["lib.rs"],
+    crate_name = "formatjs_intl",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//crates/icu_messageformat",
+        "@crates//:icu_locale",
+    ],
+)
+
+rust_test(
+    name = "formatjs_intl_test",
+    size = "small",
+    crate = ":formatjs_intl",
+)

--- a/crates/formatjs_intl/Cargo.toml
+++ b/crates/formatjs_intl/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "formatjs_intl"
+version = "0.1.0"
+edition = "2024"
+authors = ["FormatJS Team", "Long Ho <holevietlong@gmail.com>"]
+description = "High-level internationalization runtime for Rust"
+license = "BSD-3-Clause"
+repository = "https://github.com/formatjs/formatjs"
+homepage = "https://formatjs.io/"
+documentation = "https://docs.rs/formatjs_intl"
+keywords = ["icu", "i18n", "internationalization", "localization", "intl"]
+categories = ["internationalization", "localization"]
+readme = "README.md"
+rust-version = "1.95"
+
+[dependencies]
+formatjs_icu_messageformat = { path = "../icu_messageformat", version = "0.1.0" }
+icu_locale = "2.1"
+
+[lib]
+path = "lib.rs"
+crate-type = ["rlib"]

--- a/crates/formatjs_intl/README.md
+++ b/crates/formatjs_intl/README.md
@@ -4,13 +4,15 @@ High-level Rust internationalization runtime. Owns message descriptors,
 translation catalogs, ICU4X locale negotiation, and shared compiled-message
 caching. Formatting delegates to `formatjs_icu_messageformat`.
 
+`message_descriptor!` generates missing IDs with
+`[sha512:contenthash:base64:10]`. Pass `id:` to keep a semantic ID.
+
 ```rust
 use formatjs_icu_messageformat::{Value, Values};
-use formatjs_intl::{Intl, IntlCache, MessageCatalog, message};
+use formatjs_intl::{Intl, IntlCache, MessageCatalog, message_descriptor};
 use std::{collections::HashMap, sync::Arc};
 
-const TASKS: formatjs_intl::MessageDescriptor = message!(
-    id: "tasks.count",
+const TASKS: formatjs_intl::MessageDescriptor = message_descriptor!(
     default_message: "{count, plural, one {# task} other {# tasks}}",
     description: "Task count"
 );

--- a/crates/formatjs_intl/README.md
+++ b/crates/formatjs_intl/README.md
@@ -1,0 +1,40 @@
+# formatjs_intl
+
+High-level Rust internationalization runtime. Owns message descriptors,
+translation catalogs, ICU4X locale negotiation, and shared compiled-message
+caching. Formatting delegates to `formatjs_icu_messageformat`.
+
+```rust
+use formatjs_icu_messageformat::{Value, Values};
+use formatjs_intl::{Intl, IntlCache, MessageCatalog, message};
+use std::{collections::HashMap, sync::Arc};
+
+const TASKS: formatjs_intl::MessageDescriptor = message!(
+    id: "tasks.count",
+    default_message: "{count, plural, one {# task} other {# tasks}}",
+    description: "Task count"
+);
+
+let mut catalog = MessageCatalog::new();
+catalog.insert(
+    "fr",
+    HashMap::from([(
+        "tasks.count".to_owned(),
+        "{count, plural, one {# tâche} other {# tâches}}".to_owned(),
+    )]),
+)?;
+catalog.insert("en", HashMap::new())?;
+
+let intl = Intl::try_new(
+    ["fr-CA", "fr"],
+    "en",
+    Arc::new(catalog),
+    Arc::new(IntlCache::new()),
+)?;
+let values: Values = HashMap::from([("count".to_owned(), Value::from(2_i64))]);
+assert_eq!(intl.format_message_to_string(TASKS, &values)?, "2 tâches");
+# Ok::<(), formatjs_intl::Error>(())
+```
+
+Requested locales must already be ordered by preference. HTTP
+`Accept-Language` parsing stays in the application or web-framework adapter.

--- a/crates/formatjs_intl/lib.rs
+++ b/crates/formatjs_intl/lib.rs
@@ -1,0 +1,371 @@
+use formatjs_icu_messageformat::{FormattedMessage, IcuMessageFormat, Part, Values};
+use icu_locale::{Locale, fallback::LocaleFallbacker};
+use std::collections::HashMap;
+use std::error::Error as StdError;
+use std::fmt;
+use std::sync::{Arc, RwLock};
+
+pub type Messages = HashMap<String, String>;
+
+#[derive(Debug)]
+pub enum Error {
+    InvalidLocale(String),
+    MissingDefaultLocale(String),
+    CachePoisoned,
+    Message(formatjs_icu_messageformat::Error),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidLocale(locale) => write!(formatter, "Invalid locale: {locale}"),
+            Self::MissingDefaultLocale(locale) => {
+                write!(
+                    formatter,
+                    "Default locale has no translation catalog: {locale}"
+                )
+            }
+            Self::CachePoisoned => formatter.write_str("Intl cache lock is poisoned"),
+            Self::Message(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl StdError for Error {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match self {
+            Self::Message(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+
+impl From<formatjs_icu_messageformat::Error> for Error {
+    fn from(error: formatjs_icu_messageformat::Error) -> Self {
+        Self::Message(error)
+    }
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MessageDescriptor {
+    pub id: &'static str,
+    pub default_message: &'static str,
+    pub description: Option<&'static str>,
+}
+
+impl MessageDescriptor {
+    pub const fn new(id: &'static str, default_message: &'static str) -> Self {
+        Self {
+            id,
+            default_message,
+            description: None,
+        }
+    }
+
+    pub const fn with_description(mut self, description: &'static str) -> Self {
+        self.description = Some(description);
+        self
+    }
+}
+
+#[macro_export]
+macro_rules! message {
+    (
+        id: $id:literal,
+        default_message: $default_message:literal
+        $(, description: $description:literal)?
+        $(,)?
+    ) => {{
+        let descriptor = $crate::MessageDescriptor::new($id, $default_message);
+        $(let descriptor = descriptor.with_description($description);)?
+        descriptor
+    }};
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct MessageCatalog {
+    bundles: HashMap<String, Arc<Messages>>,
+}
+
+impl MessageCatalog {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn insert(&mut self, locale: impl AsRef<str>, messages: Messages) -> Result<()> {
+        let locale = parse_locale(locale.as_ref())?;
+        self.bundles.insert(locale.to_string(), Arc::new(messages));
+        Ok(())
+    }
+
+    pub fn contains_locale(&self, locale: impl fmt::Display) -> bool {
+        self.bundles.contains_key(&locale.to_string())
+    }
+
+    pub fn messages(&self, locale: impl fmt::Display) -> Option<Arc<Messages>> {
+        self.bundles.get(&locale.to_string()).cloned()
+    }
+
+    pub fn available_locales(&self) -> impl Iterator<Item = &str> {
+        self.bundles.keys().map(String::as_str)
+    }
+}
+
+#[derive(Default)]
+pub struct IntlCache {
+    messages: RwLock<HashMap<String, Arc<IcuMessageFormat>>>,
+}
+
+impl IntlCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn len(&self) -> Result<usize> {
+        self.messages
+            .read()
+            .map(|messages| messages.len())
+            .map_err(|_| Error::CachePoisoned)
+    }
+
+    pub fn is_empty(&self) -> Result<bool> {
+        self.len().map(|len| len == 0)
+    }
+
+    fn get_or_compile(&self, source: &str) -> Result<Arc<IcuMessageFormat>> {
+        if let Some(message) = self
+            .messages
+            .read()
+            .map_err(|_| Error::CachePoisoned)?
+            .get(source)
+            .cloned()
+        {
+            return Ok(message);
+        }
+
+        let message = Arc::new(IcuMessageFormat::try_new(source)?);
+        let mut messages = self.messages.write().map_err(|_| Error::CachePoisoned)?;
+        Ok(messages.entry(source.to_owned()).or_insert(message).clone())
+    }
+}
+
+pub struct Intl {
+    locale: Locale,
+    locale_string: String,
+    messages: Arc<Messages>,
+    default_messages: Arc<Messages>,
+    cache: Arc<IntlCache>,
+}
+
+impl Intl {
+    pub fn try_new<I, S>(
+        requested_locales: I,
+        default_locale: impl AsRef<str>,
+        catalog: Arc<MessageCatalog>,
+        cache: Arc<IntlCache>,
+    ) -> Result<Self>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let default_locale = parse_locale(default_locale.as_ref())?;
+        let default_messages = catalog
+            .messages(&default_locale)
+            .ok_or_else(|| Error::MissingDefaultLocale(default_locale.to_string()))?;
+        let locale = negotiate_locale(requested_locales, &default_locale, &catalog)?;
+        let messages = catalog
+            .messages(&locale)
+            .unwrap_or_else(|| default_messages.clone());
+        let locale_string = locale.to_string();
+
+        Ok(Self {
+            locale,
+            locale_string,
+            messages,
+            default_messages,
+            cache,
+        })
+    }
+
+    pub fn locale(&self) -> &Locale {
+        &self.locale
+    }
+
+    pub fn format_message<T: Clone>(
+        &self,
+        descriptor: MessageDescriptor,
+        values: &Values<T>,
+    ) -> Result<FormattedMessage<T>> {
+        let source = self.message_source(descriptor);
+        Ok(self
+            .cache
+            .get_or_compile(source)?
+            .format(&self.locale_string, values)?)
+    }
+
+    pub fn format_message_to_parts<T: Clone>(
+        &self,
+        descriptor: MessageDescriptor,
+        values: &Values<T>,
+    ) -> Result<Vec<Part<T>>> {
+        let source = self.message_source(descriptor);
+        Ok(self
+            .cache
+            .get_or_compile(source)?
+            .format_to_parts(&self.locale_string, values)?)
+    }
+
+    pub fn format_message_to_string(
+        &self,
+        descriptor: MessageDescriptor,
+        values: &Values<String>,
+    ) -> Result<String> {
+        let source = self.message_source(descriptor);
+        Ok(self
+            .cache
+            .get_or_compile(source)?
+            .format_to_string(&self.locale_string, values)?)
+    }
+
+    fn message_source(&self, descriptor: MessageDescriptor) -> &str {
+        self.messages
+            .get(descriptor.id)
+            .or_else(|| self.default_messages.get(descriptor.id))
+            .map(String::as_str)
+            .unwrap_or(descriptor.default_message)
+    }
+}
+
+pub fn negotiate_locale<I, S>(
+    requested_locales: I,
+    default_locale: &Locale,
+    catalog: &MessageCatalog,
+) -> Result<Locale>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let fallbacker = LocaleFallbacker::new();
+    for requested in requested_locales {
+        let requested = parse_locale(requested.as_ref())?;
+        let mut fallback = fallbacker
+            .for_config(Default::default())
+            .fallback_for(requested.into());
+
+        loop {
+            let candidate = fallback.get();
+            if catalog.contains_locale(candidate) {
+                return parse_locale(&candidate.to_string());
+            }
+            if candidate.is_unknown() {
+                break;
+            }
+            fallback.step();
+        }
+    }
+
+    Ok(default_locale.clone())
+}
+
+fn parse_locale(locale: &str) -> Result<Locale> {
+    locale
+        .parse()
+        .map_err(|_| Error::InvalidLocale(locale.to_owned()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use formatjs_icu_messageformat::Value;
+
+    const TASKS: MessageDescriptor = message!(
+        id: "tasks.count",
+        default_message: "{count, plural, one {# task} other {# tasks}}",
+        description: "Task count"
+    );
+
+    fn catalog() -> Arc<MessageCatalog> {
+        let mut catalog = MessageCatalog::new();
+        catalog.insert("en", Messages::new()).unwrap();
+        catalog
+            .insert(
+                "fr",
+                HashMap::from([(
+                    "tasks.count".to_owned(),
+                    "{count, plural, one {# tâche} other {# tâches}}".to_owned(),
+                )]),
+            )
+            .unwrap();
+        catalog.insert("zh-Hant", Messages::new()).unwrap();
+        Arc::new(catalog)
+    }
+
+    #[test]
+    fn negotiates_with_icu4x_fallback() {
+        let catalog = catalog();
+        let default_locale: Locale = "en".parse().unwrap();
+        assert_eq!(
+            negotiate_locale(["fr-CA"], &default_locale, &catalog)
+                .unwrap()
+                .to_string(),
+            "fr"
+        );
+        assert_eq!(
+            negotiate_locale(["zh-Hant-TW"], &default_locale, &catalog)
+                .unwrap()
+                .to_string(),
+            "zh-Hant"
+        );
+        assert_eq!(
+            negotiate_locale(["de"], &default_locale, &catalog)
+                .unwrap()
+                .to_string(),
+            "en"
+        );
+    }
+
+    #[test]
+    fn loads_translation_and_reuses_compiled_message() {
+        let cache = Arc::new(IntlCache::new());
+        let intl = Intl::try_new(["fr-CA"], "en", catalog(), cache.clone()).unwrap();
+        let values: Values = HashMap::from([("count".to_owned(), Value::from(2_i64))]);
+
+        assert_eq!(
+            intl.format_message_to_string(TASKS, &values).unwrap(),
+            "2 tâches"
+        );
+        assert_eq!(
+            intl.format_message_to_string(TASKS, &values).unwrap(),
+            "2 tâches"
+        );
+        assert_eq!(intl.locale().to_string(), "fr");
+        assert_eq!(cache.len().unwrap(), 1);
+    }
+
+    #[test]
+    fn falls_back_to_descriptor_default_message() {
+        let intl = Intl::try_new(["en-US"], "en", catalog(), Arc::new(IntlCache::new())).unwrap();
+        let values: Values = HashMap::from([("count".to_owned(), Value::from(1_i64))]);
+
+        assert_eq!(
+            intl.format_message_to_string(TASKS, &values).unwrap(),
+            "1 task"
+        );
+    }
+
+    #[test]
+    fn requires_default_catalog() {
+        let error = match Intl::try_new(
+            ["fr"],
+            "en",
+            Arc::new(MessageCatalog::new()),
+            Arc::new(IntlCache::new()),
+        ) {
+            Ok(_) => panic!("expected missing default locale error"),
+            Err(error) => error,
+        };
+        assert!(matches!(error, Error::MissingDefaultLocale(locale) if locale == "en"));
+    }
+}

--- a/crates/formatjs_intl/lib.rs
+++ b/crates/formatjs_intl/lib.rs
@@ -5,6 +5,9 @@ use std::error::Error as StdError;
 use std::fmt;
 use std::sync::{Arc, RwLock};
 
+#[doc(hidden)]
+pub use formatjs_intl_macros::__message_descriptor;
+
 pub type Messages = HashMap<String, String>;
 
 #[derive(Debug)]
@@ -71,16 +74,15 @@ impl MessageDescriptor {
 }
 
 #[macro_export]
-macro_rules! message {
-    (
-        id: $id:literal,
-        default_message: $default_message:literal
-        $(, description: $description:literal)?
-        $(,)?
-    ) => {{
-        let descriptor = $crate::MessageDescriptor::new($id, $default_message);
-        $(let descriptor = descriptor.with_description($description);)?
-        descriptor
+macro_rules! message_descriptor {
+    ($($tokens:tt)*) => {{
+        const DATA: (&str, &str, ::core::option::Option<&str>) =
+            $crate::__message_descriptor!($($tokens)*);
+        $crate::MessageDescriptor {
+            id: DATA.0,
+            default_message: DATA.1,
+            description: DATA.2,
+        }
     }};
 }
 
@@ -280,11 +282,28 @@ mod tests {
     use super::*;
     use formatjs_icu_messageformat::Value;
 
-    const TASKS: MessageDescriptor = message!(
-        id: "tasks.count",
+    const TASKS: MessageDescriptor = message_descriptor!(
         default_message: "{count, plural, one {# task} other {# tasks}}",
         description: "Task count"
     );
+
+    const EXPLICIT_ID: MessageDescriptor = message_descriptor!(
+        id: "tasks.explicit",
+        default_message: "Explicit task"
+    );
+
+    const GREETING: MessageDescriptor = message_descriptor!(
+        default_message: "Hello, {name}!",
+        description: "Greeting"
+    );
+
+    #[test]
+    fn message_descriptor_generates_or_preserves_id() {
+        assert_eq!(TASKS.id.len(), 10);
+        assert_eq!(TASKS.id, "LURAmALj1U");
+        assert_eq!(GREETING.id, "EG1xJTTqQy");
+        assert_eq!(EXPLICIT_ID.id, "tasks.explicit");
+    }
 
     fn catalog() -> Arc<MessageCatalog> {
         let mut catalog = MessageCatalog::new();
@@ -293,7 +312,7 @@ mod tests {
             .insert(
                 "fr",
                 HashMap::from([(
-                    "tasks.count".to_owned(),
+                    TASKS.id.to_owned(),
                     "{count, plural, one {# tâche} other {# tâches}}".to_owned(),
                 )]),
             )

--- a/crates/formatjs_intl_macros/BUILD.bazel
+++ b/crates/formatjs_intl_macros/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@rules_rs//rs:rust_proc_macro.bzl", "rust_proc_macro")
+
+exports_files(
+    [
+        "Cargo.toml",
+        "lib.rs",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+rust_proc_macro(
+    name = "formatjs_intl_macros",
+    srcs = ["lib.rs"],
+    crate_name = "formatjs_intl_macros",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@crates//:base64",
+        "@crates//:quote",
+        "@crates//:sha2",
+        "@crates//:syn",
+    ],
+)

--- a/crates/formatjs_intl_macros/Cargo.toml
+++ b/crates/formatjs_intl_macros/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
-name = "formatjs_intl"
+name = "formatjs_intl_macros"
 version = "0.1.0"
 edition = "2024"
 authors = ["FormatJS Team", "Long Ho <holevietlong@gmail.com>"]
-description = "High-level internationalization runtime for Rust"
+description = "Procedural macros for formatjs_intl"
 license = "BSD-3-Clause"
 repository = "https://github.com/formatjs/formatjs"
 homepage = "https://formatjs.io/"
-documentation = "https://docs.rs/formatjs_intl"
+documentation = "https://docs.rs/formatjs_intl_macros"
 keywords = ["icu", "i18n", "internationalization", "localization", "intl"]
 categories = ["internationalization", "localization"]
-readme = "README.md"
 rust-version = "1.95"
-
-[dependencies]
-formatjs_icu_messageformat = { path = "../icu_messageformat", version = "0.1.0" }
-formatjs_intl_macros = { path = "../formatjs_intl_macros", version = "0.1.0" }
-icu_locale = "2.1"
 
 [lib]
 path = "lib.rs"
-crate-type = ["rlib"]
+proc-macro = true
+
+[dependencies]
+base64 = "0.22"
+quote = "1.0"
+sha2 = "0.11"
+syn = { version = "2.0", features = ["full", "parsing"] }

--- a/crates/formatjs_intl_macros/lib.rs
+++ b/crates/formatjs_intl_macros/lib.rs
@@ -1,0 +1,99 @@
+use base64::Engine;
+use proc_macro::TokenStream;
+use quote::quote;
+use sha2::{Digest, Sha512};
+use syn::parse::{Parse, ParseStream};
+use syn::{Ident, LitStr, Token, parse_macro_input};
+
+const GENERATED_ID_LENGTH: usize = 10;
+
+#[proc_macro]
+pub fn __message_descriptor(input: TokenStream) -> TokenStream {
+    let arguments = parse_macro_input!(input as MessageDescriptorArgs);
+    let default_message = normalize_whitespace(&arguments.default_message.value());
+    let id = arguments.id.map_or_else(
+        || generate_id(&default_message, arguments.description.as_ref()),
+        |id| id.value(),
+    );
+    let description = arguments.description.map_or_else(
+        || quote!(::core::option::Option::None),
+        |description| quote!(::core::option::Option::Some(#description)),
+    );
+
+    quote!((#id, #default_message, #description)).into()
+}
+
+struct MessageDescriptorArgs {
+    id: Option<LitStr>,
+    default_message: LitStr,
+    description: Option<LitStr>,
+}
+
+impl Parse for MessageDescriptorArgs {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let mut id = None;
+        let mut default_message = None;
+        let mut description = None;
+
+        while !input.is_empty() {
+            let key: Ident = input.parse()?;
+            input.parse::<Token![:]>()?;
+            let value: LitStr = input.parse()?;
+            match key.to_string().as_str() {
+                "id" if id.is_none() => id = Some(value),
+                "default_message" if default_message.is_none() => default_message = Some(value),
+                "description" if description.is_none() => description = Some(value),
+                "id" | "default_message" | "description" => {
+                    return Err(syn::Error::new(key.span(), "duplicate message field"));
+                }
+                _ => return Err(syn::Error::new(key.span(), "unknown message field")),
+            }
+
+            if input.peek(Token![,]) {
+                input.parse::<Token![,]>()?;
+            } else if !input.is_empty() {
+                return Err(input.error("expected comma"));
+            }
+        }
+
+        Ok(Self {
+            id,
+            default_message: default_message
+                .ok_or_else(|| syn::Error::new(input.span(), "default_message is required"))?,
+            description,
+        })
+    }
+}
+
+fn generate_id(default_message: &str, description: Option<&LitStr>) -> String {
+    let mut content = default_message.as_bytes().to_vec();
+    if let Some(description) = description {
+        content.push(b'#');
+        content.extend_from_slice(description.value().as_bytes());
+    }
+    base64::engine::general_purpose::STANDARD
+        .encode(Sha512::digest(content))
+        .chars()
+        .take(GENERATED_ID_LENGTH)
+        .collect()
+}
+
+fn normalize_whitespace(value: &str) -> String {
+    let trimmed = value.trim_matches(char::is_whitespace);
+    let mut normalized = String::with_capacity(trimmed.len());
+    let mut in_whitespace = false;
+
+    for character in trimmed.chars() {
+        if character.is_whitespace() {
+            if !in_whitespace {
+                normalized.push(' ');
+                in_whitespace = true;
+            }
+        } else {
+            normalized.push(character);
+            in_whitespace = false;
+        }
+    }
+
+    normalized
+}

--- a/knowledge-base/003-rust-crate-dependency-hierarchy.md
+++ b/knowledge-base/003-rust-crate-dependency-hierarchy.md
@@ -2,13 +2,14 @@
 
 ## Workspace Members
 
-The Rust workspace (`Cargo.toml`) contains 7 members:
+The Rust workspace (`Cargo.toml`) contains 8 members:
 
 ```
 crates/
   icu_skeleton_parser/         # Number/date skeleton parser
   icu_messageformat_parser/    # ICU MessageFormat parser (+ WASM target)
   icu_messageformat/           # ICU MessageFormat runtime formatter
+  formatjs_intl_macros/        # Message descriptor procedural macros
   formatjs_intl/               # Descriptors, catalogs, locale negotiation, cache
   formatjs_cli/                # CLI binary (extract, compile, verify)
   formatjs_cli_napi/           # Node.js bindings for the Rust CLI
@@ -47,6 +48,7 @@ formatjs_icu_messageformat (v0.1.0)
 
 formatjs_intl (v0.1.0)
 ├── formatjs_icu_messageformat
+├── formatjs_intl_macros
 └── icu_locale 2.1 (locale parsing and fallback)
 ```
 
@@ -132,7 +134,8 @@ formatjs_intl (v0.1.0)
 
 **Purpose:** High-level Rust intl runtime.
 
-- Defines explicit-ID message descriptors through `message!`.
+- Defines `message_descriptor!` through a re-exported procedural macro.
+- Generates missing IDs with `[sha512:contenthash:base64:10]`; explicit IDs remain supported.
 - Selects translation catalogs with ICU4X locale fallback.
 - Falls back from selected catalog to default catalog, then descriptor message.
 - Shares parsed messages through `IntlCache` across request-scoped `Intl` values.
@@ -145,6 +148,7 @@ formatjs_intl (v0.1.0)
 | `icu_skeleton_parser`      | `@formatjs/icu-skeleton-parser`      | Rust mirror of TS implementation    |
 | `icu_messageformat_parser` | `@formatjs/icu-messageformat-parser` | Rust mirror, also compiled to WASM  |
 | `icu_messageformat`        | `intl-messageformat`                 | Low-level Rust runtime              |
+| `formatjs_intl_macros`     | Babel/TypeScript message transforms  | Rust descriptor macro backend      |
 | `formatjs_intl`            | `@formatjs/intl`                     | High-level Rust runtime             |
 | `formatjs_cli`             | `@formatjs/cli`                      | Drop-in replacement for Node.js CLI |
 

--- a/knowledge-base/003-rust-crate-dependency-hierarchy.md
+++ b/knowledge-base/003-rust-crate-dependency-hierarchy.md
@@ -2,14 +2,16 @@
 
 ## Workspace Members
 
-The Rust workspace (`Cargo.toml`) contains 4 members:
+The Rust workspace (`Cargo.toml`) contains 7 members:
 
 ```
 crates/
   icu_skeleton_parser/         # Number/date skeleton parser
   icu_messageformat_parser/    # ICU MessageFormat parser (+ WASM target)
   icu_messageformat/           # ICU MessageFormat runtime formatter
+  formatjs_intl/               # Descriptors, catalogs, locale negotiation, cache
   formatjs_cli/                # CLI binary (extract, compile, verify)
+  formatjs_cli_napi/           # Node.js bindings for the Rust CLI
 packages/
   icu-messageformat-parser/integration-tests/   # Cross-language integration tests
 ```
@@ -42,6 +44,10 @@ formatjs_icu_messageformat (v0.1.0)
 ├── formatjs_icu_messageformat_parser
 ├── formatjs_icu_skeleton_parser
 └── icu 2.1 (number, date/time, and plural formatting)
+
+formatjs_intl (v0.1.0)
+├── formatjs_icu_messageformat
+└── icu_locale 2.1 (locale parsing and fallback)
 ```
 
 ## Crate Details
@@ -122,6 +128,16 @@ formatjs_icu_messageformat (v0.1.0)
 - Uses ICU4X by default and accepts custom formatters through a trait.
 - Parses messages once; locale is supplied per formatting call.
 
+### `formatjs_intl` (v0.1.0)
+
+**Purpose:** High-level Rust intl runtime.
+
+- Defines explicit-ID message descriptors through `message!`.
+- Selects translation catalogs with ICU4X locale fallback.
+- Falls back from selected catalog to default catalog, then descriptor message.
+- Shares parsed messages through `IntlCache` across request-scoped `Intl` values.
+- Keeps requested-locale ordering and HTTP header parsing in application adapters.
+
 ## Connection to TypeScript Packages
 
 | Rust Crate                 | TypeScript Package                   | Relationship                        |
@@ -129,6 +145,7 @@ formatjs_icu_messageformat (v0.1.0)
 | `icu_skeleton_parser`      | `@formatjs/icu-skeleton-parser`      | Rust mirror of TS implementation    |
 | `icu_messageformat_parser` | `@formatjs/icu-messageformat-parser` | Rust mirror, also compiled to WASM  |
 | `icu_messageformat`        | `intl-messageformat`                 | Low-level Rust runtime              |
+| `formatjs_intl`            | `@formatjs/intl`                     | High-level Rust runtime             |
 | `formatjs_cli`             | `@formatjs/cli`                      | Drop-in replacement for Node.js CLI |
 
 **Data flow:** TypeScript scripts in `packages/icu-messageformat-parser/tools/` generate Rust source files (`time_data_generated.rs`, `regex_generated.rs`) from CLDR data. These are checked in and used by the Rust crate at compile time.

--- a/knowledge-base/003-rust-crate-dependency-hierarchy.md
+++ b/knowledge-base/003-rust-crate-dependency-hierarchy.md
@@ -148,7 +148,7 @@ formatjs_intl (v0.1.0)
 | `icu_skeleton_parser`      | `@formatjs/icu-skeleton-parser`      | Rust mirror of TS implementation    |
 | `icu_messageformat_parser` | `@formatjs/icu-messageformat-parser` | Rust mirror, also compiled to WASM  |
 | `icu_messageformat`        | `intl-messageformat`                 | Low-level Rust runtime              |
-| `formatjs_intl_macros`     | Babel/TypeScript message transforms  | Rust descriptor macro backend      |
+| `formatjs_intl_macros`     | Babel/TypeScript message transforms  | Rust descriptor macro backend       |
 | `formatjs_intl`            | `@formatjs/intl`                     | High-level Rust runtime             |
 | `formatjs_cli`             | `@formatjs/cli`                      | Drop-in replacement for Node.js CLI |
 

--- a/knowledge-base/008-package-intl-and-framework-integrations.md
+++ b/knowledge-base/008-package-intl-and-framework-integrations.md
@@ -30,8 +30,9 @@ The Rust mirror lives at `crates/formatjs_intl` as `formatjs_intl`. It keeps
 `Intl` request-scoped, while `MessageCatalog` and `IntlCache` can be shared by
 the backend. ICU4X negotiates each ordered locale list against available
 catalogs. Translation lookup falls back to the default catalog, then the
-descriptor default message. `message!` requires explicit IDs and is extracted
-from Rust source by `formatjs_cli`.
+descriptor default message. `message_descriptor!` generates missing IDs with
+`[sha512:contenthash:base64:10]` and is extracted from Rust source by
+`formatjs_cli`.
 
 ## react-intl
 

--- a/knowledge-base/008-package-intl-and-framework-integrations.md
+++ b/knowledge-base/008-package-intl-and-framework-integrations.md
@@ -26,6 +26,13 @@ are parsed without a locale, then formatted with a request locale.
 
 **Design:** Framework-agnostic core that `react-intl`, `vue-intl`, and `svelte-intl` all build upon. The framework packages add reactive bindings and components but delegate all formatting to `@formatjs/intl`.
 
+The Rust mirror lives at `crates/formatjs_intl` as `formatjs_intl`. It keeps
+`Intl` request-scoped, while `MessageCatalog` and `IntlCache` can be shared by
+the backend. ICU4X negotiates each ordered locale list against available
+catalogs. Translation lookup falls back to the default catalog, then the
+descriptor default message. `message!` requires explicit IDs and is extracted
+from Rust source by `formatjs_cli`.
+
 ## react-intl
 
 **Purpose:** React components and hooks for i18n. The most widely used FormatJS package.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -463,6 +463,13 @@
       "include-v-in-release-name": false,
       "tag-separator": "_v"
     },
+    "crates/formatjs_intl_macros": {
+      "release-type": "rust",
+      "include-component-in-tag": true,
+      "include-v-in-tag": false,
+      "include-v-in-release-name": false,
+      "tag-separator": "_v"
+    },
     "crates/formatjs_intl": {
       "release-type": "rust",
       "include-component-in-tag": true,

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -463,6 +463,13 @@
       "include-v-in-release-name": false,
       "tag-separator": "_v"
     },
+    "crates/formatjs_intl": {
+      "release-type": "rust",
+      "include-component-in-tag": true,
+      "include-v-in-tag": false,
+      "include-v-in-release-name": false,
+      "tag-separator": "_v"
+    },
     "crates/formatjs_cli": {
       "release-type": "rust",
       "include-component-in-tag": true,


### PR DESCRIPTION
## Summary

- add high-level `formatjs_intl` crate above `formatjs_icu_messageformat`
- add extractable `message_descriptor!` through a re-exported proc-macro crate
- generate missing IDs with `[sha512:contenthash:base64:10]`, while preserving explicit IDs
- negotiate ordered request locales against available catalogs with ICU4X fallback
- fall back through selected catalog, default catalog, then descriptor default
- share parsed messages across request-scoped `Intl` values with `IntlCache`
- teach `formatjs_cli extract` to parse Rust `message_descriptor!` calls with matching IDs
- wire Bazel, Cargo, crate releases, docs, and knowledge base

HTTP `Accept-Language` parsing stays in application adapters. Low-level message constructors are intentionally not extraction APIs.

## Validation

- `bazel test //crates/icu_messageformat:icu_messageformat_test //crates/formatjs_intl:formatjs_intl_test //crates/formatjs_cli:formatjs_cli_test --test_output=errors`
- `cargo metadata --locked --no-deps --format-version 1`
- repository Rust formatting and Buildifier
- JSON and YAML parsing
- `git diff --check`

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>
