### PR TITLE
fix(@formatjs/intl-getcanonicallocales): apply compound language aliases

### DIFF
--- a/docs/src/docs/polyfills/intl-getcanonicallocales.mdx
+++ b/docs/src/docs/polyfills/intl-getcanonicallocales.mdx
@@ -86,3 +86,6 @@ extensions accept a language, fields, or both, and retain `true` field values.
 
 The `rg` and `sd` Unicode keys resolve CLDR subdivision aliases. Territory
 replacements receive the required `zzzz` suffix; multiple replacements use the first.
+
+CLDR compound aliases remove matched subtags, preserve unrelated fields, and
+apply the most specific rule first, including language-independent variants.

--- a/knowledge-base/007j-polyfill-intl-getcanonicallocales.md
+++ b/knowledge-base/007j-polyfill-intl-getcanonicallocales.md
@@ -82,3 +82,6 @@ extensions accept a language, fields, or both, and retain `true` field values.
 
 The `rg` and `sd` Unicode keys resolve CLDR subdivision aliases. Territory
 replacements receive the required `zzzz` suffix; multiple replacements use the first.
+
+CLDR compound aliases remove matched subtags, preserve unrelated fields, and
+apply the most specific rule first, including language-independent variants.

--- a/knowledge-base/014-test262-conformance.md
+++ b/knowledge-base/014-test262-conformance.md
@@ -11,7 +11,7 @@ excluded because it fails.
 | datetimeformat      |      488 |               194 |              52 |
 | displaynames        |      114 |                 4 |               0 |
 | durationformat      |      220 |                 0 |               4 |
-| getcanonicallocales |       76 |                10 |               2 |
+| getcanonicallocales |       76 |                 2 |               2 |
 | listformat          |      162 |                 4 |               0 |
 | locale              |      336 |                 4 |              22 |
 | numberformat        |      498 |                22 |               0 |
@@ -20,7 +20,7 @@ excluded because it fails.
 | segmenter           |      158 |                10 |               0 |
 | supportedvaluesof   |       50 |                 2 |               6 |
 
-Total: 2,498 executions, 2,234 polyfill passes, 264 polyfill failures. The native
+Total: 2,498 executions, 2,242 polyfill passes, 256 polyfill failures. The native
 control fails 86 executions; 44 failing cases overlap. Overlap does not prove
 a polyfill is correct: each failure still needs comparison with the selected
 spec and test's feature metadata.

--- a/packages/intl-getcanonicallocales/canonicalizer.ts
+++ b/packages/intl-getcanonicallocales/canonicalizer.ts
@@ -81,17 +81,62 @@ function mergeVariants(v1: string[], v2: string[]): string[] {
   return result
 }
 
