### PR TITLE
feat(react-intl): add duration components and bindings

### DIFF
--- a/docs/src/docs/guides/runtime-requirements.mdx
+++ b/docs/src/docs/guides/runtime-requirements.mdx
@@ -17,6 +17,11 @@ React Intl relies on these `Intl` APIs:
 - (Optional) [Intl.DisplayNames](https://tc39.es/proposal-intl-displaynames/): Required if you use [`formatDisplayName`](/docs/react-intl/api#formatdisplayname)
   or [`FormattedDisplayName`](/docs/react-intl/components#formatteddisplayname). This can be polyfilled using [this package](/docs/polyfills/intl-displaynames).
 
+- (Optional) `Intl.DurationFormat`: Required for [`formatDuration`](/docs/react-intl/api#formatduration),
+  `formatDurationToParts`, [`FormattedDuration`](/docs/react-intl/components#formattedduration), and
+  `FormattedDurationParts`. This can be polyfilled using
+  [`@formatjs/intl-durationformat`](/docs/polyfills/intl-durationformat).
+
 We officially support IE11 along with 2 most recent versions of Edge, Chrome & Firefox.
 
 ## Node.js

--- a/docs/src/docs/react-intl/api.mdx
+++ b/docs/src/docs/react-intl/api.mdx
@@ -82,6 +82,14 @@ interface IntlConfig {
 }
 
 interface IntlFormatters {
+  formatDuration(
+    value: Parameters<Intl.DurationFormat['format']>[0],
+    opts?: FormatDurationOptions
+  ): string
+  formatDurationToParts(
+    value: Parameters<Intl.DurationFormat['format']>[0],
+    opts?: FormatDurationOptions
+  ): ReturnType<Intl.DurationFormat['formatToParts']>
   formatDate(value: number | Date | string, opts?: FormatDateOptions): string
   formatTime(value: number | Date | string, opts?: FormatDateOptions): string
   formatDateToParts(
@@ -571,4 +579,34 @@ const msg = defineMessage({
   defaultMessage: 'single message',
   description: 'header',
 })
+```
+
+## formatDuration
+
+Formats a duration object in the provider's locale. Accepts
+`Intl.DurationFormatOptions` except `localeMatcher`, plus a `format` name from
+`formats.duration`. Explicit options override the named format.
+
+```tsx
+const intl = useIntl()
+intl.formatDuration({minutes: 3, seconds: 42}, {style: 'long'})
+// English: "3 minutes, 42 seconds"
+```
+
+Pass an object containing duration units, rather than a timestamp or total
+milliseconds. This API requires native `Intl.DurationFormat` support or the
+[`@formatjs/intl-durationformat` polyfill](/docs/polyfills/intl-durationformat).
+It is also available through `createIntl`, including from `react-intl/server`.
+If formatting fails, `onError` receives the error and the result is an empty string.
+
+## formatDurationToParts
+
+Accepts the same arguments as `formatDuration` and returns
+`Intl.DurationFormat.prototype.formatToParts()` output, including unit metadata
+for numeric parts. Use it to customize individual pieces of the formatted
+result. If formatting fails, `onError` receives the error and the result is an
+empty array.
+
+```tsx
+intl.formatDurationToParts({minutes: 3, seconds: 42}, {style: 'long'})
 ```

--- a/docs/src/docs/react-intl/components.mdx
+++ b/docs/src/docs/react-intl/components.mdx
@@ -741,3 +741,42 @@ Since rich text formatting allows embedding `ReactElement`, in function as the c
 All the rich text gets translated together which yields higher quality output. This brings feature-parity with other translation libs as well, such as [fluent](https://projectfluent.org/) by Mozilla (using `overlays` concept).
 
 Extending this also allows users to potentially utilizing other rich text format, like [Markdown](https://daringfireball.net/projects/markdown/).
+
+## FormattedDuration
+
+Renders a duration using [`formatDuration`](./api#formatduration). Its `value`
+is an object containing duration units. Formatting options can be supplied as
+props or selected by `format` from the provider's `formats.duration`.
+
+```tsx
+<IntlProvider locale="en" formats={{duration: {clock: {style: 'digital'}}}}>
+  <FormattedDuration value={{hours: 1, minutes: 30}} format="clock" />
+  <FormattedDuration value={{minutes: 3, seconds: 42}} style="long">
+    {duration => <strong>{duration}</strong>}
+  </FormattedDuration>
+</IntlProvider>
+```
+
+Without a render function, the component uses the provider's `textComponent`
+(or a React fragment). It updates when the locale or formats change.
+Native `Intl.DurationFormat` support or the
+[`@formatjs/intl-durationformat` polyfill](/docs/polyfills/intl-durationformat)
+is required.
+
+## FormattedDurationParts
+
+Calls [`formatDurationToParts`](./api#formatdurationtoparts) with the same props
+as `FormattedDuration`. A function child is required and receives localized
+parts, including duration unit metadata for numeric parts.
+
+```tsx
+<FormattedDurationParts value={{minutes: 3, seconds: 42}} style="long">
+  {parts => (
+    <span>
+      {parts.map((part, index) =>
+        part.type === 'integer' ? <b key={index}>{part.value}</b> : part.value
+      )}
+    </span>
+  )}
+</FormattedDurationParts>
+```

--- a/knowledge-base/008-package-intl-and-framework-integrations.md
+++ b/knowledge-base/008-package-intl-and-framework-integrations.md
@@ -55,6 +55,11 @@ callers can still pass an existing values map.
 - `<FormattedMessage>` — Render ICU MessageFormat strings
 - `<FormattedNumber>`, `<FormattedDate>`, `<FormattedTime>`, `<FormattedList>`, `<FormattedDisplayName>`, `<FormattedPlural>`, `<FormattedRelativeTimeFormat>`
 
+`<FormattedDuration>` and `<FormattedDurationParts>` delegate to the core duration
+APIs and respect provider locale, named formats, and explicit options. The
+imperative methods are available through `useIntl()` and both `createIntl`
+entry points; `FormatDurationOptions` is exported from the client and server.
+
 **Hooks:**
 
 - `useIntl()` — Access intl object for imperative formatting

--- a/packages/react-intl/BUILD.bazel
+++ b/packages/react-intl/BUILD.bazel
@@ -183,6 +183,7 @@ formatjs_test(
         "tests/unit/components/date.test.tsx",
         "tests/unit/components/dateTimeRange.test.tsx",
         "tests/unit/components/displayName.test.tsx",
+        "tests/unit/components/duration.test.tsx",
         "tests/unit/components/list.test.tsx",
         "tests/unit/components/message.test.tsx",
         "tests/unit/components/number.test.tsx",

--- a/packages/react-intl/components/createFormattedComponent.tsx
+++ b/packages/react-intl/components/createFormattedComponent.tsx
@@ -1,5 +1,6 @@
 import {
   type FormatDateOptions,
+  type FormatDurationOptions,
   type FormatDisplayNameOptions,
   type FormatListOptions,
   type FormatNumberOptions,
@@ -13,6 +14,7 @@ enum DisplayName {
   formatTime = 'FormattedTime',
   formatNumber = 'FormattedNumber',
   formatList = 'FormattedList',
+  formatDuration = 'FormattedDuration',
   // Note that this DisplayName is the locale display name, not to be confused with
   // the name of the enum, which is for React component display name in dev tools.
   formatDisplayName = 'FormattedDisplayName',
@@ -30,6 +32,7 @@ type Formatter = {
   formatTime: FormatDateOptions
   formatNumber: FormatNumberOptions
   formatList: FormatListOptions
+  formatDuration: FormatDurationOptions
   formatDisplayName: FormatDisplayNameOptions
 }
 
@@ -45,6 +48,20 @@ export const FormattedNumberParts: React.FC<
   return children(intl.formatNumberToParts(value, formatProps))
 }
 FormattedNumberParts.displayName = 'FormattedNumberParts'
+
+export const FormattedDurationParts: React.FC<
+  FormatDurationOptions & {
+    value: Parameters<IntlShape['formatDuration']>[0]
+    children(
+      val: ReturnType<IntlShape['formatDurationToParts']>
+    ): React.ReactElement | null
+  }
+> = props => {
+  const intl = useIntl()
+  const {value, children, ...formatProps} = props
+  return children(intl.formatDurationToParts(value, formatProps))
+}
+FormattedDurationParts.displayName = 'FormattedDurationParts'
 
 export const FormattedListParts: React.FC<
   Formatter['formatList'] & {

--- a/packages/react-intl/index.ts
+++ b/packages/react-intl/index.ts
@@ -8,6 +8,7 @@ import {type NumberFormatOptions} from '#packages/ecma402-abstract/types/number.
 import {
   type CustomFormatConfig,
   type FormatDateOptions,
+  type FormatDurationOptions,
   type FormatTimeOptions,
   type MessageDescriptor,
 } from '@formatjs/intl'
@@ -33,6 +34,7 @@ export {
   type CustomFormatConfig,
   type CustomFormats,
   type FormatDateOptions,
+  type FormatDurationOptions,
   type FormatDisplayNameOptions,
   type FormatListOptions,
   type FormatNumberOptions,
@@ -100,6 +102,12 @@ export const FormattedNumber: React.FC<
       children?(formattedNumber: string): React.ReactElement | null
     }
 > = createFormattedComponent('formatNumber')
+export const FormattedDuration: React.FC<
+  FormatDurationOptions & {
+    value: Parameters<IntlShape['formatDuration']>[0]
+    children?(formattedDuration: string): React.ReactElement | null
+  }
+> = createFormattedComponent('formatDuration')
 export const FormattedList: React.FC<
   Intl.ListFormatOptions & {
     value: Parameters<IntlShape['formatList']>[0]
@@ -126,6 +134,7 @@ export const FormattedTimeParts: React.FC<
 export type {MessageFormatElement} from '@formatjs/icu-messageformat-parser'
 export type {PrimitiveType} from 'intl-messageformat'
 export {
+  FormattedDurationParts,
   FormattedListParts,
   FormattedNumberParts,
 } from '#packages/react-intl/components/createFormattedComponent.js'

--- a/packages/react-intl/server.ts
+++ b/packages/react-intl/server.ts
@@ -3,6 +3,7 @@ import {type MessageDescriptor} from '@formatjs/intl'
 export {
   createIntlCache,
   type IntlCache,
+  type FormatDurationOptions,
   type MessageDescriptor,
 } from '@formatjs/intl'
 export {createIntl} from '#packages/react-intl/components/createIntl.js'

--- a/packages/react-intl/tests/unit/components/duration.test.tsx
+++ b/packages/react-intl/tests/unit/components/duration.test.tsx
@@ -1,0 +1,101 @@
+import {cleanup, render} from '@testing-library/react'
+import {afterEach, expect, it} from 'vitest'
+import {
+  FormattedDuration,
+  FormattedDurationParts,
+  IntlProvider,
+  useIntl,
+} from '#packages/react-intl/index.js'
+import {createIntl as createServerIntl} from '#packages/react-intl/server.js'
+
+const DURATION = {hours: 1, minutes: 2, seconds: 3}
+
+afterEach(cleanup)
+
+it('uses provider locale and named formats and updates when they change', () => {
+  const {container, rerender} = render(
+    <IntlProvider
+      locale="en"
+      textComponent="span"
+      formats={{duration: {elapsed: {style: 'long'}}}}
+    >
+      <FormattedDuration value={DURATION} format="elapsed" />
+    </IntlProvider>
+  )
+  expect(container.innerHTML).toBe('<span>1 hour, 2 minutes, 3 seconds</span>')
+  rerender(
+    <IntlProvider
+      locale="fr"
+      formats={{duration: {elapsed: {style: 'digital'}}}}
+    >
+      <FormattedDuration value={DURATION} format="elapsed" />
+    </IntlProvider>
+  )
+  expect(container.textContent).toBe(
+    new Intl.DurationFormat('fr', {style: 'digital'}).format(DURATION)
+  )
+})
+
+it('passes the formatted duration to a render function with explicit option overrides', () => {
+  const {container} = render(
+    <IntlProvider
+      locale="en"
+      formats={{duration: {elapsed: {style: 'digital'}}}}
+    >
+      <FormattedDuration value={DURATION} format="elapsed" style="long">
+        {text => <strong>{text}</strong>}
+      </FormattedDuration>
+    </IntlProvider>
+  )
+  expect(container.innerHTML).toBe(
+    '<strong>1 hour, 2 minutes, 3 seconds</strong>'
+  )
+})
+
+it('passes localized parts including units to the render function', () => {
+  const {container} = render(
+    <IntlProvider locale="en">
+      <FormattedDurationParts value={{minutes: 3, seconds: 42}} style="long">
+        {parts => (
+          <>
+            {parts.map((part, index) =>
+              part.type === 'integer' ? (
+                <b key={index} data-unit={part.unit}>
+                  {part.value}
+                </b>
+              ) : (
+                part.value
+              )
+            )}
+          </>
+        )}
+      </FormattedDurationParts>
+    </IntlProvider>
+  )
+  expect(container.innerHTML).toBe(
+    '<b data-unit="minute">3</b> minutes, <b data-unit="second">42</b> seconds'
+  )
+})
+
+it('exposes duration formatting through useIntl and the server entry point', () => {
+  function Duration() {
+    const intl = useIntl()
+    return <>{intl.formatDuration(DURATION, {style: 'long'})}</>
+  }
+  const {container} = render(
+    <IntlProvider locale="en">
+      <Duration />
+    </IntlProvider>
+  )
+  expect(container.textContent).toBe('1 hour, 2 minutes, 3 seconds')
+  const intl = createServerIntl({locale: 'en'})
+  expect(intl.formatDuration(DURATION, {style: 'long'})).toBe(
+    container.textContent
+  )
+  expect(
+    intl
+      .formatDurationToParts(DURATION, {style: 'long'})
+      .map(part => part.value)
+      .join('')
+  ).toBe(container.textContent)
+})


### PR DESCRIPTION
React applications need to format elapsed durations with the provider's locale and formatting configuration, including custom rendering of duration parts.

Add `FormattedDuration` and `FormattedDurationParts`, delegating to the core duration APIs. The components support named formats and explicit options; `FormattedDuration` supports function children and the provider's `textComponent`. Export `FormatDurationOptions` from both client and server entry points, and document the imperative APIs and polyfill requirement.

Cover provider updates, render functions, unit-aware parts rendering, `useIntl`, and the server entry point.
