### PR TITLE
feat(@formatjs/editor): support shared locale drafts and typed save results

### DIFF
--- a/knowledge-base/008-package-intl-and-framework-integrations.md
+++ b/knowledge-base/008-package-intl-and-framework-integrations.md
@@ -77,8 +77,10 @@ callers can still pass an existing values map.
 
 ## @formatjs/editor
 
-**Purpose:** ICU MessageFormat editor UI component (React-based).
+**Purpose:** Headless ICU MessageFormat editing and translation workflows for React 19.
 
-- Interactive editor for authoring ICU messages
-- Depends on `react-intl` and `icu-messageformat-parser`
-- Work-in-progress status
+- `useMessageEditor`, `Editor`, and `Message` expose editing and parsing without DOM or styling.
+- `useTranslationEditor` adds validation, navigation, and shared drafts keyed by message and locale. `getTranslation(id, locale)` lets independently mounted views use one workflow's state.
+- `save(context?)` returns a typed saved, failed, invalid, or skipped outcome. `onSave(update, snapshot)` receives source/baseline metadata and opaque caller context, and may return a typed persistence receipt.
+- The published entry point depends on React and `icu-messageformat-parser`; consumers own persistence, design systems, and localization providers. The StyleX/React Intl demo is repository-only.
+- See `packages/editor/README.md` for state lifetime, submission snapshots, and examples.

