### PR TITLE
feat(formatjs_cli): extract Python format_message calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1315,10 +1315,12 @@ checksum = "71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8"
 name = "intl_python"
 version = "0.4.0"
 dependencies = [
+ "base64",
  "formatjs_icu_messageformat",
  "formatjs_intl",
  "icu_locale",
  "pyo3",
+ "sha2",
 ]
 
 [[package]]

--- a/crates/formatjs_cli/README.md
+++ b/crates/formatjs_cli/README.md
@@ -215,9 +215,11 @@ Existing values maps remain supported for dynamic or reused values.
 formatjs extract "src/**/*.rs" --out-file messages.json
 ```
 
-Python extraction reads explicit `define_message` calls. Message IDs and default
-messages are required string literals; descriptions are optional string literals.
-Dynamic expressions, positional arguments, and `**kwargs` are rejected.
+Python extraction reads explicit `define_message` declarations and inline
+`format_message` calls. `id` is optional; missing IDs use
+`[sha512:contenthash:base64:10]`. Descriptor fields must be string literals;
+`values` may be dynamic mappings or arbitrary keyword arguments. Descriptor
+objects declared elsewhere are extracted from their `define_message` call.
 
 ```python
 from my_app.i18n import define_message
@@ -226,6 +228,12 @@ GREETING = define_message(
     id="greeting",
     default_message="Hello, {name}!",
     description="Greeting shown on the home page",
+)
+
+greeting = intl.format_message(
+    default_message="Hello, {name}!",
+    description="Greeting shown on the home page",
+    name=user.name,
 )
 ```
 

--- a/crates/formatjs_cli/src/extract.rs
+++ b/crates/formatjs_cli/src/extract.rs
@@ -931,6 +931,46 @@ GREETING = define_message(
     }
 
     #[test]
+    fn test_extract_to_string_reads_python_format_message_call() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let file = temp_dir.path().join("messages.py");
+        fs::write(
+            &file,
+            r#"
+from intl import Intl
+
+greeting = intl.format_message(
+    default_message="Hello, {name}!",
+    values={"name": user.name},
+)
+"#,
+        )
+        .unwrap();
+
+        let output = extract_to_string(
+            &[file],
+            None,
+            None,
+            "[sha512:contenthash:base64:6]",
+            false,
+            &[],
+            &[],
+            &[],
+            true,
+            None,
+            false,
+            false,
+            true,
+        )
+        .unwrap();
+        let json: serde_json::Value = serde_json::from_str(&output).unwrap();
+
+        let message = json.as_object().unwrap().values().next().unwrap();
+        assert_eq!(message["defaultMessage"], "Hello, {name}!");
+        assert_eq!(json.as_object().unwrap().len(), 1);
+    }
+
+    #[test]
     fn test_extract_base_dir() {
         assert_eq!(extract_base_dir("src/**/*.ts"), PathBuf::from("src"));
         assert_eq!(

--- a/crates/formatjs_cli/src/python_extractor.rs
+++ b/crates/formatjs_cli/src/python_extractor.rs
@@ -1,6 +1,7 @@
 use crate::extractor::{
     MessageDescriptor, MessageExtraction, flatten_message_descriptors, normalize_whitespace,
 };
+use crate::id_generator::IdGenerator;
 use anyhow::{Result, bail};
 use ruff_python_ast::visitor::{Visitor, walk_expr};
 use ruff_python_ast::{self as ast, Expr};
@@ -10,6 +11,8 @@ use serde_json::Value;
 use std::path::Path;
 
 const DEFINE_MESSAGE: &str = "define_message";
+const FORMAT_MESSAGE: &str = "format_message";
+const PYTHON_ID_INTERPOLATION_PATTERN: &str = "[sha512:contenthash:base64:10]";
 
 pub fn extract_messages_from_python_source(
     source_text: &str,
@@ -43,11 +46,13 @@ pub fn extract_messages_from_python_source_with_diagnostics(
 ) -> Result<MessageExtraction> {
     let parsed = parse_module(source_text)
         .map_err(|error| anyhow::anyhow!("Parse error in {}: {error}", file_path.display()))?;
+    let id_generator = IdGenerator::new(PYTHON_ID_INTERPOLATION_PATTERN)?;
     let mut extractor = PythonMessageExtractor {
         source_text,
         file_path,
         extract_source_location,
         preserve_whitespace,
+        id_generator,
         messages: Vec::new(),
         errors: Vec::new(),
     };
@@ -68,12 +73,13 @@ struct PythonMessageExtractor<'a> {
     file_path: &'a Path,
     extract_source_location: bool,
     preserve_whitespace: bool,
+    id_generator: IdGenerator,
     messages: Vec<MessageDescriptor>,
     errors: Vec<String>,
 }
 
 impl PythonMessageExtractor<'_> {
-    fn descriptor(&self, call: &ast::ExprCall) -> Result<MessageDescriptor> {
+    fn define_message_descriptor(&self, call: &ast::ExprCall) -> Result<MessageDescriptor> {
         if !call.arguments.args.is_empty() {
             bail!("define_message accepts keyword arguments only");
         }
@@ -98,13 +104,82 @@ impl PythonMessageExtractor<'_> {
             }
         }
 
-        let id = id.ok_or_else(|| anyhow::anyhow!("define_message id is required"))?;
         let default_message = default_message
             .ok_or_else(|| anyhow::anyhow!("define_message default_message is required"))?;
+        self.message_descriptor(call, id, Some(default_message), description)
+    }
+
+    fn format_message_descriptor(&self, call: &ast::ExprCall) -> Result<Option<MessageDescriptor>> {
+        if call.arguments.args.len() > 1 {
+            bail!("format_message accepts at most one positional argument");
+        }
+
+        let mut id = match call.arguments.args.first() {
+            Some(argument) => match string_literal(argument) {
+                Some(id) => Some(id),
+                None => return Ok(None),
+            },
+            None => None,
+        };
+        let mut default_message = None;
+        let mut description = None;
+        let mut values = false;
+        for keyword in &call.arguments.keywords {
+            let Some(name) = keyword.arg.as_ref().map(|argument| argument.as_str()) else {
+                bail!("format_message does not accept **kwargs");
+            };
+            match name {
+                "id" if id.is_none() => {
+                    id = Some(string_literal(&keyword.value).ok_or_else(|| {
+                        anyhow::anyhow!("format_message id must be a string literal")
+                    })?);
+                }
+                "default_message" if default_message.is_none() => {
+                    default_message = Some(string_literal(&keyword.value).ok_or_else(|| {
+                        anyhow::anyhow!("format_message default_message must be a string literal")
+                    })?);
+                }
+                "description" if description.is_none() => {
+                    description = Some(string_literal(&keyword.value).ok_or_else(|| {
+                        anyhow::anyhow!("format_message description must be a string literal")
+                    })?);
+                }
+                "values" if !values => values = true,
+                "id" | "default_message" | "description" | "values" => {
+                    bail!("duplicate format_message field: {name}")
+                }
+                _ => bail!("unknown format_message field: {name}"),
+            }
+        }
+
+        if id.is_none() && default_message.is_none() {
+            bail!("format_message default_message is required when id is omitted");
+        }
+        self.message_descriptor(call, id, default_message, description)
+            .map(Some)
+    }
+
+    fn message_descriptor(
+        &self,
+        call: &ast::ExprCall,
+        id: Option<String>,
+        default_message: Option<String>,
+        description: Option<String>,
+    ) -> Result<MessageDescriptor> {
+        let normalized_default_message = default_message.as_deref().map(normalize_whitespace);
+        let description = description.map(Value::String);
+        let id = match id {
+            Some(id) => id,
+            None => self.id_generator.generate(
+                normalized_default_message.as_deref(),
+                &description,
+                None,
+            )?,
+        };
         let default_message = if self.preserve_whitespace {
             default_message
         } else {
-            normalize_whitespace(&default_message)
+            normalized_default_message
         };
         let (start, end, file) = if self.extract_source_location {
             (
@@ -118,8 +193,8 @@ impl PythonMessageExtractor<'_> {
 
         Ok(MessageDescriptor {
             id: Some(id),
-            default_message: Some(default_message),
-            description: description.map(Value::String),
+            default_message,
+            description,
             file,
             start,
             end,
@@ -138,11 +213,17 @@ impl PythonMessageExtractor<'_> {
 
 impl<'ast> Visitor<'ast> for PythonMessageExtractor<'_> {
     fn visit_expr(&mut self, expr: &'ast Expr) {
-        if let Expr::Call(call) = expr
-            && is_define_message_call(&call.func)
-        {
-            match self.descriptor(call) {
-                Ok(descriptor) => self.messages.push(descriptor),
+        if let Expr::Call(call) = expr {
+            let descriptor = if is_named_call(&call.func, DEFINE_MESSAGE) {
+                self.define_message_descriptor(call).map(Some)
+            } else if is_named_call(&call.func, FORMAT_MESSAGE) {
+                self.format_message_descriptor(call)
+            } else {
+                Ok(None)
+            };
+            match descriptor {
+                Ok(Some(descriptor)) => self.messages.push(descriptor),
+                Ok(None) => {}
                 Err(error) => self.error(call, error.to_string()),
             }
         }
@@ -150,10 +231,10 @@ impl<'ast> Visitor<'ast> for PythonMessageExtractor<'_> {
     }
 }
 
-fn is_define_message_call(function: &Expr) -> bool {
+fn is_named_call(function: &Expr, expected_name: &str) -> bool {
     match function {
-        Expr::Name(name) => name.id.as_str() == DEFINE_MESSAGE,
-        Expr::Attribute(attribute) => attribute.attr.as_str() == DEFINE_MESSAGE,
+        Expr::Name(name) => name.id.as_str() == expected_name,
+        Expr::Attribute(attribute) => attribute.attr.as_str() == expected_name,
         _ => false,
     }
 }
@@ -224,6 +305,67 @@ defineMessage(id="ignored", default_message="Not Python's API")
     }
 
     #[test]
+    fn extracts_format_message_calls() {
+        let source = r#"
+from intl import Intl
+
+greeting = intl.format_message(
+    "greeting",
+    default_message="Hello, " "{name}!",
+    values={"name": user.name},
+)
+status = format_message(id="status", default_message="Ready")
+missing = intl.format_message("missing")
+welcome = intl.format_message(
+    default_message="  Welcome,\n  {name}!  ",
+    description="Home title",
+    values={"name": user.name},
+)
+inline = intl.format_message(
+    define_message(default_message="Nested descriptor"),
+    values={"count": count},
+)
+formatMessage("ignored", default_message="Not Python's API")
+"#;
+        let messages = extract_messages_from_python_source(
+            source,
+            Path::new("messages.py"),
+            false,
+            false,
+            false,
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(messages.len(), 5);
+        assert_eq!(messages[0].id.as_deref(), Some("greeting"));
+        assert_eq!(
+            messages[0].default_message.as_deref(),
+            Some("Hello, {name}!")
+        );
+        assert_eq!(messages[1].id.as_deref(), Some("status"));
+        assert_eq!(messages[2].id.as_deref(), Some("missing"));
+        assert_eq!(messages[2].default_message, None);
+        let generated_id = IdGenerator::new(PYTHON_ID_INTERPOLATION_PATTERN)
+            .unwrap()
+            .generate(
+                Some("Welcome, {name}!"),
+                &Some(Value::String("Home title".to_owned())),
+                None,
+            )
+            .unwrap();
+        assert_eq!(messages[3].id.as_deref(), Some(generated_id.as_str()));
+        assert_eq!(
+            messages[3].default_message.as_deref(),
+            Some("Welcome, {name}!")
+        );
+        assert_eq!(
+            messages[4].default_message.as_deref(),
+            Some("Nested descriptor")
+        );
+    }
+
+    #[test]
     fn normalizes_whitespace_and_reports_source_offsets() {
         let source = r#"MESSAGE = define_message(
     id="message",
@@ -277,6 +419,41 @@ define_message(id="f-string", default_message=f"Hello {name}")
         assert!(extraction.errors[3].contains("unknown define_message field: context"));
         assert!(extraction.errors[4].contains("does not accept **kwargs"));
         assert!(extraction.errors[5].contains("default_message must be a string literal"));
+    }
+
+    #[test]
+    fn rejects_invalid_format_message_arguments() {
+        let source = r#"
+format_message(MESSAGE, name=name)
+format_message("id", "extra")
+format_message()
+format_message("dynamic", default_message=message)
+format_message("kwargs", **fields)
+format_message("unknown", context="Nope")
+format_message("duplicate", id="other")
+format_message("description", description=DESCRIPTION)
+format_message("values", values=dynamic_values)
+"#;
+        let extraction = extract_messages_from_python_source_with_diagnostics(
+            source,
+            Path::new("invalid.py"),
+            false,
+            false,
+            false,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(extraction.messages.len(), 1);
+        assert_eq!(extraction.messages[0].id.as_deref(), Some("values"));
+        assert_eq!(extraction.errors.len(), 7);
+        assert!(extraction.errors[0].contains("at most one positional argument"));
+        assert!(extraction.errors[1].contains("default_message is required when id is omitted"));
+        assert!(extraction.errors[2].contains("default_message must be a string literal"));
+        assert!(extraction.errors[3].contains("does not accept **kwargs"));
+        assert!(extraction.errors[4].contains("unknown format_message field: context"));
+        assert!(extraction.errors[5].contains("duplicate format_message field: id"));
+        assert!(extraction.errors[6].contains("description must be a string literal"));
     }
 
     #[test]

--- a/crates/intl_python/BUILD.bazel
+++ b/crates/intl_python/BUILD.bazel
@@ -7,7 +7,9 @@ pyo3_extension(
     deps = [
         "//crates/formatjs_intl",
         "//crates/icu_messageformat",
+        "@crates//:base64",
         "@crates//:icu_locale",
         "@crates//:pyo3",
+        "@crates//:sha2",
     ],
 )

--- a/crates/intl_python/Cargo.toml
+++ b/crates/intl_python/Cargo.toml
@@ -9,7 +9,9 @@ path = "lib.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
+base64 = "0.23"
 formatjs_icu_messageformat = { path = "../icu_messageformat" }
 formatjs_intl = { path = "../formatjs_intl" }
 icu_locale = "2.1"
 pyo3.workspace = true
+sha2 = "0.11"

--- a/crates/intl_python/lib.rs
+++ b/crates/intl_python/lib.rs
@@ -1,10 +1,45 @@
+use base64::Engine;
 use formatjs_icu_messageformat::{IcuMessageFormat, Value, Values};
 use formatjs_intl::{MessageCatalog, negotiate_locale};
 use icu_locale::Locale;
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyAny, PyDict};
+use sha2::{Digest, Sha512};
 use std::collections::HashMap;
+
+const GENERATED_ID_LENGTH: usize = 10;
+
+fn normalize_whitespace(value: &str) -> String {
+    let trimmed = value.trim_matches(char::is_whitespace);
+    let mut normalized = String::with_capacity(trimmed.len());
+    let mut in_whitespace = false;
+    for character in trimmed.chars() {
+        if character.is_whitespace() {
+            if !in_whitespace {
+                normalized.push(' ');
+                in_whitespace = true;
+            }
+        } else {
+            normalized.push(character);
+            in_whitespace = false;
+        }
+    }
+    normalized
+}
+
+fn generate_id(default_message: &str, description: Option<&str>) -> String {
+    let mut content = normalize_whitespace(default_message).into_bytes();
+    if let Some(description) = description {
+        content.push(b'#');
+        content.extend_from_slice(description.as_bytes());
+    }
+    base64::engine::general_purpose::STANDARD
+        .encode(Sha512::digest(content))
+        .chars()
+        .take(GENERATED_ID_LENGTH)
+        .collect()
+}
 
 fn value_from_python(value: &Bound<'_, PyAny>) -> PyResult<Value<String>> {
     if value.is_none() {
@@ -35,9 +70,7 @@ fn values_from_python(values: Option<&Bound<'_, PyDict>>) -> PyResult<Values<Str
         .map(|values| {
             values
                 .iter()
-                .map(|(key, value)| {
-                    Ok((key.extract::<String>()?, value_from_python(&value)?))
-                })
+                .map(|(key, value)| Ok((key.extract::<String>()?, value_from_python(&value)?)))
                 .collect()
         })
         .unwrap_or_else(|| Ok(Values::new()))
@@ -89,23 +122,33 @@ impl PyIntl {
         &self.locale
     }
 
-    #[pyo3(signature = (id, *, default_message = "", values = None))]
+    #[pyo3(signature = (id = None, *, default_message = "", description = None, values = None))]
     fn format_message(
         &mut self,
-        id: &str,
+        id: Option<&str>,
         default_message: &str,
+        description: Option<&str>,
         values: Option<&Bound<'_, PyDict>>,
     ) -> PyResult<String> {
+        let id = match id {
+            Some(id) => id.to_owned(),
+            None if default_message.is_empty() => {
+                return Err(PyValueError::new_err(
+                    "default_message is required when id is omitted",
+                ));
+            }
+            None => generate_id(default_message, description),
+        };
         let values = values_from_python(values)?;
         let mut candidates = Vec::with_capacity(3);
         if let Some(messages) = self.catalog.messages(&self.locale) {
-            if let Some(message) = messages.get(id).filter(|message| !message.is_empty()) {
+            if let Some(message) = messages.get(&id).filter(|message| !message.is_empty()) {
                 candidates.push((message.clone(), self.locale.clone()));
             }
         }
         if self.locale != self.default_locale {
             if let Some(messages) = self.catalog.messages(&self.default_locale) {
-                if let Some(message) = messages.get(id).filter(|message| !message.is_empty()) {
+                if let Some(message) = messages.get(&id).filter(|message| !message.is_empty()) {
                     candidates.push((message.clone(), self.default_locale.clone()));
                 }
             }
@@ -129,7 +172,7 @@ impl PyIntl {
         }
 
         Ok(if default_message.is_empty() {
-            id.to_owned()
+            id
         } else {
             default_message.to_owned()
         })

--- a/docs/src/docs/python.mdx
+++ b/docs/src/docs/python.mdx
@@ -39,6 +39,31 @@ assert intl.locale == "fr"
 assert intl.format_message("tasks", values={"count": 2}) == "2 tâches"
 ```
 
