### PR TITLE
docs: track ECMA-402 draft polyfill audit

### DIFF
--- a/knowledge-base/007-package-intl-polyfills.md
+++ b/knowledge-base/007-package-intl-polyfills.md
@@ -47,6 +47,10 @@ Each polyfill has scripts in `scripts/` that extract data from CLDR npm packages
 3. **Generate**: Output as `.generated.ts` (static) or `locale-data/{locale}.js` (dynamic)
 4. **All orchestrated via Bazel** `generate_src_file` and `ts_run_binary` targets
 
+## Conformance Audit
+
+See the [2026-09-06 ECMA-402 draft audit](./013-ecma402-audit-2026-09-06.md) for confirmed gaps, reproductions, and follow-up checklists.
+
 ## Test Strategy
 
 - **Vitest unit tests** — Core functionality

--- a/knowledge-base/013-ecma402-audit-2026-09-06.md
+++ b/knowledge-base/013-ecma402-audit-2026-09-06.md
@@ -1,0 +1,262 @@
+# ECMA-402 polyfill audit — 2026-09-06
+
+This is a tracking audit, not a conformance certification. All 12 polyfill packages were inspected. The 22 findings below have concrete runtime reproductions against Bazel-built bundles; follow-up source observations are identified separately within each finding. No polyfill behavior changes are included in this document.
+
+## Baseline
+
+- Specification: [current ECMA-402 draft](https://tc39.es/ecma402/), labeled **ECMAScript 2027**, retrieved 2026-09-06. Repository main at inspection: [`b1c961988b9a07894b1dc3dc2b5626ea48387d61`](https://github.com/tc39/ecma402/commit/b1c961988b9a07894b1dc3dc2b5626ea48387d61), dated 2026-08-17. The downloaded HTML, rather than that repository commit alone, was the comparison baseline; SHA-256: `08acf39ea00e543a008cbde507f23b41d1ba28b2983d384a522948fb39b28856`.
+- Audited FormatJS checkout: [`818055749163de00c93513938289eca7c8233f30`](https://github.com/formatjs/formatjs/commit/818055749163de00c93513938289eca7c8233f30). Polyfill packages, shared abstract operations, and `MODULE.bazel` were unchanged at refreshed main `53ee15f97` when this documentation branch was created.
+- Runtime: Bazel 9.2.0, Bazel-managed Node 24.14.0, macOS arm64. Dynamic polyfills received Bazel-generated English locale data explicitly. Static-data polyfills used their bundled data.
+- Scope: API contracts, coercion, option validation, locale metadata, and iterator behavior. This did not exhaust every locale, CLDR value, calendar, timezone transition, rounding combination, Unicode segmentation rule, collation tailoring, or browser/runtime combination. A passing test is not proof of full draft compliance.
+
+## Validation and coverage gaps
+
+All **12 package unit-test targets passed**. See [initial focused run](https://formatjs.buildbuddy.io/invocation/ec0af2e6-f7b5-41ee-987b-76f7c06d78cd) and [remaining units plus Test262](https://formatjs.buildbuddy.io/invocation/582c0131-9566-40eb-9204-e60ac1ba4a44).
+
+| Existing Test262 target | Result | Included in ordinary wildcard test runs? |
+| ----------------------- | ------ | ---------------------------------------- |
+| NumberFormat            | Pass   | Yes                                      |
+| PluralRules             | Pass   | Yes                                      |
+| DisplayNames            | Fail   | No: manual                               |
+| ListFormat              | Fail   | No: manual                               |
+| Locale                  | Fail   | No: manual                               |
+| RelativeTimeFormat      | Fail   | No: manual                               |
+| Segmenter               | Fail   | No: manual                               |
+
+The Test262 pin is [`ade328d530525333751e8a3b58f02e18624da085`](https://github.com/tc39/test262/commit/ade328d530525333751e8a3b58f02e18624da085), dated **2022-10-25**. These results are harness results, not a count of current-spec defects. Locale tests include obsolete getter APIs; ListFormat's prelude uses `polyfill-force.ts` without the generated locale-loading entry point. RelativeTimeFormat failures include output-data expectations and coercion. DisplayNames' calendar-underscore failure agrees with finding 08. Do not repair current APIs to satisfy obsolete assertions.
+
+No runnable Test262 target is wired in the inspected package BUILD files for Collator, DateTimeFormat, DurationFormat, getCanonicalLocales, or supportedValuesOf. DateTimeFormat has a main-generator target, but no harness test target.
+
+- [ ] Refresh the Test262 pin and test-data setup, separating obsolete expectations from current defects.
+- [ ] Wire the five missing API suites; remove manual exclusions as each suite becomes reliable.
+- [ ] Add current-draft regression cases below before changing implementations.
+
+## Findings
+
+All findings are **P2 correctness issues**. IDs are stable tracking references. Mark a finding complete only after regression tests cover the listed cases and the relevant focused suites pass. Constructor names below refer to the polyfill exports, not native `Intl` implementations.
+
+### 01. Canonicalize locale-list inputs
+
+- [ ] Fix and add regression coverage.
+
+`getCanonicalLocales(null)` returns `[]`; `{0: "en", length: "1"}` also returns `[]`; `[{toString() { return "en" }}]` throws `TypeError`. Expected: `TypeError`, `["en"]`, `["en"]`, respectively. Apply `ToObject`, `LengthOfArrayLike`, and element `ToString`; structural Locale detection is not an internal-slot check.
+
+[Source](https://github.com/formatjs/formatjs/blob/818055749163de00c93513938289eca7c8233f30/packages/intl-getcanonicallocales/index.ts#L53) · [Draft algorithm](https://tc39.es/ecma402/#sec-canonicalizelocalelist)
+
+### 02. Coerce supportedValuesOf keys
+
+- [ ] Fix and add regression coverage.
+
+`supportedValuesOf(new String("unit"))` throws `RangeError: Invalid key: unit`. Coerce with `ToString` before dispatch; this input must return the unit list.
+
+[Source](https://github.com/formatjs/formatjs/blob/818055749163de00c93513938289eca7c8233f30/packages/intl-supportedvaluesof/index.ts#L66) · [Draft algorithm](https://tc39.es/ecma402/#sec-intl.supportedvaluesof)
+
+### 03. Restore Number coercion at Number-only boundaries
+
+- [ ] Fix and add regression coverage.
+
+`new DateTimeFormat("en", {timeZone: "UTC"}).format(0n)` formats a date; `new RelativeTimeFormat("en").format(1n, "day")` returns `"in 1 day"`; `new DurationFormat("en").format({seconds: 1n})` returns `"1 sec"`; `new NumberFormat("en", {minimumIntegerDigits: 2n})` accepts the option. All four must throw `TypeError`. The first and third use the Decimal-returning helper; RelativeTimeFormat and `DefaultNumberOption` use `Number(...)`. Also, DurationFormat rejects `{seconds: false}` instead of treating it as zero. Preserve BigInt support at `ToIntlMathematicalValue` boundaries, including NumberFormat values and PluralRules values.
+
+[Source](https://github.com/formatjs/formatjs/blob/818055749163de00c93513938289eca7c8233f30/packages/ecma262-abstract/ToNumber.ts#L23) · [Draft algorithm](https://tc39.es/ecma402/#sec-datetime-format-functions)
+
+### 04. Accept well-formed unsupported numbering systems
+
+- [ ] Fix and add regression coverage.
+
+Both `new NumberFormat("en", {numberingSystem: "foobar"})` and `new DurationFormat("en", {numberingSystem: "foobar"})` throw `RangeError`. `foobar` is syntactically valid; these constructors should fall back to the locale default (`latn` for loaded English data). Validate Unicode type syntax, then negotiate support. DurationFormat duplicates the membership check in `core.ts`.
+
+[Source](https://github.com/formatjs/formatjs/blob/818055749163de00c93513938289eca7c8233f30/packages/ecma402-abstract/NumberFormat/InitializeNumberFormat.ts#L61) · [Draft algorithm](https://tc39.es/ecma402/#sec-resolveoptions)
+
+### 05. Validate Collator collation syntax
+
+- [ ] Fix and add regression coverage.
+
+`new Collator("en", {collation: "!"}).resolvedOptions().collation` returns `"default"`. The malformed option must throw `RangeError` before locale resolution.
+
+[Source](https://github.com/formatjs/formatjs/blob/818055749163de00c93513938289eca7c8233f30/packages/intl-collator/core.ts#L86) · [Draft algorithm](https://tc39.es/ecma402/#sec-resolveoptions)
+
+### 06. Reject Symbol comparison inputs
+
+- [ ] Fix and add regression coverage.
+
+`new Collator("en").compare(Symbol("a"), "a")` returns a comparison result. Abstract `ToString` must throw `TypeError`; the JavaScript `String` constructor accepts Symbols.
+
+[Source](https://github.com/formatjs/formatjs/blob/818055749163de00c93513938289eca7c8233f30/packages/intl-collator/core.ts#L172) · [Draft algorithm](https://tc39.es/ecma402/#sec-collator-compare-functions)
+
+### 07. Reject seconds in DateTimeFormat offset identifiers
+
+- [ ] Fix and add regression coverage.
+
+`new DateTimeFormat("en", {timeZone: "+01:00:01"}).resolvedOptions().timeZone` returns `"+01:00:01"`; `+01:00:00` is silently normalized to `+01:00`. Both inputs must throw `RangeError`, including zero seconds. Minute-only `+01:00` passes and is not missing functionality.
+
+[Source](https://github.com/formatjs/formatjs/blob/818055749163de00c93513938289eca7c8233f30/packages/ecma402-abstract/IsValidTimeZoneName.ts#L69) · [Draft algorithm](https://tc39.es/ecma402/#sec-createdatetimeformat)
+
+### 08. Reject underscore calendar codes
+
+- [ ] Fix and add regression coverage.
+
+`new DisplayNames("en", {type: "calendar"}).of("islamic_civil")` returns `"islamic_civil"`. It must throw `RangeError`. Both the preliminary validator and canonicalizer accept underscores.
+
+[Source](https://github.com/formatjs/formatjs/blob/818055749163de00c93513938289eca7c8233f30/packages/ecma402-abstract/DisplayNames/CanonicalCodeForDisplayNames.ts#L9) · [Draft algorithm](https://tc39.es/ecma402/#sec-canonicalcodefordisplaynames)
+
+### 09. Return canonical DisplayNames fallback codes
+
+- [ ] Fix and add regression coverage.
+
+`new DisplayNames("en", {type: "currency"}).of("zzz")` returns `"zzz"`. For this missing English display name, fallback must return canonical `"ZZZ"`.
+
+[Source](https://github.com/formatjs/formatjs/blob/818055749163de00c93513938289eca7c8233f30/packages/intl-displaynames/index.ts#L217) · [Draft algorithm](https://tc39.es/ecma402/#sec-Intl.DisplayNames.prototype.of)
+
+### 10. Implement the ListFormat iterator protocol
+
+- [ ] Fix and add regression coverage.
+
+`new ListFormat("en").format("ab")` returns `""` instead of `"a and b"`; `.format(1)` returns `""` instead of throwing `TypeError`. A generator yielding a non-string is not closed: its `finally` block does not run. Use the iterator protocol for all inputs except `undefined`, and close the iterator on an invalid yielded value.
+
+[Source](https://github.com/formatjs/formatjs/blob/818055749163de00c93513938289eca7c8233f30/packages/intl-listformat/index.ts#L111) · [Draft algorithm](https://tc39.es/ecma402/#sec-createstringlistfromiterable)
+
+### 11. Normalize Locale firstDayOfWeek correctly
+
+- [ ] Fix and add regression coverage.
+
+`new Locale("en", {firstDayOfWeek: "mon"})` and the same call with `"7"` throw `RangeError`; expected firstDayOfWeek values are `"mon"` and `"sun"`. The numeric array lookup discards nonnumeric identifiers and has no entry for Sunday index 7.
+
+[Source](https://github.com/formatjs/formatjs/blob/818055749163de00c93513938289eca7c8233f30/packages/intl-locale/index.ts#L443) · [Draft algorithm](https://tc39.es/ecma402/#sec-weekdaytouvalue)
+
+### 12. Treat the empty kn extension as true
+
+- [ ] Fix and add regression coverage.
+
+`new Locale("en-u-kn").numeric` returns `false`, expected `true`. The constructor recognizes only the literal string `"true"`, not the empty Unicode keyword value.
+
+[Source](https://github.com/formatjs/formatjs/blob/818055749163de00c93513938289eca7c8233f30/packages/intl-locale/index.ts#L589) · [Draft algorithm](https://tc39.es/ecma402/#sec-Intl.Locale)
+
+### 13. Update the Locale week-info result contract
+
+- [ ] Fix and add regression coverage.
+
+`new Locale("en-u-fw-mon").getWeekInfo().firstDay` returns string `"mon"`, expected number `1`. Repeated calls on the same Locale share the `weekend` array, allowing caller mutation to affect later results. Results also include `minimalDays`, which the current draft no longer returns. Convert the weekday, copy the weekend list, and return the current property set.
+
+[Source](https://github.com/formatjs/formatjs/blob/818055749163de00c93513938289eca7c8233f30/packages/intl-locale/index.ts#L783) · [Draft algorithm](https://tc39.es/ecma402/#sec-Intl.Locale.prototype.getWeekInfo)
+
+### 14. Honor Locale region preference overrides
+
+- [ ] Fix and add regression coverage.
+
+`new Locale("en-US-u-rg-gbzzzz").getWeekInfo().firstDay` returns `7`, expected `1` from the available GB week data. The implementation uses the maximized region without applying the `rg` override.
+
+[Source](https://github.com/formatjs/formatjs/blob/818055749163de00c93513938289eca7c8233f30/packages/intl-locale/index.ts#L428) · [Draft algorithm](https://tc39.es/ecma402/#sec-weekinfooflocale)
+
+### 15. Complete draft PluralRules notation handling
+
+- [ ] Fix and add regression coverage.
+
+`new PluralRules("en", {notation: "scientific"})` throws `RangeError`; the draft also accepts `scientific` and `engineering`. `{compactDisplay: "bad"}` is ignored with standard notation instead of throwing. Read and validate compactDisplay unconditionally. The digit-options call also hardcodes `standard` rather than passing the selected notation.
+
+[Source](https://github.com/formatjs/formatjs/blob/818055749163de00c93513938289eca7c8233f30/packages/ecma402-abstract/PluralRules/InitializePluralRules.ts#L68) · [Draft algorithm](https://tc39.es/ecma402/#sec-intl.pluralrules)
+
+### 16. Complete PluralRules resolvedOptions
+
+- [ ] Fix and add regression coverage.
+
+Default results omit `notation`, `roundingIncrement`, `roundingMode`, `roundingPriority`, and `trailingZeroDisplay`; compactDisplay is omitted for compact notation. Results have a null prototype instead of `Object.prototype`. English ordinal pluralCategories are `["few", "one", "other", "two"]` instead of `["one", "two", "few", "other"]`. Return the draft fields in table order and sort categories by the prescribed plural-category order.
+
+[Source](https://github.com/formatjs/formatjs/blob/818055749163de00c93513938289eca7c8233f30/packages/intl-pluralrules/index.ts#L152) · [Draft algorithm](https://tc39.es/ecma402/#sec-intl.pluralrules.prototype.resolvedoptions)
+
+### 17. Allow infinite PluralRules range endpoints
+
+- [ ] Fix and add regression coverage.
+
+`new PluralRules("en").selectRange(Infinity, Infinity)` throws `RangeError`, expected `"other"`. Reject NaN endpoints; infinity is handled by ResolvePlural.
+
+[Source](https://github.com/formatjs/formatjs/blob/818055749163de00c93513938289eca7c8233f30/packages/ecma402-abstract/PluralRules/ResolvePluralRange.ts#L51) · [Draft algorithm](https://tc39.es/ecma402/#sec-resolvepluralrange)
+
+### 18. Preserve Segmenter iterator identity and progress
+
+- [ ] Fix and add regression coverage.
+
+For `it = new Segmenter("en", {}).segment("ab")[Symbol.iterator]()`, `it[Symbol.iterator]() === it` is false. After `it.next()`, spreading `it` yields both `"a"` and `"b"`, rather than only `"b"`. Separate the Segments iterable from its iterator; an iterator must return itself and retain its position.
+
+[Source](https://github.com/formatjs/formatjs/blob/818055749163de00c93513938289eca7c8233f30/packages/intl-segmenter/segmenter.ts#L408) · [Draft algorithm](https://tc39.es/ecma402/#sec-%intlsegmentiteratorprototype%-object)
+
+### 19. Return a valid Segmenter default locale
+
+- [ ] Fix and add regression coverage.
+
+`new Segmenter(undefined, {}).resolvedOptions().locale` returns `""`. The resolved default must be a valid canonical language tag. Root segmentation rules can be used internally without exposing an empty locale.
+
+[Source](https://github.com/formatjs/formatjs/blob/818055749163de00c93513938289eca7c8233f30/packages/intl-segmenter/segmenter.ts#L159) · [Draft algorithm](https://tc39.es/ecma402/#sec-defaultlocale)
+
+### 20. Read DurationFormat fields once
+
+- [ ] Fix and add regression coverage.
+
+With a getter incrementing a counter and returning 1 for `seconds`, `.format(input)` invokes the getter three times, expected once. Cache each field in the specified order and use those values for the empty-record check.
+
+[Source](https://github.com/formatjs/formatjs/blob/818055749163de00c93513938289eca7c8233f30/packages/ecma402-abstract/DurationFormat/ToDurationRecord.ts#L48) · [Draft algorithm](https://tc39.es/ecma402/#sec-todurationrecord)
+
+### 21. Throw RangeError for nonintegral duration fields
+
+- [ ] Fix and add regression coverage.
+
+`.format({seconds: 1.5})` and `.format({seconds: NaN})` throw generic `Error`. Both must throw `RangeError`; the invariant currently defaults to `Error`.
+
+[Source](https://github.com/formatjs/formatjs/blob/818055749163de00c93513938289eca7c8233f30/packages/ecma402-abstract/DurationFormat/ToIntegerIfIntegral.ts#L6) · [Draft algorithm](https://tc39.es/ecma402/#sec-tointegerifintegral)
+
+### 22. Enforce duration magnitude limits
+
+- [ ] Fix and add regression coverage.
+
+`new DurationFormat("en").format({years: 2 ** 32})` returns `"4,294,967,296 yrs"`, expected `RangeError`. The validator checks finiteness and common sign but omits the years/months/weeks bounds and the normalized-seconds bound. Implement the latter without lossy floating-point accumulation.
+
+[Source](https://github.com/formatjs/formatjs/blob/818055749163de00c93513938289eca7c8233f30/packages/ecma402-abstract/DurationFormat/IsValidDurationRecord.ts#L18) · [Draft algorithm](https://tc39.es/ecma402/#sec-isvalidduration)
+
+## Reproduction setup
+
+Build the public entry bundles and locale data through Bazel:
+
+```bash
+bazel build //packages/intl-{collator,datetimeformat,displaynames,durationformat,getcanonicallocales,listformat,locale,numberformat,pluralrules,relativetimeformat,segmenter,supportedvaluesof}:index-bundle \
+  //packages/intl-{datetimeformat,displaynames,listformat,numberformat,pluralrules,relativetimeformat}:cldr-raw
+```
+
+Use `bazel cquery --output=files <target>` to resolve each bundle directory and generated locale-data path; do not assume a transitioned output directory. Import `index.js` from each resolved bundle. ListFormat and RelativeTimeFormat have default exports; the other constructor exports are named. Import the two standalone functions by name. For each dynamic-data constructor, call `__addLocaleData` with its generated `cldr-raw/en.json`; PluralRules instead generates `en.js`, a serialized object containing a function, which the existing test setup evaluates as an object expression.
+
+Run the expressions in each finding after that setup. To reproduce getter and iterator cases:
+
+```js
+let reads = 0
+new DurationFormat('en').format({
+  get seconds() {
+    reads++
+    return 1
+  },
+})
+console.log(reads) // observed 3; expected 1
+
+let closed = false
+function* values() {
+  try {
+    yield 1
+  } finally {
+    closed = true
+  }
+}
+try {
+  new ListFormat('en').format(values())
+} catch {}
+console.log(closed) // observed false; expected true
+
+const iterator = new Segmenter('en', {}).segment('ab')[Symbol.iterator]()
+iterator.next()
+console.log([...iterator].map(part => part.segment)) // observed ['a', 'b']; expected ['b']
+```
+
+The audit executed the probes through `bazel run` using the configured Node toolchain. Probe expectations came from the retrieved draft, not from native Node output. Controls passed for minute-only offset identifiers and `new PluralRules('en').select(1n) === 'one'`; do not remove these supported behaviors while fixing adjacent cases.
+
+## Suggested implementation order
+
+1. Shared coercion and locale-list handling (01–04), with callers tested separately so NumberFormat/PluralRules retain mathematical-value support.
+2. DurationFormat and ListFormat input contracts (10, 20–22), then constructor/output validation (05–09).
+3. Locale metadata, PluralRules draft additions, and Segmenter iteration/defaults (11–19).
+4. Refresh conformance coverage alongside these changes. Keep locale-data/version differences separate from normative algorithm failures.


### PR DESCRIPTION
Record 22 confirmed polyfill gaps against the current ECMA-402 draft, with source links, reproductions, and follow-up checklists. Link the audit from the shared polyfill architecture page.

All 12 package unit-test targets passed. Five of seven existing Test262 targets failed; the report separates the 2022 suite's stale expectations and harness gaps from current-draft findings. Runtime probes used Bazel-built bundles and generated English locale data.

Docs only; no implementation changes.
