### PR TITLE
fix(@formatjs/intl-numberformat): generate complete CLDR digit mappings

### DIFF
--- a/knowledge-base/007a-polyfill-intl-numberformat.md
+++ b/knowledge-base/007a-polyfill-intl-numberformat.md
@@ -153,3 +153,8 @@ entrypoint; root `#packages/*` imports do not cross the benchmark package bounda
 Grouping uses decimal digit counts and preserves supplementary-plane digits
 such as Adlam as complete code points. BMP digits retain the string-slicing path.
 Locale numbering-system availability remains a separate data concern.
+
+The shared digit mapping is generated from pinned CLDR `numberingSystems.json`
+numeric entries. It includes all 78 systems in the current ECMA-402 digit table;
+Latin digits use the unchanged ASCII path. Algorithmic numbering systems are not
+digit substitutions. Locale availability still comes from number locale data.

--- a/packages/ecma402-abstract/scripts/BUILD.bazel
+++ b/packages/ecma402-abstract/scripts/BUILD.bazel
@@ -6,6 +6,7 @@ ts_binary(
     data = [
         "//:node_modules/@types/fs-extra",
         "//:node_modules/@types/minimist",
+        "//:node_modules/cldr-core",
         "//:node_modules/fs-extra",
         "//:node_modules/json-stable-stringify",
         "//:node_modules/minimist",
@@ -49,6 +50,7 @@ formatjs_library(
         "//:node_modules/@types/minimist",
         "//:node_modules/@types/node",
         "//:node_modules/@types/regenerate",
+        "//:node_modules/cldr-core",
         "//:node_modules/fs-extra",
         "//:node_modules/json-stable-stringify",
         "//:node_modules/minimist",

--- a/packages/ecma402-abstract/scripts/digit-mapping.ts
+++ b/packages/ecma402-abstract/scripts/digit-mapping.ts
@@ -1,104 +1,32 @@
 import minimist, {type ParsedArgs} from 'minimist'
 import {outputFileSync} from 'fs-extra/esm'
 import stringify from 'json-stable-stringify'
-
-// Generate an array of 10 characters with consecutive codepoint, starting from `starCharCode`.
-function generateDigitChars(startCharCode: number): string[] {
-  const arr = Array.from<string>({length: 10})
-  for (let i = 0; i < 10; i++) {
-    arr[i] = String.fromCodePoint(startCharCode + i)
-  }
-  return arr
-}
-
-// https://tc39.es/ecma402/#table-numbering-system-digits
-const digitMapping: Record<string, string[]> = {
-  adlm: generateDigitChars(0x1e950),
-  ahom: generateDigitChars(0x11730),
-  arab: generateDigitChars(0x660),
-  arabext: generateDigitChars(0x6f0),
-  bali: generateDigitChars(0x1b50),
-  beng: generateDigitChars(0x9e6),
-  bhks: generateDigitChars(0x11c50),
-  brah: generateDigitChars(0x11066),
-  cakm: generateDigitChars(0x11136),
-  cham: generateDigitChars(0xaa50),
-  deva: generateDigitChars(0x966),
-  diak: generateDigitChars(0x11950),
-  fullwide: generateDigitChars(0xff10),
-  gong: generateDigitChars(0x11da0),
-  gonm: generateDigitChars(0x11d50),
-  gujr: generateDigitChars(0xae6),
-  guru: generateDigitChars(0xa66),
-  hanidec: [
-    '\u3007',
-    '\u4e00',
-    '\u4e8c',
-    '\u4e09',
-    '\u56db',
-    '\u4e94',
-    '\u516d',
-    '\u4e03',
-    '\u516b',
-    '\u4e5d',
-  ],
-  hmng: generateDigitChars(0x16b50),
-  hmnp: generateDigitChars(0x1e140),
-  java: generateDigitChars(0xa9d0),
-  kali: generateDigitChars(0xa900),
-  khmr: generateDigitChars(0x17e0),
-  knda: generateDigitChars(0xce6),
-  lana: generateDigitChars(0x1a80),
-  lanatham: generateDigitChars(0x1a90),
-  laoo: generateDigitChars(0xed0),
-  lepc: generateDigitChars(0x1a90),
-  limb: generateDigitChars(0x1946),
-  mathbold: generateDigitChars(0x1d7ce),
-  mathdbl: generateDigitChars(0x1d7d8),
-  mathmono: generateDigitChars(0x1d7f6),
-  mathsanb: generateDigitChars(0x1d7ec),
-  mathsans: generateDigitChars(0x1d7e2),
-  mlym: generateDigitChars(0xd66),
-  modi: generateDigitChars(0x11650),
-  mong: generateDigitChars(0x1810),
-  mroo: generateDigitChars(0x16a60),
-  mtei: generateDigitChars(0xabf0),
-  mymr: generateDigitChars(0x1040),
-  mymrshan: generateDigitChars(0x1090),
-  mymrtlng: generateDigitChars(0xa9f0),
-  newa: generateDigitChars(0x11450),
-  nkoo: generateDigitChars(0x07c0),
-  olck: generateDigitChars(0x1c50),
-  orya: generateDigitChars(0xb66),
-  osma: generateDigitChars(0x104a0),
-  rohg: generateDigitChars(0x10d30),
-  saur: generateDigitChars(0xa8d0),
-  segment: generateDigitChars(0x1fbf0),
-  shrd: generateDigitChars(0x111d0),
-  sind: generateDigitChars(0x112f0),
-  sinh: generateDigitChars(0x0de6),
-  sora: generateDigitChars(0x110f0),
-  sund: generateDigitChars(0x1bb0),
-  takr: generateDigitChars(0x116c0),
-  talu: generateDigitChars(0x19d0),
-  tamldec: generateDigitChars(0xbe6),
-  telu: generateDigitChars(0xc66),
-  thai: generateDigitChars(0xe50),
-  tibt: generateDigitChars(0xf20),
-  tirh: generateDigitChars(0x114d0),
-  vaii: generateDigitChars(0x1620),
-  wara: generateDigitChars(0x118e0),
-  wcho: generateDigitChars(0x1e2f0),
-}
+import numberingSystems from 'cldr-core/supplemental/numberingSystems.json' with {type: 'json'}
 
 interface Args extends ParsedArgs {
   out: string
 }
 
 function main(args: Args) {
-  const {out} = args
+  if (!args.out) throw new Error('--out is required')
+  const digitMapping: Record<string, string[]> = {}
+  // ECMA-402 §16.5.5 step 4.c.iii.1.a uses the ten code points in Table 30.
+  // https://tc39.es/ecma402/#table-numbering-system-digits
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/numberformat.html#L844-L855
+  // CLDR supplies complete digit strings, including non-contiguous hanidec.
+  for (const [name, definition] of Object.entries(
+    numberingSystems.supplemental.numberingSystems
+  )) {
+    // Latin digits need no substitution; algorithmic systems need other rules.
+    if (name === 'latn' || definition._type !== 'numeric') continue
+    if (!('_digits' in definition))
+      throw new Error(`Missing digits for ${name}`)
+    const digits = Array.from(definition._digits)
+    if (digits.length !== 10) throw new Error(`Expected ten digits for ${name}`)
+    digitMapping[name] = digits
+  }
   outputFileSync(
-    out,
+    args.out,
     `export const digitMapping: Record<string, ReadonlyArray<string>> = ${stringify(
       digitMapping,
       {space: 2}
@@ -107,5 +35,5 @@ function main(args: Args) {
 }
 
 if (import.meta.filename === process.argv[1]) {
-  main(minimist<Args>(process.argv))
+  main(minimist<Args>(process.argv.slice(2)))
 }

--- a/packages/generated/unicode/BUILD.bazel
+++ b/packages/generated/unicode/BUILD.bazel
@@ -17,6 +17,7 @@ generate_package_file(
     name = "unicode_digit_mapping",
     src = "digit-mapping.ts",
     data = [
+        "//:node_modules/cldr-core",
         "//:node_modules/json-stable-stringify",
     ],
     tool = "//packages/ecma402-abstract/scripts:digit-mapping",

--- a/packages/intl-numberformat/README.md
+++ b/packages/intl-numberformat/README.md
@@ -4,3 +4,7 @@ We've migrated the docs to https://formatjs.github.io/docs/polyfills/intl-number
 
 Digit grouping preserves complete Unicode digits, including supplementary-plane
 numbering systems, and follows the locale's primary and secondary group sizes.
+
+Numeric digit mappings follow pinned CLDR data, including Lepcha and newer
+Unicode numbering systems. Which systems a locale accepts depends on its loaded
+locale data.

--- a/packages/intl-numberformat/tests/format_to_parts.test.ts
+++ b/packages/intl-numberformat/tests/format_to_parts.test.ts
@@ -652,3 +652,36 @@ it('preserves primary and secondary grouping sizes for mapped digits', () => {
     )
   ).toBe('𞥑𞥒𞥓')
 })
+
+it.each([
+  ['lepc', '\u1c40\u1c41\u1c42\u1c43\u1c44\u1c45\u1c46\u1c47\u1c48\u1c49'],
+  [
+    'gara',
+    '\u{10d40}\u{10d41}\u{10d42}\u{10d43}\u{10d44}\u{10d45}\u{10d46}\u{10d47}\u{10d48}\u{10d49}',
+  ],
+  [
+    'kawi',
+    '\u{11f50}\u{11f51}\u{11f52}\u{11f53}\u{11f54}\u{11f55}\u{11f56}\u{11f57}\u{11f58}\u{11f59}',
+  ],
+  [
+    'outlined',
+    '\u{1ccf0}\u{1ccf1}\u{1ccf2}\u{1ccf3}\u{1ccf4}\u{1ccf5}\u{1ccf6}\u{1ccf7}\u{1ccf8}\u{1ccf9}',
+  ],
+])('uses the specified %s decimal digits', (numberingSystem, expected) => {
+  const data = require('./locale-data/en.json').data
+  expect(
+    format(
+      {
+        ...baseNumberResult,
+        formattedString: '0123456789',
+        roundedNumber: new Decimal(123456789),
+      },
+      data,
+      new Intl.PluralRules('en'),
+      {
+        ...defaultOptions,
+        numberingSystem,
+      }
+    )
+  ).toBe(expected)
+})


### PR DESCRIPTION
The handwritten digit map used Tai Tham digits for Lepcha and omitted 12 newer numeric systems. Generate the map from pinned CLDR numeric digit strings, validating ten Unicode code points per system. Latin digits keep their existing ASCII path; algorithmic systems are not treated as digit substitutions.

[ECMA-402 §16.5.5 step 4.c.iii.1.a](https://tc39.es/ecma402/#sec-partitionnotationsubpattern) uses the digit table ([algorithm source](https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/numberformat.html#L844-L855)). The table specifies [Lepcha U+1C40–U+1C49](https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/numberformat.html#L1043-L1044), matching [CLDR's source](https://github.com/unicode-org/cldr/blob/acd6d88ae493633240e19a87a721076a8a75c310/common/supplemental/numberingSystems.xml#L59).

Validation: four regressions fail on the parent and pass after the change (Lepcha, Garay, Kawi, outlined digits). An independent comparison of all 78 CLDR numeric systems against the pinned spec table finds no missing systems, extras, or digit differences. Generator and generated-file Bazel actions both declare the CLDR input. Locale numbering-system availability remains separate.

All 27 NumberFormat/shared validation gates pass, including both complete Test262 modes against unchanged baselines (486/498 each). Generator typechecks and commit hooks also pass.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>