### PR TITLE
fix: handle Cargo publish and merge options

### DIFF
--- a/tools/release-please/cargo-workspace-plugin.test.ts
+++ b/tools/release-please/cargo-workspace-plugin.test.ts
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict'
 
-import {createCargoWorkspacePlugin} from './cargo-workspace-plugin.ts'
+import {
+  createCargoWorkspacePlugin,
+  resolveWorkspacePluginOptions,
+} from './cargo-workspace-plugin.ts'
 
 const packages = {
   allPackages: [
@@ -13,6 +16,10 @@ const packages = {
       manifest: {package: {name: 'private', publish: false}},
     },
     {
+      name: 'private-empty-registries',
+      manifest: {package: {name: 'private-empty-registries', publish: []}},
+    },
+    {
       name: 'private-registry',
       manifest: {package: {name: 'private-registry', publish: ['internal']}},
     },
@@ -20,6 +27,9 @@ const packages = {
   candidatesByPackage: {
     published: {path: 'crates/published'},
     private: {path: 'crates/private'},
+    'private-empty-registries': {
+      path: 'crates/private-empty-registries',
+    },
     'private-registry': {path: 'crates/private-registry'},
   },
 }
@@ -41,3 +51,21 @@ assert.deepEqual(Object.keys(result.candidatesByPackage), [
   'published',
   'private-registry',
 ])
+
+assert.equal(
+  resolveWorkspacePluginOptions({merge: false, separatePullRequests: false})
+    .merge,
+  false
+)
+assert.equal(
+  resolveWorkspacePluginOptions({
+    merge: false,
+    separatePullRequests: false,
+    type: {merge: true},
+  }).merge,
+  true
+)
+assert.equal(
+  resolveWorkspacePluginOptions({separatePullRequests: true}).merge,
+  false
+)

--- a/tools/release-please/cargo-workspace-plugin.ts
+++ b/tools/release-please/cargo-workspace-plugin.ts
@@ -12,13 +12,22 @@ interface CargoWorkspacePackages {
   candidatesByPackage: Record<string, unknown>
 }
 
+interface WorkspacePluginOptions extends Record<string, unknown> {
+  merge?: boolean
+  separatePullRequests?: boolean
+  type?: unknown
+}
+
 export function filterPublishableCrates({
   allPackages,
   candidatesByPackage,
 }: CargoWorkspacePackages): CargoWorkspacePackages {
-  const publishablePackages = allPackages.filter(
-    pkg => pkg.manifest.package?.publish !== false
-  )
+  const publishablePackages = allPackages.filter(pkg => {
+    const publish = pkg.manifest.package?.publish
+    return (
+      publish !== false && !(Array.isArray(publish) && publish.length === 0)
+    )
+  })
   const publishableNames = new Set(publishablePackages.map(pkg => pkg.name))
 
   return {
@@ -28,6 +37,24 @@ export function filterPublishableCrates({
         publishableNames.has(name)
       )
     ),
+  }
+}
+
+export function resolveWorkspacePluginOptions(
+  options: WorkspacePluginOptions
+): WorkspacePluginOptions {
+  const typeOptions =
+    options.type && typeof options.type === 'object'
+      ? (options.type as Record<string, unknown>)
+      : {}
+
+  return {
+    ...options,
+    ...typeOptions,
+    merge:
+      (typeOptions.merge as boolean | undefined) ??
+      options.merge ??
+      !options.separatePullRequests,
   }
 }
 

--- a/tools/release-please/run.ts
+++ b/tools/release-please/run.ts
@@ -2,7 +2,10 @@ import {appendFileSync} from 'node:fs'
 import {createRequire} from 'node:module'
 
 import {githubOutputRecord} from './github-output.ts'
-import {createCargoWorkspacePlugin} from './cargo-workspace-plugin.ts'
+import {
+  createCargoWorkspacePlugin,
+  resolveWorkspacePluginOptions,
+} from './cargo-workspace-plugin.ts'
 import {BazelNpmWorkspace} from './npm-workspace-plugin.ts'
 
 const require = createRequire(import.meta.url)
@@ -84,32 +87,20 @@ function outputPullRequests(pullRequests) {
 
 function registerFormatjsPlugin() {
   registerPlugin('formatjs-cargo-workspace', options => {
-    const typeOptions =
-      options.type && typeof options.type === 'object' ? options.type : {}
     return new FormatjsCargoWorkspace(
       options.github,
       options.targetBranch,
       options.repositoryConfig,
-      {
-        ...options,
-        ...typeOptions,
-        merge: typeOptions.merge ?? !options.separatePullRequests,
-      }
+      resolveWorkspacePluginOptions(options)
     )
   })
 
   registerPlugin('formatjs-bazel-workspace', options => {
-    const typeOptions =
-      options.type && typeof options.type === 'object' ? options.type : {}
     return new BazelNpmWorkspace(
       options.github,
       options.targetBranch,
       options.repositoryConfig,
-      {
-        ...options,
-        ...typeOptions,
-        merge: typeOptions.merge ?? !options.separatePullRequests,
-      }
+      resolveWorkspacePluginOptions(options)
     )
   })
 }


### PR DESCRIPTION
## Summary

- treat `publish = []` as unpublished
- preserve explicit workspace plugin `merge` options
- share option handling across Cargo and Bazel workspace plugins

## Why

Follow-up to #6992 review feedback. Cargo uses both `publish = false` and `publish = []` to disable publishing. Release Please also passes configured `merge` at top level, which our wrapper was overwriting.

## Validation

- `bazel test //tools:release_please_cargo_workspace_test //tools:release_please_npm_workspace_test --test_output=errors`
- pre-commit hooks
- commitlint
