### PR TITLE
fix(@formatjs/intl-listformat): follow the string iterator protocol

### DIFF
--- a/docs/src/docs/polyfills/intl-listformat.mdx
+++ b/docs/src/docs/polyfills/intl-listformat.mdx
@@ -165,3 +165,9 @@ async function polyfill(locale: string) {
 ## Tests
 
 This library is fully [test262](https://github.com/tc39/test262/tree/master/test/intl402/ListFormat)-compliant.
+
+## Iterable inputs
+
+`format` and `formatToParts` accept iterables of strings, including a string's
+individual code points. `undefined` produces an empty list. Non-iterables and
+non-string elements throw `TypeError`; an invalid element also closes the iterator.

--- a/knowledge-base/007e-polyfill-intl-listformat.md
+++ b/knowledge-base/007e-polyfill-intl-listformat.md
@@ -59,3 +59,9 @@ Stage 3: supported-locales.generated.ts
 
 - Dynamic per-locale via `ListFormat.__addLocaleData()`
 - Buffered via `globalThis.__FORMATJS_LISTFORMAT_DATA__`
+
+## Iterable inputs
+
+`format` and `formatToParts` accept iterables of strings, including a string's
+individual code points. `undefined` produces an empty list. Non-iterables and
+non-string elements throw `TypeError`; an invalid element also closes the iterator.

--- a/packages/intl-listformat/index.ts
+++ b/packages/intl-listformat/index.ts
@@ -108,18 +108,15 @@ function validateInstance(instance: any, method: string) {
  * @param iterable list
  */
 function stringListFromIterable(iterable: Iterable<unknown>): string[] {
-  if (typeof iterable !== 'object') return []
+  if (iterable === undefined) return []
   const elements: string[] = []
-  const iterator = iterable[Symbol.iterator]()
-  let result: IteratorResult<unknown>
-  while (true) {
-    result = iterator.next()
-    if (result.done) break
-    if (typeof result.value !== 'string') {
-      const nextValue = result.value
-      throw new TypeError(`Iterable yielded ${nextValue} which is not a string`)
+  // StringListFromIterable uses GetIterator and closes on a non-string value.
+  // for-of provides those semantics: https://tc39.es/ecma402/#sec-createstringlistfromiterable
+  for (const value of iterable) {
+    if (typeof value !== 'string') {
+      throw new TypeError('Iterable yielded a non-string value')
     }
-    elements.push(result.value)
+    elements.push(value)
   }
   return elements
 }

--- a/packages/intl-listformat/index.ts
+++ b/packages/intl-listformat/index.ts
@@ -111,7 +111,9 @@ function stringListFromIterable(iterable: Iterable<unknown>): string[] {
   if (iterable === undefined) return []
   const elements: string[] = []
   // StringListFromIterable uses GetIterator and closes on a non-string value.
+  // ECMA-402 §14.5.5 StringListFromIterable, steps 2–4.c.ii.
   // for-of provides those semantics: https://tc39.es/ecma402/#sec-createstringlistfromiterable
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/listformat.html#L359-L367
   for (const value of iterable) {
     if (typeof value !== 'string') {
       throw new TypeError('Iterable yielded a non-string value')

--- a/packages/intl-listformat/tests/index.test.ts
+++ b/packages/intl-listformat/tests/index.test.ts
@@ -40,3 +40,57 @@ describe('Intl.ListFormat', function () {
     })
   })
 })
+
+describe('StringListFromIterable', () => {
+  for (const method of ['format', 'formatToParts'] as const) {
+    it(`${method} accepts strings and rejects non-iterables`, () => {
+      const formatter = new ListFormat('en')
+      expect(formatter[method]('ab')).toEqual(formatter[method](['a', 'b']))
+      expect(formatter[method](undefined as any)).toEqual(formatter[method]([]))
+      for (const value of [1, true, null, {}, Symbol('list')]) {
+        expect(() => formatter[method](value as any)).toThrow(TypeError)
+      }
+    })
+    it(`${method} closes the iterator without coercing invalid values`, () => {
+      let closed = false
+      function* values() {
+        try {
+          yield {
+            toString() {
+              throw new Error('must not coerce')
+            },
+          }
+        } finally {
+          closed = true
+        }
+      }
+      expect(() => new ListFormat('en')[method](values() as any)).toThrow(
+        TypeError
+      )
+      expect(closed).toBe(true)
+    })
+    it(`${method} reads each iterator value once`, () => {
+      let reads = 0
+      const iterable = {
+        [Symbol.iterator]() {
+          let done = false
+          return {
+            next(): IteratorResult<string> {
+              if (done) return {done: true, value: undefined}
+              done = true
+              return {
+                done: false,
+                get value() {
+                  reads++
+                  return 'a'
+                },
+              }
+            },
+          }
+        },
+      }
+      new ListFormat('en')[method](iterable)
+      expect(reads).toBe(1)
+    })
+  }
+})


### PR DESCRIPTION
Fix audit #7185, item 10. ListFormat now consumes strings and other iterables through the iterator protocol, rejects non-iterables, reads each yielded value once, and closes the iterator when a value is not a string.

The implementation comment cites StringListFromIterable. Adds public/internal documentation and regressions for both format and formatToParts.

Validation: `bazel test //packages/intl-listformat:intl-listformat_test` passed.
