### PR TITLE
fix(@formatjs/intl-numberformat): place approximate signs in locale patterns

### DIFF
--- a/docs/src/docs/polyfills/intl-numberformat.mdx
+++ b/docs/src/docs/polyfills/intl-numberformat.mdx
@@ -411,3 +411,6 @@ Loading regional data preserves explicitly loaded language data.
 
 Number ranges preserve locale-specific separators. Shared affixes are labeled
 `shared` by `formatRangeToParts`; distinct endpoint signs remain separate.
+
+Ranges whose endpoints format identically use a locale-aware approximately sign,
+for example `~$3` in English. Its position follows the locale's sign pattern.

--- a/knowledge-base/007a-polyfill-intl-numberformat.md
+++ b/knowledge-base/007a-polyfill-intl-numberformat.md
@@ -133,3 +133,7 @@ numbers remain ungrouped; `"always"` still requests grouping.
 Range formatting preserves complete CLDR separators, including surrounding spaces.
 Only matching affixes collapse; retained affixes have `source: "shared"`.
 Different signs and scientific or compact notation remain separate.
+
+Approximate ranges place the approximately sign in the locale's minus-sign position
+for unsigned values, or before an existing plus/minus sign. Currency prefixes,
+suffix signs, bidi literals, and unit wrappers use the same number pattern.

--- a/knowledge-base/014-test262-conformance.md
+++ b/knowledge-base/014-test262-conformance.md
@@ -14,18 +14,18 @@ excluded because it fails.
 | getcanonicallocales |       76 |                 0 |               2 |                 0 |
 | listformat          |      162 |                 2 |               0 |                 2 |
 | locale              |      336 |                 4 |              22 |                 4 |
-| numberformat        |      498 |                18 |               0 |                18 |
+| numberformat        |      498 |                14 |               0 |                14 |
 | pluralrules         |      106 |                 2 |               0 |                 2 |
 | relativetimeformat  |      160 |                 6 |               0 |                 4 |
 | segmenter           |      158 |                 4 |               0 |                 4 |
 | supportedvaluesof   |       50 |                 2 |               6 |                 4 |
 
-Total: 2,498 executions, 2,294 polyfill passes, 204 polyfill failures. The native
+Total: 2,498 executions, 2,298 polyfill passes, 200 polyfill failures. The native
 control fails 86 executions; 44 failing cases overlap. Overlap does not prove
 a polyfill is correct: each failure still needs comparison with the selected
 spec and test's feature metadata.
 
-Combined: 2,498 executions, 2,292 passes, 206 failures.
+Combined: 2,498 executions, 2,296 passes, 202 failures.
 
 Combined installation adds 6 failing executions; 4 isolated failures now pass.
 Two Locale branding cases pass with the installed getCanonicalLocales polyfill.

--- a/packages/ecma402-abstract/NumberFormat/FormatApproximately.ts
+++ b/packages/ecma402-abstract/NumberFormat/FormatApproximately.ts
@@ -1,20 +1,19 @@
-import {
-  type NumberFormatInternal,
-  type NumberFormatPart,
+import type {Decimal} from '@formatjs/bigdecimal'
+import type {
+  NumberFormatInternal,
+  NumberFormatPart,
 } from '#packages/ecma402-abstract/types/number.js'
+import {PartitionNumberPattern} from '#packages/ecma402-abstract/NumberFormat/PartitionNumberPattern.js'
 
-/**
- * https://tc39.es/ecma402/#sec-formatapproximately
- */
+// ECMA-402 §16.5.20 step 2 inserts the approximately sign at a locale-dependent position.
+// Render it in the same pattern as the number so currency, bidi, and sign placement agree.
+// https://tc39.es/ecma402/#sec-formatapproximately
+// https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/numberformat.html#L1859-L1861
+// https://unicode.org/reports/tr35/tr35-numbers.html#Approximate_Number_Formatting
+// https://github.com/unicode-org/cldr/blob/acd6d88ae493633240e19a87a721076a8a75c310/docs/ldml/tr35-numbers.md#L1854-L1858
 export function FormatApproximately(
   internalSlots: NumberFormatInternal,
-  result: NumberFormatPart[]
+  x: Decimal
 ): NumberFormatPart[] {
-  const symbols =
-    internalSlots.dataLocaleData.numbers.symbols[internalSlots.numberingSystem]
-
-  const approximatelySign = symbols.approximatelySign
-
-  result.push({type: 'approximatelySign', value: approximatelySign})
-  return result
+  return PartitionNumberPattern(internalSlots, x, true)
 }

--- a/packages/ecma402-abstract/NumberFormat/PartitionNumberPattern.ts
+++ b/packages/ecma402-abstract/NumberFormat/PartitionNumberPattern.ts
@@ -14,7 +14,8 @@ import {getPowerOf10} from '#packages/ecma402-abstract/NumberFormat/decimal-cach
  */
 export function PartitionNumberPattern(
   internalSlots: NumberFormatInternal,
-  _x: Decimal
+  _x: Decimal,
+  approximately = false
 ): NumberFormatPart[] {
   let x = _x
   // IMPL: We need to record the magnitude of the number
@@ -147,6 +148,7 @@ export function PartitionNumberPattern(
     },
     internalSlots.dataLocaleData,
     pl,
-    internalSlots
+    internalSlots,
+    approximately
   )
 }

