### PR TITLE
fix(@formatjs/intl-locale): follow likely-subtag lookup order

### DIFF
--- a/docs/src/docs/polyfills/intl-locale.mdx
+++ b/docs/src/docs/polyfills/intl-locale.mdx
@@ -202,3 +202,6 @@ without data falls back to the ordinary preferred region.
 
 Locale option getters expose canonical Unicode values, consistent with the
 serialized tag. For example, calendar option `islamicc` resolves to `islamic-civil`.
+
+`maximize()` preserves supplied components and leaves unmatched tags unchanged.
+It only searches likely-subtag candidates for the requested language.

--- a/knowledge-base/007i-polyfill-intl-locale.md
+++ b/knowledge-base/007i-polyfill-intl-locale.md
@@ -93,3 +93,6 @@ without data falls back to the ordinary preferred region.
 
 Locale option getters expose canonical Unicode values, consistent with the
 serialized tag. For example, calendar option `islamicc` resolves to `islamic-civil`.
+
+`maximize()` preserves supplied components and leaves unmatched tags unchanged.
+It only searches likely-subtag candidates for the requested language.

--- a/knowledge-base/014-test262-conformance.md
+++ b/knowledge-base/014-test262-conformance.md
@@ -13,14 +13,14 @@ excluded because it fails.
 | durationformat      |      220 |                12 |               4 |
 | getcanonicallocales |       76 |                32 |               2 |
 | listformat          |      162 |                 4 |               0 |
-| locale              |      336 |                 8 |              22 |
+| locale              |      336 |                 4 |              22 |
 | numberformat        |      498 |                24 |               0 |
 | pluralrules         |      106 |                 4 |               0 |
 | relativetimeformat  |      160 |                 8 |               0 |
 | segmenter           |      158 |                10 |               0 |
 | supportedvaluesof   |       50 |                 6 |               6 |
 
-Total: 2,498 executions, 2,126 polyfill passes, 372 polyfill failures. The native
+Total: 2,498 executions, 2,130 polyfill passes, 368 polyfill failures. The native
 control fails 86 executions; 52 failing cases overlap. Overlap does not prove
 a polyfill is correct: each failure still needs comparison with the selected
 spec and test's feature metadata.

