### PR TITLE
fix: tighten formatted value placeholder guidance

### DIFF
--- a/.agents/evals/cases/localization-review.json
+++ b/.agents/evals/cases/localization-review.json
@@ -36,6 +36,23 @@
       }
     },
     {
+      "id": "empty-rich-text-element-slots",
+      "request": "Review this React Intl message: `<regularPrice></regularPrice> <discountedPrice></discountedPrice> per month`. Both tags receive functions that return `<FormattedNumber>` elements.",
+      "expect": {
+        "outcome": "arbitration-needed",
+        "labelsInclude": ["deterministic-error"],
+        "answerIncludes": ["element slots"]
+      }
+    },
+    {
+      "id": "rich-text-with-content",
+      "request": "Review this React Intl message: `<strong>Save now</strong> to get {discount, number, ::percent} off`. `strong` wraps chunks in `<strong>`, and `discount` is the raw number `0.2`.",
+      "expect": {
+        "outcome": "pass",
+        "labelsExclude": ["deterministic-error", "ambiguous", "blocked"]
+      }
+    },
+    {
       "id": "brand-placeholder",
       "request": "Review this message: `{brand} helps you find answers.` The runtime always passes the fixed product name `Northstar`; this is not tenant data.",
       "expect": {

--- a/.agents/evals/cases/localization-review.json
+++ b/.agents/evals/cases/localization-review.json
@@ -36,6 +36,24 @@
       }
     },
     {
+      "id": "preformatted-number-element",
+      "request": "Review this React Intl message: `{priceFormatted} per month`. `priceFormatted` receives `<FormattedNumber value={price} style=\"currency\" currency=\"USD\" />`.",
+      "expect": {
+        "outcome": "arbitration-needed",
+        "labelsInclude": ["deterministic-error"],
+        "answerIncludes": ["currency/USD"]
+      }
+    },
+    {
+      "id": "preformatted-date-placeholder",
+      "request": "Review this React Intl message: `Renews on {renewalDateFormatted}`. `renewalDateFormatted` receives the string returned by `intl.formatDate(renewalDate)`.",
+      "expect": {
+        "outcome": "arbitration-needed",
+        "labelsInclude": ["deterministic-error"],
+        "answerIncludes": ["date", "skeleton"]
+      }
+    },
+    {
       "id": "empty-rich-text-element-slots",
       "request": "Review this React Intl message: `<regularPrice></regularPrice> <discountedPrice></discountedPrice> per month`. Both tags receive functions that return `<FormattedNumber>` elements.",
       "expect": {

--- a/.agents/skills/localization-review/SKILL.md
+++ b/.agents/skills/localization-review/SKILL.md
@@ -112,6 +112,34 @@ Separate translation units gain precise descriptions. Required `other` branch ca
 
 Use ICU number or date skeletons when value belongs inside sentence.
 
+Rich-text tags must wrap translatable text. Flag empty tag pairs used as slots
+for elements. They add ICU syntax without giving translators text to style and
+can become unbalanced in translations. Use a plain argument with the element
+as its value instead.
+
+```tsx
+// Avoid: empty tags are positional element slots.
+<FormattedMessage
+  defaultMessage="<regularPrice></regularPrice> <discountedPrice></discountedPrice> per month"
+  values={{
+    regularPrice: () => <FormattedNumber value={regularPrice} />,
+    discountedPrice: () => <FormattedNumber value={discountedPrice} />,
+  }}
+/>
+
+// Prefer: plain arguments receive elements directly.
+<FormattedMessage
+  defaultMessage="{regularPrice} {discountedPrice} per month"
+  values={{
+    regularPrice: <FormattedNumber value={regularPrice} />,
+    discountedPrice: <FormattedNumber value={discountedPrice} />,
+  }}
+/>
+```
+
+Keep rich-text tags when they wrap translatable content, such as
+`<strong>Save now</strong>`.
+
 ```tsx
 intl.formatMessage(
   {

--- a/.agents/skills/localization-review/SKILL.md
+++ b/.agents/skills/localization-review/SKILL.md
@@ -110,15 +110,19 @@ Separate translation units gain precise descriptions. Required `other` branch ca
 
 ## Format values natively
 
-Use ICU number or date skeletons when value belongs inside sentence.
+Prefer inline skeletons over preformatted placeholders. Sentence embeds number,
+percentage, or date expressible by skeleton: keep skeleton in message. Flag
+placeholders receiving `formatNumber` or `formatDate` output, or
+`<FormattedNumber>` or `<FormattedDate>` elements. Names such as
+`{priceFormatted}` or `{discountPercentageFormatted}` strongly signal this bug.
 
-Rich-text tags must wrap translatable text. Flag empty tag pairs used as slots
-for elements. They add ICU syntax without giving translators text to style and
-can become unbalanced in translations. Use a plain argument with the element
-as its value instead.
+Never use empty rich-text tag pair as element slot. Tags wrap translatable text.
+Empty tag is semantically argument. Flag any `defaultMessage` containing
+`<tag></tag>` with no children. Suggest plain `{placeholder}` receiving element
+as value.
 
 ```tsx
-// Avoid: empty tags are positional element slots.
+// Avoid: empty tags are element slots.
 <FormattedMessage
   defaultMessage="<regularPrice></regularPrice> <discountedPrice></discountedPrice> per month"
   values={{
@@ -127,7 +131,7 @@ as its value instead.
   }}
 />
 
-// Prefer: plain arguments receive elements directly.
+// Prefer: plain arguments receive elements.
 <FormattedMessage
   defaultMessage="{regularPrice} {discountedPrice} per month"
   values={{

--- a/.agents/skills/localization-review/SKILL.md
+++ b/.agents/skills/localization-review/SKILL.md
@@ -116,6 +116,26 @@ placeholders receiving `formatNumber` or `formatDate` output, or
 `<FormattedNumber>` or `<FormattedDate>` elements. Names such as
 `{priceFormatted}` or `{discountPercentageFormatted}` strongly signal this bug.
 
+```tsx
+// Avoid: message receives preformatted elements.
+<FormattedMessage
+  defaultMessage="Save {discountFormatted} on {priceFormatted} until {dateFormatted}"
+  values={{
+    discountFormatted: <FormattedNumber value={discount} style="percent" />,
+    priceFormatted: (
+      <FormattedNumber value={price} style="currency" currency="USD" />
+    ),
+    dateFormatted: <FormattedDate value={renewalDate} />,
+  }}
+/>
+
+// Prefer: message owns skeletons; values stay raw.
+<FormattedMessage
+  defaultMessage="Save {discount, number, ::percent} on {price, number, ::currency/USD} until {renewalDate, date, ::yyyyMMdd}"
+  values={{discount, price, renewalDate}}
+/>
+```
+
 Never use empty rich-text tag pair as element slot. Tags wrap translatable text.
 Empty tag is semantically argument. Flag any `defaultMessage` containing
 `<tag></tag>` with no children. Suggest plain `{placeholder}` receiving element


### PR DESCRIPTION
Closes #7098.

Strengthens localization-review guidance:
- prefer inline ICU skeletons over preformatted number, percentage, and date placeholders
- flag empty rich-text tag pairs used as element slots
- keep valid rich-text tags wrapping translatable content

Adds positive and negative eval cases for both rules.

Tests:
- `bazel test //.agents/evals:eval_test --test_output=errors`
- `bazel test //.agents/evals:localization_review_eval_test --test_output=streamed`
- pre-commit and commit-msg hooks