### PR TITLE
fix: retain binary-only Cargo release candidates

### DIFF
--- a/knowledge-base/001-repo-layout.md
+++ b/knowledge-base/001-repo-layout.md
@@ -141,9 +141,10 @@ Publishing, then publishes only the package paths Release Please released. Rust
 crate publishing happens in
 `crates-release.yml` from crate GitHub releases using crates.io trusted
 publishing. `formatjs_cli` is binary-only and excluded from crates.io publishing.
-The custom Cargo workspace plugin excludes crates with `package.publish = false`
-before dependency release propagation. Crate release
-runs share a FIFO `queue: max` concurrency group so
+The custom Cargo workspace plugin excludes noncandidate crates with
+`package.publish = false` or `publish = []` before dependency release
+propagation. It retains explicit binary-only candidates such as `formatjs_cli`.
+Crate release runs share a FIFO `queue: max` concurrency group so
 dependency-ordered releases wait instead of replacing pending runs. The Rust
 CLI binary artifacts remain Bazel-owned in
 `rust-cli-release.yml`. Its release build job runs on Linux, uses BuildBuddy RBE

--- a/tools/release-please/cargo-workspace-plugin.test.ts
+++ b/tools/release-please/cargo-workspace-plugin.test.ts
@@ -12,8 +12,14 @@ const packages = {
       manifest: {package: {name: 'published'}},
     },
     {
-      name: 'private',
-      manifest: {package: {name: 'private', publish: false}},
+      name: 'private-release-component',
+      manifest: {package: {name: 'private-release-component', publish: false}},
+    },
+    {
+      name: 'private-workspace-dependency',
+      manifest: {
+        package: {name: 'private-workspace-dependency', publish: false},
+      },
     },
     {
       name: 'private-empty-registries',
@@ -26,9 +32,8 @@ const packages = {
   ],
   candidatesByPackage: {
     published: {path: 'crates/published'},
-    private: {path: 'crates/private'},
-    'private-empty-registries': {
-      path: 'crates/private-empty-registries',
+    'private-release-component': {
+      path: 'crates/private-release-component',
     },
     'private-registry': {path: 'crates/private-registry'},
   },
@@ -45,10 +50,11 @@ const result = await new FormatjsCargoWorkspace().buildAllPackages([])
 
 assert.deepEqual(
   result.allPackages.map(pkg => pkg.name),
-  ['published', 'private-registry']
+  ['published', 'private-release-component', 'private-registry']
 )
 assert.deepEqual(Object.keys(result.candidatesByPackage), [
   'published',
+  'private-release-component',
   'private-registry',
 ])
 

--- a/tools/release-please/cargo-workspace-plugin.ts
+++ b/tools/release-please/cargo-workspace-plugin.ts
@@ -18,23 +18,26 @@ interface WorkspacePluginOptions extends Record<string, unknown> {
   type?: unknown
 }
 
-export function filterPublishableCrates({
+export function filterReleaseCrates({
   allPackages,
   candidatesByPackage,
 }: CargoWorkspacePackages): CargoWorkspacePackages {
-  const publishablePackages = allPackages.filter(pkg => {
+  const candidateNames = new Set(Object.keys(candidatesByPackage))
+  const releasePackages = allPackages.filter(pkg => {
     const publish = pkg.manifest.package?.publish
+    // Explicit candidates may release binaries without publishing a crate.
     return (
-      publish !== false && !(Array.isArray(publish) && publish.length === 0)
+      candidateNames.has(pkg.name) ||
+      (publish !== false && !(Array.isArray(publish) && publish.length === 0))
     )
   })
-  const publishableNames = new Set(publishablePackages.map(pkg => pkg.name))
+  const releaseNames = new Set(releasePackages.map(pkg => pkg.name))
 
   return {
-    allPackages: publishablePackages,
+    allPackages: releasePackages,
     candidatesByPackage: Object.fromEntries(
       Object.entries(candidatesByPackage).filter(([name]) =>
-        publishableNames.has(name)
+        releaseNames.has(name)
       )
     ),
   }
@@ -61,7 +64,7 @@ export function resolveWorkspacePluginOptions(
 export function createCargoWorkspacePlugin(CargoWorkspace: any) {
   return class FormatjsCargoWorkspace extends CargoWorkspace {
     async buildAllPackages(candidates: unknown[]) {
-      return filterPublishableCrates(await super.buildAllPackages(candidates))
+      return filterReleaseCrates(await super.buildAllPackages(candidates))
     }
   }
 }


### PR DESCRIPTION
Fixes Release Please runs [33193101484](https://github.com/formatjs/formatjs/actions/runs/33193101484) and [33195002768](https://github.com/formatjs/formatjs/actions/runs/33195002768).

`formatjs_cli` is an explicit Release Please component but uses `publish = false` because it ships binaries, not a crates.io package. The Cargo workspace filter removed that active candidate, leaving Release Please with zero candidates before it accessed `newCandidates[0].pullRequest`.

Keep explicit candidates regardless of Cargo publish setting. Continue excluding unpublished workspace crates that have no release candidate. Adds regression coverage and updates repository guidance.

Tests:
- `bazel test //tools:release_please_cargo_workspace_test //tools:release_please_npm_workspace_test --test_output=errors`
- pre-commit and commit-msg hooks