### PR TITLE
build: remove root npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-registry=https://registry.npmjs.org/

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -45,7 +45,6 @@ npm.npm_translate_lock(
         "//:patches/unicode-match-property-ecmascript@2.0.0.patch",
         "//:patches/unicode-match-property-value-ecmascript@2.2.1.patch",
     ],
-    npmrc = "//:.npmrc",
     patch_args = {"*": ["-p1"]},
     pnpm_lock = "//:pnpm-lock.yaml",
 )
@@ -55,7 +54,6 @@ npm.npm_translate_lock(
         "//packages/react-intl/tests/react18-typecheck:package.json",
         "//packages/react-intl/tests/react18-typecheck:pnpm-workspace.yaml",
     ],
-    npmrc = "//:.npmrc",
     pnpm_lock = "//packages/react-intl/tests/react18-typecheck:pnpm-lock.yaml",
 )
 use_repo(npm, "npm", "react18_npm")


### PR DESCRIPTION
## Summary

- remove the root `.npmrc`
- stop passing it to both `npm_translate_lock` repositories

## Why

The checked-in config forces direct access to `registry.npmjs.org`. Corporate machines block npmjs and use a configured proxy, so this override always fails instead of honoring the user's npm registry configuration.

## Validation

- `bazel build //:lefthook`
- `bazel mod deps --lockfile_mode=error`
- pre-commit hooks
