### PR TITLE
fix(@formatjs/intl-locale): use standard locale tag coercion

### DIFF
--- a/docs/src/docs/polyfills/intl-locale.mdx
+++ b/docs/src/docs/polyfills/intl-locale.mdx
@@ -182,3 +182,7 @@ when no region is explicit, and recognized `fw` first-day overrides.
 Locale getters and methods require a genuine initialized Locale instance.
 Objects inheriting from `Locale.prototype` and proxies around Locale instances
 throw `TypeError`. Failed calls do not give the receiver a Locale brand.
+
+Object locale tags use standard string coercion, including `Symbol.toPrimitive`
+with the string hint and the ordinary `valueOf` fallback. Callable objects are
+accepted; primitive values other than strings are rejected.

--- a/knowledge-base/007i-polyfill-intl-locale.md
+++ b/knowledge-base/007i-polyfill-intl-locale.md
@@ -73,3 +73,7 @@ when no region is explicit, and recognized `fw` first-day overrides.
 Locale getters and methods require a genuine initialized Locale instance.
 Objects inheriting from `Locale.prototype` and proxies around Locale instances
 throw `TypeError`. Failed calls do not give the receiver a Locale brand.
+
+Object locale tags use standard string coercion, including `Symbol.toPrimitive`
+with the string hint and the ordinary `valueOf` fallback. Callable objects are
+accepted; primitive values other than strings are rejected.

--- a/knowledge-base/014-test262-conformance.md
+++ b/knowledge-base/014-test262-conformance.md
@@ -13,14 +13,14 @@ excluded because it fails.
 | durationformat      |      220 |                12 |               4 |
 | getcanonicallocales |       76 |                32 |               2 |
 | listformat          |      162 |                 4 |               0 |
-| locale              |      336 |                46 |              22 |
+| locale              |      336 |                44 |              22 |
 | numberformat        |      498 |                24 |               0 |
 | pluralrules         |      106 |                 4 |               0 |
 | relativetimeformat  |      160 |                 8 |               0 |
 | segmenter           |      158 |                10 |               0 |
 | supportedvaluesof   |       50 |                 6 |               6 |
 
-Total: 2,498 executions, 2,088 polyfill passes, 410 polyfill failures. The native
+Total: 2,498 executions, 2,090 polyfill passes, 408 polyfill failures. The native
 control fails 86 executions; 68 failing cases overlap. Overlap does not prove
 a polyfill is correct: each failure still needs comparison with the selected
 spec and test's feature metadata.

--- a/packages/intl-locale/index.ts
+++ b/packages/intl-locale/index.ts
@@ -1,3 +1,4 @@
+import {ToString} from '#packages/ecma262-abstract/ToString.js'
 import {IsUnicodeLocaleIdentifierType} from '#packages/ecma402-abstract/IsUnicodeLocaleIdentifierType.js'
 import {HasOwnProperty} from '#packages/ecma262-abstract/HasOwnProperty.js'
 import {SameValue} from '#packages/ecma262-abstract/SameValue.js'
@@ -491,7 +492,12 @@ export class Locale {
       )
     }
 
-    if (typeof tag !== 'string' && typeof tag !== 'object') {
+    if (
+      tag === null ||
+      (typeof tag !== 'string' &&
+        typeof tag !== 'object' &&
+        typeof tag !== 'function')
+    ) {
       throw new TypeError('tag must be a string or object')
     }
 
@@ -503,7 +509,11 @@ export class Locale {
     ) {
       tag = tagInternalSlots.locale
     } else {
-      tag = tag.toString() as string
+      // ECMA-402 §15.1.1, step 9.a: use ToString, including the string hint
+      // for @@toPrimitive and the ordinary valueOf fallback.
+      // https://tc39.es/ecma402/#sec-Intl.Locale
+      // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/locale.html#L31
+      tag = ToString(tag)
     }
 
     let internalSlots = getInternalSlots(this, internalSlotsList)

--- a/packages/intl-locale/test262-baseline.json
+++ b/packages/intl-locale/test262-baseline.json
@@ -17,8 +17,6 @@
     "intl402/Locale/constructor-options-variants-invalid.js (strict mode)": "new Intl.Locale(\"en\", {variants: \"\"}) throws RangeError Expected a RangeError to be thrown but no exception was thrown at all",
     "intl402/Locale/constructor-options-variants-valid.js (default)": "new Intl.Locale(\"en\", {variants: \"spanglis\"}).toString() returns \"en-spanglis\" Expected SameValue(«\"en\"», «\"en-spanglis\"») to be true",
     "intl402/Locale/constructor-options-variants-valid.js (strict mode)": "new Intl.Locale(\"en\", {variants: \"spanglis\"}).toString() returns \"en-spanglis\" Expected SameValue(«\"en\"», «\"en-spanglis\"») to be true",
-    "intl402/Locale/constructor-tag-tostring.js (default)": "Expected a CustomError but got a RangeError",
-    "intl402/Locale/constructor-tag-tostring.js (strict mode)": "Expected a CustomError but got a RangeError",
     "intl402/Locale/extensions-grandfathered.js (default)": "Expected SameValue(«\"fr-Cyrl-FR-gaulish-u-nu-latn\"», «\"fr-Cyrl-FR-u-nu-latn\"») to be true",
     "intl402/Locale/extensions-grandfathered.js (strict mode)": "Expected SameValue(«\"fr-Cyrl-FR-gaulish-u-nu-latn\"», «\"fr-Cyrl-FR-u-nu-latn\"») to be true",
     "intl402/Locale/getters-grandfathered.js (default)": "Expected SameValue(«\"cel\"», «\"xtg\"») to be true",

--- a/packages/intl-locale/tests/index.test.ts
+++ b/packages/intl-locale/tests/index.test.ts
@@ -343,3 +343,27 @@ describe('Locale internal brand', () => {
     expect(new Locale({toString: () => 'fr'} as any).language).toBe('fr')
   })
 })
+
+test('locale tag coercion uses the string hint and ordinary fallback', () => {
+  const hints: string[] = []
+  const tag = {
+    [Symbol.toPrimitive](hint: string) {
+      hints.push(hint)
+      return 'en-US'
+    },
+    toString() {
+      throw new Error('must not call toString')
+    },
+  }
+  expect(new Locale(tag as unknown as string).toString()).toBe('en-US')
+  expect(hints).toEqual(['string'])
+  expect(
+    new Locale({
+      toString: undefined,
+      valueOf: () => 'de',
+    } as unknown as string).toString()
+  ).toBe('de')
+  const callable = Object.assign(() => {}, {toString: () => 'fr'})
+  expect(new Locale(callable as unknown as string).toString()).toBe('fr')
+  expect(() => new Locale(null as unknown as string)).toThrow(TypeError)
+})


### PR DESCRIPTION
Locale construction now uses standard string coercion for object tags. `Symbol.toPrimitive` receives the string hint, and ordinary conversion can fall back to `valueOf`. Callable objects are accepted; `null` remains a TypeError.

Comments cite ECMA-402 §15.1.1 step 9.a with a pinned source line. Regressions cover coercion precedence, the hint, fallback, callable tags, and null.

Validation: eight Locale unit/package gates passed. Test262 gained exactly two passes with no new or changed failures; the updated baseline gate passed. Aggregate: 2,090/2,498 passes, 408 failures tracked.
