### PR TITLE
fix(@formatjs/intl-datetimeformat): select independent hour12 preferences

### DIFF
--- a/docs/src/docs/polyfills/intl-datetimeformat.mdx
+++ b/docs/src/docs/polyfills/intl-datetimeformat.mdx
@@ -303,3 +303,6 @@ are applied to internal records without writing to caller options.
 
 Every locale supports explicit `h11`, `h12`, `h23`, and `h24` hour cycles through
 options and Unicode extensions. Locale preferences still select the default.
+
+The `hour12` option selects the locale’s separate 12-hour or 24-hour preference.
+For example, English uses `h12` or `h23`; Japanese uses `h11` or `h23`.

--- a/knowledge-base/007b-polyfill-intl-datetimeformat.md
+++ b/knowledge-base/007b-polyfill-intl-datetimeformat.md
@@ -169,3 +169,6 @@ are applied to internal records without writing to caller options.
 
 Every locale supports explicit `h11`, `h12`, `h23`, and `h24` hour cycles through
 options and Unicode extensions. Locale preferences still select the default.
+
+The `hour12` option selects the locale’s separate 12-hour or 24-hour preference.
+For example, English uses `h12` or `h23`; Japanese uses `h11` or `h23`.

--- a/knowledge-base/014-test262-conformance.md
+++ b/knowledge-base/014-test262-conformance.md
@@ -8,7 +8,7 @@ excluded because it fails.
 | Polyfill            | Executed | Polyfill failures | Native failures |
 | ------------------- | -------: | ----------------: | --------------: |
 | collator            |      130 |                 2 |               0 |
-| datetimeformat      |      488 |               196 |              52 |
+| datetimeformat      |      488 |               194 |              52 |
 | displaynames        |      114 |                 4 |               0 |
 | durationformat      |      220 |                 0 |               4 |
 | getcanonicallocales |       76 |                32 |               2 |
@@ -20,8 +20,8 @@ excluded because it fails.
 | segmenter           |      158 |                10 |               0 |
 | supportedvaluesof   |       50 |                 2 |               6 |
 
-Total: 2,498 executions, 2,210 polyfill passes, 288 polyfill failures. The native
-control fails 86 executions; 48 failing cases overlap. Overlap does not prove
+Total: 2,498 executions, 2,212 polyfill passes, 286 polyfill failures. The native
+control fails 86 executions; 46 failing cases overlap. Overlap does not prove
 a polyfill is correct: each failure still needs comparison with the selected
 spec and test's feature metadata.
 

--- a/packages/ecma402-abstract/DateTimeFormat/InitializeDateTimeFormat.ts
+++ b/packages/ecma402-abstract/DateTimeFormat/InitializeDateTimeFormat.ts
@@ -30,27 +30,30 @@ function isTimeRelated(opt: Opt) {
   return false
 }
 
