### PR TITLE
fix(@formatjs/intl-datetimeformat): preserve h24 midnight in ranges

### DIFF
--- a/docs/src/docs/polyfills/intl-datetimeformat.mdx
+++ b/docs/src/docs/polyfills/intl-datetimeformat.mdx
@@ -334,3 +334,6 @@ Loading regional data preserves explicitly loaded language data.
 fields belong to their endpoint; punctuation between repeated fields stays with
 that endpoint. Shared month names retain the complete date pattern for
 grammatical context.
+
+An explicit `hourCycle: "h24"` formats midnight as `24` for both single dates
+and ranges. Use `h23` for midnight `00`; `hour12: false` selects `h23`.

--- a/knowledge-base/007b-polyfill-intl-datetimeformat.md
+++ b/knowledge-base/007b-polyfill-intl-datetimeformat.md
@@ -199,3 +199,6 @@ uses default entries and excludes `-alt-*` keys before parsing skeletons.
 fields belong to their endpoint; punctuation between repeated fields stays with
 that endpoint. Shared month names retain the complete date pattern for
 grammatical context.
+
+An explicit `hourCycle: "h24"` formats midnight as `24` for both single dates
+and ranges. Use `h23` for midnight `00`; `hour12: false` selects `h23`.

--- a/packages/ecma402-abstract/DateTimeFormat/FormatDateTimePattern.ts
+++ b/packages/ecma402-abstract/DateTimeFormat/FormatDateTimePattern.ts
@@ -88,9 +88,8 @@ export interface FormatDateTimePatternImplDetails {
   localeData: Record<string, DateTimeFormatLocaleInternalData>
   getDefaultTimeZone(): string
   // GH #4535: Track if we're formatting a range where dates differ
-  // Used to avoid converting hour 0 to 24 in h24 format when it's midnight on a different date
+  // Preserve the complete pattern when formatting one range record.
   rangeFormatOptions?: {
-    isDifferentDate?: boolean
     patternParts?: IntlDateTimeFormatPart[]
   }
 }
@@ -240,29 +239,11 @@ export function FormatDateTimePattern(
           v = 12
         }
       }
-      // GH #4535: In h24 format, midnight handling depends on context.
-      //
-      // LDML Spec (UTS #35): The 'k' symbol (1-24) means 24:00 represents the END of day.
-      // "Tuesday 24:00 = Wednesday 00:00" - they represent the same instant.
-      // See: https://unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table
-      //
-      // However, in date ranges, showing 24:00 can be semantically confusing:
-      // - Different dates (May 3, 22:00 – May 4, 00:00): Show "00:00" on May 4
-      //   because "May 4, 24:00" would actually mean May 5, 00:00
-      // - Same date ranges (May 3, 00:00 – 00:45): Show "00:00" for clarity
-      //   because the times are at the START of the day, not the end
-      //
-      // Only convert 0→24 in non-range single-date formatting where 24:00
-      // conventionally means "end of day" (e.g., business closing time).
-      //
-      // Note: ICU4J's SimpleDateFormat always converts 0→24 for 'k' pattern.
-      // Our approach is more contextually appropriate for range formatting.
-      // See: https://github.com/unicode-org/icu/blob/main/icu4j/main/core/src/main/java/com/ibm/icu/text/SimpleDateFormat.java
-      if (p === 'hour' && hourCycle === 'h24') {
-        if (v === 0 && !rangeFormatOptions) {
-          // Only convert 0 to 24 when NOT formatting a range (rangeFormatOptions is undefined)
-          v = 24
-        }
+      // ECMA-402 11.5.5, step 15.f.vii.1 applies to single dates and ranges.
+      // https://tc39.es/ecma402/#sec-formatdatetimepattern
+      // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/datetimeformat.html#L1406-L1407
+      if (p === 'hour' && hourCycle === 'h24' && v === 0) {
+        v = 24
       }
       if (f === 'numeric') {
         fv = nf.format(v)

--- a/packages/ecma402-abstract/DateTimeFormat/PartitionDateTimeRangePattern.ts
+++ b/packages/ecma402-abstract/DateTimeFormat/PartitionDateTimeRangePattern.ts
@@ -135,8 +135,6 @@ export function PartitionDateTimeRangePattern(
     return result
   }
 
-  const datesDiffer =
-    tm1.year !== tm2.year || tm1.month !== tm2.month || tm1.day !== tm2.day
   const result: IntlDateTimeFormatPart[] = []
   const contextParts = PartitionPattern<IntlDateTimeFormatPartType>(
     rangePattern.patternParts
@@ -166,7 +164,6 @@ export function PartitionDateTimeRangePattern(
       {
         ...implDetails,
         rangeFormatOptions: {
-          isDifferentDate: datesDiffer,
           patternParts: contextParts,
         },
       }

--- a/packages/intl-datetimeformat/tests/format-range.test.ts
+++ b/packages/intl-datetimeformat/tests/format-range.test.ts
@@ -774,3 +774,36 @@ it('keeps date-context month grammar when the month is shared', () => {
     formatter.formatRange(start, end)
   )
 })
+
+it.each([
+  [
+    'same date',
+    Date.UTC(2024, 4, 3),
+    Date.UTC(2024, 4, 3, 0, 45),
+    ['24', '24'],
+  ],
+  [
+    'different dates',
+    Date.UTC(2024, 4, 3, 22),
+    Date.UTC(2024, 4, 4),
+    ['22', '24'],
+  ],
+  ['equal endpoints', Date.UTC(2024, 4, 3), Date.UTC(2024, 4, 3), ['24']],
+] as const)('uses h24 midnight for %s', (_name, start, end, hours) => {
+  const formatter = new DateTimeFormat('en-GB', {
+    timeZone: 'UTC',
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    hourCycle: 'h24',
+  })
+  const parts = formatter.formatRangeToParts(start, end)
+  expect(
+    parts.filter(part => part.type === 'hour').map(part => part.value)
+  ).toEqual(hours)
+  expect(parts.map(part => part.value).join('')).toBe(
+    formatter.formatRange(start, end)
+  )
+})


### PR DESCRIPTION
Explicit `hourCycle: "h24"` formatted midnight as `00` in date ranges while single-date formatting used `24`. Apply the same conversion to both, and remove the unused different-date exception. `h23` and `hour12: false` retain midnight `00`.

Spec: [ECMA-402 11.5.5, step 15.f.vii.1](https://tc39.es/ecma402/#sec-formatdatetimepattern), [source lines 1406–1407](https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/datetimeformat.html#L1406-L1407).

Validation: same-date and cross-date regressions fail before the fix and pass afterward; collapsed ranges are covered too. Shared/DateTimeFormat typechecks and unit tests pass. Isolated and combined Test262 pass against unchanged baselines, 330/488 in each mode.
