### PR TITLE
fix: support Rust 1.92 in new intl crates

### DIFF
--- a/crates/formatjs_intl/Cargo.toml
+++ b/crates/formatjs_intl/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/formatjs_intl"
 keywords = ["icu", "i18n", "internationalization", "localization", "intl"]
 categories = ["internationalization", "localization"]
 readme = "README.md"
-rust-version = "1.95"
+rust-version = "1.92"
 
 [dependencies]
 formatjs_icu_messageformat = { path = "../icu_messageformat", version = "0.1.0" }

--- a/crates/formatjs_intl_macros/Cargo.toml
+++ b/crates/formatjs_intl_macros/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://formatjs.io/"
 documentation = "https://docs.rs/formatjs_intl_macros"
 keywords = ["icu", "i18n", "internationalization", "localization", "intl"]
 categories = ["internationalization", "localization"]
-rust-version = "1.95"
+rust-version = "1.92"
 
 [lib]
 path = "lib.rs"

--- a/crates/icu_messageformat/Cargo.toml
+++ b/crates/icu_messageformat/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/formatjs_icu_messageformat"
 keywords = ["icu", "i18n", "internationalization", "messageformat", "intl"]
 categories = ["internationalization", "localization"]
 readme = "README.md"
-rust-version = "1.95"
+rust-version = "1.92"
 
 [dependencies]
 fixed_decimal = "0.7"

--- a/knowledge-base/003-rust-crate-dependency-hierarchy.md
+++ b/knowledge-base/003-rust-crate-dependency-hierarchy.md
@@ -52,6 +52,9 @@ formatjs_intl (v0.1.0)
 └── icu_locale 2.1 (locale parsing and fallback)
 ```
 
+`formatjs_icu_messageformat`, `formatjs_intl_macros`, and `formatjs_intl`
+support Rust 1.92 and newer.
+
 ## Crate Details
 
 ### `formatjs_icu_skeleton_parser` (v0.1.1)


### PR DESCRIPTION
## Summary

- lower `rust-version` from 1.95 to 1.92 for the three new Rust crates
- document the shared MSRV in the Rust crate dependency guide

The initial `0.1.0` releases declared Rust 1.95 even though the code and dependencies compile on Rust 1.92. Crates.io metadata is immutable, so Release Please will publish patch releases with the corrected requirement after this merges.

## Validation

- `cargo +1.92.0 check --locked -p formatjs_icu_messageformat -p formatjs_intl_macros -p formatjs_intl`
- `bazel test //crates/icu_messageformat:icu_messageformat_test //crates/formatjs_intl:formatjs_intl_test //crates/formatjs_cli:formatjs_cli_test --test_output=errors`
- `git diff --check`
