### PR TITLE
chore(deps): exclude Renovate from release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    authors:
+      - 'renovate[bot]'

--- a/knowledge-base/001-repo-layout.md
+++ b/knowledge-base/001-repo-layout.md
@@ -115,6 +115,8 @@ Commit-msg hook: `commitlint` validates Conventional Commits format.
 
 Release Please owns version/changelog PRs and GitHub release creation. Its
 GitHub-generated changelog notes include PR titles, PR links, and contributors.
+`.github/release.yml` excludes Renovate-authored PRs from those notes so
+dependency maintenance does not hide user-facing changes.
 For npm packages, Release Please advances versions in both package-local Bazel
 `BUILD.bazel` `x-release-please-version` markers and checked-in `package.json`
 files; `package_json_sync` keeps the rest of each generated manifest in sync.

--- a/tools/release-please/config.test.ts
+++ b/tools/release-please/config.test.ts
@@ -9,9 +9,11 @@ const require = createRequire(import.meta.url)
 const {VERSION} = require('release-please')
 const {Bazel} = require('release-please/build/src/strategies/bazel')
 const {Version} = require('release-please/build/src/version')
+const {parse} = require('yaml')
 
 const SENTINEL_VERSION = '99.88.77'
 const config = JSON.parse(readFileSync('release-please-config.json', 'utf8'))
+const releaseNotesConfig = parse(readFileSync('.github/release.yml', 'utf8'))
 const logger = {
   debug() {},
   error() {},
@@ -21,6 +23,10 @@ const logger = {
 let checked = 0
 
 assert.equal(VERSION, '17.6.0')
+assert.equal(config['changelog-type'], 'github')
+assert.deepEqual(releaseNotesConfig.changelog.exclude.authors, [
+  'renovate[bot]',
+])
 
 for (const [path, packageConfig] of Object.entries(config.packages)) {
   if (!path.startsWith('packages/')) {


### PR DESCRIPTION
## Summary

- exclude Renovate-authored PRs from GitHub-generated release notes
- validate release-note config alongside pinned Release Please config
- document release-note behavior

## Why

Release Please delegates changelog generation to GitHub. `.github/release.yml` can therefore remove Renovate PRs from release notes without changing dependency updates or version calculation.

Fixes #7029

## Test

- oxfmt check on changed files
- Release Please 17.6.0 config validation (`Verified 36 Release Please package.json updates`)
- `git diff --check`
