### PR TITLE
fix(@formatjs/intl-numberformat): preserve range separators and affixes

### DIFF
--- a/docs/src/docs/polyfills/intl-numberformat.mdx
+++ b/docs/src/docs/polyfills/intl-numberformat.mdx
@@ -408,3 +408,6 @@ numbers remain ungrouped; `"always"` still requests grouping.
 
 Locale data registers CLDR default-content variants, such as `en-US` for English.
 Loading regional data preserves explicitly loaded language data.
+
+Number ranges preserve locale-specific separators. Shared affixes are labeled
+`shared` by `formatRangeToParts`; distinct endpoint signs remain separate.

--- a/knowledge-base/007a-polyfill-intl-numberformat.md
+++ b/knowledge-base/007a-polyfill-intl-numberformat.md
@@ -129,3 +129,7 @@ option getters from affecting NumberFormat or its RelativeTimeFormat consumers.
 
 `useGrouping: "auto"` respects CLDR minimum grouping digits. Polish four-digit
 numbers remain ungrouped; `"always"` still requests grouping.
+
+Range formatting preserves complete CLDR separators, including surrounding spaces.
+Only matching affixes collapse; retained affixes have `source: "shared"`.
+Different signs and scientific or compact notation remain separate.

--- a/packages/ecma402-abstract/NumberFormat/CollapseNumberRange.ts
+++ b/packages/ecma402-abstract/NumberFormat/CollapseNumberRange.ts
@@ -4,71 +4,90 @@ import {
   type NumberFormatPartTypes,
 } from '#packages/ecma402-abstract/types/number.js'
 
-const PART_TYPES_TO_COLLAPSE = new Set<NumberFormatPartTypes>([
+const AFFIX_TYPES = new Set<NumberFormatPartTypes>([
   'unit',
-  'exponentMinusSign',
   'minusSign',
   'plusSign',
   'percentSign',
-  'exponentSeparator',
-  'percent',
-  'percentSign',
   'currency',
   'literal',
-] as const)
+])
+const DIGIT_TYPES = new Set<NumberFormatPartTypes>([
+  'integer',
+  'fraction',
+  'exponentInteger',
+])
 
