### PR TITLE
fix(@formatjs/editor): bootstrap the headless editor release

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -10,7 +10,7 @@
   "packages/cli-native-win32-x64": "1.1.18",
   "packages/cli": "6.16.23",
   "packages/ecma376": "0.5.8",
-  "packages/editor": "1.2.0",
+  "packages/editor": "0.0.0",
   "packages/eslint-plugin-formatjs": "6.6.2",
   "packages/fast-memoize": "3.1.7",
   "packages/icu-messageformat-parser": "3.5.17",

--- a/knowledge-base/013-editor-vrt.md
+++ b/knowledge-base/013-editor-vrt.md
@@ -67,3 +67,10 @@ No editor package disables Gazelle.
 registry, and Release Please npm publishing. Its public `index.ts` bundles
 headless APIs and declarations; React 19 is a peer dependency. Demo and VRT
 packages are development-only and are excluded from the npm artifact.
+
+The headless editor's initial release is `1.2.0`, configured with
+`initial-version`. Until that release lands, its Release Please manifest entry
+is `0.0.0` (unreleased). The manifest records released versions, not the next
+target: setting it to `1.2.0` makes Release Please send the nonexistent
+`@formatjs/editor@1.2.0` tag to GitHub's release-notes API as `previous_tag`.
+Release Please updates the manifest after the release PR lands.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -144,6 +144,7 @@
     },
     "packages/editor": {
       "component": "@formatjs/editor",
+      "initial-version": "1.2.0",
       "extra-files": [
         "package.json",
         {


### PR DESCRIPTION
Release Please fails while generating editor release notes because the manifest claims `1.2.0` was already released, but `@formatjs/editor@1.2.0` does not exist. This blocks the entire release PR update; the failure began with #7285, before the polyfill stack landed.

Use the unreleased `0.0.0` manifest sentinel and configure `initial-version: 1.2.0` separately. This preserves the intended headless release version without fabricating a previous tag. Existing tags and package versions stay unchanged. Document the bootstrap state in the editor knowledge base.

Release Please 17.6.0 [skips manifest tag backfill for 0.0.0](https://github.com/googleapis/release-please/blob/v17.6.0/src/manifest.ts#L675-L699) and [uses initial-version for an initial release](https://github.com/googleapis/release-please/blob/v17.6.0/src/strategies/base.ts#L709-L717).

Validation: reproduced GitHub HTTP 400 with `previous_tag_name=@formatjs/editor@1.2.0`; the initial-release notes request without that field succeeds. Both Bazel release workspace/path tests, the generated workspace graph build, and commit hooks pass. These API calls previewed notes only; no release was published.
