### PR TITLE
fix(@formatjs/intl-localematcher): isolate locale resolution records

### DIFF
--- a/docs/src/docs/polyfills/intl-localematcher.mdx
+++ b/docs/src/docs/polyfills/intl-localematcher.mdx
@@ -60,3 +60,6 @@ extensions even when matching falls back to a parent locale.
 ```tsx
 LookupSupportedLocales(['de'], ['de-AT-u-co-phonebk']) // ['de-AT-u-co-phonebk']
 ```
+
+Locale resolution uses an internal record isolated from inherited extension-key
+setters on `Object.prototype`.

--- a/knowledge-base/014-test262-conformance.md
+++ b/knowledge-base/014-test262-conformance.md
@@ -7,7 +7,7 @@ excluded because it fails.
 
 | Polyfill            | Executed | Polyfill failures | Native failures |
 | ------------------- | -------: | ----------------: | --------------: |
-| collator            |      130 |                18 |               0 |
+| collator            |      130 |                16 |               0 |
 | datetimeformat      |      488 |               242 |              52 |
 | displaynames        |      114 |                 6 |               0 |
 | durationformat      |      220 |                12 |               4 |
@@ -20,7 +20,7 @@ excluded because it fails.
 | segmenter           |      158 |                10 |               0 |
 | supportedvaluesof   |       50 |                 6 |               6 |
 
-Total: 2,498 executions, 2,086 polyfill passes, 412 polyfill failures. The native
+Total: 2,498 executions, 2,088 polyfill passes, 410 polyfill failures. The native
 control fails 86 executions; 68 failing cases overlap. Overlap does not prove
 a polyfill is correct: each failure still needs comparison with the selected
 spec and test's feature metadata.
@@ -119,3 +119,6 @@ seconds stay displayed when following a numeric time unit.
 
 Numeric duration formatting retains zero minutes between displayed hours and
 seconds, considering sub-second values before rounding when deciding visibility.
+
+Locale resolution uses an internal record isolated from inherited extension-key
+setters on `Object.prototype`.

--- a/packages/intl-collator/test262-baseline.json
+++ b/packages/intl-collator/test262-baseline.json
@@ -13,8 +13,6 @@
     "intl402/Collator/subclassing.js (strict mode)": "Expected no error, got RangeError: Incorrect locale information provided",
     "intl402/Collator/supportedLocalesOf/taint-Object-prototype.js (default)": "Expected no error, got RangeError: Incorrect locale information provided",
     "intl402/Collator/supportedLocalesOf/taint-Object-prototype.js (strict mode)": "Expected no error, got RangeError: Incorrect locale information provided",
-    "intl402/Collator/taint-Object-prototype.js (default)": "Client code can adversely affect behavior: setter for kn.",
-    "intl402/Collator/taint-Object-prototype.js (strict mode)": "Client code can adversely affect behavior: setter for kn.",
     "intl402/Collator/unicode-ext-seq-in-private-tag.js (default)": "Expected no error, got RangeError: Incorrect locale information provided",
     "intl402/Collator/unicode-ext-seq-in-private-tag.js (strict mode)": "Expected no error, got RangeError: Incorrect locale information provided",
     "intl402/Collator/usage-de.js (default)": "Actual [Ä, AE] and expected [AE, Ä] should have the same contents. search",

--- a/packages/intl-localematcher/abstract/ResolveLocale.ts
+++ b/packages/intl-localematcher/abstract/ResolveLocale.ts
@@ -57,7 +57,13 @@ export function ResolveLocale<K extends string, D extends {[k in K]: any}>(
   //   foundLocaleData !== undefined,
   //   `Missing locale data for ${foundLocale}`
   // )
-  const result: ResolveLocaleResult = {locale: 'en', dataLocale: foundLocale}
+  // ECMA-402 §9.2.7, step 8: this is an internal Record, not an object
+  // whose fields can invoke setters inherited from Object.prototype.
+  // https://tc39.es/ecma402/#sec-resolvelocale
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/negotiation.html#L242
+  const result: ResolveLocaleResult = Object.create(null)
+  result.locale = 'en'
+  result.dataLocale = foundLocale
   let components
   let keywords: Keyword[]
   if (r.extension) {

--- a/packages/intl-localematcher/tests/ResolveLocale.test.ts
+++ b/packages/intl-localematcher/tests/ResolveLocale.test.ts
@@ -84,3 +84,31 @@ test('GH #4384', function () {
     locale: 'en-x-owo',
   })
 })
+
+test('ResolveLocale records ignore inherited extension setters', () => {
+  const previous = Object.getOwnPropertyDescriptor(Object.prototype, 'kn')
+  let calls = 0
+  let result
+  try {
+    Object.defineProperty(Object.prototype, 'kn', {
+      configurable: true,
+      set() {
+        calls++
+      },
+    })
+    result = ResolveLocale(
+      ['en'],
+      ['en-u-kn'],
+      {localeMatcher: 'lookup'},
+      ['kn'],
+      {en: {kn: ['false', 'true']}},
+      () => 'en'
+    )
+  } finally {
+    if (previous) Object.defineProperty(Object.prototype, 'kn', previous)
+    else Reflect.deleteProperty(Object.prototype, 'kn')
+  }
+  expect(calls).toBe(0)
+  expect(result?.kn).toBe('true')
+  expect(result?.locale).toBe('en-u-kn')
+})


### PR DESCRIPTION
Locale resolution now stores its internal fields in an object without a prototype. Inherited setters such as `Object.prototype.kn` can no longer intercept Collator's resolved extension values.

Comments cite ECMA-402 §9.2.7 step 8 with a pinned source line. A regression poisons an inherited extension setter and verifies both the field and resolved tag.

Validation: seven localematcher unit/package gates and all twelve Test262 baselines passed after recording exactly two new Collator passes. No new or changed failures. Aggregate: 2,088/2,498 passes, 410 failures tracked.
