### PR TITLE
fix(@formatjs/intl-collator): resolve canonical collation types

### DIFF
--- a/docs/src/docs/polyfills/intl-collator.mdx
+++ b/docs/src/docs/polyfills/intl-collator.mdx
@@ -107,3 +107,6 @@ settings. Thai defaults to `true`; an explicit `false` preserves punctuation.
 
 CLDR `root` data remains available for collation inheritance, but is excluded
 from available locale identifiers used during negotiation.
+
+Collation metadata and tailoring keys use canonical BCP 47 types from CLDR,
+such as `phonebk`, `trad`, and `dict`, rather than legacy LDML names.

--- a/knowledge-base/007l-polyfill-intl-collator.md
+++ b/knowledge-base/007l-polyfill-intl-collator.md
@@ -135,3 +135,6 @@ settings. Thai defaults to `true`; an explicit `false` preserves punctuation.
 
 CLDR `root` data remains available for collation inheritance, but is excluded
 from available locale identifiers used during negotiation.
+
+Collation metadata and tailoring keys use canonical BCP 47 types from CLDR,
+such as `phonebk`, `trad`, and `dict`, rather than legacy LDML names.

--- a/knowledge-base/014-test262-conformance.md
+++ b/knowledge-base/014-test262-conformance.md
@@ -7,7 +7,7 @@ excluded because it fails.
 
 | Polyfill            | Executed | Polyfill failures | Native failures |
 | ------------------- | -------: | ----------------: | --------------: |
-| collator            |      130 |                 6 |               0 |
+| collator            |      130 |                 4 |               0 |
 | datetimeformat      |      488 |               242 |              52 |
 | displaynames        |      114 |                 4 |               0 |
 | durationformat      |      220 |                 0 |               4 |
@@ -20,7 +20,7 @@ excluded because it fails.
 | segmenter           |      158 |                10 |               0 |
 | supportedvaluesof   |       50 |                 4 |               6 |
 
-Total: 2,498 executions, 2,158 polyfill passes, 340 polyfill failures. The native
+Total: 2,498 executions, 2,160 polyfill passes, 338 polyfill failures. The native
 control fails 86 executions; 50 failing cases overlap. Overlap does not prove
 a polyfill is correct: each failure still needs comparison with the selected
 spec and test's feature metadata.

--- a/packages/generated/cldr-collation/BUILD.bazel
+++ b/packages/generated/cldr-collation/BUILD.bazel
@@ -38,6 +38,7 @@ generate_package_file(
     ],
     data = [
         ":collation_xml",
+        "//:node_modules/cldr-bcp47",
         "//:node_modules/fast-xml-parser",
     ],
     tool = "//packages/intl-collator/scripts:generate-locale-data",
@@ -52,6 +53,7 @@ generate_package_file(
     ],
     data = [
         ":collation_xml",
+        "//:node_modules/cldr-bcp47",
         "//:node_modules/fast-xml-parser",
     ],
     tool = "//packages/intl-collator/scripts:generate-tailoring-data",

