### PR TITLE
docs(deps): track Test262 results and deferred gaps

### DIFF
--- a/docs/src/docs-metadata.generated.json
+++ b/docs/src/docs-metadata.generated.json
@@ -101,11 +101,11 @@
   },
   "polyfills/intl-collator": {
     "title": "Intl Collator",
-    "description": "A spec-compliant polyfill/ponyfill for Intl.Collator."
+    "description": "A polyfill/ponyfill for Intl.Collator."
   },
   "polyfills/intl-datetimeformat": {
     "title": "Intl Datetimeformat",
-    "description": "A spec-compliant polyfill for Intl.DateTimeFormat fully tested by the official ECMAScript Conformance test suite"
+    "description": "A polyfill for Intl.DateTimeFormat tested by the official ECMAScript Conformance test suite"
   },
   "polyfills/intl-displaynames": {
     "title": "Intl Displaynames",
@@ -113,19 +113,19 @@
   },
   "polyfills/intl-durationformat": {
     "title": "Intl Durationformat",
-    "description": "A spec-compliant polyfill for Intl.DurationFormat"
+    "description": "A polyfill for Intl.DurationFormat"
   },
   "polyfills/intl-getcanonicallocales": {
     "title": "Intl Getcanonicallocales",
-    "description": "A spec-compliant polyfill/ponyfill for Intl.getCanonicalLocales tested by the official ECMAScript Conformance test suite"
+    "description": "A polyfill/ponyfill for Intl.getCanonicalLocales tested by the official ECMAScript Conformance test suite"
   },
   "polyfills/intl-listformat": {
     "title": "Intl Listformat",
-    "description": "A spec-compliant polyfill for Intl.ListFormat fully tested by the official ECMAScript Conformance test suite"
+    "description": "A polyfill for Intl.ListFormat tested by the official ECMAScript Conformance test suite"
   },
   "polyfills/intl-locale": {
     "title": "Intl Locale",
-    "description": "A spec-compliant polyfill/ponyfill for Intl.Locale tested by the official ECMAScript Conformance test suite"
+    "description": "A polyfill/ponyfill for Intl.Locale tested by the official ECMAScript Conformance test suite"
   },
   "polyfills/intl-localematcher": {
     "title": "Intl Localematcher",
@@ -137,11 +137,11 @@
   },
   "polyfills/intl-pluralrules": {
     "title": "Intl Pluralrules",
-    "description": "A spec-compliant polyfill for Intl.PluralRules fully tested by the official ECMAScript Conformance test suite"
+    "description": "A polyfill for Intl.PluralRules tested by the official ECMAScript Conformance test suite"
   },
   "polyfills/intl-relativetimeformat": {
     "title": "Intl Relativetimeformat",
-    "description": "A spec-compliant polyfill for Intl.RelativeTimeFormat fully tested by the official ECMAScript Conformance test suite"
+    "description": "A polyfill for Intl.RelativeTimeFormat tested by the official ECMAScript Conformance test suite"
   },
   "polyfills/intl-segmenter": {
     "title": "Intl Segmenter",
@@ -149,7 +149,7 @@
   },
   "polyfills/intl-supportedvaluesof": {
     "title": "Intl Supportedvaluesof",
-    "description": "A spec-compliant polyfill/ponyfill for Intl.supportedValuesOf."
+    "description": "A polyfill/ponyfill for Intl.supportedValuesOf."
   },
   "python": {
     "title": "Python",

--- a/docs/src/docs/polyfills/intl-collator.mdx
+++ b/docs/src/docs/polyfills/intl-collator.mdx
@@ -1,4 +1,4 @@
-A spec-compliant polyfill/ponyfill for `Intl.Collator`.
+A polyfill/ponyfill for `Intl.Collator`.
 
 [![npm Version](https://img.shields.io/npm/v/@formatjs/intl-collator.svg?style=flat-square)](https://www.npmjs.org/package/@formatjs/intl-collator)
 ![size](https://badgen.net/bundlephobia/minzip/@formatjs/intl-collator)
@@ -89,6 +89,11 @@ data and LDML collation XML so applications do not parse XML at runtime.
 
 This package is tested against FormatJS unit tests, parser tests, and
 conformance data generated from ICU4J and native `Intl.Collator`.
+
+The Bazel `:test262` target checks the upstream suite against a reviewed failure
+baseline. See the [conformance report](https://github.com/formatjs/formatjs/blob/main/knowledge-base/014-test262-conformance.md)
+for known limitations; `bazel test //packages/intl-collator:test262-strict`
+requires zero failures.
 
 ## Input validation
 

--- a/docs/src/docs/polyfills/intl-datetimeformat.mdx
+++ b/docs/src/docs/polyfills/intl-datetimeformat.mdx
@@ -1,4 +1,4 @@
-A spec-compliant polyfill for Intl.DateTimeFormat fully tested by the [official ECMAScript Conformance test suite](https://github.com/tc39/test262)
+A polyfill for Intl.DateTimeFormat tested by the [official ECMAScript Conformance test suite](https://github.com/tc39/test262)
 
 [![npm Version](https://img.shields.io/npm/v/@formatjs/intl-datetimeformat.svg?style=flat-square)](https://www.npmjs.org/package/@formatjs/intl-datetimeformat)
 ![size](https://badgen.net/bundlephobia/minzip/@formatjs/intl-datetimeformat)
@@ -15,7 +15,7 @@ A spec-compliant polyfill for Intl.DateTimeFormat fully tested by the [official 
 
 ## ECMA-402 Spec Compliance
 
-This package is **fully compliant** with the ECMA-402 specification for `Intl.DateTimeFormat`, including all finalized proposals.
+This package implements `Intl.DateTimeFormat`. See the [conformance report](https://github.com/formatjs/formatjs/blob/main/knowledge-base/014-test262-conformance.md) for tested coverage and known limitations.
 
 ### Implemented Features
 
@@ -264,7 +264,7 @@ if ('__setDefaultTimeZone' in Intl.DateTimeFormat) {
 
 ## Tests
 
-This library is fully [test262](https://github.com/tc39/test262/tree/master/test/intl402/DateTimeFormat)-compliant.
+The Bazel `:test262` target runs the upstream suite against a reviewed failure baseline. A green baseline check does not mean every test passed. See the [conformance report](https://github.com/formatjs/formatjs/blob/main/knowledge-base/014-test262-conformance.md); run `bazel test //packages/intl-datetimeformat:test262-strict` to require zero failures.
 
 ## Offset time zones
 

--- a/docs/src/docs/polyfills/intl-displaynames.mdx
+++ b/docs/src/docs/polyfills/intl-displaynames.mdx
@@ -5,7 +5,7 @@ A polyfill for [`Intl.DisplayNames`](https://tc39.es/proposal-intl-displaynames)
 
 ## ECMA-402 Spec Compliance
 
-This package is **fully compliant** with the ECMA-402 specification for `Intl.DisplayNames`.
+This package implements `Intl.DisplayNames`. See the [conformance report](https://github.com/formatjs/formatjs/blob/main/knowledge-base/014-test262-conformance.md) for tested coverage and known limitations.
 
 ### Specification Details
 

--- a/docs/src/docs/polyfills/intl-durationformat.mdx
+++ b/docs/src/docs/polyfills/intl-durationformat.mdx
@@ -1,11 +1,11 @@
-A spec-compliant polyfill for Intl.DurationFormat
+A polyfill for Intl.DurationFormat
 
 [![npm Version](https://img.shields.io/npm/v/@formatjs/intl-durationformat.svg?style=flat-square)](https://www.npmjs.com/package/@formatjs/intl-durationformat)
 ![size](https://badgen.net/bundlephobia/minzip/@formatjs/intl-durationformat)
 
 ## ECMA-402 Spec Compliance
 
-This package implements the **Stage 4** `Intl.DurationFormat` specification, which is included in **ECMA-402 12th Edition (June 2025)**. The implementation is **fully spec-compliant** with all features.
+This package implements `Intl.DurationFormat`. See the [conformance report](https://github.com/formatjs/formatjs/blob/main/knowledge-base/014-test262-conformance.md) for tested coverage and known limitations.
 
 ### Specification Details
 

--- a/docs/src/docs/polyfills/intl-getcanonicallocales.mdx
+++ b/docs/src/docs/polyfills/intl-getcanonicallocales.mdx
@@ -1,4 +1,4 @@
-A spec-compliant polyfill/ponyfill for `Intl.getCanonicalLocales` tested by the [official ECMAScript Conformance test suite](https://github.com/tc39/test262)
+A polyfill/ponyfill for `Intl.getCanonicalLocales` tested by the [official ECMAScript Conformance test suite](https://github.com/tc39/test262)
 
 [![npm Version](https://img.shields.io/npm/v/@formatjs/intl-getcanonicallocales.svg?style=flat-square)](https://www.npmjs.org/package/@formatjs/intl-getcanonicallocales)
 ![size](https://badgen.net/bundlephobia/minzip/@formatjs/intl-getcanonicallocales)
@@ -68,7 +68,7 @@ async function polyfill() {
 
 ## Tests
 
-This library is [test262](https://github.com/tc39/test262/tree/master/test/intl402/Intl/getCanonicalLocales)-compliant.
+The Bazel `:test262` target runs the upstream suite against a reviewed failure baseline. A green baseline check does not mean every test passed. See the [conformance report](https://github.com/formatjs/formatjs/blob/main/knowledge-base/014-test262-conformance.md); run `bazel test //packages/intl-getcanonicallocales:test262-strict` to require zero failures.
 
 ## Locale-list coercion
 

--- a/docs/src/docs/polyfills/intl-listformat.mdx
+++ b/docs/src/docs/polyfills/intl-listformat.mdx
@@ -1,11 +1,11 @@
-A spec-compliant polyfill for Intl.ListFormat fully tested by the [official ECMAScript Conformance test suite](https://github.com/tc39/test262)
+A polyfill for Intl.ListFormat tested by the [official ECMAScript Conformance test suite](https://github.com/tc39/test262)
 
 [![npm Version](https://img.shields.io/npm/v/@formatjs/intl-listformat.svg?style=flat-square)](https://www.npmjs.org/package/@formatjs/intl-listformat)
 ![size](https://badgen.net/bundlephobia/minzip/@formatjs/intl-listformat)
 
 ## ECMA-402 Spec Compliance
 
-This package is **fully compliant** with the ECMA-402 specification for `Intl.ListFormat` and is **test262-compliant**.
+This package implements `Intl.ListFormat`. See the [conformance report](https://github.com/formatjs/formatjs/blob/main/knowledge-base/014-test262-conformance.md) for tested coverage and known limitations.
 
 ### ✅ Implemented Features
 
@@ -164,7 +164,7 @@ async function polyfill(locale: string) {
 
 ## Tests
 
-This library is fully [test262](https://github.com/tc39/test262/tree/master/test/intl402/ListFormat)-compliant.
+The Bazel `:test262` target runs the upstream suite against a reviewed failure baseline. A green baseline check does not mean every test passed. See the [conformance report](https://github.com/formatjs/formatjs/blob/main/knowledge-base/014-test262-conformance.md); run `bazel test //packages/intl-listformat:test262-strict` to require zero failures.
 
 ## Iterable inputs
 

--- a/docs/src/docs/polyfills/intl-locale.mdx
+++ b/docs/src/docs/polyfills/intl-locale.mdx
@@ -1,11 +1,11 @@
-A spec-compliant polyfill/ponyfill for Intl.Locale tested by the [official ECMAScript Conformance test suite](https://github.com/tc39/test262)
+A polyfill/ponyfill for Intl.Locale tested by the [official ECMAScript Conformance test suite](https://github.com/tc39/test262)
 
 [![npm Version](https://img.shields.io/npm/v/@formatjs/intl-locale.svg?style=flat-square)](https://www.npmjs.org/package/@formatjs/intl-locale)
 ![size](https://badgen.net/bundlephobia/minzip/@formatjs/intl-locale)
 
 ## ECMA-402 Spec Compliance
 
-This package is **fully compliant** with the ECMA-402 specification for `Intl.Locale` and is **test262-compliant**.
+This package implements `Intl.Locale`. See the [conformance report](https://github.com/formatjs/formatjs/blob/main/knowledge-base/014-test262-conformance.md) for tested coverage and known limitations.
 
 ### ✅ Implemented Features
 
@@ -160,7 +160,7 @@ async function polyfill() {
 
 ## Tests
 
-This library is [test262](https://github.com/tc39/test262/tree/master/test/intl402/Locale)-compliant.
+The Bazel `:test262` target runs the upstream suite against a reviewed failure baseline. A green baseline check does not mean every test passed. See the [conformance report](https://github.com/formatjs/formatjs/blob/main/knowledge-base/014-test262-conformance.md); run `bazel test //packages/intl-locale:test262-strict` to require zero failures.
 
 ## Weekday and numeric options
 

--- a/docs/src/docs/polyfills/intl-numberformat.mdx
+++ b/docs/src/docs/polyfills/intl-numberformat.mdx
@@ -8,7 +8,7 @@ A polyfill for ESNext [`Intl.NumberFormat`][numberformat] and [`Number.prototype
 
 ## ECMA-402 Spec Compliance
 
-This package is **fully compliant** with the ECMA-402 specification for `Intl.NumberFormat`, including all finalized proposals up through **Intl.NumberFormat v3**.
+This package implements `Intl.NumberFormat`. See the [conformance report](https://github.com/formatjs/formatjs/blob/main/knowledge-base/014-test262-conformance.md) for tested coverage and known limitations.
 
 ### ✅ All Features Implemented
 

--- a/docs/src/docs/polyfills/intl-pluralrules.mdx
+++ b/docs/src/docs/polyfills/intl-pluralrules.mdx
@@ -1,11 +1,11 @@
-A spec-compliant polyfill for [`Intl.PluralRules`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/PluralRules) fully tested by the [official ECMAScript Conformance test suite](https://github.com/tc39/test262)
+A polyfill for [`Intl.PluralRules`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/PluralRules) tested by the [official ECMAScript Conformance test suite](https://github.com/tc39/test262)
 
 [![npm Version](https://img.shields.io/npm/v/@formatjs/intl-pluralrules.svg?style=flat-square)](https://www.npmjs.org/package/@formatjs/intl-pluralrules)
 ![size](https://badgen.net/bundlephobia/minzip/@formatjs/intl-pluralrules)
 
 ## ECMA-402 Spec Compliance
 
-This package is **fully compliant** with the ECMA-402 specification for `Intl.PluralRules` and is **test262-compliant**.
+This package implements `Intl.PluralRules`. See the [conformance report](https://github.com/formatjs/formatjs/blob/main/knowledge-base/014-test262-conformance.md) for tested coverage and known limitations.
 
 ### ✅ Implemented Features
 

--- a/docs/src/docs/polyfills/intl-relativetimeformat.mdx
+++ b/docs/src/docs/polyfills/intl-relativetimeformat.mdx
@@ -1,11 +1,11 @@
-A spec-compliant polyfill for Intl.RelativeTimeFormat fully tested by the [official ECMAScript Conformance test suite](https://github.com/tc39/test262)
+A polyfill for Intl.RelativeTimeFormat tested by the [official ECMAScript Conformance test suite](https://github.com/tc39/test262)
 
 [![npm Version](https://img.shields.io/npm/v/@formatjs/intl-relativetimeformat.svg?style=flat-square)](https://www.npmjs.org/package/@formatjs/intl-relativetimeformat)
 ![size](https://badgen.net/bundlephobia/minzip/@formatjs/intl-relativetimeformat)
 
 ## ECMA-402 Spec Compliance
 
-This package is **fully compliant** with the ECMA-402 specification for `Intl.RelativeTimeFormat`. All features from the finalized proposal are implemented.
+This package implements `Intl.RelativeTimeFormat`. See the [conformance report](https://github.com/formatjs/formatjs/blob/main/knowledge-base/014-test262-conformance.md) for tested coverage and known limitations.
 
 ### Specification Details
 
@@ -231,7 +231,7 @@ async function polyfill(locale: string) {
 
 ## Tests
 
-This library is fully [test262](https://github.com/tc39/test262/tree/master/test/intl402/RelativeTimeFormat)-compliant.
+The Bazel `:test262` target runs the upstream suite against a reviewed failure baseline. A green baseline check does not mean every test passed. See the [conformance report](https://github.com/formatjs/formatjs/blob/main/knowledge-base/014-test262-conformance.md); run `bazel test //packages/intl-relativetimeformat:test262-strict` to require zero failures.
 
 Loading `und` locale data preserves existing English data. Root patterns remain
 separate from language-specific patterns, regardless of registration order.

--- a/docs/src/docs/polyfills/intl-segmenter.mdx
+++ b/docs/src/docs/polyfills/intl-segmenter.mdx
@@ -5,7 +5,7 @@ A polyfill for [`Intl.Segmenter`](https://tc39.es/proposal-intl-segmenter).
 
 ## ECMA-402 Spec Compliance
 
-This package is **fully compliant** with the ECMA-402 specification for `Intl.Segmenter`.
+This package implements `Intl.Segmenter`. See the [conformance report](https://github.com/formatjs/formatjs/blob/main/knowledge-base/014-test262-conformance.md) for tested coverage and known limitations.
 
 ### Specification Details
 

--- a/docs/src/docs/polyfills/intl-supportedvaluesof.mdx
+++ b/docs/src/docs/polyfills/intl-supportedvaluesof.mdx
@@ -1,4 +1,4 @@
-A spec-compliant polyfill/ponyfill for `Intl.supportedValuesOf`.
+A polyfill/ponyfill for `Intl.supportedValuesOf`.
 
 [![npm Version](https://img.shields.io/npm/v/@formatjs/intl-supportedvaluesof.svg?style=flat-square)](https://www.npmjs.org/package/@formatjs/intl-supportedvaluesof)
 ![size](https://badgen.net/bundlephobia/minzip/@formatjs/intl-supportedvaluesof)
@@ -65,7 +65,7 @@ async function polyfill() {
 
 ## Tests
 
-This library is [test262](https://github.com/tc39/test262/tree/master/test/intl402/Intl/supportedValuesOf)-compliant.
+The Bazel `:test262` target runs the upstream suite against a reviewed failure baseline. A green baseline check does not mean every test passed. See the [conformance report](https://github.com/formatjs/formatjs/blob/main/knowledge-base/014-test262-conformance.md); run `bazel test //packages/intl-supportedvaluesof:test262-strict` to require zero failures.
 
 ## Key coercion
 

--- a/knowledge-base/007-package-intl-polyfills.md
+++ b/knowledge-base/007-package-intl-polyfills.md
@@ -64,16 +64,16 @@ All polyfills depend on `@formatjs/ecma402-abstract` and `@formatjs/intl-localem
 
 ## Individual Polyfill Docs
 
-- [007a — intl-numberformat](./007a-polyfill-intl-numberformat.md) — ECMA-402 §11
-- [007b — intl-datetimeformat](./007b-polyfill-intl-datetimeformat.md) — ECMA-402 §12 (+ IANA timezone pipeline)
-- [007c — intl-pluralrules](./007c-polyfill-intl-pluralrules.md) — ECMA-402 §16 (CLDR rule compiler)
+- [007a — intl-numberformat](./007a-polyfill-intl-numberformat.md) — ECMA-402 §16
+- [007b — intl-datetimeformat](./007b-polyfill-intl-datetimeformat.md) — ECMA-402 §11 (+ IANA timezone pipeline)
+- [007c — intl-pluralrules](./007c-polyfill-intl-pluralrules.md) — ECMA-402 §17 (CLDR rule compiler)
 - [007d — intl-displaynames](./007d-polyfill-intl-displaynames.md) — ECMA-402 §12
-- [007e — intl-listformat](./007e-polyfill-intl-listformat.md) — ECMA-402 §13
-- [007f — intl-relativetimeformat](./007f-polyfill-intl-relativetimeformat.md) — ECMA-402 §17
-- [007g — intl-durationformat](./007g-polyfill-intl-durationformat.md) — Stage 3 Proposal
-- [007h — intl-segmenter](./007h-polyfill-intl-segmenter.md) — ECMA-402 §18 (Unicode segmentation rules)
-- [007i — intl-locale](./007i-polyfill-intl-locale.md) — ECMA-402 §14 (6 CLDR data sources)
-- [007j — intl-getcanonicallocales](./007j-polyfill-intl-getcanonicallocales.md) — ECMA-402 §8.2.1
+- [007e — intl-listformat](./007e-polyfill-intl-listformat.md) — ECMA-402 §14
+- [007f — intl-relativetimeformat](./007f-polyfill-intl-relativetimeformat.md) — ECMA-402 §18
+- [007g — intl-durationformat](./007g-polyfill-intl-durationformat.md) — ECMA-402 §13
+- [007h — intl-segmenter](./007h-polyfill-intl-segmenter.md) — ECMA-402 §19 (Unicode segmentation rules)
+- [007i — intl-locale](./007i-polyfill-intl-locale.md) — ECMA-402 §15 (6 CLDR data sources)
+- [007j — intl-getcanonicallocales](./007j-polyfill-intl-getcanonicallocales.md) — ECMA-402 §8.3.1
 - [007k — intl-supportedvaluesof](./007k-polyfill-intl-supportedvaluesof.md) — ECMA-402 §8.3.2
 - [007l — intl-collator](./007l-polyfill-intl-collator.md) — ECMA-402 §10 (CLDR collation compiler)
 
@@ -105,8 +105,9 @@ All twelve package suites now select every upstream test at revision
 `419d3e0a2273ba01a3bfcbec423f2801425b8e93`; `test262.BUILD` has no file exclusions.
 The prelude also installs polyfills in nested Test262 realms. Run
 `:test262-native` for the corresponding native-only control. Both modes use
-the same stable host settings; missing Temporal support remains visible. See
-[the full baseline and runtime comparison](./014-test262-conformance.md).
+the same pinned Node 26.8.1 host; fixtures verify Temporal in nested realms. See
+[the full baseline and runtime comparison](./014-test262-conformance.md) and
+[the remaining gaps and performance report](./015-test262-progress-2026-09-09.md).
 
 Test262 execution uses rules_js generated harness rules. Strict/native modes
 are direct harness tests; baseline mode invokes the generated harness binary

--- a/knowledge-base/007c-polyfill-intl-pluralrules.md
+++ b/knowledge-base/007c-polyfill-intl-pluralrules.md
@@ -1,6 +1,6 @@
 # @formatjs/intl-pluralrules
 
-**ECMA-402 Section 16** — `Intl.PluralRules`
+**ECMA-402 Section 17** — `Intl.PluralRules`
 
 ## Purpose
 

--- a/knowledge-base/007e-polyfill-intl-listformat.md
+++ b/knowledge-base/007e-polyfill-intl-listformat.md
@@ -1,6 +1,6 @@
 # @formatjs/intl-listformat
 
-**ECMA-402 Section 13** — `Intl.ListFormat`
+**ECMA-402 Section 14** — `Intl.ListFormat`
 
 ## Purpose
 

--- a/knowledge-base/007g-polyfill-intl-durationformat.md
+++ b/knowledge-base/007g-polyfill-intl-durationformat.md
@@ -1,6 +1,6 @@
 # @formatjs/intl-durationformat
 
-**ECMA-402 Stage 3 Proposal** — `Intl.DurationFormat`
+**ECMA-402 Section 13** — `Intl.DurationFormat`
 
 ## Purpose
 

--- a/knowledge-base/007h-polyfill-intl-segmenter.md
+++ b/knowledge-base/007h-polyfill-intl-segmenter.md
@@ -1,6 +1,6 @@
 # @formatjs/intl-segmenter
 
-**ECMA-402 Section 18** — `Intl.Segmenter`
+**ECMA-402 Section 19** — `Intl.Segmenter`
 
 ## Purpose
 

--- a/knowledge-base/007i-polyfill-intl-locale.md
+++ b/knowledge-base/007i-polyfill-intl-locale.md
@@ -1,6 +1,6 @@
 # @formatjs/intl-locale
 
-**ECMA-402 Section 14** — `Intl.Locale`
+**ECMA-402 Section 15** — `Intl.Locale`
 
 ## Purpose
 

--- a/knowledge-base/007j-polyfill-intl-getcanonicallocales.md
+++ b/knowledge-base/007j-polyfill-intl-getcanonicallocales.md
@@ -1,6 +1,6 @@
 # @formatjs/intl-getcanonicallocales
 
-**ECMA-402 Section 8.2.1** — `Intl.getCanonicalLocales`
+**ECMA-402 Section 8.3.1** — `Intl.getCanonicalLocales`
 
 ## Purpose
 

--- a/knowledge-base/014-test262-conformance.md
+++ b/knowledge-base/014-test262-conformance.md
@@ -27,14 +27,12 @@ spec and test's feature metadata.
 
 Combined: 2,498 executions, 2,312 passes, 186 failures.
 
-Combined installation adds 2 failing executions; 2 isolated failures now pass.
-Two Locale branding cases pass with the installed getCanonicalLocales polyfill.
-Two RelativeTimeFormat cases pass because combined enumeration omits numbering
-systems that the NumberFormat polyfill does not support; this is not broader
-numbering-system conformance.
-Compact PluralRules now passes independently of NumberFormat locale data.
-The extra failures concern NumberFormat dependencies and optional collation data. Full raw reports accompany Bazel
-test outputs; the checked-in baselines preserve every remaining diagnostic.
+Combined installation adds two Locale collation-data expectation failures while
+fixing two native Locale-branding failures. RelativeTimeFormat has the same two
+foreign-realm failures in both modes; its numbering-system coverage no longer
+depends on suppressing unsupported systems. Compact PluralRules also passes
+independently of NumberFormat locale data. Raw reports and checked-in baselines
+preserve every remaining diagnostic.
 
 ## Harness guarantees
 
@@ -62,18 +60,12 @@ not need a directory-wide Gazelle ignore.
 
 ## Work remaining
 
-1. Fix runtime errors by spec algorithm, removing baseline entries as they pass.
-   NumberFormat range validation, branding, and option key order
-   are distinct reviewable clusters.
-2. Repair locale data and locale selection in ListFormat and RelativeTimeFormat.
-3. Implement missing Locale variants/region overrides and PluralRules notation
-   behavior. Check proposal feature metadata against the targeted ECMA-402 draft.
-4. Classify DateTimeFormat/DurationFormat Temporal cases with native controls.
-   Native failures must not be mistaken for proof that upstream tests are wrong.
-5. Fix failures from combined installation coverage, where all 12 polyfills
-   replace native Intl dependencies in every realm.
-6. Reduce all baselines to zero where implementable. Document any remaining
-   runtime limitation per test and spec requirement, never as a blanket skip.
+The [2026-09-09 tracking report](./015-test262-progress-2026-09-09.md) classifies
+all 186 remaining failures per mode, with exact testcase inventory, spec
+references, deferred tradeoffs, and performance measurements. Temporal input
+integration and non-Gregorian calendars remain substantial implementation gaps.
+Foreign-realm/native-brand limitations, optional legacy construction, and
+specific data/proposal expectations stay visible in the raw counts.
 
 ## Commands
 
@@ -158,19 +150,19 @@ Packages load only entries with standalone CLDR data files; aliases remain a
 locale-registration concern.
 
 Shared locale fixtures remove four Indian grouping failures in each mode and
-two combined French compact-plural failures. Portuguese range and Polish
-grouping diagnostics now reflect loaded locale data; those bugs remain tracked.
+two combined French compact-plural failures. Subsequent NumberFormat range and
+numbering-system fixes also resolve the Portuguese range and Polish grouping cases.
 
 ASCII locale parsing removes four combined RegExp-statics failures in Collator
 and NumberFormat. Isolated getCanonicalLocales remains at zero failures.
 
 Minute/second-only matching removes four fractional-second formatting failures in
-each mode. Range equality and flexible day periods remain failing; their
-diagnostics now reflect the newly selected patterns.
+each mode. Subsequent fixes resolve range equality at displayed precision and
+flexible day periods using CLDR rules.
 
 Calendar negotiation supports Gregorian and ISO 8601 and falls back for other
 requests. Six DateTimeFormat failures per mode are fixed; Chinese-calendar and
-Era-monthcode proposal failures remain tracked.
+Stage 4 Era/Month Code integration failures remain tracked.
 
 Standalone PluralRules now uses its own compact exponent tables for the nine
 CLDR locales with c/e operands. Two isolated failures are fixed; combined

--- a/knowledge-base/015-test262-progress-2026-09-09.md
+++ b/knowledge-base/015-test262-progress-2026-09-09.md
@@ -1,0 +1,207 @@
+# Test262 progress and deferred work — 2026-09-09
+
+The twelve polyfills execute every test in their upstream Test262 directories,
+both independently and with all twelve installed. Each mode currently records
+2,312 passes from 2,498 executions, with 186 failures kept in reviewed baselines.
+This is not 100% Test262 or ECMA-402 conformance. A green baseline gate verifies
+unchanged outcomes; the `-strict` target requires zero failures.
+
+## Reproducible scope
+
+- Test262: `419d3e0a2273ba01a3bfcbec423f2801425b8e93`; all 1,249 testcase files run in default and strict modes. Each package denominator matches its upstream directory.
+- ECMA-402 draft: [`b1c961988b9a07894b1dc3dc2b5626ea48387d61`](https://github.com/tc39/ecma402/commit/b1c961988b9a07894b1dc3dc2b5626ea48387d61), rechecked 2026-09-09.
+- Harness: checksum-pinned Node 26.8.1, including real nested realms and Temporal. Normal build/benchmark tools use Node 24.14.0.
+- Locale data: CLDR 48.2; timezone data: IANA 2026c.
+- Final verification at code revision `fa565a3ec3d5eee4451bf3338a1e1788312c73b4`:
+  all 24 baseline gates pass with `--nocache_test_results --local_test_jobs=3`.
+  Each isolated package `:test262` target and `//tools/test262:combined` was
+  invoked explicitly; every report was checked against its baseline.
+
+See [per-package totals and harness guarantees](./014-test262-conformance.md).
+The native control's failures do not establish correctness of a polyfill.
+These tests also do not exhaust every locale, calendar, timezone transition,
+Unicode rule, or browser runtime.
+
+## Remaining failures
+
+Counts below are executions in each mode, not exclusions from the denominator.
+The [categorized testcase inventory](./015a-test262-deferred-cases.json) covers
+every remaining execution. Exact diagnostics remain in the package baselines
+and `tools/test262/baselines/combined-*.json`.
+
+| Category                                     | Isolated | Combined | Disposition                                       |
+| -------------------------------------------- | -------: | -------: | ------------------------------------------------- |
+| Temporal input integration                   |      110 |      110 | Deferred implementation work                      |
+| Calendar implementation                      |       30 |       30 | Deferred implementation work                      |
+| Foreign-realm default intrinsics             |       20 |       20 | Pure-JavaScript runtime boundary                  |
+| Legacy chained constructors                  |       12 |       12 | Normative optional; intentionally not implemented |
+| Timezone identifier proposal mismatch        |        8 |        8 | Keep selected main-draft behavior                 |
+| Han decimal spacing                          |        2 |        2 | Keep CLDR 48.2 pattern                            |
+| Calendar enumeration/native interoperability |        2 |        2 | Deferred integration tradeoff                     |
+| Native Locale branding                       |        2 |        0 | Native/internal-slot boundary                     |
+| English collation data expectation           |        0 |        2 | No unsupported collation advertised               |
+| **Total**                                    |  **186** |  **186** |                                                   |
+
+### Temporal and calendars
+
+The host provides Temporal. The 110 Temporal failures concern DateTimeFormat
+acceptance, field selection, range compatibility, and timezone interpretation
+of Temporal objects. They are implementation gaps, not missing harness globals.
+A separate 30 executions exercise non-Gregorian calendars, related years,
+eras, leap months, or calendar negotiation. DateTimeFormat currently implements
+Gregorian and ISO 8601 formatting; supplying calendar names alone cannot fix
+these cases.
+
+Temporal and Intl Era/Month Code has reached Stage 4. Its
+[main-spec integration PR](https://github.com/tc39/ecma402/pull/1044) remained open
+at this audit. Stage 4 cases are not optional or early-stage proposals merely
+because integration has not landed. Implementing calendar conversion and
+Temporal-aware formatting together is deferred as substantial feature work.
+
+The approved [AvailableCalendars requirement](https://tc39.es/proposal-intl-era-monthcode/#sup-availablecalendars)
+requires every listed calendar type
+([source line 134](https://github.com/tc39/proposal-intl-era-monthcode/blob/5833eae6c9079ffbb06a9ab7cc5128ebbf6e9ac7/spec.emu#L134)).
+The two supportedValuesOf calendar cases expose a second integration boundary:
+removing `islamic` and `islamic-rgsa` fixes the required-list assertion, but the
+Node 26 native DateTimeFormat still accepts them, so the native-interoperability
+assertion starts failing. That experiment was reverted without widening either
+baseline. It would not implement the missing calendars in combined mode.
+
+### Foreign realms and native Locale branding
+
+[ECMA-262 10.1.14, step 3.a–b](https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-getprototypefromconstructor)
+requires the constructor's realm intrinsic when its `prototype` is not an
+object ([source lines 13612–13614](https://github.com/tc39/ecma262/blob/b7865f0eed2021720f84d561289401bc414874d0/spec.html#L13612-L13614)).
+[GetFunctionRealm, 7.3.24 steps 1–3](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-getfunctionrealm)
+follows internal realm, bound-target, and proxy-target slots
+([source lines 6721–6730](https://github.com/tc39/ecma262/blob/b7865f0eed2021720f84d561289401bc414874d0/spec.html#L6721-L6730)).
+Portable JavaScript exposes no general API for retrieving those slots. A
+harness-only realm registry would hide this production limitation. The 20
+executions remain failing despite the harness installing polyfills in child realms.
+
+For the isolated Locale failures, native CanonicalizeLocaleList cannot recognize
+a WeakMap-backed polyfill's `[[InitializedLocale]]` brand. The relevant branch
+is [ECMA-402 9.2.1](https://tc39.es/ecma402/#sec-canonicalizelocalelist)
+([source lines 51–63](https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/negotiation.html#L51-L63)).
+Both executions pass when the getCanonicalLocales polyfill is installed too.
+
+### Optional constructors and timezone identifiers
+
+The six NumberFormat and six DateTimeFormat legacy-construction executions
+exercise normative-optional chained constructors:
+[ChainNumberFormat 16.1.1.1](https://tc39.es/ecma402/#sec-chainnumberformat)
+([source line 63](https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/numberformat.html#L63))
+and [ChainDateTimeFormat 11.1.1.1](https://tc39.es/ecma402/#sec-chaindatetimeformat)
+([source line 29](https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/datetimeformat.html#L29)).
+They remain visible but intentionally deferred; preserving grandfathered
+construction was not a goal.
+
+The eight timezone cases expect aliases to remain unchanged under the
+canonical-tz proposal. The selected main draft instead stores the
+`[[PrimaryIdentifier]]` in
+[CreateDateTimeFormat 11.1.2, step 20.c](https://tc39.es/ecma402/#sec-createdatetimeformat)
+([source lines 100–103](https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/datetimeformat.html#L100-L103)).
+Do not replace that behavior solely to satisfy a different proposal snapshot.
+
+### Locale-data expectations
+
+The two DateTimeFormat `numbering-system.js` executions now fail on the space
+before `AM`: Test262 expects ASCII space, while the English CLDR 48.2 pattern
+contains U+202F ([CLDR source line 382](https://github.com/unicode-org/cldr-json/blob/bb334e8d6250c9363e957e131bf7e6d08ec72f91/cldr-json/cldr-dates-full/main/en/ca-gregorian.json#L382);
+[Test262 expectation line 26](https://github.com/tc39/test262/blob/419d3e0a2273ba01a3bfcbec423f2801425b8e93/test/intl402/DateTimeFormat/prototype/format/numbering-system.js#L26)).
+Supplementary digits, Han decimal digits, decimal separators,
+and two-digit fields pass their targeted checks. Keep the locale pattern;
+[ECMA-402 11.2.3](https://tc39.es/ecma402/#sec-intl.datetimeformat-internal-slots)
+makes locale data implementation-defined
+([line 222](https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/datetimeformat.html#L222))
+and recommends CLDR
+([line 854](https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/datetimeformat.html#L854)).
+
+Combined Locale adds two `getCollations` failures because Test262 expects a
+nonempty English list. [CollationsOfLocale 15.5.10, step 3](https://tc39.es/ecma402/#sec-collationsoflocale)
+copies the matching Collator `co` list and removes its initial null
+([source lines 663–675](https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/locale.html#L663-L675)).
+[Collator 10.2.3](https://tc39.es/ecma402/#sec-intl.collator-internal-slots)
+requires that initial null but does not require a nondefault English tailoring
+([source lines 93–98](https://github.com/tc39/ecma402/blob/b1c961988b9a07894b1dc3dc2b5626ea48387d61/spec/collator.html#L93-L98)).
+The current default-only English data produces an empty list. Advertising
+`emoji` or `eor` without implementing those tailorings would misrepresent support.
+
+## Performance
+
+Benchmarks ran through Bazel on macOS arm64 with pinned Node 24.14.0:
+
+- `bazel run //packages/intl-collator/benchmark:run`: six comparison cases,
+  32 comparisons per task, with native controls.
+- `bazel run //packages/intl-datetimeformat:benchmark`: six formatting/range
+  cases, 16 calls per task, with native controls.
+- `bazel run //packages/intl-numberformat/benchmark:benchmark`: eight polyfill
+  cases plus five native controls. Basic cases batch nine values; time values
+  batch 60. This fixture excludes generated-locale hydration and construction.
+
+Trials were interleaved control/candidate in ABBAABBA order, four runs per
+variant. Reported changes compare medians of trial mean latencies, not
+per-operation medians. These runs cover the named workloads, not every polyfill
+or every input.
+
+For NumberFormat and DateTimeFormat, the control runtime is
+[`ad486a6d8`](https://github.com/formatjs/formatjs/commit/ad486a6d84adc07b6db7012cff72b5e40c62f7b4).
+Apply the benchmark-only repairs from [#7304](https://github.com/formatjs/formatjs/pull/7304)
+and [#7317](https://github.com/formatjs/formatjs/pull/7317) to reproduce the local
+control `75418c5a5`; its runtime sources are unchanged. Collator comparisons
+instead change only the root-table representation, using the same benchmark
+program and identical decoded data in both variants.
+
+Combined-Locale pays startup cost for every host process: all twelve polyfills
+and their locale data are loaded repeatedly. CPU profiles identified JavaScript
+compilation of large Collator root tables as a major cost. Serializing those
+numeric payloads as `JSON.parse` strings preserves all three decoded payloads
+and exported types while reducing parser work.
+
+One complete control/candidate suite pair fell from 126.8s to 104.1s (17.9%).
+Ten representative startup profiles per variant had median sampled lifetimes
+of 664.1ms and 589.2ms. Four interleaved steady-state trials showed 7.9–13.0%
+lower median latency across six Collator cases; native controls varied from
+−0.32% to +0.78%. These are macOS arm64 measurements, not universal speed guarantees.
+
+DateTimeFormat benchmark repair exposed a same-date range regression that
+correctness tests could not reveal. The fix reuses endpoint conversions and
+NumberFormat setup within one range call; shared month grammar and source
+attribution remain covered by tests. Four interleaved trials of the fixed
+implementation against the earlier control show 5.7–7.2% lower same-date range
+latency, 27.3–28.2% lower cross-date range latency, and 4.5% lower collapsed-range
+latency. Single-date formatting changes by −0.15%; native controls span
+−0.84% to +1.31%. Each task batches 16 calls with fixed UTC inputs, excluding
+construction. Both control `75418c5a5` and candidate `fa565a3ec` use the identical
+benchmark program.
+
+NumberFormat's six other cases range from −0.89% to +0.84% in the full rerun.
+Initial one-second trials showed currency +2.72% and time values +1.85%; longer
+five-second trials restricted to those cases gave +0.81% and +1.02%, with native
+controls +0.15% and +0.37%. Those small deltas are within observed between-run
+variation. They do not prove exactly zero overhead. The same benchmark program
+was used on both revisions; only timing duration and selected tasks changed for
+the focused rerun.
+
+## Recent review stack
+
+| PR                                                      | Change                                         |
+| ------------------------------------------------------- | ---------------------------------------------- |
+| [#7307](https://github.com/formatjs/formatjs/pull/7307) | CLDR 48.2 prerequisite                         |
+| [#7308](https://github.com/formatjs/formatjs/pull/7308) | LDML number-data lookup foundation             |
+| [#7310](https://github.com/formatjs/formatjs/pull/7310) | Numbering-system data alias foundation         |
+| [#7311](https://github.com/formatjs/formatjs/pull/7311) | Numbering-system support across formatters     |
+| [#7312](https://github.com/formatjs/formatjs/pull/7312) | Gazelle-owned number-data helpers              |
+| [#7313](https://github.com/formatjs/formatjs/pull/7313) | Shared date-range parts and month grammar      |
+| [#7314](https://github.com/formatjs/formatjs/pull/7314) | h24 midnight in date ranges                    |
+| [#7315](https://github.com/formatjs/formatjs/pull/7315) | Gazelle-owned Test262 runner sources           |
+| [#7316](https://github.com/formatjs/formatjs/pull/7316) | Collator root-data startup cost                |
+| [#7317](https://github.com/formatjs/formatjs/pull/7317) | Repaired and expanded DateTimeFormat benchmark |
+| [#7318](https://github.com/formatjs/formatjs/pull/7318) | Reuse date-range formatting setup              |
+
+## Follow-up rule
+
+Keep raw failures visible. Remove baseline entries only after the testcase
+passes with the production implementation, preserve exact test selection, and
+rerun both installation modes. Unsupported features and native-control failures
+must not be converted into success by harness shims or denominator changes.

--- a/knowledge-base/015a-test262-deferred-cases.json
+++ b/knowledge-base/015a-test262-deferred-cases.json
@@ -1,0 +1,148 @@
+{
+  "test262Revision": "419d3e0a2273ba01a3bfcbec423f2801425b8e93",
+  "scenarios": ["default", "strict mode"],
+  "categories": [
+    {
+      "reason": "CLDR spacing expectation",
+      "modes": ["combined", "isolated"],
+      "tests": ["intl402/DateTimeFormat/prototype/format/numbering-system.js"]
+    },
+    {
+      "reason": "Temporal input integration",
+      "modes": ["combined", "isolated"],
+      "tests": [
+        "intl402/DateTimeFormat/prototype/format/temporal-objects-format-weekday-long.js",
+        "intl402/DateTimeFormat/prototype/format/temporal-objects-format-with-era.js",
+        "intl402/DateTimeFormat/prototype/format/temporal-objects-ignore-timezone.js",
+        "intl402/DateTimeFormat/prototype/format/temporal-objects-no-time-clip-non-latin-numerals.js",
+        "intl402/DateTimeFormat/prototype/format/temporal-objects-no-time-clip-weekday.js",
+        "intl402/DateTimeFormat/prototype/format/temporal-objects-no-time-clip.js",
+        "intl402/DateTimeFormat/prototype/format/temporal-objects-not-overlapping-options.js",
+        "intl402/DateTimeFormat/prototype/format/temporal-objects-resolved-time-zone.js",
+        "intl402/DateTimeFormat/prototype/format/temporal-plaindate-formatting-datetime-style.js",
+        "intl402/DateTimeFormat/prototype/format/temporal-plaindate-formatting-timezonename.js",
+        "intl402/DateTimeFormat/prototype/format/temporal-plaindatetime-formatting-datetime-style.js",
+        "intl402/DateTimeFormat/prototype/format/temporal-plaindatetime-formatting-timezonename.js",
+        "intl402/DateTimeFormat/prototype/format/temporal-plainmonthday-formatting-datetime-style.js",
+        "intl402/DateTimeFormat/prototype/format/temporal-plainmonthday-formatting-timezonename.js",
+        "intl402/DateTimeFormat/prototype/format/temporal-plaintime-formatting-datetime-style.js",
+        "intl402/DateTimeFormat/prototype/format/temporal-plaintime-formatting-timezonename.js",
+        "intl402/DateTimeFormat/prototype/format/temporal-plainyearmonth-formatting-datetime-style.js",
+        "intl402/DateTimeFormat/prototype/format/temporal-plainyearmonth-formatting-timezonename.js",
+        "intl402/DateTimeFormat/prototype/formatRange/temporal-objects-format-with-era.js",
+        "intl402/DateTimeFormat/prototype/formatRange/temporal-objects-ignore-timezone.js",
+        "intl402/DateTimeFormat/prototype/formatRange/temporal-objects-no-time-clip-weekday.js",
+        "intl402/DateTimeFormat/prototype/formatRange/temporal-objects-no-time-clip.js",
+        "intl402/DateTimeFormat/prototype/formatRange/temporal-objects-not-overlapping-options.js",
+        "intl402/DateTimeFormat/prototype/formatRange/temporal-objects-resolved-time-zone.js",
+        "intl402/DateTimeFormat/prototype/formatRange/temporal-objects-throws-with-different-calendars.js",
+        "intl402/DateTimeFormat/prototype/formatRange/temporal-plaindate-formatting-timezonename.js",
+        "intl402/DateTimeFormat/prototype/formatRange/temporal-plaindatetime-formatting-timezonename.js",
+        "intl402/DateTimeFormat/prototype/formatRange/temporal-plainmonthday-formatting-timezonename.js",
+        "intl402/DateTimeFormat/prototype/formatRange/temporal-plaintime-formatting-timezonename.js",
+        "intl402/DateTimeFormat/prototype/formatRange/temporal-plainyearmonth-formatting-timezonename.js",
+        "intl402/DateTimeFormat/prototype/formatRange/to-datetime-formattable-with-different-arg-kinds.js",
+        "intl402/DateTimeFormat/prototype/formatRangeToParts/temporal-objects-format-with-era.js",
+        "intl402/DateTimeFormat/prototype/formatRangeToParts/temporal-objects-ignore-timezone.js",
+        "intl402/DateTimeFormat/prototype/formatRangeToParts/temporal-objects-no-time-clip-weekday.js",
+        "intl402/DateTimeFormat/prototype/formatRangeToParts/temporal-objects-no-time-clip.js",
+        "intl402/DateTimeFormat/prototype/formatRangeToParts/temporal-objects-not-overlapping-options.js",
+        "intl402/DateTimeFormat/prototype/formatRangeToParts/temporal-objects-resolved-time-zone.js",
+        "intl402/DateTimeFormat/prototype/formatRangeToParts/temporal-objects-throws-with-different-calendars.js",
+        "intl402/DateTimeFormat/prototype/formatRangeToParts/temporal-plaindate-formatting-timezonename.js",
+        "intl402/DateTimeFormat/prototype/formatRangeToParts/temporal-plaindatetime-formatting-timezonename.js",
+        "intl402/DateTimeFormat/prototype/formatRangeToParts/temporal-plainmonthday-formatting-timezonename.js",
+        "intl402/DateTimeFormat/prototype/formatRangeToParts/temporal-plaintime-formatting-timezonename.js",
+        "intl402/DateTimeFormat/prototype/formatRangeToParts/temporal-plainyearmonth-formatting-timezonename.js",
+        "intl402/DateTimeFormat/prototype/formatRangeToParts/to-datetime-formattable-with-different-arg-kinds.js",
+        "intl402/DateTimeFormat/prototype/formatToParts/temporal-objects-format-with-era.js",
+        "intl402/DateTimeFormat/prototype/formatToParts/temporal-objects-ignore-timezone.js",
+        "intl402/DateTimeFormat/prototype/formatToParts/temporal-objects-no-time-clip-weekday.js",
+        "intl402/DateTimeFormat/prototype/formatToParts/temporal-objects-no-time-clip.js",
+        "intl402/DateTimeFormat/prototype/formatToParts/temporal-objects-not-overlapping-options.js",
+        "intl402/DateTimeFormat/prototype/formatToParts/temporal-objects-resolved-time-zone.js",
+        "intl402/DateTimeFormat/prototype/formatToParts/temporal-plaindate-formatting-timezonename.js",
+        "intl402/DateTimeFormat/prototype/formatToParts/temporal-plaindatetime-formatting-timezonename.js",
+        "intl402/DateTimeFormat/prototype/formatToParts/temporal-plainmonthday-formatting-timezonename.js",
+        "intl402/DateTimeFormat/prototype/formatToParts/temporal-plaintime-formatting-timezonename.js",
+        "intl402/DateTimeFormat/prototype/formatToParts/temporal-plainyearmonth-formatting-timezonename.js"
+      ]
+    },
+    {
+      "reason": "calendar enumeration/native interoperability",
+      "modes": ["combined", "isolated"],
+      "tests": [
+        "intl402/Intl/supportedValuesOf/calendars-required-by-intl-era-monthcode.js"
+      ]
+    },
+    {
+      "reason": "calendar implementation",
+      "modes": ["combined", "isolated"],
+      "tests": [
+        "intl402/DateTimeFormat/canonicalize-calendar.js",
+        "intl402/DateTimeFormat/prototype/format/related-year-zh.js",
+        "intl402/DateTimeFormat/prototype/formatRangeToParts/chinese-calendar-dates.js",
+        "intl402/DateTimeFormat/prototype/formatRangeToParts/dangi-calendar-dates.js",
+        "intl402/DateTimeFormat/prototype/formatRangeToParts/pattern-on-calendar.js",
+        "intl402/DateTimeFormat/prototype/formatToParts/chinese-calendar-dates.js",
+        "intl402/DateTimeFormat/prototype/formatToParts/compare-to-temporal-lunisolar.js",
+        "intl402/DateTimeFormat/prototype/formatToParts/compare-to-temporal.js",
+        "intl402/DateTimeFormat/prototype/formatToParts/dangi-calendar-dates.js",
+        "intl402/DateTimeFormat/prototype/formatToParts/era.js",
+        "intl402/DateTimeFormat/prototype/formatToParts/lunisolar-leap-months.js",
+        "intl402/DateTimeFormat/prototype/formatToParts/pattern-on-calendar.js",
+        "intl402/DateTimeFormat/prototype/formatToParts/related-year-zh.js",
+        "intl402/DateTimeFormat/prototype/formatToParts/related-year.js",
+        "intl402/DateTimeFormat/prototype/resolvedOptions/calendar.js"
+      ]
+    },
+    {
+      "reason": "collation data expectation",
+      "modes": ["combined"],
+      "tests": ["intl402/Locale/prototype/getCollations/output-array-values.js"]
+    },
+    {
+      "reason": "foreign-realm intrinsic",
+      "modes": ["combined", "isolated"],
+      "tests": [
+        "intl402/Collator/proto-from-ctor-realm.js",
+        "intl402/DateTimeFormat/proto-from-ctor-realm.js",
+        "intl402/DisplayNames/proto-from-ctor-realm.js",
+        "intl402/ListFormat/constructor/constructor/proto-from-ctor-realm.js",
+        "intl402/Locale/proto-from-ctor-realm.js",
+        "intl402/NumberFormat/proto-from-ctor-realm.js",
+        "intl402/PluralRules/proto-from-ctor-realm.js",
+        "intl402/RelativeTimeFormat/constructor/constructor/proto-from-ctor-realm.js",
+        "intl402/Segmenter/constructor/constructor/proto-from-ctor-realm.js",
+        "intl402/Segmenter/proto-from-ctor-realm.js"
+      ]
+    },
+    {
+      "reason": "native Locale brand interoperability",
+      "modes": ["isolated"],
+      "tests": ["intl402/Locale/canonicalize-locale-list-take-locale.js"]
+    },
+    {
+      "reason": "normative optional legacy construction",
+      "modes": ["combined", "isolated"],
+      "tests": [
+        "intl402/DateTimeFormat/intl-legacy-constructed-symbol-on-unwrap.js",
+        "intl402/DateTimeFormat/intl-legacy-constructed-symbol-property.js",
+        "intl402/DateTimeFormat/intl-legacy-constructed-symbol.js",
+        "intl402/NumberFormat/intl-legacy-constructed-symbol-on-unwrap.js",
+        "intl402/NumberFormat/intl-legacy-constructed-symbol-property.js",
+        "intl402/NumberFormat/intl-legacy-constructed-symbol.js"
+      ]
+    },
+    {
+      "reason": "timezone identifier proposal mismatch",
+      "modes": ["combined", "isolated"],
+      "tests": [
+        "intl402/DateTimeFormat/canonicalize-timezone.js",
+        "intl402/DateTimeFormat/canonicalize-utc-timezone.js",
+        "intl402/DateTimeFormat/timezone-case-insensitive.js",
+        "intl402/DateTimeFormat/timezone-not-canonicalized.js"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Record the final 24-suite sweep: all 1,249 upstream testcase files run in default and strict modes, with 2,312 passes and 186 tracked failures per installation mode. The report links exact spec requirements, explains deferred implementation/runtime/data tradeoffs, and includes an inventory that matches every remaining failure. No tests were removed from the denominator.

Document the combined-Locale startup improvement and paired Collator, DateTimeFormat, and NumberFormat benchmarks. Correct stale ECMA-402 section numbers and public claims of full conformance; regenerate affected page metadata.

Validation: all 24 Test262 baseline gates pass with uncached execution, and all reports match their baselines. `bazel build //docs:dist` and all six `//docs/...` checks pass. All twelve rendered polyfill pages link the current conformance report; the categorized inventory exactly matches both sets of baselines. Hooks pass.
