### PR TITLE
fix(@formatjs/intl-locale): align week info with ECMA-402

### DIFF
--- a/docs/src/docs/polyfills/intl-locale.mdx
+++ b/docs/src/docs/polyfills/intl-locale.mdx
@@ -167,3 +167,12 @@ This library is [test262](https://github.com/tc39/test262/tree/master/test/intl4
 `firstDayOfWeek` accepts Unicode type identifiers such as `mon`. Numeric strings
 `0` and `7` both become `sun`; `1` through `6` become `mon` through `sat`.
 The empty Unicode numeric keyword in `en-u-kn` sets `numeric` to `true`.
+
+## Week info compatibility
+
+`getWeekInfo()` follows the current ECMA-402 draft: `{firstDay, weekend}` with
+ISO weekday numbers (Monday = 1, Sunday = 7) and a fresh weekend array per call.
+**Breaking change:** the earlier proposal's `minimalDays` property is removed.
+Consumers that calculate local week numbers must obtain that value separately.
+Week data honors available `rg` region overrides, `sd` subdivision preferences
+when no region is explicit, and recognized `fw` first-day overrides.

--- a/docs/src/docs/polyfills/intl-locale.mdx
+++ b/docs/src/docs/polyfills/intl-locale.mdx
@@ -70,7 +70,7 @@ locale.getTimeZones() // ["America/Adak", "America/Anchorage", ...]
 
 // Text and week info
 locale.getTextInfo() // {direction: "ltr"}
-locale.getWeekInfo() // {firstDay: 7, weekend: [6, 7], minimalDays: 1}
+locale.getWeekInfo() // {firstDay: 7, weekend: [6, 7]}
 ```
 
 <Admonition type="info">

--- a/knowledge-base/007i-polyfill-intl-locale.md
+++ b/knowledge-base/007i-polyfill-intl-locale.md
@@ -58,3 +58,12 @@ numbering-systems.ts  → numbering-systems.generated.ts
 `firstDayOfWeek` accepts Unicode type identifiers such as `mon`. Numeric strings
 `0` and `7` both become `sun`; `1` through `6` become `mon` through `sat`.
 The empty Unicode numeric keyword in `en-u-kn` sets `numeric` to `true`.
+
+## Week info compatibility
+
+`getWeekInfo()` follows the current ECMA-402 draft: `{firstDay, weekend}` with
+ISO weekday numbers (Monday = 1, Sunday = 7) and a fresh weekend array per call.
+**Breaking change:** the earlier proposal's `minimalDays` property is removed.
+Consumers that calculate local week numbers must obtain that value separately.
+Week data honors available `rg` region overrides, `sd` subdivision preferences
+when no region is explicit, and recognized `fw` first-day overrides.

--- a/packages/intl-locale/index.ts
+++ b/packages/intl-locale/index.ts
@@ -428,7 +428,9 @@ function weekInfoOfLocale(loc: Locale): WeekInfoInternal {
   const locale = locInternalSlots.locale
 
   // RegionPreference uses the explicit region, subdivision, then likely subtags.
+  // ECMA-402 §15.5.8 RegionPreference, steps 1–4.
   // https://tc39.es/ecma402/#sec-regionpreference
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/locale.html#L606-L616
   const ast = parseUnicodeLocaleId(locale)
   const extension = ast.extensions.find(ext => ext.type === 'u') as
     | UnicodeExtension
@@ -779,7 +781,9 @@ export class Locale {
 
   /**
    * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getWeekInfo
+   * ECMA-402 §15.3.22 Intl.Locale.prototype.getWeekInfo, steps 3–7.
    * https://tc39.es/ecma402/#sec-Intl.Locale.prototype.getWeekInfo
+   * https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/locale.html#L420-L424
    */
   public getWeekInfo(): {
     firstDay: number
@@ -797,12 +801,16 @@ export class Locale {
     createDataProperty(info, 'firstDay', wi.firstDay)
 
     // getWeekInfo returns a fresh weekend array and no minimalDays property.
+    // ECMA-402 §15.3.22 Intl.Locale.prototype.getWeekInfo, steps 3–7.
     // https://tc39.es/ecma402/#sec-Intl.Locale.prototype.getWeekInfo
+    // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/locale.html#L420-L424
     createDataProperty(info, 'weekend', [...we])
 
     const fw = internalSlots.firstDayOfWeek
     // WeekInfoOfLocale applies recognized weekday identifiers as ISO day numbers.
+    // ECMA-402 §15.5.17 WeekInfoOfLocale, steps 8–9.b.
     // https://tc39.es/ecma402/#sec-weekinfooflocale
+    // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/locale.html#L887-L890
     const day = TABLE_1.indexOf(fw as (typeof TABLE_1)[number])
     if (day !== -1) {
       info.firstDay = day || 7

--- a/packages/intl-locale/index.ts
+++ b/packages/intl-locale/index.ts
@@ -427,12 +427,20 @@ function weekInfoOfLocale(loc: Locale): WeekInfoInternal {
 
   const locale = locInternalSlots.locale
 
-  let region: string | undefined
-  if (locale !== 'root') {
-    region = loc.maximize().region
+  // RegionPreference uses the explicit region, subdivision, then likely subtags.
+  // https://tc39.es/ecma402/#sec-regionpreference
+  const ast = parseUnicodeLocaleId(locale)
+  const extension = ast.extensions.find(ext => ext.type === 'u') as
+    | UnicodeExtension
+    | undefined
+  const subdivisionRegion = (key: string) => {
+    const value = extension?.keywords.find(entry => entry[0] === key)?.[1]
+    const match = value?.match(/^([a-z]{2}|[0-9]{3})[a-z0-9]{1,4}$/i)
+    return match ? new Locale(`und-${match[1]}`).region : undefined
   }
-
-  return getWeekDataForRegion(region)
+  const region =
+    ast.lang.region || subdivisionRegion('sd') || loc.maximize().region
+  return getWeekDataForRegion(region, subdivisionRegion('rg'))
 }
 
 const TABLE_1 = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'] as const
@@ -771,12 +779,11 @@ export class Locale {
 
   /**
    * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getWeekInfo
-   * https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.getWeekInfo
+   * https://tc39.es/ecma402/#sec-Intl.Locale.prototype.getWeekInfo
    */
   public getWeekInfo(): {
-    firstDay: string
-    weekend: {start: string; end: string}
-    minimalDays: number
+    firstDay: number
+    weekend: number[]
   } {
     const info = Object.create(Object.prototype)
     const internalSlots = getInternalSlots(this)
@@ -789,13 +796,16 @@ export class Locale {
 
     createDataProperty(info, 'firstDay', wi.firstDay)
 
-    createDataProperty(info, 'weekend', we)
-
-    createDataProperty(info, 'minimalDays', wi.minimalDays)
+    // getWeekInfo returns a fresh weekend array and no minimalDays property.
+    // https://tc39.es/ecma402/#sec-Intl.Locale.prototype.getWeekInfo
+    createDataProperty(info, 'weekend', [...we])
 
     const fw = internalSlots.firstDayOfWeek
-    if (fw !== undefined) {
-      info.firstDay = fw
+    // WeekInfoOfLocale applies recognized weekday identifiers as ISO day numbers.
+    // https://tc39.es/ecma402/#sec-weekinfooflocale
+    const day = TABLE_1.indexOf(fw as (typeof TABLE_1)[number])
+    if (day !== -1) {
+      info.firstDay = day || 7
     }
 
     return info

--- a/packages/intl-locale/preference-data.ts
+++ b/packages/intl-locale/preference-data.ts
@@ -74,7 +74,9 @@ export function getWeekDataForRegion(
   const _region = (region ? region.toUpperCase() : '') as WeekDataKey
 
   // Available region override data takes precedence over the locale's region.
+  // ECMA-402 §15.5.17 WeekInfoOfLocale, steps 4–7, Table 27.
   // https://tc39.es/ecma402/#sec-weekinfooflocale
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/locale.html#L880-L886
   const override = (regionOverride || '').toUpperCase() as WeekDataKey
   return weekData[override] || weekData[_region] || weekData['001']
 }

--- a/packages/intl-locale/preference-data.ts
+++ b/packages/intl-locale/preference-data.ts
@@ -67,8 +67,14 @@ export function getTimeZonePreferenceForRegion(region: string): string[] {
   return []
 }
 
-export function getWeekDataForRegion(region?: string): WeekInfoInternal {
+export function getWeekDataForRegion(
+  region?: string,
+  regionOverride?: string
+): WeekInfoInternal {
   const _region = (region ? region.toUpperCase() : '') as WeekDataKey
 
-  return weekData[_region || '001'] || weekData['001']
+  // Available region override data takes precedence over the locale's region.
+  // https://tc39.es/ecma402/#sec-weekinfooflocale
+  const override = (regionOverride || '').toUpperCase() as WeekDataKey
+  return weekData[override] || weekData[_region] || weekData['001']
 }

--- a/packages/intl-locale/tests/index.test.ts
+++ b/packages/intl-locale/tests/index.test.ts
@@ -167,7 +167,6 @@ test('getWeekInfo', function () {
   expect(new Locale('en-uS').getWeekInfo()).toEqual({
     firstDay: 7,
     weekend: [6, 7],
-    minimalDays: 1,
   })
 })
 
@@ -181,9 +180,7 @@ test('GH #4575', function () {
 })
 
 test('GH #5112 - getWeekInfo should be available for week calculations', function () {
-  // Issue #5112: Firefox has incomplete Intl.Locale implementation
-  // missing getWeekInfo() which breaks Luxon's localWeekNumber calculation
-  // This test ensures the polyfill provides getWeekInfo() for all locales
+  // Keep getWeekInfo available with the current ECMA-402 result shape.
 
   const locale = new Locale('en-US')
 
@@ -193,18 +190,16 @@ test('GH #5112 - getWeekInfo should be available for week calculations', functio
   const weekInfo = locale.getWeekInfo()
   expect(weekInfo).toHaveProperty('firstDay')
   expect(weekInfo).toHaveProperty('weekend')
-  expect(weekInfo).toHaveProperty('minimalDays')
+  expect(Object.keys(weekInfo)).toEqual(['firstDay', 'weekend'])
 
   // en-US uses Sunday (7) as first day of week
   expect(weekInfo.firstDay).toBe(7)
-  expect(weekInfo.minimalDays).toBe(1)
 
   // Test other locales that might have different week info
   const localeDe = new Locale('de-DE')
   const weekInfoDe = localeDe.getWeekInfo()
   // Germany uses Monday (1) as first day of week
   expect(weekInfoDe.firstDay).toBe(1)
-  expect(weekInfoDe.minimalDays).toBe(4)
 })
 
 test('GH #5112 - All Intl Locale Info methods should be available', function () {
@@ -253,4 +248,21 @@ test('treats an empty numeric keyword as true', () => {
   expect(new Locale('en-u-kn-true').numeric).toBe(true)
   expect(new Locale('en-u-kn-false').numeric).toBe(false)
   expect(new Locale('en-u-kn', {numeric: false}).numeric).toBe(false)
+})
+
+test('returns numeric weekdays and independent weekend arrays', () => {
+  const locale = new Locale('en-US', {firstDayOfWeek: 'mon'})
+  expect(locale.getWeekInfo()).toEqual({firstDay: 1, weekend: [6, 7]})
+  const info = locale.getWeekInfo()
+  info.weekend.length = 0
+  expect(locale.getWeekInfo().weekend).toEqual([6, 7])
+  expect(new Locale('en-US-u-fw-sun').getWeekInfo().firstDay).toBe(7)
+  expect(new Locale('en-US-u-fw-foobar').getWeekInfo().firstDay).toBe(7)
+})
+test('uses region and subdivision preferences for week data', () => {
+  expect(new Locale('en-US-u-rg-gbzzzz').getWeekInfo().firstDay).toBe(1)
+  expect(new Locale('en-US-u-rg-aazzzz').getWeekInfo().firstDay).toBe(7)
+  expect(new Locale('en-US-u-fw-sun-rg-gbzzzz').getWeekInfo().firstDay).toBe(7)
+  expect(new Locale('en-u-sd-gbeng').getWeekInfo().firstDay).toBe(1)
+  expect(new Locale('en-US-u-sd-gbeng').getWeekInfo().firstDay).toBe(7)
 })


### PR DESCRIPTION
**Breaking change:** remove `minimalDays` from `getWeekInfo()`, matching the current ECMA-402 draft. Return ISO numeric weekdays and fresh weekend arrays. Honor region overrides and subdivision preferences. Consumers using `minimalDays` for local week-number calculations must obtain that value separately.

Upstream removal: [tc39/proposal-intl-locale-info#99 — Normative: Remove minimal days from the proposal](https://github.com/tc39/proposal-intl-locale-info/pull/99), merged March 4, 2025, following the February 6 TG2 discussion. The revised proposal subsequently landed in ECMA-402 through [tc39/ecma402#942](https://github.com/tc39/ecma402/pull/942), merged February 19, 2026.

Addresses audit findings 13–14 from #7185. Implementation comments cite the relevant specification clauses. Includes focused regression tests and documentation.

Validation: `bazel test //packages/intl-locale/...`.
