### PR TITLE
build(deps): align Renovate Bazel lock command

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
     "packages/react-intl/example-sandboxes/**"
   ],
   "postUpgradeTasks": {
-    "commands": ["bazelisk mod deps"],
+    "commands": ["bazel mod deps --lockfile_mode=update"],
     "fileFilters": ["MODULE.bazel.lock"],
     "executionMode": "branch",
     "installTools": {


### PR DESCRIPTION
Use the same command as Renovate’s native Bazel lockfile updater:

```sh
bazel mod deps --lockfile_mode=update
```

Bazelisk remains the installed tool. Local update and strict lock validation pass.