### PR TITLE
fix(@formatjs/intl-durationformat): accept Temporal duration inputs

### DIFF
--- a/docs/src/docs/polyfills/intl-durationformat.mdx
+++ b/docs/src/docs/polyfills/intl-durationformat.mdx
@@ -226,3 +226,14 @@ Numbering-system resolution includes systems supported by the active
 `Intl.NumberFormat` dependency, keeping the locale default first. Support is
 checked lazily and refreshed when that constructor is replaced. Time-separator
 data includes every numbering-system symbol record supplied by CLDR.
+
+### Temporal integration
+
+When a Temporal implementation is available before this package is loaded,
+`format` and `formatToParts` accept ISO duration strings through `Temporal.Duration.from`.
+Temporal durations are read with captured intrinsic getters, so later changes to
+`Temporal.Duration.prototype` do not affect formatting. Ordinary duration-like
+objects keep the ECMA-402 property-read order.
+
+Without Temporal, duration-like objects remain supported; duration strings throw
+`RangeError`. This integration follows the Temporal proposal's Intl changes.

--- a/knowledge-base/007g-polyfill-intl-durationformat.md
+++ b/knowledge-base/007g-polyfill-intl-durationformat.md
@@ -79,3 +79,14 @@ Numbering-system resolution includes systems supported by the active
 `Intl.NumberFormat` dependency, keeping the locale default first. Support is
 checked lazily and refreshed when that constructor is replaced. Time-separator
 data includes every numbering-system symbol record supplied by CLDR.
+
+### Temporal integration
+
+When a Temporal implementation is available before this package is loaded,
+`format` and `formatToParts` accept ISO duration strings through `Temporal.Duration.from`.
+Temporal durations are read with captured intrinsic getters, so later changes to
+`Temporal.Duration.prototype` do not affect formatting. Ordinary duration-like
+objects keep the ECMA-402 property-read order.
+
+Without Temporal, duration-like objects remain supported; duration strings throw
+`RangeError`. This integration follows the Temporal proposal's Intl changes.

--- a/knowledge-base/014-test262-conformance.md
+++ b/knowledge-base/014-test262-conformance.md
@@ -10,7 +10,7 @@ excluded because it fails.
 | collator            |      130 |                16 |               0 |
 | datetimeformat      |      488 |               242 |              52 |
 | displaynames        |      114 |                 6 |               0 |
-| durationformat      |      220 |                 8 |               4 |
+| durationformat      |      220 |                 0 |               4 |
 | getcanonicallocales |       76 |                32 |               2 |
 | listformat          |      162 |                 4 |               0 |
 | locale              |      336 |                 4 |              22 |
@@ -20,7 +20,7 @@ excluded because it fails.
 | segmenter           |      158 |                10 |               0 |
 | supportedvaluesof   |       50 |                 6 |               6 |
 
-Total: 2,498 executions, 2,134 polyfill passes, 364 polyfill failures. The native
+Total: 2,498 executions, 2,142 polyfill passes, 356 polyfill failures. The native
 control fails 86 executions; 52 failing cases overlap. Overlap does not prove
 a polyfill is correct: each failure still needs comparison with the selected
 spec and test's feature metadata.

