### PR TITLE
fix(@formatjs/intl-getcanonicallocales): resolve subdivision aliases

### DIFF
--- a/docs/src/docs/polyfills/intl-getcanonicallocales.mdx
+++ b/docs/src/docs/polyfills/intl-getcanonicallocales.mdx
@@ -83,3 +83,6 @@ language, script, region, and variant subtags.
 
 Unicode and transformed extensions use CLDR BCP 47 aliases. Transformed
 extensions accept a language, fields, or both, and retain `true` field values.
+
+The `rg` and `sd` Unicode keys resolve CLDR subdivision aliases. Territory
+replacements receive the required `zzzz` suffix; multiple replacements use the first.

--- a/knowledge-base/007j-polyfill-intl-getcanonicallocales.md
+++ b/knowledge-base/007j-polyfill-intl-getcanonicallocales.md
@@ -79,3 +79,6 @@ language, script, region, and variant subtags.
 
 Unicode and transformed extensions use CLDR BCP 47 aliases. Transformed
 extensions accept a language, fields, or both, and retain `true` field values.
+
+The `rg` and `sd` Unicode keys resolve CLDR subdivision aliases. Territory
+replacements receive the required `zzzz` suffix; multiple replacements use the first.

--- a/knowledge-base/014-test262-conformance.md
+++ b/knowledge-base/014-test262-conformance.md
@@ -11,7 +11,7 @@ excluded because it fails.
 | datetimeformat      |      488 |               194 |              52 |
 | displaynames        |      114 |                 4 |               0 |
 | durationformat      |      220 |                 0 |               4 |
-| getcanonicallocales |       76 |                14 |               2 |
+| getcanonicallocales |       76 |                10 |               2 |
 | listformat          |      162 |                 4 |               0 |
 | locale              |      336 |                 4 |              22 |
 | numberformat        |      498 |                22 |               0 |
@@ -20,7 +20,7 @@ excluded because it fails.
 | segmenter           |      158 |                10 |               0 |
 | supportedvaluesof   |       50 |                 2 |               6 |
 
-Total: 2,498 executions, 2,230 polyfill passes, 268 polyfill failures. The native
+Total: 2,498 executions, 2,234 polyfill passes, 264 polyfill failures. The native
 control fails 86 executions; 44 failing cases overlap. Overlap does not prove
 a polyfill is correct: each failure still needs comparison with the selected
 spec and test's feature metadata.

