### PR TITLE
fix(@formatjs/intl-pluralrules): align draft options and ranges

### DIFF
--- a/docs/src/docs/polyfills/intl-pluralrules.mdx
+++ b/docs/src/docs/polyfills/intl-pluralrules.mdx
@@ -147,3 +147,12 @@ async function polyfill(locale: string) {
   await import(`@formatjs/intl-pluralrules/locale-data/${unsupportedLocale}.js`)
 }
 ```
+
+## Draft options and range behavior
+
+`notation` accepts `standard`, `scientific`, `engineering`, and `compact`.
+`compactDisplay` is validated for every notation and reported only for `compact`.
+Compact notation uses the shared compact digit defaults. `resolvedOptions()`
+returns an ordinary object, reports notation and rounding settings, and lists
+plural categories in the order `zero`, `one`, `two`, `few`, `many`, `other`.
+`selectRange()` accepts infinite endpoints; NaN still throws `RangeError`.

--- a/knowledge-base/007c-polyfill-intl-pluralrules.md
+++ b/knowledge-base/007c-polyfill-intl-pluralrules.md
@@ -119,7 +119,7 @@ When `selectRange(start, end)` is called:
 - **No make-plural dependency**: Custom compiler replaced previous make-plural dependency
 - **BigInt support**: `ToIntlMathematicalValue()` handles BigInt per ECMA-402
 - **String-based integer digits**: Stored as string for numbers > 2^53 to prevent precision loss
-- **Compact notation extension**: Non-standard but mirrors Intl.NumberFormat for consistent plural selection
+- **Notation options**: The current ECMA-402 draft includes notation and compactDisplay; compact exponents use available NumberFormat locale data
 
 ## Examples by Locale Complexity
 

--- a/knowledge-base/007c-polyfill-intl-pluralrules.md
+++ b/knowledge-base/007c-polyfill-intl-pluralrules.md
@@ -127,3 +127,12 @@ When `selectRange(start, end)` is called:
 - **English**: Cardinal: one/other; Ordinal: one/two/few/other
 - **French**: Cardinal: one/many/other (compact notation uses `e` operand for "many")
 - **Arabic**: Cardinal: zero/one/two/few/many/other (most complex, uses all 6 categories)
+
+## Draft options and range behavior
+
+`notation` accepts `standard`, `scientific`, `engineering`, and `compact`.
+`compactDisplay` is validated for every notation and reported only for `compact`.
+Compact notation uses the shared compact digit defaults. `resolvedOptions()`
+returns an ordinary object, reports notation and rounding settings, and lists
+plural categories in the order `zero`, `one`, `two`, `few`, `many`, `other`.
+`selectRange()` accepts infinite endpoints; NaN still throws `RangeError`.

--- a/packages/ecma402-abstract/PluralRules/InitializePluralRules.ts
+++ b/packages/ecma402-abstract/PluralRules/InitializePluralRules.ts
@@ -58,26 +58,26 @@ export function InitializePluralRules(
     'cardinal'
   )
 
-  // Extension: notation options for compact notation support
-  // Not in ECMA-402 spec, but mirrors Intl.NumberFormat notation option
-  // Enables proper plural selection for compact numbers (e.g., "1.2M")
+  // Read and validate notation and compactDisplay before digit options.
+  // https://tc39.es/ecma402/#sec-intl.pluralrules
   const notation = GetOption(
     opts,
     'notation',
     'string',
-    ['standard', 'compact'],
+    ['standard', 'scientific', 'engineering', 'compact'],
     'standard'
   )
   internalSlots.notation = notation
 
+  const compactDisplay = GetOption(
+    opts,
+    'compactDisplay',
+    'string',
+    ['short', 'long'],
+    'short'
+  )
   if (notation === 'compact') {
-    internalSlots.compactDisplay = GetOption(
-      opts,
-      'compactDisplay',
-      'string',
-      ['short', 'long'],
-      'short'
-    )
+    internalSlots.compactDisplay = compactDisplay
     // Implementation: Load NumberFormat locale data if available (soft dependency)
     // This is needed to calculate compact exponents using ComputeExponentForMagnitude
     if (
@@ -91,7 +91,7 @@ export function InitializePluralRules(
     }
   }
 
-  SetNumberFormatDigitOptions(internalSlots, opts, 0, 3, 'standard')
+  SetNumberFormatDigitOptions(internalSlots, opts, 0, 3, notation)
 
   return pl
 }

--- a/packages/ecma402-abstract/PluralRules/InitializePluralRules.ts
+++ b/packages/ecma402-abstract/PluralRules/InitializePluralRules.ts
@@ -59,7 +59,9 @@ export function InitializePluralRules(
   )
 
   // Read and validate notation and compactDisplay before digit options.
+  // ECMA-402 §17.1.1 Intl.PluralRules, steps 9–13.
   // https://tc39.es/ecma402/#sec-intl.pluralrules
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/pluralrules.html#L29-L34
   const notation = GetOption(
     opts,
     'notation',

--- a/packages/ecma402-abstract/PluralRules/ResolvePluralRange.ts
+++ b/packages/ecma402-abstract/PluralRules/ResolvePluralRange.ts
@@ -47,10 +47,11 @@ export function ResolvePluralRange(
     ) => LDMLPluralRule
   }
 ): LDMLPluralRule {
-  // 1. If x is not-a-number or y is not-a-number, throw a RangeError exception.
-  if (!x.isFinite() || !y.isFinite()) {
+  // ResolvePluralRange rejects NaN but permits either infinity.
+  // https://tc39.es/ecma402/#sec-resolvepluralrange
+  if (x.isNaN() || y.isNaN()) {
     throw new RangeError(
-      'selectRange requires start and end values to be finite numbers'
+      'selectRange requires start and end values not to be NaN'
     )
   }
 

--- a/packages/ecma402-abstract/PluralRules/ResolvePluralRange.ts
+++ b/packages/ecma402-abstract/PluralRules/ResolvePluralRange.ts
@@ -16,7 +16,9 @@ import {ResolvePluralInternal} from '#packages/ecma402-abstract/PluralRules/Reso
  * It resolves the appropriate plural form for a range by determining the plural forms of both the
  * start and end values, then consulting locale-specific range data.
  *
+ * ECMA-402 §17.5.4 ResolvePluralRange, steps 1–3.
  * Specification: https://tc39.es/ecma402/#sec-resolvepluralrange
+ * https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/pluralrules.html#L356-L358
  *
  * @param pluralRules - An initialized PluralRules object
  * @param x - Mathematical value for the range start
@@ -48,7 +50,9 @@ export function ResolvePluralRange(
   }
 ): LDMLPluralRule {
   // ResolvePluralRange rejects NaN but permits either infinity.
+  // ECMA-402 §17.5.4 ResolvePluralRange, steps 1–3.
   // https://tc39.es/ecma402/#sec-resolvepluralrange
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/pluralrules.html#L356-L358
   if (x.isNaN() || y.isNaN()) {
     throw new RangeError(
       'selectRange requires start and end values not to be NaN'

--- a/packages/ecma402-abstract/types/plural-rules.ts
+++ b/packages/ecma402-abstract/types/plural-rules.ts
@@ -18,9 +18,9 @@ export interface PluralRulesData {
 
 export type PluralRulesLocaleData = LocaleData<PluralRulesData>
 
-// Extends built-in PluralRulesOptions with formatjs-specific extensions
+// ECMA-402 options not yet present in all TypeScript Intl declarations.
 export interface PluralRulesOptions extends Intl.PluralRulesOptions {
-  notation?: 'standard' | 'compact'
+  notation?: 'standard' | 'scientific' | 'engineering' | 'compact'
   compactDisplay?: 'short' | 'long'
 }
 
@@ -28,7 +28,7 @@ export interface PluralRulesInternal extends NumberFormatDigitInternalSlots {
   initializedPluralRules: boolean
   locale: string
   type: 'cardinal' | 'ordinal'
-  notation: 'standard' | 'compact'
+  notation: 'standard' | 'scientific' | 'engineering' | 'compact'
   compactDisplay?: 'short' | 'long'
   dataLocaleData?: any // NumberFormatLocaleInternalData from number.ts
 }

--- a/packages/intl-pluralrules/index.ts
+++ b/packages/intl-pluralrules/index.ts
@@ -20,7 +20,7 @@ import getInternalSlots from '#packages/intl-pluralrules/get_internal_slots.js'
  * ECMA-402 Spec: selectRange method (Intl.PluralRules.prototype.selectRange)
  * https://tc39.es/ecma402/#sec-intl.pluralrules.prototype.selectrange
  *
- * Extension: notation and compactDisplay options (not in ECMA-402 spec)
+ * ECMA-402 notation and compactDisplay options
  * Mirrors Intl.NumberFormat notation option for proper plural selection with compact numbers
  */
 declare global {
@@ -30,9 +30,9 @@ declare global {
       selectRange(start: number | bigint, end: number | bigint): LDMLPluralRule
     }
     interface PluralRulesOptions {
-      // Extension: notation option (mirrors Intl.NumberFormat)
-      notation?: 'standard' | 'compact'
-      // Extension: compactDisplay option (mirrors Intl.NumberFormat)
+      // https://tc39.es/ecma402/#sec-intl.pluralrules
+      notation?: 'standard' | 'scientific' | 'engineering' | 'compact'
+      // Only reported in resolvedOptions when notation is compact.
       compactDisplay?: 'short' | 'long'
     }
   }
@@ -52,7 +52,7 @@ export interface PluralRulesInternal extends NumberFormatDigitInternalSlots {
   initializedPluralRules: boolean
   locale: string
   type: 'cardinal' | 'ordinal'
-  notation: 'standard' | 'compact'
+  notation: 'standard' | 'scientific' | 'engineering' | 'compact'
   compactDisplay?: 'short' | 'long'
   dataLocaleData?: any // NumberFormatLocaleInternalData
 }
@@ -151,12 +151,16 @@ export class PluralRules {
   }
   public resolvedOptions(): Intl.ResolvedPluralRulesOptions {
     validateInstance(this, 'resolvedOptions')
-    const opts = Object.create(null)
+    // Ordinary result object and property order follow the resolved-options table.
+    // https://tc39.es/ecma402/#sec-intl.pluralrules.prototype.resolvedoptions
+    const opts: Record<string, any> = {}
     const internalSlots = getInternalSlots(this)
     opts.locale = internalSlots.locale
     opts.type = internalSlots.type
     ;(
       [
+        'notation',
+        'compactDisplay',
         'minimumIntegerDigits',
         'minimumFractionDigits',
         'maximumFractionDigits',
@@ -170,13 +174,29 @@ export class PluralRules {
       }
     })
 
+    const categories =
+      PluralRules.localeData[internalSlots.locale].categories[
+        internalSlots.type
+      ]
     opts.pluralCategories = [
-      ...PluralRules.localeData[opts.locale].categories[
-        opts.type as 'cardinal'
-      ],
-    ]
-    return opts
+      'zero',
+      'one',
+      'two',
+      'few',
+      'many',
+      'other',
+    ].filter(category => categories.includes(category))
+    for (const field of [
+      'roundingIncrement',
+      'roundingMode',
+      'roundingPriority',
+      'trailingZeroDisplay',
+    ] as const) {
+      opts[field] = internalSlots[field]
+    }
+    return opts as Intl.ResolvedPluralRulesOptions
   }
+
   public select(val: number | bigint): LDMLPluralRule {
     validateInstance(this, 'select')
     // Use ToIntlMathematicalValue which handles bigint per ECMA-402
@@ -212,7 +232,7 @@ export class PluralRules {
    * pr.selectRange(BigInt(1), BigInt(2)); // "other"
    *
    * @throws {TypeError} If start or end is undefined
-   * @throws {RangeError} If start or end is not a finite number (Infinity, NaN)
+   * @throws {RangeError} If start or end converts to NaN
    *
    * @note Chrome's native implementation (as of early 2025) has a bug where it throws
    * "Cannot convert a BigInt value to a number" when using BigInt arguments. This is

--- a/packages/intl-pluralrules/index.ts
+++ b/packages/intl-pluralrules/index.ts
@@ -30,7 +30,9 @@ declare global {
       selectRange(start: number | bigint, end: number | bigint): LDMLPluralRule
     }
     interface PluralRulesOptions {
+      // ECMA-402 §17.1.1 Intl.PluralRules, steps 9–13.
       // https://tc39.es/ecma402/#sec-intl.pluralrules
+      // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/pluralrules.html#L29-L34
       notation?: 'standard' | 'scientific' | 'engineering' | 'compact'
       // Only reported in resolvedOptions when notation is compact.
       compactDisplay?: 'short' | 'long'
@@ -152,7 +154,9 @@ export class PluralRules {
   public resolvedOptions(): Intl.ResolvedPluralRulesOptions {
     validateInstance(this, 'resolvedOptions')
     // Ordinary result object and property order follow the resolved-options table.
+    // ECMA-402 §17.3.2 Intl.PluralRules.prototype.resolvedOptions, steps 3–5, Table 32.
     // https://tc39.es/ecma402/#sec-intl.pluralrules.prototype.resolvedoptions
+    // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/pluralrules.html#L114-L126
     const opts: Record<string, any> = {}
     const internalSlots = getInternalSlots(this)
     opts.locale = internalSlots.locale

--- a/packages/intl-pluralrules/tests/index.test.ts
+++ b/packages/intl-pluralrules/tests/index.test.ts
@@ -17,6 +17,11 @@ describe('PluralRules', function () {
       minimumIntegerDigits: 1,
       pluralCategories: ['one', 'other'],
       type: 'cardinal',
+      notation: 'standard',
+      roundingIncrement: 1,
+      roundingMode: 'halfExpand',
+      roundingPriority: 'auto',
+      trailingZeroDisplay: 'auto',
     })
   })
   it('should work for cardinal', function () {
@@ -193,8 +198,8 @@ describe('PluralRules', function () {
 
     it('should throw RangeError for non-finite values', function () {
       const pr = new PluralRules('en')
-      expect(() => pr.selectRange(Infinity, 5)).toThrow(RangeError)
-      expect(() => pr.selectRange(1, Infinity)).toThrow(RangeError)
+      expect(pr.selectRange(Infinity, 5)).toBe('other')
+      expect(pr.selectRange(1, Infinity)).toBe('other')
       expect(() => pr.selectRange(NaN, 5)).toThrow(RangeError)
       expect(() => pr.selectRange(1, NaN)).toThrow(RangeError)
     })
@@ -340,4 +345,94 @@ describe('PluralRules', function () {
 
 it('preserves plural operands above Number.MAX_SAFE_INTEGER', () => {
   expect(GetOperands('9007199254740993').IntegerDigits).toBe('9007199254740993')
+})
+
+it('reads notation and compactDisplay before digit options', () => {
+  const reads: string[] = []
+  new PluralRules(
+    'en',
+    new Proxy(
+      {},
+      {
+        get(_target, key) {
+          reads.push(String(key))
+          return undefined
+        },
+      }
+    )
+  )
+  expect(reads.slice(0, 5)).toEqual([
+    'localeMatcher',
+    'type',
+    'notation',
+    'compactDisplay',
+    'minimumIntegerDigits',
+  ])
+  for (const notation of [
+    'standard',
+    'scientific',
+    'engineering',
+    'compact',
+  ] as const) {
+    expect(
+      () => new PluralRules('en', {notation, compactDisplay: 'invalid' as any})
+    ).toThrow(RangeError)
+    const result = new PluralRules('en', {notation}).resolvedOptions() as any
+    expect(result.notation).toBe(notation)
+    expect('compactDisplay' in result).toBe(notation === 'compact')
+  }
+})
+it('reports compact digit defaults, rounding settings, and ordered categories', () => {
+  const compact = new PluralRules('en', {
+    notation: 'compact',
+    compactDisplay: 'long',
+  }).resolvedOptions() as any
+  expect(Object.getPrototypeOf(compact)).toBe(Object.prototype)
+  expect(Object.keys(compact)).toEqual([
+    'locale',
+    'type',
+    'notation',
+    'compactDisplay',
+    'minimumIntegerDigits',
+    'minimumFractionDigits',
+    'maximumFractionDigits',
+    'minimumSignificantDigits',
+    'maximumSignificantDigits',
+    'pluralCategories',
+    'roundingIncrement',
+    'roundingMode',
+    'roundingPriority',
+    'trailingZeroDisplay',
+  ])
+  expect(compact).toMatchObject({
+    compactDisplay: 'long',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+    minimumSignificantDigits: 1,
+    maximumSignificantDigits: 2,
+    roundingPriority: 'morePrecision',
+  })
+  expect(
+    new PluralRules('en', {type: 'ordinal'}).resolvedOptions().pluralCategories
+  ).toEqual(['one', 'two', 'few', 'other'])
+  const options = {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+    roundingIncrement: 5,
+    roundingMode: 'ceil',
+    trailingZeroDisplay: 'stripIfInteger',
+  } as const
+  expect(new PluralRules('en', options).resolvedOptions()).toMatchObject(
+    options
+  )
+})
+it('accepts infinite range endpoints but still rejects NaN', () => {
+  const rules = new PluralRules('en')
+  for (const infinity of [-Infinity, Infinity]) {
+    expect(rules.selectRange(infinity, infinity)).toBe('other')
+    expect(rules.selectRange(infinity, 2)).toBe('other')
+    expect(rules.selectRange(2, infinity)).toBe('other')
+  }
+  expect(() => rules.selectRange(NaN, 2)).toThrow(RangeError)
+  expect(() => rules.selectRange(2, NaN)).toThrow(RangeError)
 })


### PR DESCRIPTION
Accept all four draft notation values, validate compactDisplay regardless of notation, and pass notation into digit-option initialization. Report all resolved options with the specified property/category order. Permit infinite range endpoints while retaining NaN errors and BigInt support.

Addresses audit findings 15–17 from #7185. Implementation comments cite the relevant specification clauses. Includes focused regression tests and documentation.

Validation: `bazel test //packages/intl-pluralrules/...`.
