### PR TITLE
feat(formatjs_intl): support precompiled catalogs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -546,6 +546,7 @@ dependencies = [
  "formatjs_icu_messageformat",
  "formatjs_intl_macros",
  "icu_locale",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/formatjs_intl/BUILD.bazel
+++ b/crates/formatjs_intl/BUILD.bazel
@@ -26,4 +26,5 @@ rust_test(
     name = "formatjs_intl_test",
     size = "small",
     crate = ":formatjs_intl",
+    deps = ["@crates//:serde_json"],
 )

--- a/crates/formatjs_intl/Cargo.toml
+++ b/crates/formatjs_intl/Cargo.toml
@@ -21,3 +21,6 @@ icu_locale = "2.1"
 [lib]
 path = "lib.rs"
 crate-type = ["rlib"]
+
+[dev-dependencies]
+serde_json = "1.0"

--- a/crates/formatjs_intl/README.md
+++ b/crates/formatjs_intl/README.md
@@ -60,6 +60,13 @@ Precompile catalogs with the FormatJS CLI to skip runtime message parsing:
 formatjs compile translations/fr.json --out-file translations/fr.compiled.json --ast
 ```
 
+Add `serde_json` to load the compiled catalog:
+
+```toml
+[dependencies]
+serde_json = "1"
+```
+
 ```rust
 # use formatjs_intl::{MessageCatalog, PrecompiledMessages};
 let messages: PrecompiledMessages =

--- a/crates/formatjs_intl/README.md
+++ b/crates/formatjs_intl/README.md
@@ -54,5 +54,23 @@ let intl = intl.with_on_error(|error: &FormatMessageError| {
 # }
 ```
 
+Precompile catalogs with the FormatJS CLI to skip runtime message parsing:
+
+```sh
+formatjs compile translations/fr.json --out-file translations/fr.compiled.json --ast
+```
+
+```rust
+# use formatjs_intl::{MessageCatalog, PrecompiledMessages};
+let messages: PrecompiledMessages =
+    serde_json::from_str(include_str!("../translations/fr.compiled.json"))?;
+let mut catalog = MessageCatalog::new();
+catalog.insert_precompiled("fr", messages)?;
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+Precompiled messages are ready to format when inserted and do not use
+`IntlCache`.
+
 Requested locales must already be ordered by preference. HTTP
 `Accept-Language` parsing stays in the application or web-framework adapter.

--- a/crates/formatjs_intl/lib.rs
+++ b/crates/formatjs_intl/lib.rs
@@ -1,4 +1,6 @@
-use formatjs_icu_messageformat::{FormattedMessage, IcuMessageFormat, Part, Values};
+use formatjs_icu_messageformat::{
+    FormattedMessage, IcuMessageFormat, MessageFormatElement, Part, Values,
+};
 use icu_locale::{Locale, fallback::LocaleFallbacker};
 use std::collections::HashMap;
 use std::error::Error as StdError;
@@ -9,6 +11,26 @@ use std::sync::{Arc, RwLock};
 pub use formatjs_intl_macros::__message_descriptor;
 
 pub type Messages = HashMap<String, String>;
+pub type PrecompiledMessages = HashMap<String, Vec<MessageFormatElement>>;
+
+type CompiledMessages = HashMap<String, Arc<IcuMessageFormat>>;
+
+#[derive(Clone)]
+enum CatalogBundle {
+    Source(Arc<Messages>),
+    Precompiled(Arc<CompiledMessages>),
+}
+
+impl CatalogBundle {
+    fn get(&self, id: &str) -> Option<CatalogMessage<'_>> {
+        match self {
+            Self::Source(messages) => messages.get(id).map(|message| CatalogMessage::Source(message)),
+            Self::Precompiled(messages) => messages
+                .get(id)
+                .map(|message| CatalogMessage::Precompiled(message)),
+        }
+    }
+}
 
 #[derive(Debug)]
 pub enum Error {
@@ -126,9 +148,18 @@ macro_rules! message_descriptor {
     }};
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
 pub struct MessageCatalog {
-    bundles: HashMap<String, Arc<Messages>>,
+    bundles: HashMap<String, CatalogBundle>,
+}
+
+impl fmt::Debug for MessageCatalog {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("MessageCatalog")
+            .field("available_locales", &self.bundles.keys())
+            .finish()
+    }
 }
 
 impl MessageCatalog {
@@ -138,7 +169,26 @@ impl MessageCatalog {
 
     pub fn insert(&mut self, locale: impl AsRef<str>, messages: Messages) -> Result<()> {
         let locale = parse_locale(locale.as_ref())?;
-        self.bundles.insert(locale.to_string(), Arc::new(messages));
+        self.bundles
+            .insert(locale.to_string(), CatalogBundle::Source(Arc::new(messages)));
+        Ok(())
+    }
+
+    /// Inserts AST messages emitted by `formatjs compile --ast`.
+    pub fn insert_precompiled(
+        &mut self,
+        locale: impl AsRef<str>,
+        messages: PrecompiledMessages,
+    ) -> Result<()> {
+        let locale = parse_locale(locale.as_ref())?;
+        let messages = messages
+            .into_iter()
+            .map(|(id, ast)| (id, Arc::new(IcuMessageFormat::from_ast(ast))))
+            .collect();
+        self.bundles.insert(
+            locale.to_string(),
+            CatalogBundle::Precompiled(Arc::new(messages)),
+        );
         Ok(())
     }
 
@@ -146,12 +196,20 @@ impl MessageCatalog {
         self.bundles.contains_key(&locale.to_string())
     }
 
+    /// Returns source messages for a locale. Precompiled catalogs have no source map.
     pub fn messages(&self, locale: impl fmt::Display) -> Option<Arc<Messages>> {
-        self.bundles.get(&locale.to_string()).cloned()
+        match self.bundles.get(&locale.to_string()) {
+            Some(CatalogBundle::Source(messages)) => Some(messages.clone()),
+            _ => None,
+        }
     }
 
     pub fn available_locales(&self) -> impl Iterator<Item = &str> {
         self.bundles.keys().map(String::as_str)
+    }
+
+    fn bundle(&self, locale: impl fmt::Display) -> Option<CatalogBundle> {
+        self.bundles.get(&locale.to_string()).cloned()
     }
 }
 
@@ -197,8 +255,8 @@ pub struct Intl {
     locale: Locale,
     locale_string: String,
     default_locale_string: String,
-    messages: Arc<Messages>,
-    default_messages: Arc<Messages>,
+    messages: CatalogBundle,
+    default_messages: CatalogBundle,
     cache: Arc<IntlCache>,
     on_error: Option<Arc<dyn Fn(&FormatMessageError) + Send + Sync>>,
 }
@@ -216,11 +274,11 @@ impl Intl {
     {
         let default_locale = parse_locale(default_locale.as_ref())?;
         let default_messages = catalog
-            .messages(&default_locale)
+            .bundle(&default_locale)
             .ok_or_else(|| Error::MissingDefaultLocale(default_locale.to_string()))?;
         let locale = negotiate_locale(requested_locales, &default_locale, &catalog)?;
         let messages = catalog
-            .messages(&locale)
+            .bundle(&locale)
             .unwrap_or_else(|| default_messages.clone());
         let locale_string = locale.to_string();
         let default_locale_string = default_locale.to_string();
@@ -293,17 +351,24 @@ impl Intl {
     ) -> Result<T> {
         let candidates = self.message_candidates(descriptor);
         let verbatim_source = candidates
-            .first()
-            .map(|candidate| candidate.message)
-            .filter(|message| !message.is_empty())
+            .iter()
+            .find_map(|candidate| match candidate.message {
+                CatalogMessage::Source(message) if !message.is_empty() => Some(message),
+                _ => None,
+            })
             .unwrap_or(descriptor.id)
             .to_owned();
 
         for candidate in candidates {
-            let result = self
-                .cache
-                .get_or_compile(candidate.message)
-                .and_then(|message| format(&message, candidate.locale).map_err(Error::from));
+            let result = match candidate.message {
+                CatalogMessage::Source(source) => self
+                    .cache
+                    .get_or_compile(source)
+                    .and_then(|message| format(&message, candidate.locale).map_err(Error::from)),
+                CatalogMessage::Precompiled(message) => {
+                    format(message, candidate.locale).map_err(Error::from)
+                }
+            };
             match result {
                 Ok(message) => return Ok(message),
                 Err(Error::Message(error)) => self.report_error(FormatMessageError {
@@ -342,7 +407,7 @@ impl Intl {
         }
         push_candidate(
             &mut candidates,
-            descriptor.default_message,
+            CatalogMessage::Source(descriptor.default_message),
             &self.default_locale_string,
             MessageSource::DefaultMessage,
         );
@@ -358,22 +423,39 @@ impl Intl {
 }
 
 struct MessageCandidate<'a> {
-    message: &'a str,
+    message: CatalogMessage<'a>,
     locale: &'a str,
     source: MessageSource,
 }
 
+#[derive(Clone, Copy)]
+enum CatalogMessage<'a> {
+    Source(&'a str),
+    Precompiled(&'a IcuMessageFormat),
+}
+
 fn push_candidate<'a>(
     candidates: &mut Vec<MessageCandidate<'a>>,
-    message: &'a str,
+    message: CatalogMessage<'a>,
     locale: &'a str,
     source: MessageSource,
 ) {
-    if message.is_empty()
-        || candidates
-            .iter()
-            .any(|candidate| candidate.message == message && candidate.locale == locale)
-    {
+    if matches!(message, CatalogMessage::Source("")) {
+        return;
+    }
+    let duplicate = candidates.iter().any(|candidate| {
+        if candidate.locale != locale {
+            return false;
+        }
+        match (candidate.message, message) {
+            (CatalogMessage::Source(left), CatalogMessage::Source(right)) => left == right,
+            (CatalogMessage::Precompiled(left), CatalogMessage::Precompiled(right)) => {
+                std::ptr::eq(left, right)
+            }
+            _ => false,
+        }
+    });
+    if duplicate {
         return;
     }
     candidates.push(MessageCandidate {
@@ -515,6 +597,40 @@ mod tests {
         );
         assert_eq!(intl.locale().to_string(), "fr");
         assert_eq!(cache.len().unwrap(), 1);
+    }
+
+    #[test]
+    fn loads_formatjs_cli_precompiled_ast_without_using_cache() {
+        let messages: PrecompiledMessages = serde_json::from_str(
+            r##"{
+                "tasks.precompiled": [{
+                    "type": 6,
+                    "value": "count",
+                    "options": {
+                        "one": {"value": [{"type": 0, "value": "# tâche"}]},
+                        "other": {"value": [{"type": 7}, {"type": 0, "value": " tâches"}]}
+                    },
+                    "offset": 0,
+                    "pluralType": "cardinal"
+                }]
+            }"##,
+        )
+        .unwrap();
+        let mut catalog = MessageCatalog::new();
+        catalog.insert_precompiled("fr", messages).unwrap();
+        let cache = Arc::new(IntlCache::new());
+        let intl = Intl::try_new(["fr"], "fr", Arc::new(catalog), cache.clone()).unwrap();
+        let values: Values = HashMap::from([("count".to_owned(), Value::from(2_i64))]);
+        let descriptor = MessageDescriptor::new(
+            "tasks.precompiled",
+            "{count, plural, one {# task} other {# tasks}}",
+        );
+
+        assert_eq!(
+            intl.format_message_to_string(descriptor, &values).unwrap(),
+            "2 tâches"
+        );
+        assert!(cache.is_empty().unwrap());
     }
 
     #[test]

--- a/crates/icu_messageformat_parser/BUILD.bazel
+++ b/crates/icu_messageformat_parser/BUILD.bazel
@@ -53,6 +53,7 @@ rust_library(
         "@crates//:once_cell",
         "@crates//:regex",
         "@crates//:serde",
+        "@crates//:serde_json",
     ],
 )
 

--- a/crates/icu_messageformat_parser/error.rs
+++ b/crates/icu_messageformat_parser/error.rs
@@ -1,7 +1,7 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /// Location details for error reporting
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LocationDetails {
     pub offset: usize,
     pub line: usize,
@@ -9,7 +9,7 @@ pub struct LocationDetails {
 }
 
 /// Location range in the source string
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Location {
     pub start: LocationDetails,
     pub end: LocationDetails,

--- a/crates/icu_messageformat_parser/types.rs
+++ b/crates/icu_messageformat_parser/types.rs
@@ -1,6 +1,6 @@
 use crate::error::Location;
 use indexmap::IndexMap;
-use serde::Serialize;
+use serde::{Deserialize, Serialize, de};
 
 // Re-export types from icu-skeleton-parser
 pub use formatjs_icu_skeleton_parser::{
@@ -98,7 +98,7 @@ impl ValidPluralRule {
 }
 
 /// Plural type corresponding to Intl.PluralRulesOptions['type']
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum PluralType {
     Cardinal,
@@ -196,7 +196,7 @@ impl Serialize for DateTimeSkeletonOrStyle {
 }
 
 /// Plural or select option with message elements
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PluralOrSelectOption {
     pub value: Vec<MessageFormatElement>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -242,6 +242,125 @@ pub enum MessageFormatElement {
     Plural(PluralElement),
     Pound(PoundElement),
     Tag(TagElement),
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum DeserializedStyle {
+    String(String),
+    Number(NumberSkeleton),
+    DateTime(DateTimeSkeleton),
+}
+
+#[derive(Deserialize)]
+struct DeserializedElement {
+    #[serde(rename = "type")]
+    element_type: u8,
+    value: Option<String>,
+    style: Option<DeserializedStyle>,
+    options: Option<IndexMap<String, PluralOrSelectOption>>,
+    offset: Option<i32>,
+    #[serde(rename = "pluralType")]
+    plural_type: Option<PluralType>,
+    children: Option<Vec<MessageFormatElement>>,
+    location: Option<Location>,
+}
+
+impl<'de> Deserialize<'de> for MessageFormatElement {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let element = DeserializedElement::deserialize(deserializer)?;
+        let value = || {
+            element
+                .value
+                .clone()
+                .ok_or_else(|| de::Error::missing_field("value"))
+        };
+        let number_style = || match &element.style {
+            None => Ok(None),
+            Some(DeserializedStyle::String(style)) => {
+                Ok(Some(NumberSkeletonOrStyle::String(style.clone())))
+            }
+            Some(DeserializedStyle::Number(skeleton)) => {
+                Ok(Some(NumberSkeletonOrStyle::Skeleton(skeleton.clone())))
+            }
+            _ => Err(de::Error::custom("expected number style")),
+        };
+        let date_time_style = || match &element.style {
+            None => Ok(None),
+            Some(DeserializedStyle::String(style)) => {
+                Ok(Some(DateTimeSkeletonOrStyle::String(style.clone())))
+            }
+            Some(DeserializedStyle::DateTime(skeleton)) => Ok(Some(
+                DateTimeSkeletonOrStyle::Skeleton(skeleton.clone()),
+            )),
+            _ => Err(de::Error::custom("expected date/time style")),
+        };
+
+        match element.element_type {
+            0 => Ok(Self::Literal(LiteralElement {
+                value: value()?,
+                location: element.location,
+            })),
+            1 => Ok(Self::Argument(ArgumentElement {
+                value: value()?,
+                location: element.location,
+            })),
+            2 => Ok(Self::Number(SimpleFormatElement {
+                value: value()?,
+                style: number_style()?,
+                location: element.location,
+            })),
+            3 => Ok(Self::Date(SimpleFormatElement {
+                value: value()?,
+                style: date_time_style()?,
+                location: element.location,
+            })),
+            4 => Ok(Self::Time(SimpleFormatElement {
+                value: value()?,
+                style: date_time_style()?,
+                location: element.location,
+            })),
+            5 => Ok(Self::Select(SelectElement {
+                value: value()?,
+                options: element
+                    .options
+                    .ok_or_else(|| de::Error::missing_field("options"))?,
+                location: element.location,
+            })),
+            6 => Ok(Self::Plural(PluralElement {
+                value: value()?,
+                options: element
+                    .options
+                    .ok_or_else(|| de::Error::missing_field("options"))?
+                    .into_iter()
+                    .map(|(rule, option)| (ValidPluralRule::from_str(&rule), option))
+                    .collect(),
+                offset: element
+                    .offset
+                    .ok_or_else(|| de::Error::missing_field("offset"))?,
+                plural_type: element
+                    .plural_type
+                    .ok_or_else(|| de::Error::missing_field("pluralType"))?,
+                location: element.location,
+            })),
+            7 => Ok(Self::Pound(PoundElement {
+                location: element.location,
+            })),
+            8 => Ok(Self::Tag(TagElement {
+                value: value()?,
+                children: element
+                    .children
+                    .ok_or_else(|| de::Error::missing_field("children"))?,
+                location: element.location,
+            })),
+            element_type => Err(de::Error::custom(format!(
+                "unknown message element type {element_type}"
+            ))),
+        }
+    }
 }
 
 impl MessageFormatElement {
@@ -415,7 +534,8 @@ impl Serialize for MessageFormatElement {
 }
 
 /// Number skeleton with tokens and parsed options
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct NumberSkeleton {
     pub tokens: Vec<NumberSkeletonToken>,
     pub location: Option<Location>,
@@ -445,7 +565,8 @@ impl Serialize for NumberSkeleton {
 // NumberFormatOptions and NumberSkeletonToken are now imported from icu-skeleton-parser above
 
 /// Date/Time skeleton with pattern and parsed options
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct DateTimeSkeleton {
     pub pattern: String,
     pub location: Option<Location>,
@@ -593,5 +714,22 @@ mod tests {
         assert!(dt_skeleton.is_date_time_skeleton());
         assert!(!dt_skeleton.is_number_skeleton());
         assert_eq!(dt_skeleton.skeleton_type(), SkeletonType::DateTime);
+    }
+
+    #[test]
+    fn deserializes_compiled_ast() {
+        let ast = crate::Parser::new(
+            "<b>{name}</b> {gender, select, other {has}} {count, plural, one {# task} other {# tasks}} worth {total, number, ::currency/USD} on {date, date, ::yMMMd} at {date, time, short}",
+            crate::ParserOptions {
+                should_parse_skeletons: true,
+                ..Default::default()
+            },
+        )
+        .parse()
+        .unwrap();
+        let json = serde_json::to_string(&ast).unwrap();
+        let deserialized: Vec<MessageFormatElement> = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized, ast);
     }
 }

--- a/docs/src/docs/rust/intl.mdx
+++ b/docs/src/docs/rust/intl.mdx
@@ -12,9 +12,11 @@ compiled-message cache.
 [dependencies]
 formatjs_intl = "0.1"
 formatjs_icu_messageformat = "0.1"
+serde_json = "1"
 ```
 
 The second dependency provides `Value` and `Values` for runtime arguments.
+`serde_json` loads optional precompiled catalogs.
 
 ## Create a catalog and format a message
 
@@ -104,5 +106,27 @@ Use `id: "greeting"` when a stable semantic ID is preferred.
 `IntlCache` stores parsed messages by source string. Share one `Arc<IntlCache>`
 across request-scoped `Intl` values to avoid reparsing translations and default
 messages.
+
+## Precompiled catalogs
+
+Compile translations to FormatJS AST JSON to remove runtime message parsing:
+
+```sh
+formatjs compile translations/fr.json --out-file translations/fr.compiled.json --ast
+```
+
+Deserialize that output and insert it directly:
+
+```rust
+use formatjs_intl::{MessageCatalog, PrecompiledMessages};
+
+let messages: PrecompiledMessages =
+    serde_json::from_str(include_str!("../translations/fr.compiled.json"))?;
+let mut catalog = MessageCatalog::new();
+catalog.insert_precompiled("fr", messages)?;
+```
+
+These messages are ready to format when inserted and bypass both runtime
+parsing and `IntlCache`.
 
 See the complete [`formatjs_intl` API](https://docs.rs/formatjs_intl).

--- a/knowledge-base/003-rust-crate-dependency-hierarchy.md
+++ b/knowledge-base/003-rust-crate-dependency-hierarchy.md
@@ -146,6 +146,8 @@ support Rust 1.92 and newer.
 - Returns the first source verbatim, then the message ID, when every formatting
   candidate fails.
 - Shares parsed messages through `IntlCache` across request-scoped `Intl` values.
+- Accepts `formatjs compile --ast` output through `insert_precompiled`, making
+  messages ready to format without runtime parsing or cache entries.
 - Keeps requested-locale ordering and HTTP header parsing in application adapters.
 
 ## Connection to TypeScript Packages


### PR DESCRIPTION
## Summary

- deserialize `formatjs compile --ast` output into the Rust message AST
- add `MessageCatalog::insert_precompiled`
- bypass runtime parsing and `IntlCache` for precompiled messages
- document the precompiled catalog flow

## Validation

- `bazel test //crates/formatjs_intl:formatjs_intl_test //crates/icu_messageformat_parser:icu_messageformat_parser_test --test_output=errors`
- `bazel build //crates/formatjs_intl //crates/icu_messageformat_parser //crates/formatjs_cli`
- `bazel build //docs:dist`
- pre-commit and commit-msg hooks
