### PR TITLE
fix(@formatjs/intl-relativetimeformat): isolate internal formatter options

### DIFF
--- a/docs/src/docs/polyfills/intl-relativetimeformat.mdx
+++ b/docs/src/docs/polyfills/intl-relativetimeformat.mdx
@@ -230,3 +230,6 @@ This library is fully [test262](https://github.com/tc39/test262/tree/master/test
 
 Loading `und` locale data preserves existing English data. Root patterns remain
 separate from language-specific patterns, regardless of registration order.
+
+Internal number and plural formatters use the resolved locale. Internal number
+options have no prototype, so unrelated inherited options cannot affect them.

--- a/knowledge-base/007f-polyfill-intl-relativetimeformat.md
+++ b/knowledge-base/007f-polyfill-intl-relativetimeformat.md
@@ -67,3 +67,6 @@ Stage 3: supported-locales.generated.ts
 
 - Dynamic per-locale via `RelativeTimeFormat.__addLocaleData()`
 - Buffered via global
+
+Internal number and plural formatters use the resolved locale. Internal number
+options have no prototype, so unrelated inherited options cannot affect them.

--- a/knowledge-base/014-test262-conformance.md
+++ b/knowledge-base/014-test262-conformance.md
@@ -16,11 +16,11 @@ excluded because it fails.
 | locale              |      336 |                46 |              22 |
 | numberformat        |      498 |                24 |               0 |
 | pluralrules         |      106 |                 4 |               0 |
-| relativetimeformat  |      160 |                14 |               0 |
+| relativetimeformat  |      160 |                 8 |               0 |
 | segmenter           |      158 |                10 |               0 |
 | supportedvaluesof   |       50 |                 6 |               6 |
 
-Total: 2,498 executions, 2,080 polyfill passes, 418 polyfill failures. The native
+Total: 2,498 executions, 2,086 polyfill passes, 412 polyfill failures. The native
 control fails 86 executions; 68 failing cases overlap. Overlap does not prove
 a polyfill is correct: each failure still needs comparison with the selected
 spec and test's feature metadata.

--- a/packages/ecma402-abstract/RelativeTimeFormat/InitializeRelativeTimeFormat.ts
+++ b/packages/ecma402-abstract/RelativeTimeFormat/InitializeRelativeTimeFormat.ts
@@ -85,10 +85,14 @@ export function InitializeRelativeTimeFormat(
   const fields = localeData[r.dataLocale]
   invariant(!!fields, `Missing locale data for ${r.dataLocale}`)
   internalSlots.fields = fields
-  internalSlots.numberFormat = createMemoizedNumberFormat(locales, {
-    numberingSystem: nu,
-  })
-  internalSlots.pluralRules = createMemoizedPluralRules(locales)
+  // ECMA-402 §18.1.1, steps 14–17: isolate NumberFormat options and use
+  // the resolved locale for both internal formatters.
+  // https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/relativetimeformat.html#L34-L37
+  const nfOptions = Object.create(null)
+  nfOptions.numberingSystem = nu
+  internalSlots.numberFormat = createMemoizedNumberFormat(locale, nfOptions)
+  internalSlots.pluralRules = createMemoizedPluralRules(locale)
   internalSlots.numberingSystem = nu
   return rtf
 }

--- a/packages/intl-relativetimeformat/test262-baseline.json
+++ b/packages/intl-relativetimeformat/test262-baseline.json
@@ -1,12 +1,6 @@
 {
   "total": 160,
   "failures": {
-    "intl402/RelativeTimeFormat/constructor/constructor/options-proto.js (default)": "Should not call getter on Object.prototype: localeMatcher",
-    "intl402/RelativeTimeFormat/constructor/constructor/options-proto.js (strict mode)": "Should not call getter on Object.prototype: localeMatcher",
-    "intl402/RelativeTimeFormat/constructor/constructor/options-toobject-prototype.js (default)": "Expected no error, got RangeError: Value short out of range for Intl.NumberFormat options property style",
-    "intl402/RelativeTimeFormat/constructor/constructor/options-toobject-prototype.js (strict mode)": "Expected no error, got RangeError: Value short out of range for Intl.NumberFormat options property style",
-    "intl402/RelativeTimeFormat/constructor/constructor/options-undefined.js (default)": "Expected no error, got Error: Should not call style getter",
-    "intl402/RelativeTimeFormat/constructor/constructor/options-undefined.js (strict mode)": "Expected no error, got Error: Should not call style getter",
     "intl402/RelativeTimeFormat/constructor/constructor/proto-from-ctor-realm.js (default)": "Expected no error, got TypeError: Intl.RelativeTimeFormat must be called with 'new'",
     "intl402/RelativeTimeFormat/constructor/constructor/proto-from-ctor-realm.js (strict mode)": "Expected no error, got TypeError: Intl.RelativeTimeFormat must be called with 'new'",
     "intl402/RelativeTimeFormat/prototype/format/en-us-numbering-systems.js (default)": "locale: en-US-u-nu-arab Expected SameValue(«false», «true») to be true",


### PR DESCRIPTION
RelativeTimeFormat now creates its internal NumberFormat options without a prototype. Inherited options such as `style: 'short'` no longer leak into NumberFormat and throw. Both internal formatters receive the resolved locale.

Comments cite ECMA-402 §18.1.1 steps 14–17 with pinned source lines. The existing upstream regressions cover poisoned option getters, boxed primitive options, and omitted options.

Validation: nine package/unit gates passed. Test262 gained exactly six passes with no new or changed failures; the updated baseline gate passed. RelativeTimeFormat: 152/160. Aggregate: 2,086/2,498, with 412 failures tracked.
