### PR TITLE
fix(@formatjs/intl-displaynames): validate and canonicalize display codes

### DIFF
--- a/docs/src/docs/polyfills/intl-displaynames.mdx
+++ b/docs/src/docs/polyfills/intl-displaynames.mdx
@@ -205,3 +205,9 @@ async function polyfill(locale: string) {
   await import(`@formatjs/intl-displaynames/locale-data/${locale}.js`)
 }
 ```
+
+## Code validation and fallback
+
+Calendar codes use hyphen-separated Unicode type identifiers; underscore forms
+throw `RangeError`. When `fallback: 'code'` applies, `of` returns the canonical
+code, such as `ZZZ` for an unknown currency supplied as `zzz`.

--- a/knowledge-base/007d-polyfill-intl-displaynames.md
+++ b/knowledge-base/007d-polyfill-intl-displaynames.md
@@ -49,3 +49,9 @@ Stage 3: supported-locales.generated.ts
 - Dynamic per-locale loading via `DisplayNames.__addLocaleData()`
 - Buffered via `globalThis.__FORMATJS_DISPLAYNAMES_DATA__`
 - Tree-shakeable: `import '@formatjs/intl-displaynames/locale-data/en'`
+
+## Code validation and fallback
+
+Calendar codes use hyphen-separated Unicode type identifiers; underscore forms
+throw `RangeError`. When `fallback: 'code'` applies, `of` returns the canonical
+code, such as `ZZZ` for an unknown currency supplied as `zzz`.

--- a/packages/ecma402-abstract/DisplayNames/CanonicalCodeForDisplayNames.ts
+++ b/packages/ecma402-abstract/DisplayNames/CanonicalCodeForDisplayNames.ts
@@ -43,7 +43,9 @@ export function CanonicalCodeForDisplayNames(
   }
   if (type === 'calendar') {
     // CanonicalCodeForDisplayNames requires a Unicode type, excluding underscores.
+    // ECMA-402 §12.5.1 CanonicalCodeForDisplayNames, steps 4.a–4.c.
     // https://tc39.es/ecma402/#sec-canonicalcodefordisplaynames
+    // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/displaynames.html#L249-L251
     if (!IsUnicodeLocaleIdentifierType(code)) {
       throw RangeError('invalid calendar')
     }

--- a/packages/ecma402-abstract/DisplayNames/CanonicalCodeForDisplayNames.ts
+++ b/packages/ecma402-abstract/DisplayNames/CanonicalCodeForDisplayNames.ts
@@ -1,3 +1,4 @@
+import {IsUnicodeLocaleIdentifierType} from '#packages/ecma402-abstract/IsUnicodeLocaleIdentifierType.js'
 import {CanonicalizeLocaleList} from '#packages/ecma402-abstract/CanonicalizeLocaleList.js'
 import {IsWellFormedCurrencyCode} from '#packages/ecma402-abstract/IsWellFormedCurrencyCode.js'
 import {invariant} from '#packages/ecma402-abstract/utils.js'
@@ -6,9 +7,6 @@ import {IsValidDateTimeFieldCode} from '#packages/ecma402-abstract/DisplayNames/
 
 const UNICODE_REGION_SUBTAG_REGEX = /^([a-z]{2}|[0-9]{3})$/i
 const ALPHA_4 = /^[a-z]{4}$/i
-// Calendar codes reject backwards-compatible underscore syntax.
-// https://tc39.es/ecma402/#sec-canonicalcodefordisplaynames
-const UNICODE_TYPE_REGEX = /^[a-z0-9]{3,8}(-[a-z0-9]{3,8})*$/i
 
 function isUnicodeRegionSubtag(region: string): boolean {
   return UNICODE_REGION_SUBTAG_REGEX.test(region)
@@ -16,10 +14,6 @@ function isUnicodeRegionSubtag(region: string): boolean {
 
 function isUnicodeScriptSubtag(script: string): boolean {
   return ALPHA_4.test(script)
-}
-
-function isUnicodeLocaleIdentifierType(code: string): boolean {
-  return UNICODE_TYPE_REGEX.test(code)
 }
 
 export function CanonicalCodeForDisplayNames(
@@ -48,7 +42,9 @@ export function CanonicalCodeForDisplayNames(
     return `${code[0].toUpperCase()}${code.slice(1).toLowerCase()}`
   }
   if (type === 'calendar') {
-    if (!isUnicodeLocaleIdentifierType(code)) {
+    // CanonicalCodeForDisplayNames requires a Unicode type, excluding underscores.
+    // https://tc39.es/ecma402/#sec-canonicalcodefordisplaynames
+    if (!IsUnicodeLocaleIdentifierType(code)) {
       throw RangeError('invalid calendar')
     }
     return code.toLowerCase()

--- a/packages/ecma402-abstract/DisplayNames/CanonicalCodeForDisplayNames.ts
+++ b/packages/ecma402-abstract/DisplayNames/CanonicalCodeForDisplayNames.ts
@@ -6,7 +6,9 @@ import {IsValidDateTimeFieldCode} from '#packages/ecma402-abstract/DisplayNames/
 
 const UNICODE_REGION_SUBTAG_REGEX = /^([a-z]{2}|[0-9]{3})$/i
 const ALPHA_4 = /^[a-z]{4}$/i
-const UNICODE_TYPE_REGEX = /^[a-z0-9]{3,8}([-_][a-z0-9]{3,8})*$/i
+// Calendar codes reject backwards-compatible underscore syntax.
+// https://tc39.es/ecma402/#sec-canonicalcodefordisplaynames
+const UNICODE_TYPE_REGEX = /^[a-z0-9]{3,8}(-[a-z0-9]{3,8})*$/i
 
 function isUnicodeRegionSubtag(region: string): boolean {
   return UNICODE_REGION_SUBTAG_REGEX.test(region)

--- a/packages/intl-displaynames/index.ts
+++ b/packages/intl-displaynames/index.ts
@@ -1,3 +1,4 @@
+import {IsUnicodeLocaleIdentifierType} from '#packages/ecma402-abstract/IsUnicodeLocaleIdentifierType.js'
 import {ToString} from '#packages/ecma262-abstract/ToString.js'
 import {CanonicalizeLocaleList} from '#packages/ecma402-abstract/CanonicalizeLocaleList.js'
 import {GetOption} from '#packages/ecma402-abstract/GetOption.js'
@@ -270,7 +271,7 @@ function isValidCodeForDisplayNames(
       return IsWellFormedCurrencyCode(code)
     case 'calendar':
       // unicode locale identifier type
-      return /^[a-z0-9]{3,8}(-[a-z0-9]{3,8})*$/i.test(code)
+      return IsUnicodeLocaleIdentifierType(code)
     case 'dateTimeField':
       return IsValidDateTimeFieldCode(code)
   }

--- a/packages/intl-displaynames/index.ts
+++ b/packages/intl-displaynames/index.ts
@@ -214,7 +214,9 @@ export class DisplayNames {
     }
 
     if (fallback === 'code') {
-      return codeAsString
+      // Return the canonical code after lookup fails.
+      // https://tc39.es/ecma402/#sec-Intl.DisplayNames.prototype.of
+      return canonicalCode
     }
   }
 
@@ -268,7 +270,7 @@ function isValidCodeForDisplayNames(
       return IsWellFormedCurrencyCode(code)
     case 'calendar':
       // unicode locale identifier type
-      return /^[a-z0-9]{3,8}([-_][a-z0-9]{3,8})*$/i.test(code)
+      return /^[a-z0-9]{3,8}(-[a-z0-9]{3,8})*$/i.test(code)
     case 'dateTimeField':
       return IsValidDateTimeFieldCode(code)
   }

--- a/packages/intl-displaynames/index.ts
+++ b/packages/intl-displaynames/index.ts
@@ -216,7 +216,9 @@ export class DisplayNames {
 
     if (fallback === 'code') {
       // Return the canonical code after lookup fails.
+      // ECMA-402 §12.3.3 Intl.DisplayNames.prototype.of, steps 4–7.
       // https://tc39.es/ecma402/#sec-Intl.DisplayNames.prototype.of
+      // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/displaynames.html#L185-L188
       return canonicalCode
     }
   }

--- a/packages/intl-displaynames/tests/index.test.ts
+++ b/packages/intl-displaynames/tests/index.test.ts
@@ -288,3 +288,15 @@ describe('.resolvedOptions()', () => {
 })
 
 // TODO: add snapshot tests
+
+it('rejects underscore calendar identifiers', () => {
+  const names = new DisplayNames('en', {type: 'calendar'})
+  expect(() => names.of('islamic_civil')).toThrow(RangeError)
+  expect(() => names.of('islamic-civil')).not.toThrow()
+})
+it('returns canonical codes when display names are missing', () => {
+  expect(new DisplayNames('en', {type: 'currency'}).of('zzz')).toBe('ZZZ')
+  expect(
+    new DisplayNames('en', {type: 'currency', fallback: 'none'}).of('zzz')
+  ).toBeUndefined()
+})

--- a/packages/intl-displaynames/tests/index.test.ts
+++ b/packages/intl-displaynames/tests/index.test.ts
@@ -137,7 +137,7 @@ describe('.of()', () => {
 
     it('handles calendar codes with hyphens', () => {
       const dn = new DisplayNames('en', {type: 'calendar'})
-      // These have hyphens so they match the pattern [a-z0-9]{3,8}([-_][a-z0-9]{3,8})*
+      // These have hyphens so they match the pattern [a-z0-9]{3,8}(-[a-z0-9]{3,8})*
       expect(dn.of('islamic-civil')).toBe(
         'Hijri Calendar (tabular, civil epoch)'
       )


### PR DESCRIPTION
Reject underscore calendar identifiers and return canonical fallback codes, such as `ZZZ` for an unknown currency supplied as `zzz`.

Addresses audit findings 08–09 from #7185. Implementation comments cite the relevant specification clauses. Includes focused regression tests and documentation.

Validation: `bazel test //packages/intl-displaynames/...`.
