### PR TITLE
fix(babel-plugin-formatjs): support transparent expression wrappers

### DIFF
--- a/docs/src/docs/tooling/babel-plugin.mdx
+++ b/docs/src/docs/tooling/babel-plugin.mdx
@@ -46,6 +46,25 @@ The default message descriptors for the app's default language will be processed
 
 This plugin does not enable any syntax on its own. To extract messages from `<FormattedMessage>` elements, JSX parsing must be enabled by your own Babel configuration (e.g. `@babel/preset-react`, `@babel/preset-typescript` for `.tsx` files, or `@babel/plugin-syntax-jsx`), as it normally already is in projects that use JSX.
 
+With TypeScript parsing enabled, message values and inline descriptors can use
+`satisfies`, `as`, non-null assertions, and type assertions. These wrappers also
+work around `defineMessages` maps and entries, including nested wrappers:
+
+```tsx
+;<FormattedMessage defaultMessage={`Hello` satisfies string} />
+
+const messages = defineMessages({
+  greeting: {
+    defaultMessage: 'Hello' as const,
+    description: 'Greeting',
+  } satisfies MessageDescriptor,
+} as const)
+```
+
+Values must still be statically evaluable. String rewrites preserve their
+wrappers; `ast: true` replaces the whole message value with the compiled AST,
+and `removeDefaultMessage: true` removes the property or attribute.
+
 ### Via `babel.config.json` (Recommended)
 
 **babel.config.json**

--- a/knowledge-base/009-package-developer-tools.md
+++ b/knowledge-base/009-package-developer-tools.md
@@ -22,6 +22,9 @@
 
 - Babel AST visitor detects `FormattedMessage`, `formatMessage`, `defineMessage(s)` calls
 - Extracts `defaultMessage` and generates IDs
+- Unwraps TypeScript `as`, `satisfies`, non-null and type assertions, Flow casts, and parentheses before evaluating descriptor values and recognizing inline descriptors or `defineMessages` maps/entries
+- Rewrites strings inside wrappers; AST compilation replaces the whole message value
+- Wrapper regressions live in `tests/typescript-wrappers.test.ts`; `//packages/babel-plugin-formatjs/conformance-tests:conformance-tests_test` compares extracted messages and generated IDs with unplugin and the native CLI (required, never skipped)
 - Options: `removeDefaultMessage`, `idInterpolationPattern`, `overrideIdFn`, `ast` (pre-compile messages)
 
 **Dependencies:** @babel/core, @babel/traverse, @babel/types, ts-transformer, icu-messageformat-parser

