### PR TITLE
fix(@formatjs/intl-segmenter): reject coerced BigInt indices

### DIFF
--- a/docs/src/docs/polyfills/intl-segmenter.mdx
+++ b/docs/src/docs/polyfills/intl-segmenter.mdx
@@ -204,3 +204,7 @@ async function polyfill(locale: string) {
 from `Symbol.iterator` and resumes from its current position. `next()` belongs
 to the iterator, not the iterable returned by `segment()`.
 The fallback locale is `en`, backed by the root segmentation rules.
+
+`containing(index)` coerces its index to a number and truncates toward zero.
+BigInt values throw `TypeError`, including boxed BigInts and objects that
+coerce to BigInt. Errors thrown during coercion propagate unchanged.

--- a/knowledge-base/007h-polyfill-intl-segmenter.md
+++ b/knowledge-base/007h-polyfill-intl-segmenter.md
@@ -75,3 +75,7 @@ export const CLDR_SEGMENTATION_RULES: Record<Granularity, Record<Locale, RuleSet
 from `Symbol.iterator` and resumes from its current position. `next()` belongs
 to the iterator, not the iterable returned by `segment()`.
 The fallback locale is `en`, backed by the root segmentation rules.
+
+`containing(index)` coerces its index to a number and truncates toward zero.
+BigInt values throw `TypeError`, including boxed BigInts and objects that
+coerce to BigInt. Errors thrown during coercion propagate unchanged.

--- a/packages/intl-segmenter/segmenter.ts
+++ b/packages/intl-segmenter/segmenter.ts
@@ -420,11 +420,14 @@ class Segments implements Iterable<SegmentResult> {
         isWordLike?: boolean
       }
     | undefined {
-    if (typeof positionInput === 'bigint') {
-      throw TypeError('Index must not be a BigInt')
-    }
-
-    let position = Number(positionInput)
+    // ECMA-402 §19.5.2.1 containing, step 6: ToIntegerOrInfinity uses ToNumber.
+    // https://tc39.es/ecma402/#sec-%intlsegmentsprototype%.containing
+    // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/segmenter.html#L214
+    // Unary + rejects BigInt after object coercion and preserves thrown errors.
+    // ECMA-262 §7.1.4 ToNumber, steps 2, 8–10.
+    // https://tc39.es/ecma262/#sec-tonumber
+    // https://github.com/tc39/ecma262/blob/dcf59856a8184792a9e42f0ffb7dc064094a5dcc/spec.html#L5183-L5191
+    let position = +positionInput
 
     //https://tc39.es/ecma262/#sec-tointegerorinfinity
     // 2. If number is NaN, +0𝔽, or -0𝔽, return 0.

--- a/packages/intl-segmenter/tests/grapheme.test.ts
+++ b/packages/intl-segmenter/tests/grapheme.test.ts
@@ -50,3 +50,55 @@ it('resolves a valid locale for default and unsupported requests', () => {
   }
   expect(Segmenter.supportedLocalesOf('en')).toEqual(['en'])
 })
+
+it.each([
+  BigInt(0),
+  Object(BigInt(0)),
+  {valueOf: () => BigInt(0)},
+  {[Symbol.toPrimitive]: () => BigInt(0)},
+])('rejects BigInt indices after coercion: %s', index => {
+  const segments = new Segmenter('en', {}).segment('ab')
+  expect(() => segments.containing(index as number)).toThrow(TypeError)
+})
+
+it('coerces containing indices once with the number hint', () => {
+  const hints: string[] = []
+  const index = {
+    [Symbol.toPrimitive](hint: string) {
+      hints.push(hint)
+      return 1.9
+    },
+  }
+  const segments = new Segmenter('en', {}).segment('ab')
+  expect(segments.containing(index as unknown as number)?.segment).toBe('b')
+  expect(hints).toEqual(['number'])
+})
+
+it('preserves errors thrown while coercing containing indices', () => {
+  const error = new Error('coercion')
+  const index = {
+    valueOf() {
+      throw error
+    },
+  }
+  const segments = new Segmenter('en', {}).segment('ab')
+  expect.assertions(1)
+  try {
+    segments.containing(index as unknown as number)
+  } catch (caught) {
+    expect(caught).toBe(error)
+  }
+})
+
+it.each([
+  [undefined, 'a'],
+  [NaN, 'a'],
+  [-0, 'a'],
+  [-0.5, 'a'],
+  ['1.9', 'b'],
+  [Infinity, undefined],
+  [-Infinity, undefined],
+])('handles containing index %s', (index, expected) => {
+  const segments = new Segmenter('en', {}).segment('ab')
+  expect(segments.containing(index as number)?.segment).toBe(expected)
+})


### PR DESCRIPTION
`segment('ab').containing(Object(0n))` currently returns the first segment. Use unary numeric coercion so primitive, boxed, and object-produced BigInts throw `TypeError`, as required by ToIntegerOrInfinity.

Spec comments cite [ECMA-402 §19.5.2.1, step 6](https://tc39.es/ecma402/#sec-%intlsegmentsprototype%.containing) ([source line 214](https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/segmenter.html#L214)) and [ECMA-262 §7.1.4 ToNumber, steps 2 and 8–10](https://tc39.es/ecma262/#sec-tonumber) ([source lines 5183–5191](https://github.com/tc39/ecma262/blob/dcf59856a8184792a9e42f0ffb7dc064094a5dcc/spec.html#L5183-L5191)).

Regression tests cover BigInt coercion paths, the number hint, single coercion, thrown error identity, fractions, NaN, and infinities. Public docs and the knowledge base describe index coercion.

Validation: all 139 Bazel checks across the 12 polyfills and shared ECMA-402/262 helpers passed. All 15 public-bundle follow-up probes passed on the stack tip. Repository commit hooks passed.
