### PR TITLE
fix(@formatjs/intl-datetimeformat): mark shared date range parts

### DIFF
--- a/docs/src/docs/polyfills/intl-datetimeformat.mdx
+++ b/docs/src/docs/polyfills/intl-datetimeformat.mdx
@@ -329,3 +329,8 @@ non-breaking spaces where specified.
 
 Locale data registers CLDR default-content variants, such as `en-US` for English.
 Loading regional data preserves explicitly loaded language data.
+
+`formatRangeToParts` marks unique fields and separators as `shared`. Repeated
+fields belong to their endpoint; punctuation between repeated fields stays with
+that endpoint. Shared month names retain the complete date pattern for
+grammatical context.

--- a/knowledge-base/007b-polyfill-intl-datetimeformat.md
+++ b/knowledge-base/007b-polyfill-intl-datetimeformat.md
@@ -194,3 +194,8 @@ API provides no context to distinguish the start from the end of a day.
 
 CLDR alternate-key suffixes are metadata, not skeleton fields. The extractor
 uses default entries and excludes `-alt-*` keys before parsing skeletons.
+
+`formatRangeToParts` marks unique fields and separators as `shared`. Repeated
+fields belong to their endpoint; punctuation between repeated fields stays with
+that endpoint. Shared month names retain the complete date pattern for
+grammatical context.

--- a/knowledge-base/014-test262-conformance.md
+++ b/knowledge-base/014-test262-conformance.md
@@ -8,7 +8,7 @@ excluded because it fails.
 | Polyfill            | Executed | Polyfill failures | Native failures | Combined failures |
 | ------------------- | -------: | ----------------: | --------------: | ----------------: |
 | collator            |      130 |                 2 |               0 |                 2 |
-| datetimeformat      |      488 |               160 |              52 |               160 |
+| datetimeformat      |      488 |               158 |              52 |               158 |
 | displaynames        |      114 |                 2 |               0 |                 2 |
 | durationformat      |      220 |                 0 |               4 |                 0 |
 | getcanonicallocales |       76 |                 0 |               2 |                 0 |
@@ -20,12 +20,12 @@ excluded because it fails.
 | segmenter           |      158 |                 4 |               0 |                 4 |
 | supportedvaluesof   |       50 |                 2 |               6 |                 2 |
 
-Total: 2,498 executions, 2,310 polyfill passes, 188 polyfill failures. The native
+Total: 2,498 executions, 2,312 polyfill passes, 186 polyfill failures. The native
 control fails 86 executions; 44 failing cases overlap. Overlap does not prove
 a polyfill is correct: each failure still needs comparison with the selected
 spec and test's feature metadata.
 
-Combined: 2,498 executions, 2,310 passes, 188 failures.
+Combined: 2,498 executions, 2,312 passes, 186 failures.
 
 Combined installation adds 2 failing executions; 2 isolated failures now pass.
 Two Locale branding cases pass with the installed getCanonicalLocales polyfill.

--- a/packages/ecma402-abstract/DateTimeFormat/FormatDateTimePattern.ts
+++ b/packages/ecma402-abstract/DateTimeFormat/FormatDateTimePattern.ts
@@ -91,6 +91,7 @@ export interface FormatDateTimePatternImplDetails {
   // Used to avoid converting hour 0 to 24 in h24 format when it's midnight on a different date
   rangeFormatOptions?: {
     isDifferentDate?: boolean
+    patternParts?: IntlDateTimeFormatPart[]
   }
 }
 
