### PR TITLE
fix(@formatjs/intl-getcanonicallocales): preserve RegExp statics

### DIFF
--- a/docs/src/docs/polyfills/intl-getcanonicallocales.mdx
+++ b/docs/src/docs/polyfills/intl-getcanonicallocales.mdx
@@ -92,3 +92,6 @@ apply the most specific rule first, including language-independent variants.
 
 Canonicalization creates list elements directly without calling an overridden
 `Array.prototype.push`, including while parsing and emitting extensions.
+
+Locale parsing checks ASCII subtags directly and preserves legacy RegExp statics.
+Extension singleton matching is case-insensitive, including duplicate detection.

--- a/knowledge-base/007j-polyfill-intl-getcanonicallocales.md
+++ b/knowledge-base/007j-polyfill-intl-getcanonicallocales.md
@@ -88,3 +88,6 @@ apply the most specific rule first, including language-independent variants.
 
 Canonicalization creates list elements directly without calling an overridden
 `Array.prototype.push`, including while parsing and emitting extensions.
+
+Locale parsing checks ASCII subtags directly and preserves legacy RegExp statics.
+Extension singleton matching is case-insensitive, including duplicate detection.

--- a/knowledge-base/014-test262-conformance.md
+++ b/knowledge-base/014-test262-conformance.md
@@ -7,14 +7,14 @@ excluded because it fails.
 
 | Polyfill            | Executed | Polyfill failures | Native failures | Combined failures |
 | ------------------- | -------: | ----------------: | --------------: | ----------------: |
-| collator            |      130 |                 2 |               0 |                 4 |
+| collator            |      130 |                 2 |               0 |                 2 |
 | datetimeformat      |      488 |               194 |              52 |               194 |
 | displaynames        |      114 |                 4 |               0 |                 4 |
 | durationformat      |      220 |                 0 |               4 |                 2 |
 | getcanonicallocales |       76 |                 0 |               2 |                 0 |
 | listformat          |      162 |                 4 |               0 |                 4 |
 | locale              |      336 |                 4 |              22 |                 4 |
-| numberformat        |      498 |                18 |               0 |                20 |
+| numberformat        |      498 |                18 |               0 |                18 |
 | pluralrules         |      106 |                 4 |               0 |                 2 |
 | relativetimeformat  |      160 |                 8 |               0 |                20 |
 | segmenter           |      158 |                10 |               0 |                10 |
@@ -25,16 +25,16 @@ control fails 86 executions; 44 failing cases overlap. Overlap does not prove
 a polyfill is correct: each failure still needs comparison with the selected
 spec and test's feature metadata.
 
-Combined: 2,498 executions, 2,228 passes, 270 failures.
+Combined: 2,498 executions, 2,232 passes, 266 failures.
 
-Combined installation adds 26 failing executions; 6 isolated failures now pass.
+Combined installation adds 22 failing executions; 6 isolated failures now pass.
 Two Locale branding cases pass with the installed getCanonicalLocales polyfill.
 Two RelativeTimeFormat cases pass because combined enumeration omits numbering
 systems that the NumberFormat polyfill does not support; this is not broader
 numbering-system conformance.
 Two PluralRules compact-notation cases pass only when the NumberFormat French
 locale data is present; the isolated dependency remains unresolved.
-The extra failures concern RegExp statics, NumberFormat dependencies, calendar
+The extra failures concern NumberFormat dependencies, calendar
 display-name keys, and optional collation data. Full raw reports accompany Bazel
 test outputs; the checked-in baselines preserve every remaining diagnostic.
 
@@ -157,3 +157,6 @@ locale-registration concern.
 Shared locale fixtures remove four Indian grouping failures in each mode and
 two combined French compact-plural failures. Portuguese range and Polish
 grouping diagnostics now reflect loaded locale data; those bugs remain tracked.
+
+ASCII locale parsing removes four combined RegExp-statics failures in Collator
+and NumberFormat. Isolated getCanonicalLocales remains at zero failures.

