### PR TITLE
fix(@formatjs/intl-locale): minimize maximized locale components

### DIFF
--- a/docs/src/docs/polyfills/intl-locale.mdx
+++ b/docs/src/docs/polyfills/intl-locale.mdx
@@ -192,3 +192,6 @@ preserving extensions. Empty, malformed, and duplicate variants throw `RangeErro
 
 Locale tags are canonicalized before constructor overrides are applied, so
 alias resolution uses the original language and script context.
+
+`minimize()` tests reductions of the maximized locale, preserving variants and
+extensions. For example, `und-Thai` minimizes to `th` and `zh-Hant` to `zh-TW`.

--- a/knowledge-base/007i-polyfill-intl-locale.md
+++ b/knowledge-base/007i-polyfill-intl-locale.md
@@ -83,3 +83,6 @@ preserving extensions. Empty, malformed, and duplicate variants throw `RangeErro
 
 Locale tags are canonicalized before constructor overrides are applied, so
 alias resolution uses the original language and script context.
+
+`minimize()` tests reductions of the maximized locale, preserving variants and
+extensions. For example, `und-Thai` minimizes to `th` and `zh-Hant` to `zh-TW`.

--- a/knowledge-base/014-test262-conformance.md
+++ b/knowledge-base/014-test262-conformance.md
@@ -13,14 +13,14 @@ excluded because it fails.
 | durationformat      |      220 |                12 |               4 |
 | getcanonicallocales |       76 |                32 |               2 |
 | listformat          |      162 |                 4 |               0 |
-| locale              |      336 |                28 |              22 |
+| locale              |      336 |                24 |              22 |
 | numberformat        |      498 |                24 |               0 |
 | pluralrules         |      106 |                 4 |               0 |
 | relativetimeformat  |      160 |                 8 |               0 |
 | segmenter           |      158 |                10 |               0 |
 | supportedvaluesof   |       50 |                 6 |               6 |
 
-Total: 2,498 executions, 2,106 polyfill passes, 392 polyfill failures. The native
+Total: 2,498 executions, 2,110 polyfill passes, 388 polyfill failures. The native
 control fails 86 executions; 56 failing cases overlap. Overlap does not prove
 a polyfill is correct: each failure still needs comparison with the selected
 spec and test's feature metadata.

--- a/packages/intl-locale/index.ts
+++ b/packages/intl-locale/index.ts
@@ -308,11 +308,17 @@ function removeLikelySubtags(tag: string): string {
   if (!maxLocale) {
     return tag
   }
+  // ECMA-402 §15.3.10, step 3; UTS 35 §4.3 Remove Likely Subtags, steps 1–6.
+  // Trials use maximized components, retaining the original variants/extensions.
+  // https://tc39.es/ecma402/#sec-Intl.Locale.prototype.minimize
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/locale.html#L295
+  // https://www.unicode.org/reports/tr35/tr35-78/tr35.html#Likely_Subtags
+  // https://github.com/unicode-org/cldr/blob/acd6d88ae493633240e19a87a721076a8a75c310/docs/ldml/tr35.md#L2595-L2601
+  const ast = parseUnicodeLocaleId(maxLocale)
   maxLocale = emitUnicodeLanguageId({
     ...parseUnicodeLanguageId(maxLocale),
     variants: [],
   })
-  const ast = parseUnicodeLocaleId(tag)
   const {
     lang: {lang, script, region, variants},
   } = ast
@@ -345,7 +351,7 @@ function removeLikelySubtags(tag: string): string {
       })
     }
   }
