### PR TITLE
fix(@formatjs/intl-collator): preserve locale punctuation defaults

### DIFF
--- a/docs/src/docs/polyfills/intl-collator.mdx
+++ b/docs/src/docs/polyfills/intl-collator.mdx
@@ -101,3 +101,6 @@ left-to-right order and rejects Symbols with `TypeError`.
 `resolvedOptions` and `supportedLocalesOf` are writable, configurable methods,
 but cannot be constructed with `new`. The constructor's `prototype` property
 is non-writable; the compare getter and bound function expose the standard names.
+
+The default `ignorePunctuation` value follows the locale’s CLDR collation
+settings. Thai defaults to `true`; an explicit `false` preserves punctuation.

--- a/knowledge-base/007l-polyfill-intl-collator.md
+++ b/knowledge-base/007l-polyfill-intl-collator.md
@@ -129,3 +129,6 @@ left-to-right order and rejects Symbols with `TypeError`.
 `resolvedOptions` and `supportedLocalesOf` are writable, configurable methods,
 but cannot be constructed with `new`. The constructor's `prototype` property
 is non-writable; the compare getter and bound function expose the standard names.
+
+The default `ignorePunctuation` value follows the locale’s CLDR collation
+settings. Thai defaults to `true`; an explicit `false` preserves punctuation.

--- a/knowledge-base/014-test262-conformance.md
+++ b/knowledge-base/014-test262-conformance.md
@@ -7,7 +7,7 @@ excluded because it fails.
 
 | Polyfill            | Executed | Polyfill failures | Native failures |
 | ------------------- | -------: | ----------------: | --------------: |
-| collator            |      130 |                16 |               0 |
+| collator            |      130 |                14 |               0 |
 | datetimeformat      |      488 |               242 |              52 |
 | displaynames        |      114 |                 4 |               0 |
 | durationformat      |      220 |                 0 |               4 |
@@ -20,7 +20,7 @@ excluded because it fails.
 | segmenter           |      158 |                10 |               0 |
 | supportedvaluesof   |       50 |                 4 |               6 |
 
-Total: 2,498 executions, 2,146 polyfill passes, 352 polyfill failures. The native
+Total: 2,498 executions, 2,148 polyfill passes, 350 polyfill failures. The native
 control fails 86 executions; 50 failing cases overlap. Overlap does not prove
 a polyfill is correct: each failure still needs comparison with the selected
 spec and test's feature metadata.

--- a/packages/intl-collator/scripts/generate-locale-data.ts
+++ b/packages/intl-collator/scripts/generate-locale-data.ts
@@ -10,7 +10,7 @@ type GeneratedLocaleData = {
   readonly kf: readonly ['false', 'upper', 'lower']
   readonly defaultCollation: string
   readonly sensitivity: 'variant'
-  readonly ignorePunctuation: false
+  readonly ignorePunctuation: boolean
 }
 
 const DEFAULT_COLLATION_RE =
@@ -111,13 +111,22 @@ for (const path of resolvedPaths) {
   if (defaultType !== 'standard' && defaultType !== 'search') {
     collationTypes.add(defaultType)
   }
+  // ECMA-402 §10.1.1, steps 21–22: use the locale punctuation default.
+  // LDML alternate=shifted ignores variable punctuation at these strengths.
+  // https://tc39.es/ecma402/#sec-intl.collator
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/collator.html#L42-L43
+  // https://www.unicode.org/reports/tr35/tr35-collation.html#Setting_Options
+  const alternate = collations
+    .find(collation => collation.type === defaultType)
+    ?.rules.findLast(rule => rule.type === 'alternate')
   localeData[locale] = {
     co: [...collationTypes].sort(),
     kn: ['false', 'true'],
     kf: ['false', 'upper', 'lower'],
     defaultCollation: defaultType,
     sensitivity: 'variant',
-    ignorePunctuation: false,
+    ignorePunctuation:
+      alternate?.type === 'alternate' && alternate.value === 'shifted',
   }
 }
 

--- a/packages/intl-collator/test262-baseline.json
+++ b/packages/intl-collator/test262-baseline.json
@@ -5,8 +5,6 @@
     "intl402/Collator/legacy-regexp-statics-not-modified.js (strict mode)": "RegExp has unexpected property $_ with value de-DE-u-co-phonebk.",
     "intl402/Collator/proto-from-ctor-realm.js (default)": "newTarget.prototype is undefined Expected SameValue(«[object Intl.Collator]», «[object Intl.Collator]») to be true",
     "intl402/Collator/proto-from-ctor-realm.js (strict mode)": "newTarget.prototype is undefined Expected SameValue(«[object Intl.Collator]», «[object Intl.Collator]») to be true",
-    "intl402/Collator/prototype/resolvedOptions/ignorePunctuation-default.js (default)": "Thai default ignorePunctuation to true Expected SameValue(«false», «true») to be true",
-    "intl402/Collator/prototype/resolvedOptions/ignorePunctuation-default.js (strict mode)": "Thai default ignorePunctuation to true Expected SameValue(«false», «true») to be true",
     "intl402/Collator/prototype/resolvedOptions/resolved-collation-unicode-extensions-and-options.js (default)": "Resolved locale for locale=de-u-co-phonebk with collation=pinyin Expected SameValue(«\"de\"», «\"de-u-co-phonebk\"») to be true",
     "intl402/Collator/prototype/resolvedOptions/resolved-collation-unicode-extensions-and-options.js (strict mode)": "Resolved locale for locale=de-u-co-phonebk with collation=pinyin Expected SameValue(«\"de\"», «\"de-u-co-phonebk\"») to be true",
     "intl402/Collator/subclassing.js (default)": "Expected no error, got RangeError: Incorrect locale information provided",

--- a/packages/intl-collator/tests/index.test.ts
+++ b/packages/intl-collator/tests/index.test.ts
@@ -55,6 +55,22 @@ describe('Intl.Collator', () => {
     expect(collator.compare('a\u2014b', 'ab')).toBe(0)
   })
 
+  it('uses the CLDR punctuation default unless explicitly overridden', () => {
+    for (const locale of ['th', 'th-TH']) {
+      const collator = new Collator(locale)
+      expect(collator.resolvedOptions().ignorePunctuation).toBe(true)
+      expect(collator.compare('a-b', 'ab')).toBe(0)
+      const explicit = new Collator(locale, {ignorePunctuation: false})
+      expect(explicit.resolvedOptions().ignorePunctuation).toBe(false)
+      expect(explicit.compare('a-b', 'ab')).not.toBe(0)
+    }
+    for (const locale of ['en', 'ja']) {
+      expect(new Collator(locale).resolvedOptions().ignorePunctuation).toBe(
+        false
+      )
+    }
+  })
+
   it('supports locale filtering', () => {
     expect(Collator.supportedLocalesOf(['en', 'fr', 'sv', 'zz'])).toEqual([
       'en',


### PR DESCRIPTION
Derive Collator’s default `ignorePunctuation` from CLDR’s alternate setting. Thai now defaults to true; an explicit false still preserves punctuation.

ECMA-402 §10.1.1, steps 21–22: [section](https://tc39.es/ecma402/#sec-intl.collator), [source lines](https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/collator.html#L42-L43). CLDR supplies the locale-specific value.

Validation: all 13 Collator Bazel gates plus ICU4J conformance pass. Test262 improves from 114/130 to 116/130; no exclusions or changed remaining diagnostics.
