### PR TITLE
fix(@formatjs/intl-collator): select search collation tailoring

### DIFF
--- a/docs/src/docs/polyfills/intl-collator.mdx
+++ b/docs/src/docs/polyfills/intl-collator.mdx
@@ -110,3 +110,7 @@ from available locale identifiers used during negotiation.
 
 Collation metadata and tailoring keys use canonical BCP 47 types from CLDR,
 such as `phonebk`, `trad`, and `dict`, rather than legacy LDML names.
+
+`usage: "search"` selects CLDR search tailoring independently of sort collation
+keywords. Its resolved collation is `default`; search comparisons are intended
+for matching, not a stable sort order.

--- a/knowledge-base/007l-polyfill-intl-collator.md
+++ b/knowledge-base/007l-polyfill-intl-collator.md
@@ -138,3 +138,7 @@ from available locale identifiers used during negotiation.
 
 Collation metadata and tailoring keys use canonical BCP 47 types from CLDR,
 such as `phonebk`, `trad`, and `dict`, rather than legacy LDML names.
+
+`usage: "search"` selects CLDR search tailoring independently of sort collation
+keywords. Its resolved collation is `default`; search comparisons are intended
+for matching, not a stable sort order.

--- a/knowledge-base/014-test262-conformance.md
+++ b/knowledge-base/014-test262-conformance.md
@@ -7,7 +7,7 @@ excluded because it fails.
 
 | Polyfill            | Executed | Polyfill failures | Native failures |
 | ------------------- | -------: | ----------------: | --------------: |
-| collator            |      130 |                 4 |               0 |
+| collator            |      130 |                 2 |               0 |
 | datetimeformat      |      488 |               242 |              52 |
 | displaynames        |      114 |                 4 |               0 |
 | durationformat      |      220 |                 0 |               4 |
@@ -20,7 +20,7 @@ excluded because it fails.
 | segmenter           |      158 |                10 |               0 |
 | supportedvaluesof   |       50 |                 4 |               6 |
 
-Total: 2,498 executions, 2,160 polyfill passes, 338 polyfill failures. The native
+Total: 2,498 executions, 2,162 polyfill passes, 336 polyfill failures. The native
 control fails 86 executions; 50 failing cases overlap. Overlap does not prove
 a polyfill is correct: each failure still needs comparison with the selected
 spec and test's feature metadata.

