### PR TITLE
fix(@formatjs/intl-displaynames): use canonical calendar data keys

### DIFF
--- a/docs/src/docs/polyfills/intl-displaynames.mdx
+++ b/docs/src/docs/polyfills/intl-displaynames.mdx
@@ -217,3 +217,6 @@ separate from language-specific patterns, regardless of registration order.
 
 Language display-name codes accept Unicode language subtags of two, three, or
 five to eight ASCII letters, with optional script, region, and variant subtags.
+
+Calendar display-name data uses BCP 47 identifiers, including `gregory` and
+`ethioaa`, rather than CLDR legacy keys.

--- a/knowledge-base/007d-polyfill-intl-displaynames.md
+++ b/knowledge-base/007d-polyfill-intl-displaynames.md
@@ -58,3 +58,6 @@ code, such as `ZZZ` for an unknown currency supplied as `zzz`.
 
 Language display-name codes accept Unicode language subtags of two, three, or
 five to eight ASCII letters, with optional script, region, and variant subtags.
+
+Calendar display-name data uses BCP 47 identifiers, including `gregory` and
+`ethioaa`, rather than CLDR legacy keys.

--- a/knowledge-base/014-test262-conformance.md
+++ b/knowledge-base/014-test262-conformance.md
@@ -18,16 +18,16 @@ excluded because it fails.
 | pluralrules         |      106 |                 4 |               0 |                 2 |
 | relativetimeformat  |      160 |                 8 |               0 |                20 |
 | segmenter           |      158 |                10 |               0 |                10 |
-| supportedvaluesof   |       50 |                 2 |               6 |                 6 |
+| supportedvaluesof   |       50 |                 2 |               6 |                 4 |
 
 Total: 2,498 executions, 2,248 polyfill passes, 250 polyfill failures. The native
 control fails 86 executions; 44 failing cases overlap. Overlap does not prove
 a polyfill is correct: each failure still needs comparison with the selected
 spec and test's feature metadata.
 
-Combined: 2,498 executions, 2,232 passes, 266 failures.
+Combined: 2,498 executions, 2,234 passes, 264 failures.
 
-Combined installation adds 22 failing executions; 6 isolated failures now pass.
+Combined installation adds 20 failing executions; 6 isolated failures now pass.
 Two Locale branding cases pass with the installed getCanonicalLocales polyfill.
 Two RelativeTimeFormat cases pass because combined enumeration omits numbering
 systems that the NumberFormat polyfill does not support; this is not broader

--- a/packages/intl-displaynames/BUILD.bazel
+++ b/packages/intl-displaynames/BUILD.bazel
@@ -111,6 +111,7 @@ CLDR_RAW_FILES = ["cldr-raw/%s.json" % locale for locale in ALL_LOCALES]
 ts_run_binary(
     name = "cldr-raw",
     srcs = [
+        "//:node_modules/cldr-bcp47",
         "//:node_modules/cldr-core",
         "//:node_modules/cldr-dates-full",
         "//:node_modules/cldr-localenames-full",

--- a/packages/intl-displaynames/scripts/extract-displaynames.ts
+++ b/packages/intl-displaynames/scripts/extract-displaynames.ts
@@ -1,5 +1,6 @@
 import {type DisplayNamesData} from '#packages/ecma402-abstract/types/displaynames.js'
 import AVAILABLE_LOCALES from 'cldr-core/availableLocales.json' with {type: 'json'}
+import calendarIdentifiers from 'cldr-bcp47/bcp47/calendar.json' with {type: 'json'}
 import glob from 'fast-glob'
 import {dirname, resolve} from 'path'
 import {createRequire} from 'node:module'
@@ -66,6 +67,31 @@ function extractStyleData(
     }
   }
   return {long: longData, short: shortData, narrow: narrowData}
+}
+
+// ECMA-402 §12.3.3, steps 4–6 look up the canonical calendar code.
+// https://tc39.es/ecma402/#sec-Intl.DisplayNames.prototype.of
+// https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/displaynames.html#L185-L187
+// CLDR defines gregory/ethioaa and their legacy aliases here:
+// https://github.com/unicode-org/cldr/blob/acd6d88ae493633240e19a87a721076a8a75c310/common/bcp47/calendar.xml#L17-L19
+function extractCalendarStyleData(cldrData: CalendarRawData) {
+  const aliases: Record<string, string> = {}
+  for (const [code, value] of Object.entries(
+    calendarIdentifiers.keyword.u.ca
+  )) {
+    if (typeof value !== 'object') continue
+    const canonical = '_preferred' in value ? value._preferred : code
+    aliases[code] = canonical
+    if ('_alias' in value) {
+      for (const alias of value._alias.split(' ')) aliases[alias] = canonical
+    }
+  }
+  const data: Record<string, string> = {}
+  for (const [key, value] of Object.entries(cldrData)) {
+    const [code, style] = key.split('-alt-')
+    data[(aliases[code] || code) + (style ? '-alt-' + style : '')] = value
+  }
+  return extractStyleData(data)
 }
 
 // Currency code -> {Property -> Value}.
