### PR TITLE
ci(deps): avoid duplicate Bazel cache uploads

### DIFF
--- a/.github/actions/setup-bazel/action.yml
+++ b/.github/actions/setup-bazel/action.yml
@@ -1,0 +1,42 @@
+name: Setup Bazel
+description: Restore shared downloads and keep cache writes off pull requests.
+
+inputs:
+  disk-cache:
+    description: Job-specific action cache name.
+    required: true
+  save-repository-cache:
+    description: Allow the main test job to populate the shared download cache.
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: Restore repository cache
+      if: ${{ !(inputs.save-repository-cache == 'true' && github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)) }}
+      uses: actions/cache/restore@v5
+      with:
+        path: ${{ runner.temp }}/bazel-repo
+        key: formatjs-bazel-repository-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/MODULE.bazel', '**/MODULE.bazel.lock', '**/pnpm-lock.yaml') }}
+        restore-keys: |
+          formatjs-bazel-repository-v1-${{ runner.os }}-${{ runner.arch }}-
+
+    # Only one job saves this large archive; sibling jobs must not compress it
+    # just to lose the cache reservation race at the end of their builds.
+    - name: Restore and save repository cache
+      if: ${{ inputs.save-repository-cache == 'true' && github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+      uses: actions/cache@v5
+      with:
+        path: ${{ runner.temp }}/bazel-repo
+        key: formatjs-bazel-repository-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/MODULE.bazel', '**/MODULE.bazel.lock', '**/pnpm-lock.yaml') }}
+        restore-keys: |
+          formatjs-bazel-repository-v1-${{ runner.os }}-${{ runner.arch }}-
+
+    - name: Setup Bazel and action cache
+      uses: bazel-contrib/setup-bazel@0.19.0
+      with:
+        bazelisk-cache: true
+        disk-cache: ${{ inputs.disk-cache }}
+        repository-cache: false
+        cache-save: ${{ github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+        bazelrc: common --repository_cache=${{ runner.temp }}/bazel-repo

--- a/.github/workflows/crates-release.yml
+++ b/.github/workflows/crates-release.yml
@@ -45,11 +45,9 @@ jobs:
           ref: ${{ github.event.release.tag_name || github.ref }}
 
       - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@0.19.0
+        uses: ./.github/actions/setup-bazel
         with:
-          bazelisk-cache: true
           disk-cache: ${{ github.workflow }}
-          repository-cache: true
 
       - name: Select Crates
         id: crates

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -89,11 +89,9 @@ jobs:
           python-version: '3.14'
 
       - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@0.19.0
+        uses: ./.github/actions/setup-bazel
         with:
-          bazelisk-cache: true
           disk-cache: ${{ github.workflow }}-python-wheels
-          repository-cache: true
 
       - name: Test Python Binding
         env:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,11 +28,9 @@ jobs:
           fetch-depth: 2
 
       - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@0.19.0
+        uses: ./.github/actions/setup-bazel
         with:
-          bazelisk-cache: true
           disk-cache: ${{ github.workflow }}
-          repository-cache: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,11 +24,9 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@0.19.0
+        uses: ./.github/actions/setup-bazel
         with:
-          bazelisk-cache: true
           disk-cache: ${{ github.workflow }}-native-packages
-          repository-cache: true
 
       - name: Build Packages
         env:
@@ -239,11 +237,9 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@0.19.0
+        uses: ./.github/actions/setup-bazel
         with:
-          bazelisk-cache: true
           disk-cache: ${{ github.workflow }}
-          repository-cache: true
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6

--- a/.github/workflows/renovate-bazel-lock.yml
+++ b/.github/workflows/renovate-bazel-lock.yml
@@ -30,11 +30,9 @@ jobs:
           persist-credentials: false
 
       - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@0.19.0
+        uses: ./.github/actions/setup-bazel
         with:
-          bazelisk-cache: true
           disk-cache: ${{ github.workflow }}
-          repository-cache: true
 
       - name: Update Bazel Lockfile
         id: lockfile

--- a/.github/workflows/rust-cli-release.yml
+++ b/.github/workflows/rust-cli-release.yml
@@ -26,11 +26,9 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@0.19.0
+        uses: ./.github/actions/setup-bazel
         with:
-          bazelisk-cache: true
           disk-cache: ${{ github.workflow }}-release-binaries
-          repository-cache: true
 
       - name: Build Binaries
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,11 +21,10 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@0.19.0
+        uses: ./.github/actions/setup-bazel
         with:
-          bazelisk-cache: true
           disk-cache: ${{ github.workflow }}
-          repository-cache: true
+          save-repository-cache: true
 
       - name: Build Hermetic Timezone Data
         run: bazel build //packages/intl-datetimeformat:tz_data_generated
@@ -73,11 +72,9 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@0.19.0
+        uses: ./.github/actions/setup-bazel
         with:
-          bazelisk-cache: true
           disk-cache: ${{ github.workflow }}-examples-${{ matrix.example }}
-          repository-cache: true
 
       - name: Build Example
         working-directory: examples/${{ matrix.example }}
@@ -132,11 +129,9 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@0.19.0
+        uses: ./.github/actions/setup-bazel
         with:
-          bazelisk-cache: true
           disk-cache: ${{ github.workflow }}-release-cross-build
-          repository-cache: true
 
       - name: Build Release Artifacts
         run: |

--- a/.github/workflows/typesense-index.yml
+++ b/.github/workflows/typesense-index.yml
@@ -19,14 +19,9 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v7
 
-      - uses: bazel-contrib/setup-bazel@0.19.0
+      - uses: ./.github/actions/setup-bazel
         with:
-          # Avoid downloading Bazel every time.
-          bazelisk-cache: true
-          # Store build cache per workflow.
           disk-cache: ${{ github.workflow }}
-          # Share repository cache between workflows.
-          repository-cache: true
 
       # Build the Typesense index
       - name: Build Typesense Index

--- a/.github/workflows/verify-hooks.yml
+++ b/.github/workflows/verify-hooks.yml
@@ -29,11 +29,9 @@ jobs:
           node-version: '24'
 
       - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@0.19.0
+        uses: ./.github/actions/setup-bazel
         with:
-          bazelisk-cache: true
           disk-cache: ${{ github.workflow }}
-          repository-cache: true
 
       - name: Run Lefthook
         run: |

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -14,14 +14,9 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v7
 
-      - uses: bazel-contrib/setup-bazel@0.19.0
+      - uses: ./.github/actions/setup-bazel
         with:
-          # Avoid downloading Bazel every time.
-          bazelisk-cache: true
-          # Store build cache per workflow.
           disk-cache: ${{ github.workflow }}
-          # Share repository cache between workflows.
-          repository-cache: true
 
       # Build the docs site
       - name: Build Docs Site

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,12 @@ bazel run //:generate_package_tsconfigs
 
 This repository uses a highly optimized TypeScript build pipeline with Bazel:
 
+CI restores Bazel caches for pull requests but does not save them. Pushes to
+the default branch refresh job-specific action caches; only the main test job
+saves the shared repository download cache. A cache miss still runs the full
+build and tests. Keep new workflows on `.github/actions/setup-bazel` so parallel
+jobs do not repeatedly compress and upload the same downloads.
+
 #### Fast Parallel Type Checking with TypeScript 7
 
 Type checking is performed using the native [`tsc` from TypeScript 7](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/). `rules_ts` reads the root `typescript` version from `package.json`, and `ts_project` uses that compiler by default:

--- a/knowledge-base/001a-bazel-toolchain.md
+++ b/knowledge-base/001a-bazel-toolchain.md
@@ -76,6 +76,26 @@ across the monorepo.
 
 ## TypeScript Build Pipeline
 
+### GitHub Actions cache ownership
+
+`.github/actions/setup-bazel` keeps cache restoration separate from writes.
+Pull requests, merge groups, manual runs, and tag builds restore caches only.
+Default-branch pushes save each job's disk cache. Only `test.yml`'s `test` job
+sets `save-repository-cache: true`, so it alone saves the shared repository
+download archive after a successful default-branch push.
+
+Repository cache keys include the OS, architecture, module files, module locks,
+and pnpm locks; prefix fallback reuses older downloads after dependency changes.
+The repository cache remains content-addressed by Bazel. Cache misses download
+dependencies normally. The new cache namespace starts cold until a main test
+run populates it. This policy does not change BuildBuddy RBE or remote action
+caching.
+
+This avoids expensive duplicate archive work: main run `34421727498` spent
+329 seconds in cache cleanup, including 289 seconds compressing/reserving a
+repository cache that another job was already creating. `cache-save: false`
+skips that post-job work while preserving restoration.
+
 ### Published Packages
 
 The package directories in `PACKAGES_TO_DIST` are assembled through

--- a/knowledge-base/016-build-test-speed-2026-09-10.md
+++ b/knowledge-base/016-build-test-speed-2026-09-10.md
@@ -1,0 +1,68 @@
+# Build and test speed after the polyfill stack
+
+## Matched local measurements
+
+Compare main immediately before the final stack (`fb436f09f`) with the directly
+pushed stack (`f7e0d1a3a`). Both use Bazel 9.2.0 and Node 24.14.0 on the same
+macOS arm64 host. This isolates the final twelve changes, not every change since
+the original ECMA-402 audit.
+
+Build NumberFormat, DateTimeFormat, and Collator `:pkg` targets together, with
+six jobs, empty disk/remote action caches, and a shared warm repository download
+cache. Use a fresh output base for each cold build; no `bazel clean` is needed.
+Run two pairs in before/after, then after/before order. Timings include Bazel
+startup, analysis, and execution; these are cold output builds, not cold downloads.
+
+| Measurement                                | Before           | After            |
+| ------------------------------------------ | ---------------- | ---------------- |
+| Cold package build, both trials            | 64.418s, 61.361s | 62.774s, 62.912s |
+| Mean cold build                            | 62.890s          | 62.843s          |
+| First no-op rebuild, both trials           | 1.476s, 1.493s   | 1.433s, 1.375s   |
+| Second no-op rebuild, both trials          | 0.475s, 0.445s   | 0.409s, 0.447s   |
+| Comment-only incremental edit, both trials | 1.633s, 1.663s   | 1.743s, 1.672s   |
+| Uncached focused test median, four trials  | 2.061s           | 2.053s           |
+
+The incremental edit appends a comment to NumberFormat `core.ts`; restore it
+after each variant. This checks source invalidation but does not model a runtime
+change that alters generated data or broad dependencies. Its mean difference is
+0.060s, too little evidence to claim a meaningful regression from two trials.
+
+Focused tests are `//packages/intl-numberformat:unit_tests`,
+`//packages/intl-datetimeformat:intl-datetimeformat_test`, and
+`//packages/intl-collator:intl-collator_test`. Warm their build outputs once, then
+run four trials per variant in ABBAABBA order with `--nocache_test_results`.
+Before timings: 2.094s, 2.059s, 2.062s, 2.060s. After: 2.171s, 2.076s, 2.030s,
+2.017s. Every test passes. These measurements do not establish the cost of a
+cold `//...` Rust/TypeScript build or the full Test262 suite.
+
+For reproduction, use detached worktrees at the two commits and run:
+
+```sh
+bazel --output_base=/absolute/path/to/fresh-output-base build \
+  --repository_cache=/absolute/path/to/shared-download-cache \
+  --disk_cache= --remote_cache= --remote_executor= --jobs=6 \
+  //packages/intl-numberformat:pkg \
+  //packages/intl-datetimeformat:pkg \
+  //packages/intl-collator:pkg
+```
+
+Repeat the same command for no-op and incremental measurements. See
+[the runtime benchmark report](015-test262-progress-2026-09-09.md#performance)
+for formatting latency and combined-Locale startup results.
+
+## CI cache overhead
+
+[Main run 34421727498](https://github.com/formatjs/formatjs/actions/runs/34421727498)
+took 807s for the test job, including 334s in Run Tests and 329s in Post Setup
+Bazel. The repository cache alone spent 289s compressing/reserving an archive
+before losing a reservation race to another writer. The preceding main job took
+395s overall with 261s in Run Tests and 28s in cache cleanup. These CI runs have
+different cache and runner conditions; they are not controlled build benchmarks.
+
+The shared setup action now lets only the main test job save the repository
+cache. Other jobs restore it without registering a save. Disk-cache keys remain
+unchanged, with writes restricted to default-branch pushes. This removes PR
+archive work and duplicate repository writers without changing test selection
+or BuildBuddy execution. The new repository-cache namespace starts cold until
+its first successful main test run. PR CI validates the restore-only path;
+the writer path runs after merge on main.


### PR DESCRIPTION
A main test job spent 329 seconds saving Bazel caches, including 289 seconds compressing a repository archive before losing a reservation race. Parallel workflows all attempted to save the same downloads, and PR jobs also uploaded caches.

Centralize setup in a composite action. Only the main test job saves the shared repository cache; other jobs restore it. Default-branch pushes retain disk-cache writes with existing keys, while PRs, merge groups, manual runs, and tag builds restore only. All workflows use the same policy. BuildBuddy settings and test selection are unchanged.

Matched measurements of the final polyfill stack show effectively unchanged local build/test speed: mean cold package build 62.890s before / 62.843s after; uncached focused tests 2.061s / 2.053s. The tracking doc records commits, commands, trial order, raw timings, and limits. These measurements cover NumberFormat, DateTimeFormat, and Collator, not a cold whole-repo Rust build.

Validation: two fresh-output-base build pairs, no-op/incremental builds, four interleaved uncached test trials per revision, and commit hooks pass. actionlint 1.7.12 passes after excluding its unsupported existing `concurrency.queue` field. PR CI exercises restore-only behavior; the single writer activates on main after merge. The new repository-cache namespace starts cold until then.

CI result: all checks pass on `6e6ee34fc`. [Run 34426175183](https://github.com/formatjs/formatjs/actions/runs/34426175183) reports 0 seconds in Post Setup Bazel for both test and release-artifact jobs; logs confirm cache saving is disabled. The full test job took 343 seconds. This verifies PR cleanup behavior; it is not a controlled claim that every CI run is 464 seconds faster.