--- a/packages/intl-collator/compare.ts
+++ b/packages/intl-collator/compare.ts
@@ -269,7 +269,13 @@ function importedTailorings(
   // The visited set prevents recursive imports from looping.
   // https://www.unicode.org/reports/tr35/tr35-collation.html#Special_Purpose_Commands
   const imported = IMPORT_COLLATION_RE.exec(rule[2])
-  return imported ? tailoringEntries(imported[1], imported[2], visited) : []
+  return imported
+    ? tailoringEntries(
+        imported[1] === 'und' ? 'root' : imported[1],
+        imported[2],
+        visited
+      )
+    : []
 }
 
 function addTailoredRelation(
@@ -350,7 +356,9 @@ function tailoringEntries(
   }
   visited.add(key)
 
-  const collationData = packedCollation(locale, collation)
+  const collationData =
+    packedCollation(locale, collation) ||
+    (collation === 'search' ? packedCollation('root', 'search') : undefined)
   const entries: TailoringEntry[] = []
   const rules = collationData?.rules || []
   let reset: PackedLDMLReset | undefined
@@ -470,7 +478,9 @@ function comparePreparedStrings(
   const locale = localeBase(slots.locale)
   const tailoring = tailoringEntries(
     locale,
-    collationForComparison(locale, slots.collation)
+    slots.usage === 'search'
+      ? 'search'
+      : collationForComparison(locale, slots.collation)
   )
   return compareCollationElements(
     collationElements(left, tailoring),

--- a/packages/intl-collator/core.ts
+++ b/packages/intl-collator/core.ts
@@ -106,15 +106,16 @@ export const Collator = function (
   // ECMA-402 Collator has relevant extension keys "co", "kn", and "kf";
   // ResolveLocale negotiates them against generated locale collation data.
   // https://tc39.es/ecma402/#sec-intl.collator-internal-slots
+  const localeData = usage === 'search' ? searchLocaleData : Collator.localeData
   const r = ResolveLocale(
     Collator.availableLocales,
     requestedLocales,
     opt,
     Collator.relevantExtensionKeys,
-    Collator.localeData,
+    localeData,
     Collator.getDefaultLocale
   )
-  const resolvedLocaleData = Collator.localeData[r.dataLocale]
+  const resolvedLocaleData = localeData[r.dataLocale]
   invariant(!!resolvedLocaleData, `Missing locale data for ${r.dataLocale}`)
 
   // "sort" defaults sensitivity to "variant"; "search" takes its locale data
@@ -223,6 +224,14 @@ Collator.localeData = collationLocaleData as unknown as Record<
   string,
   CollatorLocaleData | undefined
 >
+// ECMA-402 §10.1.1, steps 9–11: search uses distinct locale data.
+// Its collation is selected by usage, not a sort-specific co keyword.
+// https://tc39.es/ecma402/#sec-intl.collator
+// https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/collator.html#L29-L33
+const searchLocaleData: Record<string, CollatorLocaleData> = Object.create(null)
+for (const locale of Collator.availableLocales) {
+  searchLocaleData[locale] = {...Collator.localeData[locale]!, co: ['default']}
+}
 Collator.polyfilled = true
 
 // ECMA-402 §10.2.1: the constructor's prototype property is non-writable.

--- a/packages/intl-collator/test262-baseline.json
+++ b/packages/intl-collator/test262-baseline.json
@@ -2,8 +2,6 @@
   "total": 130,
   "failures": {
     "intl402/Collator/proto-from-ctor-realm.js (default)": "newTarget.prototype is undefined Expected SameValue(«[object Intl.Collator]», «[object Intl.Collator]») to be true",
-    "intl402/Collator/proto-from-ctor-realm.js (strict mode)": "newTarget.prototype is undefined Expected SameValue(«[object Intl.Collator]», «[object Intl.Collator]») to be true",
-    "intl402/Collator/usage-de.js (default)": "Actual [Ä, AE] and expected [AE, Ä] should have the same contents. search",
-    "intl402/Collator/usage-de.js (strict mode)": "Actual [Ä, AE] and expected [AE, Ä] should have the same contents. search"
+    "intl402/Collator/proto-from-ctor-realm.js (strict mode)": "newTarget.prototype is undefined Expected SameValue(«[object Intl.Collator]», «[object Intl.Collator]») to be true"
   }
 }

--- a/packages/intl-collator/tests/index.test.ts
+++ b/packages/intl-collator/tests/index.test.ts
@@ -19,6 +19,22 @@ describe('Intl.Collator', () => {
     })
   })
 
+  it('uses search tailoring independently of sort collation options', () => {
+    expect(
+      ['AE', 'Ä'].sort(new Collator('de', {usage: 'sort'}).compare)
+    ).toEqual(['Ä', 'AE'])
+    const search = new Collator('de-u-co-phonebk', {
+      usage: 'search',
+      collation: 'phonebk',
+    })
+    expect(search.resolvedOptions()).toMatchObject({
+      locale: 'de',
+      collation: 'default',
+      usage: 'search',
+    })
+    expect(['AE', 'Ä'].sort(search.compare)).toEqual(['AE', 'Ä'])
+  })
+
   it('compares strings with base sensitivity', () => {
     const collator = new Collator('en', {sensitivity: 'base'})
     expect(collator.compare('resume', 'resume')).toBe(0)


### PR DESCRIPTION
Select CLDR search tailoring when `usage` is `search`, including imported root rules. Resolve search options against separate locale data so sort-specific collation keywords do not leak into search resolution. German AE/Ä comparisons now follow search ordering.

ECMA-402 §10.1.1, steps 9–11: [section](https://tc39.es/ecma402/#sec-intl.collator), [source lines](https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/collator.html#L29-L33).

Validation: all 16 Collator/ICU4J Bazel gates pass. Test262 improves from 126/130 to 128/130; only the two foreign-realm prototype cases remain. No exclusions or changed remaining diagnostics.
