### PR TITLE
docs: link ECMA-402 audit fixes and validation

### DIFF
--- a/knowledge-base/013-ecma402-audit-2026-09-06.md
+++ b/knowledge-base/013-ecma402-audit-2026-09-06.md
@@ -9,7 +9,7 @@ This is a tracking audit, not a conformance certification. All 12 polyfill packa
 - Runtime: Bazel 9.2.0, Bazel-managed Node 24.14.0, macOS arm64. Dynamic polyfills received Bazel-generated English locale data explicitly. Static-data polyfills used their bundled data.
 - Scope: API contracts, coercion, option validation, locale metadata, and iterator behavior. This did not exhaust every locale, CLDR value, calendar, timezone transition, rounding combination, Unicode segmentation rule, collation tailoring, or browser/runtime combination. A passing test is not proof of full draft compliance.
 
-## Validation and coverage gaps
+## Baseline validation and coverage gaps
 
 All **12 package unit-test targets passed**. See [initial focused run](https://formatjs.buildbuddy.io/invocation/ec0af2e6-f7b5-41ee-987b-76f7c06d78cd) and [remaining units plus Test262](https://formatjs.buildbuddy.io/invocation/582c0131-9566-40eb-9204-e60ac1ba4a44).
 
@@ -31,9 +31,58 @@ No runnable Test262 target is wired in the inspected package BUILD files for Col
 - [ ] Wire the five missing API suites; remove manual exclusions as each suite becomes reliable.
 - [ ] Add current-draft regression cases below before changing implementations.
 
+## Fix PRs
+
+All 22 findings have implementation and regression coverage in the
+[13-PR stack](https://github.com/formatjs/formatjs/pull/7186). Each PR contains
+code comments citing the specification clauses being fixed. These changes are
+submitted for review; findings remain unchecked until their fixes merge.
+
+| Findings | Fix PR                                                  | Scope                                  |
+| -------- | ------------------------------------------------------- | -------------------------------------- |
+| 01       | [#7199](https://github.com/formatjs/formatjs/pull/7199) | Locale-list coercion and branding      |
+| 02       | [#7187](https://github.com/formatjs/formatjs/pull/7187) | supportedValuesOf key coercion         |
+| 03       | [#7186](https://github.com/formatjs/formatjs/pull/7186) | Number-only coercion boundaries        |
+| 04       | [#7190](https://github.com/formatjs/formatjs/pull/7190) | Numbering-system negotiation           |
+| 05–06    | [#7191](https://github.com/formatjs/formatjs/pull/7191) | Collator validation and coercion       |
+| 07       | [#7192](https://github.com/formatjs/formatjs/pull/7192) | Offset time zones                      |
+| 08–09    | [#7193](https://github.com/formatjs/formatjs/pull/7193) | DisplayNames codes                     |
+| 10       | [#7189](https://github.com/formatjs/formatjs/pull/7189) | ListFormat iteration                   |
+| 11–12    | [#7195](https://github.com/formatjs/formatjs/pull/7195) | Locale weekday and numeric options     |
+| 13–14    | [#7196](https://github.com/formatjs/formatjs/pull/7196) | Locale week info                       |
+| 15–17    | [#7197](https://github.com/formatjs/formatjs/pull/7197) | PluralRules draft options and ranges   |
+| 18–19    | [#7198](https://github.com/formatjs/formatjs/pull/7198) | Segmenter iteration and default locale |
+| 20–22    | [#7194](https://github.com/formatjs/formatjs/pull/7194) | Duration record validation             |
+
+Compatibility changes are explicit in [#7196](https://github.com/formatjs/formatjs/pull/7196)
+and [#7198](https://github.com/formatjs/formatjs/pull/7198): `getWeekInfo()` no longer
+returns `minimalDays`; `segment()` returns a Segments iterable without the
+nonstandard `next()` method. Obtain its iterator with `Symbol.iterator`.
+The Test262 pin, missing suites, and manual exclusions remain separate follow-ups.
+
+### Fix verification
+
+Verified stack head [`3a3015cccfe6c34366b8b51aee1ef1e12e038672`](https://github.com/formatjs/formatjs/commit/3a3015cccfe6c34366b8b51aee1ef1e12e038672)
+on 2026-09-06: **139 Bazel checks passed**, covering all 12 polyfill packages,
+the shared abstract-operation packages, type declarations, package metadata,
+and the enabled NumberFormat/PluralRules Test262 suites. **43 runtime probes
+passed** against fresh Bazel-built public bundles with generated English data.
+All 28 newly added ECMA-402 comment anchors resolve in the audited draft.
+
+The boolean-duration probe's initial `0 sec` expectation was corrected to an
+empty string: [PartitionDurationFormatPattern](https://tc39.es/ecma402/#sec-partitiondurationformatpattern)
+omits zero-valued units under the default `auto` display settings. The regression
+test verifies that `{seconds: false}` formats identically to `{seconds: 0}`.
+
+```bash
+bazel test //packages/intl-{collator,datetimeformat,displaynames,durationformat,getcanonicallocales,listformat,locale,numberformat,pluralrules,relativetimeformat,segmenter,supportedvaluesof}/... \
+  //packages/ecma402-abstract/... //packages/ecma262-abstract/... \
+  --test_output=errors
+```
+
 ## Findings
 
-All findings are **P2 correctness issues**. IDs are stable tracking references. Mark a finding complete only after regression tests cover the listed cases and the relevant focused suites pass. Constructor names below refer to the polyfill exports, not native `Intl` implementations.
+All findings are **P2 correctness issues**. IDs are stable tracking references. Mark a finding complete only after its fix merges, regression tests cover the listed cases, and the relevant focused suites pass. Constructor names below refer to the polyfill exports, not native `Intl` implementations.
 
 ### 01. Canonicalize locale-list inputs
 


### PR DESCRIPTION
Link all 22 audit findings to their 13 fix PRs and record validation: 139 Bazel checks and 43 runtime probes passed. Findings remain open until their fixes merge.

Calls out the Locale and Segmenter compatibility changes and corrects the audit probe's zero-duration display expectation. The older Test262 pin and missing/manual suites remain separate follow-ups.
