### PR TITLE
codex/ecma402 coercion

### DIFF
--- a/docs/src/docs/polyfills.mdx
+++ b/docs/src/docs/polyfills.mdx
@@ -18,6 +18,13 @@ Our current list of polyfills includes:
 
 ![Polyfill Hierarchy](/img/polyfills.svg)
 
+# Numeric inputs
+
+DateTimeFormat, RelativeTimeFormat, duration fields, and numeric options use
+ECMAScript Number conversion and reject BigInt inputs. NumberFormat and
+PluralRules formatting values support BigInt through their separate
+mathematical-value conversion.
+
 # polyfill-fastly.io Integration
 
 For basic use cases, we recommend using [polyfill-fastly.io](https://polyfill-fastly.io/) or [polyfill-library](https://github.com/Financial-Times/polyfill-library) to generate polyfill bundle since it automatically resolves the dependencies above for you.

--- a/knowledge-base/004-package-ecma402-abstract.md
+++ b/knowledge-base/004-package-ecma402-abstract.md
@@ -23,3 +23,11 @@ Implements abstract operations from across the ECMA-402 specification:
 ## Dependencies
 
 `@formatjs/bigdecimal`, `@formatjs/fast-memoize`, `@formatjs/intl-localematcher`
+
+## Numeric Coercion
+
+`ToNumber` applies ECMAScript Number conversion before wrapping the result in
+Decimal. DateTimeFormat values, duration fields, RelativeTimeFormat values, and
+numeric options reject BigInt, including objects that coerce to BigInt.
+`ToIntlMathematicalValue` and formatted plural operands retain exact decimal
+values; do not route them through Number conversion.

--- a/packages/ecma262-abstract/ToNumber.ts
+++ b/packages/ecma262-abstract/ToNumber.ts
@@ -1,9 +1,15 @@
 import {Decimal} from '@formatjs/bigdecimal'
 
-/** https://tc39.es/ecma262/#sec-tonumber */
+/**
+ * ECMA-262 §7.1.4 ToNumber, steps 2, 8–10.
+ * https://tc39.es/ecma262/#sec-tonumber
+ * https://github.com/tc39/ecma262/blob/dcf59856a8184792a9e42f0ffb7dc064094a5dcc/spec.html#L5183-L5191
+ */
 export function ToNumber(arg: any): Decimal {
-  // Unary + evaluation step 3 returns ? ToNumber, preserving abrupt completions
+  // Unary + evaluation step 2 returns ? ToNumber, preserving abrupt completions
   // from ToPrimitive and rejecting BigInt/Symbol before constructing Decimal.
+  // ECMA-262 §13.5.4.1 Unary + evaluation, step 2.
   // https://tc39.es/ecma262/#sec-unary-plus-operator-runtime-semantics-evaluation
+  // https://github.com/tc39/ecma262/blob/dcf59856a8184792a9e42f0ffb7dc064094a5dcc/spec.html#L20666
   return new Decimal(+arg)
 }

--- a/packages/ecma262-abstract/ToNumber.ts
+++ b/packages/ecma262-abstract/ToNumber.ts
@@ -1,47 +1,8 @@
 import {Decimal} from '@formatjs/bigdecimal'
-import {ToPrimitive} from '#packages/ecma262-abstract/ToPrimitive.js'
 
-const ZERO = new Decimal(0)
-
-function invariant(
-  condition: boolean,
-  message: string,
-  Err: typeof Error = Error
-): asserts condition {
-  if (!condition) {
-    throw new Err(message)
-  }
-}
-
-/**
- * https://tc39.es/ecma262/#sec-tonumber
- */
+/** https://tc39.es/ecma262/#sec-tonumber */
 export function ToNumber(arg: any): Decimal {
-  if (typeof arg === 'number') {
-    return new Decimal(arg)
-  }
-  if (typeof arg === 'bigint') {
-    return new Decimal(arg.toString())
-  }
-  invariant(typeof arg !== 'symbol', 'Symbol is not supported', TypeError)
-  if (arg === undefined) {
-    return new Decimal(NaN)
-  }
-  if (arg === null || arg === 0) {
-    return ZERO
-  }
-  if (arg === true) {
-    return new Decimal(1)
-  }
-  if (typeof arg === 'string') {
-    try {
-      return new Decimal(arg)
-    } catch {
-      return new Decimal(NaN)
-    }
-  }
-  invariant(typeof arg === 'object', 'object expected', TypeError)
-  let primValue = ToPrimitive(arg, 'number')
-  invariant(typeof primValue !== 'object', 'object expected', TypeError)
-  return ToNumber(primValue)
+  // Unary plus performs ToNumber, including object coercion and rejection of
+  // BigInt/Symbol. Decimal preserves that Number result for downstream arithmetic.
+  return new Decimal(+arg)
 }

--- a/packages/ecma262-abstract/ToNumber.ts
+++ b/packages/ecma262-abstract/ToNumber.ts
@@ -2,7 +2,8 @@ import {Decimal} from '@formatjs/bigdecimal'
 
 /** https://tc39.es/ecma262/#sec-tonumber */
 export function ToNumber(arg: any): Decimal {
-  // Unary plus performs ToNumber, including object coercion and rejection of
-  // BigInt/Symbol. Decimal preserves that Number result for downstream arithmetic.
+  // Unary + evaluation step 3 returns ? ToNumber, preserving abrupt completions
+  // from ToPrimitive and rejecting BigInt/Symbol before constructing Decimal.
+  // https://tc39.es/ecma262/#sec-unary-plus-operator-runtime-semantics-evaluation
   return new Decimal(+arg)
 }

--- a/packages/ecma402-abstract/DefaultNumberOption.ts
+++ b/packages/ecma402-abstract/DefaultNumberOption.ts
@@ -1,5 +1,7 @@
 /**
+ * ECMA-402 §9.2.13 DefaultNumberOption, step 2.
  * https://tc39.es/ecma402/#sec-defaultnumberoption
+ * https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/negotiation.html#L437
  * @param val
  * @param min
  * @param max
@@ -16,7 +18,9 @@ export function DefaultNumberOption<F extends number | undefined>(
     return fallback
   }
   // DefaultNumberOption uses ToNumber, which rejects BigInt even after coercion.
+  // ECMA-402 §9.2.13 DefaultNumberOption, step 2.
   // https://tc39.es/ecma402/#sec-defaultnumberoption
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/negotiation.html#L437
   const val = +(inputVal as any)
   if (isNaN(val) || val < min || val > max) {
     throw new RangeError(`${val} is outside of range [${min}, ${max}]`)

--- a/packages/ecma402-abstract/DefaultNumberOption.ts
+++ b/packages/ecma402-abstract/DefaultNumberOption.ts
@@ -15,7 +15,9 @@ export function DefaultNumberOption<F extends number | undefined>(
     // @ts-expect-error
     return fallback
   }
-  const val = Number(inputVal)
+  // DefaultNumberOption uses ToNumber, which rejects BigInt even after coercion.
+  // https://tc39.es/ecma402/#sec-defaultnumberoption
+  const val = +(inputVal as any)
   if (isNaN(val) || val < min || val > max) {
     throw new RangeError(`${val} is outside of range [${min}, ${max}]`)
   }

--- a/packages/ecma402-abstract/PluralRules/GetOperands.ts
+++ b/packages/ecma402-abstract/PluralRules/GetOperands.ts
@@ -4,7 +4,9 @@ import Decimal from '@formatjs/bigdecimal'
 
 /**
  * CLDR Spec: Operands as defined in https://unicode.org/reports/tr35/tr35-numbers.html#Operands
+ * ECMA-402 §17.5.1 PluralRuleSelect, decimalString parameter and return definition.
  * CLDR operands for the implementation-defined PluralRuleSelect (https://tc39.es/ecma402/#sec-pluralruleselect)
+ * https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/pluralrules.html#L285-L290
  *
  * Maps CLDR operand symbols to JavaScript property names:
  * - n → Number (absolute value)
@@ -53,7 +55,9 @@ export interface OperandsRecord {
 
 /**
  * CLDR operands for the implementation-defined PluralRuleSelect
+ * ECMA-402 §17.5.1 PluralRuleSelect, decimalString parameter and return definition.
  * https://tc39.es/ecma402/#sec-pluralruleselect
+ * https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/pluralrules.html#L285-L290
  *
  * Implementation: Extended to support compact exponent (c/e operands)
  *
@@ -66,7 +70,9 @@ export function GetOperands(s: string, exponent: number = 0): OperandsRecord {
     `GetOperands should have been called with a string`
   )
   // GetOperands consumes a formatted decimal string, not an ECMAScript Number.
+  // ECMA-402 §17.5.1 PluralRuleSelect, decimalString parameter and return definition.
   // Preserve its mathematical value: https://tc39.es/ecma402/#sec-pluralruleselect
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/pluralrules.html#L285-L290
   const n = new Decimal(s)
   invariant(n.isFinite(), 'n should be finite')
   let dp = s.indexOf('.')

--- a/packages/ecma402-abstract/PluralRules/GetOperands.ts
+++ b/packages/ecma402-abstract/PluralRules/GetOperands.ts
@@ -4,7 +4,7 @@ import Decimal from '@formatjs/bigdecimal'
 
 /**
  * CLDR Spec: Operands as defined in https://unicode.org/reports/tr35/tr35-numbers.html#Operands
- * ECMA-402 Spec: GetOperands abstract operation (https://tc39.es/ecma402/#sec-getoperands)
+ * CLDR operands for the implementation-defined PluralRuleSelect (https://tc39.es/ecma402/#sec-pluralruleselect)
  *
  * Maps CLDR operand symbols to JavaScript property names:
  * - n → Number (absolute value)
@@ -52,8 +52,8 @@ export interface OperandsRecord {
 }
 
 /**
- * ECMA-402 Spec: GetOperands abstract operation
- * https://tc39.es/ecma402/#sec-getoperands
+ * CLDR operands for the implementation-defined PluralRuleSelect
+ * https://tc39.es/ecma402/#sec-pluralruleselect
  *
  * Implementation: Extended to support compact exponent (c/e operands)
  *
@@ -66,7 +66,7 @@ export function GetOperands(s: string, exponent: number = 0): OperandsRecord {
     `GetOperands should have been called with a string`
   )
   // GetOperands consumes a formatted decimal string, not an ECMAScript Number.
-  // Preserve its mathematical value: https://tc39.es/ecma402/#sec-getoperands
+  // Preserve its mathematical value: https://tc39.es/ecma402/#sec-pluralruleselect
   const n = new Decimal(s)
   invariant(n.isFinite(), 'n should be finite')
   let dp = s.indexOf('.')

--- a/packages/ecma402-abstract/PluralRules/GetOperands.ts
+++ b/packages/ecma402-abstract/PluralRules/GetOperands.ts
@@ -1,7 +1,6 @@
-import {ToNumber} from '#packages/ecma262-abstract/ToNumber.js'
 import {ZERO} from '#packages/ecma402-abstract/constants.js'
 import {invariant} from '#packages/ecma402-abstract/utils.js'
-import type Decimal from '@formatjs/bigdecimal'
+import Decimal from '@formatjs/bigdecimal'
 
 /**
  * CLDR Spec: Operands as defined in https://unicode.org/reports/tr35/tr35-numbers.html#Operands
@@ -66,7 +65,9 @@ export function GetOperands(s: string, exponent: number = 0): OperandsRecord {
     typeof s === 'string',
     `GetOperands should have been called with a string`
   )
-  const n = ToNumber(s)
+  // GetOperands consumes a formatted decimal string, not an ECMAScript Number.
+  // Preserve its mathematical value: https://tc39.es/ecma402/#sec-getoperands
+  const n = new Decimal(s)
   invariant(n.isFinite(), 'n should be finite')
   let dp = s.indexOf('.')
   let iv
@@ -74,22 +75,22 @@ export function GetOperands(s: string, exponent: number = 0): OperandsRecord {
   let v: number
   let fv = ''
   if (dp === -1) {
-    iv = n
+    iv = s
     f = ZERO
     v = 0
   } else {
     iv = s.slice(0, dp)
     fv = s.slice(dp, s.length)
-    f = ToNumber(fv)
+    f = new Decimal(fv)
     v = fv.length
   }
-  const i = ToNumber(iv).abs()
+  const i = new Decimal(iv).abs()
   let w: number
   let t: Decimal
   if (!f.isZero()) {
     const ft = fv.replace(/0+$/, '')
     w = ft.length
-    t = ToNumber(ft)
+    t = new Decimal(ft)
   } else {
     w = 0
     t = ZERO

--- a/packages/ecma402-abstract/tests/262.test.ts
+++ b/packages/ecma402-abstract/tests/262.test.ts
@@ -33,6 +33,42 @@ describe('Number coercion', () => {
       expect(ToNumber(value).toNumber()).toBe(Number(value))
     }
   )
+  it.each(['getter', 'method', 'valueOf', 'toString'])(
+    'preserves the exact exception from %s coercion',
+    kind => {
+      const error = new Error('coercion failed')
+      const fail = () => {
+        throw error
+      }
+      const value =
+        kind === 'getter'
+          ? Object.defineProperty({}, Symbol.toPrimitive, {get: fail})
+          : kind === 'method'
+            ? {[Symbol.toPrimitive]: fail}
+            : kind === 'valueOf'
+              ? {valueOf: fail}
+              : {valueOf: () => ({}), toString: fail}
+      for (const convert of [
+        ToNumber,
+        (input: unknown) => DefaultNumberOption(input, 0, 10, 0),
+      ]) {
+        let caught: unknown
+        try {
+          convert(value)
+        } catch (error) {
+          caught = error
+        }
+        expect(caught).toBe(error)
+      }
+    }
+  )
+  it.each([
+    {[Symbol.toPrimitive]: 1},
+    {[Symbol.toPrimitive]: () => ({})},
+    {valueOf: () => ({}), toString: () => ({})},
+  ])('rejects invalid object coercion: %s', value => {
+    expect(() => ToNumber(value)).toThrow(TypeError)
+  })
   it('coerces an object once with a number hint', () => {
     const hints: string[] = []
     expect(

--- a/packages/ecma402-abstract/tests/262.test.ts
+++ b/packages/ecma402-abstract/tests/262.test.ts
@@ -1,4 +1,6 @@
 import {describe, expect, it} from 'vitest'
+import {ToNumber} from '#packages/ecma262-abstract/ToNumber.js'
+import {DefaultNumberOption} from '#packages/ecma402-abstract/DefaultNumberOption.js'
 import {DayFromYear} from '#packages/ecma262-abstract/DateOperations.js'
 
 describe('262', () => {
@@ -14,5 +16,33 @@ describe('262', () => {
     it('calculates correct day number for year 2000', () => {
       expect(DayFromYear(2000)).toBe(10957)
     })
+  })
+})
+
+describe('Number coercion', () => {
+  it.each([1n, Object(1n), {valueOf: () => 1n}, Symbol('number')])(
+    'rejects non-Number numeric inputs: %s',
+    value => {
+      expect(() => ToNumber(value)).toThrow(TypeError)
+      expect(() => DefaultNumberOption(value, 0, 10, 0)).toThrow(TypeError)
+    }
+  )
+  it.each([false, '', '  ', '0x10', '9007199254740993', null])(
+    'uses ECMAScript Number conversion: %s',
+    value => {
+      expect(ToNumber(value).toNumber()).toBe(Number(value))
+    }
+  )
+  it('coerces an object once with a number hint', () => {
+    const hints: string[] = []
+    expect(
+      ToNumber({
+        [Symbol.toPrimitive](hint: string) {
+          hints.push(hint)
+          return '2'
+        },
+      }).toNumber()
+    ).toBe(2)
+    expect(hints).toEqual(['number'])
   })
 })

--- a/packages/ecma402-abstract/tests/262.test.ts
+++ b/packages/ecma402-abstract/tests/262.test.ts
@@ -62,12 +62,14 @@ describe('Number coercion', () => {
       }
     }
   )
-  it.each([
-    {[Symbol.toPrimitive]: 1},
-    {[Symbol.toPrimitive]: () => ({})},
-    {valueOf: () => ({}), toString: () => ({})},
-  ])('rejects invalid object coercion: %s', value => {
-    expect(() => ToNumber(value)).toThrow(TypeError)
+  it('rejects invalid object coercion', () => {
+    for (const value of [
+      {[Symbol.toPrimitive]: 1},
+      {[Symbol.toPrimitive]: () => ({})},
+      {valueOf: () => ({}), toString: () => ({})},
+    ]) {
+      expect(() => ToNumber(value)).toThrow(TypeError)
+    }
   })
   it('coerces an object once with a number hint', () => {
     const hints: string[] = []

--- a/packages/intl-datetimeformat/tests/index.test.ts
+++ b/packages/intl-datetimeformat/tests/index.test.ts
@@ -878,3 +878,11 @@ describe('hourCycle override', function () {
     expect(dtf12.format(date)).toMatch(/3/)
   })
 })
+
+it('rejects BigInt date arguments', () => {
+  const formatter = new DateTimeFormat('en', {timeZone: 'UTC'})
+  for (const value of [0n, Object(0n), {valueOf: () => 0n}]) {
+    expect(() => formatter.format(value as any)).toThrow(TypeError)
+    expect(() => formatter.formatToParts(value as any)).toThrow(TypeError)
+  }
+})

--- a/packages/intl-durationformat/tests/index.test.ts
+++ b/packages/intl-durationformat/tests/index.test.ts
@@ -183,3 +183,14 @@ test.skip('Intl.DurationFormat format with NumberFormatV3', function () {
     })
   ).toBe('1 yr, 2 mths, 3 days, 4 hr, 5 min, 6 sec, 7 ms, 8 μs, 9 ns')
 })
+
+test('duration fields use Number coercion', () => {
+  const formatter = new DurationFormat('en')
+  expect(formatter.format({seconds: false} as any)).toBe(
+    formatter.format({seconds: 0})
+  )
+  for (const seconds of [1n, Object(1n), {valueOf: () => 1n}]) {
+    expect(() => formatter.format({seconds} as any)).toThrow(TypeError)
+    expect(() => formatter.formatToParts({seconds} as any)).toThrow(TypeError)
+  }
+})

--- a/packages/intl-pluralrules/BUILD.bazel
+++ b/packages/intl-pluralrules/BUILD.bazel
@@ -92,6 +92,7 @@ formatjs_test(
         "//:node_modules/@formatjs/intl-getcanonicallocales",
         "//:node_modules/@formatjs/intl-locale",
         "//:node_modules/vitest",
+        "//packages/ecma402-abstract/PluralRules",
     ],
 )
 

--- a/packages/intl-pluralrules/tests/index.test.ts
+++ b/packages/intl-pluralrules/tests/index.test.ts
@@ -1,3 +1,4 @@
+import {GetOperands} from '#packages/ecma402-abstract/PluralRules/GetOperands.js'
 import '@formatjs/intl-getcanonicallocales/polyfill.js'
 import '@formatjs/intl-locale/polyfill.js'
 import {PluralRules} from '#packages/intl-pluralrules/index.js'
@@ -335,4 +336,8 @@ describe('PluralRules', function () {
       )
     })
   })
+})
+
+it('preserves plural operands above Number.MAX_SAFE_INTEGER', () => {
+  expect(GetOperands('9007199254740993').IntegerDigits).toBe('9007199254740993')
 })

--- a/packages/intl-relativetimeformat/index.ts
+++ b/packages/intl-relativetimeformat/index.ts
@@ -39,7 +39,9 @@ export default class RelativeTimeFormat {
     }
     return PartitionRelativeTimePattern(
       this,
+      // ECMA-402 §18.3.3 Intl.RelativeTimeFormat.prototype.format, step 3.
       // ToNumber rejects BigInt: https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat.prototype.format
+      // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/relativetimeformat.html#L175
       +value,
       ToString(unit) as Intl.RelativeTimeFormatUnit,
       {
@@ -62,7 +64,9 @@ export default class RelativeTimeFormat {
     }
     return PartitionRelativeTimePattern(
       this,
+      // ECMA-402 §18.3.4 Intl.RelativeTimeFormat.prototype.formatToParts, step 3.
       // ToNumber rejects BigInt: https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat.prototype.formatToParts
+      // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/relativetimeformat.html#L189
       +value,
       ToString(unit) as Intl.RelativeTimeFormatUnit,
       {getInternalSlots}

--- a/packages/intl-relativetimeformat/index.ts
+++ b/packages/intl-relativetimeformat/index.ts
@@ -39,7 +39,7 @@ export default class RelativeTimeFormat {
     }
     return PartitionRelativeTimePattern(
       this,
-      // ToNumber rejects BigInt: https://tc39.es/ecma402/#sec-intl.relativetimeformat.prototype.format
+      // ToNumber rejects BigInt: https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat.prototype.format
       +value,
       ToString(unit) as Intl.RelativeTimeFormatUnit,
       {
@@ -62,7 +62,7 @@ export default class RelativeTimeFormat {
     }
     return PartitionRelativeTimePattern(
       this,
-      // ToNumber rejects BigInt: https://tc39.es/ecma402/#sec-intl.relativetimeformat.prototype.formattoparts
+      // ToNumber rejects BigInt: https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat.prototype.formatToParts
       +value,
       ToString(unit) as Intl.RelativeTimeFormatUnit,
       {getInternalSlots}

--- a/packages/intl-relativetimeformat/index.ts
+++ b/packages/intl-relativetimeformat/index.ts
@@ -39,7 +39,8 @@ export default class RelativeTimeFormat {
     }
     return PartitionRelativeTimePattern(
       this,
-      Number(value),
+      // ToNumber rejects BigInt: https://tc39.es/ecma402/#sec-intl.relativetimeformat.prototype.format
+      +value,
       ToString(unit) as Intl.RelativeTimeFormatUnit,
       {
         getInternalSlots,
@@ -61,7 +62,8 @@ export default class RelativeTimeFormat {
     }
     return PartitionRelativeTimePattern(
       this,
-      Number(value),
+      // ToNumber rejects BigInt: https://tc39.es/ecma402/#sec-intl.relativetimeformat.prototype.formattoparts
+      +value,
       ToString(unit) as Intl.RelativeTimeFormatUnit,
       {getInternalSlots}
     )

--- a/packages/intl-relativetimeformat/tests/index.test.ts
+++ b/packages/intl-relativetimeformat/tests/index.test.ts
@@ -47,3 +47,13 @@ describe('Intl.RelativeTimeFormat', function () {
     }
   })
 })
+
+it('rejects BigInt values in both formatting methods', () => {
+  const formatter = new RelativeTimeFormat('en')
+  for (const value of [1n, Object(1n), {valueOf: () => 1n}]) {
+    expect(() => formatter.format(value as any, 'day')).toThrow(TypeError)
+    expect(() => formatter.formatToParts(value as any, 'day')).toThrow(
+      TypeError
+    )
+  }
+})


### PR DESCRIPTION
Fix Number-only input coercion from audit #7185, item 03. DateTimeFormat, RelativeTimeFormat, duration fields, and numeric options now reject BigInt, including boxed values and objects that return BigInt. Boolean duration fields convert normally.

Keep formatted plural operands on the exact Decimal path, preserving NumberFormat/PluralRules BigInt precision. Comments cite the relevant ECMA-262/402 algorithms.

Validation: six focused Bazel suites passed (shared abstracts, DateTimeFormat, RelativeTimeFormat, DurationFormat, NumberFormat, PluralRules), including coercion and unsafe-integer operand regressions.
