### PR TITLE
fix(@formatjs/intl-numberformat): validate internal receiver branding

### DIFF
--- a/docs/src/docs/polyfills/intl-numberformat.mdx
+++ b/docs/src/docs/polyfills/intl-numberformat.mdx
@@ -389,3 +389,10 @@ They have no own `prototype` property.
 `roundingPriority` compares rounding precision before trailing-zero removal.
 With `minimumSignificantDigits: 2` and `minimumFractionDigits: 2`, formatting `1`
 yields `"1.0"` for `"morePrecision"` and `"1.00"` for `"lessPrecision"`.
+
+### Receiver validation
+
+Formatting methods require an initialized NumberFormat receiver. Plain objects,
+objects inheriting NumberFormat.prototype, and proxies around instances throw
+`TypeError` before argument conversion. Changing a real instance's prototype does
+not remove its internal brand.

--- a/knowledge-base/014-test262-conformance.md
+++ b/knowledge-base/014-test262-conformance.md
@@ -14,13 +14,13 @@ excluded because it fails.
 | getcanonicallocales |       76 |                32 |               2 |
 | listformat          |      162 |                 4 |               0 |
 | locale              |      336 |                46 |              26 |
-| numberformat        |      498 |                30 |               2 |
+| numberformat        |      498 |                26 |               2 |
 | pluralrules         |      106 |                 4 |              16 |
 | relativetimeformat  |      160 |                14 |               2 |
 | segmenter           |      158 |                10 |               0 |
 | supportedvaluesof   |       50 |                 8 |               8 |
 
-Total: 2,498 executions, 1,966 polyfill passes, 532 polyfill failures. The native
+Total: 2,498 executions, 1,970 polyfill passes, 528 polyfill failures. The native
 control fails 238 executions; 200 failing cases overlap. Overlap does not prove
 a polyfill is correct: each failure still needs comparison with the selected
 spec and test's feature metadata.
@@ -85,3 +85,6 @@ and supportedLocalesOf.
 ToRawPrecision reports `e - p + 1` as its rounding magnitude. Reporting only
 `e` incorrectly favored fraction digits for morePrecision and significant digits
 for lessPrecision when both digit constraints were present.
+
+NumberFormat internal-slot reads no longer allocate records. Only constructor
+initialization can create a brand; formatting methods validate it before coercion.

