### PR TITLE
fix(@formatjs/intl-datetimeformat): normalize timezone inputs

### DIFF
--- a/docs/src/docs/polyfills/intl-datetimeformat.mdx
+++ b/docs/src/docs/polyfills/intl-datetimeformat.mdx
@@ -294,3 +294,6 @@ Resolved options follow specification property order: `hour12` follows
 `hourCycle`, and style properties follow component properties.
 
 Gregorian astronomical year zero formats as year 1 BC. Year 1 begins the AD era.
+
+Zero UTC offsets normalize to `+00:00`. Named timezone matching ignores ASCII
+letter case only; non-ASCII lookalikes are rejected.

--- a/knowledge-base/007b-polyfill-intl-datetimeformat.md
+++ b/knowledge-base/007b-polyfill-intl-datetimeformat.md
@@ -160,3 +160,6 @@ Resolved options follow specification property order: `hour12` follows
 `hourCycle`, and style properties follow component properties.
 
 Gregorian astronomical year zero formats as year 1 BC. Year 1 begins the AD era.
+
+Zero UTC offsets normalize to `+00:00`. Named timezone matching ignores ASCII
+letter case only; non-ASCII lookalikes are rejected.

--- a/knowledge-base/014-test262-conformance.md
+++ b/knowledge-base/014-test262-conformance.md
@@ -8,7 +8,7 @@ excluded because it fails.
 | Polyfill            | Executed | Polyfill failures | Native failures |
 | ------------------- | -------: | ----------------: | --------------: |
 | collator            |      130 |                 2 |               0 |
-| datetimeformat      |      488 |               216 |              52 |
+| datetimeformat      |      488 |               212 |              52 |
 | displaynames        |      114 |                 4 |               0 |
 | durationformat      |      220 |                 0 |               4 |
 | getcanonicallocales |       76 |                32 |               2 |
@@ -20,7 +20,7 @@ excluded because it fails.
 | segmenter           |      158 |                10 |               0 |
 | supportedvaluesof   |       50 |                 2 |               6 |
 
-Total: 2,498 executions, 2,190 polyfill passes, 308 polyfill failures. The native
+Total: 2,498 executions, 2,194 polyfill passes, 304 polyfill failures. The native
 control fails 86 executions; 50 failing cases overlap. Overlap does not prove
 a polyfill is correct: each failure still needs comparison with the selected
 spec and test's feature metadata.

--- a/packages/ecma402-abstract/CanonicalizeTimeZoneName.ts
+++ b/packages/ecma402-abstract/CanonicalizeTimeZoneName.ts
@@ -38,11 +38,17 @@ function ParseTimeZoneOffsetString(offsetString: string): string {
   }
 
   // 3. Extract components from parseResult
-  const sign = match[1]
   const hours = match[2]
   const minutes = match[3] ? match[3] : '00'
   const seconds = match[4]
   const fractional = match[5]
+  // ECMA-402 §11.1.3 FormatOffsetTimeZoneIdentifier, step 1: zero uses +.
+  // https://tc39.es/ecma402/#sec-formatoffsettimezoneidentifier
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/datetimeformat.html#L172
+  const sign =
+    Number(hours) || Number(minutes) || Number(seconds) || Number(fractional)
+      ? match[1]
+      : '+'
 
   // 4. Build canonical format: ±HH:MM
   let canonical = `${sign}${hours}:${minutes}`

--- a/packages/ecma402-abstract/IsValidTimeZoneName.ts
+++ b/packages/ecma402-abstract/IsValidTimeZoneName.ts
@@ -72,6 +72,13 @@ export function IsValidTimeZoneName(
   // 2. Let timeZones be AvailableNamedTimeZoneIdentifiers()
   // 3. If timeZones contains an element equal to timeZone, return true
   // NOTE: Implementation uses case-insensitive comparison per spec note
+  // ECMA-402 §6.5.2 GetAvailableNamedTimeZoneIdentifier, step 1.a:
+  // only ASCII case folding is allowed; Unicode lookalikes cannot match IANA names.
+  // https://tc39.es/ecma402/#sec-getavailablenamedtimezoneidentifier
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/locales-currencies-tz.html#L318
+  for (let i = 0; i < tz.length; i++) {
+    if (tz.charCodeAt(i) > 0x7f) return false
+  }
   const uppercasedTz = tz.toUpperCase()
   const zoneNames = new Set()
   const linkNames = new Set()

--- a/packages/ecma402-abstract/tests/CanonicalizeTimeZoneName.test.ts
+++ b/packages/ecma402-abstract/tests/CanonicalizeTimeZoneName.test.ts
@@ -96,6 +96,6 @@ describe('CanonicalizeTimeZoneName', () => {
 
     // Minimum offset
     expect(CanonicalizeTimeZoneName('+00:00', testData)).toBe('+00:00')
-    expect(CanonicalizeTimeZoneName('-00:00', testData)).toBe('-00:00')
+    expect(CanonicalizeTimeZoneName('-00:00', testData)).toBe('+00:00')
   })
 })

