### PR TITLE
fix(@formatjs/intl-numberformat): accept callable option objects

### DIFF
--- a/docs/src/docs/polyfills/intl-numberformat.mdx
+++ b/docs/src/docs/polyfills/intl-numberformat.mdx
@@ -337,3 +337,13 @@ The library will choose the best-fit localized pattern to format this compound u
 
 A well-formed but unsupported `numberingSystem` option falls back to the locale's
 supported numbering system. Only malformed Unicode type identifiers throw `RangeError`.
+
+## Callable options
+
+Options can be function objects with formatting properties. The constructor
+reads those properties without calling the function.
+
+```tsx
+const options = Object.assign(() => {}, {maximumFractionDigits: 2})
+new Intl.NumberFormat('en', options).format(1.234) // '1.23'
+```

--- a/knowledge-base/007-package-intl-polyfills.md
+++ b/knowledge-base/007-package-intl-polyfills.md
@@ -76,3 +76,9 @@ All polyfills depend on `@formatjs/ecma402-abstract` and `@formatjs/intl-localem
 - [007j — intl-getcanonicallocales](./007j-polyfill-intl-getcanonicallocales.md) — ECMA-402 §8.2.1
 - [007k — intl-supportedvaluesof](./007k-polyfill-intl-supportedvaluesof.md) — ECMA-402 §8.3.2
 - [007l — intl-collator](./007l-polyfill-intl-collator.md) — ECMA-402 §10 (CLDR collation compiler)
+
+## Option objects
+
+Shared option helpers accept callable objects without invoking them. Property
+getters run normally and their errors propagate. `GetOptionsObject` rejects
+`null` and other primitives, while omitted options create a fresh empty object.

--- a/packages/ecma402-abstract/BUILD.bazel
+++ b/packages/ecma402-abstract/BUILD.bazel
@@ -42,6 +42,7 @@ formatjs_test(
         "tests/FormatApproximately.test.ts",
         "tests/FormatNumericRange.test.ts",
         "tests/FormatNumericRangeToParts.test.ts",
+        "tests/GetOptionsObject.test.ts",
         "tests/GetStringOrBooleanOption.test.ts",
         "tests/GetUnsignedRoundingMode.test.ts",
         "tests/IsUnicodeLocaleIdentifierType.test.ts",

--- a/packages/ecma402-abstract/GetOption.ts
+++ b/packages/ecma402-abstract/GetOption.ts
@@ -15,7 +15,13 @@ export function GetOption<T extends object, K extends keyof T, F>(
   values: readonly T[K][] | undefined,
   fallback: F
 ): Exclude<T[K], undefined> | F {
-  if (typeof opts !== 'object') {
+  // ECMA-402 §9.2.11 GetOption, step 1: Get accepts callable Objects too.
+  // https://tc39.es/ecma402/#sec-getoption
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/negotiation.html#L384
+  if (
+    opts === null ||
+    (typeof opts !== 'object' && typeof opts !== 'function')
+  ) {
     throw new TypeError('Options must be an object')
   }
   let value: any = opts[prop]

--- a/packages/ecma402-abstract/GetOptionsObject.ts
+++ b/packages/ecma402-abstract/GetOptionsObject.ts
@@ -1,5 +1,7 @@
 /**
- * https://tc39.es/ecma402/#sec-getoptionsobject
+ * ECMA-262 §7.3.36 GetOptionsObject, steps 2–3.
+ * https://tc39.es/ecma262/#sec-getoptionsobject
+ * https://github.com/tc39/ecma262/blob/dcf59856a8184792a9e42f0ffb7dc064094a5dcc/spec.html#L7008-L7010
  * @param options
  * @returns
  */
@@ -7,7 +9,11 @@ export function GetOptionsObject<T extends object>(options?: T): T {
   if (typeof options === 'undefined') {
     return Object.create(null)
   }
-  if (typeof options === 'object') {
+  // Functions are Objects; null is not.
+  if (
+    options !== null &&
+    (typeof options === 'object' || typeof options === 'function')
+  ) {
     return options
   }
   throw new TypeError('Options must be an object')

--- a/packages/ecma402-abstract/tests/GetOptionsObject.test.ts
+++ b/packages/ecma402-abstract/tests/GetOptionsObject.test.ts
@@ -1,0 +1,54 @@
+import {GetOption} from '#packages/ecma402-abstract/GetOption.js'
+import {GetOptionsObject} from '#packages/ecma402-abstract/GetOptionsObject.js'
+import {expect, it} from 'vitest'
+
+it('reads callable options without invoking them', () => {
+  let reads = 0
+  const options = Object.defineProperty(
+    () => {
+      throw new Error('called')
+    },
+    'style',
+    {
+      get() {
+        reads++
+        return 'short'
+      },
+    }
+  ) as (() => never) & {style: string}
+  expect(GetOptionsObject(options)).toBe(options)
+  expect(reads).toBe(0)
+  expect(GetOption(options, 'style', 'string', ['short', 'long'], 'long')).toBe(
+    'short'
+  )
+  expect(reads).toBe(1)
+})
+
+it('preserves errors from callable option getters', () => {
+  const error = new Error('getter')
+  const options = Object.defineProperty(() => {}, 'style', {
+    get() {
+      throw error
+    },
+  }) as (() => void) & {style: string}
+  expect.assertions(1)
+  try {
+    GetOption(options, 'style', 'string', undefined, 'long')
+  } catch (caught) {
+    expect(caught).toBe(error)
+  }
+})
+
+it.each([null, true, 1, 'short', BigInt(1), Symbol('option')])(
+  'rejects non-object options: %s',
+  value => {
+    expect(() => GetOptionsObject(value as never)).toThrow(TypeError)
+  }
+)
+
+it('creates fresh empty options when omitted', () => {
+  const options = GetOptionsObject()
+  expect(Object.getPrototypeOf(options)).toBe(null)
+  expect(Reflect.ownKeys(options)).toEqual([])
+  expect(GetOptionsObject()).not.toBe(options)
+})

--- a/packages/intl-numberformat/tests/misc.test.ts
+++ b/packages/intl-numberformat/tests/misc.test.ts
@@ -505,3 +505,16 @@ it('negotiates well-formed numbering systems and rejects malformed ones', () => 
     expect(() => new NumberFormat('en', {numberingSystem})).toThrow(RangeError)
   }
 })
+
+test('accepts callable options and reads their properties', () => {
+  const options = Object.assign(
+    () => {
+      throw new Error('called')
+    },
+    {
+      maximumFractionDigits: 2,
+      useGrouping: false,
+    }
+  )
+  expect(new NumberFormat('en', options).format(1234.567)).toBe('1234.57')
+})


### PR DESCRIPTION
Callable options such as `Object.assign(() => {}, {maximumFractionDigits: 2})` currently throw. Accept functions in the shared option helpers, preserve getter behavior, and reject null in `GetOptionsObject`.

Spec comments cite [ECMA-402 §9.2.11 GetOption, step 1](https://tc39.es/ecma402/#sec-getoption) ([source line 384](https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/negotiation.html#L384)) and [ECMA-262 §7.3.36 GetOptionsObject, steps 2–3](https://tc39.es/ecma262/#sec-getoptionsobject) ([source lines 7008–7010](https://github.com/tc39/ecma262/blob/dcf59856a8184792a9e42f0ffb7dc064094a5dcc/spec.html#L7008-L7010)).

Regression tests cover callable property reads, getter error identity, primitive rejection, and public NumberFormat output. Public docs and the knowledge base describe the behavior.

Validation: all 139 Bazel checks across the 12 polyfills and shared ECMA-402/262 helpers passed. All 15 public-bundle follow-up probes passed on the stack tip. Repository commit hooks passed.
