### PR TITLE
fix(@formatjs/intl-locale): canonicalize weekday and numeric options

### DIFF
--- a/docs/src/docs/polyfills/intl-locale.mdx
+++ b/docs/src/docs/polyfills/intl-locale.mdx
@@ -161,3 +161,9 @@ async function polyfill() {
 ## Tests
 
 This library is [test262](https://github.com/tc39/test262/tree/master/test/intl402/Locale)-compliant.
+
+## Weekday and numeric options
+
+`firstDayOfWeek` accepts Unicode type identifiers such as `mon`. Numeric strings
+`0` and `7` both become `sun`; `1` through `6` become `mon` through `sat`.
+The empty Unicode numeric keyword in `en-u-kn` sets `numeric` to `true`.

--- a/knowledge-base/007i-polyfill-intl-locale.md
+++ b/knowledge-base/007i-polyfill-intl-locale.md
@@ -52,3 +52,9 @@ numbering-systems.ts  → numbering-systems.generated.ts
 - **No dynamic locale loading** — all preference data compiled into the bundle
 - Static lookups via helper functions: `getCalendarPreferenceDataForRegion()`, `getWeekDataForRegion()`, `getHourCyclesPreferenceDataForLocaleOrRegion()`, `getTimeZonePreferenceForRegion()`
 - Region is resolved from the locale tag (e.g., `en-US` → `US`)
+
+## Weekday and numeric options
+
+`firstDayOfWeek` accepts Unicode type identifiers such as `mon`. Numeric strings
+`0` and `7` both become `sun`; `1` through `6` become `mon` through `sat`.
+The empty Unicode numeric keyword in `en-u-kn` sets `numeric` to `true`.

--- a/packages/intl-locale/index.ts
+++ b/packages/intl-locale/index.ts
@@ -1,3 +1,4 @@
+import {IsUnicodeLocaleIdentifierType} from '#packages/ecma402-abstract/IsUnicodeLocaleIdentifierType.js'
 import {HasOwnProperty} from '#packages/ecma262-abstract/HasOwnProperty.js'
 import {SameValue} from '#packages/ecma262-abstract/SameValue.js'
 import {CoerceOptionsToObject} from '#packages/ecma402-abstract/CoerceOptionsToObject.js'
@@ -63,8 +64,6 @@ export interface IntlLocaleInternal extends IntlLocaleOptions {
   locale: string
   initializedLocale: boolean
 }
-
-const UNICODE_TYPE_REGEX = /^[a-z0-9]{3,8}(-[a-z0-9]{3,8})*$/i
 
 function applyOptionsToTag(tag: string, options: IntlLocaleOptions): string {
   invariant(typeof tag === 'string', 'language tag must be a string')
@@ -507,7 +506,7 @@ export class Locale {
       undefined
     )
     if (calendar !== undefined) {
-      if (!UNICODE_TYPE_REGEX.test(calendar)) {
+      if (!IsUnicodeLocaleIdentifierType(calendar)) {
         throw new RangeError('invalid calendar')
       }
     }
@@ -521,7 +520,7 @@ export class Locale {
       undefined
     )
     if (collation !== undefined) {
-      if (!UNICODE_TYPE_REGEX.test(collation)) {
+      if (!IsUnicodeLocaleIdentifierType(collation)) {
         throw new RangeError('invalid collation')
       }
     }
@@ -535,7 +534,7 @@ export class Locale {
     )
     if (fw !== undefined) {
       fw = weekdayToString(fw)
-      if (!UNICODE_TYPE_REGEX.test(fw)) {
+      if (!IsUnicodeLocaleIdentifierType(fw)) {
         throw new RangeError('Invalid firstDayOfWeek')
       }
     }
@@ -572,7 +571,7 @@ export class Locale {
       undefined
     )
     if (numberingSystem !== undefined) {
-      if (!UNICODE_TYPE_REGEX.test(numberingSystem)) {
+      if (!IsUnicodeLocaleIdentifierType(numberingSystem)) {
         throw new RangeError('Invalid numberingSystem')
       }
     }

--- a/packages/intl-locale/index.ts
+++ b/packages/intl-locale/index.ts
@@ -539,7 +539,9 @@ export class Locale {
         throw new RangeError('Invalid firstDayOfWeek')
       }
     }
-    opt.fw = fw
+    // MakeLocaleRecord canonicalizes Unicode option values before storing them.
+    // https://tc39.es/ecma402/#sec-makelocalerecord
+    opt.fw = fw?.toLowerCase()
     const hc = GetOption(
       options,
       'hourCycle',

--- a/packages/intl-locale/index.ts
+++ b/packages/intl-locale/index.ts
@@ -47,8 +47,6 @@ export interface IntlLocaleOptions {
   firstDayOfWeek?: string
 }
 
-const ALPHANUM_3_8 = /^[a-z0-9]{3,8}$/i
-
 const RELEVANT_EXTENSION_KEYS = [
   'ca',
   'co',
@@ -441,7 +439,9 @@ function weekInfoOfLocale(loc: Locale): WeekInfoInternal {
 const TABLE_1 = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'] as const
 
 function weekdayToString(fw: string) {
-  return TABLE_1[+fw]
+  // WeekdayToUValue maps only exact numeric strings; other strings pass through.
+  // https://tc39.es/ecma402/#sec-weekdaytouvalue
+  return /^[0-7]$/.test(fw) ? TABLE_1[Number(fw) % 7] : fw
 }
 
 export class Locale {
@@ -535,7 +535,7 @@ export class Locale {
     )
     if (fw !== undefined) {
       fw = weekdayToString(fw)
-      if (!ALPHANUM_3_8.test(fw)) {
+      if (!UNICODE_TYPE_REGEX.test(fw)) {
         throw new RangeError('Invalid firstDayOfWeek')
       }
     }
@@ -586,7 +586,9 @@ export class Locale {
       internalSlots.caseFirst = r.kf as 'upper'
     }
     if (relevantExtensionKeys.indexOf('kn') > -1) {
-      internalSlots.numeric = SameValue(r.kn, 'true')
+      // An empty Unicode boolean keyword has the same meaning as 'true'.
+      // https://tc39.es/ecma402/#sec-Intl.Locale
+      internalSlots.numeric = r.kn === '' || SameValue(r.kn, 'true')
     }
     internalSlots.numberingSystem = r.nu
   }

--- a/packages/intl-locale/index.ts
+++ b/packages/intl-locale/index.ts
@@ -439,7 +439,9 @@ const TABLE_1 = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'] as const
 
 function weekdayToString(fw: string) {
   // WeekdayToUValue maps only exact numeric strings; other strings pass through.
+  // ECMA-402 §15.5.15 WeekdayToUValue, steps 1–2, Table 26.
   // https://tc39.es/ecma402/#sec-weekdaytouvalue
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/locale.html#L786-L790
   return /^[0-7]$/.test(fw) ? TABLE_1[Number(fw) % 7] : fw
 }
 
@@ -539,7 +541,9 @@ export class Locale {
       }
     }
     // MakeLocaleRecord canonicalizes Unicode option values before storing them.
+    // ECMA-402 §15.1.3 MakeLocaleRecord, step 4.e.i.
     // https://tc39.es/ecma402/#sec-makelocalerecord
+    // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/locale.html#L151
     opt.fw = fw?.toLowerCase()
     const hc = GetOption(
       options,
@@ -588,7 +592,9 @@ export class Locale {
     }
     if (relevantExtensionKeys.indexOf('kn') > -1) {
       // An empty Unicode boolean keyword has the same meaning as 'true'.
+      // ECMA-402 §15.1.1 Intl.Locale, steps 42.a–42.b.i.
       // https://tc39.es/ecma402/#sec-Intl.Locale
+      // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/locale.html#L71-L74
       internalSlots.numeric = r.kn === '' || SameValue(r.kn, 'true')
     }
     internalSlots.numberingSystem = r.nu

--- a/packages/intl-locale/tests/index.test.ts
+++ b/packages/intl-locale/tests/index.test.ts
@@ -234,6 +234,7 @@ test('GH #5112 - All Intl Locale Info methods should be available', function () 
 test('canonicalizes weekday options without discarding string identifiers', () => {
   for (const [input, expected] of [
     ['mon', 'mon'],
+    ['MON', 'mon'],
     ['7', 'sun'],
     ['0', 'sun'],
     ['1', 'mon'],

--- a/packages/intl-locale/tests/index.test.ts
+++ b/packages/intl-locale/tests/index.test.ts
@@ -230,3 +230,26 @@ test('GH #5112 - All Intl Locale Info methods should be available', function () 
   expect(typeof locale.getTextInfo()).toBe('object')
   expect(typeof locale.getWeekInfo()).toBe('object')
 })
+
+test('canonicalizes weekday options without discarding string identifiers', () => {
+  for (const [input, expected] of [
+    ['mon', 'mon'],
+    ['7', 'sun'],
+    ['0', 'sun'],
+    ['1', 'mon'],
+    ['foo-bar', 'foo-bar'],
+  ]) {
+    const locale = new Locale('en', {firstDayOfWeek: input})
+    expect(locale.firstDayOfWeek).toBe(expected)
+    expect(locale.toString()).toBe(`en-u-fw-${expected}`)
+  }
+  for (const input of ['8', '1.0', '01', '', 'a_b']) {
+    expect(() => new Locale('en', {firstDayOfWeek: input})).toThrow(RangeError)
+  }
+})
+test('treats an empty numeric keyword as true', () => {
+  expect(new Locale('en-u-kn').numeric).toBe(true)
+  expect(new Locale('en-u-kn-true').numeric).toBe(true)
+  expect(new Locale('en-u-kn-false').numeric).toBe(false)
+  expect(new Locale('en-u-kn', {numeric: false}).numeric).toBe(false)
+})


### PR DESCRIPTION
Preserve valid weekday identifiers, map numeric strings 0–7 to their Unicode weekday values, and treat the empty `kn` keyword as true.

Addresses audit findings 11–12 from #7185. Implementation comments cite the relevant specification clauses. Includes focused regression tests and documentation.

Validation: `bazel test //packages/intl-locale/...`.