@@ -267,7 +293,7 @@ async function loadDisplayNames(
         region: extractStyleData(regionData),
         script: extractStyleData(scriptData),
         currency: extractCurrencyStyleData(locale, currencyData),
-        calendar: extractStyleData(calendarData),
+        calendar: extractCalendarStyleData(calendarData),
         dateTimeField: extractDateTimeFieldStyleData(dateTimeFieldData),
       },
       patterns: {

--- a/packages/intl-displaynames/tests/index.test.ts
+++ b/packages/intl-displaynames/tests/index.test.ts
@@ -102,6 +102,13 @@ describe('.of()', () => {
 
   // https://github.com/formatjs/formatjs/issues/3387
   describe('GH #3387: calendar type support', () => {
+    it('uses BCP 47 calendar identifiers with fallback disabled', () => {
+      const dn = new DisplayNames('en', {type: 'calendar', fallback: 'none'})
+      expect(dn.of('gregory')).toBe('Gregorian Calendar')
+      expect(dn.of('ethioaa')).toBe('Ethiopic Amete Alem Calendar')
+      expect(dn.of('ethiopic-amete-alem')).toBeUndefined()
+    })
+
     it('finds the calendar correctly with long style', () => {
       expect(new DisplayNames('en', {type: 'calendar'}).of('roc')).toBe(
         'Minguo Calendar'
@@ -141,7 +148,7 @@ describe('.of()', () => {
       expect(dn.of('islamic-civil')).toBe(
         'Hijri Calendar (tabular, civil epoch)'
       )
-      expect(dn.of('ethiopic-amete-alem')).toBe('Ethiopic Amete Alem Calendar')
+      expect(dn.of('ethiopic-amete-alem')).toBe('ethiopic-amete-alem')
     })
 
     it('handles calendar codes case-insensitively (canonicalizes to lowercase)', () => {

--- a/tools/test262/baselines/combined-supportedvaluesof.json
+++ b/tools/test262/baselines/combined-supportedvaluesof.json
@@ -1,8 +1,6 @@
 {
   "total": 50,
   "failures": {
-    "intl402/Intl/supportedValuesOf/calendars-accepted-by-DisplayNames.js (default)": "gregory is supported by DisplayNames Expected SameValue(«\"undefined\"», «\"string\"») to be true",
-    "intl402/Intl/supportedValuesOf/calendars-accepted-by-DisplayNames.js (strict mode)": "gregory is supported by DisplayNames Expected SameValue(«\"undefined\"», «\"string\"») to be true",
     "intl402/Intl/supportedValuesOf/calendars-required-by-intl-era-monthcode.js (default)": "Actual [gregory] and expected [buddhist, chinese, coptic, dangi, ethioaa, ethiopic, gregory, hebrew, indian, islamic-civil, islamic-tbla, islamic-umalqura, iso8601, japanese, persian, roc] should have the same contents. only the required calendars are supported",
     "intl402/Intl/supportedValuesOf/calendars-required-by-intl-era-monthcode.js (strict mode)": "Actual [gregory] and expected [buddhist, chinese, coptic, dangi, ethioaa, ethiopic, gregory, hebrew, indian, islamic-civil, islamic-tbla, islamic-umalqura, iso8601, japanese, persian, roc] should have the same contents. only the required calendars are supported",
     "intl402/Intl/supportedValuesOf/numberingSystems-with-simple-digit-mappings.js (default)": "adlm with simple digit mappings is supported",


### PR DESCRIPTION
Calendar display-name data used CLDR legacy keys, so valid BCP 47 identifiers such as `gregory` and `ethioaa` returned no name with `fallback: "none"`. Normalize data keys using CLDR calendar aliases during generation; preserve style variants. Legacy keys now follow the normal fallback behavior.

The generator comment cites ECMA-402 §12.3.3 steps 4–6 and pinned CLDR alias source lines. Public and internal docs describe the identifiers.

Validation: all DisplayNames package gates pass. The combined supportedValuesOf suite gains two calendar-name passes, with no new failures or changed diagnostics.