+Create or select an `Intl` instance for each request locale. Generated message
+IDs depend only on the normalized default message and description, so catalogs
+use the same IDs across locales.
+
+`formatjs extract "src/**/*.py"` extracts literal `define_message(...)`
+declarations and `format_message(...)` calls. Inline calls accept dynamic
+`values`. IDs are optional; missing IDs use the same 10-character generated ID
+as Rust.
+
+```python
+title = intl.format_message(
+    default_message="Welcome, {name}!",
+    name=user.name,
+)
+```
+
+Reusable descriptors match the backend authoring shape used by Bazel consumers:
+
+```python
+from intl import define_message
+
+TITLE = define_message(default_message="Welcome, {name}!")
+title = intl.format_message(TITLE, name=user.name)
+```
+
 Use `icu_messageformat` when catalog lookup happens elsewhere:
 
 ```python

--- a/knowledge-base/003-rust-crate-dependency-hierarchy.md
+++ b/knowledge-base/003-rust-crate-dependency-hierarchy.md
@@ -136,7 +136,14 @@ the crate is not published to crates.io.
 **Key implementation details:**
 
 - Uses **oxc** (v0.120) for JS/TS/JSX/TSX AST parsing (no Node.js dependency)
-- Uses Ruff's Python parser for literal `define_message(...)` declarations
+- Uses Ruff's Python parser for literal `define_message(...)` declarations and
+  inline `format_message(...)` calls
+- Python inline calls mirror Rust named fields; missing IDs use
+  `[sha512:contenthash:base64:10]`
+- Python runtime calls accept reusable `MessageDescriptor` objects, inline
+  descriptor fields, mapping values, or arbitrary value keyword arguments
+- Generated IDs are locale-independent; request-specific `Intl` instances use
+  the same descriptor IDs across locale catalogs
 - With `extract --throws`, input metadata and directory traversal errors fail the command instead of producing a partial catalog
 - **Whitespace normalization** (`extractor.rs`): Matches TypeScript CLI behavior exactly, including U+00A0 (non-breaking space) preservation via placeholder technique
 - **ID generation** (`id_generator.rs`): loader-utils style `hash`/`contenthash` interpolation with md5, sha1, and SHA-2 algorithms plus base64/base64url/base62/hex encodings. Hash is computed AFTER flattening (matching TypeScript CLI order)

--- a/python/intl/README.md
+++ b/python/intl/README.md
@@ -7,8 +7,17 @@ python -m pip install py_intl
 ```
 
 ```python
-from intl import Intl
+from intl import Intl, define_message
 
 intl = Intl(["fr-CA", "fr"], "en", {"fr": {"hello": "Bonjour"}, "en": {}})
 assert intl.format_message("hello", default_message="Hello") == "Bonjour"
+
+# IDs are optional and generated from the descriptor.
+assert intl.format_message(default_message="Welcome") == "Welcome"
+
+greeting = define_message(default_message="Hello, {name}!")
+assert intl.format_message(greeting, name="Ada") == "Hello, Ada!"
 ```
