### PR TITLE
test: use neutral brands in skill evals

### DIFF
--- a/.agents/evals/cases/localization-review.json
+++ b/.agents/evals/cases/localization-review.json
@@ -37,11 +37,11 @@
     },
     {
       "id": "brand-placeholder",
-      "request": "Review this message: `{brand} helps you find answers.` The runtime always passes the fixed product name `Perplexity`; this is not tenant data.",
+      "request": "Review this message: `{brand} helps you find answers.` The runtime always passes the fixed product name `Northstar`; this is not tenant data.",
       "expect": {
         "outcome": "arbitration-needed",
         "labelsInclude": ["deterministic-error"],
-        "answerIncludes": ["Perplexity"]
+        "answerIncludes": ["Northstar"]
       }
     },
     {

--- a/.agents/evals/cases/translate.json
+++ b/.agents/evals/cases/translate.json
@@ -11,11 +11,11 @@
     },
     {
       "id": "spanish-protected-brand",
-      "request": "Translate `Ask Perplexity about {count} topics.` to Spanish. Glossary: `Perplexity` is do-not-translate. Return the translated message.",
+      "request": "Translate `Ask Northstar about {count} topics.` to Spanish. Glossary: `Northstar` is do-not-translate. Return the translated message.",
       "expect": {
         "outcome": "pass",
-        "answerIncludes": ["Perplexity", "{count}"],
-        "answerExcludes": ["Perplejidad"]
+        "answerIncludes": ["Northstar", "{count}"],
+        "answerExcludes": ["Estrella del Norte"]
       }
     },
     {


### PR DESCRIPTION
Replace company-specific examples in localization skill evals with a neutral fictional brand. Keeps protected-brand and fixed-brand coverage unchanged.

Test: `bazel test //.agents/evals:eval_test --test_output=errors`