### PR TITLE
fix: recover partial npm releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 2
 
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.19.0
@@ -87,10 +89,33 @@ jobs:
         env:
           PATHS_RELEASED: ${{ steps.release.outputs.paths_released || '[]' }}
         run: |
-          node <<'JS'
-          const fs = require('node:fs')
-          const paths = JSON.parse(process.env.PATHS_RELEASED || '[]')
-          const npmPaths = paths.filter(path => path.startsWith('packages/'))
+          previous_manifest="$RUNNER_TEMP/release-please-manifest.previous.json"
+          if ! git show HEAD^:.release-please-manifest.json > "$previous_manifest"; then
+            echo '{}' > "$previous_manifest"
+          fi
+
+          CURRENT_MANIFEST=.release-please-manifest.json \
+          PREVIOUS_MANIFEST="$previous_manifest" \
+          node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-transform-types --input-type=module <<'JS'
+          import fs from 'node:fs'
+
+          const {collectNpmReleasePaths} = await import(
+            './tools/release-please/npm-release-paths.ts'
+          )
+          const currentManifest = JSON.parse(
+            fs.readFileSync(process.env.CURRENT_MANIFEST, 'utf8')
+          )
+          const previousManifest = JSON.parse(
+            fs.readFileSync(process.env.PREVIOUS_MANIFEST, 'utf8')
+          )
+          const pathsReleased = JSON.parse(
+            process.env.PATHS_RELEASED || '[]'
+          )
+          const npmPaths = collectNpmReleasePaths(
+            previousManifest,
+            currentManifest,
+            pathsReleased
+          )
           fs.appendFileSync(
             process.env.GITHUB_OUTPUT,
             `npm_paths=${JSON.stringify(npmPaths)}\n`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   build_windows_native:
     name: Build Windows Native Package
-    if: ${{ inputs.npm_paths != '[]' }}
+    if: ${{ contains(fromJSON(inputs.npm_paths), 'packages/cli-native-win32-x64') }}
     runs-on: windows-latest
 
     steps:
@@ -66,7 +66,7 @@ jobs:
 
   build_linux_musl_native:
     name: Build Linux musl Native Package (${{ matrix.arch }})
-    if: ${{ inputs.npm_paths != '[]' }}
+    if: ${{ contains(fromJSON(inputs.npm_paths), 'packages/cli-native-linux-x64-musl') || contains(fromJSON(inputs.npm_paths), 'packages/cli-native-linux-arm64-musl') }}
     runs-on: ${{ matrix.runner }}
 
     strategy:
@@ -129,7 +129,7 @@ jobs:
     needs:
       - build_windows_native
       - build_linux_musl_native
-    if: ${{ inputs.npm_paths != '[]' }}
+    if: ${{ always() && inputs.npm_paths != '[]' && (needs.build_windows_native.result == 'success' || needs.build_windows_native.result == 'skipped') && (needs.build_linux_musl_native.result == 'success' || needs.build_linux_musl_native.result == 'skipped') }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -170,18 +170,21 @@ jobs:
           chmod -R +w release/
 
       - name: Download Windows Native Package
+        if: ${{ contains(fromJSON(inputs.npm_paths), 'packages/cli-native-win32-x64') }}
         uses: actions/download-artifact@v8
         with:
           name: cli-native-win32-x64
           path: release/packages/cli-native-win32-x64
 
       - name: Download Linux x64 musl Native Package
+        if: ${{ contains(fromJSON(inputs.npm_paths), 'packages/cli-native-linux-x64-musl') }}
         uses: actions/download-artifact@v8
         with:
           name: cli-native-linux-x64-musl
           path: release/packages/cli-native-linux-x64-musl
 
       - name: Download Linux arm64 musl Native Package
+        if: ${{ contains(fromJSON(inputs.npm_paths), 'packages/cli-native-linux-arm64-musl') }}
         uses: actions/download-artifact@v8
         with:
           name: cli-native-linux-arm64-musl
@@ -189,6 +192,8 @@ jobs:
 
       - name: Prepare npm Package Manifests
         working-directory: release
+        env:
+          NPM_RELEASE_PATHS: ${{ inputs.npm_paths }}
         run: |
           node <<'JS'
           const fs = require('node:fs')
@@ -209,6 +214,16 @@ jobs:
             file,
             packageJson: JSON.parse(fs.readFileSync(file, 'utf8')),
           }))
