### PR TITLE
fix(@formatjs/intl-datetimeformat): reuse parsed pattern fields

### DIFF
--- a/docs/src/docs/polyfills/intl-datetimeformat.mdx
+++ b/docs/src/docs/polyfills/intl-datetimeformat.mdx
@@ -306,3 +306,6 @@ options and Unicode extensions. Locale preferences still select the default.
 
 The `hour12` option selects the locale’s separate 12-hour or 24-hour preference.
 For example, English uses `h12` or `h23`; Japanese uses `h11` or `h23`.
+
+DateTimeFormat reuses pattern fields parsed during locale registration, preserving
+legacy RegExp statics during constructor format matching.

--- a/knowledge-base/007b-polyfill-intl-datetimeformat.md
+++ b/knowledge-base/007b-polyfill-intl-datetimeformat.md
@@ -172,3 +172,6 @@ options and Unicode extensions. Locale preferences still select the default.
 
 The `hour12` option selects the locale’s separate 12-hour or 24-hour preference.
 For example, English uses `h12` or `h23`; Japanese uses `h11` or `h23`.
+
+DateTimeFormat reuses pattern fields parsed during locale registration, preserving
+legacy RegExp statics during constructor format matching.

--- a/knowledge-base/014-test262-conformance.md
+++ b/knowledge-base/014-test262-conformance.md
@@ -8,7 +8,7 @@ excluded because it fails.
 | Polyfill            | Executed | Polyfill failures | Native failures | Combined failures |
 | ------------------- | -------: | ----------------: | --------------: | ----------------: |
 | collator            |      130 |                 2 |               0 |                 2 |
-| datetimeformat      |      488 |               194 |              52 |               194 |
+| datetimeformat      |      488 |               192 |              52 |               192 |
 | displaynames        |      114 |                 4 |               0 |                 4 |
 | durationformat      |      220 |                 0 |               4 |                 2 |
 | getcanonicallocales |       76 |                 0 |               2 |                 0 |
@@ -20,12 +20,12 @@ excluded because it fails.
 | segmenter           |      158 |                10 |               0 |                10 |
 | supportedvaluesof   |       50 |                 2 |               6 |                 4 |
 
-Total: 2,498 executions, 2,248 polyfill passes, 250 polyfill failures. The native
+Total: 2,498 executions, 2,250 polyfill passes, 248 polyfill failures. The native
 control fails 86 executions; 44 failing cases overlap. Overlap does not prove
 a polyfill is correct: each failure still needs comparison with the selected
 spec and test's feature metadata.
 
-Combined: 2,498 executions, 2,248 passes, 250 failures.
+Combined: 2,498 executions, 2,250 passes, 248 failures.
 
 Combined installation adds 6 failing executions; 6 isolated failures now pass.
 Two Locale branding cases pass with the installed getCanonicalLocales polyfill.

--- a/packages/ecma402-abstract/DateTimeFormat/BestFitFormatMatcher.ts
+++ b/packages/ecma402-abstract/DateTimeFormat/BestFitFormatMatcher.ts
@@ -3,7 +3,7 @@ import {
   type TABLE_6,
 } from '#packages/ecma402-abstract/types/date-time.js'
 import {invariant} from '#packages/ecma402-abstract/utils.js'