-function resolveHourCycle(hc: string, hcDefault: string, hour12?: boolean) {
-  if (hc == null) {
-    hc = hcDefault
+function resolveHourCycle(
+  hc: string,
+  data: DateTimeFormatLocaleInternalData,
+  hour12?: boolean
+) {
+  // ECMA-402 §11.1.2, steps 13–15: hour12 selects an independent locale
+  // preference, rather than deriving h11/h24 from the default cycle.
+  // https://tc39.es/ecma402/#sec-createdatetimeformat
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/datetimeformat.html#L78-L87
+  if (hour12 === true) {
+    return (
+      data.hourCycle12 ||
+      data.hc.find(cycle => cycle === 'h11' || cycle === 'h12') ||
+      'h12'
+    )
   }
-  if (hour12 !== undefined) {
-    if (hour12) {
-      if (hcDefault === 'h11' || hcDefault === 'h23') {
-        hc = 'h11'
-      } else {
-        hc = 'h12'
-      }
-    } else {
-      invariant(!hour12, 'hour12 must not be set')
-      if (hcDefault === 'h11' || hcDefault === 'h23') {
-        hc = 'h23'
-      } else {
-        hc = 'h24'
-      }
-    }
+  if (hour12 === false) {
+    return (
+      data.hourCycle24 ||
+      data.hc.find(cycle => cycle === 'h23' || cycle === 'h24') ||
+      'h23'
+    )
   }
-  return hc
+  return hc == null ? data.hourCycle : hc
 }
 
 function applyExplicitTimePatternOptions(pattern: string, opt: Opt) {
@@ -338,7 +341,7 @@ export function InitializeDateTimeFormat(
       if (isTimeRelated(opt)) {
         const hc = resolveHourCycle(
           internalSlots.hourCycle,
-          dataLocaleData.hourCycle,
+          dataLocaleData,
           hour12
         )
         opt.hour12 = hc === 'h11' || hc === 'h12'
@@ -364,11 +367,7 @@ export function InitializeDateTimeFormat(
     // because our style data is represented as concrete 12/24 patterns.
     const hc =
       timeStyle !== undefined
-        ? resolveHourCycle(
-            internalSlots.hourCycle,
-            dataLocaleData.hourCycle,
-            hour12
-          )
+        ? resolveHourCycle(internalSlots.hourCycle, dataLocaleData, hour12)
         : undefined
     bestFormat = DateTimeStyleFormat(
       dateStyle,
@@ -397,11 +396,7 @@ export function InitializeDateTimeFormat(
   let pattern
   let rangePatterns
   if (internalSlots.hour !== undefined) {
-    const hc = resolveHourCycle(
-      internalSlots.hourCycle,
-      dataLocaleData.hourCycle,
-      hour12
-    )
+    const hc = resolveHourCycle(internalSlots.hourCycle, dataLocaleData, hour12)
     internalSlots.hourCycle = hc
 
     if (hc === 'h11' || hc === 'h12') {

--- a/packages/ecma402-abstract/types/date-time.ts
+++ b/packages/ecma402-abstract/types/date-time.ts
@@ -157,6 +157,8 @@ export interface DateTimeFormatLocaleInternalData {
    */
   hourFormat: string
   hourCycle: string
+  hourCycle12?: string
+  hourCycle24?: string
   dateFormat: {full: Formats; long: Formats; medium: Formats; short: Formats}
   timeFormat: {full: Formats; long: Formats; medium: Formats; short: Formats}
   dateTimeFormat: {full: string; long: string; medium: string; short: string}

--- a/packages/intl-datetimeformat/scripts/extract-dates.ts
+++ b/packages/intl-datetimeformat/scripts/extract-dates.ts
@@ -192,6 +192,8 @@ async function loadDatesFields(
     : []
 
   let hc: string[] = []
+  let hourCycle12 = 'h12'
+  let hourCycle24 = 'h23'
   let region: string | undefined
   try {
     if (locale !== 'root') {
@@ -205,6 +207,8 @@ async function loadDatesFields(
       processedTimeData[`${locale}-001`] ||
       processedTimeData['001']
     ).map(resolveDateTimeSymbolTable)
+    hourCycle12 = hc.find(cycle => cycle === 'h11' || cycle === 'h12') || 'h12'
+    hourCycle24 = hc.find(cycle => cycle === 'h23' || cycle === 'h24') || 'h23'
   } catch (e) {
     console.error(`Issue extracting hourCycle for ${locale}`)
     throw e
@@ -484,6 +488,8 @@ async function loadDatesFields(
     // @ts-ignore
     intervalFormats,
     hourCycle: hc[0],
+    hourCycle12,
+    hourCycle24,
     nu,
     ca: (
       calendarPreferenceData[region as keyof typeof calendarPreferenceData] ||

--- a/packages/intl-datetimeformat/test262-baseline.json
+++ b/packages/intl-datetimeformat/test262-baseline.json
@@ -185,8 +185,6 @@
     "intl402/DateTimeFormat/prototype/formatToParts/temporal-plainyearmonth-formatting-timezonename.js (strict mode)": "Expected no error, got TypeError: Do not use Temporal.PlainYearMonth.prototype.valueOf; use Temporal.PlainYearMonth.prototype.compare for comparison.",
     "intl402/DateTimeFormat/prototype/resolvedOptions/calendar.js (default)": "Resolved calendar Expected SameValue(«\"gregory\"», «\"buddhist\"») to be true",
     "intl402/DateTimeFormat/prototype/resolvedOptions/calendar.js (strict mode)": "Resolved calendar Expected SameValue(«\"gregory\"», «\"buddhist\"») to be true",
-    "intl402/DateTimeFormat/prototype/resolvedOptions/hourCycle-default.js (default)": "Expected SameValue(«\"h24\"», «\"h23\"») to be true",
-    "intl402/DateTimeFormat/prototype/resolvedOptions/hourCycle-default.js (strict mode)": "Expected SameValue(«\"h24\"», «\"h23\"») to be true",
     "intl402/DateTimeFormat/prototype/resolvedOptions/resolved-calendar-unicode-extensions-and-options.js (default)": "Resolved locale for locale=en-u-ca-iso8601 with calendar=invalid Expected SameValue(«\"en\"», «\"en-u-ca-iso8601\"») to be true",
     "intl402/DateTimeFormat/prototype/resolvedOptions/resolved-calendar-unicode-extensions-and-options.js (strict mode)": "Resolved locale for locale=en-u-ca-iso8601 with calendar=invalid Expected SameValue(«\"en\"», «\"en-u-ca-iso8601\"») to be true",
     "intl402/DateTimeFormat/prototype/resolvedOptions/resolved-numbering-system-unicode-extensions-and-options.js (default)": "Resolved locale for locale=en-u-nu-arab with numberingSystem=invalid Expected SameValue(«\"en\"», «\"en-u-nu-arab\"») to be true",

--- a/packages/intl-datetimeformat/tests/index.test.ts
+++ b/packages/intl-datetimeformat/tests/index.test.ts
@@ -224,6 +224,27 @@ describe('Intl.DateTimeFormat', function () {
     }
   })
 
+  it('uses independent locale preferences for hour12', () => {
+    for (const [locale, hourCycle12] of [
+      ['en', 'h12'],
+      ['fr', 'h12'],
+      ['ja', 'h11'],
+    ] as const) {
+      expect(
+        new DateTimeFormat(locale, {
+          hour: 'numeric',
+          hour12: true,
+        }).resolvedOptions().hourCycle
+      ).toBe(hourCycle12)
+      expect(
+        new DateTimeFormat(locale, {
+          hour: 'numeric',
+          hour12: false,
+        }).resolvedOptions().hourCycle
+      ).toBe('h23')
+    }
+  })
+
   it('smoke test EST', function () {
     expect(
       new DateTimeFormat('en', {


### PR DESCRIPTION
Select the locale’s independent 12-hour or 24-hour preference when `hour12` is set. English now uses h23 for `hour12: false`; Japanese keeps h11 for `hour12: true`.

The generator records both preferences from CLDR time data. ECMA-402 §11.1.2 steps 13–15 select these fields independently of the default cycle ([section](https://tc39.es/ecma402/#sec-createdatetimeformat), [source](https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/datetimeformat.html#L78-L87)).

Validation: all 11 DateTimeFormat and shared abstract-operation gates pass. Two additional Test262 executions pass; no added failures or changed remaining diagnostics. Total: 2,212/2,498.
