### PR TITLE
fix(@formatjs/intl-durationformat): resolve supported numbering systems

### DIFF
--- a/docs/src/docs/polyfills/intl-durationformat.mdx
+++ b/docs/src/docs/polyfills/intl-durationformat.mdx
@@ -221,3 +221,8 @@ units cannot request `always` display or be followed by a textual unit style.
 
 Zero minutes remain between displayed numeric hours and seconds, even with
 `minutesDisplay: "auto"`. For example, `{hours: 1, seconds: 1}` formats as `"1:00:01"`.
+
+Numbering-system resolution includes systems supported by the active
+`Intl.NumberFormat` dependency, keeping the locale default first. Support is
+checked lazily and refreshed when that constructor is replaced. Time-separator
+data includes every numbering-system symbol record supplied by CLDR.

--- a/knowledge-base/007g-polyfill-intl-durationformat.md
+++ b/knowledge-base/007g-polyfill-intl-durationformat.md
@@ -74,3 +74,8 @@ finite integers of a common sign. Invalid numeric fields throw `RangeError`;
 an empty record throws `TypeError`. Absolute years, months, and weeks must be
 less than `2 ** 32`; absolute normalized seconds must be less than `2 ** 53`.
 Subsecond contributions participate in the bound comparison exactly.
+
+Numbering-system resolution includes systems supported by the active
+`Intl.NumberFormat` dependency, keeping the locale default first. Support is
+checked lazily and refreshed when that constructor is replaced. Time-separator
+data includes every numbering-system symbol record supplied by CLDR.

--- a/knowledge-base/014-test262-conformance.md
+++ b/knowledge-base/014-test262-conformance.md
@@ -10,7 +10,7 @@ excluded because it fails.
 | collator            |      130 |                16 |               0 |
 | datetimeformat      |      488 |               242 |              52 |
 | displaynames        |      114 |                 6 |               0 |
-| durationformat      |      220 |                12 |               4 |
+| durationformat      |      220 |                 8 |               4 |
 | getcanonicallocales |       76 |                32 |               2 |
 | listformat          |      162 |                 4 |               0 |
 | locale              |      336 |                 4 |              22 |
@@ -20,7 +20,7 @@ excluded because it fails.
 | segmenter           |      158 |                10 |               0 |
 | supportedvaluesof   |       50 |                 6 |               6 |
 
-Total: 2,498 executions, 2,130 polyfill passes, 368 polyfill failures. The native
+Total: 2,498 executions, 2,134 polyfill passes, 364 polyfill failures. The native
 control fails 86 executions; 52 failing cases overlap. Overlap does not prove
 a polyfill is correct: each failure still needs comparison with the selected
 spec and test's feature metadata.

--- a/packages/intl-durationformat/core.ts
+++ b/packages/intl-durationformat/core.ts
@@ -1,3 +1,4 @@
+import {numberingSystemNames} from '@formatjs_generated/cldr.number/numbering-systems.js'
 import {IsUnicodeLocaleIdentifierType} from '#packages/ecma402-abstract/IsUnicodeLocaleIdentifierType.js'
 // Core implementation of Intl.DurationFormat polyfill
 // Follows the TC39 Intl.DurationFormat proposal specification
@@ -24,6 +25,33 @@ import type {
   ResolvedDurationFormatOptions,
 } from '#packages/intl-durationformat/types.js'
 import {type DurationFormatOptions} from '#packages/intl-durationformat/types.js'
+
+// NumberFormat is a runtime dependency and may be replaced by its polyfill.
+const numberingSystemsByConstructor = new WeakMap<
+  typeof Intl.NumberFormat,
+  string[]
+>()
+function supportedNumberingSystems(): string[] {
+  const NumberFormat = Intl.NumberFormat
+  let systems = numberingSystemsByConstructor.get(NumberFormat)
+  if (!systems) {
+    systems = numberingSystemNames.filter(numberingSystem => {
+      const options = Object.create(null)
+      options.numberingSystem = numberingSystem
+      try {
+        return (
+          new NumberFormat('en', options).resolvedOptions().numberingSystem ===
+          numberingSystem
+        )
+      } catch {
+        return false
+      }
+    })
+    // Missing NumberFormat locale data may be loaded before the next call.
+    if (systems.length) numberingSystemsByConstructor.set(NumberFormat, systems)
+  }
+  return systems
+}
 
 // Keys that should be included in resolvedOptions() output
 // These represent all the configurable options for duration formatting
