### PR TITLE
refactor(@formatjs/intl-numberformat): prepare numbering-system data aliases

### DIFF
--- a/packages/ecma402-abstract/types/number.ts
+++ b/packages/ecma402-abstract/types/number.ts
@@ -159,6 +159,8 @@ export interface SymbolsData {
 }
 
 export interface RawNumberData {
+  /** Numbering systems sharing the complete data of another system. */
+  aliases?: Record<string, string>
   minimumGroupingDigits?: number
   nu: string[]
   // numberingSystem -> pattern

--- a/packages/intl-numberformat/core.ts
+++ b/packages/intl-numberformat/core.ts
@@ -269,7 +269,27 @@ defineProperty(NumberFormat, 'supportedLocalesOf', {value: supportedLocalesOf})
 NumberFormat.__addLocaleData = function __addLocaleData(
   ...data: RawNumberLocaleData[]
 ) {
-  for (const {data: d, locale} of data) {
+  for (const {data: source, locale} of data) {
+    const d = source.numbers.aliases
+      ? {
+          ...source,
+          numbers: {
+            ...source.numbers,
+            symbols: {...source.numbers.symbols},
+            decimal: {...source.numbers.decimal},
+            percent: {...source.numbers.percent},
+            currency: {...source.numbers.currency},
+          },
+        }
+      : source
+    // Resolve generated aliases without changing the caller's locale data.
+    for (const system of Object.keys(source.numbers.aliases || {})) {
+      const target = source.numbers.aliases![system]
+      d.numbers.symbols[system] = d.numbers.symbols[target]
+      d.numbers.decimal[system] = d.numbers.decimal[target]
+      d.numbers.percent[system] = d.numbers.percent[target]
+      d.numbers.currency[system] = d.numbers.currency[target]
+    }
     registerLocaleData(
       locale,
       d,

--- a/packages/intl-numberformat/scripts/BUILD.bazel
+++ b/packages/intl-numberformat/scripts/BUILD.bazel
@@ -1,6 +1,8 @@
-# gazelle:ignore
 load("//tools:index.bzl", "ts_binary", "ts_compile")
 load("//tools:test.bzl", "formatjs_test")
+
+# gazelle:ignore
+load("//tools:tsconfig.bzl", "BASE_NODE_TSCONFIG", "packages_tsconfig")
 
 exports_files(glob(["*.sh"]))
 
@@ -84,4 +86,22 @@ formatjs_test(
         "//:node_modules/vitest",
     ],
     no_copy_to_bin = ["//:package.json"],
+)
+
+ts_compile(
+    name = "numbering-system-data",
+    srcs = [
+        "numbering-system-data.ts",
+        "utils.ts",
+    ],
+    package_json = False,
+    tsconfig = packages_tsconfig(BASE_NODE_TSCONFIG),
+    deps = [
+        ":number-data",
+        "//:node_modules/@types/lodash-es",
+        "//:node_modules/@types/node",
+        "//:node_modules/cldr-core",
+        "//:node_modules/lodash-es",
+        "//packages/ecma402-abstract/types",
+    ],
 )

--- a/packages/intl-numberformat/scripts/numbering-system-data.ts
+++ b/packages/intl-numberformat/scripts/numbering-system-data.ts
@@ -1,0 +1,259 @@
+import {basename, dirname, join} from 'node:path'
+import {readFileSync, readdirSync} from 'node:fs'
+import numberingSystems from 'cldr-core/supplemental/numberingSystems.json' with {type: 'json'}
+import parents from 'cldr-core/supplemental/parentLocales.json' with {type: 'json'}
+import likelySubtags from 'cldr-core/supplemental/likelySubtags.json' with {type: 'json'}
+import {isEqual} from 'lodash-es'
+import {
+  type RawNumberData,
+  type SymbolsData,
+  type DecimalFormatNum,
+  type RawCurrencyData,
+  type LDMLPluralRuleMap,
+} from '#packages/ecma402-abstract/types/number.js'
+import {
+  NumberDataResolver,
+  type NumberPathPart,
+} from '#packages/intl-numberformat/scripts/number-data.js'
+import {collapseSingleValuePluralRule, PLURAL_RULES} from './utils.ts'
+
+const part = (
+  name: string,
+  attributes?: Record<string, string>
+): NumberPathPart => ({name, attributes})
+const NUMERIC_SYSTEMS = Object.keys(
+  numberingSystems.supplemental.numberingSystems
+).filter(
+  name =>
+    numberingSystems.supplemental.numberingSystems[name as 'latn']._type ===
+    'numeric'
+)
+const COUNTS = Array.from(
+  {length: 12},
+  (_, i) => String(10 ** (i + 3)) as DecimalFormatNum
+)
+type SystemData = {
+  symbols: SymbolsData
+  decimal: RawNumberData['decimal'][string]
+  percent: string
+  currency: RawCurrencyData
+}
+
+export function numberParent(locale: string): string | undefined {
+  if (locale === 'root') return undefined
+  const explicit = (
+    parents.supplemental.parentLocales.parentLocale as Record<string, string>
+  )[locale]
+  if (explicit) return explicit === 'und' ? 'root' : explicit
+  const pieces = locale.split('-')
+  // LDML main data does not inherit across a change of script.
+  // https://unicode.org/reports/tr35/tr35.html#Parent_Locales
+  // https://github.com/unicode-org/cldr/blob/acd6d88ae493633240e19a87a721076a8a75c310/docs/ldml/tr35.md#L2118-L2128
+  if (pieces.length === 2 && pieces[1].length === 4) {
+    const likely = (
+      likelySubtags.supplemental.likelySubtags as Record<string, string>
+    )[pieces[0]]
+    if (likely && likely.split('-')[1] !== pieces[1]) return 'root'
+  }
+  return pieces.length > 1 ? pieces.slice(0, -1).join('-') : 'root'
+}
+
+export function loadNumberResolver(rootFile: string): NumberDataResolver {
+  const directory = dirname(rootFile)
+  const sources = new Map<string, string>()
+  for (const file of readdirSync(directory).sort()) {
+    if (file.endsWith('.xml'))
+      sources.set(
+        basename(file, '.xml').replace(/_/g, '-'),
+        readFileSync(join(directory, file), 'utf8')
+      )
+  }
+  return new NumberDataResolver(sources, numberParent)
+}
+
+function readSystem(
+  resolver: NumberDataResolver,
+  locale: string,
+  system: string
+): SystemData {
+  const section = (name: string) => part(name, {numberSystem: system})
+  const get = (...path: NumberPathPart[]) => resolver.get(locale, path)
+  const required = (...path: NumberPathPart[]) => {
+    const value = get(...path)
+    if (value === undefined)
+      throw new Error(
+        `Missing number data: ${locale}/${system}/${JSON.stringify(path)}`
+      )
+    return value
+  }
+  const symbols = {} as SymbolsData
+  for (const name of [
+    'decimal',
+    'group',
+    'list',
+    'percentSign',
+    'plusSign',
+    'minusSign',
+    'exponential',
+    'superscriptingExponent',
+    'perMille',
+    'infinity',
+    'nan',
+    'timeSeparator',
+    'approximatelySign',
+  ] as const) {
+    symbols[name] = required(section('symbols'), part(name))
+  }
+  for (const name of ['currencyDecimal', 'currencyGroup'] as const) {
+    const value = get(section('symbols'), part(name))
+    if (value !== undefined) symbols[name] = value
+  }
+  for (const [name, alt] of [
+    ['decimal', 'us'],
+    ['group', 'us'],
+    ['timeSeparator', 'variant'],
+  ]) {
+    const value = get(section('symbols'), part(name, {alt}))
+    if (value !== undefined)
+      Object.assign(symbols, {[`${name}-alt-${alt}`]: value})
+  }
+  const range = required(
+    section('miscPatterns'),
+    part('pattern', {type: 'range'})
+  )
+  if (!range.startsWith('{0}') || !range.endsWith('{1}'))
+    throw new Error(`Unsupported number range pattern: ${range}`)
+  symbols.rangeSign = range.slice(3, -3)
+  const compact = (kind: 'decimal' | 'currency', length: 'long' | 'short') => {
+    const base = [
+      section(`${kind}Formats`),
+      part(`${kind}FormatLength`, {type: length}),
+      part(
+        `${kind}Format`,
+        kind === 'currency' ? {type: 'standard'} : undefined
+      ),
+    ]
+    const result = {} as Record<DecimalFormatNum, LDMLPluralRuleMap<string>>
+    for (const count of COUNTS) {
+      const rules = {
+        other: required(
+          ...base,
+          part('pattern', {type: count, count: 'other'})
+        ),
+      } as LDMLPluralRuleMap<string>
+      for (const plural of PLURAL_RULES) {
+        const value = get(
+          ...base,
+          part('pattern', {type: count, count: plural})
+        )
+        if (value !== undefined) rules[plural] = value
+      }
+      result[count] = collapseSingleValuePluralRule(rules)
+    }
+    return result
+  }
+  const currency: RawCurrencyData = {
+    currencySpacing: {
+      beforeInsertBetween: required(
+        section('currencyFormats'),
+        part('currencySpacing'),
+        part('beforeCurrency'),
+        part('insertBetween')
+      ),
+      afterInsertBetween: required(
+        section('currencyFormats'),
+        part('currencySpacing'),
+        part('afterCurrency'),
+        part('insertBetween')
+      ),
+    },
+    standard: required(
+      section('currencyFormats'),
+      part('currencyFormatLength'),
+      part('currencyFormat', {type: 'standard'}),
+      part('pattern')
+    ),
+    accounting: required(
+      section('currencyFormats'),
+      part('currencyFormatLength'),
+      part('currencyFormat', {type: 'accounting'}),
+      part('pattern')
+    ),
+    unitPattern:
+      get(section('currencyFormats'), part('unitPattern', {count: 'other'})) ??
+      required(
+        part('currencyFormats', {numberSystem: 'latn'}),
+        part('unitPattern', {count: 'other'})
+      ),
+  }
+  if (
+    get(
+      section('currencyFormats'),
+      part('currencyFormatLength', {type: 'short'}),
+      part('currencyFormat', {type: 'standard'}),
+      part('pattern', {type: '1000', count: 'other'})
+    ) !== undefined
+  ) {
+    currency.short = compact('currency', 'short')
+  }
+  return {
+    symbols,
+    percent: required(
+      section('percentFormats'),
+      part('percentFormatLength'),
+      part('percentFormat'),
+      part('pattern')
+    ),
+    decimal: {
+      standard: required(
+        section('decimalFormats'),
+        part('decimalFormatLength'),
+        part('decimalFormat'),
+        part('pattern')
+      ),
+      long: compact('decimal', 'long'),
+      short: compact('decimal', 'short'),
+    },
+    currency,
+  }
+}
+
+export function expandNumberingSystems(
+  locale: string,
+  existing: RawNumberData,
+  resolver: NumberDataResolver
+): RawNumberData {
+  // ECMA-402 16.5.5, step 4.c.iii.1.a: substitute the selected system's digits.
+  // Resolve its LDML symbols and patterns too; digit substitution alone is insufficient.
+  // https://tc39.es/ecma402/#sec-partitionnotationsubpattern
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/numberformat.html#L844-L855
+  const result: RawNumberData = {
+    minimumGroupingDigits: existing.minimumGroupingDigits,
+    nu: [
+      ...existing.nu,
+      ...NUMERIC_SYSTEMS.filter(name => !existing.nu.includes(name)),
+    ],
+    symbols: {},
+    decimal: {},
+    percent: {},
+    currency: {},
+    aliases: {},
+  }
+  const latin = readSystem(resolver, locale, 'latn')
+  for (const system of result.nu) {
+    const data =
+      system === 'latn' || resolver.usesLatinData(locale, system)
+        ? latin
+        : readSystem(resolver, locale, system)
+    if (system !== 'latn' && isEqual(data, latin)) {
+      result.aliases![system] = 'latn'
+    } else {
+      result.symbols[system] = data.symbols
+      result.decimal[system] = data.decimal
+      result.percent[system] = data.percent
+      result.currency[system] = data.currency
+    }
+  }
+  resolver.clearCache()
+  return result
+}

--- a/packages/intl-numberformat/tests/misc.test.ts
+++ b/packages/intl-numberformat/tests/misc.test.ts
@@ -918,3 +918,30 @@ it('shares matching signs with a shared currency suffix', () => {
     new NumberFormat('en', {signDisplay: 'always'}).formatRange(3, 5)
   ).toBe('+3 – +5')
 })
+
+it('hydrates numbering-system aliases without mutating supplied data', () => {
+  const source = JSON.parse(JSON.stringify(require('./locale-data/en.json')))
+  source.data.numbers.aliases = {adlm: 'latn'}
+  source.data.nu.push('adlm')
+  source.data.numbers.nu.push('adlm')
+  for (const field of [
+    'symbols',
+    'decimal',
+    'percent',
+    'currency',
+    'aliases',
+  ]) {
+    Object.freeze(source.data.numbers[field])
+  }
+  Object.freeze(source.data.numbers)
+  Object.freeze(source.data)
+  Object.freeze(source)
+  NumberFormat.__addLocaleData(source)
+  expect(source.data.numbers.symbols.adlm).toBeUndefined()
+  expect(NumberFormat.localeData.en!.numbers.symbols.adlm).toBe(
+    NumberFormat.localeData.en!.numbers.symbols.latn
+  )
+  expect(new NumberFormat('en', {numberingSystem: 'adlm'}).format(123)).toBe(
+    '𞥑𞥒𞥓'
+  )
+})


### PR DESCRIPTION
Project resolved LDML number data into NumberFormat’s locale schema and hydrate shared-data aliases without mutating caller-owned input. Generated locale payloads remain unchanged until the coordinated activation PR.

The projection follows [LDML parent locales](https://unicode.org/reports/tr35/tr35.html#Parent_Locales), [source lines 2118–2128](https://github.com/unicode-org/cldr/blob/acd6d88ae493633240e19a87a721076a8a75c310/docs/ldml/tr35.md#L2118-L2128). The following PR activates numeric systems across NumberFormat, DateTimeFormat and RelativeTimeFormat together, keeping supportedValuesOf consistent.

Validation: all 30 NumberFormat, abstract-operation and generator gates pass, including the unchanged Test262 baseline. A frozen-input regression verifies alias hydration and Adlam formatting.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>