### PR TITLE
fix(@formatjs/intl-localematcher): respect Unicode extension boundaries

### DIFF
--- a/docs/src/docs/polyfills/intl-localematcher.mdx
+++ b/docs/src/docs/polyfills/intl-localematcher.mdx
@@ -63,3 +63,7 @@ LookupSupportedLocales(['de'], ['de-AT-u-co-phonebk']) // ['de-AT-u-co-phonebk']
 
 Locale resolution uses an internal record isolated from inherited extension-key
 setters on `Object.prototype`.
+
+Locale matching extracts only the Unicode `u` extension. Private-use subtags
+remain intact, including text resembling `u-co-phonebk`; trailing extensions
+are preserved separately from Unicode keywords.

--- a/knowledge-base/005-package-intl-localematcher.md
+++ b/knowledge-base/005-package-intl-localematcher.md
@@ -30,3 +30,7 @@ Uses `@formatjs/fast-memoize` to cache distance calculation results. The CLDR di
 ## Dependencies
 
 `@formatjs/fast-memoize`
+
+Locale matching extracts only the Unicode `u` extension. Private-use subtags
+remain intact, including text resembling `u-co-phonebk`; trailing extensions
+are preserved separately from Unicode keywords.

--- a/knowledge-base/014-test262-conformance.md
+++ b/knowledge-base/014-test262-conformance.md
@@ -7,20 +7,20 @@ excluded because it fails.
 
 | Polyfill            | Executed | Polyfill failures | Native failures |
 | ------------------- | -------: | ----------------: | --------------: |
-| collator            |      130 |                10 |               0 |
+| collator            |      130 |                 6 |               0 |
 | datetimeformat      |      488 |               242 |              52 |
 | displaynames        |      114 |                 4 |               0 |
 | durationformat      |      220 |                 0 |               4 |
 | getcanonicallocales |       76 |                32 |               2 |
 | listformat          |      162 |                 4 |               0 |
 | locale              |      336 |                 4 |              22 |
-| numberformat        |      498 |                24 |               0 |
+| numberformat        |      498 |                22 |               0 |
 | pluralrules         |      106 |                 4 |               0 |
 | relativetimeformat  |      160 |                 8 |               0 |
 | segmenter           |      158 |                10 |               0 |
 | supportedvaluesof   |       50 |                 4 |               6 |
 
-Total: 2,498 executions, 2,152 polyfill passes, 346 polyfill failures. The native
+Total: 2,498 executions, 2,158 polyfill passes, 340 polyfill failures. The native
 control fails 86 executions; 50 failing cases overlap. Overlap does not prove
 a polyfill is correct: each failure still needs comparison with the selected
 spec and test's feature metadata.

