### PR TITLE
fix: bootstrap Python package versions

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -42,8 +42,8 @@
   "crates/formatjs_intl": "0.4.0",
   "crates/formatjs_cli": "1.5.0",
   "crates/formatjs_cli_napi": "0.0.15",
-  "python/icu_skeleton_parser": "0.1.2",
-  "python/icu_messageformat_parser": "0.3.0",
-  "python/icu_messageformat": "0.1.2",
-  "python/intl": "0.4.0"
+  "python/icu_skeleton_parser": "0.0.0",
+  "python/icu_messageformat_parser": "0.0.0",
+  "python/icu_messageformat": "0.0.0",
+  "python/intl": "0.0.0"
 }

--- a/knowledge-base/001a-bazel-toolchain.md
+++ b/knowledge-base/001a-bazel-toolchain.md
@@ -376,6 +376,10 @@ the wheel versions in `BUILD.bazel`. Published releases use PyPI trusted publish
 time; publish it once before registering the next unclaimed name. Manual
 dispatch defaults to a build-only dry run.
 
+Unreleased Python packages use `0.0.0` in `.release-please-manifest.json` so
+the Python strategy creates their first release at `0.1.0` independently from
+the backing Rust crate versions.
+
 ## Composite Subpackages
 
 Internal packages can be split across Bazel packages:

--- a/tools/release-please/config.test.ts
+++ b/tools/release-please/config.test.ts
@@ -14,6 +14,9 @@ const {parse} = require('yaml')
 
 const SENTINEL_VERSION = '99.88.77'
 const config = JSON.parse(readFileSync('release-please-config.json', 'utf8'))
+const releasedVersions = JSON.parse(
+  readFileSync('.release-please-manifest.json', 'utf8')
+)
 const releaseNotesConfig = parse(readFileSync('.github/release.yml', 'utf8'))
 const logger = {
   debug() {},
@@ -98,6 +101,7 @@ for (const path of pythonPackages) {
   assert(packageConfig, `${path} is missing from Release Please config`)
   assert.equal(packageConfig['release-type'], 'python')
   assert.equal(packageConfig['changelog-type'], 'default')
+  assert.equal(releasedVersions[path], '0.0.0')
 
   const strategy = new Python({
     changelogNotes: {buildNotes: async () => '* fixture'},


### PR DESCRIPTION
Python packages were seeded with backing Rust crate versions, causing their first releases to jump to 0.2.0-0.5.0.

Mark all four as unreleased with Release Please's `0.0.0` sentinel. Python strategy will regenerate #7107 with independent `0.1.0` releases.

Validation: `tools/release-please/config.test.ts`