### PR TITLE
fix(@formatjs/intl-datetimeformat): reject offsets containing seconds

### DIFF
--- a/docs/src/docs/polyfills/intl-datetimeformat.mdx
+++ b/docs/src/docs/polyfills/intl-datetimeformat.mdx
@@ -260,3 +260,9 @@ if ('__setDefaultTimeZone' in Intl.DateTimeFormat) {
 ## Tests
 
 This library is fully [test262](https://github.com/tc39/test262/tree/master/test/intl402/DateTimeFormat)-compliant.
+
+## Offset time zones
+
+The `timeZone` option accepts offsets in `±HH`, `±HHMM`, and `±HH:MM` form.
+Offsets containing seconds or fractional components throw `RangeError`, including
+an explicit zero-second component.

--- a/knowledge-base/007b-polyfill-intl-datetimeformat.md
+++ b/knowledge-base/007b-polyfill-intl-datetimeformat.md
@@ -141,3 +141,9 @@ Stage 4: supported-locales.generated.ts
 - **Golden timezone subset**: Allows apps to ship 251 zones instead of 427 for smaller bundles
 - **Hour cycle fallback**: When interval formats don't exist for a locale's hour cycle, synthesizes from alternate cycle
 - **Metazone resolution**: Maps IANA zones to CLDR metazones for localized timezone names (EDT vs GMT offset)
+
+## Offset time zones
+
+The `timeZone` option accepts offsets in `±HH`, `±HHMM`, and `±HH:MM` form.
+Offsets containing seconds or fractional components throw `RangeError`, including
+an explicit zero-second component.

--- a/packages/ecma402-abstract/IsValidTimeZoneName.ts
+++ b/packages/ecma402-abstract/IsValidTimeZoneName.ts
@@ -1,19 +1,18 @@
 // Cached regex patterns for performance
 const OFFSET_TIMEZONE_PREFIX_REGEX = /^[+-]/
-const OFFSET_TIMEZONE_FORMAT_REGEX =
-  /^([+-])(\d{2})(?::?(\d{2}))?(?::?(\d{2}))?(?:\.(\d{1,9}))?$/
+const OFFSET_TIMEZONE_FORMAT_REGEX = /^([+-])(\d{2})(?::?(\d{2}))?$/
 
 /**
- * IsTimeZoneOffsetString ( offsetString )
- * https://tc39.es/ecma262/#sec-istimezoneoffsetstring
+ * IsValidDateTimeFormatOffset ( offsetString )
+ * https://tc39.es/ecma402/#sec-createdatetimeformat
  *
  * Validates whether a string represents a valid UTC offset timezone.
- * Supports formats: ±HH, ±HHMM, ±HH:MM, ±HH:MM:SS, ±HH:MM:SS.sss
+ * Supports DateTimeFormat offsets: ±HH, ±HHMM, ±HH:MM
  *
  * @param offsetString - The string to validate as a timezone offset
  * @returns true if offsetString is a valid UTC offset format
  */
-function IsTimeZoneOffsetString(offsetString: string): boolean {
+function IsValidDateTimeFormatOffset(offsetString: string): boolean {
   // 1. If offsetString does not start with '+' or '-', return false
   if (!OFFSET_TIMEZONE_PREFIX_REGEX.test(offsetString)) {
     return false
@@ -27,13 +26,12 @@ function IsTimeZoneOffsetString(offsetString: string): boolean {
     return false
   }
 
-  // 4. Validate component ranges per ECMA-262 grammar
-  // Hour must be 0-23, Minute must be 0-59, Second must be 0-59
+  // CreateDateTimeFormat rejects offsets containing seconds, even zero seconds.
+  // https://tc39.es/ecma402/#sec-createdatetimeformat
   const hours = parseInt(match[2], 10)
   const minutes = match[3] ? parseInt(match[3], 10) : 0
-  const seconds = match[4] ? parseInt(match[4], 10) : 0
 
-  if (hours > 23 || minutes > 59 || seconds > 59) {
+  if (hours > 23 || minutes > 59) {
     return false
   }
 
@@ -64,9 +62,9 @@ export function IsValidTimeZoneName(
     uppercaseLinks: Record<string, string>
   }
 ): boolean {
-  // 1. If IsTimeZoneOffsetString(timeZone) is true, return true
+  // 1. If IsValidDateTimeFormatOffset(timeZone) is true, return true
   // Per ECMA-402 PR #788, UTC offset identifiers are valid
-  if (IsTimeZoneOffsetString(tz)) {
+  if (IsValidDateTimeFormatOffset(tz)) {
     return true
   }
 

--- a/packages/ecma402-abstract/IsValidTimeZoneName.ts
+++ b/packages/ecma402-abstract/IsValidTimeZoneName.ts
@@ -13,21 +13,19 @@ const OFFSET_TIMEZONE_FORMAT_REGEX = /^([+-])(\d{2})(?::?(\d{2}))?$/
  * @returns true if offsetString is a valid UTC offset format
  */
 function IsValidDateTimeFormatOffset(offsetString: string): boolean {
-  // 1. If offsetString does not start with '+' or '-', return false
   if (!OFFSET_TIMEZONE_PREFIX_REGEX.test(offsetString)) {
     return false
   }
 
-  // 2. Let parseResult be ParseText(offsetString, UTCOffset)
+  // CreateDateTimeFormat step 19.c rejects more than one MinuteSecond node:
+  // minutes are allowed, but seconds (including :00) are not.
+  // https://tc39.es/ecma402/#sec-createdatetimeformat:~:text=If%20parseResult%20contains%20more%20than%20one
   const match = OFFSET_TIMEZONE_FORMAT_REGEX.exec(offsetString)
 
-  // 3. If parseResult is a List of errors, return false
   if (!match) {
     return false
   }
 
-  // CreateDateTimeFormat rejects offsets containing seconds, even zero seconds.
-  // https://tc39.es/ecma402/#sec-createdatetimeformat
   const hours = parseInt(match[2], 10)
   const minutes = match[3] ? parseInt(match[3], 10) : 0
 
@@ -35,7 +33,6 @@ function IsValidDateTimeFormatOffset(offsetString: string): boolean {
     return false
   }
 
-  // 5. Return true
   return true
 }
 

--- a/packages/ecma402-abstract/IsValidTimeZoneName.ts
+++ b/packages/ecma402-abstract/IsValidTimeZoneName.ts
@@ -4,7 +4,9 @@ const OFFSET_TIMEZONE_FORMAT_REGEX = /^([+-])(\d{2})(?::?(\d{2}))?$/
 
 /**
  * IsValidDateTimeFormatOffset ( offsetString )
+ * ECMA-402 §11.1.2 CreateDateTimeFormat, step 19.c.
  * https://tc39.es/ecma402/#sec-createdatetimeformat
+ * https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/datetimeformat.html#L94
  *
  * Validates whether a string represents a valid UTC offset timezone.
  * Supports DateTimeFormat offsets: ±HH, ±HHMM, ±HH:MM
@@ -19,7 +21,9 @@ function IsValidDateTimeFormatOffset(offsetString: string): boolean {
 
   // CreateDateTimeFormat step 19.c rejects more than one MinuteSecond node:
   // minutes are allowed, but seconds (including :00) are not.
-  // https://tc39.es/ecma402/#sec-createdatetimeformat:~:text=If%20parseResult%20contains%20more%20than%20one
+  // ECMA-402 §11.1.2 CreateDateTimeFormat, step 19.c.
+  // https://tc39.es/ecma402/#sec-createdatetimeformat
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/datetimeformat.html#L94
   const match = OFFSET_TIMEZONE_FORMAT_REGEX.exec(offsetString)
 
   if (!match) {

--- a/packages/ecma402-abstract/tests/IsValidTimeZoneName.test.ts
+++ b/packages/ecma402-abstract/tests/IsValidTimeZoneName.test.ts
@@ -61,13 +61,13 @@ describe('IsValidTimeZoneName', () => {
     expect(IsValidTimeZoneName('-05', testData)).toBe(true)
     expect(IsValidTimeZoneName('+00', testData)).toBe(true)
 
-    // With seconds ±HH:MM:SS
-    expect(IsValidTimeZoneName('+01:30:45', testData)).toBe(true)
-    expect(IsValidTimeZoneName('-05:00:00', testData)).toBe(true)
+    // DateTimeFormat rejects seconds, including zero.
+    expect(IsValidTimeZoneName('+01:30:45', testData)).toBe(false)
+    expect(IsValidTimeZoneName('-05:00:00', testData)).toBe(false)
 
-    // With fractional seconds ±HH:MM:SS.sss
-    expect(IsValidTimeZoneName('+01:30:45.123', testData)).toBe(true)
-    expect(IsValidTimeZoneName('-05:00:00.999999999', testData)).toBe(true)
+    // Fractional seconds are also rejected.
+    expect(IsValidTimeZoneName('+01:30:45.123', testData)).toBe(false)
+    expect(IsValidTimeZoneName('-05:00:00.999999999', testData)).toBe(false)
   })
 
   test('UTC offset timezones - invalid formats', () => {

--- a/packages/intl-datetimeformat/tests/index.test.ts
+++ b/packages/intl-datetimeformat/tests/index.test.ts
@@ -886,3 +886,24 @@ it('rejects BigInt date arguments', () => {
     expect(() => formatter.formatToParts(value as any)).toThrow(TypeError)
   }
 })
+
+it('accepts minute offsets but rejects second and fractional offsets', () => {
+  for (const timeZone of [
+    '+01:00:00',
+    '+010000',
+    '+01:00:01',
+    '+01:00:00.1',
+    '+01.1',
+  ]) {
+    expect(() => new DateTimeFormat('en', {timeZone})).toThrow(RangeError)
+  }
+  for (const [timeZone, canonical] of [
+    ['+01', '+01:00'],
+    ['+0130', '+01:30'],
+    ['-05:30', '-05:30'],
+  ]) {
+    expect(
+      new DateTimeFormat('en', {timeZone}).resolvedOptions().timeZone
+    ).toBe(canonical)
+  }
+})

--- a/packages/intl-datetimeformat/tests/offset-timezone.test.ts
+++ b/packages/intl-datetimeformat/tests/offset-timezone.test.ts
@@ -49,7 +49,7 @@ describe('Intl.DateTimeFormat with UTC offset timezones', function () {
   })
 
   it('should accept various offset formats', function () {
-    const formats = ['+01', '+0100', '+01:00', '+01:30', '+05:30:45']
+    const formats = ['+01', '+0100', '+01:00', '+01:30']
     formats.forEach(timeZone => {
       expect(() => new DateTimeFormat('en-GB', {timeZone})).not.toThrow()
     })
@@ -57,6 +57,7 @@ describe('Intl.DateTimeFormat with UTC offset timezones', function () {
 
   it('should reject invalid offset timezones', function () {
     const invalidFormats = [
+      '+05:30:45', // Seconds are not allowed by CreateDateTimeFormat
       '+24:00', // Out of range
       '+01:60', // Invalid minutes
       '+1:00', // Wrong format


### PR DESCRIPTION
Reject time-zone offsets containing seconds, including zero seconds, as required by CreateDateTimeFormat. Hour and minute offsets remain supported and canonicalized.

Closes audit finding 07 from #7185. Updates previous seconds-acceptance tests and adds constructor regressions with a spec-linked code comment.

Validation: `bazel test //packages/ecma402-abstract:ecma402-abstract_test //packages/intl-datetimeformat:intl-datetimeformat_test`.
