### PR TITLE
build: cross-compile Python release wheels

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -71,74 +71,11 @@ jobs:
             echo "selected=true"
           } >> "$GITHUB_OUTPUT"
 
-  build_linux:
-    name: Build Linux ${{ matrix.arch }} Wheel
+  build:
+    name: Build Wheels
     needs: select
     if: ${{ needs.select.outputs.selected == 'true' }}
-    runs-on: ${{ matrix.runner }}
-    container: ${{ matrix.container }}
-    defaults:
-      run:
-        shell: bash
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: x86_64
-            runner: ubuntu-latest
-            container: quay.io/pypa/manylinux_2_28_x86_64:latest
-          - arch: aarch64
-            runner: ubuntu-24.04-arm
-            container: quay.io/pypa/manylinux_2_28_aarch64:latest
-
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.release.tag_name || github.ref }}
-
-      - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@0.19.0
-        with:
-          bazelisk-cache: true
-          disk-cache: ${{ github.workflow }}-linux-${{ matrix.arch }}
-          repository-cache: true
-
-      - name: Test and Build Wheel
-        env:
-          PACKAGE: ${{ needs.select.outputs.package }}
-        run: |
-          set -euo pipefail
-          target="//python/$PACKAGE:wheel"
-          bazel test "//python/$PACKAGE:python_test" --test_output=errors
-          bazel build "$target"
-          wheel=$(bazel cquery --output=files "$target" | tail -n 1)
-          mkdir -p dist
-          cp "$wheel" dist/
-          /opt/python/cp312-cp312/bin/python -m pip install --no-index "$wheel"
-          /opt/python/cp312-cp312/bin/python -c 'import importlib, os; importlib.import_module(os.environ["PACKAGE"])'
-
-      - name: Upload Wheel
-        uses: actions/upload-artifact@v7
-        with:
-          name: python-wheel-linux-${{ matrix.arch }}
-          path: dist/*.whl
-          if-no-files-found: error
-          retention-days: 7
-
-  build_macos:
-    name: Build macOS ${{ matrix.arch }} Wheel
-    needs: select
-    if: ${{ needs.select.outputs.selected == 'true' }}
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: arm64
-            runner: macos-14
-          - arch: x86_64
-            runner: macos-15-intel
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout Repository
@@ -155,28 +92,88 @@ jobs:
         uses: bazel-contrib/setup-bazel@0.19.0
         with:
           bazelisk-cache: true
-          disk-cache: ${{ github.workflow }}-macos-${{ matrix.arch }}
+          disk-cache: ${{ github.workflow }}-python-wheels
           repository-cache: true
 
-      - name: Test and Build Wheel
+      - name: Test Python Binding
+        env:
+          PACKAGE: ${{ needs.select.outputs.package }}
+        run: bazel test "//python/$PACKAGE:python_test" --test_output=errors
+
+      - name: Build Wheels
         env:
           MACOSX_DEPLOYMENT_TARGET: '11.0'
           PACKAGE: ${{ needs.select.outputs.package }}
         run: |
           set -euo pipefail
           target="//python/$PACKAGE:wheel"
-          bazel test --action_env=MACOSX_DEPLOYMENT_TARGET "//python/$PACKAGE:python_test" --test_output=errors
-          bazel build --action_env=MACOSX_DEPLOYMENT_TARGET "$target"
-          wheel=$(bazel cquery --action_env=MACOSX_DEPLOYMENT_TARGET --output=files "$target" | tail -n 1)
           mkdir -p dist
-          cp "$wheel" dist/
-          python -m pip install --no-index "$wheel"
+
+          platforms=(
+            //platforms:linux_x86_64_gnu
+            //platforms:linux_aarch64_gnu
+            //platforms:macos_x86_64
+            //platforms:macos_aarch64
+          )
+
+          for platform in "${platforms[@]}"; do
+            bazel_args=(
+              --action_env=MACOSX_DEPLOYMENT_TARGET
+              --compilation_mode=opt
+              --platforms="$platform"
+            )
+            bazel build "${bazel_args[@]}" "$target"
+            wheel=$(bazel cquery "${bazel_args[@]}" --output=files "$target" | tail -n 1)
+            cp "$wheel" dist/
+          done
+
+      - name: Validate Native Wheels
+        run: |
+          set -euo pipefail
+          check_dir=$(mktemp -d)
+
+          for wheel in dist/*.whl; do
+            wheel_dir="$check_dir/$(basename "$wheel" .whl)"
+            mkdir "$wheel_dir"
+            unzip -q "$wheel" -d "$wheel_dir"
+            extension=$(find "$wheel_dir" -name '*.abi3.so' -print -quit)
+            description=$(file "$extension")
+
+            case "$wheel" in
+              *manylinux_2_28_x86_64.whl) expected=('ELF 64-bit' 'x86-64') ;;
+              *manylinux_2_28_aarch64.whl) expected=('ELF 64-bit' 'ARM aarch64') ;;
+              *macosx_11_0_x86_64.whl) expected=('Mach-O 64-bit' 'x86_64') ;;
+              *macosx_11_0_arm64.whl) expected=('Mach-O 64-bit' 'arm64') ;;
+              *) echo "Unexpected wheel: $wheel" >&2; exit 1 ;;
+            esac
+
+            for fragment in "${expected[@]}"; do
+              [[ "$description" == *"$fragment"* ]] || {
+                echo "Unexpected native extension: $description" >&2
+                exit 1
+              }
+            done
+
+            if [[ "$wheel" == *manylinux* ]]; then
+              max_glibc=$(strings "$extension" | grep -oE 'GLIBC_[0-9.]+' | sort -Vu | tail -n 1)
+              [[ $(printf 'GLIBC_2.28\n%s\n' "$max_glibc" | sort -V | tail -n 1) == GLIBC_2.28 ]] || {
+                echo "Wheel requires $max_glibc" >&2
+                exit 1
+              }
+            fi
+          done
+
+      - name: Smoke Test Linux Wheel
+        env:
+          PACKAGE: ${{ needs.select.outputs.package }}
+        run: |
+          python -m pip install --no-index dist/*-manylinux_2_28_x86_64.whl
           python -c 'import importlib, os; importlib.import_module(os.environ["PACKAGE"])'
 
       - name: Upload Wheel
         uses: actions/upload-artifact@v7
         with:
-          name: python-wheel-macos-${{ matrix.arch }}
+          name: python-wheels
           path: dist/*.whl
           if-no-files-found: error
           retention-days: 7
@@ -185,8 +182,7 @@ jobs:
     name: Publish to PyPI
     needs:
       - select
-      - build_linux
-      - build_macos
+      - build
     if: ${{ needs.select.outputs.selected == 'true' && needs.select.outputs.publish == 'true' }}
     runs-on: ubuntu-latest
     environment:
@@ -199,9 +195,8 @@ jobs:
       - name: Download Wheels
         uses: actions/download-artifact@v8
         with:
-          pattern: python-wheel-*
+          name: python-wheels
           path: dist
-          merge-multiple: true
 
       - name: Publish Wheels
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/docs/src/docs/python.mdx
+++ b/docs/src/docs/python.mdx
@@ -64,4 +64,5 @@ options = parse_number_skeleton("currency/USD compact-short")
 ```
 
 Python APIs use `snake_case`. Distribution names and import package names are
-identical. Wheels currently target macOS and manylinux on arm64 and x86_64.
+identical. Hermetic cross-compiled wheels target macOS and manylinux 2.28 on
+arm64 and x86_64.

--- a/knowledge-base/001a-bazel-toolchain.md
+++ b/knowledge-base/001a-bazel-toolchain.md
@@ -358,7 +358,7 @@ and crate responsibilities.
 
 `pyo3_extension()` builds a `cp312-abi3` extension with `rules_rs`, then places
 the shared library at its Python import path. `formatjs_python_wheel()` combines
-that extension with a Python facade and emits a host-platform wheel through
+that extension with a Python facade and emits a target-platform wheel through
 `rules_python`.
 
 Wheel targets keep the `platform_specific_wheel` metadata tag but are not
@@ -368,10 +368,12 @@ The published Python packages mirror the four non-CLI Rust layers:
 `icu_skeleton_parser`, `icu_messageformat_parser`, `icu_messageformat`, and
 `intl`. Distribution names and import package names both use underscores.
 
-`.github/workflows/python-release.yml` builds `cp312-abi3` wheels for macOS
-arm64/x86_64 and manylinux 2.28 arm64/x86_64. Release Please owns independent
-Python versions through its Python strategy; generic extra-file updaters change
-the wheel versions in `BUILD.bazel`. Published releases use PyPI trusted publishing through a
+`.github/workflows/python-release.yml` cross-compiles `cp312-abi3` wheels from
+one Linux runner for macOS arm64/x86_64 and manylinux 2.28 arm64/x86_64. The
+Linux platforms select hermetic LLVM's glibc 2.28 ABI; the macOS platforms use
+its hermetic Apple SDK. Release Please owns independent Python versions through
+its Python strategy; generic extra-file updaters change the wheel versions in
+`BUILD.bazel`. Published releases use PyPI trusted publishing through a
 `pypi-<distribution>` GitHub environment. PyPI permits one pending project at a
 time; publish it once before registering the next unclaimed name. Manual
 dispatch defaults to a build-only dry run.

--- a/platforms/BUILD.bazel
+++ b/platforms/BUILD.bazel
@@ -20,7 +20,28 @@ platform(
 
 platform(
     name = "linux_x86_64_gnu",
+    constraint_values = [
+        "@llvm//constraints/libc:gnu.2.28",
+    ],
     parents = ["@rules_rs//rs/platforms:x86_64-unknown-linux-gnu"],
+)
+
+platform(
+    name = "linux_aarch64_gnu",
+    constraint_values = [
+        "@llvm//constraints/libc:gnu.2.28",
+    ],
+    parents = ["@rules_rs//rs/platforms:aarch64-unknown-linux-gnu"],
+)
+
+platform(
+    name = "macos_x86_64",
+    parents = ["@rules_rs//rs/platforms:x86_64-apple-darwin"],
+)
+
+platform(
+    name = "macos_aarch64",
+    parents = ["@rules_rs//rs/platforms:aarch64-apple-darwin"],
 )
 
 platform(


### PR DESCRIPTION
Python release builds used four native runners plus manylinux containers even though the Rust toolchain already supports hermetic cross-compilation.

- Add explicit glibc 2.28 and macOS target platforms.
- Build all four `cp312-abi3` wheels on one Linux runner.
- Verify native architectures and reject Linux symbols newer than `GLIBC_2.28`.
- Keep the Linux import smoke test and PyPI trusted publishing flow.

This matches AGI's glibc 2.28 toolchain and its glibc 2.36 production images.