+
+Use the `Intl` instance negotiated for the current request. Generated IDs are
+locale-independent.

--- a/python/intl/intl/__init__.py
+++ b/python/intl/intl/__init__.py
@@ -1,5 +1,101 @@
 """High-level internationalization runtime."""
 
-from intl._native import Intl, negotiate
+import base64
+import hashlib
+from collections.abc import Mapping
+from dataclasses import dataclass
 
-__all__ = ["Intl", "negotiate"]
+from intl._native import Intl as _NativeIntl
+from intl._native import negotiate
+
+MessageValue = str | bool | int | float | None
+
+
+def _generate_id(default_message: str, description: str | None) -> str:
+    content = " ".join(default_message.split())
+    if description is not None:
+        content += f"#{description}"
+    return base64.b64encode(hashlib.sha512(content.encode()).digest()).decode()[:10]
+
+
+@dataclass(frozen=True, slots=True)
+class MessageDescriptor:
+    default_message: str
+    id: str = ""
+    description: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.id:
+            object.__setattr__(
+                self,
+                "id",
+                _generate_id(self.default_message, self.description),
+            )
+
+
+def define_message(
+    *,
+    default_message: str,
+    id: str | None = None,
+    description: str | None = None,
+) -> MessageDescriptor:
+    return MessageDescriptor(
+        id=id or "",
+        default_message=default_message,
+        description=description,
+    )
+
+
+class Intl:
+    def __init__(
+        self,
+        requested_locales: list[str],
+        default_locale: str,
+        messages: Mapping[str, Mapping[str, str]],
+    ) -> None:
+        self._native = _NativeIntl(
+            requested_locales,
+            default_locale,
+            {locale: dict(locale_messages) for locale, locale_messages in messages.items()},
+        )
+
+    @property
+    def locale(self) -> str:
+        return self._native.locale
+
+    def format_message(
+        self,
+        descriptor: MessageDescriptor | str | None = None,
+        *,
+        id: str | None = None,
+        default_message: str | None = None,
+        description: str | None = None,
+        values: Mapping[str, MessageValue] | None = None,
+        **message_values: MessageValue,
+    ) -> str:
+        if isinstance(descriptor, str):
+            if id is not None:
+                raise TypeError("id was provided twice")
+            id = descriptor
+        elif descriptor is not None:
+            if id is not None or default_message is not None or description is not None:
+                raise TypeError("descriptor fields cannot be combined with a descriptor")
+            id = descriptor.id or None
+            default_message = descriptor.default_message
+            description = descriptor.description
+
+        merged_values: dict[str, MessageValue] = dict(values or {})
+        duplicates = merged_values.keys() & message_values.keys()
+        if duplicates:
+            duplicate = min(duplicates)
+            raise TypeError(f"message value was provided twice: {duplicate}")
+        merged_values.update(message_values)
+        return self._native.format_message(
+            id,
+            default_message=default_message or "",
+            description=description,
+            values=merged_values,
+        )
+
+
+__all__ = ["Intl", "MessageDescriptor", "define_message", "negotiate"]

