### PR TITLE
fix: enable Git long paths for Windows release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v7
 
+      - name: Enable Git long paths
+        run: git config --global core.longpaths true
+
       - name: Setup MSVC
         uses: ./.github/actions/setup-msvc
 


### PR DESCRIPTION
## Summary

- Enable Git long paths in the Windows native release job.
- Match the passing Windows smoke setup so Bazel can fetch Ruff Git dependencies.

Fixes the Windows failure in https://github.com/formatjs/formatjs/actions/runs/33197921632.

## Test plan

- Pre-commit hooks
- YAML parse
- `git diff --check`