### PR TITLE
feat(eslint-plugin-formatjs): detect glued placeholders

### DIFF
--- a/docs/src/docs/guides/best-practices.mdx
+++ b/docs/src/docs/guides/best-practices.mdx
@@ -55,6 +55,30 @@ intl.formatMessage(
 
 Skeletons describe formatting, not sentence structure. Keep surrounding punctuation and words inside the message so translators can move them. See [ICU Message Syntax](/docs/core-concepts/icu-syntax) for supported skeletons.
 
+Treat measurements as formatted values. Do not join a placeholder to a unit (`{duration}day`, `{size}MB`) or format the number separately and concatenate the unit. Use an ICU number skeleton inside a message, or `formatNumber` / `<FormattedNumber>` with `style: 'unit'` for a standalone value.
+
+```tsx
+// In a message, keep the raw value and its unit format together.
+intl.formatMessage(
+  {defaultMessage: 'Retry in {duration, number, ::measure-unit/duration-day}.'},
+  {duration}
+)
+
+// For a standalone measurement, use the unit formatter directly.
+intl.formatNumber(size, {
+  style: 'unit',
+  unit: 'megabyte',
+  unitDisplay: 'short',
+})
+```
+
+Calendar names are locale data, not message copy. Do not declare or translate arrays such as `['Mon', 'Tue', ...]` or month-name maps. Format an actual date with `formatDate`, `<FormattedDate>`, or `Intl.DateTimeFormat`. For weekday-only controls, use stable reference dates and pin the time zone so the day cannot shift.
+
+```tsx
+const monday = new Date(Date.UTC(2024, 0, 1))
+intl.formatDate(monday, {weekday: 'short', timeZone: 'UTC'})
+```
+
 When a value is not part of a message, use FormatJS or the equivalent built-in `Intl` API instead of constructing locale-sensitive text yourself:
 
 - `formatNumber` or `<FormattedNumber>` for numbers and currencies

--- a/docs/src/docs/tooling/linter.mdx
+++ b/docs/src/docs/tooling/linter.mdx
@@ -852,13 +852,14 @@ Consistent coding style in JSX and less syntax clutter.
 
 ### `prefer-full-sentence`
 
-Messages should be self-contained, full sentences. Leading or trailing whitespace in a message suggests it is a fragment being concatenated with other strings, which is an anti-pattern for localization.
+Messages should be self-contained, full sentences. Leading or trailing whitespace in a message suggests it is a fragment being concatenated with other strings, which is an anti-pattern for localization. Placeholders joined directly to words, such as `{count}day`, also fail because units and spacing vary by locale.
 
 #### Why
 
 - String concatenation breaks translation because different languages have different word orders, grammar rules, and sentence structures.
 - Translators need the full sentence to produce an accurate translation.
 - Leading/trailing whitespace is a code smell indicating the message is a fragment.
+- Units should use ICU number skeletons or an `Intl` formatter instead of being joined to placeholders.
 
 ```tsx
 const messages = defineMessages({
@@ -873,6 +874,10 @@ const messages = defineMessages({
   // FAILS — trailing whitespace
   baz: {
     defaultMessage: 'You have ',
+  },
+  // FAILS — placeholder joined to a unit
+  qux: {
+    defaultMessage: '{duration}day',
   },
 })
 ```

--- a/packages/eslint-plugin-formatjs/rules/prefer-full-sentence.ts
+++ b/packages/eslint-plugin-formatjs/rules/prefer-full-sentence.ts
@@ -1,17 +1,20 @@
+import {CORE_MESSAGES} from '#packages/eslint-plugin-formatjs/messages.js'
+import {
+  extractMessages,
+  getSettings,
+} from '#packages/eslint-plugin-formatjs/util.js'
 import {
   type MessageFormatElement,
   parse,
   TYPE,
 } from '@formatjs/icu-messageformat-parser'
-import type {Node} from 'estree-jsx'
 import type {Rule} from 'eslint'
-import {
-  extractMessages,
-  getSettings,
-} from '#packages/eslint-plugin-formatjs/util.js'
-import {CORE_MESSAGES} from '#packages/eslint-plugin-formatjs/messages.js'
+import type {Node} from 'estree-jsx'
 
-type WhitespaceIssue = 'leadingWhitespace' | 'trailingWhitespace'
+type MessageIssue =
+  | 'leadingWhitespace'
+  | 'placeholderAdjacentToWord'
+  | 'trailingWhitespace'
 
 /**
  * Get the first boundary element, recursing into tags since
@@ -42,8 +45,12 @@ function getLastBoundaryElement(
   return last
 }
 
-function findWhitespaceIssues(ast: MessageFormatElement[]): WhitespaceIssue[] {
-  const issues: WhitespaceIssue[] = []
+function isPlaceholder(element: MessageFormatElement): boolean {
+  return element.type !== TYPE.literal && element.type !== TYPE.tag
+}
+
+function findMessageIssues(ast: MessageFormatElement[]): MessageIssue[] {
+  const issues: MessageIssue[] = []
 
   const first = getFirstBoundaryElement(ast)
   const last = getLastBoundaryElement(ast)
@@ -66,16 +73,34 @@ function findWhitespaceIssues(ast: MessageFormatElement[]): WhitespaceIssue[] {
     issues.push('trailingWhitespace')
   }
 
-  // Check each plural/select option branch independently
+  for (let index = 0; index < ast.length - 1; index++) {
+    const current = ast[index]
+    const next = ast[index + 1]
+    if (
+      (current.type === TYPE.literal &&
+        /\p{L}$/u.test(current.value) &&
+        isPlaceholder(next)) ||
+      (isPlaceholder(current) &&
+        next.type === TYPE.literal &&
+        /^\p{L}/u.test(next.value))
+    ) {
+      issues.push('placeholderAdjacentToWord')
+    }
+  }
+
+  // Check nested message branches independently.
   for (const element of ast) {
     switch (element.type) {
       case TYPE.plural:
       case TYPE.select: {
         for (const option of Object.values(element.options)) {
-          issues.push(...findWhitespaceIssues(option.value))
+          issues.push(...findMessageIssues(option.value))
         }
         break
       }
+      case TYPE.tag:
+        issues.push(...findMessageIssues(element.children))
+        break
     }
   }
 
@@ -107,7 +132,7 @@ function checkNode(context: Rule.RuleContext, node: Node) {
       return
     }
 
-    const issues = findWhitespaceIssues(ast)
+    const issues = findMessageIssues(ast)
 
     // Deduplicate
     const seen = new Set<string>()
@@ -138,6 +163,8 @@ export const rule: Rule.RuleModule = {
         'Messages should be full sentences — leading whitespace suggests string concatenation',
       trailingWhitespace:
         'Messages should be full sentences — trailing whitespace suggests string concatenation',
+      placeholderAdjacentToWord:
+        'Placeholders should not be joined directly to words or units — use ICU syntax or an Intl formatter',
     },
     schema: [],
   },

--- a/packages/eslint-plugin-formatjs/tests/prefer-full-sentence.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/prefer-full-sentence.test.ts
@@ -99,6 +99,26 @@ ruleTester.run(name, rule, {
       code: `import {defineMessage} from 'react-intl';defineMessage({defaultMessage: 'Hello {name} '})`,
       errors: [{messageId: 'trailingWhitespace'}],
     },
+    // Placeholder joined to a unit
+    {
+      code: `import {defineMessage} from 'react-intl';defineMessage({defaultMessage: '{count}day'})`,
+      errors: [{messageId: 'placeholderAdjacentToWord'}],
+    },
+    // Formatted placeholder joined to a unit abbreviation
+    {
+      code: `import {defineMessage} from 'react-intl';defineMessage({defaultMessage: '{size, number}MB'})`,
+      errors: [{messageId: 'placeholderAdjacentToWord'}],
+    },
+    // Word joined before a placeholder
+    {
+      code: `import {defineMessage} from 'react-intl';defineMessage({defaultMessage: 'USD{amount}'})`,
+      errors: [{messageId: 'placeholderAdjacentToWord'}],
+    },
+    // Pound placeholder joined to a pluralized unit
+    {
+      code: `import {defineMessage} from 'react-intl';defineMessage({defaultMessage: '{count, plural, one {#day} other {#days}}'})`,
+      errors: [{messageId: 'placeholderAdjacentToWord'}],
+    },
     // JSX
     {
       code: `<FormattedMessage defaultMessage=" hello" />`,


### PR DESCRIPTION
## Problem

Messages such as `{count}day` and `{size, number}MB` bake English unit placement into ICU text. Hand-declared weekday or month tables similarly duplicate locale data.

## Changes

- extend `prefer-full-sentence` to report placeholders joined directly to words, including nested plural/select/tag messages
- add focused coverage for suffixes, prefixes, formatted numbers, and plural `#`
- document ICU/Intl unit formatting and locale-aware calendar names

Closes #7035