--- a/packages/ecma402-abstract/NumberFormat/PartitionNumberRangePattern.ts
+++ b/packages/ecma402-abstract/NumberFormat/PartitionNumberRangePattern.ts
@@ -6,7 +6,6 @@ import {
 import {invariant} from '#packages/ecma402-abstract/utils.js'
 import {CollapseNumberRange} from '#packages/ecma402-abstract/NumberFormat/CollapseNumberRange.js'
 import {FormatApproximately} from '#packages/ecma402-abstract/NumberFormat/FormatApproximately.js'
-import {FormatNumeric} from '#packages/ecma402-abstract/NumberFormat/FormatNumeric.js'
 import {PartitionNumberPattern} from '#packages/ecma402-abstract/NumberFormat/PartitionNumberPattern.js'
 
 /**
@@ -32,8 +31,12 @@ export function PartitionNumberRangePattern(
   // 4. Let yResult be ? PartitionNumberPattern(numberFormat, y).
   const yResult = PartitionNumberPattern(internalSlots, y)
 
-  if (FormatNumeric(internalSlots, x) === FormatNumeric(internalSlots, y)) {
-    const appxResult = FormatApproximately(internalSlots, xResult)
+  // Reuse the already-partitioned endpoints for the FormatNumeric comparison.
+  if (
+    xResult.map(part => part.value).join('') ===
+    yResult.map(part => part.value).join('')
+  ) {
+    const appxResult = FormatApproximately(internalSlots, x)
     appxResult.forEach(el => {
       el.source = 'shared'
     })

--- a/packages/ecma402-abstract/NumberFormat/format_to_parts.ts
+++ b/packages/ecma402-abstract/NumberFormat/format_to_parts.ts
@@ -63,11 +63,16 @@ export default function formatToParts(
     unitDisplay?: NumberFormatOptionsUnitDisplay
     roundingIncrement: number
     roundingMode: RoundingModeType
-  }
+  },
+  approximately = false
 ): NumberFormatPart[] {
   const {sign, exponent, magnitude} = numberResult
   const {notation, style, numberingSystem} = options
   const defaultNumberingSystem = data.numbers.nu[0]
+  const symbols =
+    data.numbers.symbols[numberingSystem] ||
+    data.numbers.symbols[defaultNumberingSystem]
+  approximately = approximately && !!symbols.approximatelySign
 
   // #region Part 1: partition and interpolate the CLDR number pattern.
   // ----------------------------------------------------------
@@ -120,7 +125,11 @@ export default function formatToParts(
       const decimalData =
         data.numbers.decimal[numberingSystem] ||
         data.numbers.decimal[defaultNumberingSystem]
-      numberPattern = getPatternForSign(decimalData.standard, sign)
+      numberPattern = getPatternForSign(
+        decimalData.standard,
+        sign,
+        approximately
+      )
     } else if (style === 'currency') {
       const currencyData =
         data.numbers.currency[numberingSystem] ||
@@ -129,17 +138,20 @@ export default function formatToParts(
       // We replace number pattern part with `0` for easier postprocessing.
       numberPattern = getPatternForSign(
         currencyData[options.currencySign!],
-        sign
+        sign,
+        approximately
       )
     } else {
       // percent
       const percentPattern =
         data.numbers.percent[numberingSystem] ||
         data.numbers.percent[defaultNumberingSystem]
-      numberPattern = getPatternForSign(percentPattern, sign)
+      numberPattern = getPatternForSign(percentPattern, sign, approximately)
     }
   } else {
-    numberPattern = compactNumberPattern
+    numberPattern = approximately
+      ? insertApproximatelySign(compactNumberPattern, sign)
+      : compactNumberPattern
   }
 
   // Extract the decimal number pattern string. It looks like "#,##0,00", which will later be
@@ -180,13 +192,11 @@ export default function formatToParts(
     }
   }
 
-  // The following tokens are special: `{0}`, `¤`, `%`, `-`, `+`, `{c:...}.
-  const numberPatternParts = numberPattern.split(/({c:[^}]+}|\{0\}|[¤%\-+])/g)
+  // Separate number, approximately sign, affix, and compact placeholders.
+  const numberPatternParts = numberPattern.split(
+    /({c:[^}]+}|\{approximatelySign\}|\{0\}|[¤%\-+])/g
+  )
   const numberParts: NumberFormatPart[] = []
-
-  const symbols =
-    data.numbers.symbols[numberingSystem] ||
-    data.numbers.symbols[defaultNumberingSystem]
 
   for (const part of numberPatternParts) {
     if (!part) {
@@ -213,6 +223,12 @@ export default function formatToParts(
         )
         break
       }
+      case '{approximatelySign}':
+        numberParts.push({
+          type: 'approximatelySign',
+          value: symbols.approximatelySign,
+        })
+        break
       case '-':
         numberParts.push({type: 'minusSign', value: symbols.minusSign})
         break
@@ -512,21 +528,37 @@ function partitionNumberIntoParts(
   return result
 }
 
-function getPatternForSign(pattern: string, sign: -1 | 0 | 1): string {
-  if (pattern.indexOf(';') < 0) {
-    pattern = `${pattern};-${pattern}`
-  }
+// LDML approximate formatting uses the minus-sign position for unsigned values,
+// and inserts the approximately sign before an existing plus/minus sign.
+// https://unicode.org/reports/tr35/tr35-numbers.html#Approximate_Number_Formatting
+// https://github.com/unicode-org/cldr/blob/acd6d88ae493633240e19a87a721076a8a75c310/docs/ldml/tr35-numbers.md#L1854-L1858
+function getPatternForSign(
+  pattern: string,
+  sign: -1 | 0 | 1,
+  approximately = false
+): string {
+  if (pattern.indexOf(';') < 0) pattern = `${pattern};-${pattern}`
   const [zeroPattern, negativePattern] = pattern.split(';')
-  switch (sign) {
-    case 0:
-      return zeroPattern
-    case -1:
-      return negativePattern
-    default:
-      return negativePattern.indexOf('-') >= 0
-        ? negativePattern.replace(/-/g, '+')
-        : `+${zeroPattern}`
+  if (sign === 0 && approximately && negativePattern.includes('-')) {
+    return negativePattern.replace('-', '{approximatelySign}')
   }
+  let signedPattern = zeroPattern
+  if (sign === -1) signedPattern = negativePattern
+  else if (sign === 1)
+    signedPattern = negativePattern.includes('-')
+      ? negativePattern.replace(/-/g, '+')
+      : `+${zeroPattern}`
+  return approximately
+    ? insertApproximatelySign(signedPattern, sign)
+    : signedPattern
+}
+
+function insertApproximatelySign(pattern: string, sign: -1 | 0 | 1): string {
+  const symbol = sign === 1 ? '+' : '-'
+  const index = sign === 0 ? -1 : pattern.indexOf(symbol)
+  return index < 0
+    ? `{approximatelySign}${pattern}`
+    : `${pattern.slice(0, index)}{approximatelySign}${pattern.slice(index)}`
 }
 
 // Find the CLDR pattern for compact notation based on the magnitude of data and style.

--- a/packages/ecma402-abstract/tests/FormatApproximately.test.ts
+++ b/packages/ecma402-abstract/tests/FormatApproximately.test.ts
@@ -1,14 +1,32 @@
+import Decimal from '@formatjs/bigdecimal'
 import {FormatApproximately} from '#packages/ecma402-abstract/NumberFormat/FormatApproximately.js'
-import {type NumberFormatPart} from '#packages/ecma402-abstract/types/number.js'
 import {getInternalSlots} from '#packages/ecma402-abstract/tests/utils.js'
 import {describe, expect, it} from 'vitest'
+
 describe('FormatApproximately', () => {
-  const numberFormat: Intl.NumberFormat = new Intl.NumberFormat('it')
+  const numberFormat = new Intl.NumberFormat('it')
 
-  it('append approximatelySign', () => {
-    const result: NumberFormatPart[] = []
-    FormatApproximately(getInternalSlots(numberFormat), result)
+  it('places the approximately sign before the number and its sign', () => {
+    expect(
+      FormatApproximately(getInternalSlots(numberFormat), new Decimal(3))
+    ).toEqual([
+      {type: 'approximatelySign', value: '~'},
+      {type: 'integer', value: '3'},
+    ])
+    expect(
+      FormatApproximately(getInternalSlots(numberFormat), new Decimal(-3))
+    ).toEqual([
+      {type: 'approximatelySign', value: '~'},
+      {type: 'minusSign', value: '-'},
+      {type: 'integer', value: '3'},
+    ])
+  })
 
-    expect(result).toMatchObject([{type: 'approximatelySign', value: '~'}])
+  it('omits an empty approximately sign', () => {
+    const slots = getInternalSlots(numberFormat)
+    slots.dataLocaleData.numbers.symbols.latn.approximatelySign = ''
+    expect(FormatApproximately(slots, new Decimal(3))).toEqual([
+      {type: 'integer', value: '3'},
+    ])
   })
 })

--- a/packages/intl-numberformat/BUILD.bazel
+++ b/packages/intl-numberformat/BUILD.bazel
@@ -45,6 +45,9 @@ TEST_LOCALES = [
     "zh-Hans",
     "zh-Hant",
     "zh",
+    "de-CH",
+    "es-CL",
+    "fy",
 ]
 
 TEST_LOCALE_DATA = ["tests/locale-data/%s.json" % locale for locale in TEST_LOCALES]
@@ -476,12 +479,15 @@ formatjs_test(
         ":tests-locale-data-da",  # keep: generated locale data imported by tests
         ":tests-locale-data-de",  # keep: generated locale data imported by tests
         ":tests-locale-data-de-AT",  # keep: generated locale data imported by tests
+        ":tests-locale-data-de-CH",  # keep: generated locale data imported by tests
         ":tests-locale-data-en",  # keep: generated locale data imported by tests
         ":tests-locale-data-en-BS",  # keep: generated locale data imported by tests
         ":tests-locale-data-en-GB",  # keep: generated locale data imported by tests
         ":tests-locale-data-es",  # keep: generated locale data imported by tests
+        ":tests-locale-data-es-CL",  # keep: generated locale data imported by tests
         ":tests-locale-data-fr",  # keep: generated locale data imported by tests
         ":tests-locale-data-fr-CH",  # keep: generated locale data imported by tests
+        ":tests-locale-data-fy",  # keep: generated locale data imported by tests
         ":tests-locale-data-hi",  # keep: generated locale data imported by tests
         ":tests-locale-data-id",  # keep: generated locale data imported by tests
         ":tests-locale-data-it",  # keep: generated locale data imported by tests

--- a/packages/intl-numberformat/test262-baseline.json
+++ b/packages/intl-numberformat/test262-baseline.json
@@ -11,12 +11,8 @@
     "intl402/NumberFormat/proto-from-ctor-realm.js (strict mode)": "newTarget.prototype is undefined Expected SameValue(«[object Intl.NumberFormat]», «[object Intl.NumberFormat]») to be true",
     "intl402/NumberFormat/prototype/format/numbering-systems.js (default)": "numberingSystem: adlm, digit: 0 Expected SameValue(«\"٠\"», «\"𞥐\"») to be true",
     "intl402/NumberFormat/prototype/format/numbering-systems.js (strict mode)": "numberingSystem: adlm, digit: 0 Expected SameValue(«\"٠\"», «\"𞥐\"») to be true",
-    "intl402/NumberFormat/prototype/formatRange/en-US.js (default)": "Expected SameValue(«\"$3~\"», «\"~$3\"») to be true",
-    "intl402/NumberFormat/prototype/formatRange/en-US.js (strict mode)": "Expected SameValue(«\"$3~\"», «\"~$3\"») to be true",
-    "intl402/NumberFormat/prototype/formatRange/pt-PT.js (default)": "Expected SameValue(«\"3 €~\"», «\"~3 €\"») to be true",
-    "intl402/NumberFormat/prototype/formatRange/pt-PT.js (strict mode)": "Expected SameValue(«\"3 €~\"», «\"~3 €\"») to be true",
-    "intl402/NumberFormat/prototype/formatRangeToParts/en-US.js (default)": "type for entry 0 Expected SameValue(«\"currency\"», «\"approximatelySign\"») to be true",
-    "intl402/NumberFormat/prototype/formatRangeToParts/en-US.js (strict mode)": "type for entry 0 Expected SameValue(«\"currency\"», «\"approximatelySign\"») to be true",
+    "intl402/NumberFormat/prototype/formatRange/pt-PT.js (default)": "Expected SameValue(«\"+2,90 - +3,10 €\"», «\"+2,90 - 3,10 €\"») to be true",
+    "intl402/NumberFormat/prototype/formatRange/pt-PT.js (strict mode)": "Expected SameValue(«\"+2,90 - +3,10 €\"», «\"+2,90 - 3,10 €\"») to be true",
     "intl402/NumberFormat/prototype/resolvedOptions/resolved-numbering-system-unicode-extensions-and-options.js (default)": "Resolved locale for locale=en-u-nu-arab with numberingSystem=invalid Expected SameValue(«\"en\"», «\"en-u-nu-arab\"») to be true",
     "intl402/NumberFormat/prototype/resolvedOptions/resolved-numbering-system-unicode-extensions-and-options.js (strict mode)": "Resolved locale for locale=en-u-nu-arab with numberingSystem=invalid Expected SameValue(«\"en\"», «\"en-u-nu-arab\"») to be true"
   }

--- a/packages/intl-numberformat/tests/misc.test.ts
+++ b/packages/intl-numberformat/tests/misc.test.ts
@@ -51,6 +51,10 @@ const LOCALES = [
   'zh-Hans',
   'zh-Hant',
   'en-BS',
+  'de-CH',
+  'es-CL',
+  'fy',
+  'ar-SS',
 ]
 
 LOCALES.forEach(locale => {
@@ -839,4 +843,55 @@ it('preserves range separators and only collapses matching affixes', () => {
   ])
   const scientific = new NumberFormat('en', {notation: 'scientific'})
   expect(scientific.formatRange(3000, 5000)).toBe('3E3–5E3')
+})
+
+it.each(['en', 'de-CH', 'es-CL', 'fy', 'ar-SS'])(
+  'places unsigned approximate currency at the %s minus-sign position',
+  locale => {
+    const nf = new NumberFormat(locale, {
+      style: 'currency',
+      currency: 'EUR',
+      numberingSystem: 'latn',
+      maximumFractionDigits: 0,
+    })
+    const expected = nf.formatToParts(-3).map(part => ({
+      ...part,
+      ...(part.type === 'minusSign'
+        ? {type: 'approximatelySign', value: locale === 'de-CH' ? '≈' : '~'}
+        : {}),
+      source: 'shared',
+    }))
+    expect(nf.formatRangeToParts(2.9, 3.1)).toEqual(expected)
+  }
+)
+
+it('formats approximate ranges with signs, accounting, and compact notation', () => {
+  const currency = {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0,
+  } as const
+  expect(new NumberFormat('en', currency).formatRange(2.9, 3.1)).toBe('~$3')
+  const signed = new NumberFormat('en', {...currency, signDisplay: 'always'})
+  expect(signed.formatRange(2.9, 3.1)).toBe('~+$3')
+  expect(signed.formatRange(-3.1, -2.9)).toBe('~-$3')
+  const accounting = new NumberFormat('en', {
+    ...currency,
+    currencySign: 'accounting',
+  })
+  expect(accounting.formatRange(-3.1, -2.9)).toBe('~($3)')
+  expect(
+    new NumberFormat('en', {
+      notation: 'compact',
+      maximumFractionDigits: 0,
+    }).formatRange(2900, 3100)
+  ).toBe('~3K')
+  expect(
+    new NumberFormat('en', {
+      style: 'unit',
+      unit: 'meter',
+      unitDisplay: 'long',
+      maximumFractionDigits: 0,
+    }).formatRange(2.9, 3.1)
+  ).toBe('~3 meters')
 })

--- a/tools/test262/baselines/combined-numberformat.json
+++ b/tools/test262/baselines/combined-numberformat.json
@@ -11,12 +11,8 @@
     "intl402/NumberFormat/proto-from-ctor-realm.js (strict mode)": "newTarget.prototype is undefined Expected SameValue(«[object Intl.NumberFormat]», «[object Intl.NumberFormat]») to be true",
     "intl402/NumberFormat/prototype/format/numbering-systems.js (default)": "numberingSystem: adlm, digit: 0 Expected SameValue(«\"٠\"», «\"𞥐\"») to be true",
     "intl402/NumberFormat/prototype/format/numbering-systems.js (strict mode)": "numberingSystem: adlm, digit: 0 Expected SameValue(«\"٠\"», «\"𞥐\"») to be true",
-    "intl402/NumberFormat/prototype/formatRange/en-US.js (default)": "Expected SameValue(«\"$3~\"», «\"~$3\"») to be true",
-    "intl402/NumberFormat/prototype/formatRange/en-US.js (strict mode)": "Expected SameValue(«\"$3~\"», «\"~$3\"») to be true",
-    "intl402/NumberFormat/prototype/formatRange/pt-PT.js (default)": "Expected SameValue(«\"3 €~\"», «\"~3 €\"») to be true",
-    "intl402/NumberFormat/prototype/formatRange/pt-PT.js (strict mode)": "Expected SameValue(«\"3 €~\"», «\"~3 €\"») to be true",
-    "intl402/NumberFormat/prototype/formatRangeToParts/en-US.js (default)": "type for entry 0 Expected SameValue(«\"currency\"», «\"approximatelySign\"») to be true",
-    "intl402/NumberFormat/prototype/formatRangeToParts/en-US.js (strict mode)": "type for entry 0 Expected SameValue(«\"currency\"», «\"approximatelySign\"») to be true",
+    "intl402/NumberFormat/prototype/formatRange/pt-PT.js (default)": "Expected SameValue(«\"+2,90 - +3,10 €\"», «\"+2,90 - 3,10 €\"») to be true",
+    "intl402/NumberFormat/prototype/formatRange/pt-PT.js (strict mode)": "Expected SameValue(«\"+2,90 - +3,10 €\"», «\"+2,90 - 3,10 €\"») to be true",
     "intl402/NumberFormat/prototype/resolvedOptions/resolved-numbering-system-unicode-extensions-and-options.js (default)": "Resolved locale for locale=en-u-nu-arab with numberingSystem=invalid Expected SameValue(«\"en\"», «\"en-u-nu-arab\"») to be true",
     "intl402/NumberFormat/prototype/resolvedOptions/resolved-numbering-system-unicode-extensions-and-options.js (strict mode)": "Resolved locale for locale=en-u-nu-arab with numberingSystem=invalid Expected SameValue(«\"en\"», «\"en-u-nu-arab\"») to be true"
   }


### PR DESCRIPTION
Approximate ranges appended the sign after the formatted number (`$3~`). Render the approximately sign through the locale's number pattern instead, preserving currency prefixes, suffix signs, bidi literals, accounting, compact notation, and unit wrappers. Reuse the existing endpoint parts when comparing formatted values.

This follows [ECMA-402 §16.5.20 step 2](https://tc39.es/ecma402/#sec-formatapproximately) ([source lines 1859–1861](https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/numberformat.html#L1859-L1861)) and [LDML approximate number formatting](https://unicode.org/reports/tr35/tr35-numbers.html#Approximate_Number_Formatting) ([source lines 1854–1858](https://github.com/unicode-org/cldr/blob/acd6d88ae493633240e19a87a721076a8a75c310/docs/ldml/tr35-numbers.md#L1854-L1858)). The rendering flag is an internal argument, so it adds no user option or inherited property access.

Validation: all 21 package/shared gates pass. Regressions cover English, Swiss German, Chilean Spanish, Frisian, Arabic, signed/accounting currency, compact notation, and units. Both complete Test262 modes gain four passes, reaching 484/498 each, with no new failing cases. The two Portuguese range failures now reach duplicate-sign assertions; that affix-collapse fix follows separately. Actual reports and exit codes pass the reviewed baseline validator.

Shared abstract-operation validation: `bazel test //packages/ecma402-abstract:all` passes all four gates, including the root unit suite.
