### PR TITLE
fix(@formatjs/intl-supportedvaluesof): coerce keys before lookup

### DIFF
--- a/docs/src/docs/polyfills/intl-supportedvaluesof.mdx
+++ b/docs/src/docs/polyfills/intl-supportedvaluesof.mdx
@@ -66,3 +66,8 @@ async function polyfill() {
 ## Tests
 
 This library is [test262](https://github.com/tc39/test262/tree/master/test/intl402/Intl/supportedValuesOf)-compliant.
+
+## Key coercion
+
+`Intl.supportedValuesOf` converts its key to a string before validating the
+category. String wrapper objects are accepted; Symbols throw `TypeError`.

--- a/knowledge-base/007k-polyfill-intl-supportedvaluesof.md
+++ b/knowledge-base/007k-polyfill-intl-supportedvaluesof.md
@@ -66,3 +66,8 @@ export const units = ['acre', 'bit', 'byte', 'celsius', ...] as const
 - **No dynamic locale loading** — all value lists compiled into the bundle
 - `supportedValuesOf(key)` looks up the correct generated constant and returns a sorted copy
 - Each value type is a `const` array for type safety
+
+## Key coercion
+
+`Intl.supportedValuesOf` converts its key to a string before validating the
+category. String wrapper objects are accepted; Symbols throw `TypeError`.

--- a/packages/intl-supportedvaluesof/BUILD.bazel
+++ b/packages/intl-supportedvaluesof/BUILD.bazel
@@ -63,6 +63,7 @@ formatjs_library(
         "//:node_modules/@formatjs/fast-memoize",
         "//:node_modules/@formatjs_generated/cldr.number",
         "//:node_modules/@formatjs_generated/cldr.supported-values",
+        "//packages/ecma262-abstract",
         "//packages/ecma402-abstract",
     ],
 )

--- a/packages/intl-supportedvaluesof/index.ts
+++ b/packages/intl-supportedvaluesof/index.ts
@@ -16,7 +16,9 @@ export {shouldPolyfill} from '#packages/intl-supportedvaluesof/should-polyfill.j
 
 /**
  * ECMA-402 Spec: Intl.supportedValuesOf
+ * ECMA-402 §8.3.2 Intl.supportedValuesOf, step 1.
  * https://tc39.es/ecma402/#sec-intl.supportedvaluesof
+ * https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/intl.html#L103
  */
 declare global {
   namespace Intl {
@@ -50,7 +52,9 @@ export type SupportedValuesOf =
 
 /**
  * ECMA-402 Spec: Intl.supportedValuesOf(key)
+ * ECMA-402 §8.3.2 Intl.supportedValuesOf, step 1.
  * https://tc39.es/ecma402/#sec-intl.supportedvaluesof
+ * https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/intl.html#L103
  *
  * Returns an array containing the supported calendar, collation, currency,
  * numbering systems, time zone, or unit values supported by the implementation.
@@ -63,7 +67,9 @@ export type SupportedValuesOf =
  * @returns A sorted array of unique string values
  */
 export function supportedValuesOf(key: SupportedValuesOf): string[] {
+  // ECMA-402 §8.3.2 Intl.supportedValuesOf, step 1.
   // Coerce the key before dispatch: https://tc39.es/ecma402/#sec-intl.supportedvaluesof
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/intl.html#L103
   key = ToString(key) as SupportedValuesOf
   switch (key) {
     case 'calendar':

--- a/packages/intl-supportedvaluesof/index.ts
+++ b/packages/intl-supportedvaluesof/index.ts
@@ -1,3 +1,4 @@
+import {ToString} from '#packages/ecma262-abstract/ToString.js'
 import {getSupportedCalendars} from '#packages/intl-supportedvaluesof/get-supported-calendars.js'
 import {getSupportedCollations} from '#packages/intl-supportedvaluesof/get-supported-collations.js'
 import {getSupportedCurrencies} from '#packages/intl-supportedvaluesof/get-supported-currencies.js'
@@ -62,7 +63,8 @@ export type SupportedValuesOf =
  * @returns A sorted array of unique string values
  */
 export function supportedValuesOf(key: SupportedValuesOf): string[] {
-  // ECMA-402 Spec: Dispatch to appropriate getter based on key
+  // Coerce the key before dispatch: https://tc39.es/ecma402/#sec-intl.supportedvaluesof
+  key = ToString(key) as SupportedValuesOf
   switch (key) {
     case 'calendar':
       return getSupportedCalendars()

--- a/packages/intl-supportedvaluesof/tests/index.test.ts
+++ b/packages/intl-supportedvaluesof/tests/index.test.ts
@@ -164,3 +164,29 @@ describe('Intl.supportedValuesOf', () => {
     })
   })
 })
+
+it('coerces keys once with a string hint', () => {
+  const hints: string[] = []
+  const key = {
+    [Symbol.toPrimitive](hint: string) {
+      hints.push(hint)
+      return 'unit'
+    },
+  }
+  expect(supportedValuesOf(key as any)).toEqual(supportedValuesOf('unit'))
+  expect(hints).toEqual(['string'])
+  expect(supportedValuesOf(new String('unit') as any)).toEqual(
+    supportedValuesOf('unit')
+  )
+})
+it('preserves key coercion errors', () => {
+  expect(() => supportedValuesOf(Symbol('unit') as any)).toThrow(TypeError)
+  const error = new Error('coercion')
+  expect(() =>
+    supportedValuesOf({
+      toString() {
+        throw error
+      },
+    } as any)
+  ).toThrow(error)
+})


### PR DESCRIPTION
Fix audit #7185, item 02: convert supportedValuesOf keys with ToString before dispatch. Boxed strings and objects that produce valid keys now work; Symbols and coercion errors propagate correctly.

Adds the spec citation, public/internal documentation, and regression coverage. Validation: `bazel test //packages/intl-supportedvaluesof:intl-supportedvaluesof_test` passed.