+          const publishManifests = JSON.parse(
+            process.env.NPM_RELEASE_PATHS || '[]'
+          ).map(packagePath => {
+            const file = path.join(process.cwd(), packagePath, 'package.json')
+            const manifest = manifests.find(manifest => manifest.file === file)
+            if (!manifest) {
+              throw new Error(`Missing release package manifest: ${file}`)
+            }
+            return manifest
+          })
           const packageVersions = new Map(
             manifests.map(({packageJson}) => [
               packageJson.name,
@@ -217,7 +232,7 @@ jobs:
           )
           let replacements = 0
 
-          for (const {file, packageJson} of manifests) {
+          for (const {file, packageJson} of publishManifests) {
             let changed = false
 
             for (const field of dependencyFields) {
@@ -284,6 +299,24 @@ jobs:
               exit 1
             fi
 
-            echo "Publishing $package_path"
-            (cd "$package_path" && pnpm publish --access public --no-git-checks)
+            package_spec="$(
+              node -e 'const pkg = require(`./${process.argv[1]}/package.json`); process.stdout.write(`${pkg.name}@${pkg.version}`)' "$package_path"
+            )"
+            if npm view "$package_spec" version --json >/dev/null 2>&1; then
+              echo "Skipping already published $package_spec"
+              continue
+            fi
+
+            echo "Publishing $package_spec"
+            if (cd "$package_path" && pnpm publish --access public --no-git-checks); then
+              continue
+            fi
+
+            # A concurrent or partially completed run may have published it.
+            if npm view "$package_spec" version --json >/dev/null 2>&1; then
+              echo "Skipping concurrently published $package_spec"
+              continue
+            fi
+
+            exit 1
           done

--- a/knowledge-base/001-repo-layout.md
+++ b/knowledge-base/001-repo-layout.md
@@ -120,6 +120,11 @@ dependency maintenance does not hide user-facing changes.
 For npm packages, Release Please advances versions in both package-local Bazel
 `BUILD.bazel` `x-release-please-version` markers and checked-in `package.json`
 files; `package_json_sync` keeps the rest of each generated manifest in sync.
+The workflow also derives npm publish paths from the release manifest diff so
+a retry still publishes packages whose GitHub releases were created before a
+partial failure. npm publishing skips versions already present in the registry,
+prepares only requested package manifests, and builds native CLI artifacts only
+when their package paths are released.
 When Release Please creates or updates release PRs,
 `.github/workflows/release-please.yml` first builds
 `//:release_please_npm_workspace_graph` from the package manifests and runs the

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -76,6 +76,14 @@ js_test(
     node_options = ["--disable-warning=MODULE_TYPELESS_PACKAGE_JSON"],
 )
 
+js_test(
+    name = "release_please_npm_release_paths_test",
+    size = "small",
+    data = ["release-please/npm-release-paths.ts"],
+    entry_point = "release-please/npm-release-paths.test.ts",
+    node_options = ["--disable-warning=MODULE_TYPELESS_PACKAGE_JSON"],
+)
+
 formatjs_package_json(
     name = "package_json_fixture",
     package_name = "@formatjs/package-json-fixture",

--- a/tools/release-please/npm-release-paths.test.ts
+++ b/tools/release-please/npm-release-paths.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict'
+
+import {collectNpmReleasePaths} from './npm-release-paths.ts'
+
+assert.deepEqual(
+  collectNpmReleasePaths(
+    {
+      'crates/parser': '1.0.0',
+      'packages/parser': '1.0.0',
+      'packages/plugin': '2.0.0',
+    },
+    {
+      'crates/parser': '1.1.0',
+      'packages/parser': '1.1.0',
+      'packages/plugin': '2.0.0',
+    },
+    []
+  ),
+  ['packages/parser']
+)
+
+assert.deepEqual(
+  collectNpmReleasePaths(
+    {'packages/parser': '1.0.0'},
+    {'packages/parser': '1.1.0', 'packages/plugin': '2.0.0'},
+    ['packages/plugin', 'crates/parser']
+  ),
+  ['packages/plugin', 'packages/parser']
+)
+
+console.log('Verified npm release path recovery')

--- a/tools/release-please/npm-release-paths.ts
+++ b/tools/release-please/npm-release-paths.ts
@@ -1,0 +1,19 @@
+export type ReleaseManifest = Record<string, string>
+
+export function collectNpmReleasePaths(
+  previousManifest: ReleaseManifest,
+  currentManifest: ReleaseManifest,
+  pathsReleased: string[]
+): string[] {
+  const npmPaths = new Set(
+    pathsReleased.filter(path => path.startsWith('packages/'))
+  )
+
+  for (const [path, version] of Object.entries(currentManifest)) {
+    if (path.startsWith('packages/') && previousManifest[path] !== version) {
+      npmPaths.add(path)
+    }
+  }
+
+  return [...npmPaths]
+}


### PR DESCRIPTION
Fixes #7049
Fixes #7052

Release Please can create some GitHub releases before a transient failure. On
retry, `paths_released` only contains newly created releases, so earlier npm
packages never reach the publish workflow.

- Recover npm paths from the release manifest diff.
- Skip package versions already published, making publish retries safe.
- Build native CLI artifacts only when those packages are being released.

Validation:

- `bazel test //tools:release_please_npm_release_paths_test --test_output=errors`
- `oxfmt@0.62.0` on changed files
- workflow YAML parse
- `buildifier -mode=check tools/BUILD.bazel`

Backfill run [32047804553](https://github.com/formatjs/formatjs/actions/runs/32047804553)
published all seven missing npm package versions through trusted publishing.