-  return tag
+  return emitUnicodeLocaleId(ast)
 }
 
 function createArrayFromListOrRestricted(

--- a/packages/intl-locale/test262-baseline.json
+++ b/packages/intl-locale/test262-baseline.json
@@ -9,8 +9,6 @@
     "intl402/Locale/constructor-options-canonicalized.js (strict mode)": "new Intl.Locale(\"en\", { calendar: \"islamicc\" }).calendar returns islamic-civil Expected SameValue(«\"islamicc\"», «\"islamic-civil\"») to be true",
     "intl402/Locale/likely-subtags-grandfathered.js (default)": "maximized once Expected SameValue(«\"en-Latn-US\"», «\"xtg\"») to be true",
     "intl402/Locale/likely-subtags-grandfathered.js (strict mode)": "maximized once Expected SameValue(«\"en-Latn-US\"», «\"xtg\"») to be true",
-    "intl402/Locale/likely-subtags.js (default)": "\"und-Latn-AQ\".minimize() should be \"en-AQ\" Expected SameValue(«\"und-AQ\"», «\"en-AQ\"») to be true",
-    "intl402/Locale/likely-subtags.js (strict mode)": "\"und-Latn-AQ\".minimize() should be \"en-AQ\" Expected SameValue(«\"und-AQ\"», «\"en-AQ\"») to be true",
     "intl402/Locale/proto-from-ctor-realm.js (default)": "Expected no error, got TypeError: Intl.Locale must be called with 'new'",
     "intl402/Locale/proto-from-ctor-realm.js (strict mode)": "Expected no error, got TypeError: Intl.Locale must be called with 'new'",
     "intl402/Locale/prototype/calendar/canonicalize.js (default)": "Test262Error {\n  message: `'islamicc' should be canonicalized to 'islamic-civil' Expected SameValue(«\"islamicc\"», «\"islamic-civil\"») to be true`\n}",
@@ -26,8 +24,6 @@
     "intl402/Locale/prototype/getHourCycles/region-priority.js (default)": "Actual [h12, h23] and expected [h23, h12] should have the same contents. getHourCycles() for \"en-US-u-sd-gbeng-rg-gbzzzz\" should use the \"rg\" region override, like \"en-GB\"",
     "intl402/Locale/prototype/getHourCycles/region-priority.js (strict mode)": "Actual [h12, h23] and expected [h23, h12] should have the same contents. getHourCycles() for \"en-US-u-sd-gbeng-rg-gbzzzz\" should use the \"rg\" region override, like \"en-GB\"",
     "intl402/Locale/prototype/getHourCycles/subdivision-region.js (default)": "Test262Error {\n  message: `Actual [h12, h23] and expected [h23, h12] should have the same contents. getHourCycles() for \"en-u-sd-gbeng\" should equal getHourCycles() for the subdivision's region`\n}",
-    "intl402/Locale/prototype/getHourCycles/subdivision-region.js (strict mode)": "Test262Error {\n  message: `Actual [h12, h23] and expected [h23, h12] should have the same contents. getHourCycles() for \"en-u-sd-gbeng\" should equal getHourCycles() for the subdivision's region`\n}",
-    "intl402/Locale/prototype/minimize/removing-likely-subtags-first-adds-likely-subtags.js (default)": "\"und\".minimize() should be \"en\" Expected SameValue(«\"und\"», «\"en\"») to be true",
-    "intl402/Locale/prototype/minimize/removing-likely-subtags-first-adds-likely-subtags.js (strict mode)": "\"und\".minimize() should be \"en\" Expected SameValue(«\"und\"», «\"en\"») to be true"
+    "intl402/Locale/prototype/getHourCycles/subdivision-region.js (strict mode)": "Test262Error {\n  message: `Actual [h12, h23] and expected [h23, h12] should have the same contents. getHourCycles() for \"en-u-sd-gbeng\" should equal getHourCycles() for the subdivision's region`\n}"
   }
 }

--- a/packages/intl-locale/tests/likely-subtags.test.ts
+++ b/packages/intl-locale/tests/likely-subtags.test.ts
@@ -54,7 +54,7 @@ const testDataMinimal: Record<string, string> = {
   'ru-Cyrl-RU': 'ru',
   'de-Latn-AT': 'de-AT',
   'bg-Cyrl-RO': 'bg-RO',
-  'und-Latn-AQ': 'und-AQ',
+  'und-Latn-AQ': 'en-AQ',
 }
 
 // Add variants, extensions, and privateuse subtags and ensure they don't

--- a/packages/intl-locale/tests/minimize.test.ts
+++ b/packages/intl-locale/tests/minimize.test.ts
@@ -3,11 +3,11 @@ import {Locale} from '#packages/intl-locale/index.js'
 import {describe, expect, it} from 'vitest'
 const testDataMinimal: Record<string, string> = {
   // Undefined primary language.
-  // und: 'en',
-  // 'und-Thai': 'th',
-  // 'und-419': 'es-419',
-  // 'und-150': 'ru-150',
-  // 'und-AT': 'de-AT',
+  und: 'en',
+  'und-Thai': 'th',
+  'und-419': 'es-419',
+  'und-150': 'en-150',
+  'und-AT': 'de-AT',
 
   // https://unicode-org.atlassian.net/browse/ICU-13786
   'aae-Latn-IT': 'aae',
@@ -15,9 +15,9 @@ const testDataMinimal: Record<string, string> = {
 
   // https://unicode-org.atlassian.net/browse/ICU-10220
   // https://unicode-org.atlassian.net/browse/ICU-12345
-  // 'und-CW': 'pap-CW',
-  // 'und-US': 'en',
-  // 'zh-Hant': 'zh-TW',
+  'und-CW': 'pap',
+  'und-US': 'en',
+  'zh-Hant': 'zh-TW',
   'zh-Hani': 'zh-Hani',
 }
 
@@ -33,4 +33,10 @@ describe('minimize', function () {
       expect(new Locale(tag).minimize().toString()).toBe(minimal)
     })
   }
+})
+
+it('minimize preserves variants and extensions after maximizing', () => {
+  expect(new Locale('und-fonipa-u-nu-arab').minimize().toString()).toBe(
+    'en-fonipa-u-nu-arab'
+  )
 })


### PR DESCRIPTION
Locale minimization now builds trial tags from maximized language, script, and region components. `und-Thai` becomes `th`, and `zh-Hant` becomes `zh-TW`; variants and extensions are preserved.

Comments cite ECMA-402 §15.3.10 step 3 and UTS 35 §4.3 steps 1–6 with pinned source lines. Previously disabled minimization cases are enabled. The Antarctica expectation now agrees with the existing `en-Latn-AQ` maximization data.

Validation: all nine Locale unit/package/Test262 gates passed after recording exactly four new passes. No new or changed failures. Locale: 312/336; aggregate: 2,110/2,498 passes, 388 failures tracked.