-import {processDateTimePattern} from '#packages/ecma402-abstract/DateTimeFormat/skeleton.js'
+import {getDateTimePatternFields} from '#packages/ecma402-abstract/DateTimeFormat/skeleton.js'
 import {
   DATE_TIME_PROPS,
   additionPenalty,
@@ -97,13 +97,13 @@ export function BestFitFormatMatcher(
   }
 
   const skeletonFormat = {...bestFormat}
-  // ECMA-402 §11.5.3 returns an internal Record, not an inheriting object.
-  // This implementation-defined operation has no numbered steps.
+  // ECMA-402 §11.5.3 returns an internal Record (no numbered steps).
+  // Reuse registered pattern fields so matching preserves RegExp statics.
   // https://tc39.es/ecma402/#sec-bestfitformatmatcher
   // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/datetimeformat.html#L1310-L1315
   const patternFormat = Object.create(null) as Formats
   patternFormat.rawPattern = bestFormat.rawPattern
-  processDateTimePattern(bestFormat.rawPattern, patternFormat)
+  Object.assign(patternFormat, getDateTimePatternFields(bestFormat))
 
   // Kinda following https://github.com/unicode-org/icu/blob/dd50e38f459d84e9bf1b0c618be8483d318458ad/icu4j/main/classes/core/src/com/ibm/icu/text/DateTimePatternGenerator.java
   // Method adjustFieldTypes

--- a/packages/ecma402-abstract/DateTimeFormat/skeleton.ts
+++ b/packages/ecma402-abstract/DateTimeFormat/skeleton.ts
@@ -6,6 +6,19 @@ import {
   type TABLE_2,
 } from '#packages/ecma402-abstract/types/date-time.js'
 
+const patternFields = new WeakMap<Formats, Intl.DateTimeFormatOptions>()
+
+export function getDateTimePatternFields(
+  format: Formats
+): Intl.DateTimeFormatOptions {
+  const cached = patternFields.get(format)
+  if (cached) return cached
+  const fields: Intl.DateTimeFormatOptions = Object.create(null)
+  processDateTimePattern(format.rawPattern, fields)
+  patternFields.set(format, fields)
+  return fields
+}
+
 /**
  * https://unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table
  * Credit: https://github.com/caridy/intl-datetimeformat-pattern/blob/master/index.js
@@ -317,7 +330,9 @@ export function parseDateTimeSkeleton(
 
   // Process skeleton
   skeleton.replace(DATE_TIME_REGEX, m => matchSkeletonPattern(m, result))
-  const [pattern, pattern12] = processDateTimePattern(rawPattern)
+  const fields: Intl.DateTimeFormatOptions = Object.create(null)
+  const [pattern, pattern12] = processDateTimePattern(rawPattern, fields)
+  patternFields.set(result, fields)
   result.pattern = pattern
   result.pattern12 = pattern12
   return result

--- a/packages/intl-datetimeformat/test262-baseline.json
+++ b/packages/intl-datetimeformat/test262-baseline.json
@@ -13,8 +13,6 @@
     "intl402/DateTimeFormat/intl-legacy-constructed-symbol-property.js (strict mode)": "return value of Intl.DateTimeFormat constructor Expected SameValue(«[object Intl.DateTimeFormat]», «undefined») to be true",
     "intl402/DateTimeFormat/intl-legacy-constructed-symbol.js (default)": "Expected no error, got TypeError: Cannot convert undefined or null to object",
     "intl402/DateTimeFormat/intl-legacy-constructed-symbol.js (strict mode)": "Expected no error, got TypeError: Cannot convert undefined or null to object",
-    "intl402/DateTimeFormat/legacy-regexp-statics-not-modified.js (default)": "RegExp has unexpected property $_ with value d.M.y.",
-    "intl402/DateTimeFormat/legacy-regexp-statics-not-modified.js (strict mode)": "RegExp has unexpected property $_ with value d.M.y.",
     "intl402/DateTimeFormat/proto-from-ctor-realm.js (default)": "newTarget.prototype is undefined Expected SameValue(«[object Intl.DateTimeFormat]», «[object Intl.DateTimeFormat]») to be true",
     "intl402/DateTimeFormat/proto-from-ctor-realm.js (strict mode)": "newTarget.prototype is undefined Expected SameValue(«[object Intl.DateTimeFormat]», «[object Intl.DateTimeFormat]») to be true",
     "intl402/DateTimeFormat/prototype/format/bound-to-datetimeformat-instance.js (default)": "Expected no error, got RangeError: Calendar \"japanese\" is not supported. Try setting \"calendar\" to 1 of the following: gregory",

--- a/packages/intl-datetimeformat/tests/index.test.ts
+++ b/packages/intl-datetimeformat/tests/index.test.ts
@@ -21,6 +21,13 @@ describe('Intl.DateTimeFormat', function () {
   afterEach(() => {
     DateTimeFormat.__setDefaultTimeZone(DEFAULT_TIMEZONE)
   })
+  it('preserves legacy RegExp statics during construction', () => {
+    ;/sent(inel)/.exec('sentinel')
+    const before = [RegExp.lastMatch, RegExp.$1]
+    new DateTimeFormat('en', {year: 'numeric', month: 'long', timeZone: 'UTC'})
+    const after = [RegExp.lastMatch, RegExp.$1]
+    expect(after).toEqual(before)
+  })
   it('rejects values one millisecond beyond the exact TimeClip bounds', () => {
     const dtf = new DateTimeFormat('en', {timeZone: 'UTC'})
     const limit = 8_640_000_000_000_000

--- a/tools/test262/baselines/combined-datetimeformat.json
+++ b/tools/test262/baselines/combined-datetimeformat.json
@@ -13,8 +13,6 @@
     "intl402/DateTimeFormat/intl-legacy-constructed-symbol-property.js (strict mode)": "return value of Intl.DateTimeFormat constructor Expected SameValue(«[object Intl.DateTimeFormat]», «undefined») to be true",
     "intl402/DateTimeFormat/intl-legacy-constructed-symbol.js (default)": "Expected no error, got TypeError: Cannot convert undefined or null to object",
     "intl402/DateTimeFormat/intl-legacy-constructed-symbol.js (strict mode)": "Expected no error, got TypeError: Cannot convert undefined or null to object",
-    "intl402/DateTimeFormat/legacy-regexp-statics-not-modified.js (default)": "RegExp has unexpected property $_ with value d.M.y.",
-    "intl402/DateTimeFormat/legacy-regexp-statics-not-modified.js (strict mode)": "RegExp has unexpected property $_ with value d.M.y.",
     "intl402/DateTimeFormat/proto-from-ctor-realm.js (default)": "newTarget.prototype is undefined Expected SameValue(«[object Intl.DateTimeFormat]», «[object Intl.DateTimeFormat]») to be true",
     "intl402/DateTimeFormat/proto-from-ctor-realm.js (strict mode)": "newTarget.prototype is undefined Expected SameValue(«[object Intl.DateTimeFormat]», «[object Intl.DateTimeFormat]») to be true",
     "intl402/DateTimeFormat/prototype/format/bound-to-datetimeformat-instance.js (default)": "Expected no error, got RangeError: Calendar \"japanese\" is not supported. Try setting \"calendar\" to 1 of the following: gregory",


### PR DESCRIPTION
Best-fit DateTimeFormat matching reparsed locale patterns with regular expressions during construction, changing legacy RegExp statics. Cache parsed pattern fields when locale data is registered and copy those fields into the matcher's internal record. Hand-built internal test formats retain lazy parsing.

The code comment cites ECMA-402 §11.5.3 with pinned source lines. A regression test verifies constructor matching preserves `RegExp.lastMatch` and `RegExp.$1`.

Validation: all 11 package/shared-operation gates pass. Full isolated and combined Test262 runs each remove two RegExp-statics failures without new failures or changed diagnostics. Both captured reports and real exit codes validate against the reviewed baselines.
