### PR TITLE
perf(@formatjs/intl-datetimeformat): reuse range formatting setup

### DIFF
--- a/packages/ecma402-abstract/DateTimeFormat/FormatDateTimePattern.ts
+++ b/packages/ecma402-abstract/DateTimeFormat/FormatDateTimePattern.ts
@@ -87,11 +87,40 @@ export interface FormatDateTimePatternImplDetails {
   ): IntlDateTimeFormatInternal
   localeData: Record<string, DateTimeFormatLocaleInternalData>
   getDefaultTimeZone(): string
-  // GH #4535: Track if we're formatting a range where dates differ
   // Preserve the complete pattern when formatting one range record.
   rangeFormatOptions?: {
     patternParts?: IntlDateTimeFormatPart[]
+    localTime?: ReturnType<typeof ToLocalTime>
+    numberFormatters?: ReturnType<typeof createNumberFormatters>
   }
+}
+
+function createNumberFormatters(internalSlots: IntlDateTimeFormatInternal): {
+  nf: Intl.NumberFormat
+  nf2: Intl.NumberFormat
+  nf3: Intl.NumberFormat | undefined
+} {
+  const locale = internalSlots.locale
+  const nfOptions = Object.create(null)
+  nfOptions.numberingSystem = internalSlots.numberingSystem
+  nfOptions.useGrouping = false
+
+  const nf = createMemoizedNumberFormat(locale, nfOptions)
+  const nf2Options = Object.create(null)
+  nf2Options.minimumIntegerDigits = 2
+  nf2Options.numberingSystem = internalSlots.numberingSystem
+  nf2Options.useGrouping = false
+  const nf2 = createMemoizedNumberFormat(locale, nf2Options)
+  const fractionalSecondDigits = internalSlots.fractionalSecondDigits
+  let nf3: Intl.NumberFormat | undefined
+  if (fractionalSecondDigits !== undefined) {
+    const nf3Options = Object.create(null)
+    nf3Options.minimumIntegerDigits = fractionalSecondDigits
+    nf3Options.numberingSystem = internalSlots.numberingSystem
+    nf3Options.useGrouping = false
+    nf3 = createMemoizedNumberFormat(locale, nf3Options)
+  }
+  return {nf, nf2, nf3}
 }
 
 /**
@@ -118,33 +147,31 @@ export function FormatDateTimePattern(
   const dataLocaleData = localeData[dataLocale]
   /** IMPL END */
 
-  const locale = internalSlots.locale
-  const nfOptions = Object.create(null)
-  nfOptions.numberingSystem = internalSlots.numberingSystem
-  nfOptions.useGrouping = false
-
-  const nf = createMemoizedNumberFormat(locale, nfOptions)
-  const nf2Options = Object.create(null)
-  nf2Options.minimumIntegerDigits = 2
-  nf2Options.numberingSystem = internalSlots.numberingSystem
-  nf2Options.useGrouping = false
-  const nf2 = createMemoizedNumberFormat(locale, nf2Options)
+  // ECMA-402 11.5.5, steps 1-11 use identical NumberFormat options for
+  // every record in this range. Resolve the existing memoized formatters once.
+  // https://tc39.es/ecma402/#sec-formatdatetimepattern
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/datetimeformat.html#L1356-L1372
+  const numberFormatters =
+    rangeFormatOptions?.numberFormatters ||
+    createNumberFormatters(internalSlots)
+  if (rangeFormatOptions) rangeFormatOptions.numberFormatters = numberFormatters
+  const {nf, nf2, nf3} = numberFormatters
   const fractionalSecondDigits = internalSlots.fractionalSecondDigits
-  let nf3: Intl.NumberFormat
-  if (fractionalSecondDigits !== undefined) {
-    const nf3Options = Object.create(null)
-    nf3Options.minimumIntegerDigits = fractionalSecondDigits
-    nf3Options.numberingSystem = internalSlots.numberingSystem
-    nf3Options.useGrouping = false
-    nf3 = createMemoizedNumberFormat(locale, nf3Options)
-  }
-  const tm = ToLocalTime(
-    x,
-    // @ts-ignore
-    internalSlots.calendar,
-    internalSlots.timeZone,
-    {tzData}
-  )
+  // ECMA-402 11.5.5, step 12: reuse the identical endpoint conversion from
+  // PartitionDateTimeRangePattern (11.5.9, steps 7-8) within this call.
+  // https://tc39.es/ecma402/#sec-partitiondatetimerangepattern
+  // https://tc39.es/ecma402/#sec-formatdatetimepattern
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/datetimeformat.html#L1373
+  // https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/datetimeformat.html#L1529-L1530
+  const tm =
+    rangeFormatOptions?.localTime ??
+    ToLocalTime(
+      x,
+      // @ts-ignore
+      internalSlots.calendar,
+      internalSlots.timeZone,
+      {tzData}
+    )
   const result: Intl.DateTimeFormatPart[] = []
 
   // Check if month is stand-alone (no other date fields like day, year, weekday)

