### PR TITLE
fix(@formatjs/intl-displaynames): accept extended language subtags

### DIFF
--- a/docs/src/docs/polyfills/intl-displaynames.mdx
+++ b/docs/src/docs/polyfills/intl-displaynames.mdx
@@ -214,3 +214,6 @@ code, such as `ZZZ` for an unknown currency supplied as `zzz`.
 
 Loading `und` locale data preserves existing English data. Root patterns remain
 separate from language-specific patterns, regardless of registration order.
+
+Language display-name codes accept Unicode language subtags of two, three, or
+five to eight ASCII letters, with optional script, region, and variant subtags.

--- a/knowledge-base/007d-polyfill-intl-displaynames.md
+++ b/knowledge-base/007d-polyfill-intl-displaynames.md
@@ -55,3 +55,6 @@ Stage 3: supported-locales.generated.ts
 Calendar codes use hyphen-separated Unicode type identifiers; underscore forms
 throw `RangeError`. When `fallback: 'code'` applies, `of` returns the canonical
 code, such as `ZZZ` for an unknown currency supplied as `zzz`.
+
+Language display-name codes accept Unicode language subtags of two, three, or
+five to eight ASCII letters, with optional script, region, and variant subtags.

--- a/knowledge-base/014-test262-conformance.md
+++ b/knowledge-base/014-test262-conformance.md
@@ -9,7 +9,7 @@ excluded because it fails.
 | ------------------- | -------: | ----------------: | --------------: |
 | collator            |      130 |                16 |               0 |
 | datetimeformat      |      488 |               242 |              52 |
-| displaynames        |      114 |                 6 |               0 |
+| displaynames        |      114 |                 4 |               0 |
 | durationformat      |      220 |                 0 |               4 |
 | getcanonicallocales |       76 |                32 |               2 |
 | listformat          |      162 |                 4 |               0 |
@@ -20,7 +20,7 @@ excluded because it fails.
 | segmenter           |      158 |                10 |               0 |
 | supportedvaluesof   |       50 |                 6 |               6 |
 
-Total: 2,498 executions, 2,142 polyfill passes, 356 polyfill failures. The native
+Total: 2,498 executions, 2,144 polyfill passes, 354 polyfill failures. The native
 control fails 86 executions; 52 failing cases overlap. Overlap does not prove
 a polyfill is correct: each failure still needs comparison with the selected
 spec and test's feature metadata.

--- a/packages/intl-displaynames/index.ts
+++ b/packages/intl-displaynames/index.ts
@@ -253,13 +253,11 @@ function isValidCodeForDisplayNames(
 ): boolean {
   switch (type) {
     case 'language':
-      // subset of unicode_language_id
-      // languageCode ["-" scriptCode] ["-" regionCode] *("-" variant)
-      // where:
-      // - languageCode is either a two letters ISO 639-1 language code or a three letters ISO 639-2 language code.
-      // - scriptCode is should be an ISO-15924 four letters script code
-      // - regionCode is either an ISO-3166 two letters region code, or a three digits UN M49 Geographic Regions.
-      return /^[a-z]{2,3}(-[a-z]{4})?(-([a-z]{2}|\d{3}))?(-([a-z\d]{5,8}|\d[a-z\d]{3}))*$/i.test(
+      // ECMA-402 §12.5.1 CanonicalCodeForDisplayNames, step 1.a:
+      // unicode_language_subtag allows 2–3 or 5–8 ASCII letters.
+      // https://tc39.es/ecma402/#sec-canonicalcodefordisplaynames
+      // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/displaynames.html#L235-L238
+      return /^(?:[a-z]{2,3}|[a-z]{5,8})(-[a-z]{4})?(-([a-z]{2}|\d{3}))?(-([a-z\d]{5,8}|\d[a-z\d]{3}))*$/i.test(
         code
       )
     case 'region':

--- a/packages/intl-displaynames/test262-baseline.json
+++ b/packages/intl-displaynames/test262-baseline.json
@@ -3,8 +3,6 @@
   "failures": {
     "intl402/DisplayNames/proto-from-ctor-realm.js (default)": "Expected SameValue(«[object Object]», «[object Intl.DisplayNames]») to be true",
     "intl402/DisplayNames/proto-from-ctor-realm.js (strict mode)": "Expected SameValue(«[object Object]», «[object Intl.DisplayNames]») to be true",
-    "intl402/DisplayNames/prototype/of/type-language-valid.js (default)": "Expected no error, got RangeError: invalid code for Intl.DisplayNames.prototype.of",
-    "intl402/DisplayNames/prototype/of/type-language-valid.js (strict mode)": "Expected no error, got RangeError: invalid code for Intl.DisplayNames.prototype.of",
     "intl402/DisplayNames/prototype/resolvedOptions/return-object.js (default)": "locale descriptor value should be en-US; locale value should be en-US",
     "intl402/DisplayNames/prototype/resolvedOptions/return-object.js (strict mode)": "locale descriptor value should be en-US; locale value should be en-US"
   }

--- a/packages/intl-displaynames/tests/index.test.ts
+++ b/packages/intl-displaynames/tests/index.test.ts
@@ -300,3 +300,19 @@ it('returns canonical codes when display names are missing', () => {
     new DisplayNames('en', {type: 'currency', fallback: 'none'}).of('zzz')
   ).toBeUndefined()
 })
+
+it.each(['abcde', 'abcdefgh', 'abcde-Latn-US-1996'])(
+  'accepts well-formed extended language subtag %s',
+  code => {
+    expect(new DisplayNames('en', {type: 'language'}).of(code)).toBe(code)
+  }
+)
+
+it.each(['abcd', 'abcdefghi', 'en-u-ca-gregory'])(
+  'rejects code outside unicode_language_id: %s',
+  code => {
+    expect(() => new DisplayNames('en', {type: 'language'}).of(code)).toThrow(
+      RangeError
+    )
+  }
+)


### PR DESCRIPTION
DisplayNames now accepts language subtags of five to eight ASCII letters, alongside two- and three-letter subtags. The old ISO-only check rejected valid Unicode language IDs.

Comments cite ECMA-402 §12.5.1 step 1.a with pinned source lines. Regressions cover extended subtags with script/region/variants and reject invalid lengths or locale extensions.

Validation: all ten DisplayNames unit/package/Test262 gates passed after recording exactly two new passes. No new or changed failures. DisplayNames: 110/114; aggregate: 2,144/2,498 passes, 354 failures tracked.
