### PR TITLE
fix: configure Python Release Please strategy

### DIFF
--- a/knowledge-base/001-repo-layout.md
+++ b/knowledge-base/001-repo-layout.md
@@ -124,6 +124,8 @@ dependency maintenance does not hide user-facing changes.
 For npm packages, Release Please advances versions in both package-local Bazel
 `BUILD.bazel` `x-release-please-version` markers and checked-in `package.json`
 files; `package_json_sync` keeps the rest of each generated manifest in sync.
+Python packages use the Python release strategy while generic extra-file
+updaters advance their Bazel wheel versions in `BUILD.bazel`.
 The workflow also derives npm publish paths from the release manifest diff so
 a retry still publishes packages whose GitHub releases were created before a
 partial failure. npm publishing skips versions already present in the registry,

--- a/knowledge-base/001a-bazel-toolchain.md
+++ b/knowledge-base/001a-bazel-toolchain.md
@@ -370,7 +370,8 @@ The published Python packages mirror the four non-CLI Rust layers:
 
 `.github/workflows/python-release.yml` builds `cp312-abi3` wheels for macOS
 arm64/x86_64 and manylinux 2.28 arm64/x86_64. Release Please owns independent
-Python versions. Published releases use PyPI trusted publishing through a
+Python versions through its Python strategy; generic extra-file updaters change
+the wheel versions in `BUILD.bazel`. Published releases use PyPI trusted publishing through a
 `pypi-<distribution>` GitHub environment. PyPI permits one pending project at a
 time; publish it once before registering the next unclaimed name. Manual
 dispatch defaults to a build-only dry run.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -491,6 +491,8 @@
       ]
     },
     "python/icu_skeleton_parser": {
+      "release-type": "python",
+      "changelog-type": "default",
       "component": "icu_skeleton_parser",
       "extra-files": [
         {
@@ -498,10 +500,11 @@
           "path": "BUILD.bazel"
         }
       ],
-      "package-name": "icu_skeleton_parser",
-      "version-file": "BUILD.bazel"
+      "package-name": "icu_skeleton_parser"
     },
     "python/icu_messageformat_parser": {
+      "release-type": "python",
+      "changelog-type": "default",
       "component": "icu_messageformat_parser",
       "extra-files": [
         {
@@ -509,10 +512,11 @@
           "path": "BUILD.bazel"
         }
       ],
-      "package-name": "icu_messageformat_parser",
-      "version-file": "BUILD.bazel"
+      "package-name": "icu_messageformat_parser"
     },
     "python/icu_messageformat": {
+      "release-type": "python",
+      "changelog-type": "default",
       "component": "icu_messageformat",
       "extra-files": [
         {
@@ -520,10 +524,11 @@
           "path": "BUILD.bazel"
         }
       ],
-      "package-name": "icu_messageformat",
-      "version-file": "BUILD.bazel"
+      "package-name": "icu_messageformat"
     },
     "python/intl": {
+      "release-type": "python",
+      "changelog-type": "default",
       "component": "intl",
       "extra-files": [
         {
@@ -531,8 +536,7 @@
           "path": "BUILD.bazel"
         }
       ],
-      "package-name": "intl",
-      "version-file": "BUILD.bazel"
+      "package-name": "intl"
     }
   },
   "plugins": [

--- a/tools/release-please/config.test.ts
+++ b/tools/release-please/config.test.ts
@@ -8,6 +8,7 @@ const require = createRequire(import.meta.url)
 // strategy graph before the deep imports below.
 const {VERSION} = require('release-please')
 const {Bazel} = require('release-please/build/src/strategies/bazel')
+const {Python} = require('release-please/build/src/strategies/python')
 const {Version} = require('release-please/build/src/version')
 const {parse} = require('yaml')
 
@@ -95,8 +96,10 @@ let checkedPython = 0
 for (const path of pythonPackages) {
   const packageConfig = config.packages[path]
   assert(packageConfig, `${path} is missing from Release Please config`)
+  assert.equal(packageConfig['release-type'], 'python')
+  assert.equal(packageConfig['changelog-type'], 'default')
 
-  const strategy = new Bazel({
+  const strategy = new Python({
     changelogNotes: {buildNotes: async () => '* fixture'},
     component: packageConfig.component,
     extraFiles: packageConfig['extra-files'],
@@ -106,13 +109,16 @@ for (const path of pythonPackages) {
         owner: 'formatjs',
         repo: 'formatjs',
       },
+      findFilesByFilenameAndRef: async () => [],
+      getFileContentsOnBranch: async () => {
+        throw new Error('not found')
+      },
     },
     logger,
     packageName: packageConfig['package-name'],
     path,
     skipChangelog: true,
     targetBranch: 'main',
-    versionFile: packageConfig['version-file'],
   })
   const candidate = await strategy.buildReleasePullRequest(
     [],


### PR DESCRIPTION
Release Please classified Python wheels as Bazel packages because their versions live in `BUILD.bazel`. This switches them to the Python strategy while keeping Bazel version updates as generic extra files.

Use conventional changelog notes for these initial releases because their seed versions do not have GitHub tags yet. This fixes `Invalid previous_tag parameter`.

Validation: `tools/release-please/config.test.ts`