### PR TITLE
fix(@formatjs/intl-segmenter): preserve iterator progress and locale

### DIFF
--- a/docs/src/docs/polyfills/intl-segmenter.mdx
+++ b/docs/src/docs/polyfills/intl-segmenter.mdx
@@ -196,3 +196,11 @@ async function polyfill(locale: string) {
   }
 }
 ```
+
+## Iteration and default locale
+
+`segment()` returns a reusable iterable with `containing()`. Each call to its
+`Symbol.iterator` creates an independent iterator. An iterator returns itself
+from `Symbol.iterator` and resumes from its current position. `next()` belongs
+to the iterator, not the iterable returned by `segment()`.
+The fallback locale is `en`, backed by the root segmentation rules.

--- a/knowledge-base/007h-polyfill-intl-segmenter.md
+++ b/knowledge-base/007h-polyfill-intl-segmenter.md
@@ -67,3 +67,11 @@ export const CLDR_SEGMENTATION_RULES: Record<Granularity, Record<Locale, RuleSet
 - Static data structure passed to segmentation engine
 - Segmentation algorithm walks text character by character, applying rules in priority order
 - Known limitation: 35 test cases fail for Regional Indicator + Extend combinations
+
+## Iteration and default locale
+
+`segment()` returns a reusable iterable with `containing()`. Each call to its
+`Symbol.iterator` creates an independent iterator. An iterator returns itself
+from `Symbol.iterator` and resumes from its current position. `next()` belongs
+to the iterator, not the iterable returned by `segment()`.
+The fallback locale is `en`, backed by the root segmentation rules.

--- a/packages/intl-segmenter/BUILD.bazel
+++ b/packages/intl-segmenter/BUILD.bazel
@@ -76,6 +76,7 @@ formatjs_library(
     deps = [
         "//:node_modules/@formatjs/intl-localematcher",
         "//:node_modules/@formatjs_generated/unicode",
+        "//packages/ecma262-abstract",
         "//packages/ecma402-abstract",
     ],
 )

--- a/packages/intl-segmenter/scripts/benchmark.ts
+++ b/packages/intl-segmenter/scripts/benchmark.ts
@@ -4,7 +4,7 @@ import {Bench} from 'tinybench'
 // const Segmenter = Intl.Segmenter
 import {Segmenter} from '#packages/intl-segmenter/segmenter.js'
 
-import type {SegmentIterator} from '#packages/intl-segmenter/segmenter.js'
+import type {Segments} from '#packages/intl-segmenter/segmenter.js'
 const locale = 'en'
 let inputString = `
 
@@ -28,7 +28,7 @@ const cachedSegmenters = {
   sentence: new Segmenter(locale, {granularity: 'sentence'}),
 }
 