--- a/packages/intl-getcanonicallocales/canonicalizer.ts
+++ b/packages/intl-getcanonicallocales/canonicalizer.ts
@@ -1,5 +1,6 @@
 import {
   extensionAlias,
+  subdivisionAlias,
   languageAlias,
   scriptAlias,
   territoryAlias,
@@ -43,7 +44,16 @@ function canonicalizeKVs(arr: KV[], extension: 'u' | 't'): KV[] {
     if (seen.has(key)) continue
     seen.add(key)
     const value = rawValue?.toLowerCase() || ''
-    const canonical = extensionAlias[extension]?.[key]?.[value] || value
+    let canonical = extensionAlias[extension]?.[key]?.[value] || value
+    // ECMA-402 §6.2.2, step 1 applies UTS #35 Processing LocaleIds, step 3:
+    // rg/sd use subdivision aliases, including territory replacements with zzzz.
+    // https://tc39.es/ecma402/#sec-canonicalizeunicodelocaleid
+    // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/locales-currencies-tz.html#L78-L81
+    // https://unicode.org/reports/tr35/#processing-localeids
+    // https://github.com/unicode-org/cldr/blob/acd6d88ae493633240e19a87a721076a8a75c310/docs/ldml/tr35.md#L4263-L4267
+    if (extension === 'u' && (key === 'rg' || key === 'sd')) {
+      canonical = subdivisionAlias[canonical] || canonical
+    }
     result.push(
       !canonical || (extension === 'u' && canonical === 'true')
         ? [key]

--- a/packages/intl-getcanonicallocales/scripts/aliases.ts
+++ b/packages/intl-getcanonicallocales/scripts/aliases.ts
@@ -4,8 +4,13 @@ import aliases from 'cldr-core/supplemental/aliases.json' with {type: 'json'}
 import minimist from 'minimist'
 import stringify from 'json-stable-stringify'
 
-const {languageAlias, territoryAlias, scriptAlias, variantAlias} =
-  aliases.supplemental.metadata.alias
+const {
+  languageAlias,
+  territoryAlias,
+  scriptAlias,
+  variantAlias,
+  subdivisionAlias,
+} = aliases.supplemental.metadata.alias
 
 const UNICODE_TYPE = /^[a-z0-9]{3,8}(?:-[a-z0-9]{3,8})*$/
 
@@ -52,6 +57,12 @@ function main(args: Args) {
     }
   }
   const data = {
+    subdivisionAlias: Object.fromEntries(
+      Object.entries(subdivisionAlias).map(([alias, value]) => {
+        const first = value._replacement.split(' ')[0].toLowerCase()
+        return [alias, first.length === 2 ? first + 'zzzz' : first]
+      })
+    ),
     extensionAlias,
     languageAlias: Object.keys(languageAlias).reduce(
       (all: Record<string, string>, locale) => {
@@ -87,6 +98,7 @@ function main(args: Args) {
     out,
     `/* @generated */	
 // prettier-ignore  
+export const subdivisionAlias: Record<string, string> = ${stringify(data.subdivisionAlias, {space: 2})};
 export const extensionAlias: Record<string, Record<string, Record<string, string>>> = ${stringify(data.extensionAlias, {space: 2})};
 export const languageAlias: Record<string, string> = ${stringify(
       data.languageAlias,

--- a/packages/intl-getcanonicallocales/test262-baseline.json
+++ b/packages/intl-getcanonicallocales/test262-baseline.json
@@ -10,10 +10,6 @@
     "intl402/Intl/getCanonicalLocales/preferred-grandfathered.js (default)": "Expected SameValue(«\"jbo-lojban\"», «\"jbo\"») to be true",
     "intl402/Intl/getCanonicalLocales/preferred-grandfathered.js (strict mode)": "Expected SameValue(«\"jbo-lojban\"», «\"jbo\"») to be true",
     "intl402/Intl/getCanonicalLocales/preferred-variant.js (default)": "Expected SameValue(«\"ja-Latn-alalc97-hepburn\"», «\"ja-Latn-alalc97\"») to be true",
-    "intl402/Intl/getCanonicalLocales/preferred-variant.js (strict mode)": "Expected SameValue(«\"ja-Latn-alalc97-hepburn\"», «\"ja-Latn-alalc97\"») to be true",
-    "intl402/Intl/getCanonicalLocales/unicode-ext-canonicalize-region.js (default)": "Expected SameValue(«\"und-u-rg-no23\"», «\"und-u-rg-no50\"») to be true",
-    "intl402/Intl/getCanonicalLocales/unicode-ext-canonicalize-region.js (strict mode)": "Expected SameValue(«\"und-u-rg-no23\"», «\"und-u-rg-no50\"») to be true",
-    "intl402/Intl/getCanonicalLocales/unicode-ext-canonicalize-subdivision.js (default)": "Expected SameValue(«\"und-NO-u-sd-no23\"», «\"und-NO-u-sd-no50\"») to be true",
-    "intl402/Intl/getCanonicalLocales/unicode-ext-canonicalize-subdivision.js (strict mode)": "Expected SameValue(«\"und-NO-u-sd-no23\"», «\"und-NO-u-sd-no50\"») to be true"
+    "intl402/Intl/getCanonicalLocales/preferred-variant.js (strict mode)": "Expected SameValue(«\"ja-Latn-alalc97-hepburn\"», «\"ja-Latn-alalc97\"») to be true"
   }
 }

--- a/packages/intl-getcanonicallocales/tests/index.test.ts
+++ b/packages/intl-getcanonicallocales/tests/index.test.ts
@@ -45,6 +45,25 @@ describe('Intl.getCanonicalLocales', () => {
       'en-u-ks-level1',
     ])
   })
+  it('canonicalizes subdivision and region override aliases', () => {
+    expect(
+      getCanonicalLocales([
+        'und-u-rg-no23',
+        'und-NO-u-sd-no23',
+        'und-u-rg-lud',
+        'und-u-rg-fi01',
+        'und-AX-u-sd-fi01',
+        'en-u-rg-uszzzz',
+      ])
+    ).toEqual([
+      'und-u-rg-no50',
+      'und-NO-u-sd-no50',
+      'und-u-rg-lucl',
+      'und-u-rg-axzzzz',
+      'und-AX-u-sd-axzzzz',
+      'en-u-rg-uszzzz',
+    ])
+  })
   it('regular', function () {
     expect(
       getCanonicalLocales('en-u-foo-bar-nu-thai-ca-buddhist-kk-true')


### PR DESCRIPTION
Resolve CLDR subdivision aliases in the `rg` and `sd` Unicode keys. Use the first replacement when CLDR lists several; append `zzzz` when the replacement is a territory code.

ECMA-402 §6.2.2 step 1 applies CLDR canonicalization ([section](https://tc39.es/ecma402/#sec-canonicalizeunicodelocaleid), [source](https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/locales-currencies-tz.html#L78-L81)). UTS #35 Processing LocaleIds step 3 defines subdivision replacement ([section](https://unicode.org/reports/tr35/#processing-localeids), [source](https://github.com/unicode-org/cldr/blob/acd6d88ae493633240e19a87a721076a8a75c310/docs/ldml/tr35.md#L4264-L4268)).

Validation: all 27 focused package/Locale gates and all 12 isolated polyfill Test262 suites pass. Four additional executions pass; no added failures, exclusions, or changed remaining diagnostics. Total: 2,234/2,498.