--- a/packages/babel-plugin-formatjs/BUILD.bazel
+++ b/packages/babel-plugin-formatjs/BUILD.bazel
@@ -44,7 +44,10 @@ formatjs_library(
 
 formatjs_test(
     name = "babel-plugin-formatjs_test",
-    srcs = ["tests/index.test.ts"],
+    srcs = [
+        "tests/index.test.ts",
+        "tests/typescript-wrappers.test.ts",
+    ],
     data = [
         "//:node_modules/@babel/preset-env",  # keep: loaded dynamically via babel config in tests
         "//:node_modules/@babel/preset-react",  # keep: loaded dynamically via babel config in tests

--- a/packages/babel-plugin-formatjs/conformance-tests/BUILD.bazel
+++ b/packages/babel-plugin-formatjs/conformance-tests/BUILD.bazel
@@ -1,0 +1,17 @@
+load("//tools:test.bzl", "formatjs_test")
+
+formatjs_test(
+    name = "conformance-tests_test",
+    srcs = ["typescript-wrappers.test.ts"],
+    data = ["//crates/formatjs_cli"],  # keep: execute native CLI for conformance
+    tsconfig_types = ["node"],
+    deps = [
+        "//:node_modules/@babel/core",
+        "//:node_modules/@bazel/runfiles",
+        "//:node_modules/@formatjs/unplugin",
+        "//:node_modules/@types/babel__core",
+        "//:node_modules/@types/node",
+        "//:node_modules/babel-plugin-formatjs",
+        "//:node_modules/vitest",
+    ],
+)

--- a/packages/babel-plugin-formatjs/conformance-tests/typescript-wrappers.test.ts
+++ b/packages/babel-plugin-formatjs/conformance-tests/typescript-wrappers.test.ts
@@ -1,0 +1,98 @@
+import {transformSync} from '@babel/core'
+import {Runfiles} from '@bazel/runfiles'
+import {transform} from '@formatjs/unplugin/transform'
+import babelPlugin from 'babel-plugin-formatjs'
+import {execFile as nodeExecFile} from 'node:child_process'
+import {mkdtempSync, rmSync, writeFileSync} from 'node:fs'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+import {promisify} from 'node:util'
+import {afterAll, expect, test} from 'vitest'
+
+const execFile = promisify(nodeExecFile)
+const binary = new Runfiles().resolveWorkspaceRelative(
+  'crates/formatjs_cli/formatjs_cli'
+)
+const directory = mkdtempSync(join(tmpdir(), 'babel-conformance-'))
+afterAll(() => rmSync(directory, {recursive: true, force: true}))
+
+const wrappers = [
+  {name: 'plain', wrap: (value: string) => value},
+  {name: 'parentheses', wrap: (value: string) => `(${value})`},
+  {name: 'as', wrap: (value: string) => `${value} as const`},
+  {name: 'satisfies', wrap: (value: string) => `${value} satisfies Message`},
+  {name: 'non-null', wrap: (value: string) => `${value}!`},
+  {name: 'type assertion', wrap: (value: string) => `<Message>${value}`},
+  {
+    name: 'nested',
+    wrap: (value: string) => `(${value} as const satisfies Message)!`,
+  },
+]
+
+async function assertConformance(source: string, jsx = false) {
+  const filename = join(directory, jsx ? 'messages.tsx' : 'messages.ts')
+  writeFileSync(filename, source)
+  const {stdout} = await execFile(binary, ['extract', '--flatten', filename])
+  const cli = JSON.parse(stdout)
+  expect(cli).toEqual({
+    'MJezg/': {defaultMessage: 'Hello', description: 'Greeting'},
+  })
+
+  const messages: {
+    id: string
+    defaultMessage?: string
+    description?: string
+  }[] = []
+  const babel = transformSync(source, {
+    filename,
+    configFile: false,
+    babelrc: false,
+    parserOpts: {
+      plugins: jsx ? ['typescript', 'jsx'] : ['typescript'],
+      createParenthesizedExpressions: true,
+    },
+    plugins: [
+      [
+        babelPlugin,
+        {
+          flatten: true,
+          onMsgExtracted: (_: string, extracted: typeof messages) =>
+            messages.push(...extracted),
+        },
+      ],
+    ],
+  })!
+  expect(messages).toEqual([{id: 'MJezg/', ...cli['MJezg/']}])
+
+  const unplugin = transform(source, filename, {})
+  expect(unplugin).toBeDefined()
+  for (const code of [babel.code!, unplugin!.code]) {
+    const ids = [...code.matchAll(/\bid(?::\s*|=)"([^"]+)"/g)].map(
+      match => match[1]
+    )
+    expect(ids).toEqual(Object.keys(cli))
+  }
+}
+
+for (const {name, wrap} of wrappers) {
+  const descriptor = wrap(
+    `{defaultMessage: ${wrap('"Hello"')}, description: ${wrap('"Greeting"')}}`
+  )
+  test.each(['intl.formatMessage', 'intl?.formatMessage?.', 'defineMessage'])(
+    `${name}: %s descriptor and values`,
+    async callee => {
+      await assertConformance(`${callee}(${descriptor})`)
+    }
+  )
+  test(`${name}: defineMessages map, entry, and values`, async () => {
+    await assertConformance(`defineMessages(${wrap(`{hello: ${descriptor}}`)})`)
+  })
+  if (name !== 'type assertion') {
+    test(`${name}: JSX values`, async () => {
+      await assertConformance(
+        `<FormattedMessage defaultMessage={${wrap('`Hello`')}} description={${wrap('"Greeting"')}} />`,
+        true
+      )
+    })
+  }
+}

--- a/packages/babel-plugin-formatjs/tests/typescript-wrappers.test.ts
+++ b/packages/babel-plugin-formatjs/tests/typescript-wrappers.test.ts
@@ -1,0 +1,251 @@
+import {transformSync} from '@babel/core'
+import {describe, expect, test} from 'vitest'
+import plugin from '#packages/babel-plugin-formatjs/index.js'
+import type {
+  MessageDescriptor,
+  Options,
+} from '#packages/babel-plugin-formatjs/types.js'
+
+const wrappers = [
+  {name: 'literal', wrap: (value: string) => value},
+  {name: 'parentheses', wrap: (value: string) => `(${value})`},
+  {name: 'as', wrap: (value: string) => `${value} as const`},
+  {name: 'satisfies', wrap: (value: string) => `${value} satisfies Message`},
+  {name: 'non-null', wrap: (value: string) => `${value}!`},
+  {name: 'type assertion', wrap: (value: string) => `<Message>${value}`},
+  {
+    name: 'nested',
+    wrap: (value: string) => `(${value} as const satisfies Message)!`,
+  },
+]
+
+function transform(code: string, options: Options = {}, jsx = false) {
+  const messages: MessageDescriptor[] = []
+  const result = transformSync(code, {
+    filename: jsx ? 'messages.tsx' : 'messages.ts',
+    configFile: false,
+    babelrc: false,
+    parserOpts: {
+      plugins: jsx ? ['typescript', 'jsx'] : ['typescript'],
+      createParenthesizedExpressions: true,
+    },
+    plugins: [
+      [
+        plugin,
+        {
+          ...options,
+          onMsgExtracted: (_: string, extracted: MessageDescriptor[]) =>
+            messages.push(...extracted),
+        },
+      ],
+    ],
+  })!
+  return {code: result.code!, messages}
+}
+
+const expected = {
+  id: 'MJezg/',
+  defaultMessage: 'Hello',
+  description: 'Greeting',
+}
+
+describe.each(wrappers)('$name', ({name, wrap}) => {
+  test.each(['id', 'defaultMessage', 'description'])(
+    'evaluates wrapped %s',
+    property => {
+      const values: Record<string, string> = {
+        id: '"explicit"',
+        defaultMessage: '`Hello`',
+        description: '"Greeting"',
+      }
+      values[property] = wrap(values[property])
+      const descriptor = `{${Object.entries(values)
+        .map(([key, value]) => `${key}: ${value}`)
+        .join(',')}}`
+      expect(transform(`intl.formatMessage(${descriptor})`).messages).toEqual([
+        {...expected, id: 'explicit'},
+      ])
+    }
+  )
+
+  test.each([
+    'formatMessage',
+    'intl.formatMessage',
+    'intl?.formatMessage?.',
+    'defineMessage',
+    'customMessage',
+  ])('extracts wrapped %s descriptor', callee => {
+    const {messages, code} = transform(
+      `${callee}(${wrap('{defaultMessage: "Hello", description: "Greeting"}')})`,
+      {additionalFunctionNames: ['customMessage']}
+    )
+    expect(messages).toEqual([expected])
+    expect(code).toContain('id: "MJezg/"')
+    expect(code).not.toContain('description:')
+  })
+
+  for (const entry of wrappers) {
+    test(`extracts map with ${entry.name} entry`, () => {
+      const descriptor = entry.wrap(
+        '{defaultMessage: "Hello", description: "Greeting"}'
+      )
+      expect(
+        transform(`defineMessages(${wrap(`{hello: ${descriptor}}`)})`).messages
+      ).toEqual([expected])
+    })
+  }
+
+  if (name !== 'type assertion') {
+    test('extracts wrapped JSX attributes', () => {
+      const result = transform(
+        `<FormattedMessage id={${wrap('"explicit"')}} defaultMessage={${wrap('`Hello`')}} description={${wrap('"Greeting"')}} />`,
+        {},
+        true
+      )
+      expect(result.messages).toEqual([{...expected, id: 'explicit'}])
+      expect(result.code).not.toContain('description=')
+    })
+  }
+})
+
+test('preserves wrappers when rewriting strings and descriptors', () => {
+  const result = transform(
+    'defineMessage(({id: "old" satisfies string, defaultMessage: " Hello " as const} satisfies Message)!)',
+    {overrideIdFn: () => 'new'}
+  )
+  expect(result.code).toContain('"new" satisfies string')
+  expect(result.code).toContain('"Hello" as const')
+  expect(result.code).toContain('satisfies Message)!')
+  expect(result.messages).toEqual([{id: 'new', defaultMessage: 'Hello'}])
+})
+
+test('preserves JSX ID wrappers when overriding IDs', () => {
+  const result = transform(
+    '<FormattedMessage id={"old" satisfies string} defaultMessage={"Hello" as const} />',
+    {overrideIdFn: () => 'new'},
+    true
+  )
+  expect(result.code).toContain('id={"new" satisfies string}')
+  expect(result.code).toContain('defaultMessage={"Hello" as const}')
+})
+
+test.each([false, true])('compiles wrapped messages to AST (JSX=%s)', jsx => {
+  const source = jsx
+    ? '<FormattedMessage defaultMessage={"Hello" satisfies string} />'
+    : 'defineMessage({defaultMessage: "Hello" satisfies string} as const)'
+  const result = transform(source, {ast: true}, jsx)
+  expect(result.messages).toEqual([{id: 'NhX4DJ', defaultMessage: 'Hello'}])
+  expect(result.code).toContain('"value": "Hello"')
+  expect(result.code).not.toContain('satisfies string')
+  expect(() => transform(result.code, {ast: true}, jsx)).not.toThrow()
+})
+
+test.each([false, true])('removes wrapped defaultMessage (JSX=%s)', jsx => {
+  const source = jsx
+    ? '<FormattedMessage defaultMessage={"Hello" satisfies string} description={"Greeting" as const} />'
+    : 'defineMessage({defaultMessage: "Hello" satisfies string, description: "Greeting" as const} satisfies Message)'
+  const result = transform(source, {removeDefaultMessage: true}, jsx)
+  expect(result.messages).toEqual([expected])
+  expect(result.code).not.toContain('defaultMessage')
+  expect(result.code).not.toContain('description')
+  expect(result.code).toContain('MJezg/')
+})
+
+test('keeps dynamic values unevaluable, including throws=false', () => {
+  const source =
+    'defineMessage({defaultMessage: getMessage() satisfies string})'
+  expect(() => transform(source)).toThrow(
+    'Messages must be statically evaluate-able for extraction.'
+  )
+  const errors: Error[] = []
+  const result = transform(source, {
+    throws: false,
+    onMsgError: (_, error) => errors.push(error),
+  })
+  expect(result.messages).toEqual([])
+  expect(result.code).toContain('getMessage() satisfies string')
+  expect(errors).toHaveLength(1)
+})
+
+test('skips wrapped dynamic descriptors in formatMessage', () => {
+  expect(
+    transform('intl.formatMessage(descriptor satisfies Message)').messages
+  ).toEqual([])
+})
+
+test('skips wrapped precompiled descriptors', () => {
+  const result = transform(
+    'defineMessage({defaultMessage: [{type: 0, value: "Hello"}] as const})',
+    {ast: true}
+  )
+  expect(result.messages).toEqual([])
+  expect(result.code).toContain('as const')
+})
+
+test.each(['defineMessage()', 'defineMessages(dynamic satisfies Messages)'])(
+  'reports descriptor errors for %s',
+  source => {
+    expect(() => transform(source)).toThrow(
+      'must be called with an object expression'
+    )
+  }
+)
+
+test('retains Flow cast support', () => {
+  const messages: MessageDescriptor[] = []
+  transformSync(
+    'defineMessages(({hello: ({defaultMessage: ("Hello": string)}: Message)}: Messages))',
+    {
+      configFile: false,
+      babelrc: false,
+      parserOpts: {plugins: ['flow']},
+      plugins: [
+        [
+          plugin,
+          {
+            onMsgExtracted: (_: string, extracted: MessageDescriptor[]) =>
+              messages.push(...extracted),
+          },
+        ],
+      ],
+    }
+  )
+  expect(messages).toEqual([{id: 'NhX4DJ', defaultMessage: 'Hello'}])
+})
+
+test('extracts JSX satisfies with default parser parentheses handling', () => {
+  const messages: MessageDescriptor[] = []
+  transformSync(
+    '<FormattedMessage defaultMessage={`Hello` satisfies string} />',
+    {
+      configFile: false,
+      babelrc: false,
+      parserOpts: {plugins: ['typescript', 'jsx']},
+      plugins: [
+        [
+          plugin,
+          {
+            onMsgExtracted: (_: string, extracted: MessageDescriptor[]) =>
+              messages.push(...extracted),
+          },
+        ],
+      ],
+    }
+  )
+  expect(messages).toEqual([{id: 'NhX4DJ', defaultMessage: 'Hello'}])
+})
+
+test('keeps source locations on wrapped descriptors', () => {
+  const result = transform(
+    'defineMessage(({defaultMessage: "Hello"} satisfies Message)!)',
+    {extractSourceLocation: true}
+  )
+  expect(result.messages).toEqual([
+    expect.objectContaining({
+      id: 'NhX4DJ',
+      defaultMessage: 'Hello',
+      start: expect.objectContaining({line: 1, column: 15}),
+      end: expect.objectContaining({line: 1, column: 40}),
+    }),
+  ])
+})

--- a/packages/babel-plugin-formatjs/utils.ts
+++ b/packages/babel-plugin-formatjs/utils.ts
@@ -21,8 +21,22 @@ const DESCRIPTOR_PROPS = new Set<keyof MessageDescriptorPath>([
   'defaultMessage',
 ])
 
+export function unwrapExpression(path: NodePath<any>): NodePath<any> {
+  while (
+    path.isTSAsExpression() ||
+    path.isTSSatisfiesExpression() ||
+    path.isTSNonNullExpression() ||
+    path.isTSTypeAssertion() ||
+    path.isTypeCastExpression() ||
+    path.isParenthesizedExpression()
+  ) {
+    path = path.get('expression') as NodePath<any>
+  }
+  return path
+}
+
 function evaluatePath(path: NodePath<any>): string {
-  const evaluated = path.evaluate()
+  const evaluated = unwrapExpression(path).evaluate()
   if (evaluated.confident) {
     return evaluated.value
   }
@@ -52,7 +66,10 @@ function getMessageDescriptorValue(
   }
   if (path.isJSXExpressionContainer()) {
     // If this is already compiled, no need to recompiled it
-    if (isMessageNode && path.get('expression').isArrayExpression()) {
+    if (
+      isMessageNode &&
+      unwrapExpression(path.get('expression')).isArrayExpression()
+    ) {
       return ''
     }
     path = path.get('expression') as NodePath<t.StringLiteral>

--- a/packages/babel-plugin-formatjs/visitors/call-expression.ts
+++ b/packages/babel-plugin-formatjs/visitors/call-expression.ts
@@ -13,6 +13,7 @@ import {
   wasExtracted,
   storeMessage,
   tagAsExtracted,
+  unwrapExpression,
 } from '#packages/babel-plugin-formatjs/utils.js'
 import {parse} from '@formatjs/icu-messageformat-parser'
 
@@ -21,9 +22,11 @@ function assertObjectExpression(
   callee: NodePath<t.Expression | t.Super | t.Import | t.V8IntrinsicIdentifier>
 ): asserts path is NodePath<t.ObjectExpression> {
   if (!path || !path.isObjectExpression()) {
-    throw path.buildCodeFrameError(
+    throw (path || callee).buildCodeFrameError(
       `[React Intl] \`${
-        (callee.get('property') as NodePath<t.Identifier>).node.name
+        callee.isIdentifier()
+          ? callee.node.name
+          : (callee.get('property') as NodePath<t.Identifier>).node.name
       }()\` must be called with an object expression with values that are React Intl Message Descriptors, also defined as object expressions.`
     )
   }
@@ -44,20 +47,6 @@ function isFormatMessageCall(
     return !!functionNames.find(name => property.isIdentifier({name}))
   }
   return false
-}
-
-function getMessagesObjectFromExpression(
-  nodePath: NodePath<any>
-): NodePath<any> {
-  let currentPath = nodePath
-  while (
-    t.isTSAsExpression(currentPath.node) ||
-    t.isTSTypeAssertion(currentPath.node) ||
-    t.isTypeCastExpression(currentPath.node)
-  ) {
-    currentPath = currentPath.get('expression') as NodePath<any>
-  }
-  return currentPath
 }
 
 type CallExpressionPath = Parameters<VisitorFunction<'CallExpression'>>[0]
@@ -96,9 +85,8 @@ const visitCallExpression = function (
    * Process MessageDescriptor
    * @param messageDescriptor Message Descriptor
    */
-  function processMessageObject(
-    messageDescriptor: NodePath<t.ObjectExpression>
-  ) {
+  function processMessageObject(messageDescriptor: NodePath<any>) {
+    messageDescriptor = unwrapExpression(messageDescriptor)
     assertObjectExpression(messageDescriptor, callee)
 
     const properties = messageDescriptor.get(
@@ -119,7 +107,10 @@ const visitCallExpression = function (
       )
 
       // If the message is already compiled, don't re-compile it
-      if (descriptorPath.defaultMessage?.isArrayExpression()) {
+      if (
+        descriptorPath.defaultMessage &&
+        unwrapExpression(descriptorPath.defaultMessage).isArrayExpression()
+      ) {
         return
       }
 
@@ -166,7 +157,9 @@ const visitCallExpression = function (
 
     // Insert ID potentially 1st before removing nodes
     if (idProp) {
-      idProp.get('value').replaceWith(t.stringLiteral(descriptor.id))
+      unwrapExpression(idProp.get('value')).replaceWith(
+        t.stringLiteral(descriptor.id)
+      )
     } else {
       firstProp.insertBefore(
         t.objectProperty(t.identifier('id'), t.stringLiteral(descriptor.id))
@@ -195,7 +188,9 @@ const visitCallExpression = function (
             JSON.stringify(parse(descriptor.defaultMessage))
           )
         } else {
-          valueProp.replaceWith(t.stringLiteral(descriptor.defaultMessage))
+          unwrapExpression(valueProp).replaceWith(
+            t.stringLiteral(descriptor.defaultMessage)
+          )
         }
       }
     }
@@ -209,7 +204,7 @@ const visitCallExpression = function (
     callee.isIdentifier({name: 'defineMessage'})
   ) {
     const firstArgument = args[0]
-    const messagesObj = getMessagesObjectFromExpression(firstArgument)
+    const messagesObj = firstArgument && unwrapExpression(firstArgument)
 
     assertObjectExpression(messagesObj, callee)
     if (callee.isIdentifier({name: 'defineMessage'})) {
@@ -226,7 +221,7 @@ const visitCallExpression = function (
 
   // Check that this is `intl.formatMessage` call
   if (isFormatMessageCall(callee, functionNames)) {
-    const messageDescriptor = args[0]
+    const messageDescriptor = args[0] && unwrapExpression(args[0])
     if (messageDescriptor && messageDescriptor.isObjectExpression()) {
       processMessageObject(messageDescriptor)
     }

--- a/packages/babel-plugin-formatjs/visitors/jsx-opening-element.ts
+++ b/packages/babel-plugin-formatjs/visitors/jsx-opening-element.ts
@@ -15,6 +15,7 @@ import {
   storeMessage,
   tagAsExtracted,
   wasExtracted,
+  unwrapExpression,
 } from '#packages/babel-plugin-formatjs/utils.js'
 
 export const visitor: VisitorFunction<'JSXOpeningElement'> = function (
@@ -126,7 +127,17 @@ export const visitor: VisitorFunction<'JSXOpeningElement'> = function (
   // Insert ID before removing node to prevent null node insertBefore
   if (overrideIdFn || (descriptor.id && idInterpolationPattern)) {
     if (idAttr) {
-      idAttr.get('value').replaceWith(t.stringLiteral(descriptor.id))
+      const value = idAttr.get('value')
+      if (
+        value.isJSXExpressionContainer() &&
+        unwrapExpression(value.get('expression')) !== value.get('expression')
+      ) {
+        unwrapExpression(value.get('expression')).replaceWith(
+          t.stringLiteral(descriptor.id)
+        )
+      } else {
+        value.replaceWith(t.stringLiteral(descriptor.id))
+      }
     } else if (firstAttr) {
       firstAttr.insertBefore(
         t.jsxAttribute(t.jsxIdentifier('id'), t.stringLiteral(descriptor.id))


### PR DESCRIPTION
Fixes #7155. Follow-up to https://github.com/formatjs/formatjs/issues/6474#issuecomment-5523184919.

Babel now extracts messages such as `<FormattedMessage defaultMessage={'Hello' satisfies string} />` instead of throwing a static-evaluation error. Unwrap TypeScript assertions, `satisfies`, non-null assertions, Flow casts, and parentheses around message values, inline descriptors, and `defineMessages` maps/entries.

Preserve wrappers during string rewrites. AST compilation replaces the complete message value; dynamic values remain unsupported. Update public docs and the knowledge base.

Validation:
- 125 new Babel unit cases; all 159 unit tests pass.
- 34 conformance cases compare Babel extraction and generated IDs with unplugin and the native CLI. Native CLI is required, never skipped.
- Original code fails 105 new unit cases and 28 conformance cases.
- `bazel test //packages/babel-plugin-formatjs/...` passes all 11 targets, including typechecks, package checks, and Vue integration.
- `bazel build //docs:dist` passes.
