### PR TITLE
fix: skip unpublished Rust crates

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -41,6 +41,5 @@
   "crates/formatjs_intl_macros": "0.1.1",
   "crates/formatjs_intl": "0.2.0",
   "crates/formatjs_cli": "1.2.1",
-  "crates/formatjs_cli_napi": "0.0.15",
-  "packages/icu-messageformat-parser/integration-tests": "0.1.4"
+  "crates/formatjs_cli_napi": "0.0.15"
 }

--- a/knowledge-base/001-repo-layout.md
+++ b/knowledge-base/001-repo-layout.md
@@ -129,7 +129,9 @@ npm publish workflow builds the Bazel `:dist` output and uses npm Trusted
 Publishing, then publishes only the package paths Release Please released. Rust
 crate publishing happens in
 `crates-release.yml` from crate GitHub releases using crates.io trusted
-publishing. Crate release runs share a FIFO `queue: max` concurrency group so
+publishing. The custom Cargo workspace plugin excludes crates with
+`package.publish = false` before dependency release propagation. Crate release
+runs share a FIFO `queue: max` concurrency group so
 dependency-ordered releases wait instead of replacing pending runs. The Rust
 CLI binary artifacts remain Bazel-owned in
 `rust-cli-release.yml`. Its release build job runs on Linux, uses BuildBuddy RBE

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -493,7 +493,7 @@
   },
   "plugins": [
     {
-      "type": "cargo-workspace",
+      "type": "formatjs-cargo-workspace",
       "merge": false
     },
     {

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -56,6 +56,14 @@ ts_binary(
 )
 
 js_test(
+    name = "release_please_cargo_workspace_test",
+    size = "small",
+    data = ["release-please/cargo-workspace-plugin.ts"],
+    entry_point = "release-please/cargo-workspace-plugin.test.ts",
+    node_options = ["--disable-warning=MODULE_TYPELESS_PACKAGE_JSON"],
+)
+
+js_test(
     name = "release_please_npm_workspace_test",
     size = "small",
     args = ["$(rootpath //:release_please_config)"],

--- a/tools/release-please/cargo-workspace-plugin.test.ts
+++ b/tools/release-please/cargo-workspace-plugin.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict'
+
+import {createCargoWorkspacePlugin} from './cargo-workspace-plugin.ts'
+
+const packages = {
+  allPackages: [
+    {
+      name: 'published',
+      manifest: {package: {name: 'published'}},
+    },
+    {
+      name: 'private',
+      manifest: {package: {name: 'private', publish: false}},
+    },
+    {
+      name: 'private-registry',
+      manifest: {package: {name: 'private-registry', publish: ['internal']}},
+    },
+  ],
+  candidatesByPackage: {
+    published: {path: 'crates/published'},
+    private: {path: 'crates/private'},
+    'private-registry': {path: 'crates/private-registry'},
+  },
+}
+
+class FixtureCargoWorkspace {
+  async buildAllPackages() {
+    return packages
+  }
+}
+
+const FormatjsCargoWorkspace = createCargoWorkspacePlugin(FixtureCargoWorkspace)
+const result = await new FormatjsCargoWorkspace().buildAllPackages([])
+
+assert.deepEqual(
+  result.allPackages.map(pkg => pkg.name),
+  ['published', 'private-registry']
+)
+assert.deepEqual(Object.keys(result.candidatesByPackage), [
+  'published',
+  'private-registry',
+])

--- a/tools/release-please/cargo-workspace-plugin.ts
+++ b/tools/release-please/cargo-workspace-plugin.ts
@@ -1,0 +1,40 @@
+interface CargoPackage {
+  name: string
+  manifest: {
+    package?: {
+      publish?: unknown
+    }
+  }
+}
+
+interface CargoWorkspacePackages {
+  allPackages: CargoPackage[]
+  candidatesByPackage: Record<string, unknown>
+}
+
+export function filterPublishableCrates({
+  allPackages,
+  candidatesByPackage,
+}: CargoWorkspacePackages): CargoWorkspacePackages {
+  const publishablePackages = allPackages.filter(
+    pkg => pkg.manifest.package?.publish !== false
+  )
+  const publishableNames = new Set(publishablePackages.map(pkg => pkg.name))
+
+  return {
+    allPackages: publishablePackages,
+    candidatesByPackage: Object.fromEntries(
+      Object.entries(candidatesByPackage).filter(([name]) =>
+        publishableNames.has(name)
+      )
+    ),
+  }
+}
+
+export function createCargoWorkspacePlugin(CargoWorkspace: any) {
+  return class FormatjsCargoWorkspace extends CargoWorkspace {
+    async buildAllPackages(candidates: unknown[]) {
+      return filterPublishableCrates(await super.buildAllPackages(candidates))
+    }
+  }
+}

--- a/tools/release-please/run.ts
+++ b/tools/release-please/run.ts
@@ -2,10 +2,15 @@ import {appendFileSync} from 'node:fs'
 import {createRequire} from 'node:module'
 
 import {githubOutputRecord} from './github-output.ts'
+import {createCargoWorkspacePlugin} from './cargo-workspace-plugin.ts'
 import {BazelNpmWorkspace} from './npm-workspace-plugin.ts'
 
 const require = createRequire(import.meta.url)
 const {GitHub, Manifest, VERSION, registerPlugin} = require('release-please')
+const {
+  CargoWorkspace,
+} = require('release-please/build/src/plugins/cargo-workspace')
+const FormatjsCargoWorkspace = createCargoWorkspacePlugin(CargoWorkspace)
 
 const DEFAULT_CONFIG_FILE = 'release-please-config.json'
 const DEFAULT_MANIFEST_FILE = '.release-please-manifest.json'
@@ -78,6 +83,21 @@ function outputPullRequests(pullRequests) {
 }
 
 function registerFormatjsPlugin() {
+  registerPlugin('formatjs-cargo-workspace', options => {
+    const typeOptions =
+      options.type && typeof options.type === 'object' ? options.type : {}
+    return new FormatjsCargoWorkspace(
+      options.github,
+      options.targetBranch,
+      options.repositoryConfig,
+      {
+        ...options,
+        ...typeOptions,
+        merge: typeOptions.merge ?? !options.separatePullRequests,
+      }
+    )
+  })
+
   registerPlugin('formatjs-bazel-workspace', options => {
     const typeOptions =
       options.type && typeof options.type === 'object' ? options.type : {}


### PR DESCRIPTION
## Summary

- wrap Release Please's Cargo workspace plugin
- exclude workspace crates with `package.publish = false` from release propagation
- remove the stale integration-test manifest entry

## Why

The upstream Cargo workspace plugin treats every workspace member as releasable. When `formatjs_icu_messageformat_parser` changes, it creates a dependency-only release candidate for `formatjs_icu_messageformat_parser_integration_tests` even though that crate has `publish = false`.

## Validation

- `bazel test //tools:release_please_cargo_workspace_test //tools:release_please_npm_workspace_test --test_output=errors`
- `bazel run //:gazelle`
- pre-commit hooks
- commitlint