--- a/packages/intl-durationformat/BUILD.bazel
+++ b/packages/intl-durationformat/BUILD.bazel
@@ -18,6 +18,7 @@ formatjs_library(
     package_name = "@formatjs/intl-durationformat",
     srcs = [
         "abstract/PartitionDurationFormatPattern.ts",
+        "abstract/ToTemporalDurationRecord.ts",
         "constants.ts",
         "core.ts",
         "get_internal_slots.ts",

--- a/packages/intl-durationformat/abstract/ToTemporalDurationRecord.ts
+++ b/packages/intl-durationformat/abstract/ToTemporalDurationRecord.ts
@@ -1,0 +1,72 @@
+import {ToDurationRecord} from '#packages/ecma402-abstract/DurationFormat/ToDurationRecord.js'
+import type {
+  DurationInput,
+  DurationRecord,
+} from '#packages/ecma402-abstract/types/duration.js'
+
+interface TemporalDurationConstructor {
+  prototype: object
+  from(value: string): object
+}
+
+// Capture intrinsic operations before application code can replace public getters.
+// A Temporal implementation must be installed before this module is loaded.
+const temporalDuration = (
+  globalThis as typeof globalThis & {
+    Temporal?: {Duration: TemporalDurationConstructor}
+  }
+).Temporal?.Duration
+const durationFrom = temporalDuration?.from
+const fields = [
+  'years',
+  'months',
+  'weeks',
+  'days',
+  'hours',
+  'minutes',
+  'seconds',
+  'milliseconds',
+  'microseconds',
+  'nanoseconds',
+] as const
+const getters =
+  temporalDuration &&
+  fields.map(
+    field =>
+      Object.getOwnPropertyDescriptor(temporalDuration.prototype, field)!.get!
+  )
+
+// Temporal proposal: DurationFormat format/formatToParts, step 3, and
+// ToTemporalDuration steps 1–2 read branded slots or parse a duration string.
+// https://tc39.es/proposal-temporal/#sec-Intl.DurationFormat.prototype.format
+// https://github.com/tc39/proposal-temporal/blob/e8cc03fc970a65a3359e8870e3b35e687ac94e55/spec/intl.html#L1787-L1789
+// https://github.com/tc39/proposal-temporal/blob/e8cc03fc970a65a3359e8870e3b35e687ac94e55/spec/intl.html#L1804-L1806
+// https://tc39.es/proposal-temporal/#sec-temporal-totemporalduration
+// https://github.com/tc39/proposal-temporal/blob/e8cc03fc970a65a3359e8870e3b35e687ac94e55/spec/duration.html#L1078-L1082
+export function ToTemporalDurationRecord(
+  input: DurationInput | string
+): DurationRecord {
+  if (typeof input === 'string' && durationFrom) {
+    input = durationFrom.call(temporalDuration, input) as DurationInput
+  }
+  if (
+    getters &&
+    input !== null &&
+    (typeof input === 'object' || typeof input === 'function')
+  ) {
+    let years: number
+    try {
+      years = getters[0].call(input)
+    } catch {
+      // Ordinary duration-like objects retain their specified property-read order.
+      return ToDurationRecord(input)
+    }
+    const record = Object.create(null) as DurationRecord
+    record.years = years
+    for (let i = 1; i < fields.length; i++) {
+      record[fields[i]] = getters[i].call(input)
+    }
+    return record
+  }
+  return ToDurationRecord(input as DurationInput)
+}

--- a/packages/intl-durationformat/core.ts
+++ b/packages/intl-durationformat/core.ts
@@ -13,7 +13,7 @@ import {invariant} from '#packages/ecma402-abstract/utils.js'
 import {ResolveLocale} from '@formatjs/intl-localematcher'
 import {GetDurationUnitOptions} from '#packages/ecma402-abstract/DurationFormat/GetDurationUnitOptions.js'
 import {PartitionDurationFormatPattern} from '#packages/intl-durationformat/abstract/PartitionDurationFormatPattern.js'
-import {ToDurationRecord} from '#packages/ecma402-abstract/DurationFormat/ToDurationRecord.js'
+import {ToTemporalDurationRecord} from '#packages/intl-durationformat/abstract/ToTemporalDurationRecord.js'
 import {getInternalSlots} from '#packages/intl-durationformat/get_internal_slots.js'
 import {TIME_SEPARATORS} from '@formatjs_generated/cldr.number/time-separators.js'
 import type {
@@ -310,12 +310,12 @@ export class DurationFormat implements DurationFormatType {
     }
     return ro as any
   }
-  formatToParts(duration: DurationInput): DurationFormatPart[] {
+  formatToParts(duration: DurationInput | string): DurationFormatPart[] {
     const locInternalSlots = getInternalSlots(this)
     if (locInternalSlots.initializedDurationFormat === undefined) {
       throw new TypeError('Error uninitialized locale')
     }
-    const record = ToDurationRecord(duration)
+    const record = ToTemporalDurationRecord(duration)
     const parts = PartitionDurationFormatPattern(this, record)
     const result = []
     for (const {type, unit, value} of parts) {
@@ -327,12 +327,12 @@ export class DurationFormat implements DurationFormatType {
     }
     return result
   }
-  format(duration: DurationInput): string {
+  format(duration: DurationInput | string): string {
     const locInternalSlots = getInternalSlots(this)
     if (locInternalSlots.initializedDurationFormat === undefined) {
       throw new TypeError('Error uninitialized locale')
     }
-    const record = ToDurationRecord(duration)
+    const record = ToTemporalDurationRecord(duration)
     const parts = PartitionDurationFormatPattern(this, record)
     let result = ''
     for (const {value} of parts) {

--- a/packages/intl-durationformat/test262-baseline.json
+++ b/packages/intl-durationformat/test262-baseline.json
@@ -1,13 +1,4 @@
 {
   "total": 220,
-  "failures": {
-    "intl402/DurationFormat/prototype/format/taint-temporal-duration-prototype.js (default)": "Test262Error { message: '' }",
-    "intl402/DurationFormat/prototype/format/taint-temporal-duration-prototype.js (strict mode)": "Test262Error { message: '' }",
-    "intl402/DurationFormat/prototype/format/temporal-duration-string-arg.js (default)": "Expected no error, got RangeError: Invalid duration format",
-    "intl402/DurationFormat/prototype/format/temporal-duration-string-arg.js (strict mode)": "Expected no error, got RangeError: Invalid duration format",
-    "intl402/DurationFormat/prototype/formatToParts/taint-temporal-duration-prototype.js (default)": "Test262Error { message: '' }",
-    "intl402/DurationFormat/prototype/formatToParts/taint-temporal-duration-prototype.js (strict mode)": "Test262Error { message: '' }",
-    "intl402/DurationFormat/prototype/formatToParts/temporal-duration-string-arg.js (default)": "Expected no error, got RangeError: Invalid duration format",
-    "intl402/DurationFormat/prototype/formatToParts/temporal-duration-string-arg.js (strict mode)": "Expected no error, got RangeError: Invalid duration format"
-  }
+  "failures": {}
 }

--- a/packages/intl-durationformat/tests/index.test.ts
+++ b/packages/intl-durationformat/tests/index.test.ts
@@ -463,3 +463,15 @@ test('numbering system support refreshes when NumberFormat is replaced', () => {
     Intl.NumberFormat = NativeNumberFormat
   }
 })
+
+test('duration strings use Temporal when the runtime provides it', () => {
+  const formatter = new DurationFormat('en', {style: 'digital'})
+  if ('Temporal' in globalThis) {
+    expect(formatter.format('PT1H')).toBe(formatter.format({hours: 1}))
+    expect(formatter.formatToParts('PT1H')).toEqual(
+      formatter.formatToParts({hours: 1})
+    )
+  } else {
+    expect(() => formatter.format('PT1H')).toThrow(RangeError)
+  }
+})

--- a/packages/intl-durationformat/types.ts
+++ b/packages/intl-durationformat/types.ts
@@ -58,8 +58,8 @@ export interface DurationFormatLocaleInternalData {
 
 export interface DurationFormat {
   resolvedOptions(): ResolvedDurationFormatOptions
-  formatToParts(duration: DurationInput): DurationFormatPart[]
-  format(duration: DurationInput): string
+  formatToParts(duration: DurationInput | string): DurationFormatPart[]
+  format(duration: DurationInput | string): string
 }
 
 export interface IntlDurationFormatInternal {


### PR DESCRIPTION
DurationFormat now implements the Temporal proposal's duration-input integration when Temporal is installed before the package loads. ISO duration strings use captured `Temporal.Duration.from`; branded durations use captured intrinsic getters, so later prototype changes cannot affect formatting. Ordinary duration-like objects retain their existing property-read order.

Comments cite the Temporal proposal's format/formatToParts step 3 and ToTemporalDuration steps 1–2 with pinned source lines. String overloads and runtime requirements are documented. Without Temporal, ordinary duration objects remain supported and strings retain their RangeError behavior.

Validation: all eight unit/package gates passed. Both the baseline gate and strict zero-failure gate passed: **220/220 DurationFormat executions**, with no exclusions. Exactly eight new passes, no new or changed failures. Aggregate: 2,142/2,498 passes, 356 failures tracked.