+interface LanguageAliasRule {
+  type: UnicodeLanguageId
+  replacement: UnicodeLanguageId
+}
+
+function compareLanguageAliasRules(a: LanguageAliasRule, b: LanguageAliasRule) {
+  const fields = (id: UnicodeLanguageId) => [
+    Number(id.lang !== 'und'),
+    Number(!!id.script),
+    Number(!!id.region),
+    id.variants.length,
+  ]
+  const left = fields(a.type),
+    right = fields(b.type)
+  const difference =
+    right.reduce((a, b) => a + b, 0) - left.reduce((a, b) => a + b, 0)
+  if (difference) return difference
+  for (let i = 0; i < left.length; i++) {
+    if (!!left[i] !== !!right[i]) return right[i] ? 1 : -1
+  }
+  const leftTag = emitUnicodeLanguageId(a.type),
+    rightTag = emitUnicodeLanguageId(b.type)
+  return leftTag < rightTag ? -1 : leftTag > rightTag ? 1 : 0
+}
+
+// UTS #35 Alias Rules: discard invalid language IDs, then prefer more
+// specific matches. "und" represents an empty language field.
+// https://unicode.org/reports/tr35/#preprocessing
+// https://github.com/unicode-org/cldr/blob/acd6d88ae493633240e19a87a721076a8a75c310/docs/ldml/tr35.md#L4171-L4212
+const languageAliasRules = Object.keys(languageAlias)
+  .reduce<LanguageAliasRule[]>((rules, from) => {
+    const to = languageAlias[from]
+    let type: UnicodeLanguageId
+    const source = from.split(SEPARATOR)
+    try {
+      type = parseUnicodeLanguageId(source)
+    } catch {
+      return rules
+    }
+    if (source.length) return rules
+    const target = to.split(SEPARATOR)
+    const replacement = parseUnicodeLanguageId(target)
+    if (target.length)
+      throw new Error(`Invalid language alias replacement: ${to}`)
+    rules.push({type, replacement})
+    return rules
+  }, [])
+  .sort(compareLanguageAliasRules)
+  .reduce((groups: Record<string, LanguageAliasRule[]>, rule) => {
+    ;(groups[rule.type.lang] ||= []).push(rule)
+    return groups
+  }, Object.create(null))
+
 export function canonicalizeUnicodeLanguageId(
   unicodeLanguageId: UnicodeLanguageId
 ): UnicodeLanguageId {
-  /**
-   * If the language subtag matches the type attribute of a languageAlias element in Supplemental Data, replace the language subtag with the replacement value.
-   *  1. If there are additional subtags in the replacement value, add them to the result, but only if there is no corresponding subtag already in the tag.
-   *  2. Five special deprecated grandfathered codes (such as i-default) are in type attributes, and are also replaced.
-   */
-
-  // From https://github.com/unicode-org/icu/blob/master/icu4j/main/classes/core/src/com/ibm/icu/util/ULocale.java#L1246
-
   // ECMA-402 §6.2.2, step 1: canonicalize case before matching CLDR aliases.
   // https://tc39.es/ecma402/#sec-canonicalizeunicodelocaleid
   // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/locales-currencies-tz.html#L78-L81
@@ -108,104 +153,50 @@ export function canonicalizeUnicodeLanguageId(
     v.toLowerCase()
   )
 
-  // Try language _ variant
+  const original = emitUnicodeLanguageId(unicodeLanguageId)
   let finalLangAst = unicodeLanguageId
-  if (unicodeLanguageId.variants.length) {
-    let replacedLang: string = ''
-    for (const variant of unicodeLanguageId.variants) {
-      if (
-        (replacedLang =
-          languageAlias[
-            emitUnicodeLanguageId({
-              lang: unicodeLanguageId.lang,
-              variants: [variant],
-            })
-          ])
-      ) {
-        const replacedLangAst = parseUnicodeLanguageId(
-          replacedLang.split(SEPARATOR)
-        )
-        finalLangAst = {
-          lang: replacedLangAst.lang,
-          script: finalLangAst.script || replacedLangAst.script,
-          region: finalLangAst.region || replacedLangAst.region,
-          variants: mergeVariants(
-            finalLangAst.variants,
-            replacedLangAst.variants
-          ),
-        }
-        break
-      }
-    }
-  }
-
-  // language _ script _ country
-  // ug-Arab-CN -> ug-CN
-  if (finalLangAst.script && finalLangAst.region) {
-    const replacedLang =
-      languageAlias[
-        emitUnicodeLanguageId({
-          lang: finalLangAst.lang,
-          script: finalLangAst.script,
-          region: finalLangAst.region,
-          variants: [],
-        })
-      ]
-    if (replacedLang) {
-      const replacedLangAst = parseUnicodeLanguageId(
-        replacedLang.split(SEPARATOR)
-      )
-      finalLangAst = {
-        lang: replacedLangAst.lang,
-        script: replacedLangAst.script,
-        region: replacedLangAst.region,
-        variants: finalLangAst.variants,
-      }
-    }
-  }
-
-  // language _ country
-  // eg. az_AZ -> az_Latn_A
-  if (finalLangAst.region) {
-    const replacedLang =
-      languageAlias[
-        emitUnicodeLanguageId({
-          lang: finalLangAst.lang,
-          region: finalLangAst.region,
-          variants: [],
-        })
-      ]
-    if (replacedLang) {
-      const replacedLangAst = parseUnicodeLanguageId(
-        replacedLang.split(SEPARATOR)
-      )
-      finalLangAst = {
-        lang: replacedLangAst.lang,
-        script: finalLangAst.script || replacedLangAst.script,
-        region: replacedLangAst.region,
-        variants: finalLangAst.variants,
-      }
-    }
-  }
-  // only language
-  // e.g. twi -> ak
-  const replacedLang =
-    languageAlias[
-      emitUnicodeLanguageId({
-        lang: finalLangAst.lang,
-        variants: [],
-      })
-    ]
-  if (replacedLang) {
-    const replacedLangAst = parseUnicodeLanguageId(
-      replacedLang.split(SEPARATOR)
-    )
+  // ECMA-402 §6.2.2, step 1 applies UTS #35 matching and replacement.
+  // Remove matched subtags; retain fields that the rule does not replace.
+  // https://tc39.es/ecma402/#sec-canonicalizeunicodelocaleid
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/locales-currencies-tz.html#L78-L81
+  // https://unicode.org/reports/tr35/#4.-replacement
+  // https://github.com/unicode-org/cldr/blob/acd6d88ae493633240e19a87a721076a8a75c310/docs/ldml/tr35.md#L4103-L4133
+  const matches = ({type}: LanguageAliasRule) =>
+    (!type.script || type.script === finalLangAst.script) &&
+    (!type.region || type.region === finalLangAst.region) &&
+    type.variants.every(variant => finalLangAst.variants.includes(variant))
+  const languageRule = languageAliasRules[finalLangAst.lang]?.find(matches)
+  const undRule =
+    finalLangAst.lang === 'und'
+      ? undefined
+      : languageAliasRules.und?.find(matches)
+  const matched = !languageRule
+    ? undRule
+    : !undRule
+      ? languageRule
+      : compareLanguageAliasRules(languageRule, undRule) <= 0
+        ? languageRule
+        : undRule
+  if (matched) {
+    const {type, replacement} = matched
     finalLangAst = {
-      lang: replacedLangAst.lang,
-      script: finalLangAst.script || replacedLangAst.script,
-      region: finalLangAst.region || replacedLangAst.region,
-      variants: finalLangAst.variants,
+      lang:
+        type.lang !== 'und' || finalLangAst.lang === 'und'
+          ? replacement.lang
+          : finalLangAst.lang,
+      script: type.script
+        ? replacement.script
+        : finalLangAst.script || replacement.script,
+      region: type.region
+        ? replacement.region
+        : finalLangAst.region || replacement.region,
+      variants: mergeVariants(
+        finalLangAst.variants.filter(v => !type.variants.includes(v)),
+        replacement.variants
+      ),
     }
+    // Restart with the most specific rule after each replacement.
+    return canonicalizeUnicodeLanguageId(finalLangAst)
   }
 
   if (finalLangAst.region) {
@@ -261,7 +252,9 @@ export function canonicalizeUnicodeLanguageId(
     }
     finalLangAst.variants.sort()
   }
-  return finalLangAst
+  return emitUnicodeLanguageId(finalLangAst) === original
+    ? finalLangAst
+    : canonicalizeUnicodeLanguageId(finalLangAst)
 }
 
 /**

--- a/packages/intl-getcanonicallocales/test262-baseline.json
+++ b/packages/intl-getcanonicallocales/test262-baseline.json
@@ -1,15 +1,7 @@
 {
   "total": 76,
   "failures": {
-    "intl402/Intl/getCanonicalLocales/grandfathered.js (default)": "Expected SameValue(«\"jbo-lojban\"», «\"jbo\"») to be true",
-    "intl402/Intl/getCanonicalLocales/grandfathered.js (strict mode)": "Expected SameValue(«\"jbo-lojban\"», «\"jbo\"») to be true",
-    "intl402/Intl/getCanonicalLocales/non-iana-canon.js (default)": "The value of Intl.getCanonicalLocales(tag)[0] equals the value of `canonical` Expected SameValue(«\"hy-arevela\"», «\"hy\"») to be true",
-    "intl402/Intl/getCanonicalLocales/non-iana-canon.js (strict mode)": "The value of Intl.getCanonicalLocales(tag)[0] equals the value of `canonical` Expected SameValue(«\"hy-arevela\"», «\"hy\"») to be true",
     "intl402/Intl/getCanonicalLocales/overriden-push.js (default)": "Uncaught 42",
-    "intl402/Intl/getCanonicalLocales/overriden-push.js (strict mode)": "Uncaught 42",
-    "intl402/Intl/getCanonicalLocales/preferred-grandfathered.js (default)": "Expected SameValue(«\"jbo-lojban\"», «\"jbo\"») to be true",
-    "intl402/Intl/getCanonicalLocales/preferred-grandfathered.js (strict mode)": "Expected SameValue(«\"jbo-lojban\"», «\"jbo\"») to be true",
-    "intl402/Intl/getCanonicalLocales/preferred-variant.js (default)": "Expected SameValue(«\"ja-Latn-alalc97-hepburn\"», «\"ja-Latn-alalc97\"») to be true",
-    "intl402/Intl/getCanonicalLocales/preferred-variant.js (strict mode)": "Expected SameValue(«\"ja-Latn-alalc97-hepburn\"», «\"ja-Latn-alalc97\"») to be true"
+    "intl402/Intl/getCanonicalLocales/overriden-push.js (strict mode)": "Uncaught 42"
   }
 }

--- a/packages/intl-getcanonicallocales/tests/index.test.ts
+++ b/packages/intl-getcanonicallocales/tests/index.test.ts
@@ -64,6 +64,20 @@ describe('Intl.getCanonicalLocales', () => {
       'en-u-rg-uszzzz',
     ])
   })
+  it('replaces matched alias subtags and keeps unrelated variants', () => {
+    expect(
+      getCanonicalLocales([
+        'art-lojban',
+        'jbo-lojban',
+        'hy-arevela',
+        'hy-arevmda',
+        'hye-arevmda',
+        'ja-Latn-fonipa-hepburn-heploc',
+        'en-aaland',
+        'en-GB-aaland',
+      ])
+    ).toEqual(['jbo', 'hy', 'hyw', 'ja-Latn-alalc97-fonipa', 'en-AX', 'en-GB'])
+  })
   it('regular', function () {
     expect(
       getCanonicalLocales('en-u-foo-bar-nu-thai-ca-buddhist-kk-true')


### PR DESCRIPTION
Apply CLDR language aliases as matching/replacement rules. Remove matched variants, preserve unrelated fields, and restart with the most specific rule after each replacement. This fixes `jbo-lojban`, Armenian variants, and combined `hepburn-heploc` aliases. Rules are indexed by language so normal locales do not scan the full alias table.

ECMA-402 §6.2.2 step 1 applies CLDR canonicalization ([section](https://tc39.es/ecma402/#sec-canonicalizeunicodelocaleid), [source](https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/locales-currencies-tz.html#L78-L81)). UTS #35 defines matching and replacement ([section](https://unicode.org/reports/tr35/#4.-replacement), [source](https://github.com/unicode-org/cldr/blob/acd6d88ae493633240e19a87a721076a8a75c310/docs/ldml/tr35.md#L4103-L4133)) and preprocessing steps 3–5 define valid rules and their ordering ([section](https://unicode.org/reports/tr35/#preprocessing), [source](https://github.com/unicode-org/cldr/blob/acd6d88ae493633240e19a87a721076a8a75c310/docs/ldml/tr35.md#L4171-L4212)).

Validation: all 17 getCanonicalLocales/Locale gates and the other 10 polyfill Test262 suites pass. Eight additional executions pass; no added failures, exclusions, or changed remaining diagnostics. Total: 2,242/2,498.
