### PR TITLE
fix(@formatjs/intl-locale): expose canonical option values

### DIFF
--- a/docs/src/docs/polyfills/intl-locale.mdx
+++ b/docs/src/docs/polyfills/intl-locale.mdx
@@ -199,3 +199,6 @@ extensions. For example, `und-Thai` minimizes to `th` and `zh-Hant` to `zh-TW`.
 Calendar and hour-cycle preferences honor available `rg` override data, then the
 explicit region, `sd` subdivision, likely region, and world fallback. An override
 without data falls back to the ordinary preferred region.
+
+Locale option getters expose canonical Unicode values, consistent with the
+serialized tag. For example, calendar option `islamicc` resolves to `islamic-civil`.

--- a/knowledge-base/007i-polyfill-intl-locale.md
+++ b/knowledge-base/007i-polyfill-intl-locale.md
@@ -90,3 +90,6 @@ extensions. For example, `und-Thai` minimizes to `th` and `zh-Hant` to `zh-TW`.
 Calendar and hour-cycle preferences honor available `rg` override data, then the
 explicit region, `sd` subdivision, likely region, and world fallback. An override
 without data falls back to the ordinary preferred region.
+
+Locale option getters expose canonical Unicode values, consistent with the
+serialized tag. For example, calendar option `islamicc` resolves to `islamic-civil`.

--- a/knowledge-base/014-test262-conformance.md
+++ b/knowledge-base/014-test262-conformance.md
@@ -13,14 +13,14 @@ excluded because it fails.
 | durationformat      |      220 |                12 |               4 |
 | getcanonicallocales |       76 |                32 |               2 |
 | listformat          |      162 |                 4 |               0 |
-| locale              |      336 |                12 |              22 |
+| locale              |      336 |                 8 |              22 |
 | numberformat        |      498 |                24 |               0 |
 | pluralrules         |      106 |                 4 |               0 |
 | relativetimeformat  |      160 |                 8 |               0 |
 | segmenter           |      158 |                10 |               0 |
 | supportedvaluesof   |       50 |                 6 |               6 |
 
-Total: 2,498 executions, 2,122 polyfill passes, 376 polyfill failures. The native
+Total: 2,498 executions, 2,126 polyfill passes, 372 polyfill failures. The native
 control fails 86 executions; 52 failing cases overlap. Overlap does not prove
 a polyfill is correct: each failure still needs comparison with the selected
 spec and test's feature metadata.

--- a/packages/intl-locale/index.ts
+++ b/packages/intl-locale/index.ts
@@ -209,6 +209,20 @@ function applyUnicodeExtensionToTag(
   result.locale = (
     (Intl as any).getCanonicalLocales as typeof getCanonicalLocales
   )(emitUnicodeLocaleId(ast))[0]
+  // ECMA-402 §15.1.3 MakeLocaleRecord, steps 4.e.i and 4.f: store canonical
+  // option values, matching the canonical Unicode extension in the final tag.
+  // https://tc39.es/ecma402/#sec-makelocalerecord
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/locale.html#L151-L156
+  const canonicalExtension = parseUnicodeLocaleId(
+    result.locale
+  ).extensions.find(extension => extension.type === 'u') as
+    | UnicodeExtension
+    | undefined
+  for (const key of relevantExtensionKeys) {
+    result[key] = canonicalExtension?.keywords.find(
+      keyword => keyword[0] === key
+    )?.[1]
+  }
   return result
 }
 

--- a/packages/intl-locale/test262-baseline.json
+++ b/packages/intl-locale/test262-baseline.json
@@ -5,13 +5,9 @@
     "intl402/Locale/canonicalize-locale-list-take-locale.js (strict mode)": "Expected SameValue(«0», «1») to be true",
     "intl402/Locale/constructor-non-iana-canon.js (default)": "new Intl.Locale(\"posix\").maximize().toString() returns \"posix\" Expected SameValue(«\"en-Latn-US\"», «\"posix\"») to be true",
     "intl402/Locale/constructor-non-iana-canon.js (strict mode)": "new Intl.Locale(\"posix\").maximize().toString() returns \"posix\" Expected SameValue(«\"en-Latn-US\"», «\"posix\"») to be true",
-    "intl402/Locale/constructor-options-canonicalized.js (default)": "new Intl.Locale(\"en\", { calendar: \"islamicc\" }).calendar returns islamic-civil Expected SameValue(«\"islamicc\"», «\"islamic-civil\"») to be true",
-    "intl402/Locale/constructor-options-canonicalized.js (strict mode)": "new Intl.Locale(\"en\", { calendar: \"islamicc\" }).calendar returns islamic-civil Expected SameValue(«\"islamicc\"», «\"islamic-civil\"») to be true",
     "intl402/Locale/likely-subtags-grandfathered.js (default)": "maximized once Expected SameValue(«\"en-Latn-US\"», «\"xtg\"») to be true",
     "intl402/Locale/likely-subtags-grandfathered.js (strict mode)": "maximized once Expected SameValue(«\"en-Latn-US\"», «\"xtg\"») to be true",
     "intl402/Locale/proto-from-ctor-realm.js (default)": "Expected no error, got TypeError: Intl.Locale must be called with 'new'",
-    "intl402/Locale/proto-from-ctor-realm.js (strict mode)": "Expected no error, got TypeError: Intl.Locale must be called with 'new'",
-    "intl402/Locale/prototype/calendar/canonicalize.js (default)": "Test262Error {\n  message: `'islamicc' should be canonicalized to 'islamic-civil' Expected SameValue(«\"islamicc\"», «\"islamic-civil\"») to be true`\n}",
-    "intl402/Locale/prototype/calendar/canonicalize.js (strict mode)": "Test262Error {\n  message: `'islamicc' should be canonicalized to 'islamic-civil' Expected SameValue(«\"islamicc\"», «\"islamic-civil\"») to be true`\n}"
+    "intl402/Locale/proto-from-ctor-realm.js (strict mode)": "Expected no error, got TypeError: Intl.Locale must be called with 'new'"
   }
 }

--- a/packages/intl-locale/tests/index.test.ts
+++ b/packages/intl-locale/tests/index.test.ts
@@ -399,3 +399,17 @@ it.each([
   expect(locale.getCalendars()).toEqual(expected.getCalendars())
   expect(locale.getHourCycles()).toEqual(expected.getHourCycles())
 })
+
+it('stores canonical Unicode option values in locale getters', () => {
+  const locale = new Locale('en', {
+    calendar: 'ISLAMICC',
+    collation: 'DICT',
+    numberingSystem: 'LATN',
+    numeric: true,
+  })
+  expect(locale.calendar).toBe('islamic-civil')
+  expect(locale.collation).toBe('dict')
+  expect(locale.numberingSystem).toBe('latn')
+  expect(locale.numeric).toBe(true)
+  expect(locale.toString()).toBe('en-u-ca-islamic-civil-co-dict-kn-nu-latn')
+})


### PR DESCRIPTION
Locale option getters now expose canonical Unicode values consistent with the serialized tag. For example, `calendar: 'ISLAMICC'` yields `islamic-civil`, and uppercase numbering-system values are normalized.

Comments cite ECMA-402 §15.1.3 steps 4.e.i and 4.f with pinned source lines. A regression checks calendar, collation, numbering system, numeric behavior, and tag agreement.

Validation: all nine Locale unit/package/Test262 gates passed after recording exactly four new passes. No new or changed failures. Locale: 328/336; aggregate: 2,126/2,498 passes, 372 failures tracked.
