### PR TITLE
fix(@formatjs/intl-numberformat): preserve supplementary digits when grouping

### DIFF
--- a/knowledge-base/007a-polyfill-intl-numberformat.md
+++ b/knowledge-base/007a-polyfill-intl-numberformat.md
@@ -147,3 +147,9 @@ Run `bazel run //packages/intl-numberformat/benchmark:benchmark` for formatting
 benchmarks, or `:profile` in the same package for repeated formatting. These
 targets declare their generated ESM manifest and load `en.json` relative to the
 entrypoint; root `#packages/*` imports do not cross the benchmark package boundary.
+
+### Digit grouping
+
+Grouping uses decimal digit counts and preserves supplementary-plane digits
+such as Adlam as complete code points. BMP digits retain the string-slicing path.
+Locale numbering-system availability remains a separate data concern.

--- a/packages/ecma402-abstract/NumberFormat/format_to_parts.ts
+++ b/packages/ecma402-abstract/NumberFormat/format_to_parts.ts
@@ -418,6 +418,9 @@ function partitionNumberIntoParts(
     return [{type: 'infinity', value: n}]
   }
 
+  const asciiDecimalSepIndex = n.indexOf('.')
+  const integerDigitCount =
+    asciiDecimalSepIndex < 0 ? n.length : asciiDecimalSepIndex
   const digitReplacementTable = digitMapping[numberingSystem as 'arab']
   if (digitReplacementTable) {
     n = n.replace(/\d/g, digit => digitReplacementTable[+digit] || digit)
@@ -457,7 +460,7 @@ function partitionNumberIntoParts(
   const shouldUseGrouping =
     Boolean(useGrouping) &&
     (useGrouping === 'always' ||
-      Array.from(integer).length >= primaryGroupingSize + minimum)
+      integerDigitCount >= primaryGroupingSize + minimum)
   if (shouldUseGrouping) {
     const groupSepSymbol =
       style === 'currency' && symbols.currencyGroup != null
@@ -465,18 +468,27 @@ function partitionNumberIntoParts(
         : symbols.group
     const groups: string[] = []
 
-    let i = integer.length - primaryGroupingSize
-    if (i > 0) {
-      // Slice the least significant integer group
-      groups.push(integer.slice(i, i + primaryGroupingSize))
-      // Then iteratively push the more signicant groups
-      // TODO: handle surrogate pairs in some numbering system digits
-      for (i -= secondaryGroupingSize; i > 0; i -= secondaryGroupingSize) {
-        groups.push(integer.slice(i, i + secondaryGroupingSize))
-      }
-      groups.push(integer.slice(0, i + secondaryGroupingSize))
-    } else {
-      groups.push(integer)
+    // ECMA-402 §16.5.5 steps 4.c.iii.1.a and 4.c.iii.7.b group mapped
+    // digit code points, never halves of a supplementary-plane digit.
+    // https://tc39.es/ecma402/#sec-partitionnotationsubpattern
+    // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/numberformat.html#L844-L878
+    // LDML grouping sizes count digits, not UTF-16 code units.
+    // https://unicode.org/reports/tr35/tr35-numbers.html#Number_Patterns
+    // https://github.com/unicode-org/cldr/blob/acd6d88ae493633240e19a87a721076a8a75c310/docs/ldml/tr35-numbers.md#L724
+    // ASCII input gives the digit count; BMP digits can keep string slicing.
+    const codePoints =
+      integer.length === integerDigitCount ? undefined : Array.from(integer)
+    let end = integerDigitCount
+    let groupSize = primaryGroupingSize
+    while (end > 0) {
+      const start = Math.max(0, end - groupSize)
+      groups.push(
+        codePoints
+          ? codePoints.slice(start, end).join('')
+          : integer.slice(start, end)
+      )
+      end = start
+      groupSize = secondaryGroupingSize
     }
 
     while (groups.length > 0) {

--- a/packages/intl-numberformat/README.md
+++ b/packages/intl-numberformat/README.md
@@ -1,3 +1,6 @@
 # `intl-numberformat`
 
 We've migrated the docs to https://formatjs.github.io/docs/polyfills/intl-numberformat.
+
+Digit grouping preserves complete Unicode digits, including supplementary-plane
+numbering systems, and follows the locale's primary and secondary group sizes.

--- a/packages/intl-numberformat/tests/format_to_parts.test.ts
+++ b/packages/intl-numberformat/tests/format_to_parts.test.ts
@@ -565,3 +565,90 @@ it('can format numbers with primary and secondary grouping sizes', () => {
     {type: 'fraction', value: '456'},
   ])
 })
+
+it('groups supplementary-plane digits without splitting surrogate pairs', () => {
+  const data = require('./locale-data/en.json').data
+  const pl = new Intl.PluralRules('en')
+  const number = {
+    ...baseNumberResult,
+    formattedString: '12345.67',
+    roundedNumber: new Decimal('12345.67'),
+  }
+  const options = {
+    ...defaultOptions,
+    numberingSystem: 'adlm',
+    useGrouping: 'always',
+  } as const
+  expect(_formatToParts(number, data, pl, options)).toEqual([
+    {type: 'integer', value: '𞥑𞥒'},
+    {type: 'group', value: ','},
+    {type: 'integer', value: '𞥓𞥔𞥕'},
+    {type: 'decimal', value: '.'},
+    {type: 'fraction', value: '𞥖𞥗'},
+  ])
+  expect(
+    format(
+      {...number, formattedString: '1234', roundedNumber: new Decimal(1234)},
+      data,
+      pl,
+      {
+        ...options,
+        useGrouping: 'min2',
+      }
+    )
+  ).toBe('𞥑𞥒𞥓𞥔')
+  expect(
+    format(
+      {...number, formattedString: '12345', roundedNumber: new Decimal(12345)},
+      data,
+      pl,
+      {
+        ...options,
+        useGrouping: 'min2',
+      }
+    )
+  ).toBe('𞥑𞥒,𞥓𞥔𞥕')
+  expect(format(number, data, pl, {...options, useGrouping: false})).toBe(
+    '𞥑𞥒𞥓𞥔𞥕.𞥖𞥗'
+  )
+})
+
+it('preserves primary and secondary grouping sizes for mapped digits', () => {
+  const data = require('./locale-data/bn.json').data
+  const pl = new Intl.PluralRules('bn')
+  const number = {
+    ...baseNumberResult,
+    formattedString: '12345678',
+    roundedNumber: new Decimal(12345678),
+  }
+  expect(
+    format(number, data, pl, {
+      ...defaultOptions,
+      numberingSystem: 'adlm',
+      useGrouping: 'always',
+    })
+  ).toBe('𞥑,𞥒𞥓,𞥔𞥕,𞥖𞥗𞥘')
+  expect(
+    format(number, data, pl, {
+      ...defaultOptions,
+      numberingSystem: 'hanidec',
+      useGrouping: 'always',
+    })
+  ).toBe('一,二三,四五,六七八')
+  expect(
+    format(
+      {
+        ...number,
+        formattedString: '123',
+        roundedNumber: new Decimal(123),
+      },
+      data,
+      pl,
+      {
+        ...defaultOptions,
+        numberingSystem: 'adlm',
+        useGrouping: 'always',
+      }
+    )
+  ).toBe('𞥑𞥒𞥓')
+})


### PR DESCRIPTION
Number grouping split Adlam surrogate pairs, producing malformed integer parts. Count the original decimal digits and slice supplementary-plane digits at code point boundaries. BMP digits retain string slicing without an intermediate array.

[ECMA-402 §16.5.5 steps 4.c.iii.1.a and 4.c.iii.7.b](https://tc39.es/ecma402/#sec-partitionnotationsubpattern) map digit code points and form integer groups ([source lines 844–878](https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/numberformat.html#L844-L878)). [LDML Number Patterns](https://unicode.org/reports/tr35/tr35-numbers.html#Number_Patterns) defines grouping sizes in digits ([source line 724](https://github.com/unicode-org/cldr/blob/acd6d88ae493633240e19a87a721076a8a75c310/docs/ldml/tr35-numbers.md#L724)).

Validation: the regression fails on the parent with isolated surrogate halves. Tests cover exact Adlam parts, fractions, min2, disabled grouping, Indian primary/secondary grouping, and BMP Han decimal digits. All 26 NumberFormat/shared gates pass, including the full isolated Test262 baseline. Numbering-system availability is unchanged; broader data support remains separate.

Combined NumberFormat also passes its unchanged baseline (498 executions). A benchmark smoke run completes; individual case latency changes versus the parent range from -2.31% to +1.23%, requiring repeated measurements before a broader performance conclusion.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>