### PR TITLE
feat(eslint-plugin-formatjs): allow conditional ICU element blocklists

### DIFF
--- a/docs/src/docs/tooling/linter.mdx
+++ b/docs/src/docs/tooling/linter.mdx
@@ -167,11 +167,29 @@ export default [
       formatjs,
     },
     rules: {
-      'formatjs/blocklist-elements': [2, ['selectordinal']],
+      'formatjs/blocklist-elements': [
+        2,
+        [
+          'selectordinal',
+          {
+            type: 'select',
+            allow: {
+              variable: 'gender',
+              options: ['male', 'female', 'other'],
+            },
+          },
+        ],
+      ],
     },
   },
 ]
 ```
+
+String entries block every element of that type. Object entries allow an
+exception for the named variable. When `options` is present, selector options
+must match that list exactly. Both `recommended` and `strict` block
+`selectordinal` and allow `select` only for `gender` with `male`, `female`, and
+`other` options.
 
 ### `enforce-description`
 

--- a/knowledge-base/009-package-developer-tools.md
+++ b/knowledge-base/009-package-developer-tools.md
@@ -53,6 +53,12 @@
 - Validate message syntax
 - Enforce consistent ID patterns
 
+`blocklist-elements` accepts blocked element names or objects containing `type`
+and an `allow` exception. Exceptions match a `variable` and, when configured,
+the exact selector `options`. The `recommended` and `strict` configs block
+`selectordinal` and restrict `select` to `gender` with `male`, `female`, and
+`other` options.
+
 **Peer dep:** `eslint@9 || 10`
 
 ## @formatjs/cli-lib

--- a/packages/eslint-plugin-formatjs/index.ts
+++ b/packages/eslint-plugin-formatjs/index.ts
@@ -173,7 +173,16 @@ const configs: Plugin['configs'] = {
           },
         },
       ],
-      'formatjs/blocklist-elements': ['error', ['selectordinal']],
+      'formatjs/blocklist-elements': [
+        'error',
+        [
+          'selectordinal',
+          {
+            type: 'select',
+            allow: {variable: 'gender', options: ['male', 'female', 'other']},
+          },
+        ],
+      ],
       'formatjs/prefer-full-sentence': 'error',
     },
   },
@@ -207,7 +216,16 @@ const configs: Plugin['configs'] = {
           },
         },
       ],
-      'formatjs/blocklist-elements': ['error', ['selectordinal']],
+      'formatjs/blocklist-elements': [
+        'error',
+        [
+          'selectordinal',
+          {
+            type: 'select',
+            allow: {variable: 'gender', options: ['male', 'female', 'other']},
+          },
+        ],
+      ],
       'formatjs/prefer-full-sentence': 'error',
     },
   },

--- a/packages/eslint-plugin-formatjs/rules/blocklist-elements.ts
+++ b/packages/eslint-plugin-formatjs/rules/blocklist-elements.ts
@@ -47,37 +47,88 @@ export enum Element {
   tag = 'tag',
 }
 
-function verifyAst(blocklist: Element[], ast: MessageFormatElement[]) {
+interface BlocklistException {
+  variable: string
+  options?: string[]
+}
+
+type BlocklistedElement =
+  | Element
+  | {
+      type: Element
+      allow: BlocklistException
+    }
+
+function isBlocklisted(
+  blocklist: BlocklistedElement[],
+  type: Element,
+  element: MessageFormatElement
+): boolean {
+  return blocklist.some(entry => {
+    if (typeof entry === 'string') {
+      return entry === type
+    }
+    if (entry.type !== type) {
+      return false
+    }
+    if (!('value' in element) || element.value !== entry.allow.variable) {
+      return true
+    }
+    const allowedOptions = entry.allow.options
+    if (!allowedOptions) {
+      return false
+    }
+    if (!isSelectElement(element) && !isPluralElement(element)) {
+      return true
+    }
+    const options = Object.keys(element.options)
+    return (
+      options.length !== allowedOptions.length ||
+      options.some(option => !allowedOptions.includes(option))
+    )
+  })
+}
+
+function verifyAst(
+  blocklist: BlocklistedElement[],
+  ast: MessageFormatElement[]
+) {
   const errors: ReturnType<typeof getMessage>[] = []
   for (const el of ast) {
-    if (isLiteralElement(el) && blocklist.includes(Element.literal)) {
+    if (isLiteralElement(el) && isBlocklisted(blocklist, Element.literal, el)) {
       errors.push(getMessage(Element.literal))
     }
-    if (isArgumentElement(el) && blocklist.includes(Element.argument)) {
+    if (
+      isArgumentElement(el) &&
+      isBlocklisted(blocklist, Element.argument, el)
+    ) {
       errors.push(getMessage(Element.argument))
     }
-    if (isNumberElement(el) && blocklist.includes(Element.number)) {
+    if (isNumberElement(el) && isBlocklisted(blocklist, Element.number, el)) {
       errors.push(getMessage(Element.number))
     }
-    if (isDateElement(el) && blocklist.includes(Element.date)) {
+    if (isDateElement(el) && isBlocklisted(blocklist, Element.date, el)) {
       errors.push(getMessage(Element.date))
     }
-    if (isTimeElement(el) && blocklist.includes(Element.time)) {
+    if (isTimeElement(el) && isBlocklisted(blocklist, Element.time, el)) {
       errors.push(getMessage(Element.time))
     }
-    if (isSelectElement(el) && blocklist.includes(Element.select)) {
+    if (isSelectElement(el) && isBlocklisted(blocklist, Element.select, el)) {
       errors.push(getMessage(Element.select))
     }
-    if (isTagElement(el) && blocklist.includes(Element.tag)) {
+    if (isTagElement(el) && isBlocklisted(blocklist, Element.tag, el)) {
       errors.push(getMessage(Element.tag))
     }
+    if (isTagElement(el)) {
+      errors.push(...verifyAst(blocklist, el.children))
+    }
     if (isPluralElement(el)) {
-      if (blocklist.includes(Element.plural)) {
+      if (isBlocklisted(blocklist, Element.plural, el)) {
         errors.push(getMessage(Element.argument))
       }
       if (
         el.pluralType === 'ordinal' &&
-        blocklist.includes(Element.selectordinal)
+        isBlocklisted(blocklist, Element.selectordinal, el)
       ) {
         errors.push(getMessage(Element.selectordinal))
       }
@@ -85,7 +136,7 @@ function verifyAst(blocklist: Element[], ast: MessageFormatElement[]) {
     if (isSelectElement(el) || isPluralElement(el)) {
       const {options} = el
       for (const selector of Object.keys(options)) {
-        verifyAst(blocklist, options[selector].value)
+        errors.push(...verifyAst(blocklist, options[selector].value))
       }
     }
   }
@@ -150,8 +201,36 @@ export const rule: Rule.RuleModule = {
       {
         type: 'array',
         items: {
-          type: 'string',
-          enum: Object.keys(Element),
+          oneOf: [
+            {
+              type: 'string',
+              enum: Object.keys(Element),
+            },
+            {
+              type: 'object',
+              additionalProperties: false,
+              required: ['type', 'allow'],
+              properties: {
+                type: {
+                  type: 'string',
+                  enum: Object.keys(Element),
+                },
+                allow: {
+                  type: 'object',
+                  additionalProperties: false,
+                  required: ['variable'],
+                  properties: {
+                    variable: {type: 'string'},
+                    options: {
+                      type: 'array',
+                      uniqueItems: true,
+                      items: {type: 'string'},
+                    },
+                  },
+                },
+              },
+            },
+          ],
         },
       },
     ],

--- a/packages/eslint-plugin-formatjs/tests/blocklist-elements.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/blocklist-elements.test.ts
@@ -14,8 +14,27 @@ import {
   vueRuleTester,
 } from '#packages/eslint-plugin-formatjs/tests/util'
 
+const genderSelect = {
+  type: Element.select,
+  allow: {variable: 'gender', options: ['male', 'female', 'other']},
+}
+
 ruleTester.run(name, rule, {
   valid: [
+    {
+      code: `import {defineMessage} from 'react-intl'
+  defineMessage({
+      defaultMessage: '{gender, select, female {She} male {He} other {They}}'
+  })`,
+      options: [[genderSelect]],
+    },
+    {
+      code: `import {defineMessage} from 'react-intl'
+  defineMessage({
+      defaultMessage: '{foo}'
+  })`,
+      options: [[{type: Element.argument, allow: {variable: 'foo'}}]],
+    },
     {
       code: `import {defineMessage} from 'react-intl'
   defineMessage({
@@ -53,6 +72,54 @@ ruleTester.run(name, rule, {
     emptyFnCall,
   ],
   invalid: [
+    {
+      code: `import {defineMessage} from 'react-intl'
+  defineMessage({
+      defaultMessage: '{status, select, male {He} female {She} other {They}}'
+  })`,
+      options: [[genderSelect]],
+      errors: [{messageId: 'blocklist', data: {type: 'select'}}],
+    },
+    {
+      code: `import {defineMessage} from 'react-intl'
+  defineMessage({
+      defaultMessage: '{gender, select, male {He} other {They}}'
+  })`,
+      options: [[genderSelect]],
+      errors: [{messageId: 'blocklist', data: {type: 'select'}}],
+    },
+    {
+      code: `import {defineMessage} from 'react-intl'
+  defineMessage({
+      defaultMessage: '{gender, select, male {He} female {She} nonbinary {They} other {They}}'
+  })`,
+      options: [[genderSelect]],
+      errors: [{messageId: 'blocklist', data: {type: 'select'}}],
+    },
+    {
+      code: `import {defineMessage} from 'react-intl'
+  defineMessage({
+      defaultMessage: '{gender, select, male {{status, select, active {He} other {They}}} female {She} other {They}}'
+  })`,
+      options: [[genderSelect]],
+      errors: [{messageId: 'blocklist', data: {type: 'select'}}],
+    },
+    {
+      code: `import {defineMessage} from 'react-intl'
+  defineMessage({
+      defaultMessage: '<strong>{status, select, active {Active} other {Inactive}}</strong>'
+  })`,
+      options: [[genderSelect]],
+      errors: [{messageId: 'blocklist', data: {type: 'select'}}],
+    },
+    {
+      code: `import {defineMessage} from 'react-intl'
+  defineMessage({
+      defaultMessage: '{bar}'
+  })`,
+      options: [[{type: Element.argument, allow: {variable: 'foo'}}]],
+      errors: [{messageId: 'blocklist', data: {type: 'argument'}}],
+    },
     {
       code: `
               import {defineMessage} from 'react-intl'
@@ -93,6 +160,14 @@ vueRuleTester.run(`vue-${name}`, rule, {
     {
       code: `<template>
       <p>{{ $formatMessage({
+        defaultMessage: '{gender, select, male {He} female {She} other {They} }'
+      }) }}</p>
+    </template>`,
+      options: [[genderSelect]],
+    },
+    {
+      code: `<template>
+      <p>{{ $formatMessage({
         defaultMessage: '{count, plural, offset:1 one {#} other {# more} }'
       }) }} World!</p>
     </template>`,
@@ -103,6 +178,15 @@ vueRuleTester.run(`vue-${name}`, rule, {
     {code: `<script>${emptyFnCall.code}</script>`},
   ],
   invalid: [
+    {
+      code: `<template>
+      <p>{{ $formatMessage({
+        defaultMessage: '{status, select, active {Active} other {Inactive} }'
+      }) }}</p>
+    </template>`,
+      options: [[genderSelect]],
+      errors: [{messageId: 'blocklist', data: {type: 'select'}}],
+    },
     {
       code: `
               <script>


### PR DESCRIPTION
Allow ICU element blocklist exceptions by variable and exact selector options. Recommended and strict configs now only allow gender selects with male, female, and other options. Covers nested ICU elements and Vue templates.