### PR TITLE
fix(@formatjs/intl-pluralrules): generate compact exponent data

### DIFF
--- a/docs/src/docs/polyfills/intl-pluralrules.mdx
+++ b/docs/src/docs/polyfills/intl-pluralrules.mdx
@@ -156,3 +156,6 @@ Compact notation uses the shared compact digit defaults. `resolvedOptions()`
 returns an ordinary object, reports notation and rounding settings, and lists
 plural categories in the order `zero`, `one`, `two`, `few`, `many`, `other`.
 `selectRange()` accepts infinite endpoints; NaN still throws `RangeError`.
+
+Compact plural selection uses generated CLDR exponent tables for locales whose
+rules use `c`/`e`. It does not require NumberFormat locale data to be installed.

--- a/knowledge-base/007c-polyfill-intl-pluralrules.md
+++ b/knowledge-base/007c-polyfill-intl-pluralrules.md
@@ -14,11 +14,12 @@ Polyfill for `Intl.PluralRules` — evaluates CLDR plural rules to select plural
 
 ### Sources
 
-| CLDR File                                  | Data Used                                    |
-| ------------------------------------------ | -------------------------------------------- |
-| `cldr-core/supplemental/plurals.json`      | Cardinal plural rules per locale             |
-| `cldr-core/supplemental/ordinals.json`     | Ordinal plural rules per locale              |
-| `cldr-core/supplemental/pluralRanges.json` | Plural range mappings (start_end → category) |
+| CLDR File                                  | Data Used                                              |
+| ------------------------------------------ | ------------------------------------------------------ |
+| `cldr-core/supplemental/plurals.json`      | Cardinal plural rules per locale                       |
+| `cldr-core/supplemental/ordinals.json`     | Ordinal plural rules per locale                        |
+| `cldr-core/supplemental/pluralRanges.json` | Plural range mappings (start_end → category)           |
+| `cldr-numbers-full/main/*/numbers.json`    | Compact exponent tables for locales using c/e operands |
 
 ### Compilation: PluralRulesCompiler (`scripts/plural-rules-compiler.ts`)
 
