### PR TITLE
fix(@formatjs/intl-getcanonicallocales): append list elements directly

### DIFF
--- a/docs/src/docs/polyfills/intl-getcanonicallocales.mdx
+++ b/docs/src/docs/polyfills/intl-getcanonicallocales.mdx
@@ -89,3 +89,6 @@ replacements receive the required `zzzz` suffix; multiple replacements use the f
 
 CLDR compound aliases remove matched subtags, preserve unrelated fields, and
 apply the most specific rule first, including language-independent variants.
+
+Canonicalization creates list elements directly without calling an overridden
+`Array.prototype.push`, including while parsing and emitting extensions.

--- a/knowledge-base/007j-polyfill-intl-getcanonicallocales.md
+++ b/knowledge-base/007j-polyfill-intl-getcanonicallocales.md
@@ -85,3 +85,6 @@ replacements receive the required `zzzz` suffix; multiple replacements use the f
 
 CLDR compound aliases remove matched subtags, preserve unrelated fields, and
 apply the most specific rule first, including language-independent variants.
+
+Canonicalization creates list elements directly without calling an overridden
+`Array.prototype.push`, including while parsing and emitting extensions.

--- a/knowledge-base/014-test262-conformance.md
+++ b/knowledge-base/014-test262-conformance.md
@@ -11,7 +11,7 @@ excluded because it fails.
 | datetimeformat      |      488 |               194 |              52 |
 | displaynames        |      114 |                 4 |               0 |
 | durationformat      |      220 |                 0 |               4 |
-| getcanonicallocales |       76 |                 2 |               2 |
+| getcanonicallocales |       76 |                 0 |               2 |
 | listformat          |      162 |                 4 |               0 |
 | locale              |      336 |                 4 |              22 |
 | numberformat        |      498 |                22 |               0 |
@@ -20,7 +20,7 @@ excluded because it fails.
 | segmenter           |      158 |                10 |               0 |
 | supportedvaluesof   |       50 |                 2 |               6 |
 
-Total: 2,498 executions, 2,242 polyfill passes, 256 polyfill failures. The native
+Total: 2,498 executions, 2,244 polyfill passes, 254 polyfill failures. The native
 control fails 86 executions; 44 failing cases overlap. Overlap does not prove
 a polyfill is correct: each failure still needs comparison with the selected
 spec and test's feature metadata.

