### PR TITLE
fix(@formatjs/intl-supportedvaluesof): include fixed-offset time zones

### DIFF
--- a/docs/src/docs/polyfills/intl-supportedvaluesof.mdx
+++ b/docs/src/docs/polyfills/intl-supportedvaluesof.mdx
@@ -73,3 +73,7 @@ This library is [test262](https://github.com/tc39/test262/tree/master/test/intl4
 category. String wrapper objects are accepted; Symbols throw `TypeError`.
 
 `Intl.supportedValuesOf` is callable but cannot be used as a constructor.
+
+Time-zone candidates include the pinned IANA `etcetera` Zone records and `UTC`,
+in addition to continental transition zones. Runtime filtering retains primary
+identifiers and omits aliases such as `Etc/UTC`.

--- a/knowledge-base/007k-polyfill-intl-supportedvaluesof.md
+++ b/knowledge-base/007k-polyfill-intl-supportedvaluesof.md
@@ -73,3 +73,7 @@ export const units = ['acre', 'bit', 'byte', 'celsius', ...] as const
 category. String wrapper objects are accepted; Symbols throw `TypeError`.
 
 `Intl.supportedValuesOf` is callable but cannot be used as a constructor.
+
+Time-zone candidates include the pinned IANA `etcetera` Zone records and `UTC`,
+in addition to continental transition zones. Runtime filtering retains primary
+identifiers and omits aliases such as `Etc/UTC`.

--- a/knowledge-base/014-test262-conformance.md
+++ b/knowledge-base/014-test262-conformance.md
@@ -18,10 +18,10 @@ excluded because it fails.
 | pluralrules         |      106 |                 4 |               0 |
 | relativetimeformat  |      160 |                 8 |               0 |
 | segmenter           |      158 |                10 |               0 |
-| supportedvaluesof   |       50 |                 6 |               6 |
+| supportedvaluesof   |       50 |                 4 |               6 |
 
-Total: 2,498 executions, 2,144 polyfill passes, 354 polyfill failures. The native
-control fails 86 executions; 52 failing cases overlap. Overlap does not prove
+Total: 2,498 executions, 2,146 polyfill passes, 352 polyfill failures. The native
+control fails 86 executions; 50 failing cases overlap. Overlap does not prove
 a polyfill is correct: each failure still needs comparison with the selected
 spec and test's feature metadata.
 

--- a/packages/intl-supportedvaluesof/BUILD.bazel
+++ b/packages/intl-supportedvaluesof/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_lib//lib:copy_file.bzl", "copy_file")
 load("//packages/intl-datetimeformat:defs.bzl", "ZONES")
 load("//tools:compile.bzl", "formatjs_library")
 load("//tools:generated.bzl", "formatjs_generated_package", "generate_package_file")
@@ -94,10 +95,20 @@ generate_package_file(
     tool = "//packages/intl-supportedvaluesof/scripts:calendars",
 )
 
+copy_file(
+    name = "iana_etcetera",
+    src = "@iana_tzdata//:etcetera",
+    out = "iana-etcetera.txt",
+)
+
 generate_package_file(
     name = "cldr_sv_timezones",
     src = "timezones.ts",
-    args = ["--zone %s" % z for z in ZONES],
+    args = ["--zone %s" % z for z in ZONES] + [
+        "--source",
+        "$(rootpath :iana_etcetera)",
+    ],
+    data = [":iana_etcetera"],
     tags = ["cldr"],
     tool = "//packages/intl-supportedvaluesof/scripts:timezones",
 )

--- a/packages/intl-supportedvaluesof/scripts/timezones.ts
+++ b/packages/intl-supportedvaluesof/scripts/timezones.ts
@@ -1,17 +1,29 @@
+import {readFileSync} from 'node:fs'
 import minimist from 'minimist'
 import {outputFileSync} from 'fs-extra/esm'
+
 interface Args extends minimist.ParsedArgs {
+  out: string
   zone: string[]
+  source: string
 }
 function main(args: Args) {
-  const {out, zone: timezones} = args
-
-  // Output numbering systems file
+  const timezones = new Set<string>(([] as string[]).concat(args.zone || []))
+  // ECMA-402 §6.5.3 AvailablePrimaryTimeZoneIdentifiers, step 3.a.i:
+  // primary identifiers include non-continental zones. DateTimeFormat's
+  // transition-file list omits these fixed-offset Zone records from etcetera.
+  // https://tc39.es/ecma402/#sec-availableprimarytimezoneidentifiers
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/locales-currencies-tz.html#L338-L340
+  for (const line of readFileSync(args.source, 'utf8').split(/\r?\n/)) {
+    const [kind, name] = line.trim().split(/\s+/)
+    if (kind === 'Zone') timezones.add(name)
+  }
+  timezones.add('UTC')
   outputFileSync(
-    out,
+    args.out,
     `/* @generated */
 // prettier-ignore
-export const timezones = ${JSON.stringify(timezones)} as const
+export const timezones = ${JSON.stringify([...timezones].sort())} as const
 export type Timezone = typeof timezones[number]
     `
   )

--- a/packages/intl-supportedvaluesof/test262-baseline.json
+++ b/packages/intl-supportedvaluesof/test262-baseline.json
@@ -4,8 +4,6 @@
     "intl402/Intl/supportedValuesOf/calendars-required-by-intl-era-monthcode.js (default)": "Actual [buddhist, chinese, coptic, dangi, ethioaa, ethiopic, gregory, hebrew, indian, islamic, islamic-civil, islamic-rgsa, islamic-tbla, islamic-umalqura, iso8601, japanese, persian, roc] and expected [buddhist, chinese, coptic, dangi, ethioaa, ethiopic, gregory, hebrew, indian, islamic-civil, islamic-tbla, islamic-umalqura, iso8601, japanese, persian, roc] should have the same contents. only the required calendars are supported",
     "intl402/Intl/supportedValuesOf/calendars-required-by-intl-era-monthcode.js (strict mode)": "Actual [buddhist, chinese, coptic, dangi, ethioaa, ethiopic, gregory, hebrew, indian, islamic, islamic-civil, islamic-rgsa, islamic-tbla, islamic-umalqura, iso8601, japanese, persian, roc] and expected [buddhist, chinese, coptic, dangi, ethioaa, ethiopic, gregory, hebrew, indian, islamic-civil, islamic-tbla, islamic-umalqura, iso8601, japanese, persian, roc] should have the same contents. only the required calendars are supported",
     "intl402/Intl/supportedValuesOf/collations-accepted-by-Collator.js (default)": "compat supported but not returned by supportedValuesOf",
-    "intl402/Intl/supportedValuesOf/collations-accepted-by-Collator.js (strict mode)": "compat supported but not returned by supportedValuesOf",
-    "intl402/Intl/supportedValuesOf/timeZones-include-non-continental.js (default)": "non-continental timezone Etc/GMT+1 is not supported",
-    "intl402/Intl/supportedValuesOf/timeZones-include-non-continental.js (strict mode)": "non-continental timezone Etc/GMT+1 is not supported"
+    "intl402/Intl/supportedValuesOf/collations-accepted-by-Collator.js (strict mode)": "compat supported but not returned by supportedValuesOf"
   }
 }

