### PR TITLE
fix(@formatjs/intl-localematcher): preserve supported requested locale tags

### DIFF
--- a/docs/src/docs/polyfills/intl-localematcher.mdx
+++ b/docs/src/docs/polyfills/intl-localematcher.mdx
@@ -50,3 +50,13 @@ match(['fr-XX', 'en'], ['fr', 'en'], 'en') // 'fr'
 
 match(['zh'], ['fr', 'en'], 'en') // 'en'
 ```
+
+### Supported locale filtering
+
+`LookupSupportedLocales(availableLocales, requestedLocales)` returns supported
+requested tags in their original order, preserving region subtags and Unicode
+extensions even when matching falls back to a parent locale.
+
+```tsx
+LookupSupportedLocales(['de'], ['de-AT-u-co-phonebk']) // ['de-AT-u-co-phonebk']
+```

--- a/knowledge-base/014-test262-conformance.md
+++ b/knowledge-base/014-test262-conformance.md
@@ -10,7 +10,7 @@ excluded because it fails.
 | collator            |      130 |                18 |               0 |
 | datetimeformat      |      488 |               242 |              52 |
 | displaynames        |      114 |                 6 |               0 |
-| durationformat      |      220 |                14 |               4 |
+| durationformat      |      220 |                12 |               4 |
 | getcanonicallocales |       76 |                32 |               2 |
 | listformat          |      162 |                 4 |               0 |
 | locale              |      336 |                46 |              22 |
@@ -20,7 +20,7 @@ excluded because it fails.
 | segmenter           |      158 |                10 |               0 |
 | supportedvaluesof   |       50 |                 8 |               6 |
 
-Total: 2,498 executions, 2,074 polyfill passes, 424 polyfill failures. The native
+Total: 2,498 executions, 2,076 polyfill passes, 422 polyfill failures. The native
 control fails 86 executions; 68 failing cases overlap. Overlap does not prove
 a polyfill is correct: each failure still needs comparison with the selected
 spec and test's feature metadata.

--- a/packages/intl-durationformat/test262-baseline.json
+++ b/packages/intl-durationformat/test262-baseline.json
@@ -12,8 +12,6 @@
     "intl402/DurationFormat/prototype/formatToParts/temporal-duration-string-arg.js (default)": "Expected no error, got RangeError: Invalid duration format",
     "intl402/DurationFormat/prototype/formatToParts/temporal-duration-string-arg.js (strict mode)": "Expected no error, got RangeError: Invalid duration format",
     "intl402/DurationFormat/prototype/resolvedOptions/resolved-numbering-system-unicode-extensions-and-options.js (default)": "Resolved locale for locale=en-u-nu-arab with numberingSystem=invalid Expected SameValue(«\"en\"», «\"en-u-nu-arab\"») to be true",
-    "intl402/DurationFormat/prototype/resolvedOptions/resolved-numbering-system-unicode-extensions-and-options.js (strict mode)": "Resolved locale for locale=en-u-nu-arab with numberingSystem=invalid Expected SameValue(«\"en\"», «\"en-u-nu-arab\"») to be true",
-    "intl402/DurationFormat/supportedLocalesOf/locales-specific.js (default)": "Actual [sr, de, zh] and expected [sr-Thai-RS, de, zh-CN] should have the same contents. ",
-    "intl402/DurationFormat/supportedLocalesOf/locales-specific.js (strict mode)": "Actual [sr, de, zh] and expected [sr-Thai-RS, de, zh-CN] should have the same contents. "
+    "intl402/DurationFormat/prototype/resolvedOptions/resolved-numbering-system-unicode-extensions-and-options.js (strict mode)": "Resolved locale for locale=en-u-nu-arab with numberingSystem=invalid Expected SameValue(«\"en\"», «\"en-u-nu-arab\"») to be true"
   }
 }

--- a/packages/intl-localematcher/abstract/LookupSupportedLocales.ts
+++ b/packages/intl-localematcher/abstract/LookupSupportedLocales.ts
@@ -21,7 +21,10 @@ export function LookupSupportedLocales(
       noExtensionLocale
     )
     if (availableLocale) {
-      subset.push(availableLocale)
+      // ECMA-402 §9.2.9 FilterLocales, step 4.c: preserve the requested tag.
+      // https://tc39.es/ecma402/#sec-filterlocales
+      // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/negotiation.html#L344
+      subset.push(locale)
     }
   }
   return subset

--- a/packages/intl-localematcher/tests/index.test.ts
+++ b/packages/intl-localematcher/tests/index.test.ts
@@ -1,4 +1,7 @@
-import {match} from '#packages/intl-localematcher/index.js'
+import {
+  match,
+  LookupSupportedLocales,
+} from '#packages/intl-localematcher/index.js'
 import {expect, test} from 'vitest'
 test('zh-HK', function () {
   // zh-HK matches zh-HANT (returns original supported locale string as-is)
@@ -244,4 +247,13 @@ test('extension', function () {
 
 test('GH #4267', function () {
   expect(match(['fr'], ['br', 'fr'], 'en')).toEqual('fr')
+})
+
+test('supported locale filtering preserves requested tags and order', () => {
+  expect(
+    LookupSupportedLocales(
+      ['sr', 'de', 'zh'],
+      ['sr-Thai-RS', 'en', 'de-u-co-phonebk', 'zh-CN']
+    )
+  ).toEqual(['sr-Thai-RS', 'de-u-co-phonebk', 'zh-CN'])
 })

--- a/packages/intl-numberformat/tests/misc.test.ts
+++ b/packages/intl-numberformat/tests/misc.test.ts
@@ -91,7 +91,7 @@ it('should lookup locale correctly', function () {
 it('supportedLocalesOf should return correct result based on data loaded', function () {
   expect(NumberFormat.supportedLocalesOf(['zh', 'en-US', 'af'])).toEqual([
     'zh',
-    'en',
+    'en-US',
   ])
   expect(NumberFormat.supportedLocalesOf(['af'])).toEqual([])
 })


### PR DESCRIPTION
Supported-locale filtering now returns the requested locale tag after a successful match. For example, available `de` preserves requested `de-AT-u-co-phonebk` instead of returning `de`.

Comments cite ECMA-402 §9.2.9 step 4.c with a pinned source line. A regression covers parent fallback, Unicode extensions, unsupported requests, and order.

Validation: seven localematcher unit/package gates and all twelve Test262 baselines passed after recording exactly two new DurationFormat passes. No new or changed failures. Aggregate: 2,076/2,498 passes; 422 failures remain tracked.