--- a/packages/intl-getcanonicallocales/BUILD.bazel
+++ b/packages/intl-getcanonicallocales/BUILD.bazel
@@ -17,6 +17,7 @@ formatjs_library(
     name = "intl-getcanonicallocales",
     package_name = "@formatjs/intl-getcanonicallocales",
     srcs = [
+        "appendToList.ts",
         "canonicalizer.ts",
         "emitter.ts",
         "index.ts",

--- a/packages/intl-getcanonicallocales/appendToList.ts
+++ b/packages/intl-getcanonicallocales/appendToList.ts
@@ -1,0 +1,16 @@
+// ECMA-402 §9.2.1, step 7.c.vii appends to a specification List.
+// https://tc39.es/ecma402/#sec-canonicalizelocalelist
+// https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/negotiation.html#L68-L69
+// ECMA-262 §7.3.17 CreateArrayFromList, step 3.a creates own data properties.
+// https://tc39.es/ecma262/#sec-createarrayfromlist
+// https://github.com/tc39/ecma262/blob/b7865f0eed2021720f84d561289401bc414874d0/spec.html#L6556-L6561
+export function appendToList<T>(list: T[], ...values: T[]): void {
+  for (const value of values) {
+    Object.defineProperty(list, list.length, {
+      value,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    })
+  }
+}

--- a/packages/intl-getcanonicallocales/canonicalizer.ts
+++ b/packages/intl-getcanonicallocales/canonicalizer.ts
@@ -1,3 +1,4 @@
+import {appendToList} from '#packages/intl-getcanonicallocales/appendToList.js'
 import {
   extensionAlias,
   subdivisionAlias,
@@ -54,7 +55,8 @@ function canonicalizeKVs(arr: KV[], extension: 'u' | 't'): KV[] {
     if (extension === 'u' && (key === 'rg' || key === 'sd')) {
       canonical = subdivisionAlias[canonical] || canonical
     }
-    result.push(
+    appendToList(
+      result,
       !canonical || (extension === 'u' && canonical === 'true')
         ? [key]
         : [key, canonical]
@@ -75,7 +77,7 @@ function mergeVariants(v1: string[], v2: string[]): string[] {
   const result = [...v1]
   for (const v of v2) {
     if (v1.indexOf(v) < 0) {
-      result.push(v)
+      appendToList(result, v)
     }
   }
   return result
@@ -125,12 +127,12 @@ const languageAliasRules = Object.keys(languageAlias)
     const replacement = parseUnicodeLanguageId(target)
     if (target.length)
       throw new Error(`Invalid language alias replacement: ${to}`)
-    rules.push({type, replacement})
+    appendToList(rules, {type, replacement})
     return rules
   }, [])
   .sort(compareLanguageAliasRules)
   .reduce((groups: Record<string, LanguageAliasRule[]>, rule) => {
-    ;(groups[rule.type.lang] ||= []).push(rule)
+    appendToList((groups[rule.type.lang] ||= []), rule)
     return groups
   }, Object.create(null))
 

--- a/packages/intl-getcanonicallocales/emitter.ts
+++ b/packages/intl-getcanonicallocales/emitter.ts
@@ -1,3 +1,4 @@
+import {appendToList} from '#packages/intl-getcanonicallocales/appendToList.js'
 import {
   type UnicodeLanguageId,
   type UnicodeLocaleId,
@@ -18,22 +19,24 @@ export function emitUnicodeLocaleId({
 }: UnicodeLocaleId): string {
   const chunks = [emitUnicodeLanguageId(lang)]
   for (const ext of extensions) {
-    chunks.push(ext.type)
+    appendToList(chunks, ext.type)
     switch (ext.type) {
       case 'u':
-        chunks.push(
+        appendToList(
+          chunks,
           ...ext.attributes,
           ...ext.keywords.reduce((all: string[], kv) => all.concat(kv), [])
         )
         break
       case 't':
-        chunks.push(
+        appendToList(
+          chunks,
           emitUnicodeLanguageId(ext.lang).toLowerCase(),
           ...ext.fields.reduce((all: string[], kv) => all.concat(kv), [])
         )
         break
       default:
-        chunks.push(ext.value)
+        appendToList(chunks, ext.value)
         break
     }
   }

--- a/packages/intl-getcanonicallocales/index.ts
+++ b/packages/intl-getcanonicallocales/index.ts
@@ -1,3 +1,4 @@
+import {appendToList} from '#packages/intl-getcanonicallocales/appendToList.js'
 import {ToString} from '#packages/ecma262-abstract/ToString.js'
 import {CanonicalizeUnicodeLocaleId} from '#packages/intl-getcanonicallocales/canonicalizer.js'
 import {emitUnicodeLocaleId} from '#packages/intl-getcanonicallocales/emitter.js'
@@ -76,7 +77,7 @@ function CanonicalizeLocaleList(
     const canonicalizedTag = emitUnicodeLocaleId(
       CanonicalizeUnicodeLocaleId(parseUnicodeLocaleId(tag))
     )
-    if (seen.indexOf(canonicalizedTag) < 0) seen.push(canonicalizedTag)
+    if (seen.indexOf(canonicalizedTag) < 0) appendToList(seen, canonicalizedTag)
   }
   return seen
 }

--- a/packages/intl-getcanonicallocales/parser.ts
+++ b/packages/intl-getcanonicallocales/parser.ts
@@ -1,3 +1,4 @@
+import {appendToList} from '#packages/intl-getcanonicallocales/appendToList.js'
 import {
   type UnicodeLocaleId,
   type UnicodeLanguageId,
@@ -94,10 +95,10 @@ export function parseUnicodeLanguageId(
 }
 
 function parseUnicodeExtension(chunks: string[]): UnicodeExtension {
-  const keywords = []
+  const keywords: KV[] = []
   let keyword
   while (chunks.length && (keyword = parseKeyword(chunks))) {
-    keywords.push(keyword)
+    appendToList(keywords, keyword)
   }
   if (keywords.length) {
     return {
@@ -108,12 +109,12 @@ function parseUnicodeExtension(chunks: string[]): UnicodeExtension {
   }
   // Mix of attributes & keywords
   // Check for attributes first
-  const attributes = []
+  const attributes: string[] = []
   while (chunks.length && ALPHANUM_3_8.test(chunks[0])) {
-    attributes.push(chunks.shift()!)
+    appendToList(attributes, chunks.shift()!)
   }
   while (chunks.length && (keyword = parseKeyword(chunks))) {
-    keywords.push(keyword)
+    appendToList(keywords, keyword)
   }
   if (keywords.length || attributes.length) {
     return {
@@ -132,9 +133,9 @@ function parseKeyword(chunks: string[]): KV | undefined {
   }
   key = chunks.shift()!
 
-  const type = []
+  const type: string[] = []
   while (chunks.length && TYPE_REGEX.test(chunks[0])) {
-    type.push(chunks.shift())
+    appendToList(type, chunks.shift()!)
   }
   let value: string = ''
   if (type.length) {
@@ -155,14 +156,14 @@ function parseTransformedExtension(chunks: string[]): TransformedExtension {
   const fields: KV[] = []
   while (chunks.length && TKEY_REGEX.test(chunks[0])) {
     const key = chunks.shift()!
-    const value = []
+    const value: string[] = []
     while (chunks.length && ALPHANUM_3_8.test(chunks[0])) {
-      value.push(chunks.shift())
+      appendToList(value, chunks.shift()!)
     }
     if (!value.length) {
       throw new RangeError(`Missing tvalue for tkey "${key}"`)
     }
-    fields.push([key, value.join(SEPARATOR)])
+    appendToList(fields, [key, value.join(SEPARATOR)])
   }
   if (lang || fields.length) {
     return {
@@ -174,9 +175,9 @@ function parseTransformedExtension(chunks: string[]): TransformedExtension {
   throw new RangeError('Malformed transformed_extension')
 }
 function parsePuExtension(chunks: string[]): PuExtension {
-  const exts = []
+  const exts: string[] = []
   while (chunks.length && ALPHANUM_1_8.test(chunks[0])) {
-    exts.push(chunks.shift())
+    appendToList(exts, chunks.shift()!)
   }
   if (exts.length) {
     return {
@@ -187,9 +188,9 @@ function parsePuExtension(chunks: string[]): PuExtension {
   throw new RangeError('Malformed private_use_extension')
 }
 function parseOtherExtensionValue(chunks: string[]): string {
-  const exts = []
+  const exts: string[] = []
   while (chunks.length && ALPHANUM_2_8.test(chunks[0])) {
-    exts.push(chunks.shift())
+    appendToList(exts, chunks.shift()!)
   }
   if (exts.length) {
     return exts.join(SEPARATOR)
@@ -217,7 +218,7 @@ function parseExtensions(chunks: string[]): Omit<UnicodeLocaleId, 'lang'> {
           throw new RangeError('There can only be 1 -u- extension')
         }
         unicodeExtension = parseUnicodeExtension(chunks)
-        extensions.push(unicodeExtension)
+        appendToList(extensions, unicodeExtension)
         break
       case 't':
       case 'T':
@@ -225,7 +226,7 @@ function parseExtensions(chunks: string[]): Omit<UnicodeLocaleId, 'lang'> {
           throw new RangeError('There can only be 1 -t- extension')
         }
         transformedExtension = parseTransformedExtension(chunks)
-        extensions.push(transformedExtension)
+        appendToList(extensions, transformedExtension)
         break
       case 'x':
       case 'X':
@@ -233,7 +234,7 @@ function parseExtensions(chunks: string[]): Omit<UnicodeLocaleId, 'lang'> {
           throw new RangeError('There can only be 1 -x- extension')
         }
         puExtension = parsePuExtension(chunks)
-        extensions.push(puExtension)
+        appendToList(extensions, puExtension)
         break
       default:
         if (!OTHER_EXTENSION_TYPE.test(type)) {
@@ -247,7 +248,7 @@ function parseExtensions(chunks: string[]): Omit<UnicodeLocaleId, 'lang'> {
           value: parseOtherExtensionValue(chunks),
         }
         otherExtensionMap[extension.type] = extension
-        extensions.push(extension)
+        appendToList(extensions, extension)
         break
     }
   } while (chunks.length)

--- a/packages/intl-getcanonicallocales/test262-baseline.json
+++ b/packages/intl-getcanonicallocales/test262-baseline.json
@@ -1,7 +1,4 @@
 {
   "total": 76,
-  "failures": {
-    "intl402/Intl/getCanonicalLocales/overriden-push.js (default)": "Uncaught 42",
-    "intl402/Intl/getCanonicalLocales/overriden-push.js (strict mode)": "Uncaught 42"
-  }
+  "failures": {}
 }

--- a/packages/intl-getcanonicallocales/tests/index.test.ts
+++ b/packages/intl-getcanonicallocales/tests/index.test.ts
@@ -78,6 +78,31 @@ describe('Intl.getCanonicalLocales', () => {
       ])
     ).toEqual(['jbo', 'hy', 'hyw', 'ja-Latn-alalc97-fonipa', 'en-AX', 'en-GB'])
   })
+  it('does not call an overridden Array.prototype.push', () => {
+    const push = Array.prototype.push
+    let actual: string[]
+    try {
+      Array.prototype.push = () => {
+        throw new Error('observable push')
+      }
+      actual = getCanonicalLocales([
+        'en-US',
+        'SL-BISKE-ROZAJ',
+        'en-u-attr-kn-yes',
+        'en-t-en-m0-true',
+        'en-a-foo-x-private',
+      ])
+    } finally {
+      Array.prototype.push = push
+    }
+    expect(actual!).toEqual([
+      'en-US',
+      'sl-biske-rozaj',
+      'en-u-attr-kn',
+      'en-t-en-m0-true',
+      'en-a-foo-x-private',
+    ])
+  })
   it('regular', function () {
     expect(
       getCanonicalLocales('en-u-foo-bar-nu-thai-ca-buddhist-kk-true')


### PR DESCRIPTION
Create internal list elements directly instead of calling observable `Array.prototype.push`. This covers locale results, parsing, alias processing, and extension emission.

ECMA-402 §9.2.1 step 7.c.vii appends to a specification List ([section](https://tc39.es/ecma402/#sec-canonicalizelocalelist), [source](https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/negotiation.html#L68-L69)). ECMA-262 §7.3.17 CreateArrayFromList step 3.a creates own data properties ([section](https://tc39.es/ecma262/#sec-createarrayfromlist), [source](https://github.com/tc39/ecma262/blob/b7865f0eed2021720f84d561289401bc414874d0/spec.html#L6556-L6561)).

Validation: all 18 getCanonicalLocales/Locale gates, including the direct strict Test262 target, pass. The other 10 polyfill suites pass. getCanonicalLocales now passes 76/76 executions with an empty baseline; total isolated passes are 2,244/2,498.