--- a/packages/intl-datetimeformat/test262-baseline.json
+++ b/packages/intl-datetimeformat/test262-baseline.json
@@ -197,8 +197,6 @@
     "intl402/DateTimeFormat/prototype/resolvedOptions/hourCycle-timeStyle.js (strict mode)": "Expected SameValue(«\"h23\"», «\"h11\"») to be true",
     "intl402/DateTimeFormat/prototype/resolvedOptions/hourCycle.js (default)": "Expected SameValue(«\"h23\"», «\"h11\"») to be true",
     "intl402/DateTimeFormat/prototype/resolvedOptions/hourCycle.js (strict mode)": "Expected SameValue(«\"h23\"», «\"h11\"») to be true",
-    "intl402/DateTimeFormat/prototype/resolvedOptions/offset-timezone-change.js (default)": "-00 Expected SameValue(«\"-00:00\"», «\"+00:00\"») to be true",
-    "intl402/DateTimeFormat/prototype/resolvedOptions/offset-timezone-change.js (strict mode)": "-00 Expected SameValue(«\"-00:00\"», «\"+00:00\"») to be true",
     "intl402/DateTimeFormat/prototype/resolvedOptions/resolved-calendar-unicode-extensions-and-options.js (default)": "Resolved locale for locale=en-u-ca-iso8601 with calendar=invalid Expected SameValue(«\"en\"», «\"en-u-ca-iso8601\"») to be true",
     "intl402/DateTimeFormat/prototype/resolvedOptions/resolved-calendar-unicode-extensions-and-options.js (strict mode)": "Resolved locale for locale=en-u-ca-iso8601 with calendar=invalid Expected SameValue(«\"en\"», «\"en-u-ca-iso8601\"») to be true",
     "intl402/DateTimeFormat/prototype/resolvedOptions/resolved-hour-cycle-unicode-extensions-and-options.js (default)": "Resolved locale for locale=en-u-hc-h23 with hourCycle=h11 Expected SameValue(«\"en-u-hc-h23\"», «\"en\"») to be true",
@@ -213,8 +211,6 @@
     "intl402/DateTimeFormat/taint-Object-prototype-date-time-components.js (strict mode)": "Client code can adversely affect behavior: setter for year.",
     "intl402/DateTimeFormat/timezone-case-insensitive.js (default)": "Time zone created from string \"America/Yellowknife\" Expected SameValue(«\"America/Edmonton\"», «\"America/Yellowknife\"») to be true",
     "intl402/DateTimeFormat/timezone-case-insensitive.js (strict mode)": "Time zone created from string \"America/Yellowknife\" Expected SameValue(«\"America/Edmonton\"», «\"America/Yellowknife\"») to be true",
-    "intl402/DateTimeFormat/timezone-invalid.js (default)": "Invalid time zone name asıa/baku was not rejected. Expected a RangeError to be thrown but no exception was thrown at all",
-    "intl402/DateTimeFormat/timezone-invalid.js (strict mode)": "Invalid time zone name asıa/baku was not rejected. Expected a RangeError to be thrown but no exception was thrown at all",
     "intl402/DateTimeFormat/timezone-not-canonicalized.js (default)": "Expected SameValue(«\"Asia/Kolkata\"», «\"Asia/Calcutta\"») to be true",
     "intl402/DateTimeFormat/timezone-not-canonicalized.js (strict mode)": "Expected SameValue(«\"Asia/Kolkata\"», «\"Asia/Calcutta\"») to be true"
   }

--- a/packages/intl-datetimeformat/tests/index.test.ts
+++ b/packages/intl-datetimeformat/tests/index.test.ts
@@ -121,6 +121,21 @@ describe('Intl.DateTimeFormat', function () {
     }
   })
 
+  it('normalizes zero offsets and rejects non-ASCII timezone lookalikes', () => {
+    for (const timeZone of ['-00', '-0000', '-00:00', '+00']) {
+      expect(
+        new DateTimeFormat('en', {timeZone}).resolvedOptions().timeZone
+      ).toBe('+00:00')
+    }
+    expect(
+      new DateTimeFormat('en', {timeZone: 'asia/baku'}).resolvedOptions()
+        .timeZone
+    ).toBe('Asia/Baku')
+    expect(() => new DateTimeFormat('en', {timeZone: 'asıa/baku'})).toThrow(
+      RangeError
+    )
+  })
+
   it('smoke test EST', function () {
     expect(
       new DateTimeFormat('en', {


### PR DESCRIPTION
Normalize negative zero UTC offsets to `+00:00`. Reject non-ASCII timezone lookalikes, such as dotless i in `asıa/baku`, instead of accepting Unicode uppercasing as an IANA name match.

ECMA-402 §11.1.3 FormatOffsetTimeZoneIdentifier step 1 ([section](https://tc39.es/ecma402/#sec-formatoffsettimezoneidentifier), [source](https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/datetimeformat.html#L172)); §6.5.2 GetAvailableNamedTimeZoneIdentifier step 1.a ([section](https://tc39.es/ecma402/#sec-getavailablenamedtimezoneidentifier), [source](https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/locales-currencies-tz.html#L318)).

Validation: all ten DateTimeFormat Bazel gates and shared abstract-operation tests pass. Four additional Test262 passes; no exclusions or changed remaining diagnostics.
