### PR TITLE
build(deps): update Bazel lockfiles for Renovate PRs

### DIFF
--- a/.github/workflows/renovate-bazel-lock.yml
+++ b/.github/workflows/renovate-bazel-lock.yml
@@ -1,0 +1,113 @@
+name: Update Renovate Bazel Lockfile
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  generate:
+    if: >-
+      github.actor == 'renovate[bot]' &&
+      github.event.pull_request.user.login == 'renovate[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      changed: ${{ steps.lockfile.outputs.changed }}
+
+    steps:
+      - name: Checkout Renovate Branch
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Setup Bazel
+        uses: bazel-contrib/setup-bazel@0.19.0
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}
+          repository-cache: true
+
+      - name: Update Bazel Lockfile
+        id: lockfile
+        run: |
+          bazel mod deps --lockfile_mode=update
+          bazel mod deps --lockfile_mode=error
+          if git diff --quiet -- MODULE.bazel.lock; then
+            echo 'changed=false' >> "$GITHUB_OUTPUT"
+          else
+            jq empty MODULE.bazel.lock
+            echo 'changed=true' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload Bazel Lockfile
+        if: steps.lockfile.outputs.changed == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: bazel-lock-${{ github.run_id }}
+          path: MODULE.bazel.lock
+          if-no-files-found: error
+          retention-days: 1
+
+  commit:
+    needs: generate
+    if: >-
+      needs.generate.outputs.changed == 'true' &&
+      github.actor == 'renovate[bot]' &&
+      github.event.pull_request.user.login == 'renovate[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
+    env:
+      HEAD_REF: ${{ github.event.pull_request.head.ref }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+
+    steps:
+      - name: Checkout Renovate Branch
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Verify Renovate Head
+        run: test "$(git rev-parse HEAD)" = "$HEAD_SHA"
+
+      - name: Download Bazel Lockfile
+        uses: actions/download-artifact@v8
+        with:
+          name: bazel-lock-${{ github.run_id }}
+          path: generated-lock
+
+      - name: Commit Bazel Lockfile
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          test -f generated-lock/MODULE.bazel.lock
+          test ! -L generated-lock/MODULE.bazel.lock
+          test "$(wc -c < generated-lock/MODULE.bazel.lock)" -lt 10000000
+          jq empty generated-lock/MODULE.bazel.lock
+          cp generated-lock/MODULE.bazel.lock MODULE.bazel.lock
+
+          if git diff --quiet -- MODULE.bazel.lock; then
+            exit 0
+          fi
+
+          test "$(git diff --name-only)" = 'MODULE.bazel.lock'
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add MODULE.bazel.lock
+          git commit --no-verify -m 'fix(deps): update Bazel lockfile'
+          git push origin "HEAD:$HEAD_REF"
+
+          gh workflow run test.yml --ref "$HEAD_REF"
+          gh workflow run verify-hooks.yml --ref "$HEAD_REF" -f base_ref="$BASE_REF"

--- a/.github/workflows/verify-hooks.yml
+++ b/.github/workflows/verify-hooks.yml
@@ -6,6 +6,12 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      base_ref:
+        description: Base branch used for commit validation
+        required: true
+        default: main
 
 jobs:
   verify-hooks:
@@ -39,10 +45,12 @@ jobs:
           fi
 
       - name: Validate Commit Messages
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+        env:
+          BASE_REF: ${{ github.event_name == 'pull_request' && github.base_ref || inputs.base_ref }}
         run: |
-          git fetch origin ${{ github.base_ref }}
-          commits=$(git rev-list origin/${{ github.base_ref }}..HEAD)
+          git fetch origin "$BASE_REF"
+          commits=$(git rev-list "origin/$BASE_REF"..HEAD)
 
           for commit in $commits; do
             echo "Validating commit: $(git log -1 --oneline $commit)"

--- a/renovate.json
+++ b/renovate.json
@@ -8,14 +8,6 @@
     "**/node_modules/**",
     "packages/react-intl/example-sandboxes/**"
   ],
-  "postUpgradeTasks": {
-    "commands": ["bazel mod deps --lockfile_mode=update"],
-    "fileFilters": ["MODULE.bazel.lock"],
-    "executionMode": "branch",
-    "installTools": {
-      "bazelisk": {}
-    }
-  },
   "packageRules": [
     {
       "description": "Group NAPI-RS updates",


### PR DESCRIPTION
Mend-hosted Renovate cannot run our Bazel post-upgrade command because its global command allowlist is not configurable from this repo.

Add a workflow that regenerates `MODULE.bazel.lock` for same-repo Renovate PRs. Generation runs with read-only permissions; a separate job validates and commits only the lockfile. The bot commit explicitly dispatches the two required checks because `GITHUB_TOKEN` pushes do not trigger them.

Loop prevention: only Renovate-authored PR events run the jobs. The GitHub Actions bot push and dispatched workflows cannot start another lockfile update.