### PR TITLE
docs: add agent skills overview

### DIFF
--- a/docs/public/sitemap.xml
+++ b/docs/public/sitemap.xml
@@ -266,6 +266,11 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://formatjs.io/docs/skills</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://formatjs.io/docs/skills/localization-review</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>

--- a/docs/src/docs-metadata.generated.json
+++ b/docs/src/docs-metadata.generated.json
@@ -207,6 +207,10 @@
     "title": "Intl",
     "description": "---"
   },
+  "skills": {
+    "title": "Skills",
+    "description": "FormatJS agent skills review and translate localized UI and message catalogs."
+  },
   "skills/localization-review": {
     "title": "Localization Review",
     "description": "Review localized UI and translations without changing files, pull requests,"

--- a/docs/src/docs/skills.mdx
+++ b/docs/src/docs/skills.mdx
@@ -1,0 +1,30 @@
+# Agent Skills
+
+FormatJS agent skills review and translate localized UI and message catalogs.
+
+## Localization Review
+
+[Localization Review](/docs/skills/localization-review) checks user-facing
+copy, translations, and pull requests for:
+
+- Valid ICU MessageFormat syntax and placeholders.
+- Locale-aware formatting, plural rules, and accessibility.
+- Glossary compliance, protected terms, and translation readiness.
+
+The review skill reports evidence-backed findings without changing files or
+external systems.
+
+## Translate
+
+[Translate](/docs/skills/translate) creates or repairs localized UI copy and
+message catalogs while preserving:
+
+- Source meaning and approved product terminology.
+- ICU arguments, plural branches, and rich-text markup.
+- Locale-specific grammar, formatting, and accessibility context.
+
+## Discover Skills
+
+Agents can discover available skills through the
+[agent skills index](/.well-known/agent-skills/index.json). Skill instructions
+live in the FormatJS repository under `.agents/skills/`.

--- a/docs/src/utils/navigation.ts
+++ b/docs/src/utils/navigation.ts
@@ -155,6 +155,7 @@ export function getNavigationTree(): NavSection[] {
       title: 'Skills',
       order: 8,
       items: [
+        {title: 'Overview', path: 'skills'},
         {title: 'Localization Review', path: 'skills/localization-review'},
         {title: 'Translate', path: 'skills/translate'},
       ],


### PR DESCRIPTION
## Summary
- add a landing page for /docs/skills
- link localization review and translation skills from the sidebar and overview
- regenerate docs metadata and sitemap

## Test plan
- bazel test //docs/...
- bazel build //docs:dist