### PR TITLE
fix(@formatjs/intl-collator): validate collation and comparison inputs

### DIFF
--- a/docs/src/docs/polyfills/intl-collator.mdx
+++ b/docs/src/docs/polyfills/intl-collator.mdx
@@ -89,3 +89,9 @@ data and LDML collation XML so applications do not parse XML at runtime.
 
 This package is tested against FormatJS unit tests, parser tests, and
 conformance data generated from ICU4J and native `Intl.Collator`.
+
+## Input validation
+
+Malformed `collation` options throw `RangeError`; well-formed unsupported values
+fall back during locale negotiation. `compare` converts arguments to strings in
+left-to-right order and rejects Symbols with `TypeError`.

--- a/knowledge-base/007l-polyfill-intl-collator.md
+++ b/knowledge-base/007l-polyfill-intl-collator.md
@@ -117,3 +117,9 @@ behavior.
 - The placeholder exists only to enable npm trusted publishing setup.
 - The first real release should come from the normal Release Please automation
   after npm OIDC is configured.
+
+## Input validation
+
+Malformed `collation` options throw `RangeError`; well-formed unsupported values
+fall back during locale negotiation. `compare` converts arguments to strings in
+left-to-right order and rejects Symbols with `TypeError`.

--- a/packages/intl-collator/core.ts
+++ b/packages/intl-collator/core.ts
@@ -1,3 +1,4 @@
+import {ToString} from '#packages/ecma262-abstract/ToString.js'
 import {OrdinaryHasInstance} from '#packages/ecma262-abstract/OrdinaryHasInstance.js'
 import {ToObject} from '#packages/ecma262-abstract/ToObject.js'
 import {CanonicalizeLocaleList} from '#packages/ecma402-abstract/CanonicalizeLocaleList.js'
@@ -84,6 +85,14 @@ export const Collator = function (
   const opt = Object.create(null)
   opt.localeMatcher = matcher
   const collation = GetOption(opts, 'collation', 'string', undefined, undefined)
+  // Resolution option types must be well-formed before negotiation.
+  // https://tc39.es/ecma402/#sec-resolveoptions
+  if (
+    collation !== undefined &&
+    !/^[a-z0-9]{3,8}(-[a-z0-9]{3,8})*$/i.test(collation)
+  ) {
+    throw new RangeError('Invalid collation')
+  }
   if (typeof collation === 'string') {
     opt.co = collation
   }
@@ -167,9 +176,9 @@ Object.defineProperty(Collator.prototype, 'compare', {
       // Collator Compare Functions convert both arguments with ToString and
       // then call CompareStrings. The getter caches the bound compare function
       // in the collator internal slots.
-      // https://tc39.es/ecma402/#sec-collator-comparefunctions
+      // https://tc39.es/ecma402/#sec-collator-compare-functions
       boundCompare = (x: string, y: string) =>
-        compareCollatorStrings(internalSlots, String(x), String(y))
+        compareCollatorStrings(internalSlots, ToString(x), ToString(y))
       internalSlots.boundCompare = boundCompare
     }
     return boundCompare

--- a/packages/intl-collator/core.ts
+++ b/packages/intl-collator/core.ts
@@ -87,7 +87,9 @@ export const Collator = function (
   opt.localeMatcher = matcher
   const collation = GetOption(opts, 'collation', 'string', undefined, undefined)
   // ResolveOptions step 6.d.ii rejects malformed Unicode types.
-  // https://tc39.es/ecma402/#sec-resolveoptions:~:text=If%20value%20cannot%20be%20matched
+  // ECMA-402 §9.2.8 ResolveOptions, step 6.d.ii.
+  // https://tc39.es/ecma402/#sec-resolveoptions
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/negotiation.html#L314
   if (collation !== undefined && !IsUnicodeLocaleIdentifierType(collation)) {
     throw new RangeError('Invalid collation')
   }
@@ -174,7 +176,9 @@ Object.defineProperty(Collator.prototype, 'compare', {
       // Collator Compare Functions convert both arguments with ToString and
       // then call CompareStrings. The getter caches the bound compare function
       // in the collator internal slots.
+      // ECMA-402 §10.3.3.1 Collator Compare Functions, steps 5–6.
       // https://tc39.es/ecma402/#sec-collator-compare-functions
+      // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/collator.html#L222-L223
       boundCompare = (x: string, y: string) =>
         compareCollatorStrings(internalSlots, ToString(x), ToString(y))
       internalSlots.boundCompare = boundCompare

--- a/packages/intl-collator/core.ts
+++ b/packages/intl-collator/core.ts
@@ -1,3 +1,4 @@
+import {IsUnicodeLocaleIdentifierType} from '#packages/ecma402-abstract/IsUnicodeLocaleIdentifierType.js'
 import {ToString} from '#packages/ecma262-abstract/ToString.js'
 import {OrdinaryHasInstance} from '#packages/ecma262-abstract/OrdinaryHasInstance.js'
 import {ToObject} from '#packages/ecma262-abstract/ToObject.js'
@@ -85,12 +86,9 @@ export const Collator = function (
   const opt = Object.create(null)
   opt.localeMatcher = matcher
   const collation = GetOption(opts, 'collation', 'string', undefined, undefined)
-  // Resolution option types must be well-formed before negotiation.
-  // https://tc39.es/ecma402/#sec-resolveoptions
-  if (
-    collation !== undefined &&
-    !/^[a-z0-9]{3,8}(-[a-z0-9]{3,8})*$/i.test(collation)
-  ) {
+  // ResolveOptions step 6.d.ii rejects malformed Unicode types.
+  // https://tc39.es/ecma402/#sec-resolveoptions:~:text=If%20value%20cannot%20be%20matched
+  if (collation !== undefined && !IsUnicodeLocaleIdentifierType(collation)) {
     throw new RangeError('Invalid collation')
   }
   if (typeof collation === 'string') {

--- a/packages/intl-collator/tests/index.test.ts
+++ b/packages/intl-collator/tests/index.test.ts
@@ -91,3 +91,26 @@ describe('Intl.Collator', () => {
     expect(collator.compare('\u00e4', '\u00f6')).toBeLessThan(0)
   })
 })
+
+it('validates collation syntax before resolving support', () => {
+  for (const collation of ['!', '', 'ab', 'abc_def', 'abcdefghi']) {
+    expect(() => new Collator('en', {collation})).toThrow(RangeError)
+  }
+  expect(
+    new Collator('en', {collation: 'foobar'}).resolvedOptions().collation
+  ).toBe('default')
+})
+it('compare uses ToString and preserves coercion order', () => {
+  const compare = new Collator('en').compare
+  expect(() => compare(Symbol('a') as any, 'a')).toThrow(TypeError)
+  expect(() => compare('a', Symbol('a') as any)).toThrow(TypeError)
+  const calls: string[] = []
+  const value = (name: string) => ({
+    [Symbol.toPrimitive](hint: string) {
+      calls.push(`${name}:${hint}`)
+      return 'a'
+    },
+  })
+  expect(compare(value('left') as any, value('right') as any)).toBe(0)
+  expect(calls).toEqual(['left:string', 'right:string'])
+})


### PR DESCRIPTION
Validate `collation` against Unicode type syntax before locale negotiation. Use ECMA-262 ToString for comparison operands so Symbols throw and object coercion uses the string hint.

Closes audit findings 05–06 from #7185. Code comments link the relevant ECMA-402 clauses; unit tests cover malformed/unknown collations and comparison coercion.

Validation: `bazel test //packages/intl-collator:intl-collator_test`.