--- a/packages/intl-collator/compare.ts
+++ b/packages/intl-collator/compare.ts
@@ -275,12 +275,12 @@ function importedTailorings(
 function addTailoredRelation(
   entries: TailoringEntry[],
   rule: PackedLDMLRelation,
-  element: PackedCollationElement
+  elements: readonly PackedCollationElement[]
 ) {
   const value = normalizeTailoringValue(rule[2])
   entries.push({
     codePoints: stringToCodePoints(value),
-    elements: [element],
+    elements,
   })
 }
 
@@ -294,8 +294,10 @@ function addTailoredRelationGroup(
   // relations before the reset at the requested strength; otherwise each
   // relation is assigned weights after the reset anchor.
   // https://www.unicode.org/reports/tr35/tr35-collation.html#Orderings
-  const anchor = rootElementsForString(normalizeTailoringValue(resetValue))[0]
-  if (!anchor) {
+  const anchorElements = rootElementsForString(
+    normalizeTailoringValue(resetValue)
+  )
+  if (!anchorElements.length) {
     return
   }
 
@@ -305,19 +307,32 @@ function addTailoredRelationGroup(
   }
 
   const seenByLevel = [0, 0, 0, 0]
-  let previousElement = anchor
+  let previousElements = anchorElements
   for (const relation of relations) {
     const level = relationLevel(relation)
     seenByLevel[level]++
-    const baseElement = level === 2 ? previousElement : anchor
+    // LDML Part 5 §3.4 Orderings: modify the last CE at the operator's
+    // strength or stronger, preserving preceding expansion elements.
+    // https://www.unicode.org/reports/tr35/tr35-collation.html#Orderings
+    // https://github.com/unicode-org/cldr/blob/acd6d88ae493633240e19a87a721076a8a75c310/docs/ldml/tr35-collation.md#L765-L775
+    const source = level === 2 ? previousElements : anchorElements
+    let index = source.length - 1
+    while (
+      index >= 0 &&
+      !source[index].slice(0, level + 1).some(weight => weight !== 0)
+    )
+      index--
+    const prefix = source.slice(0, Math.max(0, index))
+    const baseElement: PackedCollationElement =
+      index < 0 ? [0, 0, 0, 0, 0] : source[index]
     const anchorWeight = baseElement[level]
     const offset =
       before === level + 1
         ? seenByLevel[level] - totalByLevel[level] - 1
         : seenByLevel[level]
     const element = cloneElement(baseElement, level, anchorWeight + offset)
-    previousElement = element
-    addTailoredRelation(entries, relation, element)
+    previousElements = [...prefix, element]
+    addTailoredRelation(entries, relation, previousElements)
   }
 }
 

--- a/packages/intl-collator/scripts/BUILD.bazel
+++ b/packages/intl-collator/scripts/BUILD.bazel
@@ -3,6 +3,13 @@ load("//tools:index.bzl", "ts_binary", "ts_compile")
 load("//tools:test.bzl", "formatjs_test")
 
 ts_compile(
+    name = "canonical-collation",
+    srcs = ["canonical-collation.ts"],
+    package_json = False,
+    deps = ["//:node_modules/cldr-bcp47"],
+)
+
+ts_compile(
     name = "parsers",
     srcs = [
         "parse-ldml-collation.ts",
@@ -46,10 +53,12 @@ ts_binary(
 ts_binary(
     name = "generate-locale-data",
     data = [
+        ":canonical-collation",
         ":parsers",
         "//:node_modules/@types/fs-extra",
         "//:node_modules/@types/minimist",
         "//:node_modules/@types/node",
+        "//:node_modules/cldr-bcp47",
         "//:node_modules/fast-xml-parser",
         "//:node_modules/fs-extra",
         "//:node_modules/minimist",
@@ -63,10 +72,12 @@ ts_binary(
 ts_binary(
     name = "generate-tailoring-data",
     data = [
+        ":canonical-collation",
         ":parsers",
         "//:node_modules/@types/fs-extra",
         "//:node_modules/@types/minimist",
         "//:node_modules/@types/node",
+        "//:node_modules/cldr-bcp47",
         "//:node_modules/fast-xml-parser",
         "//:node_modules/fs-extra",
         "//:node_modules/minimist",

--- a/packages/intl-collator/scripts/canonical-collation.ts
+++ b/packages/intl-collator/scripts/canonical-collation.ts
@@ -1,0 +1,22 @@
+import collationData from 'cldr-bcp47/bcp47/collation.json' with {type: 'json'}
+
+const canonicalTypes = new Map<string, string>()
+const types: Record<string, string | {_description: string; _alias?: string}> =
+  collationData.keyword.u.co
+for (const type of Object.keys(types)) {
+  const data = types[type]
+  if (type.startsWith('_')) continue
+  canonicalTypes.set(type, type)
+  if (typeof data === 'object' && typeof data._alias === 'string') {
+    for (const alias of data._alias.split(' ')) canonicalTypes.set(alias, type)
+  }
+}
+
+// ECMA-402 §9.1 [[LocaleData]] uses canonical Unicode extension values.
+// LDML collation names such as phonebook have BCP 47 aliases such as phonebk.
+// This is a locale-data constraint, not an algorithm step.
+// https://tc39.es/ecma402/#sec-internal-slots
+// https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/negotiation.html#L26
+export function canonicalCollation(type: string): string {
+  return canonicalTypes.get(type) || type
+}

--- a/packages/intl-collator/scripts/generate-locale-data.ts
+++ b/packages/intl-collator/scripts/generate-locale-data.ts
@@ -1,3 +1,4 @@
+import {canonicalCollation} from './canonical-collation.js'
 import {basename} from 'node:path'
 import minimist from 'minimist'
 import {readdirSync, readFileSync, statSync} from 'node:fs'
@@ -105,11 +106,11 @@ for (const path of resolvedPaths) {
       collation.type !== 'search' &&
       collation.type !== defaultType
     ) {
-      collationTypes.add(collation.type)
+      collationTypes.add(canonicalCollation(collation.type))
     }
   }
   if (defaultType !== 'standard' && defaultType !== 'search') {
-    collationTypes.add(defaultType)
+    collationTypes.add(canonicalCollation(defaultType))
   }
   // ECMA-402 §10.1.1, steps 21–22: use the locale punctuation default.
   // LDML alternate=shifted ignores variable punctuation at these strengths.
@@ -123,7 +124,7 @@ for (const path of resolvedPaths) {
     co: [...collationTypes].sort(),
     kn: ['false', 'true'],
     kf: ['false', 'upper', 'lower'],
-    defaultCollation: defaultType,
+    defaultCollation: canonicalCollation(defaultType),
     sensitivity: 'variant',
     ignorePunctuation:
       alternate?.type === 'alternate' && alternate.value === 'shifted',

--- a/packages/intl-collator/scripts/generate-tailoring-data.ts
+++ b/packages/intl-collator/scripts/generate-tailoring-data.ts
@@ -1,3 +1,4 @@
+import {canonicalCollation} from './canonical-collation.js'
 import {basename} from 'node:path'
 import {readdirSync, readFileSync, statSync} from 'node:fs'
 import {outputFileSync} from 'fs-extra/esm'
@@ -127,7 +128,8 @@ for (const path of paths) {
       continue
     }
     const localeTailorings = (tailorings[locale] ||= {})
-    localeTailorings[collation.type] = packCollation(collation)
+    localeTailorings[canonicalCollation(collation.type)] =
+      packCollation(collation)
   }
 }
 

--- a/packages/intl-collator/test262-baseline.json
+++ b/packages/intl-collator/test262-baseline.json
@@ -3,8 +3,6 @@
   "failures": {
     "intl402/Collator/proto-from-ctor-realm.js (default)": "newTarget.prototype is undefined Expected SameValue(«[object Intl.Collator]», «[object Intl.Collator]») to be true",
     "intl402/Collator/proto-from-ctor-realm.js (strict mode)": "newTarget.prototype is undefined Expected SameValue(«[object Intl.Collator]», «[object Intl.Collator]») to be true",
-    "intl402/Collator/prototype/resolvedOptions/resolved-collation-unicode-extensions-and-options.js (default)": "Resolved locale for locale=de-u-co-phonebk with collation=pinyin Expected SameValue(«\"de\"», «\"de-u-co-phonebk\"») to be true",
-    "intl402/Collator/prototype/resolvedOptions/resolved-collation-unicode-extensions-and-options.js (strict mode)": "Resolved locale for locale=de-u-co-phonebk with collation=pinyin Expected SameValue(«\"de\"», «\"de-u-co-phonebk\"») to be true",
     "intl402/Collator/usage-de.js (default)": "Actual [Ä, AE] and expected [AE, Ä] should have the same contents. search",
     "intl402/Collator/usage-de.js (strict mode)": "Actual [Ä, AE] and expected [AE, Ä] should have the same contents. search"
   }

--- a/packages/intl-collator/tests/index.test.ts
+++ b/packages/intl-collator/tests/index.test.ts
@@ -90,6 +90,24 @@ describe('Intl.Collator', () => {
     ])
   })
 
+  it('uses canonical collation types for negotiation and tailorings', () => {
+    expect(
+      new Collator('de-u-co-phonebk', {collation: 'pinyin'}).resolvedOptions()
+    ).toMatchObject({locale: 'de-u-co-phonebk', collation: 'phonebk'})
+    const phonebook = new Collator('de-u-co-phonebk')
+    expect(
+      ['A', 'b', 'Af', 'Ab', 'od', 'off', 'Ä', 'ö'].sort(phonebook.compare)
+    ).toEqual(['A', 'Ab', 'Ä', 'Af', 'b', 'od', 'ö', 'off'])
+    expect(new Collator('es-u-co-trad').resolvedOptions().collation).toBe(
+      'trad'
+    )
+    expect(new Collator('si-u-co-dict').resolvedOptions().collation).toBe(
+      'dict'
+    )
+    expect(new Collator('es-u-co-trad').compare('cz', 'ch')).toBeLessThan(0)
+    expect(new Collator('es').compare('cz', 'ch')).toBeGreaterThan(0)
+  })
+
   it('resolves generated collation metadata', () => {
     expect(new Collator('zh-u-co-pinyin').resolvedOptions()).toMatchObject({
       locale: 'zh-u-co-pinyin',


### PR DESCRIPTION
Use CLDR’s BCP 47 collation identifiers in locale metadata and tailoring keys, so `de-u-co-phonebk` is recognized and survives an unsupported `collation` option. Preserve multi-element reset anchors so German phonebook ordering treats umlauts as AE/OE/UE expansions.

ECMA-402 §9.1’s canonical locale-data constraint: [section](https://tc39.es/ecma402/#sec-internal-slots), [source line](https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/negotiation.html#L26). Expansion handling follows [LDML Orderings](https://www.unicode.org/reports/tr35/tr35-collation.html#Orderings), [source lines](https://github.com/unicode-org/cldr/blob/acd6d88ae493633240e19a87a721076a8a75c310/docs/ldml/tr35-collation.md#L765-L775).

Validation: all 16 Collator/ICU4J Bazel gates pass. Test262 improves from 124/130 to 126/130; no exclusions or new failures. Regression tests cover phonebook order and Spanish traditional contractions.