--- a/packages/intl-getcanonicallocales/parser.ts
+++ b/packages/intl-getcanonicallocales/parser.ts
@@ -9,25 +9,59 @@ import {
   type KV,
 } from '#packages/intl-getcanonicallocales/types.js'
 
-const ALPHANUM_1_8 = /^[a-z0-9]{1,8}$/i
-const ALPHANUM_2_8 = /^[a-z0-9]{2,8}$/i
-const ALPHANUM_3_8 = /^[a-z0-9]{3,8}$/i
+// ECMA-402 §6.2.1, step 2 validates ASCII locale grammar without observable
+// RegExp execution, including changes to legacy RegExp constructor statics.
+// https://tc39.es/ecma402/#sec-iswellformedlanguagetag
+// https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/locales-currencies-tz.html#L46
+function isLetter(code: number): boolean {
+  return (code >= 65 && code <= 90) || (code >= 97 && code <= 122)
+}
 
-const KEY_REGEX = /^[a-z0-9][a-z]$/i
+function isDigit(code: number): boolean {
+  return code >= 48 && code <= 57
+}
 
-const TYPE_REGEX = /^[a-z0-9]{3,8}$/i
-const ALPHA_4 = /^[a-z]{4}$/i
-// alphanum-[tTuUxX]
-const OTHER_EXTENSION_TYPE = /^[0-9a-svwyz]$/i
-const UNICODE_REGION_SUBTAG_REGEX = /^([a-z]{2}|[0-9]{3})$/i
-const UNICODE_VARIANT_SUBTAG_REGEX = /^([a-z0-9]{5,8}|[0-9][a-z0-9]{3})$/i
-const UNICODE_LANGUAGE_SUBTAG_REGEX = /^([a-z]{2,3}|[a-z]{5,8})$/i
-const TKEY_REGEX = /^[a-z][0-9]$/i
+function isSubtag(
+  value: string,
+  min: number,
+  max: number,
+  digits = false
+): boolean {
+  if (value.length < min || value.length > max) return false
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i)
+    if (!isLetter(code) && !(digits && isDigit(code))) return false
+  }
+  return true
+}
+
+function isUnicodeKey(value: string): boolean {
+  return (
+    value.length === 2 &&
+    isSubtag(value, 2, 2, true) &&
+    isLetter(value.charCodeAt(1))
+  )
+}
+
+function isTransformedKey(value: string): boolean {
+  return (
+    value.length === 2 &&
+    isLetter(value.charCodeAt(0)) &&
+    isDigit(value.charCodeAt(1))
+  )
+}
+
+function isOtherExtensionType(value: string): boolean {
+  const type = value.toLowerCase()
+  return (
+    isSubtag(type, 1, 1, true) && type !== 't' && type !== 'u' && type !== 'x'
+  )
+}
 
 export const SEPARATOR = '-'
 
 export function isUnicodeLanguageSubtag(lang: string): boolean {
-  return UNICODE_LANGUAGE_SUBTAG_REGEX.test(lang)
+  return lang.length !== 4 && isSubtag(lang, 2, 8)
 }
 
 export function isStructurallyValidLanguageTag(tag: string): boolean {
@@ -40,15 +74,24 @@ export function isStructurallyValidLanguageTag(tag: string): boolean {
 }
 
 export function isUnicodeRegionSubtag(region: string): boolean {
-  return UNICODE_REGION_SUBTAG_REGEX.test(region)
+  return (
+    isSubtag(region, 2, 2) ||
+    (region.length === 3 &&
+      isDigit(region.charCodeAt(0)) &&
+      isDigit(region.charCodeAt(1)) &&
+      isDigit(region.charCodeAt(2)))
+  )
 }
 
 export function isUnicodeScriptSubtag(script: string): boolean {
-  return ALPHA_4.test(script)
+  return isSubtag(script, 4, 4)
 }
 
 export function isUnicodeVariantSubtag(variant: string): boolean {
-  return UNICODE_VARIANT_SUBTAG_REGEX.test(variant)
+  return (
+    isSubtag(variant, 5, 8, true) ||
+    (isSubtag(variant, 4, 4, true) && isDigit(variant.charCodeAt(0)))
+  )
 }
 
 export function parseUnicodeLanguageId(
@@ -110,7 +153,7 @@ function parseUnicodeExtension(chunks: string[]): UnicodeExtension {
   // Mix of attributes & keywords
   // Check for attributes first
   const attributes: string[] = []
-  while (chunks.length && ALPHANUM_3_8.test(chunks[0])) {
+  while (chunks.length && isSubtag(chunks[0], 3, 8, true)) {
     appendToList(attributes, chunks.shift()!)
   }
   while (chunks.length && (keyword = parseKeyword(chunks))) {
@@ -128,13 +171,13 @@ function parseUnicodeExtension(chunks: string[]): UnicodeExtension {
 
 function parseKeyword(chunks: string[]): KV | undefined {
   let key
-  if (!KEY_REGEX.test(chunks[0])) {
+  if (!isUnicodeKey(chunks[0])) {
     return
   }
   key = chunks.shift()!
 
   const type: string[] = []
-  while (chunks.length && TYPE_REGEX.test(chunks[0])) {
+  while (chunks.length && isSubtag(chunks[0], 3, 8, true)) {
     appendToList(type, chunks.shift()!)
   }
   let value: string = ''
@@ -154,10 +197,10 @@ function parseTransformedExtension(chunks: string[]): TransformedExtension {
     lang = parseUnicodeLanguageId(chunks)
   }
   const fields: KV[] = []
-  while (chunks.length && TKEY_REGEX.test(chunks[0])) {
+  while (chunks.length && isTransformedKey(chunks[0])) {
     const key = chunks.shift()!
     const value: string[] = []
-    while (chunks.length && ALPHANUM_3_8.test(chunks[0])) {
+    while (chunks.length && isSubtag(chunks[0], 3, 8, true)) {
       appendToList(value, chunks.shift()!)
     }
     if (!value.length) {
@@ -176,7 +219,7 @@ function parseTransformedExtension(chunks: string[]): TransformedExtension {
 }
 function parsePuExtension(chunks: string[]): PuExtension {
   const exts: string[] = []
-  while (chunks.length && ALPHANUM_1_8.test(chunks[0])) {
+  while (chunks.length && isSubtag(chunks[0], 1, 8, true)) {
     appendToList(exts, chunks.shift()!)
   }
   if (exts.length) {
@@ -189,7 +232,7 @@ function parsePuExtension(chunks: string[]): PuExtension {
 }
 function parseOtherExtensionValue(chunks: string[]): string {
   const exts: string[] = []
-  while (chunks.length && ALPHANUM_2_8.test(chunks[0])) {
+  while (chunks.length && isSubtag(chunks[0], 2, 8, true)) {
     appendToList(exts, chunks.shift()!)
   }
   if (exts.length) {
@@ -210,7 +253,7 @@ function parseExtensions(chunks: string[]): Omit<UnicodeLocaleId, 'lang'> {
   let puExtension
   const otherExtensionMap: Record<string, OtherExtension> = {}
   do {
-    const type = chunks.shift()!
+    const type = chunks.shift()!.toLowerCase()
     switch (type) {
       case 'u':
       case 'U':
@@ -237,7 +280,7 @@ function parseExtensions(chunks: string[]): Omit<UnicodeLocaleId, 'lang'> {
         appendToList(extensions, puExtension)
         break
       default:
-        if (!OTHER_EXTENSION_TYPE.test(type)) {
+        if (!isOtherExtensionType(type)) {
           throw new RangeError('Malformed extension type')
         }
         if (type in otherExtensionMap) {

--- a/packages/intl-getcanonicallocales/tests/index.test.ts
+++ b/packages/intl-getcanonicallocales/tests/index.test.ts
@@ -103,6 +103,29 @@ describe('Intl.getCanonicalLocales', () => {
       'en-a-foo-x-private',
     ])
   })
+  it('preserves legacy RegExp statics during canonicalization', () => {
+    ;/sent(inel)/.exec('sentinel')
+    const match = RegExp.lastMatch
+    const group = RegExp.$1
+    const actual = getCanonicalLocales([
+      'en-u-co-phonebk',
+      'JA-latn-hepburn-heploc',
+      'en-t-en-m0-names',
+      'en-A-FOO',
+    ])
+    const afterMatch = RegExp.lastMatch
+    const afterGroup = RegExp.$1
+    expect(actual).toEqual([
+      'en-u-co-phonebk',
+      'ja-Latn-alalc97',
+      'en-t-en-m0-prprname',
+      'en-a-foo',
+    ])
+    expect(afterMatch).toBe(match)
+    expect(afterGroup).toBe(group)
+    expect(() => getCanonicalLocales('en-a-foo-A-bar')).toThrow(RangeError)
+    expect(() => getCanonicalLocales('en\n')).toThrow(RangeError)
+  })
   it('regular', function () {
     expect(
       getCanonicalLocales('en-u-foo-bar-nu-thai-ca-buddhist-kk-true')

--- a/tools/test262/baselines/combined-collator.json
+++ b/tools/test262/baselines/combined-collator.json
@@ -1,8 +1,6 @@
 {
   "total": 130,
   "failures": {
-    "intl402/Collator/legacy-regexp-statics-not-modified.js (default)": "RegExp has unexpected property $_ with value phonebk.",
-    "intl402/Collator/legacy-regexp-statics-not-modified.js (strict mode)": "RegExp has unexpected property $_ with value phonebk.",
     "intl402/Collator/proto-from-ctor-realm.js (default)": "newTarget.prototype is undefined Expected SameValue(«[object Intl.Collator]», «[object Intl.Collator]») to be true",
     "intl402/Collator/proto-from-ctor-realm.js (strict mode)": "newTarget.prototype is undefined Expected SameValue(«[object Intl.Collator]», «[object Intl.Collator]») to be true"
   }

--- a/tools/test262/baselines/combined-numberformat.json
+++ b/tools/test262/baselines/combined-numberformat.json
@@ -7,8 +7,6 @@
     "intl402/NumberFormat/intl-legacy-constructed-symbol-property.js (strict mode)": "value of legacy symbol property must be an Intl.NumberFormat",
     "intl402/NumberFormat/intl-legacy-constructed-symbol.js (default)": "Expected true but got false",
     "intl402/NumberFormat/intl-legacy-constructed-symbol.js (strict mode)": "Expected true but got false",
-    "intl402/NumberFormat/legacy-regexp-statics-not-modified.js (default)": "RegExp has unexpected property $1 with value zu.",
-    "intl402/NumberFormat/legacy-regexp-statics-not-modified.js (strict mode)": "RegExp has unexpected property $1 with value zu.",
     "intl402/NumberFormat/proto-from-ctor-realm.js (default)": "newTarget.prototype is undefined Expected SameValue(«[object Intl.NumberFormat]», «[object Intl.NumberFormat]») to be true",
     "intl402/NumberFormat/proto-from-ctor-realm.js (strict mode)": "newTarget.prototype is undefined Expected SameValue(«[object Intl.NumberFormat]», «[object Intl.NumberFormat]») to be true",
     "intl402/NumberFormat/prototype/format/numbering-systems.js (default)": "numberingSystem: adlm, digit: 0 Expected SameValue(«\"0\"», «\"𞥐\"») to be true",


### PR DESCRIPTION
Validate locale subtags with ASCII character checks so canonicalization does not modify legacy RegExp statics. Extension singleton matching is also case-insensitive, including duplicate detection.

The parser comment cites ECMA-402 §6.2.1 step 2 and pinned source lines. Regression tests cover preserved RegExp statics, uppercase singleton canonicalization, duplicate singletons and trailing newlines.

Validation: getCanonicalLocales/Locale package gates, all twelve isolated Test262 suites, strict getCanonicalLocales (76/76), and both affected combined suites. Four combined failures removed; no added or changed diagnostics.