--- a/packages/editor/BUILD.bazel
+++ b/packages/editor/BUILD.bazel
@@ -74,6 +74,7 @@ formatjs_test(
     name = "unit_test",
     srcs = [
         "editor.test.tsx",
+        "multi-locale.test.tsx",
         "workflow.test.tsx",
     ],
     data = [

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -104,6 +104,76 @@ Clean drafts adopt external changes; dirty drafts retain their text. `reset()`
 restores the latest saved baseline. Remount when switching unrelated catalogs
 that reuse message IDs, or when intentionally discarding all drafts.
 
+### Multiple locale views
+
+Mount one workflow above your locale views. `getTranslation(id, locale)` exposes
+the value, baseline, validation, save feedback, and actions for that pair, sharing
+the same draft store as the selected-message API:
+
+```tsx
+const draft = workflow.getTranslation(messageId, locale)
+if (!draft) return null
+return (
+  <YourTextArea
+    value={draft.value}
+    onValueChange={draft.setTranslation}
+    invalid={!!draft.validationError}
+  />
+)
+```
+
+Each view can call `draft.reset()` and `draft.save()` independently. Hiding or
+unmounting a view preserves its draft while the owning workflow remains mounted.
+Keep available locales in the workflow's `locales` option; choose which views
+to display in your UI. The getter returns `undefined` for IDs or locales absent
+from the current options. Drafts survive their temporary removal, including saves
+that complete while a message is outside a loaded page.
+
+### Save results and context
+
+`save(context?)` resolves to a discriminated result. Successful persistence returns
+`{status: 'saved', value}` with the value returned by `onSave`. Failures return
+`{status: 'failed', error}` and also populate `saveError`. Validation failures return
+`{status: 'invalid', validationError}`. Saves that do not call persistence return
+`{status: 'skipped', reason}`, where the reason is `unavailable`, `unchanged`, or
+`pending`. The pending guard is scoped to a message/locale pair, so different pairs
+can save concurrently.
+
+The optional caller context and persistence result are generic types:
+
+```tsx
+type SaveContext = {intent: 'save' | 'review'}
+type Receipt = {revision: string}
+
+const workflow = useTranslationEditor<SaveContext, Receipt>({
+  messages,
+  locales,
+  onSave: async (update, snapshot) => {
+    return persist(update, {
+      intent: snapshot.context?.intent ?? 'save',
+      previousTranslation: snapshot.baselineTranslation,
+      source: snapshot.source,
+    })
+  },
+})
+
+const result = await workflow.save({intent: 'review'})
+if (result.status === 'saved') showReceipt(result.value.revision)
+```
+
+`onSave` receives the submitted translation and a frozen metadata object containing
+the source, baseline translation, and context. Draft state and its `save` action
+are render snapshots: retaining an action for a confirmation dialog retains that
+translation, source, and baseline even if selection or edits subsequently change.
+Context is passed by reference, not cloned; pass immutable context values.
+Persistence policy, confirmation UI, and receipt presentation remain with the
+consumer.
+
+Existing one-argument `onSave` callbacks and callers that await or ignore `save()`
+continue to work. Callers that explicitly annotate `save()` as `Promise<void>`
+must change that annotation to `Promise<TranslationSaveResult>` (with their result
+type parameter, if needed).
+
 `validateTranslation(source, translation)` returns `null` or a localizable error
 code: `empty`, `invalid-source`, `invalid-translation`, or `structure`. It checks
 arguments, tag nesting, formatting styles, select branches, plural type/offset,

--- a/packages/editor/index.ts
+++ b/packages/editor/index.ts
@@ -13,6 +13,9 @@ export type {
   MessageStatus,
   SourceLocation,
   TranslationUpdate,
+  TranslationDraftState,
+  TranslationSaveResult,
+  TranslationSaveSnapshot,
   TranslationEditorOptions,
   TranslationEditorState,
 } from '#packages/editor/workflow.js'

--- a/packages/editor/multi-locale.test.tsx
+++ b/packages/editor/multi-locale.test.tsx
@@ -1,0 +1,315 @@
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  renderHook,
+  screen,
+} from '@testing-library/react'
+import {afterEach, describe, expect, it, vi} from 'vitest'
+import {
+  useTranslationEditor,
+  type EditorMessage,
+  type TranslationSaveResult,
+  type TranslationSaveSnapshot,
+  type TranslationUpdate,
+} from '#packages/editor/index.js'
+
+afterEach(cleanup)
+const SOURCE = 'Hello {name}'
+const FRENCH = 'Bonjour {name}'
+const GERMAN = 'Hallo {name}'
+const DRAFT = 'Salut {name}'
+const NEWER_DRAFT = 'Bienvenue {name}'
+const messages: EditorMessage[] = [
+  {
+    id: 'greeting',
+    defaultMessage: SOURCE,
+    translations: {fr: FRENCH, de: GERMAN},
+  },
+]
+const locales = ['fr', 'de']
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason: unknown) => void
+  const promise = new Promise<T>((yes, no) => {
+    resolve = yes
+    reject = no
+  })
+  return {promise, resolve, reject}
+}
+
+describe('multi-locale drafts', () => {
+  it('keeps independent drafts and validation when locale views unmount', () => {
+    function Example({visibleLocales}: {visibleLocales: string[]}) {
+      const workflow = useTranslationEditor({
+        messages,
+        locales,
+        onSave: () => {},
+      })
+      return visibleLocales.map(locale => {
+        const draft = workflow.getTranslation('greeting', locale)!
+        return (
+          <textarea
+            key={locale}
+            aria-label={locale}
+            aria-invalid={!!draft.validationError}
+            value={draft.value}
+            onChange={event => draft.setTranslation(event.target.value)}
+          />
+        )
+      })
+    }
+    const {rerender} = render(<Example visibleLocales={locales} />)
+    fireEvent.change(screen.getByRole('textbox', {name: 'fr'}), {
+      target: {value: DRAFT},
+    })
+    fireEvent.change(screen.getByRole('textbox', {name: 'de'}), {
+      target: {value: 'Hallo'},
+    })
+    expect(
+      screen.getByRole('textbox', {name: 'de'}).getAttribute('aria-invalid')
+    ).toBe('true')
+    expect(
+      screen.getByRole('textbox', {name: 'fr'}).getAttribute('aria-invalid')
+    ).toBe('false')
+    rerender(<Example visibleLocales={[]} />)
+    expect(screen.queryAllByRole('textbox')).toHaveLength(0)
+    rerender(<Example visibleLocales={locales} />)
+    expect(
+      (screen.getByRole('textbox', {name: 'fr'}) as HTMLTextAreaElement).value
+    ).toBe(DRAFT)
+    expect(
+      (screen.getByRole('textbox', {name: 'de'}) as HTMLTextAreaElement).value
+    ).toBe('Hallo')
+  })
+
+  it('shares drafts with the existing selected-locale workflow and scopes reset', () => {
+    const {result} = renderHook(() =>
+      useTranslationEditor({messages, locales, onSave: () => {}})
+    )
+    act(() =>
+      result.current.getTranslation('greeting', 'fr')!.setTranslation(DRAFT)
+    )
+    act(() =>
+      result.current
+        .getTranslation('greeting', 'de')!
+        .setTranslation('Guten Tag {name}')
+    )
+    expect(result.current.editor.selectedMessage?.translatedMessage).toBe(DRAFT)
+    act(() => result.current.reset())
+    expect(result.current.getTranslation('greeting', 'fr')!.value).toBe(FRENCH)
+    expect(result.current.getTranslation('greeting', 'de')!.changed).toBe(true)
+    act(() => result.current.setLocale('de'))
+    expect(result.current.editor.selectedMessage?.translatedMessage).toBe(
+      'Guten Tag {name}'
+    )
+  })
+
+  it('returns caller results and immutable submission metadata without mixing concurrent locales', async () => {
+    type Context = {intent: 'review' | 'save'}
+    type Receipt = {revision: string}
+    const requests = {fr: deferred<Receipt>(), de: deferred<Receipt>()}
+    const onSave = vi.fn(
+      (
+        update: TranslationUpdate,
+        snapshot: TranslationSaveSnapshot<Context>
+      ) => {
+        expect(Object.isFrozen(snapshot)).toBe(true)
+        return requests[update.locale as 'fr' | 'de'].promise
+      }
+    )
+    const {result} = renderHook(() =>
+      useTranslationEditor<Context, Receipt>({messages, locales, onSave})
+    )
+    act(() =>
+      result.current.getTranslation('greeting', 'fr')!.setTranslation(DRAFT)
+    )
+    act(() =>
+      result.current
+        .getTranslation('greeting', 'de')!
+        .setTranslation('Guten Tag {name}')
+    )
+    let french!: Promise<TranslationSaveResult<Receipt>>
+    let german!: Promise<TranslationSaveResult<Receipt>>
+    act(() => {
+      french = result.current
+        .getTranslation('greeting', 'fr')!
+        .save({intent: 'review'})
+      german = result.current
+        .getTranslation('greeting', 'de')!
+        .save({intent: 'save'})
+    })
+    expect(result.current.getTranslation('greeting', 'fr')!.isSaving).toBe(true)
+    expect(result.current.getTranslation('greeting', 'de')!.isSaving).toBe(true)
+    expect(onSave).toHaveBeenNthCalledWith(
+      1,
+      {id: 'greeting', locale: 'fr', translation: DRAFT},
+      {source: SOURCE, baselineTranslation: FRENCH, context: {intent: 'review'}}
+    )
+    expect(onSave).toHaveBeenNthCalledWith(
+      2,
+      {id: 'greeting', locale: 'de', translation: 'Guten Tag {name}'},
+      {source: SOURCE, baselineTranslation: GERMAN, context: {intent: 'save'}}
+    )
+    act(() =>
+      result.current
+        .getTranslation('greeting', 'fr')!
+        .setTranslation(NEWER_DRAFT)
+    )
+    await act(async () => {
+      requests.de.resolve({revision: 'de-1'})
+      expect(await german).toEqual({status: 'saved', value: {revision: 'de-1'}})
+    })
+    expect(result.current.getTranslation('greeting', 'fr')!.isSaving).toBe(true)
+    expect(result.current.getTranslation('greeting', 'de')!.saved).toBe(true)
+    await act(async () => {
+      requests.fr.resolve({revision: 'fr-1'})
+      expect(await french).toEqual({status: 'saved', value: {revision: 'fr-1'}})
+    })
+    expect(result.current.getTranslation('greeting', 'fr')!.value).toBe(
+      NEWER_DRAFT
+    )
+    expect(result.current.getTranslation('greeting', 'fr')!.changed).toBe(true)
+    act(() => result.current.getTranslation('greeting', 'fr')!.reset())
+    expect(result.current.getTranslation('greeting', 'fr')!.value).toBe(DRAFT)
+  })
+
+  it('submits the confirmed render snapshot after selection, drafts, and catalog metadata change', async () => {
+    const onSave = vi.fn(() => 'revision-1')
+    const {result, rerender} = renderHook(
+      props =>
+        useTranslationEditor<{intent: string}, string>({...props, onSave}),
+      {initialProps: {messages, locales}}
+    )
+    act(() => result.current.editor.setTranslation(DRAFT))
+    const confirmed = result.current.getTranslation('greeting', 'fr')!
+    act(() => result.current.editor.setTranslation(NEWER_DRAFT))
+    act(() => result.current.setLocale('de'))
+    rerender({
+      messages: [
+        {
+          id: 'greeting',
+          defaultMessage: 'Welcome {name}',
+          translations: {fr: 'Bonsoir {name}', de: GERMAN},
+        },
+      ],
+      locales,
+    })
+    await act(async () => {
+      expect(await confirmed.save({intent: 'review'})).toEqual({
+        status: 'saved',
+        value: 'revision-1',
+      })
+    })
+    expect(onSave).toHaveBeenCalledExactlyOnceWith(
+      {id: 'greeting', locale: 'fr', translation: DRAFT},
+      {source: SOURCE, baselineTranslation: FRENCH, context: {intent: 'review'}}
+    )
+    expect(result.current.getTranslation('greeting', 'fr')!.value).toBe(
+      NEWER_DRAFT
+    )
+    expect(result.current.getTranslation('greeting', 'fr')!.baseline).toBe(
+      DRAFT
+    )
+    expect(result.current.getTranslation('greeting', 'fr')!.changed).toBe(true)
+    expect(result.current.editor.selectedMessage?.translatedMessage).toBe(
+      GERMAN
+    )
+  })
+
+  it('reports pending and failed saves explicitly, preserves the draft, and supports retry', async () => {
+    const request = deferred<string>()
+    const error = new Error('Offline')
+    const onSave = vi
+      .fn()
+      .mockImplementationOnce(() => request.promise)
+      .mockResolvedValue('revision-2')
+    const {result} = renderHook(() =>
+      useTranslationEditor({messages, locales, onSave})
+    )
+    act(() => result.current.editor.setTranslation(DRAFT))
+    let save!: ReturnType<typeof result.current.save>
+    act(() => {
+      save = result.current.save()
+    })
+    await act(async () => {
+      expect(
+        await result.current.getTranslation('greeting', 'fr')!.save()
+      ).toEqual({status: 'skipped', reason: 'pending'})
+      request.reject(error)
+      expect(await save).toEqual({status: 'failed', error})
+    })
+    expect(onSave).toHaveBeenCalledTimes(1)
+    expect(result.current.saveError).toBe(error)
+    expect(
+      result.current.getTranslation('greeting', 'de')!.saveError
+    ).toBeNull()
+    expect(result.current.editor.selectedMessage?.translatedMessage).toBe(DRAFT)
+    await act(async () => {
+      expect(await result.current.save()).toEqual({
+        status: 'saved',
+        value: 'revision-2',
+      })
+    })
+    expect(result.current.saved).toBe(true)
+    expect(result.current.saveError).toBeNull()
+  })
+
+  it('returns validation and unavailable outcomes without calling persistence', async () => {
+    const onSave = vi.fn()
+    const {result, rerender} = renderHook(
+      props => useTranslationEditor({...props, onSave}),
+      {initialProps: {messages, locales}}
+    )
+    expect(await result.current.save()).toEqual({
+      status: 'skipped',
+      reason: 'unchanged',
+    })
+    act(() => result.current.editor.setTranslation('Missing placeholder'))
+    expect(await result.current.save()).toEqual({
+      status: 'invalid',
+      validationError: 'structure',
+    })
+    act(() => result.current.editor.setTranslation(DRAFT))
+    const removed = result.current.getTranslation('greeting', 'fr')!
+    rerender({messages, locales: ['de']})
+    expect(await removed.save()).toEqual({
+      status: 'skipped',
+      reason: 'unavailable',
+    })
+    expect(result.current.getTranslation('greeting', 'fr')).toBeUndefined()
+    expect(result.current.getTranslation('unknown', 'de')).toBeUndefined()
+    rerender({messages: [], locales: []})
+    expect(await result.current.save()).toEqual({
+      status: 'skipped',
+      reason: 'unavailable',
+    })
+    expect(onSave).not.toHaveBeenCalled()
+  })
+
+  it('preserves a completed save while its message is absent from a loaded page', async () => {
+    const request = deferred<void>()
+    const {result, rerender} = renderHook(
+      props => useTranslationEditor({...props, onSave: () => request.promise}),
+      {initialProps: {messages, locales}}
+    )
+    act(() => result.current.editor.setTranslation(DRAFT))
+    let save!: ReturnType<typeof result.current.save>
+    act(() => {
+      save = result.current.save()
+    })
+    rerender({messages: [], locales})
+    await act(async () => {
+      request.resolve()
+      await save
+    })
+    rerender({messages, locales})
+    const draft = result.current.getTranslation('greeting', 'fr')!
+    expect(draft.value).toBe(DRAFT)
+    expect(draft.baseline).toBe(DRAFT)
+    expect(draft.saved).toBe(true)
+    expect(draft.isSaving).toBe(false)
+  })
+})

