### PR TITLE
feat(formatjs_intl): align Python runtime fallback

### DIFF
--- a/crates/formatjs_intl/lib.rs
+++ b/crates/formatjs_intl/lib.rs
@@ -38,6 +38,7 @@ impl CatalogBundle {
 pub enum Error {
     InvalidLocale(String),
     MissingDefaultLocale(String),
+    MissingTranslation { id: String, locale: String },
     CachePoisoned,
     Message(formatjs_icu_messageformat::Error),
 }
@@ -51,6 +52,9 @@ impl fmt::Display for Error {
                     formatter,
                     "Default locale has no translation catalog: {locale}"
                 )
+            }
+            Self::MissingTranslation { id, locale } => {
+                write!(formatter, "Missing message \"{id}\" for locale \"{locale}\"")
             }
             Self::CachePoisoned => formatter.write_str("Intl cache lock is poisoned"),
             Self::Message(error) => error.fmt(formatter),
@@ -90,7 +94,7 @@ pub enum MessageSource {
 #[derive(Debug)]
 pub struct FormatMessageError {
     /// Descriptor passed to the formatting call.
-    pub descriptor: MessageDescriptor,
+    pub descriptor: OwnedMessageDescriptor,
     /// Locale used for the failed formatting attempt.
     pub locale: String,
     /// Source of the message that failed.
@@ -134,6 +138,55 @@ impl MessageDescriptor {
     pub const fn with_description(mut self, description: &'static str) -> Self {
         self.description = Some(description);
         self
+    }
+
+    pub const fn as_ref(self) -> MessageDescriptorRef<'static> {
+        MessageDescriptorRef {
+            id: self.id,
+            default_message: self.default_message,
+            description: self.description,
+        }
+    }
+}
+
+/// Borrowed message descriptor for runtime-defined messages.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MessageDescriptorRef<'a> {
+    pub id: &'a str,
+    pub default_message: &'a str,
+    pub description: Option<&'a str>,
+}
+
+impl<'a> MessageDescriptorRef<'a> {
+    pub const fn new(id: &'a str, default_message: &'a str) -> Self {
+        Self {
+            id,
+            default_message,
+            description: None,
+        }
+    }
+
+    pub const fn with_description(mut self, description: &'a str) -> Self {
+        self.description = Some(description);
+        self
+    }
+}
+
+/// Owned descriptor snapshot attached to recovered formatting errors.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OwnedMessageDescriptor {
+    pub id: String,
+    pub default_message: String,
+    pub description: Option<String>,
+}
+
+impl From<MessageDescriptorRef<'_>> for OwnedMessageDescriptor {
+    fn from(descriptor: MessageDescriptorRef<'_>) -> Self {
+        Self {
+            id: descriptor.id.to_owned(),
+            default_message: descriptor.default_message.to_owned(),
+            description: descriptor.description.map(str::to_owned),
+        }
     }
 }
 
