### PR TITLE
chore: build PyPI bootstrap wheels

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -100,6 +100,7 @@ jobs:
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.19.0
         with:
+          bazelisk-version: 1.29.0
           bazelisk-cache: true
           disk-cache: ${{ github.workflow }}-linux-${{ matrix.arch }}
           repository-cache: true

--- a/python/icu_messageformat/BUILD.bazel
+++ b/python/icu_messageformat/BUILD.bazel
@@ -41,5 +41,5 @@ formatjs_python_wheel(
         "python/icu_messageformat",
     ],
     summary = "ICU MessageFormat runtime backed by Rust and ICU4X",
-    version = "0.1.0",  # x-release-please-version
+    version = "0.0.0",  # x-release-please-version
 )

--- a/python/icu_messageformat_parser/BUILD.bazel
+++ b/python/icu_messageformat_parser/BUILD.bazel
@@ -41,5 +41,5 @@ formatjs_python_wheel(
         "python/icu_messageformat_parser",
     ],
     summary = "ICU MessageFormat parser backed by Rust",
-    version = "0.1.0",  # x-release-please-version
+    version = "0.0.0",  # x-release-please-version
 )

--- a/python/icu_skeleton_parser/BUILD.bazel
+++ b/python/icu_skeleton_parser/BUILD.bazel
@@ -41,5 +41,5 @@ formatjs_python_wheel(
         "python/icu_skeleton_parser",
     ],
     summary = "ICU number and date skeleton parser backed by Rust",
-    version = "0.1.0",  # x-release-please-version
+    version = "0.0.0",  # x-release-please-version
 )

--- a/python/intl/BUILD.bazel
+++ b/python/intl/BUILD.bazel
@@ -41,5 +41,5 @@ formatjs_python_wheel(
         "python/intl",
     ],
     summary = "High-level internationalization runtime backed by FormatJS Rust",
-    version = "0.1.0",  # x-release-please-version
+    version = "0.0.0",  # x-release-please-version
 )


### PR DESCRIPTION
Temporary workflow-dispatch ref for publishing `0.0.0` wheels and materializing PyPI projects for OIDC setup.

Do not merge. Real first releases remain `0.1.0` through Release Please.