### PR TITLE
fix(@formatjs/intl-durationformat): retain zero minutes between numeric fields

### DIFF
--- a/docs/src/docs/polyfills/intl-durationformat.mdx
+++ b/docs/src/docs/polyfills/intl-durationformat.mdx
@@ -218,3 +218,6 @@ input Number's exact integer value, including values beyond the safe-integer ran
 A numeric time style propagates through smaller units. Minutes and seconds
 remain displayed by default; smaller fractional units use `auto`. Fractional
 units cannot request `always` display or be followed by a textual unit style.
+
+Zero minutes remain between displayed numeric hours and seconds, even with
+`minutesDisplay: "auto"`. For example, `{hours: 1, seconds: 1}` formats as `"1:00:01"`.

--- a/knowledge-base/014-test262-conformance.md
+++ b/knowledge-base/014-test262-conformance.md
@@ -10,7 +10,7 @@ excluded because it fails.
 | collator            |      130 |                18 |               0 |
 | datetimeformat      |      488 |               242 |              52 |
 | displaynames        |      114 |                 6 |               0 |
-| durationformat      |      220 |                18 |               4 |
+| durationformat      |      220 |                14 |               4 |
 | getcanonicallocales |       76 |                32 |               2 |
 | listformat          |      162 |                 4 |               0 |
 | locale              |      336 |                46 |              22 |
@@ -20,7 +20,7 @@ excluded because it fails.
 | segmenter           |      158 |                10 |               0 |
 | supportedvaluesof   |       50 |                 8 |               6 |
 
-Total: 2,498 executions, 2,070 polyfill passes, 428 polyfill failures. The native
+Total: 2,498 executions, 2,074 polyfill passes, 424 polyfill failures. The native
 control fails 86 executions; 68 failing cases overlap. Overlap does not prove
 a polyfill is correct: each failure still needs comparison with the selected
 spec and test's feature metadata.
@@ -116,3 +116,6 @@ instead of their shortest rounded decimal representation.
 GetDurationUnitOptions propagates numeric/fractional styles before reading display
 options and validates fractional units after normalization. Default minutes and
 seconds stay displayed when following a numeric time unit.
+
+Numeric duration formatting retains zero minutes between displayed hours and
+seconds, considering sub-second values before rounding when deciding visibility.

--- a/packages/intl-durationformat/abstract/PartitionDurationFormatPattern.ts
+++ b/packages/intl-durationformat/abstract/PartitionDurationFormatPattern.ts
@@ -91,7 +91,23 @@ export function PartitionDurationFormatPattern(
         done = true
       }
     }
-    if (!value.isZero() || display !== 'auto') {
+    // ECMA-402 §13.5.12, step 15.a: keep zero minutes between displayed
+    // numeric hours and seconds, even when minutesDisplay is auto.
+    // https://tc39.es/ecma402/#sec-formatnumericunits
+    // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/durationformat.html#L863-L864
+    const minutesBetweenHoursAndSeconds =
+      unit === 'minutes' &&
+      separated &&
+      (internalSlots.secondsDisplay === 'always' ||
+        duration.seconds !== 0 ||
+        duration.milliseconds !== 0 ||
+        duration.microseconds !== 0 ||
+        duration.nanoseconds !== 0)
+    if (
+      !value.isZero() ||
+      display !== 'auto' ||
+      minutesBetweenHoursAndSeconds
+    ) {
       // ECMA-402 §13.5.15 step 4.h.iii.2 and §13.5.12 steps 16–18:
       // display the duration sign once, including on a leading zero unit.
       // https://tc39.es/ecma402/#sec-partitiondurationformatpattern

--- a/packages/intl-durationformat/test262-baseline.json
+++ b/packages/intl-durationformat/test262-baseline.json
@@ -3,10 +3,6 @@
   "failures": {
     "intl402/DurationFormat/constructor-options-numberingSystem-valid.js (default)": "adlm is supported by DurationFormat Expected SameValue(«\"latn\"», «\"adlm\"») to be true",
     "intl402/DurationFormat/constructor-options-numberingSystem-valid.js (strict mode)": "adlm is supported by DurationFormat Expected SameValue(«\"latn\"», «\"adlm\"») to be true",
-    "intl402/DurationFormat/prototype/format/numeric-hour-with-zero-minutes-and-non-zero-seconds-with-auto-display-and-zero-fractional.js (default)": "Duration is {\"hours\":0,\"minutes\":0,\"seconds\":1} Expected SameValue(«\"0, 01\"», «\"0:00:01\"») to be true",
-    "intl402/DurationFormat/prototype/format/numeric-hour-with-zero-minutes-and-non-zero-seconds-with-auto-display-and-zero-fractional.js (strict mode)": "Duration is {\"hours\":0,\"minutes\":0,\"seconds\":1} Expected SameValue(«\"0, 01\"», «\"0:00:01\"») to be true",
-    "intl402/DurationFormat/prototype/format/numeric-hour-with-zero-minutes-and-non-zero-seconds-with-auto-display.js (default)": "Duration is {\"hours\":0,\"minutes\":0,\"seconds\":1} Expected SameValue(«\"0, 01\"», «\"0:00:01\"») to be true",
-    "intl402/DurationFormat/prototype/format/numeric-hour-with-zero-minutes-and-non-zero-seconds-with-auto-display.js (strict mode)": "Duration is {\"hours\":0,\"minutes\":0,\"seconds\":1} Expected SameValue(«\"0, 01\"», «\"0:00:01\"») to be true",
     "intl402/DurationFormat/prototype/format/taint-temporal-duration-prototype.js (default)": "Test262Error { message: '' }",
     "intl402/DurationFormat/prototype/format/taint-temporal-duration-prototype.js (strict mode)": "Test262Error { message: '' }",
     "intl402/DurationFormat/prototype/format/temporal-duration-string-arg.js (default)": "Expected no error, got RangeError: Invalid duration format",

--- a/packages/intl-durationformat/tests/index.test.ts
+++ b/packages/intl-durationformat/tests/index.test.ts
@@ -405,3 +405,26 @@ test('numeric duration styles propagate through fractional units', () => {
       })
   ).toThrow(RangeError)
 })
+
+test('zero minutes remain between displayed numeric hours and seconds', () => {
+  const options = {
+    hours: 'numeric',
+    minutesDisplay: 'auto',
+    secondsDisplay: 'auto',
+  } as const
+  const formatter = new DurationFormat('en', options)
+  expect(formatter.format({seconds: 1})).toBe('0:00:01')
+  expect(formatter.format({hours: 1, nanoseconds: 1})).toBe('1:00:00.000000001')
+  expect(
+    new DurationFormat('en', {...options, fractionalDigits: 0}).format({
+      hours: 1,
+      nanoseconds: 1,
+    })
+  ).toBe('1:00:00')
+  expect(formatter.format({hours: 1})).toBe('1')
+  expect(
+    new DurationFormat('en', {...options, hoursDisplay: 'auto'}).format({
+      seconds: 1,
+    })
+  ).toBe('01')
+})


### PR DESCRIPTION
Numeric duration formatting now retains zero minutes between displayed hours and seconds, even with `minutesDisplay: auto`. Sub-second values determine visibility before rounding.

Comments cite ECMA-402 §13.5.12 step 15.a with pinned source lines. Regressions cover explicit auto displays, sub-second rounding, and omitted endpoint fields.

Validation: all eight DurationFormat unit/package gates passed. Test262 gained exactly four passes with no new or changed failures. DurationFormat: 206/220; aggregate: 2,074/2,498, with 424 failures still tracked.
