### PR TITLE
perf(@formatjs/intl-collator): reduce root data startup cost

### DIFF
--- a/docs/src/docs/polyfills/intl-collator.mdx
+++ b/docs/src/docs/polyfills/intl-collator.mdx
@@ -114,3 +114,15 @@ such as `phonebk`, `trad`, and `dict`, rather than legacy LDML names.
 `usage: "search"` selects CLDR search tailoring independently of sort collation
 keywords. Its resolved collation is `default`; search comparisons are intended
 for matching, not a stable sort order.
+
+## Benchmarks
+
+From a repository checkout:
+
+```sh
+bazel run //packages/intl-collator/benchmark:run
+```
+
+The benchmark compares Latin, accent, numeric, normalization, Swedish tailoring,
+and CJK cases with native `Intl.Collator`. Each timed task performs 32 comparisons;
+formatter construction and module initialization are excluded.

--- a/knowledge-base/007l-polyfill-intl-collator.md
+++ b/knowledge-base/007l-polyfill-intl-collator.md
@@ -143,3 +143,15 @@ such as `phonebk`, `trad`, and `dict`, rather than legacy LDML names.
 `usage: "search"` selects CLDR search tailoring independently of sort collation
 keywords. Its resolved collation is `default`; search comparisons are intended
 for matching, not a stable sort order.
+
+## Startup and comparison benchmarks
+
+Root trie, element, and prefix tables are emitted as JSON strings decoded once
+per module evaluation. Their exported values and types stay unchanged; this
+avoids compiling large numeric JavaScript literals in each Test262 process.
+
+Run `bazel run //packages/intl-collator/benchmark:run` for Latin, accent, numeric,
+normalization, Swedish tailoring, and CJK comparisons with native controls.
+Each timed task batches 32 comparisons. Construction and module initialization
+are outside the timed region. The benchmark package is Gazelle-managed; its
+private module manifest prevents package self-reference during execution.

--- a/packages/intl-collator/benchmark/BUILD.bazel
+++ b/packages/intl-collator/benchmark/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@aspect_rules_js//js:defs.bzl", "js_binary")
+load("//tools:compile.bzl", "formatjs_library")
+load("//tools:package_json.bzl", "generate_package_json")
+
+generate_package_json(
+    package_name = "intl-collator-benchmark",
+    private = True,
+    type = "module",
+    version = "1.0.0",
+)
+
+js_binary(
+    name = "run",
+    data = [
+        ":generated_package_json",  # keep: isolate package self-reference during execution
+        "//:node_modules/@formatjs/intl-collator",
+        "//:node_modules/tinybench",
+    ],
+    entry_point = "benchmark.ts",
+    tags = ["manual"],
+)
+
+formatjs_library(
+    name = "benchmark",
+    srcs = ["benchmark.ts"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//:node_modules/@formatjs/intl-collator",
+        "//:node_modules/tinybench",
+    ],
+)

--- a/packages/intl-collator/benchmark/benchmark.ts
+++ b/packages/intl-collator/benchmark/benchmark.ts
@@ -1,0 +1,42 @@
+import {Collator} from '@formatjs/intl-collator'
+import {Bench} from 'tinybench'
+
+const cases: {
+  name: string
+  locale: string
+  options?: Intl.CollatorOptions
+  left: string
+  right: string
+}[] = [
+  {name: 'Latin', locale: 'en', left: 'apple', right: 'banana'},
+  {name: 'accent', locale: 'en', left: 'café', right: 'cafe'},
+  {
+    name: 'numeric',
+    locale: 'en',
+    options: {numeric: true},
+    left: 'item 9',
+    right: 'item 10',
+  },
+  {name: 'normalization', locale: 'en', left: 'café', right: 'cafe\u0301'},
+  {name: 'Swedish tailoring', locale: 'sv', left: 'zebra', right: 'ångström'},
+  {name: 'CJK', locale: 'zh', left: '中文', right: '汉字'},
+]
+
+async function main() {
+  const bench = new Bench({time: 1000})
+  for (const {name, locale, options, left, right} of cases) {
+    const compare = new Collator(locale, options).compare
+    const nativeCompare = new Intl.Collator(locale, options).compare
+    // Batch comparisons to reduce timer and sample-storage overhead.
+    bench.add(`compare ${name} x32 (polyfill)`, () => {
+      for (let i = 0; i < 32; i++) compare(left, right)
+    })
+    bench.add(`compare ${name} x32 (native)`, () => {
+      for (let i = 0; i < 32; i++) nativeCompare(left, right)
+    })
+  }
+  await bench.run()
+  console.table(bench.table())
+}
+
+await main()

--- a/packages/intl-collator/scripts/generate-root-data.ts
+++ b/packages/intl-collator/scripts/generate-root-data.ts
@@ -56,7 +56,8 @@ function countTrieNodes(node: PackedTrieNode): number {
 }
 
 function serialize(value: unknown): string {
-  return JSON.stringify(value)
+  // Keep large numeric tables out of the JavaScript parser during startup.
+  return `JSON.parse(${JSON.stringify(JSON.stringify(value))})`
 }
 
 const argv = minimist(process.argv.slice(2), {


### PR DESCRIPTION
Decode root collation tables from JSON strings at module initialization. This avoids compiling large numeric literals while preserving the exact generated values, exported types, and statistics.

On the same Darwin arm64 host, full combined-Locale execution fell from 126.8s to 104.1s with unchanged failures. Ten startup profiles per variant showed median process lifetime falling from 664ms to 589ms. Four interleaved steady-state trials per variant showed 8–13% lower comparison latency across six cases; native controls stayed within 0.8%.

Validation: exact generated-data/source comparison, all 15 focused Collator/parser/package/Test262 gates, both full combined-Locale runs, benchmark typechecks, and hooks pass. Added a Gazelle-managed benchmark with native controls: `bazel run //packages/intl-collator/benchmark:run`. Each timed task batches 32 comparisons; initialization and construction are excluded.
