### PR TITLE
fix(formatjs_cli): preserve IDs for empty descriptions

### DIFF
--- a/crates/formatjs_cli/src/id_generator.rs
+++ b/crates/formatjs_cli/src/id_generator.rs
@@ -405,6 +405,9 @@ fn hash_content(default_message: Option<&str>, description: &Option<Value>) -> V
         content.extend_from_slice(msg.as_bytes());
     }
     if let Some(desc) = description {
+        if desc.as_str() == Some("") {
+            return content;
+        }
         content.push(b'#');
         // Extract string value for string types to match TypeScript CLI behavior.
         // TypeScript uses: typeof description === 'string' ? description : stringify(description)
@@ -608,6 +611,24 @@ mod tests {
         assert_eq!(id1, "ePueQ5h1ce");
         assert_eq!(id2, "fTO7rwuRCr");
         assert_ne!(id1, id2, "Different messages should produce different IDs");
+    }
+
+    #[test]
+    fn test_generate_id_empty_description_matches_missing_description() {
+        for description in [None, Some(Value::String(String::new()))] {
+            let id = generate_id(
+                "[sha512:contenthash:base64:6]",
+                Some("My message with empty description"),
+                &description,
+                None,
+            )
+            .unwrap();
+            assert_eq!(id, "L91vdv");
+        }
+        assert_eq!(
+            hash_content(Some("Hello"), &Some(Value::String(" ".into()))),
+            b"Hello# "
+        );
     }
 
     #[test]

--- a/docs/src/docs/tooling/cli.mdx
+++ b/docs/src/docs/tooling/cli.mdx
@@ -322,6 +322,8 @@ The target file path where the plugin will output an aggregated `.json` file of 
 
 If certain message descriptors don't have id, this `pattern` will be used to automatically generate IDs for them. Default to `[sha512:contenthash:base64:6]`. See [nodejs crypto createHash](https://nodejs.org/api/crypto.html#crypto_crypto_createhash_algorithm_options) for hash algorithms & [nodejs buffer docs](https://nodejs.org/api/buffer.html#buffer_buffers_and_character_encodings) for digest encodings.
 
+An empty string description generates the same ID as an omitted description. The extracted catalog still preserves `description: ""`.
+
 ### `--extract-source-location`
 
 Whether the metadata about the location of the message in the source file should be extracted. If `true`, then `file`, `start`, and `end` fields will exist for each extracted message descriptors. (default: `false`)

--- a/knowledge-base/009-package-developer-tools.md
+++ b/knowledge-base/009-package-developer-tools.md
@@ -120,6 +120,8 @@ The native binding is required for extraction and compilation.
 
 The Rust CLI (`crates/formatjs_cli/`) is a 20.90x faster drop-in replacement in the checked-in extraction benchmark, with parallelized catalog parsing for large compile and structural verify workloads.
 
+Empty string descriptions do not contribute to generated message ID hashes, matching the TypeScript transformer. Keep `description: ""` in extracted catalogs. Regression coverage lives in the Rust ID generator and CLI/unplugin conformance tests.
+
 ## Utility Packages
 
 ### @formatjs/bigdecimal

--- a/packages/cli/integration-tests/conformance-tests/test_cases/26_empty_description.txt
+++ b/packages/cli/integration-tests/conformance-tests/test_cases/26_empty_description.txt
@@ -1,0 +1,39 @@
+import {FormattedMessage, defineMessage} from 'react-intl';
+const messages = <>
+  <FormattedMessage defaultMessage="My message with empty description" description="" />
+  <FormattedMessage defaultMessage="My message" description="some description" />
+  <FormattedMessage defaultMessage="Missing description" />
+  <FormattedMessage id="explicit" defaultMessage="Explicit ID" description="" />
+</>;
+defineMessage({defaultMessage: 'Empty object description', description: ''});
+---
+{
+  "command": "extract",
+  "args": [
+    "--id-interpolation-pattern",
+    "[sha512:contenthash:base64:6]"
+  ],
+  "fileType": "tsx"
+}
+---
+{
+  "L91vdv": {
+    "defaultMessage": "My message with empty description",
+    "description": ""
+  },
+  "iK6ydf": {
+    "defaultMessage": "My message",
+    "description": "some description"
+  },
+  "0TnIHc": {
+    "defaultMessage": "Missing description"
+  },
+  "eifMvm": {
+    "defaultMessage": "Empty object description",
+    "description": ""
+  },
+  "explicit": {
+    "defaultMessage": "Explicit ID",
+    "description": ""
+  }
+}

--- a/packages/unplugin/conformance-tests/cli-unplugin-conformance.test.ts
+++ b/packages/unplugin/conformance-tests/cli-unplugin-conformance.test.ts
@@ -83,6 +83,19 @@ describe('formatjs_cli vs @formatjs/unplugin conformance', () => {
     expect(pluginIds).toEqual(cliIds)
   }
 
+  test('empty descriptions preserve generated IDs', async () => {
+    await assertConformance(
+      `import {FormattedMessage, defineMessage} from 'react-intl';
+       const messages = <>
+         <FormattedMessage defaultMessage="My message with empty description" description="" />
+         <FormattedMessage defaultMessage="My message" description="some description" />
+         <FormattedMessage defaultMessage="Missing description" />
+       </>;
+       defineMessage({defaultMessage: 'Empty object description', description: ''});`,
+      'empty-description.tsx'
+    )
+  })
+
   test.each([
     'formatMessage',
     '$formatMessage',


### PR DESCRIPTION
Empty string descriptions added a trailing `#` to the Rust CLI's hash input, changing IDs when migrating from the TypeScript CLI. Ignore empty descriptions when hashing while preserving `description: ""` in extracted catalogs. The reported message now generates `L91vdv` instead of `y8eG/x`.

Adds Rust regression coverage, a CLI fixture, CLI/unplugin parity coverage, and documentation. Nonempty descriptions and explicit IDs keep their behavior.

Fixes #7256.

Validation: `bazel test //crates/formatjs_cli:formatjs_cli_test //packages/cli/integration-tests:conformance_test //packages/unplugin:conformance_test` passed. Pre-commit hooks and commitlint passed.
