### PR TITLE
feat(formatjs_intl): add extractable format_message macro

### DIFF
--- a/crates/formatjs_cli/README.md
+++ b/crates/formatjs_cli/README.md
@@ -208,13 +208,21 @@ Extract string messages from React components that use react-intl:
 formatjs extract "src/**/*.tsx" --out-file messages.json
 ```
 
-Rust extraction reads `formatjs_intl::message_descriptor!` descriptors. Missing
-IDs use `[sha512:contenthash:base64:10]`:
+Rust extraction reads `formatjs_intl::message_descriptor!` descriptors and
+inline `formatjs_intl::format_message!` calls. Missing IDs use
+`[sha512:contenthash:base64:10]`:
 
 ```rust
 const GREETING: formatjs_intl::MessageDescriptor = formatjs_intl::message_descriptor!(
     default_message: "Hello, {name}!",
     description: "Greeting"
+);
+
+let greeting = formatjs_intl::format_message!(
+    &intl,
+    default_message: "Hello, {name}!",
+    description: "Greeting",
+    values: &values,
 );
 ```
 

--- a/crates/formatjs_cli/src/rust_extractor.rs
+++ b/crates/formatjs_cli/src/rust_extractor.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use syn::parse::{Parse, ParseStream};
 use syn::spanned::Spanned;
 use syn::visit::{self, Visit};
-use syn::{Ident, LitStr, Macro, Token};
+use syn::{Expr, Ident, LitStr, Macro, Token};
 
 const RUST_ID_INTERPOLATION_PATTERN: &str = "[sha512:contenthash:base64:10]";
 
@@ -102,8 +102,13 @@ impl RustMessageExtractor<'_> {
 impl<'ast> Visit<'ast> for RustMessageExtractor<'_> {
     fn visit_macro(&mut self, node: &'ast Macro) {
         let name = node.path.segments.last().map(|segment| &segment.ident);
-        if name.is_some_and(|name| name == "message_descriptor") {
-            match syn::parse2::<MessageArgs>(node.tokens.clone()) {
+        if name.is_some_and(|name| name == "message_descriptor" || name == "format_message") {
+            let arguments = if name.is_some_and(|name| name == "format_message") {
+                syn::parse2::<FormatMessageArgs>(node.tokens.clone()).map(|args| args.message)
+            } else {
+                syn::parse2::<MessageArgs>(node.tokens.clone())
+            };
+            match arguments {
                 Ok(arguments) => match self.descriptor(arguments, node.span()) {
                     Ok(descriptor) => self.messages.push(descriptor),
                     Err(error) => self.error(node.span(), error.to_string()),
@@ -112,6 +117,19 @@ impl<'ast> Visit<'ast> for RustMessageExtractor<'_> {
             }
         }
         visit::visit_macro(self, node);
+    }
+}
+
+struct FormatMessageArgs {
+    message: MessageArgs,
+}
+
+impl Parse for FormatMessageArgs {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        input.parse::<Expr>()?;
+        input.parse::<Token![,]>()?;
+        let message = parse_message_args(input, true)?;
+        Ok(Self { message })
     }
 }
 
@@ -134,42 +152,59 @@ struct MessageArgs {
 
 impl Parse for MessageArgs {
     fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
-        let mut id = None;
-        let mut default_message = None;
-        let mut description = None;
-        while !input.is_empty() {
-            let key: Ident = input.parse()?;
-            if input.peek(Token![:]) {
-                input.parse::<Token![:]>()?;
-            } else {
-                input.parse::<Token![=]>()?;
+        parse_message_args(input, false)
+    }
+}
+
+fn parse_message_args(input: ParseStream<'_>, allow_values: bool) -> syn::Result<MessageArgs> {
+    let mut id = None;
+    let mut default_message = None;
+    let mut description = None;
+    let mut values = false;
+    while !input.is_empty() {
+        let key: Ident = input.parse()?;
+        if input.peek(Token![:]) {
+            input.parse::<Token![:]>()?;
+        } else {
+            input.parse::<Token![=]>()?;
+        }
+        match key.to_string().as_str() {
+            "values" if allow_values && !values => {
+                input.parse::<Expr>()?;
+                values = true;
             }
-            let value: LitStr = input.parse()?;
-            match key.to_string().as_str() {
-                "id" if id.is_none() => id = Some(value.value()),
-                "default_message" if default_message.is_none() => {
-                    default_message = Some(value.value())
-                }
-                "description" if description.is_none() => description = Some(value.value()),
-                "id" | "default_message" | "description" => {
-                    return Err(syn::Error::new(key.span(), "duplicate message field"));
-                }
-                _ => return Err(syn::Error::new(key.span(), "unknown message field")),
+            "values" if allow_values => {
+                return Err(syn::Error::new(key.span(), "duplicate message field"));
             }
-            if input.peek(Token![,]) {
-                input.parse::<Token![,]>()?;
-            } else if !input.is_empty() {
-                return Err(input.error("expected comma"));
+            "values" => return Err(syn::Error::new(key.span(), "unknown message field")),
+            field => {
+                let value: LitStr = input.parse()?;
+                match field {
+                    "id" if id.is_none() => id = Some(value.value()),
+                    "default_message" if default_message.is_none() => {
+                        default_message = Some(value.value())
+                    }
+                    "description" if description.is_none() => description = Some(value.value()),
+                    "id" | "default_message" | "description" => {
+                        return Err(syn::Error::new(key.span(), "duplicate message field"));
+                    }
+                    _ => return Err(syn::Error::new(key.span(), "unknown message field")),
+                }
             }
         }
-
-        Ok(Self {
-            id,
-            default_message: default_message
-                .ok_or_else(|| syn::Error::new(Span::call_site(), "default_message is required"))?,
-            description,
-        })
+        if input.peek(Token![,]) {
+            input.parse::<Token![,]>()?;
+        } else if !input.is_empty() {
+            return Err(input.error("expected comma"));
+        }
     }
+
+    Ok(MessageArgs {
+        id,
+        default_message: default_message
+            .ok_or_else(|| syn::Error::new(Span::call_site(), "default_message is required"))?,
+        description,
+    })
 }
 
 #[cfg(test)]
@@ -217,6 +252,35 @@ mod tests {
         )
         .unwrap();
         assert_eq!(messages[0].id.as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn extracts_format_message_macros() {
+        let messages = extract_messages_from_rust_source(
+            r#"fn render(intl: &Intl, values: &Values<String>) {
+                format_message!(
+                    &intl,
+                    default_message: "Hello, {name}!",
+                    description: "Greeting",
+                    values: values,
+                );
+                formatjs_intl::format_message!(
+                    &intl,
+                    id: "approval.title",
+                    default_message: "Approve to continue",
+                );
+            }"#,
+            Path::new("src/main.rs"),
+            false,
+            false,
+            false,
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].id.as_deref(), Some("EG1xJTTqQy"));
+        assert_eq!(messages[1].id.as_deref(), Some("approval.title"));
     }
 
     #[test]

--- a/crates/formatjs_intl/README.md
+++ b/crates/formatjs_intl/README.md
@@ -39,10 +39,35 @@ assert_eq!(intl.format_message_to_string(TASKS, &values)?, "2 tâches");
 # Ok::<(), formatjs_intl::Error>(())
 ```
 