@@ -65,7 +66,7 @@ function(num, isOrdinal, exponent = 0) {
 
 ```
 Stage 1: cldr-raw (cldr-raw.ts + PluralRulesCompiler)
-  Input: plurals.json + ordinals.json + pluralRanges.json
+  Input: plurals.json + ordinals.json + pluralRanges.json + compact number patterns
   Process: Compile CLDR rules → JS functions via eval()
   Output: cldr-raw/{locale}.js (227 files with serialized function objects)
 
@@ -119,7 +120,7 @@ When `selectRange(start, end)` is called:
 - **No make-plural dependency**: Custom compiler replaced previous make-plural dependency
 - **BigInt support**: `ToIntlMathematicalValue()` handles BigInt per ECMA-402
 - **String-based integer digits**: Stored as string for numbers > 2^53 to prevent precision loss
-- **Notation options**: The current ECMA-402 draft includes notation and compactDisplay; compact exponents use available NumberFormat locale data
+- **Notation options**: The current ECMA-402 draft includes notation and compactDisplay; compact exponents use generated locale data
 
 ## Examples by Locale Complexity
 
@@ -136,3 +137,6 @@ Compact notation uses the shared compact digit defaults. `resolvedOptions()`
 returns an ordinary object, reports notation and rounding settings, and lists
 plural categories in the order `zero`, `one`, `two`, `few`, `many`, `other`.
 `selectRange()` accepts infinite endpoints; NaN still throws `RangeError`.
+
+Compact plural selection uses generated CLDR exponent tables for locales whose
+rules use `c`/`e`. It does not require NumberFormat locale data to be installed.

--- a/knowledge-base/014-test262-conformance.md
+++ b/knowledge-base/014-test262-conformance.md
@@ -15,27 +15,25 @@ excluded because it fails.
 | listformat          |      162 |                 4 |               0 |                 4 |
 | locale              |      336 |                 4 |              22 |                 4 |
 | numberformat        |      498 |                18 |               0 |                18 |
-| pluralrules         |      106 |                 4 |               0 |                 2 |
+| pluralrules         |      106 |                 2 |               0 |                 2 |
 | relativetimeformat  |      160 |                 8 |               0 |                 6 |
 | segmenter           |      158 |                10 |               0 |                10 |
 | supportedvaluesof   |       50 |                 2 |               6 |                 4 |
 
-Total: 2,498 executions, 2,260 polyfill passes, 238 polyfill failures. The native
+Total: 2,498 executions, 2,262 polyfill passes, 236 polyfill failures. The native
 control fails 86 executions; 44 failing cases overlap. Overlap does not prove
 a polyfill is correct: each failure still needs comparison with the selected
 spec and test's feature metadata.
 
 Combined: 2,498 executions, 2,260 passes, 238 failures.
 
-Combined installation adds 6 failing executions; 6 isolated failures now pass.
+Combined installation adds 6 failing executions; 4 isolated failures now pass.
 Two Locale branding cases pass with the installed getCanonicalLocales polyfill.
 Two RelativeTimeFormat cases pass because combined enumeration omits numbering
 systems that the NumberFormat polyfill does not support; this is not broader
 numbering-system conformance.
-Two PluralRules compact-notation cases pass only when the NumberFormat French
-locale data is present; the isolated dependency remains unresolved.
-The extra failures concern NumberFormat dependencies, calendar
-display-name keys, and optional collation data. Full raw reports accompany Bazel
+Compact PluralRules now passes independently of NumberFormat locale data.
+The extra failures concern NumberFormat dependencies and optional collation data. Full raw reports accompany Bazel
 test outputs; the checked-in baselines preserve every remaining diagnostic.
 
 ## Harness guarantees
@@ -168,3 +166,7 @@ diagnostics now reflect the newly selected patterns.
 Calendar negotiation supports Gregorian and ISO 8601 and falls back for other
 requests. Six DateTimeFormat failures per mode are fixed; Chinese-calendar and
 Era-monthcode proposal failures remain tracked.
+
+Standalone PluralRules now uses its own compact exponent tables for the nine
+CLDR locales with c/e operands. Two isolated failures are fixed; combined
+selection no longer depends on NumberFormat locale data.

--- a/packages/ecma402-abstract/PluralRules/InitializePluralRules.ts
+++ b/packages/ecma402-abstract/PluralRules/InitializePluralRules.ts
@@ -80,17 +80,7 @@ export function InitializePluralRules(
   )
   if (notation === 'compact') {
     internalSlots.compactDisplay = compactDisplay
-    // Implementation: Load NumberFormat locale data if available (soft dependency)
-    // This is needed to calculate compact exponents using ComputeExponentForMagnitude
-    if (
-      typeof Intl !== 'undefined' &&
-      Intl.NumberFormat &&
-      (Intl.NumberFormat as any).localeData
-    ) {
-      internalSlots.dataLocaleData = (Intl.NumberFormat as any).localeData[
-        r.locale
-      ]
-    }
+    internalSlots.compactExponents = localeData[r.dataLocale]?.compactExponents
   }
 
   SetNumberFormatDigitOptions(internalSlots, opts, 0, 3, notation)

--- a/packages/ecma402-abstract/PluralRules/ResolvePlural.ts
+++ b/packages/ecma402-abstract/PluralRules/ResolvePlural.ts
@@ -1,12 +1,11 @@
 import {Type} from '#packages/ecma262-abstract/Type.js'
-import {ComputeExponentForMagnitude} from '#packages/ecma402-abstract/NumberFormat/ComputeExponentForMagnitude.js'
 import {FormatNumericToString} from '#packages/ecma402-abstract/NumberFormat/FormatNumericToString.js'
 import {
   type LDMLPluralRule,
   type PluralRulesInternal,
 } from '#packages/ecma402-abstract/types/plural-rules.js'
 import {invariant} from '#packages/ecma402-abstract/utils.js'
-import Decimal from '@formatjs/bigdecimal'
+import type Decimal from '@formatjs/bigdecimal'
 import {
   GetOperands,
   type OperandsRecord,
@@ -73,30 +72,31 @@ export function ResolvePluralInternal(
   const res = FormatNumericToString(internalSlots, n)
   const s = res.formattedString
 
-  // Extension: Calculate compact exponent if using compact notation
-  // This enables CLDR c/e operands for proper plural selection with compact numbers
+  // ECMA-402 §17.5.2, step 10 selects from the rounded decimal string.
+  // Own CLDR data keeps compact selection independent of NumberFormat.
+  // https://tc39.es/ecma402/#sec-resolveplural
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/pluralrules.html#L316-L321
   let exponent = 0
-  if (notation === 'compact' && !n.isZero()) {
-    // Implementation: Only calculate exponent if NumberFormat locale data is available (soft dependency)
-    if (internalSlots.dataLocaleData?.numbers) {
-      try {
-        // Calculate magnitude (floor of log10 of absolute value)
-        const magnitudeNum = Math.floor(Math.log10(Math.abs(n.toNumber())))
-        const magnitude = new Decimal(magnitudeNum)
-        // Use ComputeExponentForMagnitude from ecma402-abstract
-        // This determines which compact notation pattern to use (K, M, B, etc.)
-        // Cast to any since it expects NumberFormatInternal
-        exponent = ComputeExponentForMagnitude(internalSlots as any, magnitude)
-      } catch {
-        // Gracefully fall back to 0 if exponent calculation fails
-        exponent = 0
+  if (notation === 'compact') {
+    const patterns =
+      internalSlots.compactExponents?.[internalSlots.compactDisplay || 'short']
+    const unsigned = s[0] === '-' ? s.slice(1) : s
+    const integer = unsigned.split('.')[0]
+    let first = 0
+    while (first < integer.length && integer[first] === '0') first++
+    const magnitude = integer.length - first - 1
+    let selectedMagnitude = -1
+    if (patterns) {
+      for (const key in patterns) {
+        const threshold = Number(key)
+        if (threshold <= magnitude && threshold > selectedMagnitude) {
+          selectedMagnitude = threshold
+          exponent = patterns[threshold]
+        }
       }
     }
-    // Otherwise, exponent remains 0 (standard behavior without NumberFormat data)
   }
 
-  // ECMA-402 Spec: Extract CLDR operands from the formatted string
-  // Extension: Pass exponent for c/e operands
   const operands = GetOperands(s, exponent)
 
   // ECMA-402 Spec: Select the appropriate plural category using the locale's plural rules

--- a/packages/ecma402-abstract/types/plural-rules.ts
+++ b/packages/ecma402-abstract/types/plural-rules.ts
@@ -7,7 +7,13 @@ export interface PluralRangesData {
   ordinal?: Record<string, LDMLPluralRule>
 }
 
+export type CompactExponentData = Record<
+  'short' | 'long',
+  Record<number, number>
+>
+
 export interface PluralRulesData {
+  compactExponents?: CompactExponentData
   categories: {
     cardinal: string[]
     ordinal: string[]
@@ -30,5 +36,5 @@ export interface PluralRulesInternal extends NumberFormatDigitInternalSlots {
   type: 'cardinal' | 'ordinal'
   notation: 'standard' | 'scientific' | 'engineering' | 'compact'
   compactDisplay?: 'short' | 'long'
-  dataLocaleData?: any // NumberFormatLocaleInternalData from number.ts
+  compactExponents?: CompactExponentData
 }

--- a/packages/intl-pluralrules/BUILD.bazel
+++ b/packages/intl-pluralrules/BUILD.bazel
@@ -10,9 +10,17 @@ load(":locales.generated.bzl", "ALL_LOCALES")
 PACKAGE_NAME = "intl-pluralrules"
 
 TEST_LOCALES = [
+    "ca",
     "en",
-    "zh",
+    "es",
     "fr",
+    "it",
+    "lld",
+    "pt",
+    "pt-PT",
+    "scn",
+    "vec",
+    "zh",
 ]
 
 TEST_LOCALE_DATA = ["tests/locale-data/%s.ts" % locale for locale in TEST_LOCALES]
@@ -81,8 +89,16 @@ formatjs_test(
     srcs = [
         "tests/index.test.ts",
         "tests/supported-locales-of.test.ts",
+        ":tests-locale-data-ca",  # keep: generated locale data imported by tests
         ":tests-locale-data-en",  # keep: generated locale data imported by tests
+        ":tests-locale-data-es",  # keep: generated locale data imported by tests
         ":tests-locale-data-fr",  # keep: generated locale data imported by tests
+        ":tests-locale-data-it",  # keep: generated locale data imported by tests
+        ":tests-locale-data-lld",  # keep: generated locale data imported by tests
+        ":tests-locale-data-pt",  # keep: generated locale data imported by tests
+        ":tests-locale-data-pt-PT",  # keep: generated locale data imported by tests
+        ":tests-locale-data-scn",  # keep: generated locale data imported by tests
+        ":tests-locale-data-vec",  # keep: generated locale data imported by tests
         ":tests-locale-data-zh",  # keep: generated locale data imported by tests
     ],
     no_copy_to_bin = ["//:package.json"],
@@ -117,6 +133,7 @@ ts_run_binary(
         "//:node_modules/@types/serialize-javascript",
         "//:node_modules/@typescript/typescript6",
         "//:node_modules/cldr-core",
+        "//:node_modules/cldr-numbers-full",
         "//:node_modules/fs-extra",
         "//:node_modules/json-stable-stringify",
         "//:node_modules/minimist",

--- a/packages/intl-pluralrules/index.ts
+++ b/packages/intl-pluralrules/index.ts
@@ -3,6 +3,7 @@ import {SupportedLocales} from '#packages/ecma402-abstract/SupportedLocales.js'
 import {ToIntlMathematicalValue} from '#packages/ecma402-abstract/ToIntlMathematicalValue.js'
 import {type NumberFormatDigitInternalSlots} from '#packages/ecma402-abstract/types/number.js'
 import {
+  type CompactExponentData,
   type LDMLPluralRule,
   type PluralRulesData,
   type PluralRulesLocaleData,
@@ -56,7 +57,7 @@ export interface PluralRulesInternal extends NumberFormatDigitInternalSlots {
   type: 'cardinal' | 'ordinal'
   notation: 'standard' | 'scientific' | 'engineering' | 'compact'
   compactDisplay?: 'short' | 'long'
-  dataLocaleData?: any // NumberFormatLocaleInternalData
+  compactExponents?: CompactExponentData
 }
 
 /**

--- a/packages/intl-pluralrules/scripts/cldr-raw.ts
+++ b/packages/intl-pluralrules/scripts/cldr-raw.ts
@@ -1,7 +1,10 @@
 import {join} from 'path'
 import {outputFileSync} from 'fs-extra/esm'
 import serialize from 'serialize-javascript'
-import {type LDMLPluralRule} from '#packages/ecma402-abstract/types/plural-rules.js'
+import {
+  type CompactExponentData,
+  type LDMLPluralRule,
+} from '#packages/ecma402-abstract/types/plural-rules.js'
 import plurals from 'cldr-core/supplemental/plurals.json' with {type: 'json'}
 import ordinals from 'cldr-core/supplemental/ordinals.json' with {type: 'json'}
 import pluralRanges from 'cldr-core/supplemental/pluralRanges.json' with {type: 'json'}
@@ -45,6 +48,7 @@ function parsePluralRanges(locale: string) {
  */
 interface LocaleData {
   data: {
+    compactExponents?: CompactExponentData
     // CLDR spec: Available plural categories for this locale
     categories: {cardinal: string[]; ordinal: string[]}
     // Implementation: Compiled plural rule function
@@ -59,12 +63,47 @@ interface LocaleData {
   locale: string
 }
 
-function generateLocaleData(locale: string): LocaleData | undefined {
+// LDML Compact Number Formats, steps 3 and 5–6 derive the scale from
+// the threshold and zero digits; the literal pattern "0" disables scaling.
+// https://unicode.org/reports/tr35/tr35-numbers.html#Compact_Number_Formats
+// https://github.com/unicode-org/cldr/blob/acd6d88ae493633240e19a87a721076a8a75c310/docs/ldml/tr35-numbers.md#L442-L458
+async function loadCompactExponents(
+  locale: string
+): Promise<CompactExponentData> {
+  const {default: raw} = await import(
+    `cldr-numbers-full/main/${locale}/numbers.json`,
+    {with: {type: 'json'}}
+  )
+  const numbers = raw.main[locale].numbers
+  const formats =
+    numbers[`decimalFormats-numberSystem-${numbers.defaultNumberingSystem}`]
+  const result: CompactExponentData = {short: {}, long: {}}
+  for (const style of ['short', 'long'] as const) {
+    for (const [key, pattern] of Object.entries(
+      formats[style].decimalFormat
+    ) as [string, string][]) {
+      if (!key.endsWith('-count-other')) continue
+      const threshold = key.slice(0, -'-count-other'.length)
+      const zeroes = pattern.match(/0+/)
+      if (!zeroes) throw new Error(`Missing compact digits: ${locale} ${key}`)
+      result[style][threshold.length - 1] =
+        pattern === '0' ? 0 : threshold.length - zeroes[0].length
+    }
+  }
+  return result
+}
+
+async function generateLocaleData(
+  locale: string
+): Promise<LocaleData | undefined> {
   const cardinalRules = cardinalsData[locale]
   const ordinalRules = ordinalsData[locale]
 
   // Implementation: Compile CLDR plural rules to optimized JavaScript function
   const compiler = new PluralRulesCompiler(locale, cardinalRules, ordinalRules)
+  const compactExponents = compiler.usesCompactExponent()
+    ? await loadCompactExponents(locale)
+    : undefined
   const fnCode = compiler.compile() // Returns JavaScript function code string
 
   // Implementation: Convert function code string to actual function using eval
@@ -78,6 +117,7 @@ function generateLocaleData(locale: string): LocaleData | undefined {
   return {
     data: {
       categories: compiler.categories,
+      ...(compactExponents && {compactExponents}),
       fn,
       ...(pluralRanges && {pluralRanges}),
     },
@@ -90,7 +130,7 @@ interface Args extends minimist.ParsedArgs {
   out: string
 }
 
-function main(args: Args) {
+async function main(args: Args) {
   const {outDir, out} = args
 
   const locales = languages
@@ -106,14 +146,16 @@ function main(args: Args) {
     .sort()
 
   if (outDir) {
-    locales.forEach(locale => {
-      console.log(join(outDir, `${locale}.js`))
-      const data = generateLocaleData(locale)
-      if (data) {
-        // Use serialize-javascript to properly serialize the function
-        outputFileSync(join(outDir, `${locale}.js`), serialize(data))
-      }
-    })
+    await Promise.all(
+      locales.map(async locale => {
+        console.log(join(outDir, `${locale}.js`))
+        const data = await generateLocaleData(locale)
+        if (data) {
+          // Use serialize-javascript to properly serialize the function
+          outputFileSync(join(outDir, `${locale}.js`), serialize(data))
+        }
+      })
+    )
   } else if (out) {
     outputFileSync(
       out,

--- a/packages/intl-pluralrules/scripts/plural-rules-compiler.ts
+++ b/packages/intl-pluralrules/scripts/plural-rules-compiler.ts
@@ -280,6 +280,11 @@ export class PluralRulesCompiler {
   /**
    * Detects which operands are used in the plural rules
    */
+  usesCompactExponent(): boolean {
+    const operands = this.detectUsedOperands()
+    return operands.has('c') || operands.has('e')
+  }
+
   private detectUsedOperands(): Set<string> {
     const used = new Set<string>()
 

--- a/packages/intl-pluralrules/test262-baseline.json
+++ b/packages/intl-pluralrules/test262-baseline.json
@@ -2,8 +2,6 @@
   "total": 106,
   "failures": {
     "intl402/PluralRules/proto-from-ctor-realm.js (default)": "Expected no error, got TypeError: Intl.PluralRules must be called with 'new'",
-    "intl402/PluralRules/proto-from-ctor-realm.js (strict mode)": "Expected no error, got TypeError: Intl.PluralRules must be called with 'new'",
-    "intl402/PluralRules/prototype/select/notation.js (default)": "compact notation: 1500000 Expected SameValue(«\"other\"», «\"many\"») to be true",
-    "intl402/PluralRules/prototype/select/notation.js (strict mode)": "compact notation: 1500000 Expected SameValue(«\"other\"», «\"many\"») to be true"
+    "intl402/PluralRules/proto-from-ctor-realm.js (strict mode)": "Expected no error, got TypeError: Intl.PluralRules must be called with 'new'"
   }
 }

--- a/packages/intl-pluralrules/tests/index.test.ts
+++ b/packages/intl-pluralrules/tests/index.test.ts
@@ -6,7 +6,15 @@ import {describe, expect, it} from 'vitest'
 // @ts-ignore
 import en from '#packages/intl-pluralrules/tests/locale-data/en.js'
 import fr from '#packages/intl-pluralrules/tests/locale-data/fr.js'
-PluralRules.__addLocaleData(en, fr)
+import ca from '#packages/intl-pluralrules/tests/locale-data/ca.js'
+import es from '#packages/intl-pluralrules/tests/locale-data/es.js'
+import itData from '#packages/intl-pluralrules/tests/locale-data/it.js'
+import lld from '#packages/intl-pluralrules/tests/locale-data/lld.js'
+import pt from '#packages/intl-pluralrules/tests/locale-data/pt.js'
+import ptPT from '#packages/intl-pluralrules/tests/locale-data/pt-PT.js'
+import scn from '#packages/intl-pluralrules/tests/locale-data/scn.js'
+import vec from '#packages/intl-pluralrules/tests/locale-data/vec.js'
+PluralRules.__addLocaleData(en, fr, ca, es, itData, lld, pt, ptPT, scn, vec)
 
 describe('PluralRules', function () {
   it('default locale', function () {
@@ -226,45 +234,56 @@ describe('PluralRules', function () {
   })
 
   describe('compact notation with c/e operand', function () {
-    // Tests for compact decimal notation plural rules
-    // Based on: https://docs.google.com/document/d/1Wx9Drhpl9p2ZqVZMGQ7KUF4pUfPtuJupv8oQ_Gf6sEE
-    // Note: c and e are synonyms - both represent the exponent
-    // The c/e operand is calculated from compact notation formatting
-
-    it('should handle French million with compact notation', function () {
-      const pr = new PluralRules('fr', {notation: 'compact'})
-
-      // French rule: e = 0 and i != 0 and i % 1000000 = 0 and v = 0 or e != 0..5
-      // Note: Without NumberFormat locale data, falls back to standard behavior (e=0)
-      // With NumberFormat data: For millions (exponent=6), e != 0..5 applies → many
-      // Without NumberFormat data: Falls back to standard rules
-      expect(pr.select(1000000)).toBe('many') // 1M divisible by 1M, v=0 → many (standard)
-      expect(pr.select(1200000)).toBe('other') // 1.2M not divisible by 1M → other (fallback)
-      expect(pr.select(234500000)).toBe('other') // 234.5M not divisible by 1M → other (fallback)
+    it('selects French compact categories without NumberFormat locale data', () => {
+      const previous = Object.getOwnPropertyDescriptor(
+        Intl.NumberFormat,
+        'localeData'
+      )
+      const results: string[] = []
+      Object.defineProperty(Intl.NumberFormat, 'localeData', {
+        configurable: true,
+        get() {
+          throw new Error('Ambient NumberFormat data read')
+        },
+      })
+      try {
+        for (const compactDisplay of ['short', 'long'] as const) {
+          const pr = new PluralRules('fr', {
+            notation: 'compact',
+            compactDisplay,
+          })
+          for (const value of [1500000, -1500000, 234500000, 1.2e30]) {
+            results.push(pr.select(value))
+          }
+        }
+      } finally {
+        if (previous)
+          Object.defineProperty(Intl.NumberFormat, 'localeData', previous)
+        else
+          delete (
+            Intl.NumberFormat as typeof Intl.NumberFormat & {
+              localeData?: unknown
+            }
+          ).localeData
+      }
+      expect(results).toEqual(Array(8).fill('many'))
+      expect(new PluralRules('fr').select(1500000)).toBe('other')
     })
 
-    it('should distinguish compact vs non-compact for French', function () {
-      // Standard notation: no compact exponent (c/e=0)
-      const prStandard = new PluralRules('fr')
-      // 1,000,000 is divisible by 1M with v=0 → many (first part of rule)
-      expect(prStandard.select(1000000)).toBe('many')
-      // 1,200,000 is NOT divisible by 1M → other
-      expect(prStandard.select(1200000)).toBe('other')
-
-      // Compact notation: with compact exponent (c/e=6 for millions)
-      // Note: These tests would pass only if NumberFormat locale data is loaded
-      const prCompact = new PluralRules('fr', {notation: 'compact'})
-      // Without NumberFormat data, falls back to standard behavior (exponent=0)
-      expect(prCompact.select(1200000)).toBe('other') // fallback to standard
-    })
-
-    it('should handle French thousand with compact notation', function () {
-      const pr = new PluralRules('fr', {notation: 'compact'})
-
-      // French rule: e != 0..5 means e must be >= 6 for "many"
-      // Note: Without NumberFormat data, falls back to e=0 (standard behavior)
-      expect(pr.select(1000)).toBe('other') // Not divisible by 1M → other
-      expect(pr.select(1200)).toBe('other') // Not divisible by 1M → other
+    it('uses the rounded decimal magnitude for compact selection', () => {
+      const pr = new PluralRules('fr', {
+        notation: 'compact',
+        maximumSignificantDigits: 2,
+      })
+      expect(pr.select(999999)).toBe('many')
+      expect(pr.select(1000)).toBe('other')
+      expect(pr.select(1200)).toBe('other')
+      expect(
+        new PluralRules('fr', {
+          notation: 'compact',
+          minimumIntegerDigits: 12,
+        }).select(1200)
+      ).toBe('other')
     })
 
     it('should handle exact millions without compact notation', function () {
@@ -295,7 +314,8 @@ describe('PluralRules', function () {
 
       for (const locale of locales) {
         const pr = new PluralRules(locale, {notation: 'compact'})
-        // Basic smoke test - should not throw (will fall back to standard if no NumberFormat data)
+        expect(pr.resolvedOptions().locale).toBe(locale)
+        // Exercise each locale's generated compact data.
         expect(() => pr.select(1000000)).not.toThrow()
         expect(() => pr.select(1200)).not.toThrow()
         // Should return valid plural categories
@@ -329,7 +349,7 @@ describe('PluralRules', function () {
         compactDisplay: 'long',
       })
 
-      // Both should work (falls back to standard without NumberFormat data)
+      // Both widths use their own generated compact data.
       expect(() => prShort.select(1000000)).not.toThrow()
       expect(() => prLong.select(1000000)).not.toThrow()
       // Both should return valid plural categories


### PR DESCRIPTION
Compact PluralRules depended on ambient NumberFormat locale data, so French 1.5 million selected the wrong category when used alone. Generate small short/long exponent tables for the nine CLDR locales whose rules use c/e operands. Resolve selection from the rounded decimal string without reading NumberFormat.

Comments cite ECMA-402 §17.5.2 step 10 and LDML compact-format steps with pinned source lines. Tests reject ambient data access, cover rounding across a compact threshold, and load every compact-operand locale through declared Bazel fixtures.

Validation: package/shared-operation builds and tests pass after declaring the new fixtures. Isolated Test262 gains two passes; combined Test262 remains green. Both actual reports and exit codes validate against reviewed baselines.
