### PR TITLE
build(deps): regenerate Bazel lockfile in Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,14 @@
     "**/node_modules/**",
     "packages/react-intl/example-sandboxes/**"
   ],
+  "postUpgradeTasks": {
+    "commands": ["bazelisk mod deps"],
+    "fileFilters": ["MODULE.bazel.lock"],
+    "executionMode": "branch",
+    "installTools": {
+      "bazelisk": {}
+    }
+  },
   "packageRules": [
     {
       "description": "Group NAPI-RS updates",


### PR DESCRIPTION
Run `bazelisk mod deps` once per Renovate branch and commit `MODULE.bazel.lock`. Renovate installs Bazelisk for the task.

Mend-hosted Renovate blocks post-upgrade commands by default. This needs `bazelisk mod deps` allowlisted for the repository before it runs.