--- a/packages/intl-collator/test262-baseline.json
+++ b/packages/intl-collator/test262-baseline.json
@@ -1,14 +1,10 @@
 {
   "total": 130,
   "failures": {
-    "intl402/Collator/legacy-regexp-statics-not-modified.js (default)": "RegExp has unexpected property $_ with value de-DE-u-co-phonebk.",
-    "intl402/Collator/legacy-regexp-statics-not-modified.js (strict mode)": "RegExp has unexpected property $_ with value de-DE-u-co-phonebk.",
     "intl402/Collator/proto-from-ctor-realm.js (default)": "newTarget.prototype is undefined Expected SameValue(«[object Intl.Collator]», «[object Intl.Collator]») to be true",
     "intl402/Collator/proto-from-ctor-realm.js (strict mode)": "newTarget.prototype is undefined Expected SameValue(«[object Intl.Collator]», «[object Intl.Collator]») to be true",
     "intl402/Collator/prototype/resolvedOptions/resolved-collation-unicode-extensions-and-options.js (default)": "Resolved locale for locale=de-u-co-phonebk with collation=pinyin Expected SameValue(«\"de\"», «\"de-u-co-phonebk\"») to be true",
     "intl402/Collator/prototype/resolvedOptions/resolved-collation-unicode-extensions-and-options.js (strict mode)": "Resolved locale for locale=de-u-co-phonebk with collation=pinyin Expected SameValue(«\"de\"», «\"de-u-co-phonebk\"») to be true",
-    "intl402/Collator/unicode-ext-seq-in-private-tag.js (default)": "Expected no error, got RangeError: Incorrect locale information provided",
-    "intl402/Collator/unicode-ext-seq-in-private-tag.js (strict mode)": "Expected no error, got RangeError: Incorrect locale information provided",
     "intl402/Collator/usage-de.js (default)": "Actual [Ä, AE] and expected [AE, Ä] should have the same contents. search",
     "intl402/Collator/usage-de.js (strict mode)": "Actual [Ä, AE] and expected [AE, Ä] should have the same contents. search"
   }

--- a/packages/intl-localematcher/abstract/BestFitMatcher.ts
+++ b/packages/intl-localematcher/abstract/BestFitMatcher.ts
@@ -1,6 +1,6 @@
 import type {LookupMatcherResult} from '#packages/intl-localematcher/abstract/types.js'
 import {
-  UNICODE_EXTENSION_SEQUENCE_REGEX,
+  splitUnicodeExtension,
   findBestMatch,
 } from '#packages/intl-localematcher/abstract/utils.js'
 
@@ -20,7 +20,7 @@ export function BestFitMatcher(
   const noExtensionLocales: string[] = []
   const noExtensionLocaleMap = requestedLocales.reduce<Record<string, string>>(
     (all, l) => {
-      const noExtensionLocale = l.replace(UNICODE_EXTENSION_SEQUENCE_REGEX, '')
+      const {locale: noExtensionLocale} = splitUnicodeExtension(l)
       noExtensionLocales.push(noExtensionLocale)
       all[noExtensionLocale] = l
       return all
@@ -31,10 +31,9 @@ export function BestFitMatcher(
   const result = findBestMatch(noExtensionLocales, availableLocales)
   if (result.matchedSupportedLocale && result.matchedDesiredLocale) {
     foundLocale = result.matchedSupportedLocale
-    extension =
-      noExtensionLocaleMap[result.matchedDesiredLocale].slice(
-        result.matchedDesiredLocale.length
-      ) || undefined
+    extension = splitUnicodeExtension(
+      noExtensionLocaleMap[result.matchedDesiredLocale]
+    ).extension
   }
 
   if (!foundLocale) {

--- a/packages/intl-localematcher/abstract/InsertUnicodeExtensionAndCanonicalize.ts
+++ b/packages/intl-localematcher/abstract/InsertUnicodeExtensionAndCanonicalize.ts
@@ -1,6 +1,9 @@
 import {CanonicalizeUnicodeLocaleId} from '#packages/intl-localematcher/abstract/CanonicalizeUnicodeLocaleId.js'
 import type {Keyword} from '#packages/intl-localematcher/abstract/types.js'
-import {invariant} from '#packages/intl-localematcher/abstract/utils.js'
+import {
+  invariant,
+  splitUnicodeExtension,
+} from '#packages/intl-localematcher/abstract/utils.js'
 
 export function InsertUnicodeExtensionAndCanonicalize(
   locale: string,
@@ -8,7 +11,7 @@ export function InsertUnicodeExtensionAndCanonicalize(
   keywords: Array<Keyword>
 ): string {
   invariant(
-    locale.indexOf('-u-') === -1,
+    splitUnicodeExtension(locale).extension === undefined,
     'Expected locale to not have a Unicode locale extension'
   )
   let extension = '-u'

--- a/packages/intl-localematcher/abstract/LookupMatcher.ts
+++ b/packages/intl-localematcher/abstract/LookupMatcher.ts
@@ -1,6 +1,6 @@
 import {BestAvailableLocale} from '#packages/intl-localematcher/abstract/BestAvailableLocale.js'
 import type {LookupMatcherResult} from '#packages/intl-localematcher/abstract/types.js'
-import {UNICODE_EXTENSION_SEQUENCE_REGEX} from '#packages/intl-localematcher/abstract/utils.js'
+import {splitUnicodeExtension} from '#packages/intl-localematcher/abstract/utils.js'
 
 /**
  * https://tc39.es/ecma402/#sec-lookupmatcher
@@ -15,19 +15,14 @@ export function LookupMatcher(
 ): LookupMatcherResult {
   const result: LookupMatcherResult = {locale: ''}
   for (const locale of requestedLocales) {
-    const noExtensionLocale = locale.replace(
-      UNICODE_EXTENSION_SEQUENCE_REGEX,
-      ''
-    )
+    const {locale: noExtensionLocale, extension} = splitUnicodeExtension(locale)
     const availableLocale = BestAvailableLocale(
       availableLocales,
       noExtensionLocale
     )
     if (availableLocale) {
       result.locale = availableLocale
-      if (locale !== noExtensionLocale) {
-        result.extension = locale.slice(noExtensionLocale.length, locale.length)
-      }
+      if (extension) result.extension = extension
       return result
     }
   }

--- a/packages/intl-localematcher/abstract/LookupSupportedLocales.ts
+++ b/packages/intl-localematcher/abstract/LookupSupportedLocales.ts
@@ -1,5 +1,5 @@
 import {BestAvailableLocale} from '#packages/intl-localematcher/abstract/BestAvailableLocale.js'
-import {UNICODE_EXTENSION_SEQUENCE_REGEX} from '#packages/intl-localematcher/abstract/utils.js'
+import {splitUnicodeExtension} from '#packages/intl-localematcher/abstract/utils.js'
 
 /**
  * https://tc39.es/ecma402/#sec-lookupsupportedlocales
@@ -12,10 +12,7 @@ export function LookupSupportedLocales(
 ): string[] {
   const subset: string[] = []
   for (const locale of requestedLocales) {
-    const noExtensionLocale = locale.replace(
-      UNICODE_EXTENSION_SEQUENCE_REGEX,
-      ''
-    )
+    const {locale: noExtensionLocale} = splitUnicodeExtension(locale)
     const availableLocale = BestAvailableLocale(
       availableLocales,
       noExtensionLocale

--- a/packages/intl-localematcher/abstract/utils.ts
+++ b/packages/intl-localematcher/abstract/utils.ts
@@ -1,8 +1,27 @@
 import {memoize} from '@formatjs/fast-memoize'
 import {data as jsonData} from '#packages/intl-localematcher/abstract/languageMatching.js'
 import {regions} from '@formatjs_generated/cldr.core/regions.js'
-export const UNICODE_EXTENSION_SEQUENCE_REGEX: RegExp =
-  /-u(?:-[0-9a-z]{2,8})+/gi
+// ECMA-402 §9.2.3, steps 1.b.i–ii: extract only the Unicode extension.
+// A private-use subtag named "u" does not start a Unicode extension.
+// https://tc39.es/ecma402/#sec-lookupmatchinglocalebyprefix
+// https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/negotiation.html#L116-L118
+export function splitUnicodeExtension(locale: string): {
+  locale: string
+  extension?: string
+} {
+  const subtags = locale.split('-')
+  for (let i = 1; i < subtags.length; i++) {
+    if (subtags[i] === 'x') break
+    if (subtags[i] !== 'u') continue
+    let end = i + 1
+    while (end < subtags.length && subtags[end].length > 1) end++
+    return {
+      locale: [...subtags.slice(0, i), ...subtags.slice(end)].join('-'),
+      extension: '-' + subtags.slice(i, end).join('-'),
+    }
+  }
+  return {locale}
+}
 
 /**
  * Asserts that a condition is true, throwing an error if it is not.

--- a/packages/intl-localematcher/tests/BestFitMatcher.test.ts
+++ b/packages/intl-localematcher/tests/BestFitMatcher.test.ts
@@ -78,3 +78,16 @@ test('bestFitMatcher testing $americas: es-KY', function () {
     }
   )
 })
+
+test('respects Unicode extension boundaries', () => {
+  for (const [tag, extension] of [
+    ['de-x-u-co-phonebk', undefined],
+    ['de-u-co-phonebk-x-private', '-u-co-phonebk'],
+    ['de-t-en-u-co-phonebk-x-u-kn', '-u-co-phonebk'],
+  ]) {
+    expect(BestFitMatcher(['de'], [tag!], () => 'en')).toEqual({
+      locale: 'de',
+      ...(extension ? {extension} : {}),
+    })
+  }
+})

--- a/packages/intl-localematcher/tests/LookupMatcher.test.ts
+++ b/packages/intl-localematcher/tests/LookupMatcher.test.ts
@@ -18,3 +18,16 @@ test('LookupMatcher', function () {
     extension: '-u-ca-gregory',
   })
 })
+
+test('respects Unicode extension boundaries', () => {
+  for (const [tag, extension] of [
+    ['de-x-u-co-phonebk', undefined],
+    ['de-u-co-phonebk-x-private', '-u-co-phonebk'],
+    ['de-t-en-u-co-phonebk-x-u-kn', '-u-co-phonebk'],
+  ]) {
+    expect(LookupMatcher(['de'], [tag!], () => 'en')).toEqual({
+      locale: 'de',
+      ...(extension ? {extension} : {}),
+    })
+  }
+})

--- a/packages/intl-localematcher/tests/ResolveLocale.test.ts
+++ b/packages/intl-localematcher/tests/ResolveLocale.test.ts
@@ -112,3 +112,17 @@ test('ResolveLocale records ignore inherited extension setters', () => {
   expect(result?.kn).toBe('true')
   expect(result?.locale).toBe('en-u-kn')
 })
+
+test('inserts supported keywords before private-use text', () => {
+  const locale = 'de-x-u-private'
+  expect(
+    ResolveLocale(
+      [locale],
+      ['de-u-co-phonebk-x-u-private'],
+      {localeMatcher: 'lookup'},
+      ['co'],
+      {[locale]: {co: ['default', 'phonebk']}},
+      () => locale
+    )
+  ).toMatchObject({locale: 'de-u-co-phonebk-x-u-private', co: 'phonebk'})
+})

--- a/packages/intl-numberformat/test262-baseline.json
+++ b/packages/intl-numberformat/test262-baseline.json
@@ -7,8 +7,6 @@
     "intl402/NumberFormat/intl-legacy-constructed-symbol-property.js (strict mode)": "value of legacy symbol property must be an Intl.NumberFormat",
     "intl402/NumberFormat/intl-legacy-constructed-symbol.js (default)": "Expected true but got false",
     "intl402/NumberFormat/intl-legacy-constructed-symbol.js (strict mode)": "Expected true but got false",
-    "intl402/NumberFormat/legacy-regexp-statics-not-modified.js (default)": "RegExp has unexpected property $_ with value de-DE-u-nu-latn.",
-    "intl402/NumberFormat/legacy-regexp-statics-not-modified.js (strict mode)": "RegExp has unexpected property $_ with value de-DE-u-nu-latn.",
     "intl402/NumberFormat/proto-from-ctor-realm.js (default)": "newTarget.prototype is undefined Expected SameValue(«[object Intl.NumberFormat]», «[object Intl.NumberFormat]») to be true",
     "intl402/NumberFormat/proto-from-ctor-realm.js (strict mode)": "newTarget.prototype is undefined Expected SameValue(«[object Intl.NumberFormat]», «[object Intl.NumberFormat]») to be true",
     "intl402/NumberFormat/prototype/format/numbering-systems.js (default)": "numberingSystem: adlm, digit: 0 Expected SameValue(«\"0\"», «\"𞥐\"») to be true",


### PR DESCRIPTION
Extract Unicode extensions by subtag boundaries, preserving private-use text and trailing extensions. `de-x-u-co-phonebk` now matches German without treating its private text as collation options. Removing the regex also preserves legacy RegExp statics in Collator and NumberFormat.

ECMA-402 §9.2.3, steps 1.b.i–ii: [section](https://tc39.es/ecma402/#sec-lookupmatchinglocalebyprefix), [source lines](https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/negotiation.html#L116-L118).

Validation: seven locale matcher gates and all twelve polyfill baseline gates pass. Six failures removed: four Collator, two NumberFormat. No exclusions or changed remaining diagnostics.