@@ -336,16 +364,15 @@ export class DurationFormat implements DurationFormatType {
   ).reduce<Record<string, DurationFormatLocaleInternalData | undefined>>(
     (all, locale) => {
       DurationFormat.availableLocales.add(locale)
-      const nu = [...TIME_SEPARATORS.localeData[locale].nu]
-      // ECMA-402 DurationFormat resolves `numberingSystem` through the
-      // locale-data [[nu]] list. Keep the locale default first, but allow the
-      // spec-visible `latn` override even when CLDR only needs the default
-      // numbering system for time-separator data.
-      if (!nu.includes('latn')) {
-        nu.push('latn')
-      }
       all[locale] = {
-        nu,
+        // ECMA-402 §13.2.3 [[LocaleData]] constraints (not algorithm steps):
+        // expose numbering systems supported by the NumberFormat dependency.
+        // https://tc39.es/ecma402/#sec-Intl.DurationFormat-internal-slots
+        // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/durationformat.html#L162-L169
+        get nu() {
+          const defaults = TIME_SEPARATORS.localeData[locale].nu
+          return [...new Set([...defaults, ...supportedNumberingSystems()])]
+        },
         digitalFormat: {
           default: TIME_SEPARATORS.default,
           ...TIME_SEPARATORS.localeData[locale as 'da'].separator,

--- a/packages/intl-durationformat/scripts/time-separators.ts
+++ b/packages/intl-durationformat/scripts/time-separators.ts
@@ -43,7 +43,10 @@ async function main(args: Args) {
     result.localeData[locale] = {
       nu: numberingSystems,
     }
-    const localeData = numberingSystems.reduce<Record<string, string>>(
+    const symbolSystems = Object.keys(numbersData)
+      .filter(key => key.startsWith('symbols-numberSystem-'))
+      .map(key => key.slice('symbols-numberSystem-'.length))
+    const localeData = symbolSystems.reduce<Record<string, string>>(
       (all, numberingSystem) => {
         const separator =
           numbersData[

--- a/packages/intl-durationformat/test262-baseline.json
+++ b/packages/intl-durationformat/test262-baseline.json
@@ -1,8 +1,6 @@
 {
   "total": 220,
   "failures": {
-    "intl402/DurationFormat/constructor-options-numberingSystem-valid.js (default)": "adlm is supported by DurationFormat Expected SameValue(«\"latn\"», «\"adlm\"») to be true",
-    "intl402/DurationFormat/constructor-options-numberingSystem-valid.js (strict mode)": "adlm is supported by DurationFormat Expected SameValue(«\"latn\"», «\"adlm\"») to be true",
     "intl402/DurationFormat/prototype/format/taint-temporal-duration-prototype.js (default)": "Test262Error { message: '' }",
     "intl402/DurationFormat/prototype/format/taint-temporal-duration-prototype.js (strict mode)": "Test262Error { message: '' }",
     "intl402/DurationFormat/prototype/format/temporal-duration-string-arg.js (default)": "Expected no error, got RangeError: Invalid duration format",
@@ -10,8 +8,6 @@
     "intl402/DurationFormat/prototype/formatToParts/taint-temporal-duration-prototype.js (default)": "Test262Error { message: '' }",
     "intl402/DurationFormat/prototype/formatToParts/taint-temporal-duration-prototype.js (strict mode)": "Test262Error { message: '' }",
     "intl402/DurationFormat/prototype/formatToParts/temporal-duration-string-arg.js (default)": "Expected no error, got RangeError: Invalid duration format",
-    "intl402/DurationFormat/prototype/formatToParts/temporal-duration-string-arg.js (strict mode)": "Expected no error, got RangeError: Invalid duration format",
-    "intl402/DurationFormat/prototype/resolvedOptions/resolved-numbering-system-unicode-extensions-and-options.js (default)": "Resolved locale for locale=en-u-nu-arab with numberingSystem=invalid Expected SameValue(«\"en\"», «\"en-u-nu-arab\"») to be true",
-    "intl402/DurationFormat/prototype/resolvedOptions/resolved-numbering-system-unicode-extensions-and-options.js (strict mode)": "Resolved locale for locale=en-u-nu-arab with numberingSystem=invalid Expected SameValue(«\"en\"», «\"en-u-nu-arab\"») to be true"
+    "intl402/DurationFormat/prototype/formatToParts/temporal-duration-string-arg.js (strict mode)": "Expected no error, got RangeError: Invalid duration format"
   }
 }

--- a/packages/intl-durationformat/tests/index.test.ts
+++ b/packages/intl-durationformat/tests/index.test.ts
@@ -428,3 +428,38 @@ test('zero minutes remain between displayed numeric hours and seconds', () => {
     })
   ).toBe('01')
 })
+
+test('DurationFormat resolves numbering systems supported by NumberFormat', () => {
+  const formatter = new DurationFormat('en-u-nu-arab', {
+    numberingSystem: 'foobar',
+    style: 'digital',
+  })
+  expect(formatter.resolvedOptions().locale).toBe('en-u-nu-arab')
+  expect(formatter.resolvedOptions().numberingSystem).toBe('arab')
+  expect(formatter.format({hours: 1, minutes: 2, seconds: 3})).toBe('١:٠٢:٠٣')
+  expect(
+    new DurationFormat('en', {numberingSystem: 'deva'}).resolvedOptions()
+      .numberingSystem
+  ).toBe('deva')
+})
+
+test('numbering system support refreshes when NumberFormat is replaced', () => {
+  const NativeNumberFormat = Intl.NumberFormat
+  try {
+    new DurationFormat('en', {numberingSystem: 'arab'})
+    Intl.NumberFormat = class extends NativeNumberFormat {
+      constructor(
+        locales?: Intl.LocalesArgument,
+        options?: Intl.NumberFormatOptions
+      ) {
+        super(locales, {...options, numberingSystem: 'latn'})
+      }
+    } as typeof Intl.NumberFormat
+    expect(
+      new DurationFormat('en', {numberingSystem: 'arab'}).resolvedOptions()
+        .numberingSystem
+    ).toBe('latn')
+  } finally {
+    Intl.NumberFormat = NativeNumberFormat
+  }
+})

--- a/packages/intl-durationformat/types.ts
+++ b/packages/intl-durationformat/types.ts
@@ -6,10 +6,14 @@ export type {DurationInput, DurationRecord}
 
 // Public --------------------------------------------------------------------------------------------------------------
 
-export type DurationFormatOptions = Partial<ResolvedDurationFormatOptions>
+export type DurationFormatOptions = Partial<
+  Omit<ResolvedDurationFormatOptions, 'locale'>
+> & {
+  localeMatcher?: 'best fit' | 'lookup'
+}
 
 export interface ResolvedDurationFormatOptions {
-  localeMatcher: 'best fit' | 'lookup'
+  locale: string
   style: 'long' | 'short' | 'narrow' | 'digital'
   years: 'long' | 'short' | 'narrow'
   yearsDisplay: 'always' | 'auto'
@@ -33,7 +37,6 @@ export interface ResolvedDurationFormatOptions {
   nanosecondsDisplay: 'always' | 'auto'
   fractionalDigits?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9
   numberingSystem: string
-  round: boolean
 }
 
 export interface DurationFormatPart {


### PR DESCRIPTION
DurationFormat now resolves numbering systems supported by its active NumberFormat dependency, retaining each locale's default first. Support is checked lazily and cached per constructor, so replacing NumberFormat refreshes it. CLDR extraction retains separators for every available numbering-system symbol record.

Resolved-option types now include `locale` and exclude non-result fields. Comments cite ECMA-402 §13.2.3's locale-data constraints with pinned source lines. Regressions cover extension fallback, Arabic/Devanagari digits, and NumberFormat replacement.

Validation: all nine DurationFormat unit/package/Test262 gates passed after recording exactly four new passes. No new or changed failures. DurationFormat: 212/220; aggregate: 2,134/2,498 passes, 364 failures tracked.