--- a/packages/ecma402-abstract/DateTimeFormat/PartitionDateTimeRangePattern.ts
+++ b/packages/ecma402-abstract/DateTimeFormat/PartitionDateTimeRangePattern.ts
@@ -130,7 +130,10 @@ export function PartitionDateTimeRangePattern(
     }
   }
   if (rangePattern === undefined) {
-    const result = FormatDateTimePattern(dtf, parts, x, implDetails)
+    const result = FormatDateTimePattern(dtf, parts, x, {
+      ...implDetails,
+      rangeFormatOptions: {localTime: tm1},
+    })
     for (const part of result) part.source = RangePatternType.shared
     return result
   }
@@ -145,6 +148,10 @@ export function PartitionDateTimeRangePattern(
       )
       .join('')
   )
+  const rangeFormatOptions: NonNullable<
+    FormatDateTimePatternImplDetails['rangeFormatOptions']
+  > = {patternParts: contextParts}
+  const rangeImplDetails = {...implDetails, rangeFormatOptions}
   for (const part of rangePattern.patternParts) {
     const {source} = part
     // Steps 19.a and 19.f use each pattern without changing locale data.
@@ -157,16 +164,13 @@ export function PartitionDateTimeRangePattern(
       continue
     }
     const value = source === RangePatternType.endRange ? y : x
+    rangeFormatOptions.localTime =
+      source === RangePatternType.endRange ? tm2 : tm1
     const formatted = FormatDateTimePattern(
       dtf,
       PartitionPattern<IntlDateTimeFormatPartType>(partPattern),
       value,
-      {
-        ...implDetails,
-        rangeFormatOptions: {
-          patternParts: contextParts,
-        },
-      }
+      rangeImplDetails
     )
     for (const item of formatted) {
       item.source = source

--- a/packages/intl-datetimeformat/tests/format-range.test.ts
+++ b/packages/intl-datetimeformat/tests/format-range.test.ts
@@ -807,3 +807,33 @@ it.each([
     formatter.formatRange(start, end)
   )
 })
+
+it.each([
+  [
+    'spring forward',
+    Date.UTC(2024, 2, 10, 6, 30),
+    Date.UTC(2024, 2, 10, 7, 30),
+    ['01', '03'],
+  ],
+  [
+    'fall back',
+    Date.UTC(2024, 10, 3, 4, 30),
+    Date.UTC(2024, 10, 3, 7, 30),
+    ['00', '02'],
+  ],
+] as const)('uses each endpoint time across %s', (_name, start, end, hours) => {
+  const formatter = new DateTimeFormat('en-GB', {
+    timeZone: 'America/New_York',
+    hour: '2-digit',
+    minute: '2-digit',
+    hourCycle: 'h23',
+  })
+  const parts = formatter.formatRangeToParts(start, end)
+  expect(parts.filter(part => part.type === 'hour')).toEqual([
+    {type: 'hour', value: hours[0], source: 'startRange'},
+    {type: 'hour', value: hours[1], source: 'endRange'},
+  ])
+  expect(parts.map(part => part.value).join('')).toBe(
+    formatter.formatRange(start, end)
+  )
+})


### PR DESCRIPTION
Correct range part attribution split shared fields into separate formatting records, repeating endpoint conversion and NumberFormat setup. Four paired trials against the earlier implementation found same-date `formatRange` and `formatRangeToParts` about 32% and 36% slower.

Reuse the two endpoint local-time records and resolve the existing memoized NumberFormat instances once per range. The context lives for one call; shared fields keep the full pattern for grammatical context. Code comments cite ECMA-402 11.5.5 steps 1–12 and 11.5.9 steps 7–8, with pinned source lines.

Validation: seven focused unit/typecheck gates pass, including new spring/fall DST endpoint checks. Both DateTimeFormat Test262 modes retain 330 passes / 488 executions and exactly the same 158 tracked failures. Four interleaved control/candidate trials now show same-date ranges 5.7–7.2% faster than the earlier implementation, cross-date ranges 27.3–28.2% faster, and collapsed ranges 4.5% faster. Single-date formatting changes by −0.15%; native controls range from −0.84% to +1.31%. All tasks batch 16 calls, use fixed UTC inputs, and exclude construction. Control `75418c5a5` and candidate `fa565a3ec` use the identical benchmark program with Bazel-pinned Node 24.14.0.
