### PR TITLE
fix(@formatjs/intl-numberformat): share signs with range unit suffixes

### DIFF
--- a/docs/src/docs/polyfills/intl-numberformat.mdx
+++ b/docs/src/docs/polyfills/intl-numberformat.mdx
@@ -414,3 +414,6 @@ Number ranges preserve locale-specific separators. Shared affixes are labeled
 
 Ranges whose endpoints format identically use a locale-aware approximately sign,
 for example `~$3` in English. Its position follows the locale's sign pattern.
+
+Matching signs can share a currency or unit affix across a range; mixed signs
+remain separate.

--- a/knowledge-base/007a-polyfill-intl-numberformat.md
+++ b/knowledge-base/007a-polyfill-intl-numberformat.md
@@ -137,3 +137,6 @@ Different signs and scientific or compact notation remain separate.
 Approximate ranges place the approximately sign in the locale's minus-sign position
 for unsigned values, or before an existing plus/minus sign. Currency prefixes,
 suffix signs, bidi literals, and unit wrappers use the same number pattern.
+
+Matching sign prefixes can be shared alongside a shared currency or unit suffix.
+Mixed signs remain attached to their endpoints.

--- a/knowledge-base/014-test262-conformance.md
+++ b/knowledge-base/014-test262-conformance.md
@@ -14,18 +14,18 @@ excluded because it fails.
 | getcanonicallocales |       76 |                 0 |               2 |                 0 |
 | listformat          |      162 |                 2 |               0 |                 2 |
 | locale              |      336 |                 4 |              22 |                 4 |
-| numberformat        |      498 |                14 |               0 |                14 |
+| numberformat        |      498 |                12 |               0 |                12 |
 | pluralrules         |      106 |                 2 |               0 |                 2 |
 | relativetimeformat  |      160 |                 6 |               0 |                 4 |
 | segmenter           |      158 |                 4 |               0 |                 4 |
 | supportedvaluesof   |       50 |                 2 |               6 |                 4 |
 
-Total: 2,498 executions, 2,298 polyfill passes, 200 polyfill failures. The native
+Total: 2,498 executions, 2,300 polyfill passes, 198 polyfill failures. The native
 control fails 86 executions; 44 failing cases overlap. Overlap does not prove
 a polyfill is correct: each failure still needs comparison with the selected
 spec and test's feature metadata.
 
-Combined: 2,498 executions, 2,296 passes, 202 failures.
+Combined: 2,498 executions, 2,298 passes, 200 failures.
 
 Combined installation adds 6 failing executions; 4 isolated failures now pass.
 Two Locale branding cases pass with the installed getCanonicalLocales polyfill.

--- a/packages/ecma402-abstract/NumberFormat/CollapseNumberRange.ts
+++ b/packages/ecma402-abstract/NumberFormat/CollapseNumberRange.ts
@@ -28,14 +28,21 @@ function affixLength(parts: NumberFormatPart[], fromEnd: boolean): number {
   return length
 }
 
