### PR TITLE
fix: rename Python intl distribution

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -57,7 +57,7 @@ jobs:
               icu_skeleton_parser@*) package=icu_skeleton_parser ;;
               icu_messageformat_parser@*) package=icu_messageformat_parser ;;
               icu_messageformat@*) package=icu_messageformat ;;
-              intl@*) package=intl ;;
+              py_intl@*) package=intl ;;
               *)
                 echo "selected=false" >> "$GITHUB_OUTPUT"
                 exit 0

--- a/docs/src/docs/python.mdx
+++ b/docs/src/docs/python.mdx
@@ -10,7 +10,7 @@ newer for the same platform.
 
 | Package                    | Rust backend                        | Use it for                                       |
 | -------------------------- | ----------------------------------- | ------------------------------------------------ |
-| `intl`                     | `formatjs_intl`                     | Catalog lookup, locale negotiation, and fallback |
+| `py_intl`                  | `formatjs_intl`                     | Catalog lookup, locale negotiation, and fallback |
 | `icu_messageformat`        | `formatjs_icu_messageformat`        | Formatting one ICU message                       |
 | `icu_messageformat_parser` | `formatjs_icu_messageformat_parser` | Parsing or printing ICU MessageFormat ASTs       |
 | `icu_skeleton_parser`      | `formatjs_icu_skeleton_parser`      | Parsing ICU number and date/time skeletons       |
@@ -18,7 +18,7 @@ newer for the same platform.
 Install only the layer needed by the application:
 
 ```sh
-python -m pip install intl
+python -m pip install py_intl
 ```
 
 ## Format messages
@@ -63,6 +63,6 @@ assert print_ast(ast) == "Hello, {name}!"
 options = parse_number_skeleton("currency/USD compact-short")
 ```
 
-Python APIs use `snake_case`. Distribution names and import package names are
-identical. Hermetic cross-compiled wheels target macOS and manylinux 2.28 on
-arm64 and x86_64.
+Python APIs use `snake_case`. The `py_intl` distribution imports as `intl`;
+other distribution and import package names match. Hermetic cross-compiled
+wheels target macOS and manylinux 2.28 on arm64 and x86_64.

--- a/knowledge-base/001a-bazel-toolchain.md
+++ b/knowledge-base/001a-bazel-toolchain.md
@@ -366,7 +366,8 @@ Wheel targets keep the `platform_specific_wheel` metadata tag but are not
 
 The published Python packages mirror the four non-CLI Rust layers:
 `icu_skeleton_parser`, `icu_messageformat_parser`, `icu_messageformat`, and
-`intl`. Distribution names and import package names both use underscores.
+`py_intl`. Python imports use `intl`; other distribution and import package
+names match.
 
 `.github/workflows/python-release.yml` cross-compiles `cp312-abi3` wheels from
 one Linux runner for macOS arm64/x86_64 and manylinux 2.28 arm64/x86_64. The
@@ -374,7 +375,8 @@ Linux platforms select hermetic LLVM's glibc 2.28 ABI; the macOS platforms use
 its hermetic Apple SDK. Release Please owns independent Python versions through
 its Python strategy; generic extra-file updaters change the wheel versions in
 `BUILD.bazel`. Published releases use PyPI trusted publishing through a
-`pypi-<distribution>` GitHub environment. PyPI permits one pending project at a
+`pypi-<package>` GitHub environment. `py_intl` uses `pypi-intl` because its
+source package and import remain `intl`. PyPI permits one pending project at a
 time; publish it once before registering the next unclaimed name. Manual
 dispatch defaults to a build-only dry run.
 

--- a/python/intl/BUILD.bazel
+++ b/python/intl/BUILD.bazel
@@ -32,7 +32,7 @@ py_test(
 formatjs_python_wheel(
     name = "wheel",
     description_file = "README.md",
-    distribution = "intl",
+    distribution = "py_intl",
     extension = "//crates/intl_python:intl",
     library = ":intl",
     license = "BSD-3-Clause",

--- a/python/intl/README.md
+++ b/python/intl/README.md
@@ -1,9 +1,9 @@
-# intl
+# py_intl
 
 Python bindings for FormatJS's high-level Rust internationalization runtime.
 
 ```sh
-python -m pip install intl
+python -m pip install py_intl
 ```
 
 ```python

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -529,14 +529,14 @@
     "python/intl": {
       "release-type": "python",
       "changelog-type": "default",
-      "component": "intl",
+      "component": "py_intl",
       "extra-files": [
         {
           "type": "generic",
           "path": "BUILD.bazel"
         }
       ],
-      "package-name": "intl"
+      "package-name": "py_intl"
     }
   },
   "plugins": [


### PR DESCRIPTION
PyPI rejects `intl` because it is too similar to the existing `python-intl` project.

- Publish the distribution as `py_intl` while keeping `import intl`.
- Route `py_intl@*` Release Please tags through the existing `python/intl` build.
- Keep trusted publishing on the `pypi-intl` environment.
- Update public docs and the Bazel knowledge base.