-const collectSegments = (iterator: SegmentIterator) => {
+const collectSegments = (iterator: Segments) => {
   let r
   const collected = []
   let i = iterator[Symbol.iterator]()

--- a/packages/intl-segmenter/segmenter.ts
+++ b/packages/intl-segmenter/segmenter.ts
@@ -154,7 +154,9 @@ export class Segmenter {
     setSlot(this, 'granularity', granularity)
 
     // DefaultLocale must be a structurally valid, canonical language tag.
+    // ECMA-402 §6.2.3 DefaultLocale, return-value definition.
     // https://tc39.es/ecma402/#sec-defaultlocale
+    // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/locales-currencies-tz.html#L109
     const r = ResolveLocale(
       Segmenter.availableLocales,
       requestedLocales,
@@ -397,7 +399,9 @@ const createSegmentDataObject = (
   return returnValue
 }
 // Segments creates independent iterators; iterators retain their own position.
-// https://tc39.es/ecma402/#sec-%segmentsprototype%-@@iterator
+// ECMA-402 §19.5.2.2 %IntlSegmentsPrototype% [ %Symbol.iterator% ], step 5.
+// https://tc39.es/ecma402/#sec-%intlsegmentsprototype%-%symbol.iterator%
+// https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/segmenter.html#L230
 class Segments implements Iterable<SegmentResult> {
   constructor(
     private readonly segmenter: Segmenter,
@@ -519,7 +523,9 @@ class SegmentIterator
 }
 
 // %IntlSegmentIteratorPrototype% inherits the standard iterator prototype.
+// ECMA-402 §19.6.2 The %IntlSegmentIteratorPrototype% Object, third bullet.
 // https://tc39.es/ecma402/#sec-%intlsegmentiteratorprototype%-object
+// https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/segmenter.html#L279
 Object.setPrototypeOf(
   SegmentIterator.prototype,
   Object.getPrototypeOf(Object.getPrototypeOf([][Symbol.iterator]()))

--- a/packages/intl-segmenter/segmenter.ts
+++ b/packages/intl-segmenter/segmenter.ts
@@ -1,3 +1,4 @@
+import {ToString} from '#packages/ecma262-abstract/ToString.js'
 import {CanonicalizeLocaleList} from '#packages/ecma402-abstract/CanonicalizeLocaleList.js'
 import {GetOption} from '#packages/ecma402-abstract/GetOption.js'
 import {GetOptionsObject} from '#packages/ecma402-abstract/GetOptionsObject.js'
@@ -40,9 +41,12 @@ type SegmentationTypeTypeRaw = {
   suppressions: ReadonlyArray<string>
 }
 
-type SegmentResult =
-  | {segment: string; breakingRule?: string; nonBreakingRules?: string[]}
-  | undefined
+type SegmentResult = {
+  segment: string
+  index: number
+  input: string
+  isWordLike?: boolean
+}
 
 export interface SegmenterOptions {
   localeMatcher?: 'lookup' | 'best fit'
@@ -149,25 +153,26 @@ export class Segmenter {
     ) as keyof typeof SegmentationRules.root
     setSlot(this, 'granularity', granularity)
 
-    //TODO: figure out correct availible locales
+    // DefaultLocale must be a structurally valid, canonical language tag.
+    // https://tc39.es/ecma402/#sec-defaultlocale
     const r = ResolveLocale(
-      Segmenter.availableLocales, //availible locales
+      Segmenter.availableLocales,
       requestedLocales,
       opt,
       [], // there is no relevantExtensionKeys
       {},
-      () => '' //use only root rules
+      () => 'en'
     )
     setSlot(this, 'locale', r.locale)
 
     //root rules based on granularity
-    this.mergedSegmentationTypeValue = SegmentationRules.root[granularity]
+    this.mergedSegmentationTypeValue = {...SegmentationRules.root[granularity]}
 
     //merge root rules with locale ones if locale is specified
     if (r.locale.length) {
       const localeOverrides =
         SegmentationRules[r.locale as keyof typeof SegmentationRules]
-      if (granularity in localeOverrides) {
+      if (localeOverrides && granularity in localeOverrides) {
         const localeSegmentationTypeValue: SegmentationTypeTypeRaw =
           localeOverrides[granularity as keyof typeof localeOverrides]
         this.mergedSegmentationTypeValue.variables = {
@@ -260,9 +265,9 @@ export class Segmenter {
     return breaksAtResult(true, '999')
   }
 
-  segment(input: string): SegmentIterator {
+  segment(input: string): Segments {
     checkReceiver(this, 'segment')
-    return new SegmentIterator(this, input)
+    return new Segments(this, ToString(input))
   }
 
   resolvedOptions(): SegmenterResolvedOptions {
@@ -277,9 +282,10 @@ export class Segmenter {
     }
   }
 
-  static availableLocales: Set<string> = new Set(
-    Object.keys(SegmentationRules).filter(key => key !== 'root')
-  )
+  static availableLocales: Set<string> = new Set([
+    'en',
+    ...Object.keys(SegmentationRules).filter(key => key !== 'root'),
+  ])
   static supportedLocalesOf(
     locales?: string | string[],
     options?: Pick<SegmenterOptions, 'localeMatcher'>
@@ -390,67 +396,16 @@ const createSegmentDataObject = (
   }
   return returnValue
 }
-class SegmentIterator
-  implements Iterable<SegmentResult>, Iterator<SegmentResult>
-{
-  private readonly segmenter
-  private lastSegmentIndex
-  private input
-  constructor(segmenter: Segmenter, input: string) {
-    this.segmenter = segmenter
-    this.lastSegmentIndex = 0
-    if (typeof input == 'symbol') {
-      throw TypeError(`Input must not be a symbol`)
-    }
-    this.input = String(input)
-  }
+// Segments creates independent iterators; iterators retain their own position.
+// https://tc39.es/ecma402/#sec-%segmentsprototype%-@@iterator
+class Segments implements Iterable<SegmentResult> {
+  constructor(
+    private readonly segmenter: Segmenter,
+    private readonly input: string
+  ) {}
 
   [Symbol.iterator](): SegmentIterator {
     return new SegmentIterator(this.segmenter, this.input)
-  }
-
-  next():
-    | {
-        done: boolean
-        value: {
-          segment: string
-          index: number
-          input: string
-          isWordLike?: boolean
-        }
-      }
-    | {
-        done: boolean
-        value: undefined
-      } {
-    //using only the relevant bit of the string
-    let checkString = this.input.substring(this.lastSegmentIndex)
-
-    //loop from the start of the checkString, until exactly length (breaksAt returns break at pos=== lenght)
-    for (let position = 1; position <= checkString.length; position++) {
-      const {breaks, matchingRule} = this.segmenter.breaksAt(
-        position,
-        checkString
-      )
-      if (breaks) {
-        const segment = checkString.substring(0, position)
-        const index = this.lastSegmentIndex
-        this.lastSegmentIndex += position
-
-        return {
-          done: false,
-          value: createSegmentDataObject(
-            this.segmenter,
-            segment,
-            index,
-            this.input,
-            matchingRule
-          ),
-        }
-      }
-    }
-    //no segment was found by the loop, therefore the segmentation is done
-    return {done: true, value: undefined}
   }
 
   containing(positionInput: number):
@@ -515,7 +470,66 @@ class SegmentIterator
   }
 }
 
-export type {SegmentIterator}
+class SegmentIterator
+  implements Iterable<SegmentResult>, Iterator<SegmentResult>
+{
+  private readonly segmenter
+  private lastSegmentIndex
+  private input
+  constructor(segmenter: Segmenter, input: string) {
+    this.segmenter = segmenter
+    this.lastSegmentIndex = 0
+    this.input = input
+  }
+
+  [Symbol.iterator](): SegmentIterator {
+    return this
+  }
+
+  next(): IteratorResult<SegmentResult> {
+    //using only the relevant bit of the string
+    let checkString = this.input.substring(this.lastSegmentIndex)
+
+    //loop from the start of the checkString, until exactly length (breaksAt returns break at pos=== lenght)
+    for (let position = 1; position <= checkString.length; position++) {
+      const {breaks, matchingRule} = this.segmenter.breaksAt(
+        position,
+        checkString
+      )
+      if (breaks) {
+        const segment = checkString.substring(0, position)
+        const index = this.lastSegmentIndex
+        this.lastSegmentIndex += position
+
+        return {
+          done: false,
+          value: createSegmentDataObject(
+            this.segmenter,
+            segment,
+            index,
+            this.input,
+            matchingRule
+          ),
+        }
+      }
+    }
+    //no segment was found by the loop, therefore the segmentation is done
+    return {done: true, value: undefined}
+  }
+}
+
+// %IntlSegmentIteratorPrototype% inherits the standard iterator prototype.
+// https://tc39.es/ecma402/#sec-%intlsegmentiteratorprototype%-object
+Object.setPrototypeOf(
+  SegmentIterator.prototype,
+  Object.getPrototypeOf(Object.getPrototypeOf([][Symbol.iterator]()))
+)
+Object.defineProperty(SegmentIterator.prototype, Symbol.toStringTag, {
+  value: 'Segmenter String Iterator',
+  configurable: true,
+})
+
+export type {Segments, SegmentIterator}
 
 interface SegmenterInternalSlots {
   locale: string

--- a/packages/intl-segmenter/tests/grapheme.test.ts
+++ b/packages/intl-segmenter/tests/grapheme.test.ts
@@ -16,3 +16,37 @@ describe('Granularity grapheme', () => {
     }
   )
 })
+
+it('keeps iterator progress and creates independent iterators', () => {
+  const segments = new Segmenter('en', {granularity: 'grapheme'}).segment('abc')
+  const iterator = segments[Symbol.iterator]()
+  expect(iterator[Symbol.iterator]()).toBe(iterator)
+  expect(iterator.next().value?.segment).toBe('a')
+  expect(Array.from(iterator, item => item.segment)).toEqual(['b', 'c'])
+  expect(iterator.next()).toEqual({done: true, value: undefined})
+  expect(Array.from(iterator)).toEqual([])
+  expect(Array.from(segments, item => item.segment)).toEqual(['a', 'b', 'c'])
+  expect(Array.from(segments, item => item.segment)).toEqual(['a', 'b', 'c'])
+  expect(segments.containing(1)?.segment).toBe('b')
+  expect('next' in segments).toBe(false)
+  expect(Object.prototype.toString.call(iterator)).toBe(
+    '[object Segmenter String Iterator]'
+  )
+  const iteratorPrototype = Object.getPrototypeOf(
+    Object.getPrototypeOf([][Symbol.iterator]())
+  )
+  expect(Object.getPrototypeOf(Object.getPrototypeOf(iterator))).toBe(
+    iteratorPrototype
+  )
+})
+it('resolves a valid locale for default and unsupported requests', () => {
+  for (const locales of [undefined, 'zxx']) {
+    const segmenter = new Segmenter(locales, {granularity: 'grapheme'})
+    expect(segmenter.resolvedOptions().locale).toBe('en')
+    expect(Array.from(segmenter.segment('ab'), item => item.segment)).toEqual([
+      'a',
+      'b',
+    ])
+  }
+  expect(Segmenter.supportedLocalesOf('en')).toEqual(['en'])
+})


### PR DESCRIPTION
Separate the reusable Segments iterable from its stateful iterator. Iterators return themselves and resume correctly. Resolve the default locale to `en` and avoid mutating shared root rules. The nonstandard `next()` method on the Segments result is removed; obtain an iterator with `Symbol.iterator` instead.

Addresses audit findings 18–19 from #7185. Implementation comments cite the relevant specification clauses. Includes focused regression tests and documentation.

Validation: `bazel test //packages/intl-segmenter/...`.