@@ -375,6 +428,14 @@ impl Intl {
         descriptor: MessageDescriptor,
         values: &Values<T>,
     ) -> Result<FormattedMessage<T>> {
+        self.format_message_ref(descriptor.as_ref(), values)
+    }
+
+    pub fn format_message_ref<T: Clone>(
+        &self,
+        descriptor: MessageDescriptorRef<'_>,
+        values: &Values<T>,
+    ) -> Result<FormattedMessage<T>> {
         self.format_with_fallback(
             descriptor,
             |message, locale| message.format(locale, values),
@@ -387,6 +448,14 @@ impl Intl {
         descriptor: MessageDescriptor,
         values: &Values<T>,
     ) -> Result<Vec<Part<T>>> {
+        self.format_message_to_parts_ref(descriptor.as_ref(), values)
+    }
+
+    pub fn format_message_to_parts_ref<T: Clone>(
+        &self,
+        descriptor: MessageDescriptorRef<'_>,
+        values: &Values<T>,
+    ) -> Result<Vec<Part<T>>> {
         self.format_with_fallback(
             descriptor,
             |message, locale| message.format_to_parts(locale, values),
@@ -397,6 +466,14 @@ impl Intl {
     pub fn format_message_to_string(
         &self,
         descriptor: MessageDescriptor,
+        values: &Values<String>,
+    ) -> Result<String> {
+        self.format_message_to_string_ref(descriptor.as_ref(), values)
+    }
+
+    pub fn format_message_to_string_ref(
+        &self,
+        descriptor: MessageDescriptorRef<'_>,
         values: &Values<String>,
     ) -> Result<String> {
         self.format_with_fallback(
@@ -416,12 +493,23 @@ impl Intl {
             .unwrap_or_else(|_| descriptor.default_message.to_owned())
     }
 
-    fn format_with_fallback<T>(
+    /// Formats a runtime-defined string descriptor, returning its default on infrastructure errors.
+    pub fn format_message_to_string_or_default_ref(
         &self,
-        descriptor: MessageDescriptor,
+        descriptor: MessageDescriptorRef<'_>,
+        values: &Values<String>,
+    ) -> String {
+        self.format_message_to_string_ref(descriptor, values)
+            .unwrap_or_else(|_| descriptor.default_message.to_owned())
+    }
+
+    fn format_with_fallback<'a, T>(
+        &'a self,
+        descriptor: MessageDescriptorRef<'a>,
         format: impl Fn(&IcuMessageFormat, &str) -> formatjs_icu_messageformat::Result<T>,
         verbatim: impl Fn(String) -> T,
     ) -> Result<T> {
+        self.report_missing_translation(descriptor);
         let candidates = self.message_candidates(descriptor);
         let verbatim_source = candidates
             .iter()
@@ -447,7 +535,7 @@ impl Intl {
                 Err(error) => {
                     let is_message_error = matches!(error, Error::Message(_));
                     let error = FormatMessageError {
-                        descriptor,
+                        descriptor: descriptor.into(),
                         locale: candidate.locale.to_owned(),
                         source: candidate.source,
                         error,
@@ -463,7 +551,10 @@ impl Intl {
         Ok(verbatim(verbatim_source))
     }
 
-    fn message_candidates(&self, descriptor: MessageDescriptor) -> Vec<MessageCandidate<'_>> {
+    fn message_candidates<'a>(
+        &'a self,
+        descriptor: MessageDescriptorRef<'a>,
+    ) -> Vec<MessageCandidate<'a>> {
         let mut candidates = Vec::with_capacity(3);
 
         if let Some(message) = self.messages.get(descriptor.id) {
@@ -492,6 +583,30 @@ impl Intl {
         );
 
         candidates
+    }
+
+    fn report_missing_translation(&self, descriptor: MessageDescriptorRef<'_>) {
+        if self.on_error.is_none() {
+            return;
+        }
+        let missing = matches!(
+            self.messages.get(descriptor.id),
+            None | Some(CatalogMessage::Source(""))
+        );
+        if missing
+            && (self.locale_string != self.default_locale_string
+                || descriptor.default_message.is_empty())
+        {
+            self.report_error(&FormatMessageError {
+                descriptor: descriptor.into(),
+                locale: self.locale_string.clone(),
+                source: MessageSource::Translation,
+                error: Error::MissingTranslation {
+                    id: descriptor.id.to_owned(),
+                    locale: self.locale_string.clone(),
+                },
+            });
+        }
     }
 
     fn report_error(&self, error: &FormatMessageError) {
@@ -667,7 +782,7 @@ mod tests {
             .unwrap()
             .with_on_error(move |error| {
                 captured_errors.lock().unwrap().push((
-                    error.descriptor.id,
+                    error.descriptor.id.to_owned(),
                     error.source,
                     matches!(error.error, Error::CachePoisoned),
                 ));
@@ -683,7 +798,7 @@ mod tests {
         );
         assert_eq!(
             *errors.lock().unwrap(),
-            vec![("n5ixSZR8gf", MessageSource::DefaultMessage, true)]
+            vec![("n5ixSZR8gf".to_owned(), MessageSource::DefaultMessage, true)]
         );
     }
 
@@ -787,6 +902,32 @@ mod tests {
         assert_eq!(
             intl.format_message_to_string(TASKS, &values).unwrap(),
             "1 task"
+        );
+    }
+
+    #[test]
+    fn reports_missing_translation_before_fallback() {
+        let errors = Arc::new(Mutex::new(Vec::new()));
+        let captured_errors = errors.clone();
+        let intl = Intl::try_new(["fr"], "en", catalog(), Arc::new(IntlCache::new()))
+            .unwrap()
+            .with_on_error(move |error| {
+                captured_errors.lock().unwrap().push((
+                    error.descriptor.id.to_owned(),
+                    error.locale.clone(),
+                    matches!(error.error, Error::MissingTranslation { .. }),
+                ));
+            });
+
+        let descriptor = MessageDescriptor::new("missing", "Fallback");
+        assert_eq!(
+            intl.format_message_to_string(descriptor, &Values::new())
+                .unwrap(),
+            "Fallback"
+        );
+        assert_eq!(
+            *errors.lock().unwrap(),
+            vec![("missing".to_owned(), "fr".to_owned(), true)]
         );
     }
 

--- a/crates/intl_python/lib.rs
+++ b/crates/intl_python/lib.rs
@@ -1,12 +1,16 @@
 use base64::Engine;
-use formatjs_icu_messageformat::{IcuMessageFormat, Value, Values};
-use formatjs_intl::{MessageCatalog, negotiate_locale};
+use formatjs_icu_messageformat::{DateTimeValue, Value, Values};
+use formatjs_intl::{
+    Error as IntlError, Intl, IntlCache, MessageCatalog, MessageDescriptorRef, MessageSource,
+    negotiate_locale,
+};
 use icu_locale::Locale;
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
-use pyo3::types::{PyAny, PyDict};
+use pyo3::types::{PyAny, PyDate, PyDateTime, PyDict};
 use sha2::{Digest, Sha512};
 use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
 
 const GENERATED_ID_LENGTH: usize = 10;
 
@@ -45,6 +49,32 @@ fn value_from_python(value: &Bound<'_, PyAny>) -> PyResult<Value<String>> {
     if value.is_none() {
         return Ok(Value::Null);
     }
+    if let Ok(value) = value.cast::<PyDateTime>() {
+        return DateTimeValue::try_new(
+            value.getattr("year")?.extract()?,
+            value.getattr("month")?.extract()?,
+            value.getattr("day")?.extract()?,
+            value.getattr("hour")?.extract()?,
+            value.getattr("minute")?.extract()?,
+            value.getattr("second")?.extract()?,
+            value.getattr("microsecond")?.extract::<u32>()? * 1_000,
+        )
+        .map(Value::DateTime)
+        .map_err(|error| PyValueError::new_err(error.to_string()));
+    }
+    if let Ok(value) = value.cast::<PyDate>() {
+        return DateTimeValue::try_new(
+            value.getattr("year")?.extract()?,
+            value.getattr("month")?.extract()?,
+            value.getattr("day")?.extract()?,
+            0,
+            0,
+            0,
+            0,
+        )
+        .map(Value::DateTime)
+        .map_err(|error| PyValueError::new_err(error.to_string()));
+    }
     if let Ok(value) = value.extract::<bool>() {
         return Ok(Value::Boolean(value));
     }
@@ -61,7 +91,7 @@ fn value_from_python(value: &Bound<'_, PyAny>) -> PyResult<Value<String>> {
         return Ok(Value::String(value));
     }
     Err(PyTypeError::new_err(
-        "message values must be str, bool, int, float, or None",
+        "message values must be str, bool, int, float, date, datetime, or None",
     ))
 }
 
@@ -78,19 +108,32 @@ fn values_from_python(values: Option<&Bound<'_, PyDict>>) -> PyResult<Values<Str
 
 #[pyclass(name = "Intl", unsendable)]
 struct PyIntl {
-    locale: String,
-    default_locale: String,
-    catalog: MessageCatalog,
-    cache: HashMap<String, IcuMessageFormat>,
+    intl: Intl,
+    callback_error: Arc<Mutex<Option<PyErr>>>,
+}
+
+fn cache() -> Arc<IntlCache> {
+    static CACHE: OnceLock<Arc<IntlCache>> = OnceLock::new();
+    CACHE.get_or_init(|| Arc::new(IntlCache::new())).clone()
+}
+
+fn source_name(source: MessageSource) -> &'static str {
+    match source {
+        MessageSource::Translation => "translation",
+        MessageSource::DefaultCatalog => "default_catalog",
+        MessageSource::DefaultMessage => "default_message",
+    }
 }
 
 #[pymethods]
 impl PyIntl {
     #[new]
+    #[pyo3(signature = (requested_locales, default_locale, messages, on_error = None))]
     fn new(
         requested_locales: Vec<String>,
         default_locale: String,
         messages: HashMap<String, HashMap<String, String>>,
+        on_error: Option<Py<PyAny>>,
     ) -> PyResult<Self> {
         let mut catalog = MessageCatalog::new();
         for (locale, messages) in messages {
@@ -98,38 +141,69 @@ impl PyIntl {
                 .insert(locale, messages)
                 .map_err(|error| PyValueError::new_err(error.to_string()))?;
         }
-        if !catalog.contains_locale(&default_locale) {
-            return Err(PyValueError::new_err(format!(
-                "Default locale has no translation catalog: {default_locale}"
-            )));
-        }
-        let parsed_default_locale = default_locale
-            .parse::<Locale>()
-            .map_err(|error| PyValueError::new_err(error.to_string()))?;
-        let locale = negotiate_locale(&requested_locales, &parsed_default_locale, &catalog)
-            .map_err(|error| PyValueError::new_err(error.to_string()))?
-            .to_string();
-        Ok(Self {
-            locale,
+        let mut intl = Intl::try_new(
+            requested_locales,
             default_locale,
-            catalog,
-            cache: HashMap::new(),
+            Arc::new(catalog),
+            cache(),
+        )
+        .map_err(|error| PyValueError::new_err(error.to_string()))?;
+        let callback_error = Arc::new(Mutex::new(None));
+        if let Some(callback) = on_error {
+            let captured_error = callback_error.clone();
+            intl = intl.with_on_error(move |error| {
+                if captured_error
+                    .lock()
+                    .expect("callback error lock")
+                    .is_some()
+                {
+                    return;
+                }
+                let code = match &error.error {
+                    IntlError::MissingTranslation { .. } => "MISSING_TRANSLATION",
+                    _ => "FORMAT_ERROR",
+                };
+                Python::attach(|py| {
+                    if let Err(callback_error) = callback.call1(
+                        py,
+                        (
+                            code,
+                            error.descriptor.id.as_str(),
+                            error.descriptor.default_message.as_str(),
+                            error.descriptor.description.as_deref(),
+                            error.locale.as_str(),
+                            source_name(error.source),
+                            error.to_string(),
+                        ),
+                    ) {
+                        *captured_error.lock().expect("callback error lock") = Some(callback_error);
+                    }
+                });
+            });
+        }
+        Ok(Self {
+            intl,
+            callback_error,
         })
     }
 
     #[getter]
-    fn locale(&self) -> &str {
-        &self.locale
+    fn locale(&self) -> String {
+        self.intl.locale().to_string()
     }
 
     #[pyo3(signature = (id = None, *, default_message = "", description = None, values = None))]
     fn format_message(
-        &mut self,
+        &self,
         id: Option<&str>,
         default_message: &str,
         description: Option<&str>,
         values: Option<&Bound<'_, PyDict>>,
     ) -> PyResult<String> {
+        self.callback_error
+            .lock()
+            .expect("callback error lock")
+            .take();
         let id = match id {
             Some(id) => id.to_owned(),
             None if default_message.is_empty() => {
@@ -140,42 +214,24 @@ impl PyIntl {
             None => generate_id(default_message, description),
         };
         let values = values_from_python(values)?;
-        let mut candidates = Vec::with_capacity(3);
-        if let Some(messages) = self.catalog.messages(&self.locale) {
-            if let Some(message) = messages.get(&id).filter(|message| !message.is_empty()) {
-                candidates.push((message.clone(), self.locale.clone()));
+        let descriptor = match description {
+            Some(description) => {
+                MessageDescriptorRef::new(&id, default_message).with_description(description)
             }
+            None => MessageDescriptorRef::new(&id, default_message),
+        };
+        let formatted = self
+            .intl
+            .format_message_to_string_or_default_ref(descriptor, &values);
+        if let Some(error) = self
+            .callback_error
+            .lock()
+            .expect("callback error lock")
+            .take()
+        {
+            return Err(error);
         }
-        if self.locale != self.default_locale {
-            if let Some(messages) = self.catalog.messages(&self.default_locale) {
-                if let Some(message) = messages.get(&id).filter(|message| !message.is_empty()) {
-                    candidates.push((message.clone(), self.default_locale.clone()));
-                }
-            }
-        }
-        if !default_message.is_empty() {
-            candidates.push((default_message.to_owned(), self.default_locale.clone()));
-        }
-
-        for (message, locale) in candidates {
-            if !self.cache.contains_key(&message) {
-                let compiled = match IcuMessageFormat::try_new(&message) {
-                    Ok(compiled) => compiled,
-                    Err(_) => continue,
-                };
-                self.cache.insert(message.clone(), compiled);
-            }
-            let compiled = self.cache.get(&message).expect("cached message");
-            if let Ok(formatted) = compiled.format_to_string(&locale, &values) {
-                return Ok(formatted);
-            }
-        }
-
-        Ok(if default_message.is_empty() {
-            id
-        } else {
-            default_message.to_owned()
-        })
+        Ok(formatted)
     }
 }
 

--- a/docs/src/docs/python.mdx
+++ b/docs/src/docs/python.mdx
@@ -24,8 +24,11 @@ python -m pip install py_intl
 ## Format messages
 
 ```python
-from intl import Intl
+from datetime import date
 
+from intl import Intl, IntlError
+
+errors: list[IntlError] = []
 intl = Intl(
     ["fr-CA", "fr"],
     "en",
@@ -33,6 +36,7 @@ intl = Intl(
         "en": {},
         "fr": {"tasks": "{count, plural, one {# tâche} other {# tâches}}"},
     },
+    on_error=errors.append,
 )
 
 assert intl.locale == "fr"
@@ -51,7 +55,7 @@ as Rust.
 ```python
 title = intl.format_message(
     default_message="Welcome, {name}!",
-    name=user.name,
+    values={"name": user.name},
 )
 ```
 
@@ -61,8 +65,23 @@ Reusable descriptors match the backend authoring shape used by Bazel consumers:
 from intl import define_message
 
 TITLE = define_message(default_message="Welcome, {name}!")
-title = intl.format_message(TITLE, name=user.name)
+title = intl.format_message(TITLE, values={"name": user.name})
 ```
+
+Python `date` and `datetime` values work with ICU date and time arguments:
+
+```python
+created = intl.format_message(
+    default_message="Created {value, date, medium}",
+    values={"value": date(2024, 1, 2)},
+)
+```
+
+Datetime fields are formatted as supplied. Convert timezone-aware values to the
+desired presentation timezone before formatting.
+
+Like `@formatjs/intl`, formatting returns the formatted value directly.
+Recovered missing translations and formatting failures are sent to `on_error`.
 
 Use `icu_messageformat` when catalog lookup happens elsewhere:
 

--- a/knowledge-base/003-rust-crate-dependency-hierarchy.md
+++ b/knowledge-base/003-rust-crate-dependency-hierarchy.md
@@ -185,6 +185,10 @@ the crate is not published to crates.io.
 - Falls back from selected catalog to default catalog, then descriptor message.
 - Retries parse and format failures through the same chain, using each source's
   locale; `with_on_error` exposes recovered message and infrastructure errors.
+- Reports missing negotiated-locale messages through `with_on_error` before
+  continuing through the fallback chain.
+- Accepts borrowed runtime descriptors through `MessageDescriptorRef`; static
+  Rust descriptors keep the existing `MessageDescriptor` API.
 - `format_message!` returns the descriptor default verbatim when cache
   infrastructure prevents formatting; fallible methods preserve explicit errors.
 - Returns the first source verbatim, then the message ID, when every formatting
@@ -233,6 +237,11 @@ PyO3 binding crates. Python names mirror the Rust layers without the
 | `icu_messageformat_parser` | `formatjs_icu_messageformat_parser` |
 | `icu_messageformat`        | `formatjs_icu_messageformat`        |
 | `intl`                     | `formatjs_intl`                     |
+
+The `intl` binding delegates catalog lookup, caching, and fallback to the Rust
+`Intl` implementation. Its Python facade accepts `date` and `datetime` message
+values and exposes recovered runtime issues through `on_error` while returning
+formatted strings directly.
 
 The CLI has no Python package. See [Python documentation](/docs/python) for
 public APIs.

--- a/python/intl/README.md
+++ b/python/intl/README.md
@@ -7,17 +7,31 @@ python -m pip install py_intl
 ```
 
 ```python
-from intl import Intl, define_message
+from datetime import date
 
-intl = Intl(["fr-CA", "fr"], "en", {"fr": {"hello": "Bonjour"}, "en": {}})
+from intl import Intl, IntlError, define_message
+
+errors: list[IntlError] = []
+intl = Intl(
+    ["fr-CA", "fr"],
+    "en",
+    {"fr": {"hello": "Bonjour"}, "en": {}},
+    on_error=errors.append,
+)
 assert intl.format_message("hello", default_message="Hello") == "Bonjour"
 
 # IDs are optional and generated from the descriptor.
 assert intl.format_message(default_message="Welcome") == "Welcome"
 
 greeting = define_message(default_message="Hello, {name}!")
-assert intl.format_message(greeting, name="Ada") == "Hello, Ada!"
+assert intl.format_message(greeting, values={"name": "Ada"}) == "Hello, Ada!"
+
+created = define_message(default_message="Created {value, date, medium}")
+assert intl.format_message(created, values={"value": date(2024, 1, 2)}) == "Created Jan 2, 2024"
 ```
 
 Use the `Intl` instance negotiated for the current request. Generated IDs are
-locale-independent.
+locale-independent. `on_error` receives recovered missing-translation and
+formatting errors while `format_message` continues through FormatJS fallback.
+Datetime fields are formatted as supplied; convert timezone-aware values before
+formatting when another presentation timezone is required.

--- a/python/intl/intl/__init__.py
+++ b/python/intl/intl/__init__.py
@@ -2,13 +2,15 @@
 
 import base64
 import hashlib
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
+from datetime import date, datetime
+from enum import StrEnum
 
 from intl._native import Intl as _NativeIntl
 from intl._native import negotiate
 
-MessageValue = str | bool | int | float | None
+MessageValue = str | bool | int | float | date | datetime | None
 
 
 def _generate_id(default_message: str, description: str | None) -> str:
@@ -46,17 +48,71 @@ def define_message(
     )
 
 
+class IntlErrorCode(StrEnum):
+    FORMAT_ERROR = "FORMAT_ERROR"
+    MISSING_TRANSLATION = "MISSING_TRANSLATION"
+
+
+class MessageSource(StrEnum):
+    TRANSLATION = "translation"
+    DEFAULT_CATALOG = "default_catalog"
+    DEFAULT_MESSAGE = "default_message"
+
+
+class IntlError(Exception):
+    def __init__(
+        self,
+        code: IntlErrorCode,
+        descriptor: MessageDescriptor,
+        locale: str,
+        source: MessageSource,
+        message: str,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.descriptor = descriptor
+        self.locale = locale
+        self.source = source
+        self.message = message
+
+
 class Intl:
     def __init__(
         self,
         requested_locales: list[str],
         default_locale: str,
         messages: Mapping[str, Mapping[str, str]],
+        on_error: Callable[[IntlError], None] | None = None,
     ) -> None:
+        def handle_error(
+            code: str,
+            message_id: str,
+            default_message: str,
+            description: str | None,
+            locale: str,
+            source: str,
+            message: str,
+        ) -> None:
+            if on_error is not None:
+                on_error(
+                    IntlError(
+                        code=IntlErrorCode(code),
+                        descriptor=MessageDescriptor(
+                            id=message_id,
+                            default_message=default_message,
+                            description=description,
+                        ),
+                        locale=locale,
+                        source=MessageSource(source),
+                        message=message,
+                    )
+                )
+
         self._native = _NativeIntl(
             requested_locales,
             default_locale,
             {locale: dict(locale_messages) for locale, locale_messages in messages.items()},
+            handle_error if on_error is not None else None,
         )
 
     @property
@@ -71,7 +127,6 @@ class Intl:
         default_message: str | None = None,
         description: str | None = None,
         values: Mapping[str, MessageValue] | None = None,
-        **message_values: MessageValue,
     ) -> str:
         if isinstance(descriptor, str):
             if id is not None:
@@ -84,18 +139,20 @@ class Intl:
             default_message = descriptor.default_message
             description = descriptor.description
 
-        merged_values: dict[str, MessageValue] = dict(values or {})
-        duplicates = merged_values.keys() & message_values.keys()
-        if duplicates:
-            duplicate = min(duplicates)
-            raise TypeError(f"message value was provided twice: {duplicate}")
-        merged_values.update(message_values)
         return self._native.format_message(
             id,
             default_message=default_message or "",
             description=description,
-            values=merged_values,
+            values=dict(values or {}),
         )
 
 
-__all__ = ["Intl", "MessageDescriptor", "define_message", "negotiate"]
+__all__ = [
+    "Intl",
+    "IntlError",
+    "IntlErrorCode",
+    "MessageDescriptor",
+    "MessageSource",
+    "define_message",
+    "negotiate",
+]

--- a/python/intl/intl/__init__.pyi
+++ b/python/intl/intl/__init__.pyi
@@ -1,7 +1,9 @@
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
-from typing import Mapping
+from datetime import date, datetime
+from enum import StrEnum
 
-MessageValue = str | bool | int | float | None
+MessageValue = str | bool | int | float | date | datetime | None
 
 @dataclass(frozen=True, slots=True)
 class MessageDescriptor:
@@ -17,12 +19,37 @@ def define_message(
     description: str | None = None,
 ) -> MessageDescriptor: ...
 
+class IntlErrorCode(StrEnum):
+    FORMAT_ERROR = "FORMAT_ERROR"
+    MISSING_TRANSLATION = "MISSING_TRANSLATION"
+
+class MessageSource(StrEnum):
+    TRANSLATION = "translation"
+    DEFAULT_CATALOG = "default_catalog"
+    DEFAULT_MESSAGE = "default_message"
+
+class IntlError(Exception):
+    code: IntlErrorCode
+    descriptor: MessageDescriptor
+    locale: str
+    source: MessageSource
+    message: str
+    def __init__(
+        self,
+        code: IntlErrorCode,
+        descriptor: MessageDescriptor,
+        locale: str,
+        source: MessageSource,
+        message: str,
+    ) -> None: ...
+
 class Intl:
     def __init__(
         self,
         requested_locales: list[str],
         default_locale: str,
         messages: Mapping[str, Mapping[str, str]],
+        on_error: Callable[[IntlError], None] | None = None,
     ) -> None: ...
     @property
     def locale(self) -> str: ...
@@ -34,7 +61,6 @@ class Intl:
         default_message: str | None = None,
         description: str | None = None,
         values: Mapping[str, MessageValue] | None = None,
-        **message_values: MessageValue,
     ) -> str: ...
 
 def negotiate(

--- a/python/intl/tests/test_binding.py
+++ b/python/intl/tests/test_binding.py
@@ -1,7 +1,30 @@
 import base64
 import hashlib
+from collections.abc import Callable
+from datetime import date, datetime
 
-from intl import Intl, MessageDescriptor, define_message, negotiate
+from intl import (
+    Intl,
+    IntlError,
+    IntlErrorCode,
+    MessageDescriptor,
+    MessageSource,
+    define_message,
+    negotiate,
+)
+
+
+def assert_raises(
+    error_type: type[Exception],
+    expected_message: str,
+    callback: Callable[[], object],
+) -> None:
+    try:
+        callback()
+    except error_type as error:
+        assert expected_message in str(error)
+    else:
+        raise AssertionError(f"expected {error_type.__name__}")
 
 
 def test_negotiates_locale() -> None:
@@ -31,7 +54,7 @@ def test_formats_translation_and_fallback() -> None:
                 id="tasks",
                 default_message="{count, plural, one {# task} other {# tasks}}",
             ),
-            count=2,
+            values={"count": 2},
         )
         == "2 tâches"
     )
@@ -50,14 +73,189 @@ def test_formats_translation_and_fallback() -> None:
     assert runtime.format_message(descriptor) == "Bienvenue"
     assert descriptor.id == generated_id
 
+def test_reports_fallback_and_formats_python_dates() -> None:
+    errors: list[IntlError] = []
+    runtime = Intl(["fr"], "en", {"en": {}, "fr": {}}, on_error=errors.append)
+
+    assert runtime.format_message("missing", default_message="Fallback") == "Fallback"
+    assert len(errors) == 1
+    assert errors[0].code == IntlErrorCode.MISSING_TRANSLATION
+    assert errors[0].descriptor.id == "missing"
+    assert errors[0].locale == "fr"
+    assert errors[0].source == MessageSource.TRANSLATION
+
+    errors.clear()
+    broken = Intl(
+        ["fr"],
+        "en",
+        {"en": {}, "fr": {"broken": "{broken"}},
+        on_error=errors.append,
+    )
+    assert broken.format_message("broken", default_message="Safe") == "Safe"
+    assert len(errors) == 1
+    assert errors[0].code == IntlErrorCode.FORMAT_ERROR
+    assert errors[0].source == MessageSource.TRANSLATION
+
+    def reject_fallback(_error: IntlError) -> None:
+        raise RuntimeError("fallback rejected")
+
+    strict = Intl(["fr"], "en", {"en": {}, "fr": {}}, on_error=reject_fallback)
     try:
-        runtime.format_message("tasks", values={"count": 1}, count=2)
-    except TypeError as error:
-        assert str(error) == "message value was provided twice: count"
+        strict.format_message("missing", default_message="Fallback")
+    except RuntimeError as error:
+        assert str(error) == "fallback rejected"
     else:
-        raise AssertionError("duplicate message value should fail")
+        raise AssertionError("on_error exception should propagate")
+
+    english = Intl(["en"], "en", {"en": {}})
+    message = MessageDescriptor(
+        id="created",
+        default_message="Created {value, date, medium}",
+    )
+    assert english.format_message(message, values={"value": date(2024, 1, 2)}) == (
+        "Created Jan 2, 2024"
+    )
+    assert english.format_message(
+        message, values={"value": datetime(2024, 1, 2, 3, 4, 5)}
+    ) == ("Created Jan 2, 2024")
+
+
+def test_formats_arguments_selects_and_plurals() -> None:
+    runtime = Intl(
+        ["en"],
+        "en",
+        {
+            "en": {
+                "greeting": "Hello, {name}!",
+                "role": "{role, select, admin {Administrator} other {User}}",
+                "tasks": "{count, plural, =0 {No tasks} one {# task} other {# tasks}}",
+            }
+        },
+    )
+
+    assert runtime.format_message("greeting", values={"name": "Ada"}) == "Hello, Ada!"
+    assert runtime.format_message("role", values={"role": "admin"}) == "Administrator"
+    assert runtime.format_message("role", values={"role": "member"}) == "User"
+    assert runtime.format_message("tasks", values={"count": 0}) == "No tasks"
+    assert runtime.format_message("tasks", values={"count": 1}) == "1 task"
+    assert runtime.format_message("tasks", values={"count": 4}) == "4 tasks"
+
+
+def test_falls_back_across_catalogs_and_descriptor() -> None:
+    errors: list[IntlError] = []
+    runtime = Intl(
+        ["fr"],
+        "en",
+        {
+            "fr": {"syntax": "{broken"},
+            "en": {
+                "syntax": "English fallback",
+                "catalog-broken": "{broken",
+            },
+        },
+        on_error=errors.append,
+    )
+
+    assert runtime.format_message("syntax", default_message="Descriptor fallback") == (
+        "English fallback"
+    )
+    assert [(error.code, error.source, error.locale) for error in errors] == [
+        (IntlErrorCode.FORMAT_ERROR, MessageSource.TRANSLATION, "fr")
+    ]
+
+    errors.clear()
+    assert runtime.format_message(
+        "catalog-broken", default_message="Descriptor fallback"
+    ) == ("Descriptor fallback")
+    assert [(error.code, error.source, error.locale) for error in errors] == [
+        (IntlErrorCode.MISSING_TRANSLATION, MessageSource.TRANSLATION, "fr"),
+        (IntlErrorCode.FORMAT_ERROR, MessageSource.DEFAULT_CATALOG, "en"),
+    ]
+
+
+def test_returns_verbatim_translation_after_all_formatting_fails() -> None:
+    errors: list[IntlError] = []
+    runtime = Intl(
+        ["fr"],
+        "en",
+        {
+            "fr": {"missing-value": "Traduction {name}"},
+            "en": {"missing-value": "Catalog {name}"},
+        },
+        on_error=errors.append,
+    )
+
+    assert runtime.format_message(
+        "missing-value", default_message="Default {name}"
+    ) == ("Traduction {name}")
+    assert [error.code for error in errors] == [IntlErrorCode.FORMAT_ERROR] * 3
+    assert [error.source for error in errors] == [
+        MessageSource.TRANSLATION,
+        MessageSource.DEFAULT_CATALOG,
+        MessageSource.DEFAULT_MESSAGE,
+    ]
+
+
+def test_handles_missing_and_empty_messages() -> None:
+    errors: list[IntlError] = []
+    runtime = Intl(
+        ["fr"],
+        "en",
+        {"fr": {"empty": ""}, "en": {"empty": "English fallback"}},
+        on_error=errors.append,
+    )
+
+    assert runtime.format_message("missing") == "missing"
+    assert runtime.format_message("empty", default_message="Descriptor fallback") == (
+        "English fallback"
+    )
+    assert [error.code for error in errors] == [
+        IntlErrorCode.MISSING_TRANSLATION,
+        IntlErrorCode.MISSING_TRANSLATION,
+    ]
+
+    default_errors: list[IntlError] = []
+    default_runtime = Intl(
+        ["en"], "en", {"en": {}}, on_error=default_errors.append
+    )
+    assert default_runtime.format_message("missing", default_message="Fallback") == "Fallback"
+    assert default_errors == []
+
+
+def test_rejects_invalid_calls_and_values() -> None:
+    runtime = Intl(["en"], "en", {"en": {}})
+    descriptor = MessageDescriptor(id="message", default_message="Message")
+
+    assert_raises(
+        ValueError,
+        "default_message is required when id is omitted",
+        runtime.format_message,
+    )
+    assert_raises(
+        TypeError,
+        "id was provided twice",
+        lambda: runtime.format_message("first", id="second"),
+    )
+    assert_raises(
+        TypeError,
+        "descriptor fields cannot be combined with a descriptor",
+        lambda: runtime.format_message(descriptor, default_message="Other"),
+    )
+    assert_raises(
+        TypeError,
+        "message values must be str, bool, int, float, date, datetime, or None",
+        lambda: runtime.format_message(
+            "message", values={"unsupported": object()}  # type: ignore[dict-item]
+        ),
+    )
 
 
 if __name__ == "__main__":
     test_negotiates_locale()
     test_formats_translation_and_fallback()
+    test_reports_fallback_and_formats_python_dates()
+    test_formats_arguments_selects_and_plurals()
+    test_falls_back_across_catalogs_and_descriptor()
+    test_returns_verbatim_translation_after_all_formatting_fails()
+    test_handles_missing_and_empty_messages()
+    test_rejects_invalid_calls_and_values()


### PR DESCRIPTION
Stacked on #7129.

Make `py_intl` use the shared Rust `Intl` runtime instead of duplicating catalog fallback and caching.

- add borrowed runtime descriptors for Python-defined messages
- expose recovered missing-translation and formatting errors through `on_error`
- accept Python `date` and `datetime` message values
- keep `format_message` returning the formatted string directly

Tests:
- `bazel test //crates/formatjs_cli:formatjs_cli_test //crates/formatjs_intl:formatjs_intl_test //python/intl:python_test //docs:docs_metadata_test --test_output=errors`
- `bazel build //python/intl:wheel`
- `bazel mod deps --lockfile_mode=error`