### PR TITLE
fix(@formatjs/intl-numberformat): repair benchmark entrypoints

### DIFF
--- a/knowledge-base/007a-polyfill-intl-numberformat.md
+++ b/knowledge-base/007a-polyfill-intl-numberformat.md
@@ -140,3 +140,10 @@ suffix signs, bidi literals, and unit wrappers use the same number pattern.
 
 Matching sign prefixes can be shared alongside a shared currency or unit suffix.
 Mixed signs remain attached to their endpoints.
+
+## Benchmarks
+
+Run `bazel run //packages/intl-numberformat/benchmark:benchmark` for formatting
+benchmarks, or `:profile` in the same package for repeated formatting. These
+targets declare their generated ESM manifest and load `en.json` relative to the
+entrypoint; root `#packages/*` imports do not cross the benchmark package boundary.

--- a/packages/intl-numberformat/benchmark/BUILD.bazel
+++ b/packages/intl-numberformat/benchmark/BUILD.bazel
@@ -5,6 +5,7 @@ load("//tools:package_json.bzl", "generate_package_json")
 generate_package_json(
     package_name = "intl-numberformat-benchmark",
     private = True,
+    type = "module",
     version = "1.0.0",
 )
 
@@ -12,6 +13,7 @@ ts_binary(
     name = "benchmark",
     data = [
         "en.json",
+        ":generated_package_json",
         "//:node_modules/@formatjs/intl-numberformat",
         "//:node_modules/tinybench",
     ],
@@ -22,6 +24,7 @@ ts_binary(
     name = "profile",
     data = [
         "en.json",
+        ":generated_package_json",
         "//:node_modules/@formatjs/intl-numberformat",
     ],
     entry_point = "profile.ts",
@@ -31,6 +34,7 @@ ts_binary(
     name = "profile_cpu",
     data = [
         "en.json",
+        ":generated_package_json",
         "//:node_modules/@formatjs/intl-numberformat",
     ],
     entry_point = "profile.ts",
@@ -44,6 +48,7 @@ ts_binary(
 ts_binary(
     name = "analyze_profile",
     data = [
+        ":generated_package_json",
         "//:node_modules/@types/minimist",
         "//:node_modules/@types/node",
         "//:node_modules/minimist",

--- a/packages/intl-numberformat/benchmark/README.md
+++ b/packages/intl-numberformat/benchmark/README.md
@@ -29,13 +29,8 @@ Using Bazel:
 bazel run //packages/intl-numberformat/benchmark:benchmark
 ```
 
-Or using tsx directly from the root:
-
-```bash
-cd packages/intl-numberformat/benchmark
-pnpm install
-pnpm exec tsx benchmark.ts
-```
+The Bazel targets include their generated ESM package manifest and local locale
+fixture. Run through Bazel so measurements use the workspace package build.
 
 ### CPU Profiling
 

--- a/packages/intl-numberformat/benchmark/benchmark.ts
+++ b/packages/intl-numberformat/benchmark/benchmark.ts
@@ -1,8 +1,9 @@
+import {readFileSync} from 'node:fs'
 import {Bench} from 'tinybench'
 import {NumberFormat} from '@formatjs/intl-numberformat'
-// @ts-ignore
-import en from '#packages/intl-numberformat/benchmark/en.json' with {type: 'json'}
-// @ts-ignore
+const en = JSON.parse(
+  readFileSync(new URL('./en.json', import.meta.url), 'utf8')
+)
 NumberFormat.__addLocaleData(en)
 
 // Test cases that match the issue description - repeated formatting with similar values

--- a/packages/intl-numberformat/benchmark/profile.ts
+++ b/packages/intl-numberformat/benchmark/profile.ts
@@ -1,7 +1,8 @@
+import {readFileSync} from 'node:fs'
 import {NumberFormat} from '@formatjs/intl-numberformat'
-// @ts-ignore
-import en from '#packages/intl-numberformat/benchmark/en.json' with {type: 'json'}
-// @ts-ignore
+const en = JSON.parse(
+  readFileSync(new URL('./en.json', import.meta.url), 'utf8')
+)
 NumberFormat.__addLocaleData(en)
 
 // Test values matching the benchmark


### PR DESCRIPTION
The NumberFormat benchmark and profiler crashed because the benchmark package cannot resolve the root `#packages/*` fixture import. Read the declared locale fixture through a module-relative file URL and include the generated ESM manifest in each binary's runfiles.

Validation: both `bazel run //packages/intl-numberformat/benchmark:benchmark` and `:profile` complete; the profiler executes 900,000 formatting calls. Commit hooks pass. This repairs measurement entrypoints without changing polyfill behavior.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>