--- a/packages/editor/workflow.test.tsx
+++ b/packages/editor/workflow.test.tsx
@@ -5,6 +5,7 @@ import {
   validateTranslation,
   type EditorMessage,
   type TranslationEditorOptions,
+  type TranslationSaveResult,
 } from './index.js'
 
 afterEach(cleanup)
@@ -48,7 +49,7 @@ describe('translation workflow', () => {
     const onSave = vi.fn(() => request.promise)
     const {result} = renderHook(() => useTranslationEditor(options({onSave})))
     act(() => result.current.editor.setTranslation('Saved {name}'))
-    let save!: Promise<void>
+    let save!: Promise<TranslationSaveResult>
     act(() => {
       save = result.current.save()
     })
@@ -68,11 +69,14 @@ describe('translation workflow', () => {
     expect(result.current.editor.selectedMessage?.translatedMessage).toBe(
       'Saved {name}'
     )
-    expect(onSave).toHaveBeenCalledExactlyOnceWith({
-      id: 'a',
-      locale: 'fr',
-      translation: 'Saved {name}',
-    })
+    expect(onSave).toHaveBeenCalledExactlyOnceWith(
+      {id: 'a', locale: 'fr', translation: 'Saved {name}'},
+      {
+        source: 'First {name}',
+        baselineTranslation: 'Premier {name}',
+        context: undefined,
+      }
+    )
   })
 
   it('preserves edits typed while persistence updates controlled messages', async () => {
@@ -83,7 +87,7 @@ describe('translation workflow', () => {
       {initialProps: initial}
     )
     act(() => result.current.editor.setTranslation('Submitted {name}'))
-    let save!: Promise<void>
+    let save!: Promise<TranslationSaveResult>
     act(() => {
       save = result.current.save()
     })
@@ -144,11 +148,14 @@ describe('translation workflow', () => {
     await act(async () => {
       await result.current.save()
     })
-    expect(onSave).toHaveBeenCalledWith({
-      id: 'a',
-      locale: 'fr',
-      translation: 'Bonjour {name}',
-    })
+    expect(onSave).toHaveBeenCalledWith(
+      {id: 'a', locale: 'fr', translation: 'Bonjour {name}'},
+      {
+        source: 'First {name}',
+        baselineTranslation: 'Premier {name}',
+        context: undefined,
+      }
+    )
     rerender({...initial, locales: ['ru']})
     expect(result.current.locale).toBe('ru')
     expect(result.current.editor.selectedMessage?.translatedMessage).toBe('')
@@ -174,7 +181,7 @@ describe('translation workflow', () => {
     const onSave = vi.fn(() => request.promise)
     const {result} = renderHook(() => useTranslationEditor(options({onSave})))
     act(() => result.current.editor.setTranslation('Changed {name}'))
-    let save!: Promise<void>
+    let save!: Promise<TranslationSaveResult>
     act(() => {
       save = result.current.save()
       void result.current.save()

--- a/packages/editor/workflow.ts
+++ b/packages/editor/workflow.ts
@@ -24,14 +24,41 @@ export interface TranslationUpdate {
   translation: string
 }
 export type MessageStatus = 'all' | 'translated' | 'missing'
-export interface TranslationEditorOptions {
+/** Render-snapshot metadata plus consumer-owned context supplied to save. */
+export interface TranslationSaveSnapshot<TContext = void> {
+  readonly source: string
+  readonly baselineTranslation: string
+  readonly context: TContext | undefined
+}
+export type TranslationSaveResult<TResult = void> =
+  | {status: 'saved'; value: TResult}
+  | {status: 'failed'; error: Error}
+  | {status: 'invalid'; validationError: TranslationValidationError}
+  | {status: 'skipped'; reason: 'unavailable' | 'unchanged' | 'pending'}
+export interface TranslationEditorOptions<TContext = void, TResult = void> {
   messages: readonly EditorMessage[]
   locales: readonly string[]
-  onSave: (update: TranslationUpdate) => void | Promise<void>
+  onSave: (
+    update: TranslationUpdate,
+    snapshot: TranslationSaveSnapshot<TContext>
+  ) => TResult | Promise<TResult>
   defaultLocale?: string
   pageSize?: number
 }
-export interface TranslationEditorState {
+/** A render snapshot and actions for one message/locale pair. */
+export interface TranslationDraftState<TContext = void, TResult = void> {
+  readonly value: string
+  readonly baseline: string
+  readonly validationError: TranslationValidationError | null
+  readonly changed: boolean
+  readonly isSaving: boolean
+  readonly saveError: Error | null
+  readonly saved: boolean
+  setTranslation: (value: string) => void
+  reset: () => void
+  save: (context?: TContext) => Promise<TranslationSaveResult<TResult>>
+}
+export interface TranslationEditorState<TContext = void, TResult = void> {
   editor: EditorState
   selectedMessage: EditorMessage | undefined
   locale: string | undefined
@@ -50,8 +77,12 @@ export interface TranslationEditorState {
   isSaving: boolean
   saveError: Error | null
   saved: boolean
-  save: () => Promise<void>
+  save: (context?: TContext) => Promise<TranslationSaveResult<TResult>>
   reset: () => void
+  getTranslation: (
+    id: string,
+    locale: string
+  ) => TranslationDraftState<TContext, TResult> | undefined
 }
 interface Draft {
   value: string
@@ -83,13 +114,16 @@ function reconcile(draft: Draft | undefined, remote: string): Draft {
 }
 
 /** Per-message, per-locale drafts layered on the existing headless editor. */
-export function useTranslationEditor({
+export function useTranslationEditor<TContext = void, TResult = void>({
   messages,
   locales,
   onSave,
   defaultLocale,
   pageSize = 100,
-}: TranslationEditorOptions): TranslationEditorState {
+}: TranslationEditorOptions<TContext, TResult>): TranslationEditorState<
+  TContext,
+  TResult
+> {
   const [requestedLocale, requestLocale] = useState(defaultLocale)
   const locale =
     requestedLocale && locales.includes(requestedLocale)
@@ -116,16 +150,19 @@ export function useTranslationEditor({
     return [...values].sort()
   }, [messages])
   const catalog = catalogs.includes(requestedCatalog) ? requestedCatalog : ''
-  const getDraft = (id: string): Draft =>
+  const getDraft = (id: string, targetLocale = locale ?? ''): Draft =>
     reconcile(
-      drafts[draftKey(id, locale ?? '')],
-      remoteValues.current.get(draftKey(id, locale ?? '')) ?? ''
+      drafts[draftKey(id, targetLocale)],
+      remoteValues.current.get(draftKey(id, targetLocale)) ?? ''
     )
   function update(key: string, change: (draft: Draft) => Draft): void {
     setDrafts(current => ({
       ...current,
       [key]: change(
-        reconcile(current[key], remoteValues.current.get(key) ?? '')
+        reconcile(
+          current[key],
+          remoteValues.current.get(key) ?? current[key]?.remote ?? ''
+        )
       ),
     }))
   }
@@ -161,10 +198,6 @@ export function useTranslationEditor({
   const selectedMessage = messages.find(
     message => message.id === editor.selectedMessage?.id
   )
-  const selected =
-    selectedMessage && locale !== undefined
-      ? getDraft(selectedMessage.id)
-      : undefined
   const size =
     Number.isFinite(pageSize) && pageSize > 0
       ? Math.max(1, Math.floor(pageSize))
@@ -174,42 +207,85 @@ export function useTranslationEditor({
   useEffect(() => {
     requestPage(current => Math.min(current, pageCount - 1))
   }, [pageCount])
-  const validationError =
-    selectedMessage && selected
-      ? validateTranslation(selectedMessage.defaultMessage, selected.value)
-      : null
-  const changed = selected !== undefined && selected.value !== selected.baseline
-  async function save(): Promise<void> {
-    if (
-      !selectedMessage ||
-      !selected ||
-      locale === undefined ||
-      !changed ||
-      validationError
-    )
-      return
-    const key = draftKey(selectedMessage.id, locale)
-    if (pending.current.has(key)) return
-    const submitted = selected.value
-    pending.current.add(key)
-    update(key, draft => ({...draft, saving: true, error: null, saved: false}))
-    try {
-      await onSave({id: selectedMessage.id, locale, translation: submitted})
-      update(key, draft => ({
-        ...draft,
-        baseline: submitted,
-        saved: true,
-      }))
-    } catch (error) {
-      update(key, draft => ({
-        ...draft,
-        error: error instanceof Error ? error : new Error(String(error)),
-      }))
-    } finally {
-      pending.current.delete(key)
-      update(key, draft => ({...draft, saving: false}))
+  function getTranslation(
+    id: string,
+    targetLocale: string
+  ): TranslationDraftState<TContext, TResult> | undefined {
+    const message = messages.find(value => value.id === id)
+    if (!message || !locales.includes(targetLocale)) return undefined
+    const key = draftKey(id, targetLocale)
+    const draft = getDraft(id, targetLocale)
+    const source = message.defaultMessage
+    const validationError = validateTranslation(source, draft.value)
+    const changed = draft.value !== draft.baseline
+    return {
+      value: draft.value,
+      baseline: draft.baseline,
+      validationError,
+      changed,
+      isSaving: draft.saving,
+      saveError: draft.error,
+      saved: draft.saved && !changed,
+      setTranslation: value => {
+        if (!remoteValues.current.has(key)) return
+        update(key, current => ({...current, value, error: null, saved: false}))
+      },
+      reset: () => {
+        if (!remoteValues.current.has(key)) return
+        update(key, current => ({
+          ...current,
+          value: current.baseline,
+          error: null,
+          saved: false,
+        }))
+      },
+      save: async context => {
+        if (!remoteValues.current.has(key))
+          return {status: 'skipped', reason: 'unavailable'}
+        if (pending.current.has(key))
+          return {status: 'skipped', reason: 'pending'}
+        if (!changed) return {status: 'skipped', reason: 'unchanged'}
+        if (validationError) return {status: 'invalid', validationError}
+        const submitted = draft.value
+        const snapshot: TranslationSaveSnapshot<TContext> = Object.freeze({
+          source,
+          baselineTranslation: draft.baseline,
+          context,
+        })
+        pending.current.add(key)
+        update(key, current => ({
+          ...current,
+          saving: true,
+          error: null,
+          saved: false,
+        }))
+        try {
+          const value = await onSave(
+            {id, locale: targetLocale, translation: submitted},
+            snapshot
+          )
+          update(key, current => ({
+            ...current,
+            baseline: submitted,
+            saved: true,
+          }))
+          return {status: 'saved', value}
+        } catch (error) {
+          const saveError =
+            error instanceof Error ? error : new Error(String(error))
+          update(key, current => ({...current, error: saveError}))
+          return {status: 'failed', error: saveError}
+        } finally {
+          pending.current.delete(key)
+          update(key, current => ({...current, saving: false}))
+        }
+      },
     }
   }
+  const selectedTranslation =
+    selectedMessage && locale !== undefined
+      ? getTranslation(selectedMessage.id, locale)
+      : undefined
   return {
     editor: {
       ...editor,
@@ -244,20 +320,16 @@ export function useTranslationEditor({
           : 0
       ),
     pageMessages: editor.messages.slice(page * size, (page + 1) * size),
-    validationError,
-    changed,
-    isSaving: selected?.saving ?? false,
-    saveError: selected?.error ?? null,
-    saved: !!selected?.saved && !changed,
-    save,
-    reset: () => {
-      if (selectedMessage && locale !== undefined)
-        update(draftKey(selectedMessage.id, locale), draft => ({
-          ...draft,
-          value: draft.baseline,
-          error: null,
-          saved: false,
-        }))
-    },
+    validationError: selectedTranslation?.validationError ?? null,
+    changed: selectedTranslation?.changed ?? false,
+    isSaving: selectedTranslation?.isSaving ?? false,
+    saveError: selectedTranslation?.saveError ?? null,
+    saved: selectedTranslation?.saved ?? false,
+    save: async context =>
+      selectedTranslation
+        ? selectedTranslation.save(context)
+        : {status: 'skipped', reason: 'unavailable'},
+    reset: () => selectedTranslation?.reset(),
+    getTranslation,
   }
 }


### PR DESCRIPTION
Adds `getTranslation(id, locale)` so multiple locale views share one workflow's drafts, validation, reset, and save state. Drafts survive hidden views and temporary removal from loaded messages.

`save(context?)` returns a typed outcome and forwards opaque caller context plus frozen source/baseline metadata to `onSave`. Retained save actions preserve the confirmed render snapshot; concurrent saves remain isolated by message and locale. Explicit `Promise<void>` save annotations must migrate to `Promise<TranslationSaveResult>`.

Includes public API docs and regression coverage for concurrent saves, confirmation snapshots across catalog changes, edits during persistence, retries, and completion outside the loaded page.

Validation: 27 editor tests, package exports/imports/manifest checks, editor and demo type checks, and all commit hooks passed. The broader editor sweep built the npm package and passed all nine runnable test targets; VRT type-check analysis was blocked locally by npm registry DNS resolution.