@@ -148,8 +149,12 @@ export function FormatDateTimePattern(
   const result: Intl.DateTimeFormatPart[] = []
 
   // Check if month is stand-alone (no other date fields like day, year, weekday)
-  const hasMonth = patternParts.some(part => part.type === 'month')
-  const hasOtherDateFields = patternParts.some(
+  // Month grammar depends on the complete date pattern, including shared fields.
+  // ECMA-402 11.5.5, step 15.f.x: https://tc39.es/ecma402/#sec-formatdatetimepattern
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/datetimeformat.html#L1419
+  const contextParts = rangeFormatOptions?.patternParts || patternParts
+  const hasMonth = contextParts.some(part => part.type === 'month')
+  const hasOtherDateFields = contextParts.some(
     part =>
       part.type === 'day' ||
       part.type === 'year' ||

--- a/packages/ecma402-abstract/DateTimeFormat/PartitionDateTimeRangePattern.ts
+++ b/packages/ecma402-abstract/DateTimeFormat/PartitionDateTimeRangePattern.ts
@@ -138,6 +138,15 @@ export function PartitionDateTimeRangePattern(
   const datesDiffer =
     tm1.year !== tm2.year || tm1.month !== tm2.month || tm1.day !== tm2.day
   const result: IntlDateTimeFormatPart[] = []
+  const contextParts = PartitionPattern<IntlDateTimeFormatPartType>(
+    rangePattern.patternParts
+      .map(part =>
+        part.pattern === '{0}' || part.pattern === '{1}'
+          ? pattern
+          : part.pattern
+      )
+      .join('')
+  )
   for (const part of rangePattern.patternParts) {
     const {source} = part
     // Steps 19.a and 19.f use each pattern without changing locale data.
@@ -145,12 +154,22 @@ export function PartitionDateTimeRangePattern(
     // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/datetimeformat.html#L1577-L1587
     const partPattern =
       part.pattern === '{0}' || part.pattern === '{1}' ? pattern : part.pattern
+    if (!partPattern.includes('{')) {
+      result.push({type: 'literal', value: partPattern, source})
+      continue
+    }
     const value = source === RangePatternType.endRange ? y : x
     const formatted = FormatDateTimePattern(
       dtf,
       PartitionPattern<IntlDateTimeFormatPartType>(partPattern),
       value,
-      {...implDetails, rangeFormatOptions: {isDifferentDate: datesDiffer}}
+      {
+        ...implDetails,
+        rangeFormatOptions: {
+          isDifferentDate: datesDiffer,
+          patternParts: contextParts,
+        },
+      }
     )
     for (const item of formatted) {
       item.source = source

--- a/packages/ecma402-abstract/DateTimeFormat/skeleton.ts
+++ b/packages/ecma402-abstract/DateTimeFormat/skeleton.ts
@@ -372,35 +372,43 @@ export function splitFallbackRangePattern(
 }
 
 export function splitRangePattern(pattern: string): Array<RangePatternPart> {
-  const PART_REGEX = /\{(.*?)\}/g
-  // Map of part and index within the string
-  const parts: Record<string, number> = {}
+  const fields = new Map<string, {start: number; end: number}>()
+  const part = /\{(.*?)\}/g
   let match
-  let splitIndex = 0
-  while ((match = PART_REGEX.exec(pattern))) {
-    if (!(match[0] in parts)) {
-      parts[match[0]] = match.index
+  let startBegin = pattern.length
+  let startEnd = 0
+  let endBegin = pattern.length
+  let endEnd = 0
+  while ((match = part.exec(pattern))) {
+    const first = fields.get(match[1])
+    const end = match.index + match[0].length
+    if (first) {
+      startBegin = Math.min(startBegin, first.start)
+      startEnd = Math.max(startEnd, first.end)
+      endBegin = Math.min(endBegin, match.index)
+      endEnd = Math.max(endEnd, end)
     } else {
-      splitIndex = match.index
-      break
+      fields.set(match[1], {start: match.index, end})
     }
   }
-  if (!splitIndex) {
-    return [
-      {
-        source: RangePatternType.startRange,
-        pattern,
-      },
-    ]
+  if (!startEnd) return [{source: RangePatternType.shared, pattern}]
+
+  // ECMA-402 11.5.9, step 19.f.i preserves each range record's source.
+  // Repeated fields bound each endpoint; outer text and the separator are shared.
+  // ICU derives the same spans from repeated field positions:
+  // https://github.com/unicode-org/icu/blob/030fa1a4791ee7c2f58505ebb61253c3032916ec/icu4c/source/i18n/formattedval_iterimpl.cpp#L86-L122
+  // https://tc39.es/ecma402/#sec-partitiondatetimerangepattern
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/datetimeformat.html#L1577-L1587
+  // https://unicode.org/reports/tr35/tr35-dates.html#intervalFormats
+  // https://github.com/unicode-org/cldr/blob/acd6d88ae493633240e19a87a721076a8a75c310/docs/ldml/tr35-dates.md#L868-L882
+  const result: RangePatternPart[] = []
+  function append(begin: number, end: number, source: RangePatternType) {
+    if (begin < end) result.push({source, pattern: pattern.slice(begin, end)})
   }
-  return [
-    {
-      source: RangePatternType.startRange,
-      pattern: pattern.slice(0, splitIndex),
-    },
-    {
-      source: RangePatternType.endRange,
-      pattern: pattern.slice(splitIndex),
-    },
-  ]
+  append(0, startBegin, RangePatternType.shared)
+  append(startBegin, startEnd, RangePatternType.startRange)
+  append(startEnd, endBegin, RangePatternType.shared)
+  append(endBegin, endEnd, RangePatternType.endRange)
+  append(endEnd, pattern.length, RangePatternType.shared)
+  return result
 }

--- a/packages/intl-datetimeformat/test262-baseline.json
+++ b/packages/intl-datetimeformat/test262-baseline.json
@@ -85,8 +85,6 @@
     "intl402/DateTimeFormat/prototype/formatRangeToParts/chinese-calendar-dates.js (strict mode)": "relatedYear component of 2000-01-01T00:00Z formatted in chinese is missing Expected SameValue(«undefined», «undefined») to be false",
     "intl402/DateTimeFormat/prototype/formatRangeToParts/dangi-calendar-dates.js (default)": "relatedYear component of 2000-01-01T00:00Z formatted in dangi is missing Expected SameValue(«undefined», «undefined») to be false",
     "intl402/DateTimeFormat/prototype/formatRangeToParts/dangi-calendar-dates.js (strict mode)": "relatedYear component of 2000-01-01T00:00Z formatted in dangi is missing Expected SameValue(«undefined», «undefined») to be false",
-    "intl402/DateTimeFormat/prototype/formatRangeToParts/en-US.js (default)": "source for entry 5 Expected SameValue(«\"startRange\"», «\"shared\"») to be true",
-    "intl402/DateTimeFormat/prototype/formatRangeToParts/en-US.js (strict mode)": "source for entry 5 Expected SameValue(«\"startRange\"», «\"shared\"») to be true",
     "intl402/DateTimeFormat/prototype/formatRangeToParts/pattern-on-calendar.js (default)": "Expected SameValue(«false», «true») to be true",
     "intl402/DateTimeFormat/prototype/formatRangeToParts/pattern-on-calendar.js (strict mode)": "Expected SameValue(«false», «true») to be true",
     "intl402/DateTimeFormat/prototype/formatRangeToParts/temporal-objects-format-with-era.js (default)": "Expected no error, got TypeError: Do not use Temporal.PlainDate.prototype.valueOf; use Temporal.PlainDate.prototype.compare for comparison.",

--- a/packages/intl-datetimeformat/tests/abstract/skeleton.test.ts
+++ b/packages/intl-datetimeformat/tests/abstract/skeleton.test.ts
@@ -4,29 +4,35 @@ import {
   splitRangePattern,
 } from '#packages/ecma402-abstract/DateTimeFormat/skeleton.js'
 import {expect, test} from 'vitest'
-test('splitRangePattern basic case', function () {
+test('splitRangePattern shares unique fields and the separator', () => {
   expect(splitRangePattern('{month} {day} - {day}')).toEqual([
-    {
-      pattern: '{month} {day} - ',
-      source: 'startRange',
-    },
-    {
-      pattern: '{day}',
-      source: 'endRange',
-    },
+    {pattern: '{month} ', source: 'shared'},
+    {pattern: '{day}', source: 'startRange'},
+    {pattern: ' - ', source: 'shared'},
+    {pattern: '{day}', source: 'endRange'},
   ])
 })
 
-test('splitRangePattern zh', function () {
+test('splitRangePattern preserves CJK literals outside endpoint fields', () => {
   expect(splitRangePattern('{month}月{day}日至{day}日')).toEqual([
-    {
-      pattern: '{month}月{day}日至',
-      source: 'startRange',
-    },
-    {
-      pattern: '{day}日',
-      source: 'endRange',
-    },
+    {pattern: '{month}月', source: 'shared'},
+    {pattern: '{day}', source: 'startRange'},
+    {pattern: '日至', source: 'shared'},
+    {pattern: '{day}', source: 'endRange'},
+    {pattern: '日', source: 'shared'},
+  ])
+})
+
+test('splitRangePattern retains punctuation within repeated date spans', () => {
+  expect(
+    splitRangePattern('{month}/{day}/{year} through {month}/{day}/{year}')
+  ).toEqual([
+    {pattern: '{month}/{day}/{year}', source: 'startRange'},
+    {pattern: ' through ', source: 'shared'},
+    {pattern: '{month}/{day}/{year}', source: 'endRange'},
+  ])
+  expect(splitRangePattern('{month} {year}')).toEqual([
+    {pattern: '{month} {year}', source: 'shared'},
   ])
 })
 
@@ -51,10 +57,9 @@ test('parseDateTimeSkeleton', function () {
         day: 'numeric',
         month: 'short',
         patternParts: [
-          {
-            pattern: '{month} {day} – ',
-            source: 'startRange',
-          },
+          {pattern: '{month} ', source: 'shared'},
+          {pattern: '{day}', source: 'startRange'},
+          {pattern: ' – ', source: 'shared'},
           {
             pattern: '{day}',
             source: 'endRange',
@@ -65,10 +70,8 @@ test('parseDateTimeSkeleton', function () {
         day: 'numeric',
         month: 'short',
         patternParts: [
-          {
-            pattern: '{month} {day} – ',
-            source: 'startRange',
-          },
+          {pattern: '{month} {day}', source: 'startRange'},
+          {pattern: ' – ', source: 'shared'},
           {
             pattern: '{month} {day}',
             source: 'endRange',
@@ -97,10 +100,9 @@ test('parseDateTimeSkeleton', function () {
         day: 'numeric',
         month: 'short',
         patternParts: [
-          {
-            pattern: '{month} {day} – ',
-            source: 'startRange',
-          },
+          {pattern: '{month} ', source: 'shared'},
+          {pattern: '{day}', source: 'startRange'},
+          {pattern: ' – ', source: 'shared'},
           {
             pattern: '{day}',
             source: 'endRange',
@@ -111,10 +113,8 @@ test('parseDateTimeSkeleton', function () {
         day: 'numeric',
         month: 'short',
         patternParts: [
-          {
-            pattern: '{month} {day} – ',
-            source: 'startRange',
-          },
+          {pattern: '{month} {day}', source: 'startRange'},
+          {pattern: ' – ', source: 'shared'},
           {
             pattern: '{month} {day}',
             source: 'endRange',

--- a/packages/intl-datetimeformat/tests/format-range.test.ts
+++ b/packages/intl-datetimeformat/tests/format-range.test.ts
@@ -4,12 +4,13 @@ import {DateTimeFormat} from '#packages/intl-datetimeformat/core'
 import allData from '@formatjs_generated/tz/all-tz.js'
 import enGB from '#packages/intl-datetimeformat/tests/locale-data/en-GB.json' with {type: 'json'}
 import en from '#packages/intl-datetimeformat/tests/locale-data/en.json' with {type: 'json'}
+import ru from '#packages/intl-datetimeformat/tests/locale-data/ru.json' with {type: 'json'}
 import fa from '#packages/intl-datetimeformat/tests/locale-data/fa.json' with {type: 'json'}
 import nl from '#packages/intl-datetimeformat/tests/locale-data/nl.json' with {type: 'json'}
 import zhHans from '#packages/intl-datetimeformat/tests/locale-data/zh-Hans.json' with {type: 'json'}
 import {describe, expect, it, test} from 'vitest'
 // @ts-ignore
-DateTimeFormat.__addLocaleData(en, enGB, zhHans, fa, nl)
+DateTimeFormat.__addLocaleData(en, enGB, zhHans, fa, nl, ru)
 DateTimeFormat.__addTZData(allData)
 describe('DateTimeFormat range format', function () {
   it('basic', function () {
@@ -32,12 +33,12 @@ describe('DateTimeFormat range format', function () {
       }).formatRangeToParts(d1, d2)
     ).toEqual([
       {
-        source: 'startRange',
+        source: 'shared',
         type: 'month',
         value: 'Feb',
       },
       {
-        source: 'startRange',
+        source: 'shared',
         type: 'literal',
         value: ' ',
       },
@@ -47,7 +48,7 @@ describe('DateTimeFormat range format', function () {
         value: '1',
       },
       {
-        source: 'startRange',
+        source: 'shared',
         type: 'literal',
         value: ' – ',
       },
@@ -754,4 +755,22 @@ it('preserves both day periods across 11 AM and noon', () => {
   expect(
     parts.filter(part => part.type === 'dayPeriod').map(part => part.value)
   ).toEqual(['AM', 'PM'])
+})
+
+it('keeps date-context month grammar when the month is shared', () => {
+  const formatter = new DateTimeFormat('ru', {
+    timeZone: 'UTC',
+    month: 'short',
+    day: 'numeric',
+  })
+  const start = Date.UTC(2024, 4, 3)
+  const end = Date.UTC(2024, 4, 5)
+  const parts = formatter.formatRangeToParts(start, end)
+  expect(parts).toContainEqual({type: 'month', value: 'мая', source: 'shared'})
+  expect(
+    parts.filter(part => part.type === 'day').map(part => part.source)
+  ).toEqual(['startRange', 'endRange'])
+  expect(parts.map(part => part.value).join('')).toBe(
+    formatter.formatRange(start, end)
+  )
 })

--- a/tools/test262/baselines/combined-datetimeformat.json
+++ b/tools/test262/baselines/combined-datetimeformat.json
@@ -85,8 +85,6 @@
     "intl402/DateTimeFormat/prototype/formatRangeToParts/chinese-calendar-dates.js (strict mode)": "relatedYear component of 2000-01-01T00:00Z formatted in chinese is missing Expected SameValue(«undefined», «undefined») to be false",
     "intl402/DateTimeFormat/prototype/formatRangeToParts/dangi-calendar-dates.js (default)": "relatedYear component of 2000-01-01T00:00Z formatted in dangi is missing Expected SameValue(«undefined», «undefined») to be false",
     "intl402/DateTimeFormat/prototype/formatRangeToParts/dangi-calendar-dates.js (strict mode)": "relatedYear component of 2000-01-01T00:00Z formatted in dangi is missing Expected SameValue(«undefined», «undefined») to be false",
-    "intl402/DateTimeFormat/prototype/formatRangeToParts/en-US.js (default)": "source for entry 5 Expected SameValue(«\"startRange\"», «\"shared\"») to be true",
-    "intl402/DateTimeFormat/prototype/formatRangeToParts/en-US.js (strict mode)": "source for entry 5 Expected SameValue(«\"startRange\"», «\"shared\"») to be true",
     "intl402/DateTimeFormat/prototype/formatRangeToParts/pattern-on-calendar.js (default)": "Expected SameValue(«false», «true») to be true",
     "intl402/DateTimeFormat/prototype/formatRangeToParts/pattern-on-calendar.js (strict mode)": "Expected SameValue(«false», «true») to be true",
     "intl402/DateTimeFormat/prototype/formatRangeToParts/temporal-objects-format-with-era.js (default)": "Expected no error, got TypeError: Do not use Temporal.PlainDate.prototype.valueOf; use Temporal.PlainDate.prototype.compare for comparison.",


### PR DESCRIPTION
`formatRangeToParts` assigned shared month names and separators to the first endpoint. Bound each endpoint by repeated fields; keep outer fields and separators shared, matching ICU's interval span calculation. Preserve complete-pattern context for grammatical month names.

Spec: [ECMA-402 11.5.9, step 19.f.i](https://tc39.es/ecma402/#sec-partitiondatetimerangepattern), [source lines 1577–1587](https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/datetimeformat.html#L1577-L1587); [11.5.5, step 15.f.x](https://tc39.es/ecma402/#sec-formatdatetimepattern), [line 1419](https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/datetimeformat.html#L1419). [ICU span calculation](https://github.com/unicode-org/icu/blob/030fa1a4791ee7c2f58505ebb61253c3032916ec/icu4c/source/i18n/formattedval_iterimpl.cpp#L86-L122).

Validation: shared abstract gates, DateTimeFormat unit tests, and isolated/combined Test262 pass. Both modes gain two executions with no new failures or changed diagnostics: DateTimeFormat 330/488, all polyfills 2,312/2,498. Includes Russian month grammar and CJK/literal span regressions.