+Use `format_message!` for inline application copy. It creates the same
+descriptor, is recognized by `formatjs extract`, and returns a `String`:
+
+```rust
+# use formatjs_icu_messageformat::Values;
+# use formatjs_intl::{Intl, format_message};
+# fn render(intl: &Intl, values: &Values<String>) {
+let title = format_message!(
+    intl,
+    default_message: "Approve to continue",
+    description: "Approval card title",
+);
+let detail = format_message!(
+    intl,
+    default_message: "Allow access to {path}?",
+    description: "Directory approval explanation",
+    values: values,
+);
+# }
+```
+
+If cache infrastructure fails, this macro reports the error through
+`with_on_error` and returns `default_message` verbatim. Fallible formatting
+methods remain available when callers need explicit error handling.
+
 Message formatting falls back from the selected locale catalog to the default
 locale catalog, then the descriptor's `default_message`. Invalid translations
-also use this chain. Attach `with_on_error` to observe formatting errors while
-returning the fallback:
+also use this chain. Attach `with_on_error` to observe recovered formatting and
+infrastructure errors:
 
 ```rust
 # use formatjs_intl::{FormatMessageError, Intl};

--- a/crates/formatjs_intl/lib.rs
+++ b/crates/formatjs_intl/lib.rs
@@ -8,6 +8,8 @@ use std::fmt;
 use std::sync::{Arc, RwLock};
 
 #[doc(hidden)]
+pub use formatjs_icu_messageformat::Values as __Values;
+#[doc(hidden)]
 pub use formatjs_intl_macros::__message_descriptor;
 
 pub type Messages = HashMap<String, String>;
@@ -93,8 +95,8 @@ pub struct FormatMessageError {
     pub locale: String,
     /// Source of the message that failed.
     pub source: MessageSource,
-    /// Low-level parse or formatting error.
-    pub error: formatjs_icu_messageformat::Error,
+    /// Formatting or infrastructure error.
+    pub error: Error,
 }
 
 impl fmt::Display for FormatMessageError {
@@ -145,6 +147,40 @@ macro_rules! message_descriptor {
             default_message: DATA.1,
             description: DATA.2,
         }
+    }};
+}
+
+/// Formats an extractable message and returns its default message if infrastructure fails.
+#[macro_export]
+macro_rules! format_message {
+    (
+        $intl:expr,
+        $(id: $id:literal,)?
+        default_message: $default_message:literal
+        $(, description: $description:literal)?
+        , values: $values:expr
+        $(,)?
+    ) => {{
+        let descriptor = $crate::message_descriptor!(
+            $(id: $id,)?
+            default_message: $default_message
+            $(, description: $description)?
+        );
+        $intl.format_message_to_string_or_default(descriptor, $values)
+    }};
+    (
+        $intl:expr,
+        $(id: $id:literal,)?
+        default_message: $default_message:literal
+        $(, description: $description:literal)?
+        $(,)?
+    ) => {{
+        let descriptor = $crate::message_descriptor!(
+            $(id: $id,)?
+            default_message: $default_message
+            $(, description: $description)?
+        );
+        $intl.format_message_to_string_or_default(descriptor, &$crate::__Values::new())
     }};
 }
 
@@ -343,6 +379,16 @@ impl Intl {
         )
     }
 
+    /// Formats a string, returning `default_message` if infrastructure prevents formatting.
+    pub fn format_message_to_string_or_default(
+        &self,
+        descriptor: MessageDescriptor,
+        values: &Values<String>,
+    ) -> String {
+        self.format_message_to_string(descriptor, values)
+            .unwrap_or_else(|_| descriptor.default_message.to_owned())
+    }
+
     fn format_with_fallback<T>(
         &self,
         descriptor: MessageDescriptor,
@@ -371,13 +417,19 @@ impl Intl {
             };
             match result {
                 Ok(message) => return Ok(message),
-                Err(Error::Message(error)) => self.report_error(FormatMessageError {
-                    descriptor,
-                    locale: candidate.locale.to_owned(),
-                    source: candidate.source,
-                    error,
-                }),
-                Err(error) => return Err(error),
+                Err(error) => {
+                    let is_message_error = matches!(error, Error::Message(_));
+                    let error = FormatMessageError {
+                        descriptor,
+                        locale: candidate.locale.to_owned(),
+                        source: candidate.source,
+                        error,
+                    };
+                    self.report_error(&error);
+                    if !is_message_error {
+                        return Err(error.error);
+                    }
+                }
             }
         }
 
@@ -415,9 +467,9 @@ impl Intl {
         candidates
     }
 
-    fn report_error(&self, error: FormatMessageError) {
+    fn report_error(&self, error: &FormatMessageError) {
         if let Some(on_error) = &self.on_error {
-            on_error(&error);
+            on_error(error);
         }
     }
 }
@@ -539,6 +591,64 @@ mod tests {
         assert_eq!(TASKS.id, "LURAmALj1U");
         assert_eq!(GREETING.id, "EG1xJTTqQy");
         assert_eq!(EXPLICIT_ID.id, "tasks.explicit");
+    }
+
+    #[test]
+    fn format_message_macro_formats_with_optional_values() {
+        let intl = Intl::try_new(["fr"], "en", catalog(), Arc::new(IntlCache::new())).unwrap();
+        let values: Values = HashMap::from([("count".to_owned(), Value::from(2_i64))]);
+
+        assert_eq!(
+            format_message!(
+                &intl,
+                default_message: "{count, plural, one {# task} other {# tasks}}",
+                description: "Task count",
+                values: &values,
+            ),
+            "2 tâches"
+        );
+        assert_eq!(
+            format_message!(
+                &intl,
+                id: "approval.title",
+                default_message: "Approve to continue",
+            ),
+            "Approve to continue"
+        );
+    }
+
+    #[test]
+    fn format_message_macro_reports_cache_failure_and_returns_default() {
+        let cache = Arc::new(IntlCache::new());
+        let poisoned_cache = cache.clone();
+        let _ = std::panic::catch_unwind(move || {
+            let _messages = poisoned_cache.messages.write().unwrap();
+            panic!("poison cache");
+        });
+        let errors = Arc::new(Mutex::new(Vec::new()));
+        let captured_errors = errors.clone();
+        let intl = Intl::try_new(["en"], "en", catalog(), cache)
+            .unwrap()
+            .with_on_error(move |error| {
+                captured_errors.lock().unwrap().push((
+                    error.descriptor.id,
+                    error.source,
+                    matches!(error.error, Error::CachePoisoned),
+                ));
+            });
+
+        assert_eq!(
+            format_message!(
+                &intl,
+                default_message: "Approve to continue",
+                description: "Approval card title",
+            ),
+            "Approve to continue"
+        );
+        assert_eq!(
+            *errors.lock().unwrap(),
+            vec![("n5ixSZR8gf", MessageSource::DefaultMessage, true)]
+        );
     }
 
     fn catalog() -> Arc<MessageCatalog> {

--- a/docs/src/docs/rust/intl.mdx
+++ b/docs/src/docs/rust/intl.mdx
@@ -101,6 +101,32 @@ formatjs extract "src/**/*.rs" --out-file messages.json
 
 Use `id: "greeting"` when a stable semantic ID is preferred.
 
+## Inline formatting
+
+`format_message!` creates an extractable descriptor and formats it in one
+expression. `values` is optional:
+
+```rust
+use formatjs_intl::format_message;
+
+let title = format_message!(
+    &intl,
+    default_message: "Approve to continue",
+    description: "Approval card title",
+);
+let greeting = format_message!(
+    &intl,
+    default_message: "Hello, {name}!",
+    description: "Greeting shown after sign-in",
+    values: &values,
+);
+```
+
+The macro returns `String`. It uses normal catalog and default-message fallback.
+If cache infrastructure prevents formatting, it reports the error through
+`with_on_error` and returns `default_message` verbatim. Use
+`format_message_to_string` when explicit `Result` handling is required.
+
 ## Shared cache
 
 `IntlCache` stores parsed messages by source string. Share one `Arc<IntlCache>`

--- a/knowledge-base/003-rust-crate-dependency-hierarchy.md
+++ b/knowledge-base/003-rust-crate-dependency-hierarchy.md
@@ -139,11 +139,14 @@ support Rust 1.92 and newer.
 **Purpose:** High-level Rust intl runtime.
 
 - Defines `message_descriptor!` through a re-exported procedural macro.
+- Defines extractable `format_message!` for infallible inline string formatting.
 - Generates missing IDs with `[sha512:contenthash:base64:10]`; explicit IDs remain supported.
 - Selects translation catalogs with ICU4X locale fallback.
 - Falls back from selected catalog to default catalog, then descriptor message.
 - Retries parse and format failures through the same chain, using each source's
-  locale; `with_on_error` exposes recovered message errors.
+  locale; `with_on_error` exposes recovered message and infrastructure errors.
+- `format_message!` returns the descriptor default verbatim when cache
+  infrastructure prevents formatting; fallible methods preserve explicit errors.
 - Returns the first source verbatim, then the message ID, when every formatting
   candidate fails.
 - Shares parsed messages through `IntlCache` across request-scoped `Intl` values.

--- a/knowledge-base/008-package-intl-and-framework-integrations.md
+++ b/knowledge-base/008-package-intl-and-framework-integrations.md
@@ -32,7 +32,9 @@ the backend. ICU4X negotiates each ordered locale list against available
 catalogs. Translation lookup falls back to the default catalog, then the
 descriptor default message. `message_descriptor!` generates missing IDs with
 `[sha512:contenthash:base64:10]` and is extracted from Rust source by
-`formatjs_cli`.
+`formatjs_cli`. `format_message!` provides the same extraction and ID behavior
+for inline calls, returns `String`, and uses the descriptor default verbatim if
+cache infrastructure fails.
 
 ## react-intl
 


### PR DESCRIPTION
## Summary

- add extractable `format_message!` calls with optional values
- return `String` while preserving fallible formatting APIs
- report cache failures through `with_on_error`, then return `default_message`
- teach Rust extraction to read inline formatting calls

Closes #7015

## Validation

- `bazel test //crates/formatjs_intl:formatjs_intl_test //crates/formatjs_cli:formatjs_cli_test --test_output=errors`
- `ast-grep scan crates/formatjs_intl/lib.rs crates/formatjs_cli/src/rust_extractor.rs`
- repository Rust formatter passed

Full pre-commit formatting and Gazelle were blocked before execution because Bazel could not resolve `registry.npmjs.org` for `codescythe` and `oxlint`.