--- a/packages/intl-numberformat/core.ts
+++ b/packages/intl-numberformat/core.ts
@@ -66,7 +66,7 @@ export const NumberFormat = function (
   }
 
   InitializeNumberFormat(this as any, locales, options, {
-    getInternalSlots,
+    getInternalSlots: nf => getInternalSlots(nf, true),
     localeData: NumberFormat.localeData,
     availableLocales: NumberFormat.availableLocales,
     getDefaultLocale: NumberFormat.getDefaultLocale,
@@ -98,6 +98,10 @@ export const NumberFormat = function (
 // https://github.com/tc39/ecma262/blob/b7865f0eed2021720f84d561289401bc414874d0/spec.html#L30375-L30385
 const {formatToParts, formatRange, formatRangeToParts} = {
   formatToParts(this: Intl.NumberFormat, x: number | bigint | Decimal) {
+    // ECMA-402 §16.3.6 step 2 precedes argument conversion in step 3.
+    // https://tc39.es/ecma402/#sec-intl.numberformat.prototype.formattoparts
+    // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/numberformat.html#L492-L493
+    getInternalSlots(this)
     return FormatNumericToParts(this, ToIntlMathematicalValue(x), {
       getInternalSlots,
     })
@@ -108,6 +112,7 @@ const {formatToParts, formatRange, formatRangeToParts} = {
     start: number | bigint | Decimal,
     end: number | bigint | Decimal
   ) {
+    getInternalSlots(this)
     // ECMA-402 §16.3.4, step 3: reject missing endpoints before coercion.
     // https://tc39.es/ecma402/#sec-intl.numberformat.prototype.formatrange
     // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/numberformat.html#L463-L465
@@ -129,6 +134,7 @@ const {formatToParts, formatRange, formatRangeToParts} = {
     start: number | bigint | Decimal,
     end: number | bigint | Decimal
   ) {
+    getInternalSlots(this)
     // ECMA-402 §16.3.5, step 3: reject missing endpoints before coercion.
     // https://tc39.es/ecma402/#sec-intl.numberformat.prototype.formatrangetoparts
     // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/numberformat.html#L478-L480
@@ -160,11 +166,6 @@ defineProperty(NumberFormat.prototype, 'formatRangeToParts', {
 
 const {resolvedOptions} = {
   resolvedOptions() {
-    if (typeof this !== 'object' || !OrdinaryHasInstance(NumberFormat, this)) {
-      throw TypeError(
-        'Method Intl.NumberFormat.prototype.resolvedOptions called on incompatible receiver'
-      )
-    }
     const internalSlots = getInternalSlots(this as any)
     const ro: Record<string, unknown> = {}
     for (const key of RESOLVED_OPTIONS_KEYS) {
@@ -192,11 +193,6 @@ const formatDescriptor = {
   enumerable: false,
   configurable: true,
   get(this: NumberFormat) {
-    if (typeof this !== 'object' || !OrdinaryHasInstance(NumberFormat, this)) {
-      throw TypeError(
-        'Intl.NumberFormat format property accessor called on incompatible receiver'
-      )
-    }
     const internalSlots = getInternalSlots(this as any)
     let boundFormat = internalSlots.boundFormat
     if (boundFormat === undefined) {

--- a/packages/intl-numberformat/get_internal_slots.ts
+++ b/packages/intl-numberformat/get_internal_slots.ts
@@ -5,12 +5,19 @@ import {type NumberFormatInternal} from '#packages/ecma402-abstract/types/number
 const internalSlotMap = new WeakMap<Intl.NumberFormat, NumberFormatInternal>()
 
 export default function getInternalSlots(
-  x: Intl.NumberFormat
+  x: Intl.NumberFormat,
+  initialize = false
 ): NumberFormatInternal {
   let internalSlots = internalSlotMap.get(x)
-  if (!internalSlots) {
+  if (!internalSlots && initialize) {
     internalSlots = Object.create(null) as NumberFormatInternal
     internalSlotMap.set(x, internalSlots)
+  }
+  // ECMA-402 §16.3.3 step 3: require the receiver's internal brand.
+  // https://tc39.es/ecma402/#sec-intl.numberformat.prototype.format
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/numberformat.html#L438-L441
+  if (!internalSlots) {
+    throw new TypeError('Receiver is not an initialized Intl.NumberFormat')
   }
   return internalSlots
 }

--- a/packages/intl-numberformat/test262-baseline.json
+++ b/packages/intl-numberformat/test262-baseline.json
@@ -1,8 +1,8 @@
 {
   "total": 498,
   "failures": {
-    "intl402/NumberFormat/intl-legacy-constructed-symbol-on-unwrap.js (default)": "Expected SameValue(«\"object\"», «\"symbol\"») to be true",
-    "intl402/NumberFormat/intl-legacy-constructed-symbol-on-unwrap.js (strict mode)": "Expected SameValue(«\"object\"», «\"symbol\"») to be true",
+    "intl402/NumberFormat/intl-legacy-constructed-symbol-on-unwrap.js (default)": "Expected no error, got TypeError: Receiver is not an initialized Intl.NumberFormat",
+    "intl402/NumberFormat/intl-legacy-constructed-symbol-on-unwrap.js (strict mode)": "Expected no error, got TypeError: Receiver is not an initialized Intl.NumberFormat",
     "intl402/NumberFormat/intl-legacy-constructed-symbol-property.js (default)": "value of legacy symbol property must be an Intl.NumberFormat",
     "intl402/NumberFormat/intl-legacy-constructed-symbol-property.js (strict mode)": "value of legacy symbol property must be an Intl.NumberFormat",
     "intl402/NumberFormat/intl-legacy-constructed-symbol.js (default)": "Expected true but got false",
@@ -11,8 +11,6 @@
     "intl402/NumberFormat/legacy-regexp-statics-not-modified.js (strict mode)": "RegExp has unexpected property $_ with value de-DE-u-nu-latn.",
     "intl402/NumberFormat/proto-from-ctor-realm.js (default)": "newTarget.prototype is undefined Expected SameValue(«[object Intl.NumberFormat]», «[object Intl.NumberFormat]») to be true",
     "intl402/NumberFormat/proto-from-ctor-realm.js (strict mode)": "newTarget.prototype is undefined Expected SameValue(«[object Intl.NumberFormat]», «[object Intl.NumberFormat]») to be true",
-    "intl402/NumberFormat/prototype/format/no-instanceof.js (default)": "Expected a TypeError to be thrown but no exception was thrown at all",
-    "intl402/NumberFormat/prototype/format/no-instanceof.js (strict mode)": "Expected a TypeError to be thrown but no exception was thrown at all",
     "intl402/NumberFormat/prototype/format/numbering-systems.js (default)": "numberingSystem: adlm, digit: 0 Expected SameValue(«\"0\"», «\"𞥐\"») to be true",
     "intl402/NumberFormat/prototype/format/numbering-systems.js (strict mode)": "numberingSystem: adlm, digit: 0 Expected SameValue(«\"0\"», «\"𞥐\"») to be true",
     "intl402/NumberFormat/prototype/format/useGrouping-en-IN.js (default)": "(omitted) Expected SameValue(«\"100,000\"», «\"1,00,000\"») to be true",
@@ -25,8 +23,6 @@
     "intl402/NumberFormat/prototype/formatRange/pt-PT.js (strict mode)": "Expected SameValue(«\"‏3–‏5 €\"», «\"3 - 5 €\"») to be true",
     "intl402/NumberFormat/prototype/formatRangeToParts/en-US.js (default)": "value for entry 2 Expected SameValue(«\"–\"», «\" – \"») to be true",
     "intl402/NumberFormat/prototype/formatRangeToParts/en-US.js (strict mode)": "value for entry 2 Expected SameValue(«\"–\"», «\" – \"») to be true",
-    "intl402/NumberFormat/prototype/resolvedOptions/no-instanceof.js (default)": "Expected a TypeError to be thrown but no exception was thrown at all",
-    "intl402/NumberFormat/prototype/resolvedOptions/no-instanceof.js (strict mode)": "Expected a TypeError to be thrown but no exception was thrown at all",
     "intl402/NumberFormat/prototype/resolvedOptions/resolved-numbering-system-unicode-extensions-and-options.js (default)": "Resolved locale for locale=en-u-nu-arab with numberingSystem=invalid Expected SameValue(«\"en\"», «\"en-u-nu-arab\"») to be true",
     "intl402/NumberFormat/prototype/resolvedOptions/resolved-numbering-system-unicode-extensions-and-options.js (strict mode)": "Resolved locale for locale=en-u-nu-arab with numberingSystem=invalid Expected SameValue(«\"en\"», «\"en-u-nu-arab\"») to be true",
     "intl402/NumberFormat/prototype/resolvedOptions/return-keys-order-default.js (default)": "Actual [locale, numberingSystem, style, currency, currencyDisplay, currencySign, minimumIntegerDigits, minimumFractionDigits, maximumFractionDigits, minimumSignificantDigits, maximumSignificantDigits, useGrouping, notation, compactDisplay, signDisplay, roundingIncrement, roundingMode, trailingZeroDisplay, roundingPriority] and expected [locale, numberingSystem, style, currency, currencyDisplay, currencySign, minimumIntegerDigits, minimumFractionDigits, maximumFractionDigits, minimumSignificantDigits, maximumSignificantDigits, useGrouping, notation, compactDisplay, signDisplay, roundingIncrement, roundingMode, roundingPriority, trailingZeroDisplay] should have the same contents. resolvedOptions() property key order with options {\"notation\":\"compact\",\"style\":\"currency\",\"currency\":\"XTS\"}",

--- a/packages/intl-numberformat/tests/misc.test.ts
+++ b/packages/intl-numberformat/tests/misc.test.ts
@@ -701,3 +701,60 @@ describe('rounding priority precision', () => {
     }
   )
 })
+
+describe('NumberFormat receiver branding', () => {
+  const format = Object.getOwnPropertyDescriptor(
+    NumberFormat.prototype,
+    'format'
+  )!.get!
+  it('rejects inherited and proxied receivers without coercing arguments', () => {
+    const value = {
+      valueOf() {
+        throw new Error('must not coerce')
+      },
+    }
+    const receivers = [
+      undefined,
+      null,
+      1,
+      Symbol(),
+      {},
+      Object.create(NumberFormat.prototype),
+      new Proxy(new NumberFormat('en'), {}),
+    ]
+    for (const receiver of receivers) {
+      for (let attempt = 0; attempt < 2; attempt++) {
+        expect(() => format.call(receiver)).toThrow(TypeError)
+        expect(() =>
+          NumberFormat.prototype.resolvedOptions.call(receiver)
+        ).toThrow(TypeError)
+        expect(() =>
+          NumberFormat.prototype.formatToParts.call(receiver, value as any)
+        ).toThrow(TypeError)
+        expect(() =>
+          NumberFormat.prototype.formatRange.call(
+            receiver,
+            value as any,
+            value as any
+          )
+        ).toThrow(TypeError)
+        expect(() =>
+          NumberFormat.prototype.formatRangeToParts.call(
+            receiver,
+            value as any,
+            value as any
+          )
+        ).toThrow(TypeError)
+      }
+    }
+  })
+
+  it('accepts a branded receiver after its prototype changes', () => {
+    const formatter = new NumberFormat('en')
+    Object.setPrototypeOf(formatter, null)
+    expect(format.call(formatter)(123)).toBe('123')
+    expect(NumberFormat.prototype.resolvedOptions.call(formatter).locale).toBe(
+      'en'
+    )
+  })
+})


### PR DESCRIPTION
NumberFormat slot reads previously created empty records for invalid receivers. Reads now require an existing internal brand; only initialization creates records. Formatting methods validate receivers before coercing values and accept genuine instances after their prototype changes.

Comments cite ECMA-402 receiver checks with pinned source lines. Regressions cover inherited objects, proxies, primitives, repeated invalid calls, coercion order, and changed prototypes.

Validation: all 19 NumberFormat unit/package gates passed. Test262 gained four passes with no new failures. Two existing normative-optional legacy-constructor failures now report brand rejection instead of a symbol assertion; both remain in the baseline. Aggregate: 1,970/2,498 pass, 528 remain.