-function canCollapse(a: NumberFormatPart[], b: NumberFormatPart[]): boolean {
+function canCollapse(
+  a: NumberFormatPart[],
+  b: NumberFormatPart[],
+  sharedSuffix = false
+): boolean {
   return (
     a.length === b.length &&
     a.some(part => part.type !== 'literal') &&
     a.every(
       (part, i) => part.type === b[i].type && part.value === b[i].value
     ) &&
-    Array.from(a.map(part => part.value).join('')).length > 1
+    (Array.from(a.map(part => part.value).join('')).length > 1 ||
+      (sharedSuffix &&
+        a.length === 1 &&
+        (a[0].type === 'plusSign' || a[0].type === 'minusSign')))
   )
 }
 
@@ -63,15 +70,27 @@ export function CollapseNumberRange(
 
   const startPrefix = start.slice(0, affixLength(start, false))
   const endPrefix = end.slice(0, affixLength(end, false))
-  if (canCollapse(startPrefix, endPrefix)) {
-    prefix.push(...start.splice(0, startPrefix.length))
-    end.splice(0, endPrefix.length)
-  }
   const startSuffixLength = affixLength(start, true)
   const endSuffixLength = affixLength(end, true)
   const startSuffix = start.slice(start.length - startSuffixLength)
   const endSuffix = end.slice(end.length - endSuffixLength)
-  if (canCollapse(startSuffix, endSuffix)) {
+  const collapseSuffix = canCollapse(startSuffix, endSuffix)
+  // A shared currency/unit suffix also permits sharing identical sign prefixes.
+  // The complete shared affix is more than one code point; mixed signs stay distinct.
+  // ECMA-402 §16.5.21, ambiguity constraint, and LDML collapsing steps 1–3 above.
+  const sharedUnit =
+    collapseSuffix &&
+    startSuffix.some(
+      part =>
+        part.type === 'currency' ||
+        part.type === 'unit' ||
+        part.type === 'percentSign'
+    )
+  if (canCollapse(startPrefix, endPrefix, sharedUnit)) {
+    prefix.push(...start.splice(0, startPrefix.length))
+    end.splice(0, endPrefix.length)
+  }
+  if (collapseSuffix) {
     start.splice(start.length - startSuffixLength)
     suffix.push(...end.splice(end.length - endSuffixLength))
   }

--- a/packages/ecma402-abstract/tests/CollapseNumberRange.test.ts
+++ b/packages/ecma402-abstract/tests/CollapseNumberRange.test.ts
@@ -48,7 +48,7 @@ describe('CollapseNumberRange', () => {
   test('collapses matching currency suffixes with valid endpoint sources', () => {
     const parts = collapse(negativeMillions('1'), negativeMillions('2'))
     expect(parts.map(part => part.value).join('')).toBe(
-      '-1.000.000,00 - -2.000.000,00 €'
+      '-1.000.000,00-2.000.000,00 €'
     )
     expect(parts[parts.length - 1]).toEqual({
       type: 'currency',

--- a/packages/intl-numberformat/test262-baseline.json
+++ b/packages/intl-numberformat/test262-baseline.json
@@ -11,8 +11,6 @@
     "intl402/NumberFormat/proto-from-ctor-realm.js (strict mode)": "newTarget.prototype is undefined Expected SameValue(«[object Intl.NumberFormat]», «[object Intl.NumberFormat]») to be true",
     "intl402/NumberFormat/prototype/format/numbering-systems.js (default)": "numberingSystem: adlm, digit: 0 Expected SameValue(«\"٠\"», «\"𞥐\"») to be true",
     "intl402/NumberFormat/prototype/format/numbering-systems.js (strict mode)": "numberingSystem: adlm, digit: 0 Expected SameValue(«\"٠\"», «\"𞥐\"») to be true",
-    "intl402/NumberFormat/prototype/formatRange/pt-PT.js (default)": "Expected SameValue(«\"+2,90 - +3,10 €\"», «\"+2,90 - 3,10 €\"») to be true",
-    "intl402/NumberFormat/prototype/formatRange/pt-PT.js (strict mode)": "Expected SameValue(«\"+2,90 - +3,10 €\"», «\"+2,90 - 3,10 €\"») to be true",
     "intl402/NumberFormat/prototype/resolvedOptions/resolved-numbering-system-unicode-extensions-and-options.js (default)": "Resolved locale for locale=en-u-nu-arab with numberingSystem=invalid Expected SameValue(«\"en\"», «\"en-u-nu-arab\"») to be true",
     "intl402/NumberFormat/prototype/resolvedOptions/resolved-numbering-system-unicode-extensions-and-options.js (strict mode)": "Resolved locale for locale=en-u-nu-arab with numberingSystem=invalid Expected SameValue(«\"en\"», «\"en-u-nu-arab\"») to be true"
   }

--- a/packages/intl-numberformat/tests/misc.test.ts
+++ b/packages/intl-numberformat/tests/misc.test.ts
@@ -895,3 +895,26 @@ it('formats approximate ranges with signs, accounting, and compact notation', ()
     }).formatRange(2.9, 3.1)
   ).toBe('~3 meters')
 })
+
+it('shares matching signs with a shared currency suffix', () => {
+  const nf = new NumberFormat('pt-PT', {
+    style: 'currency',
+    currency: 'EUR',
+    signDisplay: 'always',
+  })
+  expect(nf.formatRange(2.9, 3.1)).toBe('+2,90 - 3,10 €')
+  expect(
+    nf.formatRangeToParts(2.9, 3.1).filter(part => part.type === 'plusSign')
+  ).toEqual([{type: 'plusSign', value: '+', source: 'shared'}])
+  expect(nf.formatRange(-3.1, -2.9)).toBe('-3,10 - 2,90 €')
+  expect(nf.formatRange(-2.9, 3.1)).toBe('-2,90 - +3,10 €')
+  expect(
+    nf
+      .formatRangeToParts(-2.9, 3.1)
+      .filter(part => part.type === 'minusSign' || part.type === 'plusSign')
+      .map(part => part.source)
+  ).toEqual(['startRange', 'endRange'])
+  expect(
+    new NumberFormat('en', {signDisplay: 'always'}).formatRange(3, 5)
+  ).toBe('+3 – +5')
+})

--- a/tools/test262/baselines/combined-numberformat.json
+++ b/tools/test262/baselines/combined-numberformat.json
@@ -11,8 +11,6 @@
     "intl402/NumberFormat/proto-from-ctor-realm.js (strict mode)": "newTarget.prototype is undefined Expected SameValue(«[object Intl.NumberFormat]», «[object Intl.NumberFormat]») to be true",
     "intl402/NumberFormat/prototype/format/numbering-systems.js (default)": "numberingSystem: adlm, digit: 0 Expected SameValue(«\"٠\"», «\"𞥐\"») to be true",
     "intl402/NumberFormat/prototype/format/numbering-systems.js (strict mode)": "numberingSystem: adlm, digit: 0 Expected SameValue(«\"٠\"», «\"𞥐\"») to be true",
-    "intl402/NumberFormat/prototype/formatRange/pt-PT.js (default)": "Expected SameValue(«\"+2,90 - +3,10 €\"», «\"+2,90 - 3,10 €\"») to be true",
-    "intl402/NumberFormat/prototype/formatRange/pt-PT.js (strict mode)": "Expected SameValue(«\"+2,90 - +3,10 €\"», «\"+2,90 - 3,10 €\"») to be true",
     "intl402/NumberFormat/prototype/resolvedOptions/resolved-numbering-system-unicode-extensions-and-options.js (default)": "Resolved locale for locale=en-u-nu-arab with numberingSystem=invalid Expected SameValue(«\"en\"», «\"en-u-nu-arab\"») to be true",
     "intl402/NumberFormat/prototype/resolvedOptions/resolved-numbering-system-unicode-extensions-and-options.js (strict mode)": "Resolved locale for locale=en-u-nu-arab with numberingSystem=invalid Expected SameValue(«\"en\"», «\"en-u-nu-arab\"») to be true"
   }


### PR DESCRIPTION
Portuguese currency ranges retained a duplicate sign after sharing the currency suffix (`+2,90 - +3,10 €`). Share identical sign prefixes alongside a shared currency or unit suffix, producing `+2,90 - 3,10 €`. Mixed signs and standalone decimal signs remain separate.

This is permitted by [ECMA-402 §16.5.21's ambiguity constraint](https://tc39.es/ecma402/#sec-collapsenumberrange) ([source lines 1874–1878](https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/numberformat.html#L1874-L1878)). The complete shared affix has more than one code point, following [LDML range collapsing](https://unicode.org/reports/tr35/tr35-numbers.html#Collapsing_Number_Ranges) ([source lines 1886–1898](https://github.com/unicode-org/cldr/blob/acd6d88ae493633240e19a87a721076a8a75c310/docs/ldml/tr35-numbers.md#L1886-L1898)).

Validation: focused unit tests and typechecks cover positive, negative, mixed-sign, decimal-only, and part-source cases. All 21 package/shared gates pass. Both complete Test262 modes gain two passes, reaching 486/498 each, with no new or changed failures. Actual reports and exit codes pass the updated baseline validator.

Shared abstract-operation validation: `bazel test //packages/ecma402-abstract:all` passes all four gates, including the root unit suite.
