### PR TITLE
fix(@formatjs/intl-durationformat): validate duration records exactly

### DIFF
--- a/docs/src/docs/polyfills/intl-durationformat.mdx
+++ b/docs/src/docs/polyfills/intl-durationformat.mdx
@@ -189,3 +189,11 @@ async function polyfill(locale: string) {
 
 A well-formed but unsupported `numberingSystem` option falls back to the locale's
 supported numbering system. Only malformed Unicode type identifiers throw `RangeError`.
+
+## Duration record validation
+
+Each duration field is read once in the ECMA-402 order. Fields must convert to
+finite integers of a common sign. Invalid numeric fields throw `RangeError`;
+an empty record throws `TypeError`. Absolute years, months, and weeks must be
+less than `2 ** 32`; absolute normalized seconds must be less than `2 ** 53`.
+Subsecond contributions participate in the bound comparison exactly.

--- a/knowledge-base/007g-polyfill-intl-durationformat.md
+++ b/knowledge-base/007g-polyfill-intl-durationformat.md
@@ -66,3 +66,11 @@ export const TIME_SEPARATORS = {
 
 A well-formed but unsupported `numberingSystem` option falls back to the locale's
 supported numbering system. Only malformed Unicode type identifiers throw `RangeError`.
+
+## Duration record validation
+
+Each duration field is read once in the ECMA-402 order. Fields must convert to
+finite integers of a common sign. Invalid numeric fields throw `RangeError`;
+an empty record throws `TypeError`. Absolute years, months, and weeks must be
+less than `2 ** 32`; absolute normalized seconds must be less than `2 ** 53`.
+Subsecond contributions participate in the bound comparison exactly.

--- a/packages/ecma402-abstract/DurationFormat/IsValidDurationRecord.ts
+++ b/packages/ecma402-abstract/DurationFormat/IsValidDurationRecord.ts
@@ -24,14 +24,15 @@ export function IsValidDurationRecord(record: DurationRecord): boolean {
     return false
   }
   // Scaling integral Number values with BigInt avoids rounding at 2**53 seconds.
+  const billion = BigInt(1000000000)
   const normalizedNanoseconds =
-    BigInt(record.days) * 86400n * 1000000000n +
-    BigInt(record.hours) * 3600n * 1000000000n +
-    BigInt(record.minutes) * 60n * 1000000000n +
-    BigInt(record.seconds) * 1000000000n +
-    BigInt(record.milliseconds) * 1000000n +
-    BigInt(record.microseconds) * 1000n +
+    BigInt(record.days) * BigInt(86400) * billion +
+    BigInt(record.hours) * BigInt(3600) * billion +
+    BigInt(record.minutes) * BigInt(60) * billion +
+    BigInt(record.seconds) * billion +
+    BigInt(record.milliseconds) * BigInt(1000000) +
+    BigInt(record.microseconds) * BigInt(1000) +
     BigInt(record.nanoseconds)
-  const limit = 2n ** 53n * 1000000000n
+  const limit = BigInt(2 ** 53) * billion
   return normalizedNanoseconds > -limit && normalizedNanoseconds < limit
 }

--- a/packages/ecma402-abstract/DurationFormat/IsValidDurationRecord.ts
+++ b/packages/ecma402-abstract/DurationFormat/IsValidDurationRecord.ts
@@ -1,4 +1,3 @@
-import {invariant} from '#packages/ecma402-abstract/utils.js'
 import {TABLE_1} from '#packages/ecma402-abstract/DurationFormat/constants.js'
 import {type DurationRecord} from '#packages/ecma402-abstract/types/duration.js'
 import {DurationRecordSign} from '#packages/ecma402-abstract/DurationFormat/DurationRecordSign.js'
@@ -7,7 +6,7 @@ export function IsValidDurationRecord(record: DurationRecord): boolean {
   const sign = DurationRecordSign(record)
   for (const key of TABLE_1) {
     const v = record[key]
-    invariant(isFinite(Number(v)), `${key} is not finite`)
+    if (!Number.isFinite(v)) return false
     if (v < 0 && sign > 0) {
       return false
     }
@@ -15,5 +14,24 @@ export function IsValidDurationRecord(record: DurationRecord): boolean {
       return false
     }
   }
-  return true
+  // IsValidDuration bounds calendar units and exact normalized seconds.
+  // https://tc39.es/ecma402/#sec-isvalidduration
+  if (
+    (['years', 'months', 'weeks'] as const).some(
+      unit => Math.abs(record[unit]) >= 2 ** 32
+    )
+  ) {
+    return false
+  }
+  // Scaling integral Number values with BigInt avoids rounding at 2**53 seconds.
+  const normalizedNanoseconds =
+    BigInt(record.days) * 86400n * 1000000000n +
+    BigInt(record.hours) * 3600n * 1000000000n +
+    BigInt(record.minutes) * 60n * 1000000000n +
+    BigInt(record.seconds) * 1000000000n +
+    BigInt(record.milliseconds) * 1000000n +
+    BigInt(record.microseconds) * 1000n +
+    BigInt(record.nanoseconds)
+  const limit = 2n ** 53n * 1000000000n
+  return normalizedNanoseconds > -limit && normalizedNanoseconds < limit
 }

--- a/packages/ecma402-abstract/DurationFormat/IsValidDurationRecord.ts
+++ b/packages/ecma402-abstract/DurationFormat/IsValidDurationRecord.ts
@@ -15,7 +15,9 @@ export function IsValidDurationRecord(record: DurationRecord): boolean {
     }
   }
   // IsValidDuration bounds calendar units and exact normalized seconds.
