### PR TITLE
fix(@formatjs/intl-supportedvaluesof): make the built-in non-constructible

### DIFF
--- a/docs/src/docs/polyfills/intl-supportedvaluesof.mdx
+++ b/docs/src/docs/polyfills/intl-supportedvaluesof.mdx
@@ -71,3 +71,5 @@ This library is [test262](https://github.com/tc39/test262/tree/master/test/intl4
 
 `Intl.supportedValuesOf` converts its key to a string before validating the
 category. String wrapper objects are accepted; Symbols throw `TypeError`.
+
+`Intl.supportedValuesOf` is callable but cannot be used as a constructor.

--- a/knowledge-base/007k-polyfill-intl-supportedvaluesof.md
+++ b/knowledge-base/007k-polyfill-intl-supportedvaluesof.md
@@ -71,3 +71,5 @@ export const units = ['acre', 'bit', 'byte', 'celsius', ...] as const
 
 `Intl.supportedValuesOf` converts its key to a string before validating the
 category. String wrapper objects are accepted; Symbols throw `TypeError`.
+
+`Intl.supportedValuesOf` is callable but cannot be used as a constructor.

--- a/knowledge-base/014-test262-conformance.md
+++ b/knowledge-base/014-test262-conformance.md
@@ -18,9 +18,9 @@ excluded because it fails.
 | pluralrules         |      106 |                 4 |               0 |
 | relativetimeformat  |      160 |                14 |               0 |
 | segmenter           |      158 |                10 |               0 |
-| supportedvaluesof   |       50 |                 8 |               6 |
+| supportedvaluesof   |       50 |                 6 |               6 |
 
-Total: 2,498 executions, 2,076 polyfill passes, 422 polyfill failures. The native
+Total: 2,498 executions, 2,078 polyfill passes, 420 polyfill failures. The native
 control fails 86 executions; 68 failing cases overlap. Overlap does not prove
 a polyfill is correct: each failure still needs comparison with the selected
 spec and test's feature metadata.

--- a/packages/intl-supportedvaluesof/index.ts
+++ b/packages/intl-supportedvaluesof/index.ts
@@ -66,26 +66,32 @@ export type SupportedValuesOf =
  * @param key - The category of values to return
  * @returns A sorted array of unique string values
  */
-export function supportedValuesOf(key: SupportedValuesOf): string[] {
-  // ECMA-402 §8.3.2 Intl.supportedValuesOf, step 1.
-  // Coerce the key before dispatch: https://tc39.es/ecma402/#sec-intl.supportedvaluesof
-  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/intl.html#L103
-  key = ToString(key) as SupportedValuesOf
-  switch (key) {
-    case 'calendar':
-      return getSupportedCalendars()
-    case 'collation':
-      return getSupportedCollations()
-    case 'currency':
-      return getSupportedCurrencies()
-    case 'numberingSystem':
-      return getSupportedNumberingSystems()
-    case 'timeZone':
-      return getSupportedTimeZones()
-    case 'unit':
-      return getSupportedUnits()
-    default:
-      // ECMA-402 Spec: Throw RangeError for invalid keys
-      throw RangeError('Invalid key: ' + key)
-  }
-}
+// ECMA-262 §17, built-in function objects: non-constructors lack [[Construct]]
+// and an own prototype property (these requirements are not algorithm steps).
+// https://tc39.es/ecma262/#sec-ecmascript-standard-built-in-objects
+// https://github.com/tc39/ecma262/blob/b7865f0eed2021720f84d561289401bc414874d0/spec.html#L30375-L30376
+export const supportedValuesOf: (key: SupportedValuesOf) => string[] = {
+  supportedValuesOf(key: SupportedValuesOf): string[] {
+    // ECMA-402 §8.3.2 Intl.supportedValuesOf, step 1.
+    // Coerce the key before dispatch: https://tc39.es/ecma402/#sec-intl.supportedvaluesof
+    // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/intl.html#L103
+    key = ToString(key) as SupportedValuesOf
+    switch (key) {
+      case 'calendar':
+        return getSupportedCalendars()
+      case 'collation':
+        return getSupportedCollations()
+      case 'currency':
+        return getSupportedCurrencies()
+      case 'numberingSystem':
+        return getSupportedNumberingSystems()
+      case 'timeZone':
+        return getSupportedTimeZones()
+      case 'unit':
+        return getSupportedUnits()
+      default:
+        // ECMA-402 Spec: Throw RangeError for invalid keys
+        throw RangeError('Invalid key: ' + key)
+    }
+  },
+}.supportedValuesOf

--- a/packages/intl-supportedvaluesof/test262-baseline.json
+++ b/packages/intl-supportedvaluesof/test262-baseline.json
@@ -1,8 +1,6 @@
 {
   "total": 50,
   "failures": {
-    "intl402/Intl/supportedValuesOf/builtin.js (default)": "Test262Error {\n  message: \"Intl.supportedValuesOf doesn't have an own 'prototype' property\"\n}",
-    "intl402/Intl/supportedValuesOf/builtin.js (strict mode)": "Test262Error {\n  message: \"Intl.supportedValuesOf doesn't have an own 'prototype' property\"\n}",
     "intl402/Intl/supportedValuesOf/calendars-required-by-intl-era-monthcode.js (default)": "Actual [buddhist, chinese, coptic, dangi, ethioaa, ethiopic, gregory, hebrew, indian, islamic, islamic-civil, islamic-rgsa, islamic-tbla, islamic-umalqura, iso8601, japanese, persian, roc] and expected [buddhist, chinese, coptic, dangi, ethioaa, ethiopic, gregory, hebrew, indian, islamic-civil, islamic-tbla, islamic-umalqura, iso8601, japanese, persian, roc] should have the same contents. only the required calendars are supported",
     "intl402/Intl/supportedValuesOf/calendars-required-by-intl-era-monthcode.js (strict mode)": "Actual [buddhist, chinese, coptic, dangi, ethioaa, ethiopic, gregory, hebrew, indian, islamic, islamic-civil, islamic-rgsa, islamic-tbla, islamic-umalqura, iso8601, japanese, persian, roc] and expected [buddhist, chinese, coptic, dangi, ethioaa, ethiopic, gregory, hebrew, indian, islamic-civil, islamic-tbla, islamic-umalqura, iso8601, japanese, persian, roc] should have the same contents. only the required calendars are supported",
     "intl402/Intl/supportedValuesOf/collations-accepted-by-Collator.js (default)": "compat supported but not returned by supportedValuesOf",

--- a/packages/intl-supportedvaluesof/tests/index.test.ts
+++ b/packages/intl-supportedvaluesof/tests/index.test.ts
@@ -190,3 +190,12 @@ it('preserves key coercion errors', () => {
     } as any)
   ).toThrow(error)
 })
+
+it('supportedValuesOf is a non-constructible built-in function', () => {
+  expect(supportedValuesOf.name).toBe('supportedValuesOf')
+  expect(supportedValuesOf.length).toBe(1)
+  expect(Object.hasOwn(supportedValuesOf, 'prototype')).toBe(false)
+  expect(() => Reflect.construct(supportedValuesOf, ['unit'])).toThrow(
+    TypeError
+  )
+})


### PR DESCRIPTION
`Intl.supportedValuesOf` now uses a concise method definition, so it has no own `prototype` and rejects construction. Its name, length, and call behavior remain intact.

The code cites ECMA-262 §17's built-in function requirements with pinned source lines. A regression checks metadata and `Reflect.construct`.

Validation: all eight package/unit gates passed. Test262 gained exactly two passes with no new or changed failures; the updated baseline gate passed. Aggregate: 2,078/2,498 passes, 420 failures tracked.