--- a/python/intl/intl/__init__.pyi
+++ b/python/intl/intl/__init__.pyi
@@ -1,6 +1,21 @@
+from dataclasses import dataclass
 from typing import Mapping
 
 MessageValue = str | bool | int | float | None
+
+@dataclass(frozen=True, slots=True)
+class MessageDescriptor:
+    default_message: str
+    id: str = ""
+    description: str | None = None
+    def __post_init__(self) -> None: ...
+
+def define_message(
+    *,
+    default_message: str,
+    id: str | None = None,
+    description: str | None = None,
+) -> MessageDescriptor: ...
 
 class Intl:
     def __init__(
@@ -13,10 +28,13 @@ class Intl:
     def locale(self) -> str: ...
     def format_message(
         self,
-        id: str,
+        descriptor: MessageDescriptor | str | None = None,
         *,
-        default_message: str = "",
+        id: str | None = None,
+        default_message: str | None = None,
+        description: str | None = None,
         values: Mapping[str, MessageValue] | None = None,
+        **message_values: MessageValue,
     ) -> str: ...
 
 def negotiate(

--- a/python/intl/tests/test_binding.py
+++ b/python/intl/tests/test_binding.py
@@ -1,4 +1,7 @@
-from intl import Intl, negotiate
+import base64
+import hashlib
+
+from intl import Intl, MessageDescriptor, define_message, negotiate
 
 
 def test_negotiates_locale() -> None:
@@ -6,14 +9,55 @@ def test_negotiates_locale() -> None:
 
 
 def test_formats_translation_and_fallback() -> None:
+    generated_id = base64.b64encode(
+        hashlib.sha512(b"Welcome#Home title").digest()
+    ).decode()[:10]
     runtime = Intl(
         ["fr-CA", "fr"],
         "en",
         {
             "en": {"tasks": "{count, plural, one {# task} other {# tasks}}"},
-            "fr": {"tasks": "{count, plural, one {# tâche} other {# tâches}}"},
+            "fr": {
+                "tasks": "{count, plural, one {# tâche} other {# tâches}}",
+                generated_id: "Bienvenue",
+            },
         },
     )
     assert runtime.locale == "fr"
     assert runtime.format_message("tasks", values={"count": 2}) == "2 tâches"
+    assert (
+        runtime.format_message(
+            MessageDescriptor(
+                id="tasks",
+                default_message="{count, plural, one {# task} other {# tasks}}",
+            ),
+            count=2,
+        )
+        == "2 tâches"
+    )
     assert runtime.format_message("missing", default_message="Fallback") == "Fallback"
+    assert (
+        runtime.format_message(
+            default_message="Welcome",
+            description="Home title",
+        )
+        == "Bienvenue"
+    )
+    descriptor = define_message(
+        default_message="Welcome",
+        description="Home title",
+    )
+    assert runtime.format_message(descriptor) == "Bienvenue"
+    assert descriptor.id == generated_id
+
+    try:
+        runtime.format_message("tasks", values={"count": 1}, count=2)
+    except TypeError as error:
+        assert str(error) == "message value was provided twice: count"
+    else:
+        raise AssertionError("duplicate message value should fail")
+
+
+if __name__ == "__main__":
+    test_negotiates_locale()
+    test_formats_translation_and_fallback()


### PR DESCRIPTION
Extract Python `format_message(...)` calls alongside `define_message(...)`.

- mirror Rust descriptor fields: optional `id`, literal `default_message`/`description`
- accept reusable descriptor objects, inline descriptor kwargs, mapping values, and arbitrary value kwargs
- generate locale-independent 10-character IDs when `id` is omitted
- add typed `MessageDescriptor` and `define_message` authoring helpers

Tests:
- `bazel test //crates/formatjs_cli:formatjs_cli_test //python/intl:python_test --test_output=errors`
- `bazel build //python/intl:wheel`
- `bazel mod deps --lockfile_mode=error`