### PR TITLE
fix(@formatjs/intl-segmenter): register CLDR locale coverage

### DIFF
--- a/docs/src/docs/polyfills/intl-segmenter.mdx
+++ b/docs/src/docs/polyfills/intl-segmenter.mdx
@@ -208,3 +208,6 @@ The fallback locale is `en`, backed by the root segmentation rules.
 `containing(index)` coerces its index to a number and truncates toward zero.
 BigInt values throw `TypeError`, including boxed BigInts and objects that
 coerce to BigInt. Errors thrown during coercion propagate unchanged.
+
+Locales without dedicated CLDR tailoring use root Unicode segmentation rules.
+Regional locales retain their language's tailoring, including sentence suppressions.

--- a/knowledge-base/007h-polyfill-intl-segmenter.md
+++ b/knowledge-base/007h-polyfill-intl-segmenter.md
@@ -79,3 +79,7 @@ The fallback locale is `en`, backed by the root segmentation rules.
 `containing(index)` coerces its index to a number and truncates toward zero.
 BigInt values throw `TypeError`, including boxed BigInts and objects that
 coerce to BigInt. Errors thrown during coercion propagate unchanged.
+
+Available locales come from pinned CLDR locale metadata, including default-content
+variants and required fallback tags. Locales without tailoring use root UAX rules;
+regional locales retain their language's tailoring and sentence suppressions.

--- a/knowledge-base/014-test262-conformance.md
+++ b/knowledge-base/014-test262-conformance.md
@@ -17,15 +17,15 @@ excluded because it fails.
 | numberformat        |      498 |                18 |               0 |                18 |
 | pluralrules         |      106 |                 2 |               0 |                 2 |
 | relativetimeformat  |      160 |                 6 |               0 |                 4 |
-| segmenter           |      158 |                10 |               0 |                10 |
+| segmenter           |      158 |                 4 |               0 |                 4 |
 | supportedvaluesof   |       50 |                 2 |               6 |                 4 |
 
-Total: 2,498 executions, 2,288 polyfill passes, 210 polyfill failures. The native
+Total: 2,498 executions, 2,294 polyfill passes, 204 polyfill failures. The native
 control fails 86 executions; 44 failing cases overlap. Overlap does not prove
 a polyfill is correct: each failure still needs comparison with the selected
 spec and test's feature metadata.
 
-Combined: 2,498 executions, 2,286 passes, 212 failures.
+Combined: 2,498 executions, 2,292 passes, 206 failures.
 
 Combined installation adds 6 failing executions; 4 isolated failures now pass.
 Two Locale branding cases pass with the installed getCanonicalLocales polyfill.

