### PR TITLE
fix(@formatjs/intl-getcanonicallocales): follow locale-list coercion

### DIFF
--- a/docs/src/docs/polyfills/intl-getcanonicallocales.mdx
+++ b/docs/src/docs/polyfills/intl-getcanonicallocales.mdx
@@ -69,3 +69,11 @@ async function polyfill() {
 ## Tests
 
 This library is [test262](https://github.com/tc39/test262/tree/master/test/intl402/Intl/getCanonicalLocales)-compliant.
+
+## Locale-list coercion
+
+`getCanonicalLocales` rejects `null`, coerces array-like lengths once with
+`ToLength`, and accepts string-coercible object entries. Native Locale values
+and values from the installed Locale polyfill use their intrinsic locale tag,
+ignoring overridden instance properties. Objects that merely expose `language`
+and `baseName` are treated as ordinary array-like inputs.

--- a/knowledge-base/007j-polyfill-intl-getcanonicallocales.md
+++ b/knowledge-base/007j-polyfill-intl-getcanonicallocales.md
@@ -65,3 +65,11 @@ export const likelySubtags: Record<string, string> = {
 - Static imports in `index.ts`
 - Used by `parseUnicodeLanguageId()` for locale string parsing and canonicalization
 - No dynamic loading needed — data is small enough to bundle directly
+
+## Locale-list coercion
+
+`getCanonicalLocales` rejects `null`, coerces array-like lengths once with
+`ToLength`, and accepts string-coercible object entries. Native Locale values
+and values from the installed Locale polyfill use their intrinsic locale tag,
+ignoring overridden instance properties. Objects that merely expose `language`
+and `baseName` are treated as ordinary array-like inputs.

--- a/packages/intl-getcanonicallocales/BUILD.bazel
+++ b/packages/intl-getcanonicallocales/BUILD.bazel
@@ -55,6 +55,7 @@ formatjs_library(
     },
     deps = [
         "//:node_modules/@formatjs_generated/cldr.core",
+        "//packages/ecma262-abstract",
         "//packages/ecma402-abstract",
     ],
 )

--- a/packages/intl-getcanonicallocales/index.ts
+++ b/packages/intl-getcanonicallocales/index.ts
@@ -1,31 +1,36 @@
+import {ToString} from '#packages/ecma262-abstract/ToString.js'
 import {CanonicalizeUnicodeLocaleId} from '#packages/intl-getcanonicallocales/canonicalizer.js'
 import {emitUnicodeLocaleId} from '#packages/intl-getcanonicallocales/emitter.js'
 import {parseUnicodeLocaleId} from '#packages/intl-getcanonicallocales/parser.js'
 
-/**
- * Check if value is an Intl.Locale object by checking for [[InitializedLocale]] internal slot
- * We detect this by checking if it's an Intl.Locale instance
- *
- * Per ECMA-402 #sec-canonicalizelocalelist step 7.c:
- * "If Type(kValue) is Object and kValue has an [[InitializedLocale]] internal slot, then
- *  Let tag be kValue.[[Locale]]"
- *
- * https://tc39.es/ecma402/#sec-canonicalizelocalelist
- */
-function isLocaleObject(value: any): value is Intl.Locale {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    typeof value.toString === 'function' &&
-    typeof value.baseName === 'string' &&
-    typeof value.language === 'string'
+// Keep the original intrinsic when Intl.Locale is later replaced by a polyfill.
+const originalLocaleToString =
+  typeof Intl !== 'undefined' ? Intl.Locale?.prototype.toString : undefined
+
+function localeString(value: unknown): string | undefined {
+  if (
+    value === null ||
+    (typeof value !== 'object' && typeof value !== 'function')
   )
+    return undefined
+  // Probe the Locale brand without reading user properties or calling an own toString.
+  // https://tc39.es/ecma402/#sec-canonicalizelocalelist
+  const currentLocaleToString =
+    typeof Intl !== 'undefined' ? Intl.Locale?.prototype.toString : undefined
+  for (const method of [originalLocaleToString, currentLocaleToString]) {
+    if (method) {
+      try {
+        const tag = method.call(value)
+        if (typeof tag === 'string') return tag
+      } catch {
+        // The intrinsic rejects objects without its Locale internal slots.
+      }
+    }
+  }
+  return undefined
 }
 
-/**
- * https://tc39.es/ecma402/#sec-canonicalizelocalelist
- * @param locales
- */
+/** https://tc39.es/ecma402/#sec-canonicalizelocalelist */
 function CanonicalizeLocaleList(
   locales?:
     | string[]
@@ -34,58 +39,37 @@ function CanonicalizeLocaleList(
     | Intl.Locale[]
     | ArrayLike<string | Intl.Locale>
 ): string[] {
-  // Step 1-2: If locales is undefined, return empty list
-  if (locales === undefined) {
-    return []
-  }
-
+  if (locales === undefined) return []
+  if (locales === null) throw new TypeError('Cannot convert null to an object')
+  const singleLocale = localeString(locales)
+  const list =
+    typeof locales === 'string'
+      ? [locales]
+      : singleLocale !== undefined
+        ? [singleLocale]
+        : Object(locales)
+  // LengthOfArrayLike performs ToLength: read once, coerce, truncate, and clamp.
+  // https://tc39.es/ecma262/#sec-lengthofarraylike
+  const length = +list.length
+  const len = isNaN(length)
+    ? 0
+    : Math.min(Math.max(Math.floor(length), 0), 9007199254740991)
   const seen: string[] = []
-
-  // Step 3-4: Handle string or Locale object by wrapping in array
-  // Per spec: "If Type(locales) is String or Type(locales) is Object and locales has an
-  // [[InitializedLocale]] internal slot, then Let O be CreateArrayFromList(« locales »)"
-  if (typeof locales === 'string' || isLocaleObject(locales)) {
-    locales = [locales as string | Intl.Locale]
-  }
-
-  // Step 5-6: Convert to object and get length for array-like objects
-  // Per spec: "Let O be ? ToObject(locales)" and "Let len be ? ToLength(? Get(O, "length"))"
-  const O = Object(locales)
-  const len = typeof O.length === 'number' ? O.length : 0
-
-  // Step 7: Iterate through elements
   for (let k = 0; k < len; k++) {
-    // Check if property exists
-    if (!(k in O)) {
-      continue
+    if (!(k in list)) continue
+    const value = list[k]
+    if (
+      value === null ||
+      !['string', 'object', 'function'].includes(typeof value)
+    ) {
+      throw new TypeError('Locale list entries must be strings or objects')
     }
-
-    const kValue = O[k]
-
-    // Step 7c-d: Extract locale string
-    let tag: string
-    if (typeof kValue === 'string') {
-      tag = kValue
-    } else if (isLocaleObject(kValue)) {
-      // For Intl.Locale objects, use toString() which returns the canonicalized locale
-      tag = kValue.toString()
-    } else {
-      throw new TypeError(
-        `Invalid locale type: expected string or Intl.Locale, got ${typeof kValue}`
-      )
-    }
-
-    // Step 7e-g: Validate and canonicalize
+    const tag = localeString(value) ?? ToString(value)
     const canonicalizedTag = emitUnicodeLocaleId(
       CanonicalizeUnicodeLocaleId(parseUnicodeLocaleId(tag))
     )
-
-    // Step 7h: Deduplicate
-    if (seen.indexOf(canonicalizedTag) < 0) {
-      seen.push(canonicalizedTag)
-    }
+    if (seen.indexOf(canonicalizedTag) < 0) seen.push(canonicalizedTag)
   }
-
   return seen
 }
 

--- a/packages/intl-getcanonicallocales/index.ts
+++ b/packages/intl-getcanonicallocales/index.ts
@@ -14,7 +14,9 @@ function localeString(value: unknown): string | undefined {
   )
     return undefined
   // Probe the Locale brand without reading user properties or calling an own toString.
+  // ECMA-402 §9.2.1 CanonicalizeLocaleList, steps 3–7.
   // https://tc39.es/ecma402/#sec-canonicalizelocalelist
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/negotiation.html#L51-L70
   const currentLocaleToString =
     typeof Intl !== 'undefined' ? Intl.Locale?.prototype.toString : undefined
   for (const method of [originalLocaleToString, currentLocaleToString]) {
@@ -30,7 +32,11 @@ function localeString(value: unknown): string | undefined {
   return undefined
 }
 
-/** https://tc39.es/ecma402/#sec-canonicalizelocalelist */
+/**
+ * ECMA-402 §9.2.1 CanonicalizeLocaleList, steps 3–7.
+ * https://tc39.es/ecma402/#sec-canonicalizelocalelist
+ * https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/negotiation.html#L51-L70
+ */
 function CanonicalizeLocaleList(
   locales?:
     | string[]
@@ -49,7 +55,9 @@ function CanonicalizeLocaleList(
         ? [singleLocale]
         : Object(locales)
   // LengthOfArrayLike performs ToLength: read once, coerce, truncate, and clamp.
+  // ECMA-262 §7.3.18 LengthOfArrayLike, step 1.
   // https://tc39.es/ecma262/#sec-lengthofarraylike
+  // https://github.com/tc39/ecma262/blob/dcf59856a8184792a9e42f0ffb7dc064094a5dcc/spec.html#L6576
   const length = +list.length
   const len = isNaN(length)
     ? 0

--- a/packages/intl-getcanonicallocales/tests/index.test.ts
+++ b/packages/intl-getcanonicallocales/tests/index.test.ts
@@ -112,9 +112,9 @@ describe('Intl.getCanonicalLocales', () => {
       expect(() => getCanonicalLocales([123 as any])).toThrow(TypeError)
     })
 
-    it('should throw TypeError for invalid locale type in array-like', function () {
+    it('should throw RangeError after coercing an invalid object entry', function () {
       const arrayLike = {0: 'en-US', 1: {not: 'a locale'}, length: 2}
-      expect(() => getCanonicalLocales(arrayLike as any)).toThrow(TypeError)
+      expect(() => getCanonicalLocales(arrayLike as any)).toThrow(RangeError)
     })
 
     it('should throw RangeError for invalid locale string', function () {
@@ -132,4 +132,84 @@ describe('Intl.getCanonicalLocales', () => {
       )
     })
   })
+})
+
+it('applies ToObject and reads/coerces array-like length once', () => {
+  expect(() => getCanonicalLocales(null as any)).toThrow(TypeError)
+  let reads = 0
+  expect(
+    getCanonicalLocales({
+      0: 'en',
+      1: 'fr',
+      get length() {
+        reads++
+        return '1.9'
+      },
+    } as any)
+  ).toEqual(['en'])
+  expect(reads).toBe(1)
+  for (const length of [-1, NaN, undefined]) {
+    expect(getCanonicalLocales({0: 'en', length} as any)).toEqual([])
+  }
+  for (const length of [1n, Symbol()]) {
+    expect(() => getCanonicalLocales({length} as any)).toThrow(TypeError)
+  }
+})
+it('coerces object and callable entries with the string hint', () => {
+  const hints: string[] = []
+  const value = {
+    [Symbol.toPrimitive](hint: string) {
+      hints.push(hint)
+      return 'en'
+    },
+  }
+  const callable = Object.assign(() => {}, {toString: () => 'fr'})
+  expect(getCanonicalLocales([value, callable] as any)).toEqual(['en', 'fr'])
+  expect(hints).toEqual(['string'])
+  expect(() => getCanonicalLocales([null] as any)).toThrow(TypeError)
+  expect(() => getCanonicalLocales([Symbol()] as any)).toThrow(TypeError)
+})
+it('reads Locale internal data without invoking overridden properties', () => {
+  const locale = new Intl.Locale('en-US')
+  Object.defineProperties(locale, {
+    toString: {
+      value() {
+        throw new Error('must not call')
+      },
+    },
+    baseName: {
+      get() {
+        throw new Error('must not read')
+      },
+    },
+    language: {
+      get() {
+        throw new Error('must not read')
+      },
+    },
+  })
+  expect(getCanonicalLocales(locale)).toEqual(['en-US'])
+  expect(getCanonicalLocales([locale])).toEqual(['en-US'])
+})
+it('does not identify Locale objects by their visible properties', () => {
+  const reads: string[] = []
+  const list = new Proxy(
+    {0: 'en', length: 1},
+    {
+      get(target, key) {
+        reads.push(String(key))
+        return Reflect.get(target, key)
+      },
+    }
+  )
+  expect(getCanonicalLocales(list)).toEqual(['en'])
+  expect(reads).toEqual(['length', '0'])
+  const fake = {
+    baseName: 'fr',
+    language: 'fr',
+    toString: () => 'fr',
+    0: 'en',
+    length: 1,
+  }
+  expect(getCanonicalLocales(fake)).toEqual(['en'])
 })

--- a/packages/intl-locale/index.ts
+++ b/packages/intl-locale/index.ts
@@ -638,7 +638,9 @@ export class Locale {
 
   public toString(): string {
     // The intrinsic must reject uninitialized receivers before exposing [[Locale]].
+    // ECMA-402 §15.3.15 Intl.Locale.prototype.toString, steps 2–3.
     // https://tc39.es/ecma402/#sec-Intl.Locale.prototype.toString
+    // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/locale.html#L346-L347
     const slots = getInternalSlots(this)
     if (!HasOwnProperty(slots, 'initializedLocale')) {
       throw new TypeError('Error uninitialized locale')

--- a/packages/intl-locale/index.ts
+++ b/packages/intl-locale/index.ts
@@ -637,7 +637,13 @@ export class Locale {
   }
 
   public toString(): string {
-    return getInternalSlots(this).locale
+    // The intrinsic must reject uninitialized receivers before exposing [[Locale]].
+    // https://tc39.es/ecma402/#sec-Intl.Locale.prototype.toString
+    const slots = getInternalSlots(this)
+    if (!HasOwnProperty(slots, 'initializedLocale')) {
+      throw new TypeError('Error uninitialized locale')
+    }
+    return slots.locale
   }
 
   public get baseName(): string {

--- a/packages/intl-locale/tests/index.test.ts
+++ b/packages/intl-locale/tests/index.test.ts
@@ -1,3 +1,4 @@
+import {getCanonicalLocales} from '@formatjs/intl-getcanonicallocales'
 import '@formatjs/intl-getcanonicallocales/polyfill.js'
 import {Locale} from '#packages/intl-locale/index.js'
 import {describe, expect, it, test} from 'vitest'
@@ -265,4 +266,23 @@ test('uses region and subdivision preferences for week data', () => {
   expect(new Locale('en-US-u-fw-sun-rg-gbzzzz').getWeekInfo().firstDay).toBe(7)
   expect(new Locale('en-u-sd-gbeng').getWeekInfo().firstDay).toBe(1)
   expect(new Locale('en-US-u-sd-gbeng').getWeekInfo().firstDay).toBe(7)
+})
+
+test('Locale intrinsic supports canonicalization after polyfill installation', () => {
+  const NativeLocale = Intl.Locale
+  const native = new NativeLocale('fr')
+  const locale = new Locale('en')
+  Object.defineProperty(locale, 'toString', {
+    value() {
+      throw new Error('must not call')
+    },
+  })
+  try {
+    Object.defineProperty(Intl, 'Locale', {value: Locale})
+    expect(getCanonicalLocales(locale as any)).toEqual(['en'])
+    expect(getCanonicalLocales([locale, native] as any)).toEqual(['en', 'fr'])
+    expect(() => Locale.prototype.toString.call({} as any)).toThrow(TypeError)
+  } finally {
+    Object.defineProperty(Intl, 'Locale', {value: NativeLocale})
+  }
 })


### PR DESCRIPTION
Apply ToObject, LengthOfArrayLike, and element ToString to locale-list inputs. Use Locale intrinsics for brand checks so user properties cannot spoof Locale identity or override its stored tag. Support the installed Locale polyfill and preserve access to original native Locale values.

Addresses audit findings 01 from #7185. Implementation comments cite the relevant specification clauses. Includes focused regression tests and documentation.

Validation: `bazel test //packages/intl-getcanonicallocales/... //packages/intl-locale/...`.