--- a/packages/intl-supportedvaluesof/tests/index.test.ts
+++ b/packages/intl-supportedvaluesof/tests/index.test.ts
@@ -199,3 +199,18 @@ it('supportedValuesOf is a non-constructible built-in function', () => {
     TypeError
   )
 })
+
+it('enumerates non-continental primary time zones', () => {
+  const zones = supportedValuesOf('timeZone')
+  expect(zones).toEqual(
+    expect.arrayContaining([
+      'UTC',
+      'Etc/GMT+1',
+      'Etc/GMT+12',
+      'Etc/GMT-1',
+      'Etc/GMT-14',
+    ])
+  )
+  expect(zones).not.toContain('Etc/UTC')
+  expect(zones).not.toContain('Etc/GMT')
+})


### PR DESCRIPTION
Include UTC and fixed-offset IANA `Etc/GMT` zones in supportedValuesOf candidates. Read Zone records from the pinned tzdata `etcetera` file; keep DateTimeFormat validation and alias filtering.

ECMA-402 §6.5.3, step 3.a.i: [section](https://tc39.es/ecma402/#sec-availableprimarytimezoneidentifiers), [source lines](https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/locales-currencies-tz.html#L338-L340).

Validation: all nine supportedValuesOf Bazel gates pass. Test262 improves from 44/50 to 46/50; two failures removed, no exclusions or changed remaining diagnostics.
