### PR TITLE
feat(formatjs_intl): accept inline named values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -564,6 +564,7 @@ name = "formatjs_intl_macros"
 version = "0.1.2"
 dependencies = [
  "base64",
+ "formatjs_icu_messageformat_parser",
  "quote",
  "sha2",
  "syn 3.0.3",

--- a/crates/formatjs_cli/README.md
+++ b/crates/formatjs_cli/README.md
@@ -222,9 +222,12 @@ let greeting = formatjs_intl::format_message!(
     &intl,
     default_message: "Hello, {name}!",
     description: "Greeting",
-    values: &values,
+    values: { name: user.name() },
 );
 ```
+
+Inline value names are checked against `default_message` at compile time.
+Existing values maps remain supported for dynamic or reused values.
 
 ```bash
 formatjs extract "src/**/*.rs" --out-file messages.json

--- a/crates/formatjs_cli/src/rust_extractor.rs
+++ b/crates/formatjs_cli/src/rust_extractor.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use syn::parse::{Parse, ParseStream};
 use syn::spanned::Spanned;
 use syn::visit::{self, Visit};
-use syn::{Expr, Ident, LitStr, Macro, Token};
+use syn::{Expr, Ident, LitStr, Macro, Token, braced};
 
 const RUST_ID_INTERPOLATION_PATTERN: &str = "[sha512:contenthash:base64:10]";
 
@@ -170,7 +170,22 @@ fn parse_message_args(input: ParseStream<'_>, allow_values: bool) -> syn::Result
         }
         match key.to_string().as_str() {
             "values" if allow_values && !values => {
-                input.parse::<Expr>()?;
+                if input.peek(syn::token::Brace) {
+                    let content;
+                    braced!(content in input);
+                    while !content.is_empty() {
+                        content.parse::<Ident>()?;
+                        content.parse::<Token![:]>()?;
+                        content.parse::<Expr>()?;
+                        if content.peek(Token![,]) {
+                            content.parse::<Token![,]>()?;
+                        } else if !content.is_empty() {
+                            return Err(content.error("expected comma"));
+                        }
+                    }
+                } else {
+                    input.parse::<Expr>()?;
+                }
                 values = true;
             }
             "values" if allow_values => {
@@ -264,6 +279,11 @@ mod tests {
                     description: "Greeting",
                     values: values,
                 );
+                format_message!(
+                    &intl,
+                    default_message: "{count, plural, one {# task} other {{name} has # tasks}}",
+                    values: { count: count, name: user.name() },
+                );
                 formatjs_intl::format_message!(
                     &intl,
                     id: "approval.title",
@@ -278,9 +298,13 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(messages.len(), 2);
+        assert_eq!(messages.len(), 3);
         assert_eq!(messages[0].id.as_deref(), Some("EG1xJTTqQy"));
-        assert_eq!(messages[1].id.as_deref(), Some("approval.title"));
+        assert_eq!(
+            messages[1].default_message.as_deref(),
+            Some("{count, plural, one {# task} other {{name} has # tasks}}")
+        );
+        assert_eq!(messages[2].id.as_deref(), Some("approval.title"));
     }
 
     #[test]

--- a/crates/formatjs_intl/README.md
+++ b/crates/formatjs_intl/README.md
@@ -43,9 +43,8 @@ Use `format_message!` for inline application copy. It creates the same
 descriptor, is recognized by `formatjs extract`, and returns a `String`:
 
 ```rust
-# use formatjs_icu_messageformat::Values;
 # use formatjs_intl::{Intl, format_message};
-# fn render(intl: &Intl, values: &Values<String>) {
+# fn render(intl: &Intl, path: &str) {
 let title = format_message!(
     intl,
     default_message: "Approve to continue",
@@ -55,10 +54,14 @@ let detail = format_message!(
     intl,
     default_message: "Allow access to {path}?",
     description: "Directory approval explanation",
-    values: values,
+    values: { path: path },
 );
 # }
 ```
+
+Inline values are converted to `Value` automatically. Their names are checked
+against `default_message` at compile time, including nested select and plural
+arguments. Use `values: &values` to pass a dynamically assembled or reused map.
 
 If cache infrastructure fails, this macro reports the error through
 `with_on_error` and returns `default_message` verbatim. Fallible formatting

--- a/crates/formatjs_intl/lib.rs
+++ b/crates/formatjs_intl/lib.rs
@@ -8,9 +8,9 @@ use std::fmt;
 use std::sync::{Arc, RwLock};
 
 #[doc(hidden)]
-pub use formatjs_icu_messageformat::Values as __Values;
+pub use formatjs_icu_messageformat::{Value as __Value, Values as __Values};
 #[doc(hidden)]
-pub use formatjs_intl_macros::__message_descriptor;
+pub use formatjs_intl_macros::{__message_descriptor, __validate_message_values};
 
 pub type Messages = HashMap<String, String>;
 pub type PrecompiledMessages = HashMap<String, Vec<MessageFormatElement>>;
@@ -158,6 +158,32 @@ macro_rules! format_message {
         $(id: $id:literal,)?
         default_message: $default_message:literal
         $(, description: $description:literal)?
+        , values: { $($name:ident : $value:expr),+ $(,)? }
+        $(,)?
+    ) => {{
+        const _: () = $crate::__validate_message_values!(
+            $default_message; $($name),+
+        );
+        let values = $crate::__Values::from([
+            $(
+                (
+                    ::std::string::String::from(::core::stringify!($name)),
+                    $crate::__Value::from($value),
+                ),
+            )+
+        ]);
+        let descriptor = $crate::message_descriptor!(
+            $(id: $id,)?
+            default_message: $default_message
+            $(, description: $description)?
+        );
+        $intl.format_message_to_string_or_default(descriptor, &values)
+    }};
+    (
+        $intl:expr,
+        $(id: $id:literal,)?
+        default_message: $default_message:literal
+        $(, description: $description:literal)?
         , values: $values:expr
         $(,)?
     ) => {{
@@ -175,6 +201,7 @@ macro_rules! format_message {
         $(, description: $description:literal)?
         $(,)?
     ) => {{
+        const _: () = $crate::__validate_message_values!($default_message;);
         let descriptor = $crate::message_descriptor!(
             $(id: $id,)?
             default_message: $default_message
@@ -598,6 +625,15 @@ mod tests {
         let intl = Intl::try_new(["fr"], "en", catalog(), Arc::new(IntlCache::new())).unwrap();
         let values: Values = HashMap::from([("count".to_owned(), Value::from(2_i64))]);
 
+        assert_eq!(
+            format_message!(
+                &intl,
+                default_message: "{count, plural, one {# task} other {# tasks}}",
+                description: "Task count",
+                values: { count: 2_i64 },
+            ),
+            "2 tâches"
+        );
         assert_eq!(
             format_message!(
                 &intl,

--- a/crates/formatjs_intl_macros/BUILD.bazel
+++ b/crates/formatjs_intl_macros/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_rs//rs:rust_proc_macro.bzl", "rust_proc_macro")
+load("@rules_rs//rs:rust_test.bzl", "rust_test")
 
 exports_files(
     [
@@ -14,9 +15,16 @@ rust_proc_macro(
     crate_name = "formatjs_intl_macros",
     visibility = ["//visibility:public"],
     deps = [
+        "//crates/icu_messageformat_parser",
         "@crates//:base64",
         "@crates//:quote",
         "@crates//:sha2",
         "@crates//:syn",
     ],
+)
+
+rust_test(
+    name = "formatjs_intl_macros_test",
+    size = "small",
+    crate = ":formatjs_intl_macros",
 )

--- a/crates/formatjs_intl_macros/Cargo.toml
+++ b/crates/formatjs_intl_macros/Cargo.toml
@@ -18,6 +18,7 @@ proc-macro = true
 
 [dependencies]
 base64 = "0.23"
+formatjs_icu_messageformat_parser = { path = "../icu_messageformat_parser", version = "0.3.0" }
 quote = "1.0"
 sha2 = "0.11"
 syn = { version = "3.0", features = ["full", "parsing"] }

--- a/crates/formatjs_intl_macros/lib.rs
+++ b/crates/formatjs_intl_macros/lib.rs
@@ -1,7 +1,9 @@
 use base64::Engine;
+use formatjs_icu_messageformat_parser::{MessageFormatElement, Parser, ParserOptions};
 use proc_macro::TokenStream;
 use quote::quote;
 use sha2::{Digest, Sha512};
+use std::collections::{BTreeMap, BTreeSet};
 use syn::parse::{Parse, ParseStream};
 use syn::{Ident, LitStr, Token, parse_macro_input};
 
@@ -21,6 +23,118 @@ pub fn __message_descriptor(input: TokenStream) -> TokenStream {
     );
 
     quote!((#id, #default_message, #description)).into()
+}
+
+#[proc_macro]
+pub fn __validate_message_values(input: TokenStream) -> TokenStream {
+    let arguments = parse_macro_input!(input as ValidateMessageValuesArgs);
+    match validate_message_values(&arguments) {
+        Ok(()) => quote!(()).into(),
+        Err(error) => error.into_compile_error().into(),
+    }
+}
+
+struct ValidateMessageValuesArgs {
+    default_message: LitStr,
+    values: Vec<Ident>,
+}
+
+impl Parse for ValidateMessageValuesArgs {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let default_message = input.parse()?;
+        input.parse::<Token![;]>()?;
+        let mut values = Vec::new();
+        while !input.is_empty() {
+            values.push(input.parse()?);
+            if input.peek(Token![,]) {
+                input.parse::<Token![,]>()?;
+            } else if !input.is_empty() {
+                return Err(input.error("expected comma"));
+            }
+        }
+        Ok(Self {
+            default_message,
+            values,
+        })
+    }
+}
+
+fn validate_message_values(arguments: &ValidateMessageValuesArgs) -> syn::Result<()> {
+    let ast = Parser::new(
+        arguments.default_message.value(),
+        ParserOptions::default(),
+    )
+    .parse()
+    .map_err(|error| {
+        syn::Error::new(
+            arguments.default_message.span(),
+            format!("invalid ICU message: {error}"),
+        )
+    })?;
+    let mut required = BTreeSet::new();
+    collect_message_values(&ast, &mut required);
+
+    let mut supplied = BTreeMap::new();
+    for value in &arguments.values {
+        let name = value.to_string();
+        if supplied.insert(name.clone(), value.span()).is_some() {
+            return Err(syn::Error::new(
+                value.span(),
+                format!("duplicate ICU value `{name}`"),
+            ));
+        }
+    }
+
+    let supplied_names = supplied.keys().cloned().collect::<BTreeSet<_>>();
+    if let Some(name) = required.difference(&supplied_names).next() {
+        return Err(syn::Error::new(
+            arguments.default_message.span(),
+            format!("missing ICU value `{name}`"),
+        ));
+    }
+    if let Some(name) = supplied_names.difference(&required).next() {
+        return Err(syn::Error::new(
+            supplied[name],
+            format!("unused ICU value `{name}`"),
+        ));
+    }
+    Ok(())
+}
+
+fn collect_message_values(ast: &[MessageFormatElement], values: &mut BTreeSet<String>) {
+    for element in ast {
+        match element {
+            MessageFormatElement::Argument(argument) => {
+                values.insert(argument.value.clone());
+            }
+            MessageFormatElement::Number(number) => {
+                values.insert(number.value.clone());
+            }
+            MessageFormatElement::Date(date) => {
+                values.insert(date.value.clone());
+            }
+            MessageFormatElement::Time(time) => {
+                values.insert(time.value.clone());
+            }
+            MessageFormatElement::Select(select) => {
+                values.insert(select.value.clone());
+                for option in select.options.values() {
+                    collect_message_values(&option.value, values);
+                }
+            }
+            MessageFormatElement::Plural(plural) => {
+                values.insert(plural.value.clone());
+                for option in plural.options.values() {
+                    collect_message_values(&option.value, values);
+                }
+            }
+            MessageFormatElement::Tag(tag) => {
+                values.insert(tag.value.clone());
+                collect_message_values(&tag.children, values);
+            }
+            MessageFormatElement::Literal(_) | MessageFormatElement::Pound(_) => {}
+        }
+    }
 }
 
 struct MessageDescriptorArgs {
@@ -96,4 +210,43 @@ fn normalize_whitespace(value: &str) -> String {
     }
 
     normalized
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn validate(input: &str) -> syn::Result<()> {
+        validate_message_values(&syn::parse_str(input)?)
+    }
+
+    #[test]
+    fn validates_nested_icu_values() {
+        validate(
+            r#""{gender, select, other {{name} has {count, plural, one {one task} other {# tasks}} worth {amount, number}, due {due, date} at {time, time}. <b>Review</b>}}"; gender, name, count, amount, due, time, b"#,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn rejects_missing_unused_and_duplicate_values() {
+        assert!(
+            validate(r#""Hello, {name}";"#)
+                .unwrap_err()
+                .to_string()
+                .contains("missing ICU value `name`")
+        );
+        assert!(
+            validate(r#""Hello"; name"#)
+                .unwrap_err()
+                .to_string()
+                .contains("unused ICU value `name`")
+        );
+        assert!(
+            validate(r#""Hello, {name}"; name, name"#)
+                .unwrap_err()
+                .to_string()
+                .contains("duplicate ICU value `name`")
+        );
+    }
 }

--- a/knowledge-base/003-rust-crate-dependency-hierarchy.md
+++ b/knowledge-base/003-rust-crate-dependency-hierarchy.md
@@ -140,6 +140,9 @@ support Rust 1.92 and newer.
 
 - Defines `message_descriptor!` through a re-exported procedural macro.
 - Defines extractable `format_message!` for infallible inline string formatting.
+- Accepts checked inline `values: { name: expression }`; its procedural macro
+  parses the default ICU message and rejects missing, unused, or duplicate names.
+- Keeps `values: &values` for dynamically assembled or reused maps.
 - Generates missing IDs with `[sha512:contenthash:base64:10]`; explicit IDs remain supported.
 - Selects translation catalogs with ICU4X locale fallback.
 - Falls back from selected catalog to default catalog, then descriptor message.

--- a/knowledge-base/008-package-intl-and-framework-integrations.md
+++ b/knowledge-base/008-package-intl-and-framework-integrations.md
@@ -34,7 +34,9 @@ descriptor default message. `message_descriptor!` generates missing IDs with
 `[sha512:contenthash:base64:10]` and is extracted from Rust source by
 `formatjs_cli`. `format_message!` provides the same extraction and ID behavior
 for inline calls, returns `String`, and uses the descriptor default verbatim if
-cache infrastructure fails.
+cache infrastructure fails. Inline `values: { name: expression }` are converted
+to runtime values and checked against the default ICU message at compile time;
+callers can still pass an existing values map.
 
 ## react-intl
 


### PR DESCRIPTION
## Summary

- accept `values: { name: expression }` in `format_message!`
- validate missing, unused, and duplicate ICU value names at compile time
- keep existing values-map support and teach Rust extraction about grouped values
- document runtime and extraction behavior

## Test

- `bazel test //crates/formatjs_intl_macros:formatjs_intl_macros_test //crates/formatjs_intl:formatjs_intl_test //crates/formatjs_cli:formatjs_cli_test --test_output=errors`

Fixes #7019