-/**
- * https://tc39.es/ecma402/#sec-collapsenumberrange
- * LDML: https://unicode-org.github.io/cldr/ldml/tr35-numbers.html#collapsing-number-ranges
- */
+function affixLength(parts: NumberFormatPart[], fromEnd: boolean): number {
+  let length = 0
+  while (length < parts.length) {
+    const part = parts[fromEnd ? parts.length - length - 1 : length]
+    if (!AFFIX_TYPES.has(part.type)) break
+    length++
+  }
+  return length
+}
+
+function canCollapse(a: NumberFormatPart[], b: NumberFormatPart[]): boolean {
+  return (
+    a.length === b.length &&
+    a.some(part => part.type !== 'literal') &&
+    a.every(
+      (part, i) => part.type === b[i].type && part.value === b[i].value
+    ) &&
+    Array.from(a.map(part => part.value).join('')).length > 1
+  )
+}
+
+// ECMA-402 §16.5.21 forbids collapsing ranges into ambiguous results.
+// Only identical affixes collapse; scientific and compact notation remain intact.
+// https://tc39.es/ecma402/#sec-collapsenumberrange
+// https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/numberformat.html#L1874-L1878
+// LDML collapsing steps 1–3 and range-spacing heuristics:
+// https://unicode.org/reports/tr35/tr35-numbers.html#Collapsing_Number_Ranges
+// https://github.com/unicode-org/cldr/blob/acd6d88ae493633240e19a87a721076a8a75c310/docs/ldml/tr35-numbers.md#L1886-L1921
 export function CollapseNumberRange(
-  numberFormat: Intl.NumberFormat,
+  _numberFormat: Intl.NumberFormat,
   result: NumberFormatPart[],
-  {
-    getInternalSlots,
-  }: {
+  _options: {
     getInternalSlots(nf: Intl.NumberFormat): NumberFormatInternal
   }
 ): NumberFormatPart[] {
-  const internalSlots = getInternalSlots(numberFormat)
-  const symbols =
-    internalSlots.dataLocaleData.numbers.symbols[internalSlots.numberingSystem]
-  const rangeSignRegex = new RegExp(`s?[${symbols.rangeSign}]s?`)
-  const rangeSignIndex = result.findIndex(
-    r => r.type === 'literal' && rangeSignRegex.test(r.value)
-  )
+  const separatorIndex = result.findIndex(part => part.source === 'shared')
+  if (separatorIndex < 0) return result
+  const start = result.slice(0, separatorIndex)
+  const end = result.slice(separatorIndex + 1)
+  const separator = {...result[separatorIndex]}
+  const prefix: NumberFormatPart[] = []
+  const suffix: NumberFormatPart[] = []
 
-  let prefixSignParts = []
-  for (let i = rangeSignIndex - 1; i >= 0; i--) {
-    if (!PART_TYPES_TO_COLLAPSE.has(result[i].type)) {
-      break
-    }
-    prefixSignParts.unshift(result[i])
+  const startPrefix = start.slice(0, affixLength(start, false))
+  const endPrefix = end.slice(0, affixLength(end, false))
+  if (canCollapse(startPrefix, endPrefix)) {
+    prefix.push(...start.splice(0, startPrefix.length))
+    end.splice(0, endPrefix.length)
   }
+  const startSuffixLength = affixLength(start, true)
+  const endSuffixLength = affixLength(end, true)
+  const startSuffix = start.slice(start.length - startSuffixLength)
+  const endSuffix = end.slice(end.length - endSuffixLength)
+  if (canCollapse(startSuffix, endSuffix)) {
+    start.splice(start.length - startSuffixLength)
+    suffix.push(...end.splice(end.length - endSuffixLength))
+  }
+  for (const part of [...prefix, ...suffix]) part.source = 'shared'
 
-  // Don't collapse if it's a single code point
-  if (Array.from(prefixSignParts.map(p => p.value).join('')).length > 1) {
-    const newResult = Array.from(result)
-    newResult.splice(
-      rangeSignIndex - prefixSignParts.length,
-      prefixSignParts.length
-    )
-    return newResult
+  if (
+    start.length &&
+    end.length &&
+    (!DIGIT_TYPES.has(start[start.length - 1].type) ||
+      !DIGIT_TYPES.has(end[0].type))
+  ) {
+    // Use ordinary spaces for the optional spacing around uncollapsed affixes.
+    if (!separator.value || separator.value.charAt(0).trim())
+      separator.value = ` ${separator.value}`
+    if (separator.value.charAt(separator.value.length - 1).trim())
+      separator.value += ' '
   }
-
-  let suffixSignParts = []
-  for (let i = rangeSignIndex + 1; i < result.length; i++) {
-    if (!PART_TYPES_TO_COLLAPSE.has(result[i].type)) {
-      break
-    }
-    suffixSignParts.push(result[i])
-  }
-
-  // Don't collapse if it's a single code point
-  if (Array.from(suffixSignParts.map(p => p.value).join('')).length > 1) {
-    const newResult = Array.from(result)
-    newResult.splice(rangeSignIndex + 1, suffixSignParts.length)
-    return newResult
-  }
-  return result
+  return [...prefix, ...start, separator, ...end, ...suffix]
 }

--- a/packages/ecma402-abstract/NumberFormat/FormatNumericRangeToParts.ts
+++ b/packages/ecma402-abstract/NumberFormat/FormatNumericRangeToParts.ts
@@ -22,10 +22,12 @@ export function FormatNumericRangeToParts(
     getInternalSlots,
   })
 
-  return parts.map((part, index) => ({
+  // ECMA-402 §16.5.23 steps 4.b–4.d create only type, value, and source.
+  // https://tc39.es/ecma402/#sec-formatnumericrangetoparts
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/numberformat.html#L1920-L1922
+  return parts.map(part => ({
     type: part.type,
     value: part.value,
     source: part.source,
-    result: index.toString(),
   }))
 }

--- a/packages/ecma402-abstract/tests/CollapseNumberRange.test.ts
+++ b/packages/ecma402-abstract/tests/CollapseNumberRange.test.ts
@@ -1,173 +1,72 @@
 import {CollapseNumberRange} from '#packages/ecma402-abstract/NumberFormat/CollapseNumberRange.js'
+import type {NumberFormatPart} from '#packages/ecma402-abstract/types/number.js'
 import {getInternalSlots} from '#packages/ecma402-abstract/tests/utils.js'
 import {describe, expect, test} from 'vitest'
-const numberFormat: Intl.NumberFormat = new Intl.NumberFormat('it')
+
+const numberFormat = new Intl.NumberFormat('it')
+
+function collapse(start: NumberFormatPart[], end: NumberFormatPart[]) {
+  // PartitionNumberRangePattern assigns endpoint sources before collapsing.
+  // ECMA-402 §16.5.19 steps 6–9; only the separator starts as shared.
+  // https://tc39.es/ecma402/#sec-partitionnumberrangepattern
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/numberformat.html#L1836-L1841
+  return CollapseNumberRange(
+    numberFormat,
+    [
+      ...start.map(part => ({...part, source: 'startRange' as const})),
+      {type: 'literal', value: '-', source: 'shared'},
+      ...end.map(part => ({...part, source: 'endRange' as const})),
+    ],
+    {getInternalSlots}
+  )
+}
+
+function currencyAmount(integer: string, currency = '€'): NumberFormatPart[] {
+  return [
+    {type: 'integer', value: integer},
+    {type: 'literal', value: ' '},
+    {type: 'currency', value: currency},
+  ]
+}
+
+function negativeMillions(integer: string): NumberFormatPart[] {
+  return [
+    {type: 'minusSign', value: '-'},
+    {type: 'integer', value: integer},
+    {type: 'group', value: '.'},
+    {type: 'integer', value: '000'},
+    {type: 'group', value: '.'},
+    {type: 'integer', value: '000'},
+    {type: 'decimal', value: ','},
+    {type: 'fraction', value: '00'},
+    {type: 'literal', value: ' '},
+    {type: 'currency', value: '€'},
+  ]
+}
 
 describe('CollapseNumberRange', () => {
-  test('returns the same result', () => {
+  test('collapses matching currency suffixes with valid endpoint sources', () => {
+    const parts = collapse(negativeMillions('1'), negativeMillions('2'))
+    expect(parts.map(part => part.value).join('')).toBe(
+      '-1.000.000,00 - -2.000.000,00 €'
+    )
+    expect(parts[parts.length - 1]).toEqual({
+      type: 'currency',
+      value: '€',
+      source: 'shared',
+    })
     expect(
-      CollapseNumberRange(
-        numberFormat,
-        [
-          {
-            type: 'minusSign',
-            value: '-',
-            source: 'shared',
-          },
-          {
-            type: 'integer',
-            value: '1',
-            source: 'startRange',
-          },
-          {
-            type: 'group',
-            value: '.',
-            source: 'startRange',
-          },
-          {
-            type: 'integer',
-            value: '000',
-            source: 'startRange',
-          },
-          {
-            type: 'group',
-            value: '.',
-            source: 'startRange',
-          },
-          {
-            type: 'integer',
-            value: '000',
-            source: 'startRange',
-          },
-          {
-            type: 'decimal',
-            value: ',',
-            source: 'startRange',
-          },
-          {
-            type: 'fraction',
-            value: '00',
-            source: 'startRange',
-          },
-          {
-            type: 'literal',
-            value: ' ',
-            source: 'shared',
-          },
-          {
-            type: 'currency',
-            value: '€',
-            source: 'shared',
-          },
-          {
-            type: 'literal',
-            value: '-',
-            source: 'shared',
-          },
-          {
-            type: 'minusSign',
-            value: '-',
-            source: 'shared',
-          },
-          {
-            type: 'integer',
-            value: '2',
-            source: 'endRange',
-          },
-          {
-            type: 'group',
-            value: '.',
-            source: 'endRange',
-          },
-          {
-            type: 'integer',
-            value: '000',
-            source: 'endRange',
-          },
-          {
-            type: 'group',
-            value: '.',
-            source: 'endRange',
-          },
-          {
-            type: 'integer',
-            value: '000',
-            source: 'endRange',
-          },
-          {
-            type: 'decimal',
-            value: ',',
-            source: 'endRange',
-          },
-          {
-            type: 'fraction',
-            value: '00',
-            source: 'endRange',
-          },
-          {
-            type: 'literal',
-            value: ' ',
-            source: 'shared',
-          },
-          {
-            type: 'currency',
-            value: '€',
-            source: 'shared',
-          },
-        ],
-        {
-          getInternalSlots,
-        }
-      )
-        .map(p => p.value)
-        .join('')
-    ).toBe('-1.000.000,00--2.000.000,00 €')
-    expect(
-      CollapseNumberRange(
-        numberFormat,
-        [
-          {
-            type: 'integer',
-            value: '10',
-            source: 'startRange',
-          },
-          {
-            type: 'literal',
-            value: ' ',
-            source: 'shared',
-          },
-          {
-            type: 'currency',
-            value: '€',
-            source: 'shared',
-          },
-          {
-            type: 'literal',
-            value: '-',
-            source: 'shared',
-          },
-          {
-            type: 'integer',
-            value: '100',
-            source: 'endRange',
-          },
-          {
-            type: 'literal',
-            value: ' ',
-            source: 'shared',
-          },
-          {
-            type: 'currency',
-            value: '€',
-            source: 'shared',
-          },
-        ],
-        {
-          getInternalSlots,
-        }
-      )
-        .map(p => p.value)
+      collapse(currencyAmount('10'), currencyAmount('100'))
+        .map(part => part.value)
         .join('')
     ).toBe('10-100 €')
+  })
+
+  test('keeps different currency affixes on their endpoints', () => {
+    const parts = collapse(currencyAmount('10'), currencyAmount('100', '$'))
+    expect(parts.map(part => part.value).join('')).toBe('10 € - 100 $')
+    expect(
+      parts.filter(part => part.type === 'currency').map(part => part.source)
+    ).toEqual(['startRange', 'endRange'])
   })
 })

--- a/packages/ecma402-abstract/tests/FormatNumericRange.test.ts
+++ b/packages/ecma402-abstract/tests/FormatNumericRange.test.ts
@@ -35,6 +35,6 @@ describe('FormatNumericRange', () => {
       {getInternalSlots}
     )
 
-    expect(result).toBe('-10--3')
+    expect(result).toBe('-10 - -3')
   })
 })

--- a/packages/ecma402-abstract/tests/FormatNumericRangeToParts.test.ts
+++ b/packages/ecma402-abstract/tests/FormatNumericRangeToParts.test.ts
@@ -15,10 +15,10 @@ describe('FormatNumericRangeToParts', () => {
       }
     )
 
-    expect(result).toMatchObject([
-      {result: '0', source: 'startRange', type: 'integer', value: '3'},
-      {result: '1', source: 'shared', type: 'literal', value: '-'},
-      {result: '2', source: 'endRange', type: 'integer', value: '10'},
+    expect(result).toEqual([
+      {source: 'startRange', type: 'integer', value: '3'},
+      {source: 'shared', type: 'literal', value: '-'},
+      {source: 'endRange', type: 'integer', value: '10'},
     ])
   })
 
@@ -32,11 +32,11 @@ describe('FormatNumericRangeToParts', () => {
       }
     )
 
-    expect(result).toMatchObject([
-      {result: '0', source: 'startRange', type: 'minusSign', value: '-'},
-      {result: '1', source: 'startRange', type: 'integer', value: '3'},
-      {result: '2', source: 'shared', type: 'literal', value: '-'},
-      {result: '3', source: 'endRange', type: 'integer', value: '10'},
+    expect(result).toEqual([
+      {source: 'startRange', type: 'minusSign', value: '-'},
+      {source: 'startRange', type: 'integer', value: '3'},
+      {source: 'shared', type: 'literal', value: '-'},
+      {source: 'endRange', type: 'integer', value: '10'},
     ])
   })
 
@@ -50,12 +50,12 @@ describe('FormatNumericRangeToParts', () => {
       }
     )
 
-    expect(result).toMatchObject([
-      {result: '0', source: 'startRange', type: 'minusSign', value: '-'},
-      {result: '1', source: 'startRange', type: 'integer', value: '10'},
-      {result: '2', source: 'shared', type: 'literal', value: '-'},
-      {result: '3', source: 'endRange', type: 'minusSign', value: '-'},
-      {result: '4', source: 'endRange', type: 'integer', value: '3'},
+    expect(result).toEqual([
+      {source: 'startRange', type: 'minusSign', value: '-'},
+      {source: 'startRange', type: 'integer', value: '10'},
+      {source: 'shared', type: 'literal', value: ' - '},
+      {source: 'endRange', type: 'minusSign', value: '-'},
+      {source: 'endRange', type: 'integer', value: '3'},
     ])
   })
 })

--- a/packages/ecma402-abstract/types/number.ts
+++ b/packages/ecma402-abstract/types/number.ts
@@ -285,6 +285,4 @@ export interface NumberFormatPart {
   source?: string
 }
 
-export interface NumberRangeToParts extends NumberFormatPart {
-  result: string
-}
+export type NumberRangeToParts = NumberFormatPart

--- a/packages/intl-numberformat/BUILD.bazel
+++ b/packages/intl-numberformat/BUILD.bazel
@@ -35,6 +35,7 @@ TEST_LOCALES = [
     "nl",
     "pl",
     "pt",
+    "pt-PT",
     "ru",
     "sv",
     "sw",
@@ -491,6 +492,7 @@ formatjs_test(
         ":tests-locale-data-nl",  # keep: generated locale data imported by tests
         ":tests-locale-data-pl",  # keep: generated locale data imported by tests
         ":tests-locale-data-pt",  # keep: generated locale data imported by tests
+        ":tests-locale-data-pt-PT",  # keep: generated locale data imported by tests
         ":tests-locale-data-ru",  # keep: generated locale data imported by tests
         ":tests-locale-data-sv",  # keep: generated locale data imported by tests
         ":tests-locale-data-sw",  # keep: generated locale data imported by tests

--- a/packages/intl-numberformat/scripts/extract-numbers.ts
+++ b/packages/intl-numberformat/scripts/extract-numbers.ts
@@ -63,11 +63,17 @@ function extractNumbers(d: Numbers): RawNumberData {
     minimumGroupingDigits: Number(d.minimumGroupingDigits),
     nu,
     symbols: nu.reduce((all: Record<string, SymbolsData>, ns) => {
-      const rangeSign = d[
-        `miscPatterns-numberSystem-${ns}` as 'miscPatterns-numberSystem-latn'
-      ].range
-        .match(/[^{}01]/)!
-        .at(0) as string
+      const rangePattern =
+        d[`miscPatterns-numberSystem-${ns}` as 'miscPatterns-numberSystem-latn']
+          .range
+      // ECMA-402 §16.5.19 steps 7–8 preserve the complete separator.
+      // https://tc39.es/ecma402/#sec-partitionnumberrangepattern
+      // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/numberformat.html#L1838-L1839
+      invariant(
+        rangePattern.startsWith('{0}') && rangePattern.endsWith('{1}'),
+        `Unsupported number range pattern: ${rangePattern}`
+      )
+      const rangeSign = rangePattern.slice(3, -3)
 
       all[ns] = {
         ...d[`symbols-numberSystem-${ns}` as 'symbols-numberSystem-latn'],

--- a/packages/intl-numberformat/test262-baseline.json
+++ b/packages/intl-numberformat/test262-baseline.json
@@ -11,12 +11,12 @@
     "intl402/NumberFormat/proto-from-ctor-realm.js (strict mode)": "newTarget.prototype is undefined Expected SameValue(«[object Intl.NumberFormat]», «[object Intl.NumberFormat]») to be true",
     "intl402/NumberFormat/prototype/format/numbering-systems.js (default)": "numberingSystem: adlm, digit: 0 Expected SameValue(«\"٠\"», «\"𞥐\"») to be true",
     "intl402/NumberFormat/prototype/format/numbering-systems.js (strict mode)": "numberingSystem: adlm, digit: 0 Expected SameValue(«\"٠\"», «\"𞥐\"») to be true",
-    "intl402/NumberFormat/prototype/formatRange/en-US.js (default)": "Expected SameValue(«\"$3–$5\"», «\"$3 – $5\"») to be true",
-    "intl402/NumberFormat/prototype/formatRange/en-US.js (strict mode)": "Expected SameValue(«\"$3–$5\"», «\"$3 – $5\"») to be true",
-    "intl402/NumberFormat/prototype/formatRange/pt-PT.js (default)": "Expected SameValue(«\"3 5 €\"», «\"3 - 5 €\"») to be true",
-    "intl402/NumberFormat/prototype/formatRange/pt-PT.js (strict mode)": "Expected SameValue(«\"3 5 €\"», «\"3 - 5 €\"») to be true",
-    "intl402/NumberFormat/prototype/formatRangeToParts/en-US.js (default)": "value for entry 2 Expected SameValue(«\"–\"», «\" – \"») to be true",
-    "intl402/NumberFormat/prototype/formatRangeToParts/en-US.js (strict mode)": "value for entry 2 Expected SameValue(«\"–\"», «\" – \"») to be true",
+    "intl402/NumberFormat/prototype/formatRange/en-US.js (default)": "Expected SameValue(«\"$3~\"», «\"~$3\"») to be true",
+    "intl402/NumberFormat/prototype/formatRange/en-US.js (strict mode)": "Expected SameValue(«\"$3~\"», «\"~$3\"») to be true",
+    "intl402/NumberFormat/prototype/formatRange/pt-PT.js (default)": "Expected SameValue(«\"3 €~\"», «\"~3 €\"») to be true",
+    "intl402/NumberFormat/prototype/formatRange/pt-PT.js (strict mode)": "Expected SameValue(«\"3 €~\"», «\"~3 €\"») to be true",
+    "intl402/NumberFormat/prototype/formatRangeToParts/en-US.js (default)": "type for entry 0 Expected SameValue(«\"currency\"», «\"approximatelySign\"») to be true",
+    "intl402/NumberFormat/prototype/formatRangeToParts/en-US.js (strict mode)": "type for entry 0 Expected SameValue(«\"currency\"», «\"approximatelySign\"») to be true",
     "intl402/NumberFormat/prototype/resolvedOptions/resolved-numbering-system-unicode-extensions-and-options.js (default)": "Resolved locale for locale=en-u-nu-arab with numberingSystem=invalid Expected SameValue(«\"en\"», «\"en-u-nu-arab\"») to be true",
     "intl402/NumberFormat/prototype/resolvedOptions/resolved-numbering-system-unicode-extensions-and-options.js (strict mode)": "Resolved locale for locale=en-u-nu-arab with numberingSystem=invalid Expected SameValue(«\"en\"», «\"en-u-nu-arab\"») to be true"
   }

--- a/packages/intl-numberformat/tests/misc.test.ts
+++ b/packages/intl-numberformat/tests/misc.test.ts
@@ -41,6 +41,7 @@ const LOCALES = [
   'nl',
   'pl',
   'pt',
+  'pt-PT',
   'ru',
   'sv',
   'th',
@@ -810,4 +811,32 @@ describe('locale minimum grouping digits', () => {
       '1000'
     )
   })
+})
+
+it('preserves range separators and only collapses matching affixes', () => {
+  const portuguese = new NumberFormat('pt-PT', {
+    style: 'currency',
+    currency: 'EUR',
+    maximumFractionDigits: 0,
+  })
+  expect(portuguese.formatRange(3, 5)).toBe('3 - 5 €')
+  expect(
+    portuguese.formatRangeToParts(3, 5).filter(part => part.type === 'currency')
+  ).toEqual([{type: 'currency', value: '€', source: 'shared'}])
+  const currency = {style: 'currency', currency: 'USD'} as const
+  expect(
+    new NumberFormat('en', {...currency, maximumFractionDigits: 0}).formatRange(
+      3,
+      5
+    )
+  ).toBe('$3 – $5')
+  const signed = new NumberFormat('en', {...currency, signDisplay: 'always'})
+  expect(signed.formatRange(2.9, 3.1)).toBe('+$2.90–3.10')
+  expect(signed.formatRange(-2.9, 3.1)).toBe('-$2.90 – +$3.10')
+  expect(signed.formatRangeToParts(2.9, 3.1).slice(0, 2)).toEqual([
+    {type: 'plusSign', value: '+', source: 'shared'},
+    {type: 'currency', value: '$', source: 'shared'},
+  ])
+  const scientific = new NumberFormat('en', {notation: 'scientific'})
+  expect(scientific.formatRange(3000, 5000)).toBe('3E3–5E3')
 })

--- a/tools/test262/baselines/combined-numberformat.json
+++ b/tools/test262/baselines/combined-numberformat.json
@@ -11,12 +11,12 @@
     "intl402/NumberFormat/proto-from-ctor-realm.js (strict mode)": "newTarget.prototype is undefined Expected SameValue(«[object Intl.NumberFormat]», «[object Intl.NumberFormat]») to be true",
     "intl402/NumberFormat/prototype/format/numbering-systems.js (default)": "numberingSystem: adlm, digit: 0 Expected SameValue(«\"٠\"», «\"𞥐\"») to be true",
     "intl402/NumberFormat/prototype/format/numbering-systems.js (strict mode)": "numberingSystem: adlm, digit: 0 Expected SameValue(«\"٠\"», «\"𞥐\"») to be true",
-    "intl402/NumberFormat/prototype/formatRange/en-US.js (default)": "Expected SameValue(«\"$3–$5\"», «\"$3 – $5\"») to be true",
-    "intl402/NumberFormat/prototype/formatRange/en-US.js (strict mode)": "Expected SameValue(«\"$3–$5\"», «\"$3 – $5\"») to be true",
-    "intl402/NumberFormat/prototype/formatRange/pt-PT.js (default)": "Expected SameValue(«\"3 5 €\"», «\"3 - 5 €\"») to be true",
-    "intl402/NumberFormat/prototype/formatRange/pt-PT.js (strict mode)": "Expected SameValue(«\"3 5 €\"», «\"3 - 5 €\"») to be true",
-    "intl402/NumberFormat/prototype/formatRangeToParts/en-US.js (default)": "value for entry 2 Expected SameValue(«\"–\"», «\" – \"») to be true",
-    "intl402/NumberFormat/prototype/formatRangeToParts/en-US.js (strict mode)": "value for entry 2 Expected SameValue(«\"–\"», «\" – \"») to be true",
+    "intl402/NumberFormat/prototype/formatRange/en-US.js (default)": "Expected SameValue(«\"$3~\"», «\"~$3\"») to be true",
+    "intl402/NumberFormat/prototype/formatRange/en-US.js (strict mode)": "Expected SameValue(«\"$3~\"», «\"~$3\"») to be true",
+    "intl402/NumberFormat/prototype/formatRange/pt-PT.js (default)": "Expected SameValue(«\"3 €~\"», «\"~3 €\"») to be true",
+    "intl402/NumberFormat/prototype/formatRange/pt-PT.js (strict mode)": "Expected SameValue(«\"3 €~\"», «\"~3 €\"») to be true",
+    "intl402/NumberFormat/prototype/formatRangeToParts/en-US.js (default)": "type for entry 0 Expected SameValue(«\"currency\"», «\"approximatelySign\"») to be true",
+    "intl402/NumberFormat/prototype/formatRangeToParts/en-US.js (strict mode)": "type for entry 0 Expected SameValue(«\"currency\"», «\"approximatelySign\"») to be true",
     "intl402/NumberFormat/prototype/resolvedOptions/resolved-numbering-system-unicode-extensions-and-options.js (default)": "Resolved locale for locale=en-u-nu-arab with numberingSystem=invalid Expected SameValue(«\"en\"», «\"en-u-nu-arab\"») to be true",
     "intl402/NumberFormat/prototype/resolvedOptions/resolved-numbering-system-unicode-extensions-and-options.js (strict mode)": "Resolved locale for locale=en-u-nu-arab with numberingSystem=invalid Expected SameValue(«\"en\"», «\"en-u-nu-arab\"») to be true"
   }


### PR DESCRIPTION
Number ranges truncated CLDR separators and removed affixes without checking both endpoints. Preserve complete separators, collapse only matching affixes, mark retained affixes as shared, and space uncollapsed boundary affixes. Mixed signs and scientific/compact notation remain distinct. Range parts also stop exposing an extra `result` property.

Spec references:
- [ECMA-402 §16.5.19 steps 7–8](https://tc39.es/ecma402/#sec-partitionnumberrangepattern), [source lines 1838–1839](https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/numberformat.html#L1838-L1839).
- [§16.5.21, ambiguity constraint](https://tc39.es/ecma402/#sec-collapsenumberrange), [source lines 1874–1878](https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/numberformat.html#L1874-L1878).
- [§16.5.23 steps 4.b–4.d](https://tc39.es/ecma402/#sec-formatnumericrangetoparts), [source lines 1920–1922](https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/numberformat.html#L1920-L1922).
- [LDML range collapsing and spacing](https://unicode.org/reports/tr35/tr35-numbers.html#Collapsing_Number_Ranges), [source lines 1886–1921](https://github.com/unicode-org/cldr/blob/acd6d88ae493633240e19a87a721076a8a75c310/docs/ldml/tr35-numbers.md#L1886-L1921).

Validation: package/shared typechecks and regression tests cover Portuguese separators, shared currency/sign sources, mixed signs, scientific notation, and exact public part properties. Full isolated and combined Test262 remain 480/498 each: six existing failing executions advance from separator assertions to approximation-placement assertions. No failures added or hidden; approximation is a separate follow-up.

Shared abstract-operation validation: `bazel test //packages/ecma402-abstract:all` passes all four gates, including the root unit suite.