--- a/packages/intl-segmenter/BUILD.bazel
+++ b/packages/intl-segmenter/BUILD.bazel
@@ -75,6 +75,7 @@ formatjs_library(
     },
     deps = [
         "//:node_modules/@formatjs/intl-localematcher",
+        "//:node_modules/@formatjs_generated/cldr.supported-locales",
         "//:node_modules/@formatjs_generated/unicode",
         "//packages/ecma262-abstract",
         "//packages/ecma402-abstract",
@@ -138,6 +139,7 @@ rolldown_bundle(
     visibility = ["//tools/test262:__pkg__"],
     deps = [
         "//:node_modules/@formatjs/intl-localematcher",
+        "//:node_modules/@formatjs_generated/cldr.supported-locales",
         "//:node_modules/@formatjs_generated/unicode",
         "//packages/ecma402-abstract",
     ],
@@ -160,6 +162,7 @@ rolldown_bundle(
     target = "es2020",
     deps = [
         "//:node_modules/@formatjs/intl-localematcher",
+        "//:node_modules/@formatjs_generated/cldr.supported-locales",
         "//packages/ecma402-abstract",
     ],
 )

--- a/packages/intl-segmenter/segmenter.ts
+++ b/packages/intl-segmenter/segmenter.ts
@@ -1,3 +1,4 @@
+import {availableLocales as cldrLocales} from '@formatjs_generated/cldr.supported-locales/default-content.js'
 import {ToString} from '#packages/ecma262-abstract/ToString.js'
 import {CanonicalizeLocaleList} from '#packages/ecma402-abstract/CanonicalizeLocaleList.js'
 import {GetOption} from '#packages/ecma402-abstract/GetOption.js'
@@ -170,10 +171,16 @@ export class Segmenter {
     //root rules based on granularity
     this.mergedSegmentationTypeValue = {...SegmentationRules.root[granularity]}
 
-    //merge root rules with locale ones if locale is specified
+    // ECMA-402 §19.8.1 steps 5.a and 7 use locale-sensitive boundaries.
+    // Regional locales inherit their language's CLDR tailoring.
+    // https://tc39.es/ecma402/#sec-findboundary
+    // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/segmenter.html#L398-L406
     if (r.locale.length) {
       const localeOverrides =
-        SegmentationRules[r.locale as keyof typeof SegmentationRules]
+        SegmentationRules[r.locale as keyof typeof SegmentationRules] ||
+        SegmentationRules[
+          r.locale.split('-')[0] as keyof typeof SegmentationRules
+        ]
       if (localeOverrides && granularity in localeOverrides) {
         const localeSegmentationTypeValue: SegmentationTypeTypeRaw =
           localeOverrides[granularity as keyof typeof localeOverrides]
@@ -284,10 +291,10 @@ export class Segmenter {
     }
   }
 
-  static availableLocales: Set<string> = new Set([
-    'en',
-    ...Object.keys(SegmentationRules).filter(key => key !== 'root'),
-  ])
+  // ECMA-402 §19.2.3 allows locale coverage backed by root segmentation rules.
+  // https://tc39.es/ecma402/#sec-intl.segmenter-internal-slots
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/segmenter.html#L64-L66
+  static availableLocales: Set<string> = new Set(cldrLocales)
   static supportedLocalesOf(
     locales?: string | string[],
     options?: Pick<SegmenterOptions, 'localeMatcher'>

--- a/packages/intl-segmenter/test262-baseline.json
+++ b/packages/intl-segmenter/test262-baseline.json
@@ -1,15 +1,9 @@
 {
   "total": 158,
   "failures": {
-    "intl402/Segmenter/constructor/constructor/locales-valid.js (default)": "Single-element array: expected one of sr, found en",
-    "intl402/Segmenter/constructor/constructor/locales-valid.js (strict mode)": "Single-element array: expected one of sr, found en",
     "intl402/Segmenter/constructor/constructor/proto-from-ctor-realm.js (default)": "newTarget.prototype is undefined Expected SameValue(«[object Object]», «[object Intl.Segmenter]») to be true",
     "intl402/Segmenter/constructor/constructor/proto-from-ctor-realm.js (strict mode)": "newTarget.prototype is undefined Expected SameValue(«[object Object]», «[object Intl.Segmenter]») to be true",
-    "intl402/Segmenter/constructor/supportedLocalesOf/locales-specific.js (default)": "Actual [] and expected [sr] should have the same contents. ",
-    "intl402/Segmenter/constructor/supportedLocalesOf/locales-specific.js (strict mode)": "Actual [] and expected [sr] should have the same contents. ",
     "intl402/Segmenter/proto-from-ctor-realm.js (default)": "newTarget.prototype is undefined Expected SameValue(«[object Object]», «[object Intl.Segmenter]») to be true",
-    "intl402/Segmenter/proto-from-ctor-realm.js (strict mode)": "newTarget.prototype is undefined Expected SameValue(«[object Object]», «[object Intl.Segmenter]») to be true",
-    "intl402/Segmenter/prototype/resolvedOptions/type-without-lbs.js (default)": "locale descriptor value should be en-US; locale value should be en-US",
-    "intl402/Segmenter/prototype/resolvedOptions/type-without-lbs.js (strict mode)": "locale descriptor value should be en-US; locale value should be en-US"
+    "intl402/Segmenter/proto-from-ctor-realm.js (strict mode)": "newTarget.prototype is undefined Expected SameValue(«[object Object]», «[object Intl.Segmenter]») to be true"
   }
 }

--- a/packages/intl-segmenter/tests/sentence.test.ts
+++ b/packages/intl-segmenter/tests/sentence.test.ts
@@ -65,3 +65,37 @@ describe('Granularity sentence', () => {
     }
   )
 })
+
+it('uses root rules for Serbian and language tailorings for regional locales', () => {
+  for (const granularity of ['grapheme', 'word', 'sentence'] as const) {
+    const serbian = new Segmenter('sr', {granularity, localeMatcher: 'lookup'})
+    expect(serbian.resolvedOptions().locale).toBe('sr')
+    const cases = {
+      grapheme: ['А́😀', ['А́', '😀']],
+      word: ['Здраво свете!', ['Здраво', ' ', 'свете', '!']],
+      sentence: ['Здраво. Свете!', ['Здраво. ', 'Свете!']],
+    } as const
+    const [input, expected] = cases[granularity]
+    expect([...serbian.segment(input)].map(part => part.segment)).toEqual(
+      expected
+    )
+    const options = {granularity, localeMatcher: 'lookup'} as const
+    for (const [regional, language] of [
+      ['en-US', 'en'],
+      ['de-DE', 'de'],
+    ]) {
+      const formatter = new Segmenter(regional, options)
+      expect(formatter.resolvedOptions().locale).toBe(regional)
+      expect([
+        ...formatter.segment('Mr. Smith met Dr. Jones. Guten Tag!'),
+      ]).toEqual([
+        ...new Segmenter(language, options).segment(
+          'Mr. Smith met Dr. Jones. Guten Tag!'
+        ),
+      ])
+    }
+  }
+  expect(
+    Segmenter.supportedLocalesOf(['sr', 'en-US'], {localeMatcher: 'lookup'})
+  ).toEqual(['sr', 'en-US'])
+})

--- a/tools/generate-default-content.ts
+++ b/tools/generate-default-content.ts
@@ -1,5 +1,6 @@
 import {outputFileSync} from 'fs-extra/esm'
 import minimist from 'minimist'
+import localeData from 'cldr-core/availableLocales.json' with {type: 'json'}
 import content from 'cldr-core/defaultContent.json' with {type: 'json'}
 
 interface Args extends minimist.ParsedArgs {
@@ -17,9 +18,25 @@ function main(args: Args) {
     const parent = locale.split('-').slice(0, -1).join('-')
     ;(children[parent] ||= []).push(locale)
   }
+  // ECMA-402 §9.1 also requires less-specific and scriptless fallback tags.
+  // https://tc39.es/ecma402/#sec-internal-slots
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/negotiation.html#L18-L22
+  const locales = new Set([
+    ...localeData.availableLocales.full,
+    ...content.defaultContent,
+  ])
+  for (const locale of locales) {
+    const parts = locale.split('-')
+    while (parts.length > 1) {
+      if (parts.length > 2 && parts[1].length === 4)
+        locales.add([parts[0], ...parts.slice(2)].join('-'))
+      parts.pop()
+      locales.add(parts.join('-'))
+    }
+  }
   outputFileSync(
     args.out,
-    `export const defaultContent: Record<string, string[]> = ${JSON.stringify(children)}\n`
+    `export const defaultContent: Record<string, string[]> = ${JSON.stringify(children)}\nexport const availableLocales: string[] = ${JSON.stringify([...locales].sort())}\n`
   )
 }
 

--- a/tools/test262/baselines/combined-segmenter.json
+++ b/tools/test262/baselines/combined-segmenter.json
@@ -1,15 +1,9 @@
 {
   "total": 158,
   "failures": {
-    "intl402/Segmenter/constructor/constructor/locales-valid.js (default)": "Single-element array: expected one of sr, found en",
-    "intl402/Segmenter/constructor/constructor/locales-valid.js (strict mode)": "Single-element array: expected one of sr, found en",
     "intl402/Segmenter/constructor/constructor/proto-from-ctor-realm.js (default)": "newTarget.prototype is undefined Expected SameValue(«[object Object]», «[object Intl.Segmenter]») to be true",
     "intl402/Segmenter/constructor/constructor/proto-from-ctor-realm.js (strict mode)": "newTarget.prototype is undefined Expected SameValue(«[object Object]», «[object Intl.Segmenter]») to be true",
-    "intl402/Segmenter/constructor/supportedLocalesOf/locales-specific.js (default)": "Actual [] and expected [sr] should have the same contents. ",
-    "intl402/Segmenter/constructor/supportedLocalesOf/locales-specific.js (strict mode)": "Actual [] and expected [sr] should have the same contents. ",
     "intl402/Segmenter/proto-from-ctor-realm.js (default)": "newTarget.prototype is undefined Expected SameValue(«[object Object]», «[object Intl.Segmenter]») to be true",
-    "intl402/Segmenter/proto-from-ctor-realm.js (strict mode)": "newTarget.prototype is undefined Expected SameValue(«[object Object]», «[object Intl.Segmenter]») to be true",
-    "intl402/Segmenter/prototype/resolvedOptions/type-without-lbs.js (default)": "locale descriptor value should be en-US; locale value should be en-US",
-    "intl402/Segmenter/prototype/resolvedOptions/type-without-lbs.js (strict mode)": "locale descriptor value should be en-US; locale value should be en-US"
+    "intl402/Segmenter/proto-from-ctor-realm.js (strict mode)": "newTarget.prototype is undefined Expected SameValue(«[object Object]», «[object Intl.Segmenter]») to be true"
   }
 }


### PR DESCRIPTION
Segmenter only advertised locales with CLDR tailoring records, rejecting supported root-rule locales such as Serbian and reducing `en-US` to `en`. Register pinned CLDR locales, default-content variants, and required fallback tags. Regional locales retain their language's tailoring and sentence suppressions; other locales use the existing root Unicode rules.

This follows [ECMA-402 §19.2.3, AvailableLocales](https://tc39.es/ecma402/#sec-intl.segmenter-internal-slots) ([source lines 64–66](https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/segmenter.html#L64-L66)), [§9.1 fallback requirements](https://tc39.es/ecma402/#sec-internal-slots) ([source lines 18–22](https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/negotiation.html#L18-L22)), and [§19.8.1 steps 5.a and 7](https://tc39.es/ecma402/#sec-findboundary) ([source lines 398–406](https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/segmenter.html#L398-L406)).

Validation: all eight package test/build gates pass, including Serbian segmentation and regional tailoring regressions. Both complete Test262 modes gain six passes with no new or changed failures: 154/158 each. The four remaining executions concern foreign-realm constructor prototypes. Actual reports and exit codes pass the updated baseline validator.
