### PR TITLE
fix(formatjs_cli): fail on input resolution errors

### DIFF
--- a/crates/formatjs_cli/README.md
+++ b/crates/formatjs_cli/README.md
@@ -244,7 +244,7 @@ formatjs extract "src/**/*.{js,ts,tsx}" \
 - `--additional-component-names <NAMES>` - Additional component names to extract from (comma-separated)
 - `--additional-function-names <NAMES>` - Additional function names to extract from (comma-separated)
 - `--ignore <PATTERNS>` - Glob patterns to exclude
-- `--throws` - Throw exception when failing to process any file
+- `--throws` - Exit with an error when input resolution, traversal, or extraction fails
 - `--pragma <PRAGMA>` - Parse custom pragma for file metadata (e.g., `@intl-meta`)
 - `--preserve-whitespace` - Preserve whitespace and newlines
 - `--flatten` - Hoist selectors and flatten sentences

--- a/crates/formatjs_cli/src/extract.rs
+++ b/crates/formatjs_cli/src/extract.rs
@@ -86,7 +86,7 @@ pub fn extract_to_string(
     let file_list = if let Some(in_f) = in_file {
         read_file_list(in_f)?
     } else {
-        resolve_files_from_globs(files, ignore, follow_links)?
+        resolve_files_from_globs(files, ignore, follow_links, throws)?
     };
 
     // Step 2: Extract messages from all files
@@ -240,32 +240,85 @@ fn resolve_files_from_globs(
     globs: &[PathBuf],
     ignore: &[String],
     follow_links: bool,
+    throws: bool,
 ) -> Result<Vec<PathBuf>> {
     let mut files = Vec::new();
 
     for glob_path in globs {
-        if glob_path.is_file() {
-            if !should_ignore(glob_path, ignore) && is_supported_file(glob_path) {
-                files.push(glob_path.to_path_buf());
-            }
-            continue;
-        }
-
         let glob_str = glob_path
             .to_str()
             .context("Invalid UTF-8 in glob pattern")?;
+        let is_glob = glob_str.contains(|c| matches!(c, '*' | '?' | '[' | '{'));
+
+        match fs::metadata(glob_path) {
+            Ok(metadata) if metadata.is_file() => {
+                if !should_ignore(glob_path, ignore) && is_supported_file(glob_path) {
+                    files.push(glob_path.to_path_buf());
+                }
+                continue;
+            }
+            Ok(_) if !is_glob => {
+                let message = format!("Input path is not a file: {}", glob_path.display());
+                if throws {
+                    anyhow::bail!(message);
+                }
+                eprintln!("{message}");
+                continue;
+            }
+            Err(error) if !is_glob => {
+                let message = format!(
+                    "Failed to resolve input file {}: {error}",
+                    glob_path.display()
+                );
+                if throws {
+                    anyhow::bail!(message);
+                }
+                eprintln!("{message}");
+                continue;
+            }
+            _ => {}
+        }
 
         let base_dir = extract_base_dir(glob_str);
 
-        if !base_dir.exists() {
-            continue;
+        match base_dir.try_exists() {
+            Ok(true) => {}
+            Ok(false) => {
+                if throws {
+                    anyhow::bail!(
+                        "Failed to resolve glob pattern {glob_str}: base directory {} does not exist",
+                        base_dir.display()
+                    );
+                }
+                continue;
+            }
+            Err(error) => {
+                let message = format!(
+                    "Failed to access base directory {} for glob pattern {glob_str}: {error}",
+                    base_dir.display()
+                );
+                if throws {
+                    anyhow::bail!(message);
+                }
+                eprintln!("{message}");
+                continue;
+            }
         }
 
-        for entry in WalkDir::new(&base_dir)
-            .follow_links(follow_links)
-            .into_iter()
-            .filter_map(|e| e.ok())
-        {
+        for entry in WalkDir::new(&base_dir).follow_links(follow_links) {
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(error) => {
+                    let message = format!(
+                        "Failed to traverse files for glob pattern {glob_str}: {error}"
+                    );
+                    if throws {
+                        anyhow::bail!(message);
+                    }
+                    eprintln!("{message}");
+                    continue;
+                }
+            };
             let path = entry.path();
 
             // Skip directories
@@ -499,7 +552,7 @@ import { FormattedMessage } from 'react-intl';
 
         let pattern = format!("{}/**/*.{{ts,tsx}}", temp_dir.path().display());
         let globs = vec![PathBuf::from(&pattern)];
-        let files = resolve_files_from_globs(&globs, &[], true).unwrap();
+        let files = resolve_files_from_globs(&globs, &[], true, false).unwrap();
 
         assert_eq!(files.len(), 2);
         let extensions: Vec<String> = files
@@ -725,7 +778,7 @@ fn main() {
         let pattern = format!("{}/**/*.ts", temp_dir.path().display());
         let globs = vec![PathBuf::from(&pattern)];
         let ignore = vec!["**/node_modules/**".to_string(), "**/*.test.ts".to_string()];
-        let files = resolve_files_from_globs(&globs, &ignore, true).unwrap();
+        let files = resolve_files_from_globs(&globs, &ignore, true, false).unwrap();
 
         assert_eq!(files.len(), 1);
         assert!(files[0].to_string_lossy().contains("app.ts"));
@@ -743,7 +796,7 @@ fn main() {
 
         let pattern = format!("{}/**/*.{{ts,tsx}}", temp_dir.path().display());
         let globs = vec![PathBuf::from(&pattern)];
-        let files = resolve_files_from_globs(&globs, &[], true).unwrap();
+        let files = resolve_files_from_globs(&globs, &[], true, false).unwrap();
 
         assert_eq!(files.len(), 2);
         let names: Vec<String> = files
@@ -757,8 +810,44 @@ fn main() {
     #[test]
     fn test_resolve_files_nonexistent_base_dir() {
         let globs = vec![PathBuf::from("/nonexistent/path/**/*.ts")];
-        let files = resolve_files_from_globs(&globs, &[], true).unwrap();
+        let files = resolve_files_from_globs(&globs, &[], true, false).unwrap();
         assert!(files.is_empty());
+    }
+
+    #[test]
+    fn test_resolve_files_nonexistent_base_dir_throws() {
+        let globs = vec![PathBuf::from("/nonexistent/path/**/*.ts")];
+        let error = resolve_files_from_globs(&globs, &[], true, true).unwrap_err();
+
+        assert!(error.to_string().contains("base directory /nonexistent/path does not exist"));
+    }
+
+    #[test]
+    fn test_resolve_files_missing_literal_throws() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let missing_file = temp_dir.path().join("missing.tsx");
+        let error =
+            resolve_files_from_globs(&[missing_file.clone()], &[], true, true).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains(&format!("Failed to resolve input file {}", missing_file.display()))
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_resolve_files_walk_error_throws() {
+        use std::os::unix::fs::symlink;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        symlink(temp_dir.path(), temp_dir.path().join("loop")).unwrap();
+        let pattern = format!("{}/**/*.ts", temp_dir.path().display());
+        let error =
+            resolve_files_from_globs(&[PathBuf::from(pattern)], &[], true, true).unwrap_err();
+
+        assert!(error.to_string().contains("Failed to traverse files"));
     }
 
     #[test]
@@ -769,7 +858,7 @@ fn main() {
         fs::write(&file, "// app").unwrap();
 
         let globs = vec![file.clone()];
-        let files = resolve_files_from_globs(&globs, &[], true).unwrap();
+        let files = resolve_files_from_globs(&globs, &[], true, false).unwrap();
 
         assert_eq!(files.len(), 1);
         assert_eq!(files[0], file);
@@ -784,7 +873,7 @@ fn main() {
         fs::write(&file, "// app").unwrap();
 
         let globs = vec![file.clone()];
-        let files = resolve_files_from_globs(&globs, &[], true).unwrap();
+        let files = resolve_files_from_globs(&globs, &[], true, false).unwrap();
 
         assert_eq!(files.len(), 1);
         assert_eq!(files[0], file);
@@ -2138,5 +2227,37 @@ const msg = defineMessage({
             result.is_err(),
             "Extract should fail with throws:true when any file has errors"
         );
+    }
+
+    #[test]
+    fn test_extract_with_throws_true_fails_on_missing_input() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let missing_file = temp_dir.path().join("missing.tsx");
+        let output_file = temp_dir.path().join("output.json");
+
+        let error = extract(
+            &[missing_file.clone()],
+            None,
+            None,
+            Some(&output_file),
+            "[sha512:contenthash:base64:6]",
+            false,
+            &[],
+            &[],
+            &[],
+            true,
+            None,
+            false,
+            false,
+            true,
+        )
+        .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains(&format!("Failed to resolve input file {}", missing_file.display()))
+        );
+        assert!(!output_file.exists());
     }
 }

--- a/crates/formatjs_cli/src/extract.rs
+++ b/crates/formatjs_cli/src/extract.rs
@@ -83,11 +83,12 @@ pub fn extract_to_string(
     follow_links: bool,
 ) -> Result<String> {
     // Step 1: Resolve file list from glob patterns or in_file
-    let file_list = if let Some(in_f) = in_file {
+    let input_files = if let Some(in_f) = in_file {
         read_file_list(in_f)?
     } else {
-        resolve_files_from_globs(files, ignore, follow_links, throws)?
+        files.to_vec()
     };
+    let file_list = resolve_files_from_globs(&input_files, ignore, follow_links, throws)?;
 
     // Step 2: Extract messages from all files
     let mut all_messages: BTreeMap<String, MessageDescriptor> = BTreeMap::new();
@@ -252,9 +253,19 @@ fn resolve_files_from_globs(
 
         match fs::metadata(glob_path) {
             Ok(metadata) if metadata.is_file() => {
-                if !should_ignore(glob_path, ignore) && is_supported_file(glob_path) {
-                    files.push(glob_path.to_path_buf());
+                if should_ignore(glob_path, ignore) {
+                    continue;
                 }
+                if is_supported_file(glob_path) {
+                    files.push(glob_path.to_path_buf());
+                    continue;
+                }
+
+                let message = format!("Unsupported input file type: {}", glob_path.display());
+                if throws {
+                    anyhow::bail!(message);
+                }
+                eprintln!("{message}");
                 continue;
             }
             Ok(_) if !is_glob => {
@@ -290,6 +301,7 @@ fn resolve_files_from_globs(
                         base_dir.display()
                     );
                 }
+                // A glob matching nothing is valid in best-effort mode.
                 continue;
             }
             Err(error) => {
@@ -833,6 +845,20 @@ fn main() {
             error
                 .to_string()
                 .contains(&format!("Failed to resolve input file {}", missing_file.display()))
+        );
+    }
+
+    #[test]
+    fn test_resolve_files_unsupported_literal_throws() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let unsupported_file = temp_dir.path().join("messages.txt");
+        fs::write(&unsupported_file, "not source").unwrap();
+        let error =
+            resolve_files_from_globs(&[unsupported_file.clone()], &[], true, true).unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            format!("Unsupported input file type: {}", unsupported_file.display())
         );
     }
 
@@ -2239,6 +2265,40 @@ const msg = defineMessage({
             &[missing_file.clone()],
             None,
             None,
+            Some(&output_file),
+            "[sha512:contenthash:base64:6]",
+            false,
+            &[],
+            &[],
+            &[],
+            true,
+            None,
+            false,
+            false,
+            true,
+        )
+        .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains(&format!("Failed to resolve input file {}", missing_file.display()))
+        );
+        assert!(!output_file.exists());
+    }
+
+    #[test]
+    fn test_extract_in_file_with_throws_true_fails_on_missing_input() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let missing_file = temp_dir.path().join("missing.tsx");
+        let input_file = temp_dir.path().join("files.txt");
+        let output_file = temp_dir.path().join("output.json");
+        fs::write(&input_file, format!("{}\n", missing_file.display())).unwrap();
+
+        let error = extract(
+            &[],
+            None,
+            Some(&input_file),
             Some(&output_file),
             "[sha512:contenthash:base64:6]",
             false,

--- a/docs/src/docs/tooling/cli.mdx
+++ b/docs/src/docs/tooling/cli.mdx
@@ -397,7 +397,7 @@ List of glob paths to **not** extract translations from.
 
 ### `--throws`
 
-Whether to throw an exception when we fail to process any file in the batch.
+Whether to throw an exception when we fail to resolve, traverse, or process any file in the batch.
 
 ### `--pragma [pragma]`
 

--- a/knowledge-base/003-rust-crate-dependency-hierarchy.md
+++ b/knowledge-base/003-rust-crate-dependency-hierarchy.md
@@ -118,6 +118,7 @@ support Rust 1.92 and newer.
 **Key implementation details:**
 
 - Uses **oxc** (v0.120) for JS/TS/JSX/TSX AST parsing (no Node.js dependency)
+- With `extract --throws`, input metadata and directory traversal errors fail the command instead of producing a partial catalog
 - **Whitespace normalization** (`extractor.rs`): Matches TypeScript CLI behavior exactly, including U+00A0 (non-breaking space) preservation via placeholder technique
 - **ID generation** (`id_generator.rs`): loader-utils style `hash`/`contenthash` interpolation with md5, sha1, and SHA-2 algorithms plus base64/base64url/base62/hex encodings. Hash is computed AFTER flattening (matching TypeScript CLI order)
 - **6 output formatters:** default, simple, crowdin, lokalise, transifex, smartling


### PR DESCRIPTION
## Summary

- distinguish literal inputs from glob patterns before traversal
- validate positional and `--in-file` inputs through the same resolver
- fail on missing inputs, unsupported literal files, inaccessible glob bases, and traversal errors when `--throws` is enabled
- keep best-effort behavior without `--throws`, but report filesystem errors to stderr
- document the stricter native CLI behavior

Fixes #7004.

## Compatibility

`extract "optional/**/*.ts" --throws` now fails when the glob base directory does not exist. Callers relying on absent optional directories should create the directory or omit `--throws`.

## Validation

- `bazel test //crates/formatjs_cli:formatjs_cli_test`
- direct `formatjs extract missing.tsx --throws` exits 1 with the filesystem error
- direct extraction without `--throws` exits 0 and reports the filesystem warning