--- a/packages/intl-locale/index.ts
+++ b/packages/intl-locale/index.ts
@@ -251,66 +251,34 @@ function mergeUnicodeLanguageId(
 
 function addLikelySubtags(tag: string): string {
   const ast = parseUnicodeLocaleId(tag)
-  const unicodeLangId = ast.lang
-  const {lang, script, region, variants} = unicodeLangId
-  if (script && region) {
-    const match =
-      likelySubtags[
-        emitUnicodeLanguageId({lang, script, region, variants: []}) as 'aa'
-      ]
-    if (match) {
-      const parts = parseUnicodeLanguageId(match)
-      ast.lang = mergeUnicodeLanguageId(
-        undefined,
-        undefined,
-        undefined,
-        variants,
-        parts
-      )
-      return emitUnicodeLocaleId(ast)
-    }
+  const {lang, variants} = ast.lang
+  const script = ast.lang.script === 'Zzzz' ? undefined : ast.lang.script
+  const region = ast.lang.region === 'ZZ' ? undefined : ast.lang.region
+  // ECMA-402 §15.3.9, step 3; UTS 35 §4.3 Add Likely Subtags,
+  // steps 1.2–1.4, 2, and 3: preserve supplied components and report no match.
+  // https://tc39.es/ecma402/#sec-Intl.Locale.prototype.maximize
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/locale.html#L284
+  // https://www.unicode.org/reports/tr35/tr35-78/tr35.html#Likely_Subtags
+  // https://github.com/unicode-org/cldr/blob/acd6d88ae493633240e19a87a721076a8a75c310/docs/ldml/tr35.md#L2542-L2556
+  if (lang !== 'und' && script && region) return tag
+  for (const candidate of [
+    {lang, script, region, variants: []},
+    {lang, script, variants: []},
+    {lang, region, variants: []},
+    {lang, variants: []},
+  ]) {
+    const match = likelySubtags[emitUnicodeLanguageId(candidate) as 'aa']
+    if (!match) continue
+    ast.lang = mergeUnicodeLanguageId(
+      lang,
+      script,
+      region,
+      variants,
+      parseUnicodeLanguageId(match)
+    )
+    return emitUnicodeLocaleId(ast)
   }
-  if (script) {
-    const match =
-      likelySubtags[emitUnicodeLanguageId({lang, script, variants: []}) as 'aa']
-    if (match) {
-      const parts = parseUnicodeLanguageId(match)
-      ast.lang = mergeUnicodeLanguageId(
-        undefined,
-        undefined,
-        region,
-        variants,
-        parts
-      )
-      return emitUnicodeLocaleId(ast)
-    }
-  }
-  if (region) {
-    const match =
-      likelySubtags[emitUnicodeLanguageId({lang, region, variants: []}) as 'aa']
-    if (match) {
-      const parts = parseUnicodeLanguageId(match)
-      ast.lang = mergeUnicodeLanguageId(
-        undefined,
-        script,
-        undefined,
-        variants,
-        parts
-      )
-      return emitUnicodeLocaleId(ast)
-    }
-  }
-  const match =
-    likelySubtags[lang as 'aa'] ||
-    likelySubtags[
-      emitUnicodeLanguageId({lang: 'und', script, variants: []}) as 'aa'
-    ]
-  if (!match) {
-    throw new Error(`No match for addLikelySubtags`)
-  }
-  const parts = parseUnicodeLanguageId(match)
-  ast.lang = mergeUnicodeLanguageId(undefined, script, region, variants, parts)
-  return emitUnicodeLocaleId(ast)
+  return tag
 }
 
 /**

--- a/packages/intl-locale/test262-baseline.json
+++ b/packages/intl-locale/test262-baseline.json
@@ -3,10 +3,6 @@
   "failures": {
     "intl402/Locale/canonicalize-locale-list-take-locale.js (default)": "Expected SameValue(«0», «1») to be true",
     "intl402/Locale/canonicalize-locale-list-take-locale.js (strict mode)": "Expected SameValue(«0», «1») to be true",
-    "intl402/Locale/constructor-non-iana-canon.js (default)": "new Intl.Locale(\"posix\").maximize().toString() returns \"posix\" Expected SameValue(«\"en-Latn-US\"», «\"posix\"») to be true",
-    "intl402/Locale/constructor-non-iana-canon.js (strict mode)": "new Intl.Locale(\"posix\").maximize().toString() returns \"posix\" Expected SameValue(«\"en-Latn-US\"», «\"posix\"») to be true",
-    "intl402/Locale/likely-subtags-grandfathered.js (default)": "maximized once Expected SameValue(«\"en-Latn-US\"», «\"xtg\"») to be true",
-    "intl402/Locale/likely-subtags-grandfathered.js (strict mode)": "maximized once Expected SameValue(«\"en-Latn-US\"», «\"xtg\"») to be true",
     "intl402/Locale/proto-from-ctor-realm.js (default)": "Expected no error, got TypeError: Intl.Locale must be called with 'new'",
     "intl402/Locale/proto-from-ctor-realm.js (strict mode)": "Expected no error, got TypeError: Intl.Locale must be called with 'new'"
   }

--- a/packages/intl-locale/tests/likely-subtags.test.ts
+++ b/packages/intl-locale/tests/likely-subtags.test.ts
@@ -107,3 +107,10 @@ describe('likely-subtags', function () {
     expect(() => new Locale('x-private')).toThrowError(RangeError)
   })
 })
+
+it.each(['posix', 'xtg', 'zz-Latn', 'zz-Latn-GB'])(
+  'maximize preserves unmatched or already complete tag %s',
+  tag => {
+    expect(new Locale(tag).maximize().toString()).toBe(tag)
+  }
+)


### PR DESCRIPTION
Locale maximization now follows the specified lookup sequence for the requested language. Unmatched tags such as `posix` and `xtg` remain unchanged, and supplied language/script/region components are preserved.

Comments cite ECMA-402 §15.3.9 step 3 and UTS 35 §4.3's lookup/return steps with pinned source lines. Regressions cover unmatched languages, partial tags, and complete tags.

Validation: 20 gates passed, including Locale unit/package tests and all twelve polyfill Test262 baselines. Exactly four new Locale passes, no new or changed failures. Locale: 332/336; aggregate: 2,130/2,498 passes, 368 failures tracked.
