### PR TITLE
codex/editor es2016 compatibility

### DIFF
--- a/packages/editor/validation.ts
+++ b/packages/editor/validation.ts
@@ -60,10 +60,10 @@ function compatibleElement(
         .join(',')
     if (exactKeys(source) !== exactKeys(target)) return false
     // New locale categories inherit the source's fallback contract.
-    return Object.entries(target.options).every(([key, option]) =>
+    return Object.keys(target.options).every(key =>
       compatible(
         (source.options[key] ?? source.options.other).value,
-        option.value
+        target.options[key].value
       )
     )
   }

--- a/packages/editor/workflow.ts
+++ b/packages/editor/workflow.ts
@@ -101,22 +101,20 @@ export function useTranslationEditor({
   const [drafts, setDrafts] = useState<Record<string, Draft>>({})
   const pending = useRef(new Set<string>())
   const remoteValues = useRef(new Map<string, string>())
-  remoteValues.current = new Map(
-    messages.flatMap(message =>
-      locales.map(
-        value =>
-          [
-            draftKey(message.id, value),
-            message.translations[value] ?? '',
-          ] as const
-      )
-    )
-  )
-  const catalogs = useMemo(
-    () =>
-      [...new Set(messages.flatMap(message => message.catalogs ?? []))].sort(),
-    [messages]
-  )
+  const values = new Map<string, string>()
+  for (const message of messages) {
+    for (const value of locales) {
+      values.set(draftKey(message.id, value), message.translations[value] ?? '')
+    }
+  }
+  remoteValues.current = values
+  const catalogs = useMemo(() => {
+    const values = new Set<string>()
+    for (const message of messages) {
+      for (const catalog of message.catalogs ?? []) values.add(catalog)
+    }
+    return [...values].sort()
+  }, [messages])
   const catalog = catalogs.includes(requestedCatalog) ? requestedCatalog : ''
   const getDraft = (id: string): Draft =>
     reconcile(


### PR DESCRIPTION
The translation editor used `Object.entries` and `Array.prototype.flatMap`, which fail the package's ES2016 typechecks. Use `Object.keys` and loops for the same validation, draft lookup, and sorted catalog behavior.

This repairs the inherited build failure blocking the Test262 stack without raising the package's library requirements.

Validation: all editor package builds and four tests/typechecks pass; three harness fixture/validator tests pass.