+  // ECMA-402 §13.5.5 IsValidDuration, steps 3–8.
   // https://tc39.es/ecma402/#sec-isvalidduration
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/durationformat.html#L569-L574
   if (
     (['years', 'months', 'weeks'] as const).some(
       unit => Math.abs(record[unit]) >= 2 ** 32

--- a/packages/ecma402-abstract/DurationFormat/ToDurationRecord.ts
+++ b/packages/ecma402-abstract/DurationFormat/ToDurationRecord.ts
@@ -6,7 +6,10 @@ import {IsValidDurationRecord} from '#packages/ecma402-abstract/DurationFormat/I
 import {ToIntegerIfIntegral} from '#packages/ecma402-abstract/DurationFormat/ToIntegerIfIntegral.js'
 
 export function ToDurationRecord(input: DurationInput): DurationRecord {
-  if (typeof input !== 'object') {
+  if (
+    (typeof input !== 'object' || input === null) &&
+    typeof input !== 'function'
+  ) {
     if (typeof input === 'string') {
       throw new RangeError('Invalid duration format')
     }
@@ -24,48 +27,28 @@ export function ToDurationRecord(input: DurationInput): DurationRecord {
     microseconds: 0,
     nanoseconds: 0,
   }
-  if (input.days !== undefined) {
-    result.days = ToIntegerIfIntegral(input.days)
+  // Read each field once, in ToDurationRecord's specified order.
+  // https://tc39.es/ecma402/#sec-todurationrecord
+  let anyDefined = false
+  for (const field of [
+    'days',
+    'hours',
+    'microseconds',
+    'milliseconds',
+    'minutes',
+    'months',
+    'nanoseconds',
+    'seconds',
+    'weeks',
+    'years',
+  ] as const) {
+    const value = input[field]
+    if (value !== undefined) {
+      anyDefined = true
+      result[field] = ToIntegerIfIntegral(value)
+    }
   }
-  if (input.hours !== undefined) {
-    result.hours = ToIntegerIfIntegral(input.hours)
-  }
-  if (input.microseconds !== undefined) {
-    result.microseconds = ToIntegerIfIntegral(input.microseconds)
-  }
-  if (input.milliseconds !== undefined) {
-    result.milliseconds = ToIntegerIfIntegral(input.milliseconds)
-  }
-  if (input.minutes !== undefined) {
-    result.minutes = ToIntegerIfIntegral(input.minutes)
-  }
-  if (input.months !== undefined) {
-    result.months = ToIntegerIfIntegral(input.months)
-  }
-  if (input.nanoseconds !== undefined) {
-    result.nanoseconds = ToIntegerIfIntegral(input.nanoseconds)
-  }
-  if (input.seconds !== undefined) {
-    result.seconds = ToIntegerIfIntegral(input.seconds)
-  }
-  if (input.weeks !== undefined) {
-    result.weeks = ToIntegerIfIntegral(input.weeks)
-  }
-  if (input.years !== undefined) {
-    result.years = ToIntegerIfIntegral(input.years)
-  }
-  if (
-    input.years === undefined &&
-    input.months === undefined &&
-    input.weeks === undefined &&
-    input.days === undefined &&
-    input.hours === undefined &&
-    input.minutes === undefined &&
-    input.seconds === undefined &&
-    input.milliseconds === undefined &&
-    input.microseconds === undefined &&
-    input.nanoseconds === undefined
-  ) {
+  if (!anyDefined) {
     throw new TypeError('Invalid duration format')
   }
   if (!IsValidDurationRecord(result)) {

--- a/packages/ecma402-abstract/DurationFormat/ToDurationRecord.ts
+++ b/packages/ecma402-abstract/DurationFormat/ToDurationRecord.ts
@@ -28,7 +28,9 @@ export function ToDurationRecord(input: DurationInput): DurationRecord {
     nanoseconds: 0,
   }
   // Read each field once, in ToDurationRecord's specified order.
+  // ECMA-402 §13.5.3 ToDurationRecord, steps 3–24.a.
   // https://tc39.es/ecma402/#sec-todurationrecord
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/durationformat.html#L495-L517
   let anyDefined = false
   for (const field of [
     'days',

--- a/packages/ecma402-abstract/DurationFormat/ToIntegerIfIntegral.ts
+++ b/packages/ecma402-abstract/DurationFormat/ToIntegerIfIntegral.ts
@@ -4,7 +4,9 @@ import {invariant} from '#packages/ecma402-abstract/utils.js'
 export function ToIntegerIfIntegral(arg: any): number {
   const number = ToNumber(arg)
   // Nonintegral Number values require RangeError, without coercing arg again.
+  // ECMA-402 §13.5.2 ToIntegerIfIntegral, steps 1–2.
   // https://tc39.es/ecma402/#sec-tointegerifintegral
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/durationformat.html#L473-L474
   invariant(number.isInteger(), 'Duration field is not an integer', RangeError)
   return number.toNumber()
 }

--- a/packages/ecma402-abstract/DurationFormat/ToIntegerIfIntegral.ts
+++ b/packages/ecma402-abstract/DurationFormat/ToIntegerIfIntegral.ts
@@ -3,6 +3,8 @@ import {invariant} from '#packages/ecma402-abstract/utils.js'
 
 export function ToIntegerIfIntegral(arg: any): number {
   const number = ToNumber(arg)
-  invariant(number.isInteger(), `${arg} is not an integer`)
+  // Nonintegral Number values require RangeError, without coercing arg again.
+  // https://tc39.es/ecma402/#sec-tointegerifintegral
+  invariant(number.isInteger(), 'Duration field is not an integer', RangeError)
   return number.toNumber()
 }

--- a/packages/intl-durationformat/tests/index.test.ts
+++ b/packages/intl-durationformat/tests/index.test.ts
@@ -208,3 +208,78 @@ test('negotiates well-formed numbering systems and rejects malformed ones', () =
     )
   }
 })
+
+test('reads duration fields once in specification order', () => {
+  const reads: string[] = []
+  const input = new Proxy(
+    {seconds: 1},
+    {
+      get(target, key) {
+        reads.push(String(key))
+        return Reflect.get(target, key)
+      },
+    }
+  )
+  new DurationFormat('en').format(input)
+  expect(reads).toEqual([
+    'days',
+    'hours',
+    'microseconds',
+    'milliseconds',
+    'minutes',
+    'months',
+    'nanoseconds',
+    'seconds',
+    'weeks',
+    'years',
+  ])
+})
+test('accepts callable duration objects and rejects empty records', () => {
+  const formatter = new DurationFormat('en')
+  const input = Object.assign(() => {}, {seconds: 1})
+  expect(formatter.format(input)).toBe(formatter.format({seconds: 1}))
+  expect(() => formatter.format({})).toThrow(TypeError)
+  expect(() => formatter.format(null as any)).toThrow(TypeError)
+})
+test('uses RangeError for nonintegral fields without repeated coercion', () => {
+  const formatter = new DurationFormat('en')
+  for (const seconds of [1.5, NaN, Infinity, -Infinity]) {
+    expect(() => formatter.format({seconds})).toThrow(RangeError)
+    expect(() => formatter.formatToParts({seconds})).toThrow(RangeError)
+  }
+  let calls = 0
+  const seconds = {
+    [Symbol.toPrimitive]() {
+      calls++
+      return 1.5
+    },
+  }
+  expect(() => formatter.format({seconds} as any)).toThrow(RangeError)
+  expect(calls).toBe(1)
+})
+test('enforces exact duration magnitude limits', () => {
+  const formatter = new DurationFormat('en')
+  for (const sign of [-1, 1]) {
+    for (const unit of ['years', 'months', 'weeks'] as const) {
+      expect(() => formatter.format({[unit]: sign * 2 ** 32})).toThrow(
+        RangeError
+      )
+      expect(() =>
+        formatter.format({[unit]: sign * (2 ** 32 - 1)})
+      ).not.toThrow()
+    }
+    expect(() => formatter.format({seconds: sign * 2 ** 53})).toThrow(
+      RangeError
+    )
+    const below = {
+      seconds: sign * (2 ** 53 - 1),
+      milliseconds: sign * 999,
+      microseconds: sign * 999,
+      nanoseconds: sign * 999,
+    }
+    expect(() => formatter.format(below)).not.toThrow()
+    expect(() =>
+      formatter.format({...below, nanoseconds: sign * 1000})
+    ).toThrow(RangeError)
+  }
+})


### PR DESCRIPTION
Read duration fields once in specification order. Throw RangeError for nonintegral fields without coercing them again. Enforce calendar-unit and normalized-second bounds with exact subsecond accumulation.

Addresses audit findings 20–22 from #7185. Implementation comments cite the relevant specification clauses. Includes focused regression tests and documentation.

Validation: `bazel test //packages/intl-durationformat/... //packages/ecma402-abstract:ecma402-abstract_test`.
