### PR TITLE
feat(formatjs_intl): add checked FormattedMessage output

### DIFF
--- a/crates/formatjs_cli/README.md
+++ b/crates/formatjs_cli/README.md
@@ -191,7 +191,7 @@ formatjs extract "src/**/*.tsx" --out-file messages.json
 ```
 
 Rust extraction reads `formatjs_intl::message_descriptor!` descriptors and
-inline `formatjs_intl::format_message!` calls. Missing IDs use
+inline `formatjs_intl::format_message!` or `formatjs_intl::formatted_message!` calls. Missing IDs use
 `[sha512:contenthash:base64:10]`:
 
 ```rust

--- a/crates/formatjs_cli/src/rust_extractor.rs
+++ b/crates/formatjs_cli/src/rust_extractor.rs
@@ -127,8 +127,10 @@ impl RustMessageExtractor<'_> {
 impl<'ast> Visit<'ast> for RustMessageExtractor<'_> {
     fn visit_macro(&mut self, node: &'ast Macro) {
         let name = node.path.segments.last().map(|segment| &segment.ident);
-        if name.is_some_and(|name| name == "message_descriptor" || name == "format_message") {
-            let arguments = if name.is_some_and(|name| name == "format_message") {
+        let is_format =
+            name.is_some_and(|name| name == "format_message" || name == "formatted_message");
+        if is_format || name.is_some_and(|name| name == "message_descriptor") {
+            let arguments = if is_format {
                 syn::parse2::<FormatMessageArgs>(node.tokens.clone()).map(|args| args.message)
             } else {
                 syn::parse2::<MessageArgs>(node.tokens.clone())
@@ -296,8 +298,8 @@ mod tests {
 
     #[test]
     fn extracts_format_message_macros() {
-        let messages = extract_messages_from_rust_source(
-            r#"fn render(intl: &Intl, values: &Values<String>) {
+        for macro_name in ["format_message", "formatted_message"] {
+            let source = r#"fn render(intl: &Intl, values: &Values<String>) {
                 format_message!(
                     &intl,
                     default_message: "Hello, {name}!",
@@ -314,22 +316,26 @@ mod tests {
                     id: "approval.title",
                     default_message: "Approve to continue",
                 );
-            }"#,
-            Path::new("src/main.rs"),
-            false,
-            false,
-            false,
-            true,
-        )
-        .unwrap();
+            }"#
+            .replace("format_message!", &format!("{macro_name}!"));
+            let messages = extract_messages_from_rust_source(
+                &source,
+                Path::new("src/main.rs"),
+                false,
+                false,
+                false,
+                true,
+            )
+            .unwrap();
 
-        assert_eq!(messages.len(), 3);
-        assert_eq!(messages[0].id.as_deref(), Some("EG1xJTTqQy"));
-        assert_eq!(
-            messages[1].default_message.as_deref(),
-            Some("{count, plural, one {# task} other {{name} has # tasks}}")
-        );
-        assert_eq!(messages[2].id.as_deref(), Some("approval.title"));
+            assert_eq!(messages.len(), 3);
+            assert_eq!(messages[0].id.as_deref(), Some("EG1xJTTqQy"));
+            assert_eq!(
+                messages[1].default_message.as_deref(),
+                Some("{count, plural, one {# task} other {{name} has # tasks}}")
+            );
+            assert_eq!(messages[2].id.as_deref(), Some("approval.title"));
+        }
     }
 
     #[test]

--- a/crates/formatjs_intl/BUILD.bazel
+++ b/crates/formatjs_intl/BUILD.bazel
@@ -1,18 +1,23 @@
 load("@rules_rs//rs:rust_library.bzl", "rust_library")
 load("@rules_rs//rs:rust_test.bzl", "rust_test")
+load("@rules_rust//rust:defs.bzl", "rust_doc_test")
 
 exports_files(
     [
         "Cargo.toml",
         "README.md",
         "lib.rs",
+        "formatted_message.rs",
     ],
     visibility = ["//visibility:public"],
 )
 
 rust_library(
     name = "formatjs_intl",
-    srcs = ["lib.rs"],
+    srcs = [
+        "formatted_message.rs",
+        "lib.rs",
+    ],
     crate_name = "formatjs_intl",
     visibility = ["//visibility:public"],
     deps = [
@@ -27,4 +32,10 @@ rust_test(
     size = "small",
     crate = ":formatjs_intl",
     deps = ["@crates//:serde_json"],
+)
+
+rust_doc_test(
+    name = "formatjs_intl_doc_test",
+    size = "small",
+    crate = ":formatjs_intl",
 )

--- a/crates/formatjs_intl/README.md
+++ b/crates/formatjs_intl/README.md
@@ -82,6 +82,43 @@ let intl = intl.with_on_error(|error: &FormatMessageError| {
 # }
 ```
 
+## Typed presentation text
+
+Use `formatted_message!` when an interface should accept formatted text rather
+than arbitrary strings. It returns `formatjs_intl::FormattedMessage` and uses
+the same extraction, IDs, locale negotiation, fallback, and `with_on_error`
+reporting as `format_message!`.
+
+```rust
+# use formatjs_intl::{Intl, FormattedMessage, formatted_message};
+# fn render(intl: &Intl, path: &str) -> FormattedMessage {
+formatted_message!(
+    intl,
+    default_message: "Open {path}?",
+    description: "Confirmation before opening a selected file",
+    values: { path: FormattedMessage::verbatim(path) },
+)
+# }
+```
+
+Replacements accept `FormattedMessage` (including borrowed messages), numbers,
+booleans, and `formatjs_icu_messageformat::DateTimeValue`. Raw `String`/`&str`
+values do not compile. Use `FormattedMessage::verbatim(...)` to explicitly
+accept content that should not be translated, such as a filename. Applications
+remain responsible for which content may be displayed.
+
+For reusable replacement maps, use `MessageValues` and pass `values: &values`.
+For static descriptors, `Intl::format_message_typed` returns
+`Result<FormattedMessage>` and `format_message_typed_or_default` also recovers
+infrastructure failures with the descriptor default. Read the result with
+`as_str()` or consume it with `into_string()` at the final presentation step.
+
+The type records an explicit formatting/verbatim path; it does not guarantee
+translation coverage, successful interpolation, HTML escaping, or sanitized
+content. It is separate from the existing low-level
+`formatjs_icu_messageformat::FormattedMessage<T>` rich-text result. Existing
+string and rich-text formatting interfaces remain unchanged.
+
 Precompile catalogs with the FormatJS CLI to skip runtime message parsing:
 
 ```sh

--- a/crates/formatjs_intl/formatted_message.rs
+++ b/crates/formatjs_intl/formatted_message.rs
@@ -1,0 +1,369 @@
+use std::fmt;
+
+use formatjs_icu_messageformat::{DateTimeValue, Values};
+
+use crate::{Intl, MessageDescriptor, Result};
+
+/// Text produced by checked formatting or explicitly accepted as verbatim content.
+///
+/// This records the formatting path, not translation coverage, successful interpolation,
+/// HTML escaping, or permission to display sensitive content. Normal catalog and
+/// default-message fallback still apply. Unlike the low-level rich-text
+/// `formatjs_icu_messageformat::FormattedMessage<T>`, its contents are private.
+///
+/// Raw strings cannot implicitly enter a typed presentation interface:
+///
+/// ```compile_fail
+/// let _: formatjs_intl::FormattedMessage = String::from("request failed").into();
+/// ```
+///
+/// ```compile_fail
+/// let _: formatjs_intl::FormattedMessage = "request failed".into();
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FormattedMessage(String);
+
+impl FormattedMessage {
+    /// Explicitly accepts content that should not be translated, such as a name or path.
+    /// Applications decide which sources are appropriate; this performs no sanitization.
+    pub fn verbatim(text: impl Into<String>) -> Self {
+        Self(text.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl fmt::Display for FormattedMessage {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl AsRef<str> for FormattedMessage {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+/// Checked replacements: formatted/verbatim messages, numbers, booleans, and dates.
+///
+/// ```compile_fail
+/// let mut values = formatjs_intl::MessageValues::new();
+/// values.insert("detail", String::from("request failed"));
+/// ```
+///
+/// ```compile_fail
+/// let mut values = formatjs_intl::MessageValues::new();
+/// values.insert("detail", "request failed");
+/// ```
+#[derive(Default)]
+pub struct MessageValues(Values<String>);
+
+impl MessageValues {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn insert(&mut self, name: impl Into<String>, value: impl MessageArgument) {
+        value.insert_into(self, name.into());
+    }
+}
+
+mod private {
+    pub trait Sealed {}
+}
+
+/// An interpolation value accepted by checked formatting.
+/// Sealed so unchecked string or rich-text values cannot implement this trait.
+pub trait MessageArgument: private::Sealed {
+    #[doc(hidden)]
+    fn insert_into(self, values: &mut MessageValues, name: String);
+}
+
+impl private::Sealed for FormattedMessage {}
+
+impl MessageArgument for FormattedMessage {
+    fn insert_into(self, values: &mut MessageValues, name: String) {
+        values.0.insert(name, self.0.into());
+    }
+}
+
+macro_rules! arguments {
+    ($($ty:ty),+ $(,)?) => {
+        $(
+            impl private::Sealed for $ty {}
+
+            impl MessageArgument for $ty {
+                fn insert_into(self, values: &mut MessageValues, name: String) {
+                    values.0.insert(name, self.into());
+                }
+            }
+        )+
+    };
+}
+
+arguments!(i64, u64, f64, bool, DateTimeValue);
+
+macro_rules! numeric_arguments {
+    ($target:ty; $($source:ty),+ $(,)?) => {
+        $(
+            impl private::Sealed for $source {}
+
+            impl MessageArgument for $source {
+                fn insert_into(self, values: &mut MessageValues, name: String) {
+                    (self as $target).insert_into(values, name);
+                }
+            }
+        )+
+    };
+}
+
+numeric_arguments!(i64; i8, i16, i32, isize);
+numeric_arguments!(u64; u8, u16, u32, usize);
+numeric_arguments!(f64; f32);
+
+impl<T: MessageArgument + Clone> private::Sealed for &T {}
+
+impl<T: MessageArgument + Clone> MessageArgument for &T {
+    fn insert_into(self, values: &mut MessageValues, name: String) {
+        T::clone(self).insert_into(values, name);
+    }
+}
+
+impl Intl {
+    /// Formats a static descriptor with checked replacements, preserving normal fallback.
+    /// Descriptor text is application-authored; use [`crate::message_descriptor!`]
+    /// to make it extractable. Only infrastructure errors escape the fallback chain.
+    pub fn format_message_typed(
+        &self,
+        descriptor: MessageDescriptor,
+        values: &MessageValues,
+    ) -> Result<FormattedMessage> {
+        self.format_message_to_string(descriptor, &values.0)
+            .map(FormattedMessage)
+    }
+
+    /// Checked formatting that returns the descriptor default on infrastructure errors.
+    pub fn format_message_typed_or_default(
+        &self,
+        descriptor: MessageDescriptor,
+        values: &MessageValues,
+    ) -> FormattedMessage {
+        FormattedMessage(self.format_message_to_string_or_default(descriptor, &values.0))
+    }
+}
+
+/// Formats extractable text with checked replacements and returns [`FormattedMessage`].
+/// Uses the same IDs, locale negotiation, fallback, and error reporting as
+/// [`crate::format_message!`]. Inline replacement names are checked at compile time.
+///
+/// ```
+/// # use formatjs_intl::{Intl, FormattedMessage, formatted_message};
+/// # fn render(intl: &Intl, path: &str) -> FormattedMessage {
+/// formatted_message!(
+///     intl,
+///     default_message: "Open {path}?",
+///     values: { path: FormattedMessage::verbatim(path) },
+/// )
+/// # }
+/// ```
+///
+/// Raw strings and unchecked maps cannot bypass the replacement check:
+///
+/// ```compile_fail
+/// # fn render(intl: &formatjs_intl::Intl) {
+/// formatjs_intl::formatted_message!(intl, default_message: "Failed: {detail}",
+///     values: { detail: "request failed" });
+/// # }
+/// ```
+///
+/// ```compile_fail
+/// # fn render(intl: &formatjs_intl::Intl) {
+/// let values = formatjs_icu_messageformat::Values::<String>::new();
+/// formatjs_intl::formatted_message!(intl, default_message: "Failed: {detail}",
+///     values: &values);
+/// # }
+/// ```
+///
+/// ```compile_fail
+/// # fn render(intl: &formatjs_intl::Intl) {
+/// formatjs_intl::formatted_message!(intl, default_message: "Hello, {name}!");
+/// # }
+/// ```
+///
+/// ```compile_fail
+/// # fn render(intl: &formatjs_intl::Intl) {
+/// formatjs_intl::formatted_message!(intl, default_message: "{count} items",
+///     values: { wrong_name: 2 });
+/// # }
+/// ```
+#[macro_export]
+macro_rules! formatted_message {
+    (
+        $intl:expr,
+        $(id: $id:literal,)?
+        default_message: $default_message:literal
+        $(, description: $description:literal)?
+        , values: { $($name:ident : $value:expr),+ $(,)? }
+        $(,)?
+    ) => {{
+        const _: () = $crate::__validate_message_values!(
+            $default_message; $($name),+
+        );
+        let mut values = $crate::MessageValues::new();
+        $(values.insert(::core::stringify!($name), $value);)+
+        $crate::formatted_message!(
+            $intl,
+            $(id: $id,)?
+            default_message: $default_message
+            $(, description: $description)?
+            , values: &values
+        )
+    }};
+    (
+        $intl:expr,
+        $(id: $id:literal,)?
+        default_message: $default_message:literal
+        $(, description: $description:literal)?
+        , values: $values:expr
+        $(,)?
+    ) => {{
+        let descriptor = $crate::message_descriptor!(
+            $(id: $id,)?
+            default_message: $default_message
+            $(, description: $description)?
+        );
+        $intl.format_message_typed_or_default(descriptor, $values)
+    }};
+    (
+        $intl:expr,
+        $(id: $id:literal,)?
+        default_message: $default_message:literal
+        $(, description: $description:literal)?
+        $(,)?
+    ) => {{
+        const _: () = $crate::__validate_message_values!($default_message;);
+        $crate::formatted_message!(
+            $intl,
+            $(id: $id,)?
+            default_message: $default_message
+            $(, description: $description)?
+            , values: &$crate::MessageValues::new()
+        )
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    use super::*;
+    use crate::{IntlCache, MessageCatalog, MessageSource, message_descriptor};
+
+    const SUMMARY: MessageDescriptor = message_descriptor!(
+        id: "summary",
+        default_message: "{count, plural, one {# item} other {# items}}: {nested} ({path})"
+    );
+    const TRANSLATED_SUMMARY: &str =
+        "{count, plural, one {# élément} other {# éléments}} : {nested} ({path})";
+
+    fn intl() -> Intl {
+        let mut catalog = MessageCatalog::new();
+        catalog.insert("en", HashMap::new()).unwrap();
+        catalog
+            .insert(
+                "fr",
+                HashMap::from([
+                    (SUMMARY.id.into(), TRANSLATED_SUMMARY.into()),
+                    ("done".into(), "Terminé".into()),
+                ]),
+            )
+            .unwrap();
+        Intl::try_new(
+            ["fr-CA"],
+            "en",
+            Arc::new(catalog),
+            Arc::new(IntlCache::new()),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn typed_messages_preserve_locale_pluralization_and_nested_content() {
+        let intl = intl();
+        let nested = formatted_message!(&intl, id: "done", default_message: "Done");
+        let path = FormattedMessage::verbatim("/tmp/{report}.txt");
+        for (count, expected) in [
+            (0, "0 élément : Terminé (/tmp/{report}.txt)"),
+            (2, "2 éléments : Terminé (/tmp/{report}.txt)"),
+        ] {
+            let inline = formatted_message!(
+                &intl, id: "summary",
+                default_message: "{count, plural, one {# item} other {# items}}: {nested} ({path})",
+                values: { count: count, nested: &nested, path: &path },
+            );
+            let mut values = MessageValues::new();
+            values.insert("count", count);
+            values.insert("nested", &nested);
+            values.insert("path", &path);
+            let mapped = formatted_message!(
+                &intl, id: "summary",
+                default_message: "{count, plural, one {# item} other {# items}}: {nested} ({path})",
+                values: &values,
+            );
+            assert_eq!(inline.as_str(), expected);
+            assert_eq!(mapped, inline);
+            assert_eq!(intl.format_message_typed(SUMMARY, &values).unwrap(), inline);
+            assert_eq!(inline.into_string(), expected);
+        }
+    }
+
+    #[test]
+    fn fallback_retains_typed_output_and_reports_missing_translation() {
+        let failures = Arc::new(Mutex::new(Vec::new()));
+        let captured = failures.clone();
+        let intl = intl().with_on_error(move |error| {
+            captured
+                .lock()
+                .unwrap()
+                .push((error.descriptor.id.clone(), error.source));
+        });
+        let message = formatted_message!(
+            &intl, id: "missing", default_message: "{count, plural, one {# item} other {# items}}",
+            values: { count: 0 },
+        );
+        // The English fallback uses English plural rules, even for a French request.
+        assert_eq!(message.as_str(), "0 items");
+        assert_eq!(
+            *failures.lock().unwrap(),
+            [("missing".into(), MessageSource::Translation)]
+        );
+    }
+
+    #[test]
+    fn infrastructure_errors_remain_fallible_or_return_the_descriptor_default() {
+        let intl = intl();
+        let cache = intl.cache.clone();
+        let _ = std::panic::catch_unwind(move || {
+            let _messages = cache.messages.write().unwrap();
+            panic!("poison cache");
+        });
+        let values = MessageValues::new();
+        assert!(matches!(
+            intl.format_message_typed(SUMMARY, &values),
+            Err(crate::Error::CachePoisoned)
+        ));
+        assert_eq!(
+            intl.format_message_typed_or_default(SUMMARY, &values)
+                .as_str(),
+            SUMMARY.default_message,
+        );
+    }
+}

--- a/crates/formatjs_intl/lib.rs
+++ b/crates/formatjs_intl/lib.rs
@@ -1,5 +1,5 @@
 use formatjs_icu_messageformat::{
-    FormattedMessage, IcuMessageFormat, MessageFormatElement, Part, Values,
+    FormattedMessage as RichFormattedMessage, IcuMessageFormat, MessageFormatElement, Part, Values,
 };
 use icu_locale::{Locale, fallback::LocaleFallbacker};
 use std::collections::HashMap;
@@ -11,6 +11,10 @@ use std::sync::{Arc, RwLock};
 pub use formatjs_icu_messageformat::{Value as __Value, Values as __Values};
 #[doc(hidden)]
 pub use formatjs_intl_macros::{__message_descriptor, __validate_message_values};
+
+mod formatted_message;
+
+pub use formatted_message::{FormattedMessage, MessageArgument, MessageValues};
 
 pub type Messages = HashMap<String, String>;
 pub type PrecompiledMessages = HashMap<String, Vec<MessageFormatElement>>;
@@ -427,7 +431,7 @@ impl Intl {
         &self,
         descriptor: MessageDescriptor,
         values: &Values<T>,
-    ) -> Result<FormattedMessage<T>> {
+    ) -> Result<RichFormattedMessage<T>> {
         self.format_message_ref(descriptor.as_ref(), values)
     }
 
@@ -435,11 +439,11 @@ impl Intl {
         &self,
         descriptor: MessageDescriptorRef<'_>,
         values: &Values<T>,
-    ) -> Result<FormattedMessage<T>> {
+    ) -> Result<RichFormattedMessage<T>> {
         self.format_with_fallback(
             descriptor,
             |message, locale| message.format(locale, values),
-            FormattedMessage::Literal,
+            RichFormattedMessage::Literal,
         )
     }
 
@@ -1048,7 +1052,7 @@ mod tests {
         );
         assert_eq!(
             intl.format_message(INVALID_DEFAULT, &values).unwrap(),
-            FormattedMessage::Literal("{translated".to_owned())
+            RichFormattedMessage::Literal("{translated".to_owned())
         );
         assert_eq!(
             intl

--- a/docs/src/docs/rust/intl.mdx
+++ b/docs/src/docs/rust/intl.mdx
@@ -127,6 +127,44 @@ If cache infrastructure prevents formatting, it reports the error through
 `with_on_error` and returns `default_message` verbatim. Use
 `format_message_to_string` when explicit `Result` handling is required.
 
+## Typed presentation text
+
+Use `formatted_message!` when an interface should accept formatted text rather
+than arbitrary strings. It returns `formatjs_intl::FormattedMessage` and uses
+the same extraction, IDs, locale negotiation, fallback, and `with_on_error`
+reporting as `format_message!`.
+
+```rust
+use formatjs_intl::{Intl, FormattedMessage, formatted_message};
+
+fn render(intl: &Intl, path: &str) -> FormattedMessage {
+    formatted_message!(
+        intl,
+        default_message: "Open {path}?",
+        description: "Confirmation before opening a selected file",
+        values: { path: FormattedMessage::verbatim(path) },
+    )
+}
+```
+
+Replacements accept `FormattedMessage` (including borrowed messages), numbers,
+booleans, and `formatjs_icu_messageformat::DateTimeValue`. Raw `String`/`&str`
+values do not compile. Use `FormattedMessage::verbatim(...)` to explicitly
+accept content that should not be translated, such as a filename. Applications
+remain responsible for which content may be displayed.
+
+For reusable replacement maps, use `MessageValues` and pass `values: &values`.
+For static descriptors, `Intl::format_message_typed` returns
+`Result<FormattedMessage>` and `format_message_typed_or_default` also recovers
+infrastructure failures with the descriptor default. Read the result with
+`as_str()` or consume it with `into_string()` at the final presentation step.
+
+The type records an explicit formatting/verbatim path; it does not guarantee
+translation coverage, successful interpolation, HTML escaping, or sanitized
+content. It is separate from the existing low-level
+`formatjs_icu_messageformat::FormattedMessage<T>` rich-text result. Existing
+string and rich-text formatting interfaces remain unchanged.
+
 ## Shared cache
 
 `IntlCache` stores parsed messages by source string. Share one `Arc<IntlCache>`

--- a/knowledge-base/003-rust-crate-dependency-hierarchy.md
+++ b/knowledge-base/003-rust-crate-dependency-hierarchy.md
@@ -177,6 +177,10 @@ the crate is not published to crates.io.
 
 - Defines `message_descriptor!` through a re-exported procedural macro.
 - Defines extractable `format_message!` for infallible inline string formatting.
+- Defines `formatted_message!` for opaque `FormattedMessage` output with checked
+  interpolation through `MessageValues`; raw strings require explicit
+  `FormattedMessage::verbatim`. It shares extraction, IDs, and runtime fallback
+  with the string interface.
 - Accepts checked inline `values: { name: expression }`; its procedural macro
   parses the default ICU message and rejects missing, unused, or duplicate names.
 - Keeps `values: &values` for dynamically assembled or reused maps.

--- a/knowledge-base/008-package-intl-and-framework-integrations.md
+++ b/knowledge-base/008-package-intl-and-framework-integrations.md
@@ -45,6 +45,18 @@ cache infrastructure fails. Inline `values: { name: expression }` are converted
 to runtime values and checked against the default ICU message at compile time;
 callers can still pass an existing values map.
 
+`formatted_message!` is the opt-in checked-text interface. It returns the opaque
+`formatjs_intl::FormattedMessage` and accepts only formatted/explicitly verbatim
+text, numbers, booleans, and dates through sealed `MessageArgument` conversions.
+`MessageValues` provides checked reusable maps. `FormattedMessage::verbatim`
+marks intentionally untranslated content; ordinary strings cannot convert
+implicitly. Static-descriptor callers use `Intl::format_message_typed` or
+`format_message_typed_or_default`. All paths reuse the existing formatter and
+fallback chain. The CLI extracts both inline macros with identical ID rules.
+The type does not promise translation coverage, escaping, or successful
+interpolation, and is distinct from the low-level rich-text result of the same
+name. Locale selection and domain error presentation remain application-owned.
+
 ## react-intl
 
 **Purpose:** React components and hooks for i18n. The most widely used FormatJS package.


### PR DESCRIPTION
Rust applications that require intentionally formatted text at presentation interfaces currently receive an ordinary `String` from `format_message!`. They must maintain their own wrapper and argument checks to prevent unrelated diagnostic strings from flowing into those interfaces.

Add an opt-in `formatjs_intl::FormattedMessage` with private contents and a `formatted_message!` macro. Interpolation accepts nested formatted messages, numeric/boolean/date values, and explicitly untranslated text through `FormattedMessage::verbatim(...)`; raw strings and unchecked value maps do not implicitly enter this path. `MessageValues` supports reusable checked maps, and static descriptors have fallible and fallback-returning methods on `Intl`.

```rust
let confirmation: FormattedMessage = formatted_message!(
    &intl,
    default_message: "Open {path}?",
    values: { path: FormattedMessage::verbatim(path) },
);
```

The typed path delegates to existing locale negotiation, catalog fallback, and error reporting. The CLI extracts the new macro using the existing descriptor and ID rules. Existing string APIs and the low-level rich-text `formatjs_icu_messageformat::FormattedMessage<T>` remain compatible. Locale selection and decisions about which content may be displayed remain application responsibilities; the type does not promise translation coverage or sanitization.

Coverage exercises translated pluralization, nested and verbatim replacements, fallback and infrastructure errors, extraction parity, and compile-time rejection of raw strings, unchecked maps, and incorrect placeholder names. Public docs and the Rust knowledge base describe the new interface.
