### PR TITLE
fix: queue crate release workflows

### DIFF
--- a/.github/workflows/crates-release.yml
+++ b/.github/workflows/crates-release.yml
@@ -27,6 +27,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}
+  queue: max
   cancel-in-progress: false
 
 jobs:

--- a/knowledge-base/001-repo-layout.md
+++ b/knowledge-base/001-repo-layout.md
@@ -129,7 +129,9 @@ npm publish workflow builds the Bazel `:dist` output and uses npm Trusted
 Publishing, then publishes only the package paths Release Please released. Rust
 crate publishing happens in
 `crates-release.yml` from crate GitHub releases using crates.io trusted
-publishing. The Rust CLI binary artifacts remain Bazel-owned in
+publishing. Crate release runs share a FIFO `queue: max` concurrency group so
+dependency-ordered releases wait instead of replacing pending runs. The Rust
+CLI binary artifacts remain Bazel-owned in
 `rust-cli-release.yml`. Its release build job runs on Linux, uses BuildBuddy RBE
 when credentials are available, and cross-compiles the macOS, Linux, and Windows
 standalone CLI artifacts before uploading assets and checksums to the


### PR DESCRIPTION
## Summary

- queue every crate release run instead of replacing pending runs
- document serialized crate publishing

## Why

Release Please can publish dependent crate releases seconds apart. GitHub's default single pending slot canceled `formatjs_intl_macros`, then `formatjs_intl` failed because its dependency was missing.

## Validation

- `git diff --check`
- verified `queue: max` against GitHub Actions concurrency docs

Canonical Bazel formatting was attempted but dependency download failed with `Unknown host: registry.npmjs.org`; CI will run it.
