### PR TITLE
fix(@formatjs/intl-datetimeformat): format year zero in the BC era

### DIFF
--- a/docs/src/docs/polyfills/intl-datetimeformat.mdx
+++ b/docs/src/docs/polyfills/intl-datetimeformat.mdx
@@ -292,3 +292,5 @@ arguments. Inheriting its prototype does not create a DateTimeFormat instance.
 
 Resolved options follow specification property order: `hour12` follows
 `hourCycle`, and style properties follow component properties.
+
+Gregorian astronomical year zero formats as year 1 BC. Year 1 begins the AD era.

--- a/knowledge-base/007b-polyfill-intl-datetimeformat.md
+++ b/knowledge-base/007b-polyfill-intl-datetimeformat.md
@@ -158,3 +158,5 @@ arguments. Inheriting its prototype does not create a DateTimeFormat instance.
 
 Resolved options follow specification property order: `hour12` follows
 `hourCycle`, and style properties follow component properties.
+
+Gregorian astronomical year zero formats as year 1 BC. Year 1 begins the AD era.

--- a/knowledge-base/014-test262-conformance.md
+++ b/knowledge-base/014-test262-conformance.md
@@ -8,7 +8,7 @@ excluded because it fails.
 | Polyfill            | Executed | Polyfill failures | Native failures |
 | ------------------- | -------: | ----------------: | --------------: |
 | collator            |      130 |                 2 |               0 |
-| datetimeformat      |      488 |               218 |              52 |
+| datetimeformat      |      488 |               216 |              52 |
 | displaynames        |      114 |                 4 |               0 |
 | durationformat      |      220 |                 0 |               4 |
 | getcanonicallocales |       76 |                32 |               2 |
@@ -20,7 +20,7 @@ excluded because it fails.
 | segmenter           |      158 |                10 |               0 |
 | supportedvaluesof   |       50 |                 2 |               6 |
 
-Total: 2,498 executions, 2,188 polyfill passes, 310 polyfill failures. The native
+Total: 2,498 executions, 2,190 polyfill passes, 308 polyfill failures. The native
 control fails 86 executions; 50 failing cases overlap. Overlap does not prove
 a polyfill is correct: each failure still needs comparison with the selected
 spec and test's feature metadata.

--- a/packages/ecma402-abstract/DateTimeFormat/ToLocalTime.ts
+++ b/packages/ecma402-abstract/DateTimeFormat/ToLocalTime.ts
@@ -166,7 +166,11 @@ export function ToLocalTime(
   const year = YearFromTime(tz)
   return {
     weekday: WeekDay(tz),
-    era: year < 0 ? 'BC' : 'AD',
+    // ECMA-402 §11.5.13, ToLocalTime record table, [[Era]] row:
+    // astronomical year zero belongs to BC.
+    // https://tc39.es/ecma402/#table-datetimeformat-tolocaltime-record
+    // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/datetimeformat.html#L1683-L1686
+    era: year < 1 ? 'BC' : 'AD',
     year,
     relatedYear: undefined,
     yearName: undefined,

--- a/packages/intl-datetimeformat/test262-baseline.json
+++ b/packages/intl-datetimeformat/test262-baseline.json
@@ -31,8 +31,6 @@
     "intl402/DateTimeFormat/prototype/format/fractionalSecondDigits.js (strict mode)": "no fractionalSecondDigits Expected SameValue(«\"1:02:03 AM\"», «\"02:03\"») to be true",
     "intl402/DateTimeFormat/prototype/format/numbering-system.js (default)": "en-US: display one numeric-styled unit Expected SameValue(«false», «true») to be true",
     "intl402/DateTimeFormat/prototype/format/numbering-system.js (strict mode)": "en-US: display one numeric-styled unit Expected SameValue(«false», «true») to be true",
-    "intl402/DateTimeFormat/prototype/format/proleptic-gregorian-calendar.js (default)": "Test262Error {\n  message: \"Formatted year doesn't contain expected era – expected /BC/, got 1 AD.\"\n}",
-    "intl402/DateTimeFormat/prototype/format/proleptic-gregorian-calendar.js (strict mode)": "Test262Error {\n  message: \"Formatted year doesn't contain expected era – expected /BC/, got 1 AD.\"\n}",
     "intl402/DateTimeFormat/prototype/format/related-year-zh.js (default)": "Expected no error, got RangeError: Calendar \"chinese\" is not supported. Try setting \"calendar\" to 1 of the following: gregory",
     "intl402/DateTimeFormat/prototype/format/related-year-zh.js (strict mode)": "Expected no error, got RangeError: Calendar \"chinese\" is not supported. Try setting \"calendar\" to 1 of the following: gregory",
     "intl402/DateTimeFormat/prototype/format/taint-Object-prototype.js (default)": "Client code can adversely affect behavior: setter for day.",

--- a/packages/intl-datetimeformat/tests/index.test.ts
+++ b/packages/intl-datetimeformat/tests/index.test.ts
@@ -102,6 +102,25 @@ describe('Intl.DateTimeFormat', function () {
     expect(keys.indexOf('hour')).toBeGreaterThan(keys.indexOf('hour12'))
   })
 
+  it('formats astronomical year zero as 1 BC', () => {
+    const dtf = new DateTimeFormat('en', {
+      timeZone: 'UTC',
+      year: 'numeric',
+      era: 'short',
+    })
+    for (const [year, expectedYear, era] of [
+      [-1, '2', 'BC'],
+      [0, '1', 'BC'],
+      [1, '1', 'AD'],
+    ] as const) {
+      const date = new Date(0)
+      date.setUTCFullYear(year, 0, 1)
+      const parts = dtf.formatToParts(date)
+      expect(parts.find(part => part.type === 'era')?.value).toBe(era)
+      expect(parts.find(part => part.type === 'year')?.value).toBe(expectedYear)
+    }
+  })
+
   it('smoke test EST', function () {
     expect(
       new DateTimeFormat('en', {


### PR DESCRIPTION
Format astronomical year zero as 1 BC instead of 1 AD. Keep adjacent years consistent: year -1 is 2 BC, and year 1 is 1 AD.

ECMA-402 §11.5.13 ToLocalTime record table, [[Era]] row ([section](https://tc39.es/ecma402/#table-datetimeformat-tolocaltime-record), [source](https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/datetimeformat.html#L1683-L1686)). This table requirement has no numbered step.

Validation: all ten DateTimeFormat Bazel gates pass. Two additional Test262 passes; no exclusions or changed remaining diagnostics.
