### PR TITLE
fix(eslint-plugin-formatjs): align message recognition across tools

### DIFF
--- a/crates/formatjs_cli/src/extractor.rs
+++ b/crates/formatjs_cli/src/extractor.rs
@@ -348,6 +348,9 @@ impl<'a> MessageExtractor<'a> {
     ) -> &'b Expression<'a> {
         loop {
             match expr {
+                Expression::ParenthesizedExpression(parenthesized) => {
+                    expr = &parenthesized.expression
+                }
                 Expression::TSAsExpression(ts_as) => expr = &ts_as.expression,
                 Expression::TSSatisfiesExpression(ts_satisfies) => expr = &ts_satisfies.expression,
                 Expression::TSTypeAssertion(ts_type_assertion) => {
@@ -576,36 +579,38 @@ impl<'a> MessageExtractor<'a> {
 
         for prop in &obj.properties {
             if let ObjectPropertyKind::ObjectProperty(p) = prop {
-                if let PropertyKey::StaticIdentifier(key) = &p.key {
-                    match key.name.as_str() {
-                        "id" => {
-                            descriptor.id = self.extract_string_literal(&p.value, Some(true));
-                            if descriptor.id.is_none() {
-                                extraction_error = true;
-                                let loc = self.format_location(p.span.start);
-                                self.errors.push(format!(
-                                    "{} [FormatJS] `id` must be a string literal to be extracted.",
-                                    loc
-                                ));
-                            }
+                let name = match &p.key {
+                    PropertyKey::StaticIdentifier(key) => key.name.as_str(),
+                    PropertyKey::StringLiteral(key) => key.value.as_str(),
+                    _ => continue,
+                };
+                match name {
+                    "id" => {
+                        descriptor.id = self.extract_string_literal(&p.value, Some(true));
+                        if descriptor.id.is_none() {
+                            extraction_error = true;
+                            let loc = self.format_location(p.span.start);
+                            self.errors.push(format!(
+                                "{} [FormatJS] `id` must be a string literal to be extracted.",
+                                loc
+                            ));
                         }
-                        "defaultMessage" => {
-                            descriptor.default_message =
-                                self.extract_string_literal(&p.value, None);
-                            if descriptor.default_message.is_none() {
-                                extraction_error = true;
-                                let loc = self.format_location(p.span.start);
-                                self.errors.push(format!(
+                    }
+                    "defaultMessage" => {
+                        descriptor.default_message = self.extract_string_literal(&p.value, None);
+                        if descriptor.default_message.is_none() {
+                            extraction_error = true;
+                            let loc = self.format_location(p.span.start);
+                            self.errors.push(format!(
                                     "{} [FormatJS] `defaultMessage` must be a string literal to be extracted.",
                                     loc
                                 ));
-                            }
                         }
-                        "description" => {
-                            descriptor.description = self.extract_description(&p.value);
-                        }
-                        _ => {}
                     }
+                    "description" => {
+                        descriptor.description = self.extract_description(&p.value);
+                    }
+                    _ => {}
                 }
             }
         }

--- a/crates/formatjs_cli/src/extractor.rs
+++ b/crates/formatjs_cli/src/extractor.rs
@@ -914,6 +914,134 @@ mod tests {
     }
 
     #[test]
+    fn test_message_recognition_parenthesized_descriptors() {
+        let descriptor = "{id: 'greeting', defaultMessage: 'Hello', description: 'Greeting'}";
+        let sources = [
+            format!("wrappedIntl.formatMessage(({descriptor}))"),
+            format!("messages.defineMessage((({descriptor} as const) satisfies MessageDescriptor)!)"),
+            format!("messages.defineMessages(({{greeting: {descriptor}}}))"),
+            format!("messages.defineMessages({{greeting: ({descriptor})}})"),
+            format!("messages.defineMessages(({{greeting: (<MessageDescriptor>{descriptor})!}} as const)!)"),
+            "wrappedIntl.formatMessage({id: ('greeting' as const), defaultMessage: ('Hello'), description: ('Greeting' satisfies string)})".to_string(),
+        ];
+        let function_names = vec![
+            "formatMessage".to_string(),
+            "defineMessage".to_string(),
+            "defineMessages".to_string(),
+        ];
+
+        for source in sources {
+            let messages = extract_messages_from_source(
+                &source,
+                Path::new("test.ts"),
+                SourceType::default().with_typescript(true),
+                true,
+                &[],
+                &function_names,
+                HashMap::new(),
+                false,
+                false,
+                false,
+            )
+            .unwrap();
+
+            assert_eq!(messages.len(), 1, "{source}");
+            let message = &messages[0];
+            assert_eq!(message.id.as_deref(), Some("greeting"), "{source}");
+            assert_eq!(
+                message.default_message.as_deref(),
+                Some("Hello"),
+                "{source}"
+            );
+            assert_eq!(
+                message.description,
+                Some(Value::String("Greeting".to_string())),
+                "{source}"
+            );
+            assert_eq!(message.start, Some(0), "{source}");
+            assert_eq!(message.end, Some(source.len() as u32), "{source}");
+        }
+    }
+
+    #[test]
+    fn test_message_recognition_quoted_descriptor_keys() {
+        let sources = [
+            r#"wrappedIntl.formatMessage({'id': 'greeting', "defaultMessage": 'Hello', 'description': 'Greeting'})"#,
+            r#"messages.defineMessage({"id": 'greeting', 'defaultMessage': 'Hello', "description": 'Greeting'})"#,
+            r#"messages.defineMessages({'greeting': {'id': 'greeting', 'defaultMessage': 'Hello', 'description': 'Greeting'}})"#,
+        ];
+        let function_names = vec![
+            "formatMessage".to_string(),
+            "defineMessage".to_string(),
+            "defineMessages".to_string(),
+        ];
+
+        for source in sources {
+            let messages = extract_messages_from_source(
+                source,
+                Path::new("test.ts"),
+                SourceType::default().with_typescript(true),
+                false,
+                &[],
+                &function_names,
+                HashMap::new(),
+                false,
+                false,
+                false,
+            )
+            .unwrap();
+
+            assert_eq!(messages.len(), 1, "{source}");
+            assert_eq!(messages[0].id.as_deref(), Some("greeting"), "{source}");
+            assert_eq!(
+                messages[0].default_message.as_deref(),
+                Some("Hello"),
+                "{source}"
+            );
+            assert_eq!(
+                messages[0].description,
+                Some(Value::String("Greeting".to_string())),
+                "{source}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_message_recognition_quoted_keys_reject_non_static_values() {
+        for (source, property) in [
+            (
+                "wrappedIntl.formatMessage({'id': getId(), defaultMessage: 'Hello'})",
+                "id",
+            ),
+            (
+                "wrappedIntl.formatMessage({id: 'greeting', 'defaultMessage': getMessage()})",
+                "defaultMessage",
+            ),
+        ] {
+            let extraction = extract_messages_from_source_with_diagnostics(
+                source,
+                Path::new("test.ts"),
+                SourceType::default().with_typescript(true),
+                false,
+                &[],
+                &["formatMessage".to_string()],
+                HashMap::new(),
+                false,
+                false,
+                false,
+            )
+            .unwrap();
+
+            assert!(extraction.messages.is_empty(), "{source}");
+            assert_eq!(extraction.errors.len(), 1, "{source}");
+            assert!(
+                extraction.errors[0].contains(&format!("`{property}` must be a string literal")),
+                "{source}"
+            );
+        }
+    }
+
+    #[test]
     fn test_extract_with_source_location() {
         let source = r#"
             <FormattedMessage defaultMessage="Test message" />

--- a/docs/src/docs/tooling/cli.mdx
+++ b/docs/src/docs/tooling/cli.mdx
@@ -170,6 +170,11 @@ formatjs compile "lang/*.json" --out-file compiled.json --ast
 formatjs verify "lang/*.json" --source-locale en --missing-keys
 ```
 
+JavaScript and TypeScript extraction accepts inline message descriptors wrapped
+in parentheses, `as`, `satisfies`, non-null assertions, and angle-bracket
+assertions. This includes `defineMessages` maps and their entries. Descriptor
+keys such as `defaultMessage`, `description`, and `id` may be quoted strings.
+
 The native CLI also extracts `formatjs_intl::message_descriptor!` calls from
 Rust source:
 

--- a/docs/src/docs/tooling/linter.mdx
+++ b/docs/src/docs/tooling/linter.mdx
@@ -51,7 +51,7 @@ export default [
 
 ### React
 
-Currently this uses `intl.formatMessage`, `defineMessage`, `defineMessages`, `<FormattedMessage>` from `react-intl` as hooks to verify the message. Therefore, in your code use 1 of the following mechanisms:
+The plugin checks `formatMessage`, `$formatMessage`, `$t`, `defineMessage`, `defineMessages`, and `<FormattedMessage>` messages. Function calls match by name, including methods on any receiver, just like `@formatjs/unplugin`. For example, `wrappedIntl.formatMessage(...)` and `messages.defineMessages(...)` are checked without resolving imports or receiver types:
 
 ```tsx
 const messages = defineMessages({
@@ -78,6 +78,20 @@ function foo() {
 }
 ```
 
+TypeScript wrappers (`as`, `satisfies`, non-null assertions, and angle-bracket
+assertions in `.ts` files) do not hide inline descriptors. This also applies to
+`defineMessages` maps and their individual entries. Autofixes preserve the
+surrounding wrappers.
+
+```tsx
+const wrappedIntl = useIntl()
+wrappedIntl.formatMessage({defaultMessage: 'Hello'} as const)
+
+messages.defineMessages({
+  greeting: {defaultMessage: 'Hello'} satisfies MessageDescriptor,
+} as const)
+```
+
 ### Vue
 
 This will check against `intl.formatMessage`, `$formatMessage` function calls in both your JS/TS & your SFC `.vue` files. For example:
@@ -100,7 +114,7 @@ These settings are applied globally to all formatjs rules once specified. See [S
 
 ### `formatjs.additionalFunctionNames`
 
-Similar to [babel-plugin-formatjs](/docs/tooling/babel-plugin#additionalfunctionnames) & [@formatjs/ts-transformer](/docs/tooling/ts-transformer#additionalfunctionnames), this allows you to specify additional function names to check besides `formatMessage` & `$formatMessage`.
+Similar to [babel-plugin-formatjs](/docs/tooling/babel-plugin#additionalfunctionnames) & [@formatjs/ts-transformer](/docs/tooling/ts-transformer#additionalfunctionnames), this allows you to specify additional function names to check besides `formatMessage`, `$formatMessage`, and `$t`. These names also match methods: configuring `customMessage` checks both `customMessage(...)` and `helpers.customMessage(...)`.
 
 ### `formatjs.additionalComponentNames`
 

--- a/docs/src/docs/tooling/unplugin.mdx
+++ b/docs/src/docs/tooling/unplugin.mdx
@@ -46,6 +46,13 @@ pnpm add -D @formatjs/unplugin
 
 The plugin processes message descriptors from: `defineMessages()`, `defineMessage()`, `intl.formatMessage`, `$t`, `$formatMessage` and `<FormattedMessage>`.
 
+Calls match by function or method name, regardless of receiver. This includes
+namespaced declarations and configured `additionalFunctionNames`. Parentheses
+and TypeScript wrappers (`as`, `satisfies`, non-null assertions, and angle-bracket
+assertions) are transparent around inline descriptors, `defineMessages` maps,
+and individual entries, including nested combinations. Transformations preserve
+these wrappers.
+
 ### Vite
 
 ```ts

--- a/knowledge-base/009-package-developer-tools.md
+++ b/knowledge-base/009-package-developer-tools.md
@@ -36,6 +36,7 @@
 - Uses `magic-string` for source map-preserving transformations
 - Single codebase for all bundlers via the `unplugin` framework
 - Replicates babel-plugin-formatjs + ts-transformer functionality without Babel/TS dependency
+- Unwraps parentheses and TypeScript wrappers around descriptors and declaration maps
 - Separate entry points per bundler: `vite.ts`, `webpack.ts`, `rollup.ts`, `esbuild.ts`, `rspack.ts`
 
 **Options:** `idInterpolationPattern`, `overrideIdFn`, `removeDefaultMessage`, `ast`, `preserveWhitespace`
@@ -59,6 +60,18 @@ the exact selector `options`. The `recommended` and `strict` configs block
 `selectordinal` and restrict `select` to `gender` with `male`, `female`, and
 `other` options.
 
+Message call recognition matches unplugin by callee name, regardless of receiver:
+`formatMessage`, `$formatMessage`, `$t`, `defineMessage(s)`, and configured
+`additionalFunctionNames` work as direct calls or methods, including optional
+calls. `util.ts` unwraps TypeScript assertions, `satisfies`, and non-null
+expressions around descriptors, `defineMessages` maps, and map entries. It keeps
+the inner object/property nodes for diagnostics and fixes. Descriptor keys may
+be identifiers or quoted strings. `excludeMessageDeclCalls` still excludes both
+direct and namespaced declarations. Cross-tool regression tests live in
+`tests/message-recognition.test.ts`. Native CLI/unplugin conformance also covers
+receiver names, configured functions, descriptor keys, and wrapper combinations
+in `packages/unplugin/conformance-tests/cli-unplugin-conformance.test.ts`.
+
 **Peer dep:** `eslint@9 || 10`
 
 ## @formatjs/cli-lib
@@ -77,6 +90,8 @@ the exact selector `options`. The `recommended` and `strict` configs block
   uses Ruff through the native `formatjs_cli_napi` extractor.
 - Vue, Svelte, Handlebars, and GTS/Glimmer keep small JavaScript container
   adapters. Embedded script fragments are sent to the same native extractor.
+- Native JS/TS extraction unwraps parentheses and TypeScript wrappers around
+  descriptors and declaration maps, and accepts quoted descriptor keys.
 - Programmatic options such as callbacks, custom ID functions, pragma metadata,
   source locations, stdin, and custom formatters are applied around structured
   native results.

--- a/packages/eslint-plugin-formatjs/BUILD.bazel
+++ b/packages/eslint-plugin-formatjs/BUILD.bazel
@@ -114,6 +114,7 @@ formatjs_test(
         "tests/enforce-placeholders.test.ts",
         "tests/enforce-plural-rules.test.ts",
         "tests/fixtures.ts",
+        "tests/message-recognition.test.ts",
         "tests/no-camel-case.test.ts",
         "tests/no-complex-selectors.test.ts",
         "tests/no-emoji.test.ts",
@@ -135,6 +136,7 @@ formatjs_test(
     tsconfig = packages_tsconfig(ESNEXT_TSCONFIG),
     deps = [
         ":eslint-plugin-formatjs",
+        "//:node_modules/@formatjs/unplugin",
         "//:node_modules/eslint",
         "//:node_modules/oxlint",
         "//:node_modules/vitest",

--- a/packages/eslint-plugin-formatjs/rules/prefer-formatted-message.ts
+++ b/packages/eslint-plugin-formatjs/rules/prefer-formatted-message.ts
@@ -1,6 +1,9 @@
 import type {JSXElement} from 'estree-jsx'
 import type {Rule} from 'eslint'
-import {isIntlFormatMessageCall} from '#packages/eslint-plugin-formatjs/util.js'
+import {
+  getSettings,
+  isIntlFormatMessageCall,
+} from '#packages/eslint-plugin-formatjs/util.js'
 
 export const name = 'prefer-formatted-message'
 
@@ -20,12 +23,13 @@ export const rule: Rule.RuleModule = {
   },
   // TODO: Vue support
   create(context) {
+    const {additionalFunctionNames} = getSettings(context)
     return {
       JSXElement: (node: JSXElement) => {
         node.children.forEach(child => {
           if (
             child.type !== 'JSXExpressionContainer' ||
-            !isIntlFormatMessageCall(child.expression)
+            !isIntlFormatMessageCall(child.expression, additionalFunctionNames)
           ) {
             return
           }

--- a/packages/eslint-plugin-formatjs/tests/message-recognition.test.ts
+++ b/packages/eslint-plugin-formatjs/tests/message-recognition.test.ts
@@ -1,0 +1,147 @@
+import {describe, expect, test} from 'vitest'
+import {transform} from '@formatjs/unplugin/transform'
+import {rule as descriptionRule} from '#packages/eslint-plugin-formatjs/rules/enforce-description.js'
+import {rule as idRule} from '#packages/eslint-plugin-formatjs/rules/enforce-id.js'
+import {rule as preferFormattedMessageRule} from '#packages/eslint-plugin-formatjs/rules/prefer-formatted-message.js'
+import {ruleTester} from '#packages/eslint-plugin-formatjs/tests/util.js'
+
+const descriptor = `{defaultMessage: 'Hello'}`
+const wrappers = [
+  (expression: string) => expression,
+  (expression: string) => `(${expression})`,
+  (expression: string) => `${expression} as const`,
+  (expression: string) => `${expression} satisfies MessageDescriptor`,
+  (expression: string) => `${expression}!`,
+  (expression: string) => `<MessageDescriptor>${expression}`,
+  (expression: string) =>
+    `(${expression} as const satisfies MessageDescriptor)!`,
+]
+const formatCallees = [
+  'formatMessage',
+  '$formatMessage',
+  '$t',
+  'intl.formatMessage',
+  'wrappedIntl.formatMessage',
+  'this.props.wrappedIntl.formatMessage',
+  'getIntl().formatMessage',
+  'wrappedIntl.$formatMessage',
+  'wrappedIntl.$t',
+  'wrappedIntl?.formatMessage',
+  'wrappedIntl.formatMessage?.',
+  'wrappedIntl?.formatMessage?.',
+  'customMessage',
+  'helpers.customMessage',
+]
+const declarationCallees = ['defineMessage', 'messages.defineMessage']
+const additionalFunctionNames = ['customMessage']
+const settings = {formatjs: {additionalFunctionNames}}
+const singleCases = [...formatCallees, ...declarationCallees].flatMap(callee =>
+  wrappers.map(wrap => `${callee}(${wrap(descriptor)})`)
+)
+const multipleCases = ['defineMessages', 'messages.defineMessages'].flatMap(
+  callee =>
+    wrappers.flatMap(wrapMap =>
+      wrappers.map(
+        wrapDescriptor =>
+          `${callee}(${wrapMap(`{hello: ${wrapDescriptor(descriptor)}}`)})`
+      )
+    )
+)
+const quotedKeyCases = [
+  `wrappedIntl.formatMessage({'defaultMessage': 'Hello'})`,
+  `messages.defineMessages({'hello': {'defaultMessage': 'Hello'}})`,
+]
+const recognizedCases = [...singleCases, ...multipleCases, ...quotedKeyCases]
+const ignoredCases = [
+  'unrelated({defaultMessage: "Hello"})',
+  'helpers.unrelated({defaultMessage: "Hello"})',
+  'wrappedIntl.formatMessage()',
+  'wrappedIntl.formatMessage(message)',
+  'wrappedIntl.formatMessage(message as MessageDescriptor)',
+  'wrappedIntl.formatMessage(...messages)',
+  'defineMessages(messages as const)',
+  'defineMessages({hello: message as MessageDescriptor})',
+  'defineMessages({...messages})',
+  'wrappedIntl["formatMessage"]({defaultMessage: "Hello"})',
+]
+
+ruleTester.run('message recognition parity', descriptionRule, {
+  valid: ignoredCases.map(code => ({code, filename: 'test.ts', settings})),
+  invalid: recognizedCases.map(code => ({
+    code,
+    filename: 'test.ts',
+    settings,
+    errors: [{messageId: 'enforceDescription'}],
+  })),
+})
+
+ruleTester.run('excluded message declarations', descriptionRule, {
+  valid: [
+    ...declarationCallees.map(callee => `${callee}(${descriptor})`),
+    ...multipleCases,
+  ].map(code => ({
+    code,
+    filename: 'test.ts',
+    settings: {
+      formatjs: {
+        excludeMessageDeclCalls: true,
+        additionalFunctionNames: ['defineMessage', 'defineMessages'],
+      },
+    },
+  })),
+  invalid: [
+    {
+      code: `wrappedIntl.formatMessage(${descriptor})`,
+      settings: {formatjs: {excludeMessageDeclCalls: true}},
+      errors: [{messageId: 'enforceDescription'}],
+    },
+  ],
+})
+
+ruleTester.run('descriptor wrapper autofixes', idRule, {
+  valid: [],
+  invalid: recognizedCases.map(code => ({
+    code,
+    filename: 'test.ts',
+    settings,
+    options: [{idInterpolationPattern: '[sha512:contenthash:base64:6]'}],
+    output: code.replace("'Hello'", "'Hello', id: 'NhX4DJ'"),
+    errors: [
+      {
+        message:
+          '"id" does not match with hash pattern [sha512:contenthash:base64:6].\nExpected: NhX4DJ\nActual: {{actual}}',
+      },
+    ],
+  })),
+})
+
+ruleTester.run(
+  'prefer formatted message receiver and wrapper parity',
+  preferFormattedMessageRule,
+  {
+    valid: [
+      `<img alt={wrappedIntl.formatMessage(${descriptor} as const)} />`,
+      '<div>{wrappedIntl.formatMessage(message)}</div>',
+    ],
+    invalid: [
+      `<div>{wrappedIntl.formatMessage(${descriptor} as const)}</div>`,
+      `<div>{wrappedIntl?.formatMessage(${descriptor})}</div>`,
+      `<div>{wrappedIntl.formatMessage?.(${descriptor})}</div>`,
+      `<div>{wrappedIntl.$formatMessage(${descriptor}!)}</div>`,
+      `<div>{helpers.customMessage(${descriptor})}</div>`,
+    ].map(code => ({code, settings, errors: [{messageId: 'jsxChildren'}]})),
+  }
+)
+
+describe('unplugin message recognition parity', () => {
+  test.each(recognizedCases)('transforms %s', code => {
+    const output = transform(code, 'test.ts', {additionalFunctionNames})
+    expect(output?.code).toContain('id: "NhX4DJ"')
+  })
+
+  test.each(ignoredCases)('ignores %s', code => {
+    expect(
+      transform(code, 'test.ts', {additionalFunctionNames})
+    ).toBeUndefined()
+  })
+})

--- a/packages/eslint-plugin-formatjs/tests/util.ts
+++ b/packages/eslint-plugin-formatjs/tests/util.ts
@@ -8,6 +8,7 @@ RuleTester.describe = describe
 RuleTester.it = it
 
 interface TestCaseBase {
+  filename?: string
   code: string
   output?: string
   options?: unknown[]

--- a/packages/eslint-plugin-formatjs/util.ts
+++ b/packages/eslint-plugin-formatjs/util.ts
@@ -18,7 +18,6 @@ export interface MessageDescriptor {
 
 const FORMAT_FUNCTION_NAMES = new Set(['$formatMessage', 'formatMessage', '$t'])
 const COMPONENT_NAMES = new Set(['FormattedMessage'])
-const DECLARATION_FUNCTION_NAMES = new Set(['defineMessage'])
 
 export interface Settings {
   excludeMessageDeclCalls?: boolean
@@ -146,65 +145,55 @@ function staticallyEvaluateStringConcat(
     : ['', false]
 }
 
-export function isIntlFormatMessageCall(node: Node): boolean {
-  // GH #4890: Check for both MemberExpression (intl.formatMessage) and Identifier (formatMessage) patterns
+function unwrapObjectExpression(
+  node?: MessagePropertyValue
+): ObjectExpression | undefined {
+  switch (node?.type) {
+    case 'TSAsExpression':
+    case 'TSSatisfiesExpression':
+    case 'TSNonNullExpression':
+    case 'TSTypeAssertion':
+      return unwrapObjectExpression(node.expression)
+    case 'ObjectExpression':
+      return node
+  }
+}
+
+function getCalleeName(node: Node): string | undefined {
+  if (node.type === 'Identifier') {
+    return node.name
+  }
+  if (node.type === 'MemberExpression' && node.property.type === 'Identifier') {
+    return node.property.name
+  }
+}
+
+export function isIntlFormatMessageCall(
+  node: Node,
+  additionalFunctionNames: string[] = []
+): boolean {
+  if (node.type === 'ChainExpression') {
+    return isIntlFormatMessageCall(node.expression, additionalFunctionNames)
+  }
   if (node.type !== 'CallExpression') {
     return false
   }
-
-  // Check if call has at least one argument that is an object expression
-  if (
-    node.arguments.length < 1 ||
-    node.arguments[0].type !== 'ObjectExpression'
-  ) {
-    return false
-  }
-
-  // Pattern 1: intl.formatMessage() or something.intl.formatMessage()
-  if (node.callee.type === 'MemberExpression') {
-    return (
-      ((node.callee.object.type === 'Identifier' &&
-        node.callee.object.name === 'intl') ||
-        (node.callee.object.type === 'MemberExpression' &&
-          node.callee.object.property.type === 'Identifier' &&
-          node.callee.object.property.name === 'intl')) &&
-      node.callee.property.type === 'Identifier' &&
-      (node.callee.property.name === 'formatMessage' ||
-        node.callee.property.name === '$t')
-    )
-  }
-
-  // Pattern 2: formatMessage() (destructured from useIntl)
-  if (node.callee.type === 'Identifier') {
-    return FORMAT_FUNCTION_NAMES.has(node.callee.name)
-  }
-
-  return false
-}
-
-function isSingleMessageDescriptorDeclaration(
-  node: Node,
-  functionNames: Set<string>
-) {
-  return (
-    node.type === 'CallExpression' &&
-    node.callee.type === 'Identifier' &&
-    functionNames.has(node.callee.name)
-  )
-}
-
-function isMultipleMessageDescriptorDeclaration(node: Node) {
-  return (
-    node.type === 'CallExpression' &&
-    node.callee.type === 'Identifier' &&
-    node.callee.name === 'defineMessages'
+  const descriptor = node.arguments[0]
+  const calleeName = getCalleeName(node.callee)
+  return !!(
+    calleeName &&
+    (FORMAT_FUNCTION_NAMES.has(calleeName) ||
+      additionalFunctionNames.includes(calleeName)) &&
+    descriptor?.type !== 'SpreadElement' &&
+    unwrapObjectExpression(descriptor)
   )
 }
 
 export function extractMessageDescriptor(
-  node?: Expression
+  expression?: MessagePropertyValue
 ): MessageDescriptorNodeInfo | undefined {
-  if (!node || node.type !== 'ObjectExpression') {
+  const node = unwrapObjectExpression(expression)
+  if (!node) {
     return
   }
   const result: MessageDescriptorNodeInfo = {
@@ -216,13 +205,18 @@ export function extractMessageDescriptor(
     idValueNode: undefined,
   }
   for (const prop of node.properties) {
-    if (prop.type !== 'Property' || prop.key.type !== 'Identifier') {
+    if (prop.type !== 'Property') {
       continue
     }
 
     // Only extract values for message-related props
     // GH #5069: Don't process other props like tagName, values, etc.
-    const propName = prop.key.name
+    const propName =
+      prop.key.type === 'Identifier'
+        ? prop.key.name
+        : prop.key.type === 'Literal'
+          ? prop.key.value
+          : undefined
     if (
       propName !== 'id' &&
       propName !== 'defaultMessage' &&
@@ -347,8 +341,9 @@ function extractMessageDescriptorFromJSXElement(
   return [result, values]
 }
 
-function extractMessageDescriptors(node?: Expression) {
-  if (!node || node.type !== 'ObjectExpression' || !node.properties.length) {
+function extractMessageDescriptors(expression?: Expression) {
+  const node = unwrapObjectExpression(expression)
+  if (!node) {
     return []
   }
   const msgs = []
@@ -356,11 +351,7 @@ function extractMessageDescriptors(node?: Expression) {
     if (prop.type !== 'Property') {
       continue
     }
-    const msg = prop.value
-    if (msg.type !== 'ObjectExpression') {
-      continue
-    }
-    const nodeInfo = extractMessageDescriptor(msg as Expression)
+    const nodeInfo = extractMessageDescriptor(prop.value)
     if (nodeInfo) {
       msgs.push(nodeInfo)
     }
@@ -392,24 +383,24 @@ export function extractMessages(
     if (!args0 || args0.type === 'SpreadElement') {
       return []
     }
+    const calleeName = getCalleeName(node.callee)
+    if (!calleeName) {
+      return []
+    }
+    if (calleeName === 'defineMessages') {
+      return excludeMessageDeclCalls
+        ? []
+        : extractMessageDescriptors(args0).map(msg => [msg, undefined])
+    }
     if (
-      (!excludeMessageDeclCalls &&
-        isSingleMessageDescriptorDeclaration(
-          node,
-          DECLARATION_FUNCTION_NAMES
-        )) ||
-      isIntlFormatMessageCall(node) ||
-      isSingleMessageDescriptorDeclaration(node, allFormatFunctionNames)
+      calleeName === 'defineMessage'
+        ? !excludeMessageDeclCalls
+        : allFormatFunctionNames.has(calleeName)
     ) {
       const msgDescriptorNodeInfo = extractMessageDescriptor(args0)
       if (msgDescriptorNodeInfo && (!args1 || args1.type !== 'SpreadElement')) {
         return [[msgDescriptorNodeInfo, args1 as Expression]]
       }
-    } else if (
-      !excludeMessageDeclCalls &&
-      isMultipleMessageDescriptorDeclaration(node)
-    ) {
-      return extractMessageDescriptors(args0).map(msg => [msg, undefined])
     }
   } else if (
     node.type === 'JSXOpeningElement' &&

--- a/packages/unplugin/conformance-tests/cli-unplugin-conformance.test.ts
+++ b/packages/unplugin/conformance-tests/cli-unplugin-conformance.test.ts
@@ -9,7 +9,7 @@
  * transformed at bundle time by the Vite/Rollup/esbuild plugin share identical
  * IDs, preventing mismatches in production.
  */
-import {exec as nodeExec} from 'child_process'
+import {execFile as nodeExecFile} from 'child_process'
 import {mkdirSync, rmSync, writeFileSync} from 'fs'
 import {join, resolve} from 'path'
 import {promisify} from 'util'
@@ -17,7 +17,7 @@ import {afterAll, beforeAll, describe, expect, test} from 'vitest'
 import {transform} from '#packages/unplugin/transform.js'
 import {resolveRustBinaryPath} from '#packages/unplugin/conformance-tests/rust-binary-utils.js'
 
-const exec = promisify(nodeExec)
+const execFile = promisify(nodeExecFile)
 
 const RUST_BIN_PATH = resolveRustBinaryPath(import.meta.dirname)
 const ARTIFACT_PATH = resolve(import.meta.dirname, 'test_artifacts')
@@ -52,25 +52,91 @@ describe('formatjs_cli vs @formatjs/unplugin conformance', () => {
    * Assert that `formatjs_cli extract --flatten` and the unplugin transform
    * (default options: flatten=true) produce identical IDs for the given code.
    */
-  async function assertConformance(code: string, filename: string) {
+  async function assertConformance(
+    code: string,
+    filename: string,
+    additionalFunctionNames: string[] = []
+  ) {
     const tempFile = join(ARTIFACT_PATH, filename)
     writeFileSync(tempFile, code)
 
     // CLI: --flatten matches the plugin's default flatten=true
-    const {stdout} = await exec(
-      `"${RUST_BIN_PATH}" extract --flatten "${tempFile}"`
-    )
+    const {stdout} = await execFile(RUST_BIN_PATH!, [
+      'extract',
+      '--flatten',
+      ...additionalFunctionNames.flatMap(name => [
+        '--additional-function-names',
+        name,
+      ]),
+      tempFile,
+    ])
     const cliOutput: Record<string, {defaultMessage: string}> =
       JSON.parse(stdout)
     const cliIds = Object.keys(cliOutput).sort()
 
     // Plugin: default options (flatten=true, idInterpolationPattern=[sha512:contenthash:base64:6])
-    const result = transform(code, tempFile, {})
+    const result = transform(code, tempFile, {additionalFunctionNames})
     expect(result, 'unplugin should transform the code').toBeDefined()
     const pluginIds = extractPluginIds(result!.code)
 
+    expect(cliIds.length).toBeGreaterThan(0)
     expect(pluginIds).toEqual(cliIds)
   }
+
+  test.each([
+    'formatMessage',
+    '$formatMessage',
+    '$t',
+    'wrappedIntl.formatMessage',
+    'this.props.wrappedIntl.formatMessage',
+    'getIntl().formatMessage',
+    'wrappedIntl.$formatMessage',
+    'wrappedIntl.$t',
+    'wrappedIntl?.formatMessage',
+    'wrappedIntl.formatMessage?.',
+    'wrappedIntl?.formatMessage?.',
+    'defineMessage',
+    'messages.defineMessage',
+    'customMessage',
+    'helpers.customMessage',
+  ])('recognizes %s with a wrapped descriptor', async callee => {
+    await assertConformance(
+      `${callee}(({defaultMessage: 'Hello'} as const satisfies MessageDescriptor)!)`,
+      'wrapped-receiver.ts',
+      ['customMessage']
+    )
+  })
+
+  const descriptorWrappers = [
+    (expression: string) => expression,
+    (expression: string) => `(${expression})`,
+    (expression: string) => `${expression} as const`,
+    (expression: string) => `${expression} satisfies MessageDescriptor`,
+    (expression: string) => `${expression}!`,
+    (expression: string) => `<MessageDescriptor>${expression}`,
+    (expression: string) =>
+      `(${expression} as const satisfies MessageDescriptor)!`,
+  ]
+  for (const [mapIndex, wrapMap] of descriptorWrappers.entries()) {
+    for (const [
+      descriptorIndex,
+      wrapDescriptor,
+    ] of descriptorWrappers.entries()) {
+      test(`namespaced defineMessages wrappers ${mapIndex}/${descriptorIndex}`, async () => {
+        await assertConformance(
+          `messages.defineMessages(${wrapMap(`{hello: ${wrapDescriptor(`{defaultMessage: 'Hello'}`)}}`)})`,
+          'wrapped-map.ts'
+        )
+      })
+    }
+  }
+
+  test('quoted descriptor keys', async () => {
+    await assertConformance(
+      `wrappedIntl.formatMessage({'defaultMessage': 'Hello', 'description': 'Greeting'})`,
+      'quoted-keys.ts'
+    )
+  })
 
   test('plain formatMessage without description', async () => {
     await assertConformance(

--- a/packages/unplugin/transform.ts
+++ b/packages/unplugin/transform.ts
@@ -116,6 +116,7 @@ export function transform(
   function unwrapTransparentTypeScriptExpression(node: any): any {
     let current = node
     while (
+      current?.type === 'ParenthesizedExpression' ||
       current?.type === 'TSAsExpression' ||
       current?.type === 'TSSatisfiesExpression' ||
       current?.type === 'TSTypeAssertion' ||


### PR DESCRIPTION
Fixes #7150.

Match message calls by name across receivers, namespaced declarations, optional calls, and configured functions. ESLint now unwraps descriptor and `defineMessages` wrappers while preserving autofix ranges and declaration exclusions.

Conformance tests also exposed missing parenthesis handling in unplugin and the native CLI, plus quoted descriptor keys in ESLint and the CLI. Align those paths and update the tooling docs.

Three new Rust unit tests cover nested wrappers, quoted keys, and rejection of non-static values. All three fail against the original extractor.

Validation: 764 ESLint/unplugin recognition and autofix checks (493 fail on main), 80 native CLI/unplugin conformance tests with no skips, 238 Rust tests, full ESLint unit/integration/typechecks, unplugin unit/typechecks, and the docs build.
