### PR TITLE
fix(@formatjs/intl-numberformat): isolate internal plural options

### DIFF
--- a/docs/src/docs/polyfills/intl-numberformat.mdx
+++ b/docs/src/docs/polyfills/intl-numberformat.mdx
@@ -399,3 +399,6 @@ not remove its internal brand.
 
 `resolvedOptions()` returns properties in specification order, including
 `roundingPriority` before `trailingZeroDisplay`.
+
+Internal plural selection uses options with a null prototype, preventing inherited
+option getters from affecting NumberFormat or its RelativeTimeFormat consumers.

--- a/knowledge-base/007a-polyfill-intl-numberformat.md
+++ b/knowledge-base/007a-polyfill-intl-numberformat.md
@@ -123,3 +123,6 @@ and the `Intl.supportedValuesOf("unit")` list.
 
 `resolvedOptions()` returns properties in specification order, including
 `roundingPriority` before `trailingZeroDisplay`.
+
+Internal plural selection uses options with a null prototype, preventing inherited
+option getters from affecting NumberFormat or its RelativeTimeFormat consumers.

--- a/knowledge-base/014-test262-conformance.md
+++ b/knowledge-base/014-test262-conformance.md
@@ -16,7 +16,7 @@ excluded because it fails.
 | locale              |      336 |                 4 |              22 |                 4 |
 | numberformat        |      498 |                18 |               0 |                18 |
 | pluralrules         |      106 |                 4 |               0 |                 2 |
-| relativetimeformat  |      160 |                 8 |               0 |                20 |
+| relativetimeformat  |      160 |                 8 |               0 |                18 |
 | segmenter           |      158 |                10 |               0 |                10 |
 | supportedvaluesof   |       50 |                 2 |               6 |                 4 |
 
@@ -25,9 +25,9 @@ control fails 86 executions; 44 failing cases overlap. Overlap does not prove
 a polyfill is correct: each failure still needs comparison with the selected
 spec and test's feature metadata.
 
-Combined: 2,498 executions, 2,234 passes, 264 failures.
+Combined: 2,498 executions, 2,236 passes, 262 failures.
 
-Combined installation adds 20 failing executions; 6 isolated failures now pass.
+Combined installation adds 18 failing executions; 6 isolated failures now pass.
 Two Locale branding cases pass with the installed getCanonicalLocales polyfill.
 Two RelativeTimeFormat cases pass because combined enumeration omits numbering
 systems that the NumberFormat polyfill does not support; this is not broader

--- a/packages/intl-numberformat/core.ts
+++ b/packages/intl-numberformat/core.ts
@@ -81,13 +81,20 @@ export const NumberFormat = function (
     `Cannot load locale-dependent data for ${dataLocale}.`
   )
 
-  internalSlots.pl = createMemoizedPluralRules(dataLocale, {
-    minimumFractionDigits: internalSlots.minimumFractionDigits,
-    maximumFractionDigits: internalSlots.maximumFractionDigits,
-    minimumIntegerDigits: internalSlots.minimumIntegerDigits,
-    minimumSignificantDigits: internalSlots.minimumSignificantDigits,
-    maximumSignificantDigits: internalSlots.maximumSignificantDigits,
-  })
+  // ECMA-402 §16.1.1, steps 3–4 read localeMatcher from the caller's
+  // options. Internal plural selection must not add inherited option reads.
+  // https://tc39.es/ecma402/#sec-intl.numberformat
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/numberformat.html#L23-L24
+  internalSlots.pl = createMemoizedPluralRules(
+    dataLocale,
+    Object.assign(Object.create(null), {
+      minimumFractionDigits: internalSlots.minimumFractionDigits,
+      maximumFractionDigits: internalSlots.maximumFractionDigits,
+      minimumIntegerDigits: internalSlots.minimumIntegerDigits,
+      minimumSignificantDigits: internalSlots.minimumSignificantDigits,
+      maximumSignificantDigits: internalSlots.maximumSignificantDigits,
+    })
+  )
   return this
 } as NumberFormatConstructor
 

--- a/packages/intl-numberformat/tests/misc.test.ts
+++ b/packages/intl-numberformat/tests/misc.test.ts
@@ -772,3 +772,27 @@ test.each(['auto', 'morePrecision', 'lessPrecision'] as const)(
     expect(options.roundingPriority).toBe(roundingPriority)
   }
 )
+
+describe('internal PluralRules options', () => {
+  it('does not observe inherited option getters', () => {
+    const previous = Object.getOwnPropertyDescriptor(
+      Object.prototype,
+      'localeMatcher'
+    )
+    let formatted: string
+    Object.defineProperty(Object.prototype, 'localeMatcher', {
+      configurable: true,
+      get() {
+        throw new Error('Inherited localeMatcher read')
+      },
+    })
+    try {
+      formatted = new NumberFormat('en', Object.create(null)).format(123)
+    } finally {
+      if (previous)
+        Object.defineProperty(Object.prototype, 'localeMatcher', previous)
+      else delete (Object.prototype as {localeMatcher?: unknown}).localeMatcher
+    }
+    expect(formatted!).toBe('123')
+  })
+})

--- a/tools/test262/baselines/combined-relativetimeformat.json
+++ b/tools/test262/baselines/combined-relativetimeformat.json
@@ -1,8 +1,6 @@
 {
   "total": 160,
   "failures": {
-    "intl402/RelativeTimeFormat/constructor/constructor/options-proto.js (default)": "Should not call getter on Object.prototype: localeMatcher",
-    "intl402/RelativeTimeFormat/constructor/constructor/options-proto.js (strict mode)": "Should not call getter on Object.prototype: localeMatcher",
     "intl402/RelativeTimeFormat/constructor/constructor/proto-from-ctor-realm.js (default)": "Expected no error, got TypeError: Intl.RelativeTimeFormat must be called with 'new'",
     "intl402/RelativeTimeFormat/constructor/constructor/proto-from-ctor-realm.js (strict mode)": "Expected no error, got TypeError: Intl.RelativeTimeFormat must be called with 'new'",
     "intl402/RelativeTimeFormat/prototype/format/pl-pl-style-long.js (default)": "Expected SameValue(«\"za 1 000 sekund\"», «\"za 1000 sekund\"») to be true",


### PR DESCRIPTION
NumberFormat passed an ordinary options object to its internal PluralRules helper. An inherited `localeMatcher` getter could run even when the caller supplied a null-prototype options object, including through RelativeTimeFormat. Use a null-prototype internal record.

The regression test installs a throwing inherited getter and restores it afterward. The code comment cites ECMA-402 §16.1.1 steps 3–4 with pinned source lines.

Validation: all 20 NumberFormat package gates pass. Combined RelativeTimeFormat gains two passes; no new failures or changed diagnostics.
