### PR TITLE
fix(@formatjs/intl-getcanonicallocales): canonicalize locale extensions

### DIFF
--- a/docs/src/docs/polyfills/intl-getcanonicallocales.mdx
+++ b/docs/src/docs/polyfills/intl-getcanonicallocales.mdx
@@ -77,3 +77,9 @@ This library is [test262](https://github.com/tc39/test262/tree/master/test/intl4
 and values from the installed Locale polyfill use their intrinsic locale tag,
 ignoring overridden instance properties. Objects that merely expose `language`
 and `baseName` are treated as ordinary array-like inputs.
+
+Locale identifier casing is normalized before CLDR alias lookup, including
+language, script, region, and variant subtags.
+
+Unicode and transformed extensions use CLDR BCP 47 aliases. Transformed
+extensions accept a language, fields, or both, and retain `true` field values.

--- a/knowledge-base/007j-polyfill-intl-getcanonicallocales.md
+++ b/knowledge-base/007j-polyfill-intl-getcanonicallocales.md
@@ -73,3 +73,9 @@ export const likelySubtags: Record<string, string> = {
 and values from the installed Locale polyfill use their intrinsic locale tag,
 ignoring overridden instance properties. Objects that merely expose `language`
 and `baseName` are treated as ordinary array-like inputs.
+
+Locale identifier casing is normalized before CLDR alias lookup, including
+language, script, region, and variant subtags.
+
+Unicode and transformed extensions use CLDR BCP 47 aliases. Transformed
+extensions accept a language, fields, or both, and retain `true` field values.

--- a/knowledge-base/014-test262-conformance.md
+++ b/knowledge-base/014-test262-conformance.md
@@ -11,7 +11,7 @@ excluded because it fails.
 | datetimeformat      |      488 |               194 |              52 |
 | displaynames        |      114 |                 4 |               0 |
 | durationformat      |      220 |                 0 |               4 |
-| getcanonicallocales |       76 |                32 |               2 |
+| getcanonicallocales |       76 |                14 |               2 |
 | listformat          |      162 |                 4 |               0 |
 | locale              |      336 |                 4 |              22 |
 | numberformat        |      498 |                22 |               0 |
@@ -20,8 +20,8 @@ excluded because it fails.
 | segmenter           |      158 |                10 |               0 |
 | supportedvaluesof   |       50 |                 2 |               6 |
 
-Total: 2,498 executions, 2,212 polyfill passes, 286 polyfill failures. The native
-control fails 86 executions; 46 failing cases overlap. Overlap does not prove
+Total: 2,498 executions, 2,230 polyfill passes, 268 polyfill failures. The native
+control fails 86 executions; 44 failing cases overlap. Overlap does not prove
 a polyfill is correct: each failure still needs comparison with the selected
 spec and test's feature metadata.
 

--- a/packages/intl-getcanonicallocales/BUILD.bazel
+++ b/packages/intl-getcanonicallocales/BUILD.bazel
@@ -78,6 +78,7 @@ generate_package_file(
     name = "cldr_core_aliases",
     src = "aliases.ts",
     data = [
+        "//:node_modules/cldr-bcp47",
         "//:node_modules/cldr-core",
         "//:node_modules/json-stable-stringify",
     ],
@@ -166,6 +167,11 @@ rolldown_bundle(
     srcs = [":srcs"],
     entry_point = "polyfill.ts",
     target = "es6",
+    deps = [
+        "//:node_modules/@formatjs_generated/cldr.core",
+        "//packages/ecma262-abstract",
+        "//packages/ecma402-abstract",
+    ],
 )
 
 rolldown_bundle(

--- a/packages/intl-getcanonicallocales/canonicalizer.ts
+++ b/packages/intl-getcanonicallocales/canonicalizer.ts
@@ -1,4 +1,5 @@
 import {
+  extensionAlias,
   languageAlias,
   scriptAlias,
   territoryAlias,
@@ -28,19 +29,26 @@ function canonicalizeAttrs(strs: string[]): string[] {
   ).sort()
 }
 
-function canonicalizeKVs(arr: KV[]): KV[] {
-  const all: Record<string, any> = {}
+function canonicalizeKVs(arr: KV[], extension: 'u' | 't'): KV[] {
+  const seen = new Set<string>()
   const result: KV[] = []
-  for (const kv of arr) {
-    if (kv[0] in all) {
-      continue
-    }
-    all[kv[0]] = 1
-    if (!kv[1] || kv[1] === 'true') {
-      result.push([kv[0].toLowerCase()])
-    } else {
-      result.push([kv[0].toLowerCase(), kv[1].toLowerCase()])
-    }
+  // ECMA-402 §6.2.2, step 1 applies UTS #35 Processing LocaleIds, step 2.
+  // Canonicalize aliases before removing Unicode "true" values; tvalues keep it.
+  // https://tc39.es/ecma402/#sec-canonicalizeunicodelocaleid
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/locales-currencies-tz.html#L78-L81
+  // https://unicode.org/reports/tr35/#processing-localeids
+  // https://github.com/unicode-org/cldr/blob/acd6d88ae493633240e19a87a721076a8a75c310/docs/ldml/tr35.md#L4255-L4262
+  for (const [rawKey, rawValue] of arr) {
+    const key = rawKey.toLowerCase()
+    if (seen.has(key)) continue
+    seen.add(key)
+    const value = rawValue?.toLowerCase() || ''
+    const canonical = extensionAlias[extension]?.[key]?.[value] || value
+    result.push(
+      !canonical || (extension === 'u' && canonical === 'true')
+        ? [key]
+        : [key, canonical]
+    )
   }
   return result.sort(compareKV)
 }
@@ -63,15 +71,6 @@ function mergeVariants(v1: string[], v2: string[]): string[] {
   return result
 }
 
-/**
- * CAVEAT: We don't do this section in the spec bc they have no JSON data
- * Use the bcp47 data to replace keys, types, tfields, and tvalues by their canonical forms. See Section 3.6.4 U Extension Data Files) and Section 3.7.1 T Extension Data Files. The aliases are in the alias attribute value, while the canonical is in the name attribute value. For example,
-Because of the following bcp47 data:
-<key name="ms"…>…<type name="uksystem" … alias="imperial" … />…</key>
-We get the following transformation:
-en-u-ms-imperial ⇒ en-u-ms-uksystem
- * @param lang 
- */
 export function canonicalizeUnicodeLanguageId(
   unicodeLanguageId: UnicodeLanguageId
 ): UnicodeLanguageId {
@@ -82,6 +81,22 @@ export function canonicalizeUnicodeLanguageId(
    */
 
   // From https://github.com/unicode-org/icu/blob/master/icu4j/main/classes/core/src/com/ibm/icu/util/ULocale.java#L1246
+
+  // ECMA-402 §6.2.2, step 1: canonicalize case before matching CLDR aliases.
+  // https://tc39.es/ecma402/#sec-canonicalizeunicodelocaleid
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/locales-currencies-tz.html#L78-L81
+  unicodeLanguageId.lang = unicodeLanguageId.lang.toLowerCase()
+  if (unicodeLanguageId.script) {
+    unicodeLanguageId.script =
+      unicodeLanguageId.script[0].toUpperCase() +
+      unicodeLanguageId.script.slice(1).toLowerCase()
+  }
+  if (unicodeLanguageId.region) {
+    unicodeLanguageId.region = unicodeLanguageId.region.toUpperCase()
+  }
+  unicodeLanguageId.variants = unicodeLanguageId.variants.map(v =>
+    v.toLowerCase()
+  )
 
   // Try language _ variant
   let finalLangAst = unicodeLanguageId
@@ -254,7 +269,7 @@ export function CanonicalizeUnicodeLocaleId(
     for (const extension of locale.extensions) {
       switch (extension.type) {
         case 'u':
-          extension.keywords = canonicalizeKVs(extension.keywords)
+          extension.keywords = canonicalizeKVs(extension.keywords, 'u')
           if (extension.attributes) {
             extension.attributes = canonicalizeAttrs(extension.attributes)
           }
@@ -263,7 +278,7 @@ export function CanonicalizeUnicodeLocaleId(
           if (extension.lang) {
             extension.lang = canonicalizeUnicodeLanguageId(extension.lang)
           }
-          extension.fields = canonicalizeKVs(extension.fields)
+          extension.fields = canonicalizeKVs(extension.fields, 't')
           break
         default:
           extension.value = extension.value.toLowerCase()

--- a/packages/intl-getcanonicallocales/emitter.ts
+++ b/packages/intl-getcanonicallocales/emitter.ts
@@ -28,7 +28,7 @@ export function emitUnicodeLocaleId({
         break
       case 't':
         chunks.push(
-          emitUnicodeLanguageId(ext.lang),
+          emitUnicodeLanguageId(ext.lang).toLowerCase(),
           ...ext.fields.reduce((all: string[], kv) => all.concat(kv), [])
         )
         break

--- a/packages/intl-getcanonicallocales/parser.ts
+++ b/packages/intl-getcanonicallocales/parser.ts
@@ -145,10 +145,12 @@ function parseKeyword(chunks: string[]): KV | undefined {
 
 function parseTransformedExtension(chunks: string[]): TransformedExtension {
   let lang: UnicodeLanguageId | undefined
-  try {
+  // ECMA-402 §6.2.1, step 2: transformed extensions allow a language,
+  // fields, or both. Do not consume a field key as a failed language parse.
+  // https://tc39.es/ecma402/#sec-iswellformedlanguagetag
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/locales-currencies-tz.html#L46
+  if (chunks.length && isUnicodeLanguageSubtag(chunks[0])) {
     lang = parseUnicodeLanguageId(chunks)
-  } catch {
-    // Try just parsing tfield
   }
   const fields: KV[] = []
   while (chunks.length && TKEY_REGEX.test(chunks[0])) {
@@ -162,7 +164,7 @@ function parseTransformedExtension(chunks: string[]): TransformedExtension {
     }
     fields.push([key, value.join(SEPARATOR)])
   }
-  if (fields.length) {
+  if (lang || fields.length) {
     return {
       type: 't',
       fields,
@@ -192,7 +194,10 @@ function parseOtherExtensionValue(chunks: string[]): string {
   if (exts.length) {
     return exts.join(SEPARATOR)
   }
-  return ''
+  // ECMA-402 §6.2.1, step 2: every extension singleton needs a value.
+  // https://tc39.es/ecma402/#sec-iswellformedlanguagetag
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/locales-currencies-tz.html#L46
+  throw new RangeError('Missing extension value')
 }
 function parseExtensions(chunks: string[]): Omit<UnicodeLocaleId, 'lang'> {
   if (!chunks.length) {

--- a/packages/intl-getcanonicallocales/scripts/aliases.ts
+++ b/packages/intl-getcanonicallocales/scripts/aliases.ts
@@ -1,3 +1,4 @@
+import {readFileSync, readdirSync} from 'node:fs'
 import {outputFileSync} from 'fs-extra/esm'
 import aliases from 'cldr-core/supplemental/aliases.json' with {type: 'json'}
 import minimist from 'minimist'
@@ -6,8 +7,52 @@ import stringify from 'json-stable-stringify'
 const {languageAlias, territoryAlias, scriptAlias, variantAlias} =
   aliases.supplemental.metadata.alias
 
-function main({out}: minimist.ParsedArgs) {
+const UNICODE_TYPE = /^[a-z0-9]{3,8}(?:-[a-z0-9]{3,8})*$/
+
+interface Args extends minimist.ParsedArgs {
+  out: string
+}
+
+interface TypeData {
+  _alias?: string
+  _preferred?: string
+}
+
+function main(args: Args) {
+  const {out} = args
+  const extensionAlias: Record<
+    string,
+    Record<string, Record<string, string>>
+  > = {}
+  const directory = new URL(
+    './bcp47/',
+    import.meta.resolve('cldr-bcp47/package.json')
+  )
+  for (const file of readdirSync(directory).sort()) {
+    if (!file.endsWith('.json')) continue
+    const {keyword} = JSON.parse(
+      readFileSync(new URL(file, directory), 'utf8')
+    ) as {
+      keyword: Record<string, Record<string, Record<string, TypeData | string>>>
+    }
+    for (const [extension, keys] of Object.entries(keyword)) {
+      for (const [key, types] of Object.entries(keys)) {
+        for (const [type, metadata] of Object.entries(types)) {
+          if (typeof metadata !== 'object') continue
+          const canonical = metadata._preferred || type
+          for (const alias of [type, ...(metadata._alias || '').split(' ')]) {
+            const normalized = alias.toLowerCase()
+            if (normalized === canonical || !UNICODE_TYPE.test(normalized))
+              continue
+            ;((extensionAlias[extension] ||= {})[key] ||= {})[normalized] =
+              canonical
+          }
+        }
+      }
+    }
+  }
   const data = {
+    extensionAlias,
     languageAlias: Object.keys(languageAlias).reduce(
       (all: Record<string, string>, locale) => {
         all[locale] = languageAlias[locale as 'zh-cmn']._replacement
@@ -42,6 +87,7 @@ function main({out}: minimist.ParsedArgs) {
     out,
     `/* @generated */	
 // prettier-ignore  
+export const extensionAlias: Record<string, Record<string, Record<string, string>>> = ${stringify(data.extensionAlias, {space: 2})};
 export const languageAlias: Record<string, string> = ${stringify(
       data.languageAlias,
       {space: 2}
@@ -63,5 +109,5 @@ export const variantAlias: Record<string, string> = ${stringify(
 }
 
 if (import.meta.filename === process.argv[1]) {
-  main(minimist(process.argv))
+  main(minimist<Args>(process.argv.slice(2)))
 }

--- a/packages/intl-getcanonicallocales/test262-baseline.json
+++ b/packages/intl-getcanonicallocales/test262-baseline.json
@@ -1,12 +1,8 @@
 {
   "total": 76,
   "failures": {
-    "intl402/Intl/getCanonicalLocales/canonicalized-tags.js (default)": "Expected SameValue(«\"DE-DE\"», «\"de-DE\"») to be true",
-    "intl402/Intl/getCanonicalLocales/canonicalized-tags.js (strict mode)": "Expected SameValue(«\"DE-DE\"», «\"de-DE\"») to be true",
     "intl402/Intl/getCanonicalLocales/grandfathered.js (default)": "Expected SameValue(«\"jbo-lojban\"», «\"jbo\"») to be true",
     "intl402/Intl/getCanonicalLocales/grandfathered.js (strict mode)": "Expected SameValue(«\"jbo-lojban\"», «\"jbo\"») to be true",
-    "intl402/Intl/getCanonicalLocales/main.js (default)": "Actual [ab-CD, FF] and expected [ab-CD, ff] should have the same contents. ab-CD,ff",
-    "intl402/Intl/getCanonicalLocales/main.js (strict mode)": "Actual [ab-CD, FF] and expected [ab-CD, ff] should have the same contents. ab-CD,ff",
     "intl402/Intl/getCanonicalLocales/non-iana-canon.js (default)": "The value of Intl.getCanonicalLocales(tag)[0] equals the value of `canonical` Expected SameValue(«\"hy-arevela\"», «\"hy\"») to be true",
     "intl402/Intl/getCanonicalLocales/non-iana-canon.js (strict mode)": "The value of Intl.getCanonicalLocales(tag)[0] equals the value of `canonical` Expected SameValue(«\"hy-arevela\"», «\"hy\"») to be true",
     "intl402/Intl/getCanonicalLocales/overriden-push.js (default)": "Uncaught 42",
@@ -15,23 +11,9 @@
     "intl402/Intl/getCanonicalLocales/preferred-grandfathered.js (strict mode)": "Expected SameValue(«\"jbo-lojban\"», «\"jbo\"») to be true",
     "intl402/Intl/getCanonicalLocales/preferred-variant.js (default)": "Expected SameValue(«\"ja-Latn-alalc97-hepburn\"», «\"ja-Latn-alalc97\"») to be true",
     "intl402/Intl/getCanonicalLocales/preferred-variant.js (strict mode)": "Expected SameValue(«\"ja-Latn-alalc97-hepburn\"», «\"ja-Latn-alalc97\"») to be true",
-    "intl402/Intl/getCanonicalLocales/transformed-ext-canonical.js (default)": "Expected no error, got RangeError: Malformed transformed_extension",
-    "intl402/Intl/getCanonicalLocales/transformed-ext-canonical.js (strict mode)": "Expected no error, got RangeError: Malformed transformed_extension",
-    "intl402/Intl/getCanonicalLocales/transformed-ext-valid.js (default)": "Expected no error, got RangeError: Malformed transformed_extension",
-    "intl402/Intl/getCanonicalLocales/transformed-ext-valid.js (strict mode)": "Expected no error, got RangeError: Malformed transformed_extension",
-    "intl402/Intl/getCanonicalLocales/unicode-ext-canonicalize-calendar.js (default)": "Expected SameValue(«\"und-u-ca-ethiopic-amete-alem\"», «\"und-u-ca-ethioaa\"») to be true",
-    "intl402/Intl/getCanonicalLocales/unicode-ext-canonicalize-calendar.js (strict mode)": "Expected SameValue(«\"und-u-ca-ethiopic-amete-alem\"», «\"und-u-ca-ethioaa\"») to be true",
-    "intl402/Intl/getCanonicalLocales/unicode-ext-canonicalize-col-strength.js (default)": "Expected SameValue(«\"und-u-ks-primary\"», «\"und-u-ks-level1\"») to be true",
-    "intl402/Intl/getCanonicalLocales/unicode-ext-canonicalize-col-strength.js (strict mode)": "Expected SameValue(«\"und-u-ks-primary\"», «\"und-u-ks-level1\"») to be true",
-    "intl402/Intl/getCanonicalLocales/unicode-ext-canonicalize-measurement-system.js (default)": "Expected SameValue(«\"und-u-ms-imperial\"», «\"und-u-ms-uksystem\"») to be true",
-    "intl402/Intl/getCanonicalLocales/unicode-ext-canonicalize-measurement-system.js (strict mode)": "Expected SameValue(«\"und-u-ms-imperial\"», «\"und-u-ms-uksystem\"») to be true",
     "intl402/Intl/getCanonicalLocales/unicode-ext-canonicalize-region.js (default)": "Expected SameValue(«\"und-u-rg-no23\"», «\"und-u-rg-no50\"») to be true",
     "intl402/Intl/getCanonicalLocales/unicode-ext-canonicalize-region.js (strict mode)": "Expected SameValue(«\"und-u-rg-no23\"», «\"und-u-rg-no50\"») to be true",
     "intl402/Intl/getCanonicalLocales/unicode-ext-canonicalize-subdivision.js (default)": "Expected SameValue(«\"und-NO-u-sd-no23\"», «\"und-NO-u-sd-no50\"») to be true",
-    "intl402/Intl/getCanonicalLocales/unicode-ext-canonicalize-subdivision.js (strict mode)": "Expected SameValue(«\"und-NO-u-sd-no23\"», «\"und-NO-u-sd-no50\"») to be true",
-    "intl402/Intl/getCanonicalLocales/unicode-ext-canonicalize-timezone.js (default)": "Expected SameValue(«\"und-u-tz-cnckg\"», «\"und-u-tz-cnsha\"») to be true",
-    "intl402/Intl/getCanonicalLocales/unicode-ext-canonicalize-timezone.js (strict mode)": "Expected SameValue(«\"und-u-tz-cnckg\"», «\"und-u-tz-cnsha\"») to be true",
-    "intl402/Intl/getCanonicalLocales/unicode-ext-canonicalize-yes-to-true.js (default)": "Expected SameValue(«\"und-u-kb-yes\"», «\"und-u-kb\"») to be true",
-    "intl402/Intl/getCanonicalLocales/unicode-ext-canonicalize-yes-to-true.js (strict mode)": "Expected SameValue(«\"und-u-kb-yes\"», «\"und-u-kb\"») to be true"
+    "intl402/Intl/getCanonicalLocales/unicode-ext-canonicalize-subdivision.js (strict mode)": "Expected SameValue(«\"und-NO-u-sd-no23\"», «\"und-NO-u-sd-no50\"») to be true"
   }
 }

--- a/packages/intl-getcanonicallocales/tests/index.test.ts
+++ b/packages/intl-getcanonicallocales/tests/index.test.ts
@@ -1,6 +1,50 @@
 import {getCanonicalLocales} from '#packages/intl-getcanonicallocales/index.js'
 import {describe, expect, it} from 'vitest'
 describe('Intl.getCanonicalLocales', () => {
+  it('normalizes case before alias lookup', () => {
+    expect(
+      getCanonicalLocales([
+        'DE-de',
+        'de-DE',
+        'CMN-hANS',
+        'SGN-gr',
+        'SL-ROZAJ-BISKE',
+      ])
+    ).toEqual(['de-DE', 'zh-Hans', 'gss', 'sl-biske-rozaj'])
+  })
+  it('accepts language-only and field-only transformed extensions', () => {
+    expect(
+      getCanonicalLocales([
+        'en-t-EN-Latn-CA',
+        'en-t-d0-ascii',
+        'en-t-en-i0-handwrit',
+      ])
+    ).toEqual(['en-t-en-latn-ca', 'en-t-d0-ascii', 'en-t-en-i0-handwrit'])
+    expect(() => getCanonicalLocales('en-t')).toThrow(RangeError)
+    expect(() => getCanonicalLocales('en-t-d0')).toThrow(RangeError)
+    expect(() => getCanonicalLocales('en-t-en-0')).toThrow(RangeError)
+    expect(() => getCanonicalLocales('en-a')).toThrow(RangeError)
+  })
+  it('canonicalizes extension aliases while preserving transformed true', () => {
+    expect(
+      getCanonicalLocales([
+        'en-t-m0-true',
+        'und-Latn-t-und-hani-m0-names',
+        'en-u-ca-islamicc',
+        'en-u-ms-imperial',
+        'en-u-kn-yes',
+        'en-u-KN-TRUE-kn-false',
+        'en-u-ks-primary',
+      ])
+    ).toEqual([
+      'en-t-m0-true',
+      'und-Latn-t-und-hani-m0-prprname',
+      'en-u-ca-islamic-civil',
+      'en-u-ms-uksystem',
+      'en-u-kn',
+      'en-u-ks-level1',
+    ])
+  })
   it('regular', function () {
     expect(
       getCanonicalLocales('en-u-foo-bar-nu-thai-ca-buddhist-kk-true')


### PR DESCRIPTION
Canonicalize locale casing before alias lookup and apply generated CLDR BCP 47 aliases to Unicode and transformed extensions. Accept language-only and field-only transformed extensions, preserve transformed `true` values, and reject empty extension values.

ECMA-402 §6.2.1 step 2 validates the locale grammar ([section](https://tc39.es/ecma402/#sec-iswellformedlanguagetag), [source](https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/locales-currencies-tz.html#L46)). §6.2.2 step 1 applies CLDR canonicalization ([section](https://tc39.es/ecma402/#sec-canonicalizeunicodelocaleid), [source](https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/locales-currencies-tz.html#L78-L81)), including UTS #35 Processing LocaleIds step 2 ([section](https://unicode.org/reports/tr35/#processing-localeids), [source](https://github.com/unicode-org/cldr/blob/acd6d88ae493633240e19a87a721076a8a75c310/docs/ldml/tr35.md#L4255-L4262)).

Alias generation reads the pinned, declared Bazel CLDR package. Runtime bundles contain only generated alias maps. The published IIFE explicitly declares its generated-data and abstract-operation dependencies, so a sandbox cannot read stale aliases from another action.

Validation: all 27 focused package/Locale gates and all 12 isolated polyfill Test262 suites pass. Eighteen additional executions pass; no added failures, exclusions, or changed remaining diagnostics. Total: 2,230/2,498.
