### PR TITLE
fix(formatjs_cli): extract messages from tagged template literals

### DIFF
--- a/crates/formatjs_cli/src/extractor.rs
+++ b/crates/formatjs_cli/src/extractor.rs
@@ -290,8 +290,7 @@ impl<'a> MessageExtractor<'a> {
             Expression::TemplateLiteral(tpl) => {
                 self.extract_template_literal(tpl, preserve_whitespace)
             }
-            // Tagged templates like dedent`...` are treated as their raw template,
-            // matching @formatjs/ts-transformer and eslint-plugin-formatjs.
+            // The tag is ignored: dedent`...` extracts as its raw template, like ts-transformer.
             Expression::TaggedTemplateExpression(tagged) => {
                 self.extract_template_literal(&tagged.quasi, preserve_whitespace)
             }

--- a/crates/formatjs_cli/src/extractor.rs
+++ b/crates/formatjs_cli/src/extractor.rs
@@ -287,15 +287,13 @@ impl<'a> MessageExtractor<'a> {
                     Some(normalize_whitespace(&value))
                 }
             }
-            Expression::TemplateLiteral(tpl)
-                if tpl.quasis.len() == 1 && tpl.expressions.is_empty() =>
-            {
-                let value = tpl.quasis[0].value.cooked.as_ref()?.to_string();
-                if preserve_whitespace.unwrap_or(self.preserve_whitespace) {
-                    Some(value)
-                } else {
-                    Some(normalize_whitespace(&value))
-                }
+            Expression::TemplateLiteral(tpl) => {
+                self.extract_template_literal(tpl, preserve_whitespace)
+            }
+            // Tagged templates like dedent`...` are treated as their raw template,
+            // matching @formatjs/ts-transformer and eslint-plugin-formatjs.
+            Expression::TaggedTemplateExpression(tagged) => {
+                self.extract_template_literal(&tagged.quasi, preserve_whitespace)
             }
             // Handle string concatenation (e.g., 'Hello' + ' ' + 'World')
             Expression::BinaryExpression(bin) if bin.operator == BinaryOperator::Addition => {
@@ -304,6 +302,22 @@ impl<'a> MessageExtractor<'a> {
                 Some(format!("{}{}", left, right))
             }
             _ => None,
+        }
+    }
+
+    fn extract_template_literal(
+        &self,
+        tpl: &TemplateLiteral,
+        preserve_whitespace: Option<bool>,
+    ) -> Option<String> {
+        if tpl.quasis.len() != 1 || !tpl.expressions.is_empty() {
+            return None;
+        }
+        let value = tpl.quasis[0].value.cooked.as_ref()?.to_string();
+        if preserve_whitespace.unwrap_or(self.preserve_whitespace) {
+            Some(value)
+        } else {
+            Some(normalize_whitespace(&value))
         }
     }
 

--- a/crates/formatjs_cli/src/extractor.rs
+++ b/crates/formatjs_cli/src/extractor.rs
@@ -1536,7 +1536,7 @@ mod tests {
     #[test]
     fn test_fixture_template_literal() {
         let component_names = vec!["FormattedMessage".to_string()];
-        let function_names = vec![];
+        let function_names = vec!["defineMessage".to_string()];
 
         let messages = extract_from_fixture(
             "templateLiteral.tsx",
@@ -1546,8 +1546,91 @@ mod tests {
         )
         .expect("Failed to extract from templateLiteral.tsx");
 
-        // Should extract messages from template literals
-        assert!(messages.len() >= 1);
+        // Matches the ts-transformer snapshot for this fixture: plain and tagged
+        // (dedent`...`) no-substitution templates are both extracted.
+        let by_id = |id: &str| {
+            messages
+                .iter()
+                .find(|m| m.id.as_deref() == Some(id))
+                .unwrap_or_else(|| panic!("missing message `{id}`"))
+        };
+        assert_eq!(messages.len(), 4);
+        assert_eq!(
+            by_id("template").default_message.as_deref(),
+            Some("should remove newline and extra spaces")
+        );
+        assert_eq!(
+            by_id("template dedent").default_message.as_deref(),
+            Some("dedent Hello World!")
+        );
+        assert_eq!(
+            by_id("foo.bar.baz").default_message.as_deref(),
+            Some("Hello World!")
+        );
+        assert_eq!(
+            by_id("dedent foo.bar.baz").default_message.as_deref(),
+            Some("dedent Hello World!")
+        );
+    }
+
+    #[test]
+    fn test_tagged_template_literal() {
+        let source = r#"
+            import { defineMessage, FormattedMessage } from 'react-intl';
+            defineMessage({
+                id: 'greeting',
+                defaultMessage: dedent`
+                    Hello {name},
+                    welcome back.
+                `,
+                description: dedent`Shown after login`,
+            });
+            <FormattedMessage
+                id={dedent`farewell`}
+                defaultMessage={dedent`Goodbye {name}`}
+            />;
+            defineMessage({
+                id: 'dynamic',
+                defaultMessage: dedent`Hello ${name}`,
+            });
+        "#;
+
+        let file_path = PathBuf::from("test.tsx");
+        let source_type = SourceType::from_path(&file_path).unwrap();
+        let component_names = vec!["FormattedMessage".to_string()];
+        let function_names = vec!["defineMessage".to_string()];
+
+        let messages = extract_messages_from_source(
+            source,
+            &file_path,
+            source_type,
+            false,
+            &component_names,
+            &function_names,
+            HashMap::new(),
+            true,
+            false,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].id.as_deref(), Some("greeting"));
+        assert_eq!(
+            messages[0].default_message.as_deref(),
+            Some(
+                "\n                    Hello {name},\n                    welcome back.\n                "
+            )
+        );
+        assert_eq!(
+            messages[0].description,
+            Some(Value::String("Shown after login".to_string()))
+        );
+        assert_eq!(messages[1].id.as_deref(), Some("farewell"));
+        assert_eq!(
+            messages[1].default_message.as_deref(),
+            Some("Goodbye {name}")
+        );
     }
 
     #[test]


### PR DESCRIPTION
`@formatjs/cli-lib` 9.0.5 switched to native extraction (#7046). The Rust extractor rejects a tagged no-substitution template such as

```ts
defaultMessage: dedent`
  Hi {name},
  your ticket is ready.
`,
```

with `` `defaultMessage` must be a string literal to be extracted ``, so every message written that way silently dropped out of the catalog. `@formatjs/ts-transformer` and `eslint-plugin-formatjs` both accept these (the `templateLiteral.tsx` fixture and its snapshot already cover `dedent`), so this restores parity.

The first commit tightens `test_fixture_template_literal`, which only asserted that at least one message was extracted, and adds an inline test for tagged templates in function calls, JSX attributes and descriptions. Both fail on `main`. The second commit adds the `TaggedTemplateExpression` arm. A tagged template with substitutions still falls through to the existing "must be a string literal" error.

Tested with `cargo test -p formatjs_cli` (239 passed). I don't have Bazel set up locally.
