### PR TITLE
fix(formatjs_intl): restrict verbatim text to domain sources

### DIFF
--- a/crates/formatjs_intl/README.md
+++ b/crates/formatjs_intl/README.md
@@ -87,37 +87,60 @@ let intl = intl.with_on_error(|error: &FormatMessageError| {
 Use `formatted_message!` when an interface should accept formatted text rather
 than arbitrary strings. It returns `formatjs_intl::FormattedMessage` and uses
 the same extraction, IDs, locale negotiation, fallback, and `with_on_error`
-reporting as `format_message!`.
+reporting as `format_message!`. There is no raw-string constructor.
+
+Untranslated content must come from an application-owned type implementing
+`VerbatimSource`. Implement that trait beside the domain type's controlled
+constructors, not on a generic string wrapper or diagnostic error.
 
 ```rust
-# use formatjs_intl::{Intl, FormattedMessage, formatted_message};
-# fn render(intl: &Intl, path: &str) -> FormattedMessage {
-formatted_message!(
-    intl,
-    default_message: "Open {path}?",
-    description: "Confirmation before opening a selected file",
-    values: { path: FormattedMessage::verbatim(path) },
-)
-# }
+use formatjs_intl::{Intl, FormattedMessage, Verbatim, VerbatimSource, formatted_message};
+
+struct SelectedFile {
+    name: String,
+}
+
+impl VerbatimSource for SelectedFile {
+    fn as_verbatim(&self) -> &str {
+        &self.name
+    }
+}
+
+fn render(intl: &Intl, file: &SelectedFile) -> FormattedMessage {
+    formatted_message!(
+        intl,
+        default_message: "Open {path}?",
+        description: "Confirmation before opening a selected file",
+        values: { path: Verbatim::new(file) },
+    )
+}
 ```
 
-Replacements accept `FormattedMessage` (including borrowed messages), numbers,
-booleans, and `formatjs_icu_messageformat::DateTimeValue`. Raw `String`/`&str`
-values do not compile. Use `FormattedMessage::verbatim(...)` to explicitly
-accept content that should not be translated, such as a filename. Applications
-remain responsible for which content may be displayed.
+`Verbatim` is interpolation-only: it cannot convert directly to
+`FormattedMessage`. Strings, paths, and arbitrary `Display` values do not
+implement `VerbatimSource`, so `Verbatim::new(&error.to_string())` does not
+compile. Applications remain responsible for reviewing their domain types and
+trait implementations; this is a type-level guard, not a security sandbox.
 
+Other replacements accept nested `FormattedMessage` values (including borrowed
+messages), numbers, booleans, and `formatjs_icu_messageformat::DateTimeValue`.
 For reusable replacement maps, use `MessageValues` and pass `values: &values`.
 For static descriptors, `Intl::format_message_typed` returns
 `Result<FormattedMessage>` and `format_message_typed_or_default` also recovers
 infrastructure failures with the descriptor default. Read the result with
 `as_str()` or consume it with `into_string()` at the final presentation step.
 
-The type records an explicit formatting/verbatim path; it does not guarantee
-translation coverage, successful interpolation, HTML escaping, or sanitized
-content. It is separate from the existing low-level
-`formatjs_icu_messageformat::FormattedMessage<T>` rich-text result. Existing
-string and rich-text formatting interfaces remain unchanged.
+Migration: `FormattedMessage::verbatim(...)` has been removed. Move permitted
+untranslated sources behind domain-owned `VerbatimSource` implementations and
+interpolate them with `Verbatim::new(&source)` in an authored message. Do not
+replace the old constructor with a catch-all string wrapper or a `"{detail}"`
+message that forwards diagnostics.
+
+The type records a formatting path; it does not guarantee translation coverage,
+successful interpolation, HTML escaping, or sanitized content. It is separate
+from the existing low-level `formatjs_icu_messageformat::FormattedMessage<T>`
+rich-text result. Existing string and rich-text formatting interfaces remain
+unchanged.
 
 Precompile catalogs with the FormatJS CLI to skip runtime message parsing:
 

--- a/crates/formatjs_intl/formatted_message.rs
+++ b/crates/formatjs_intl/formatted_message.rs
@@ -4,7 +4,7 @@ use formatjs_icu_messageformat::{DateTimeValue, Values};
 
 use crate::{Intl, MessageDescriptor, Result};
 
-/// Text produced by checked formatting or explicitly accepted as verbatim content.
+/// Text produced by checked formatting.
 ///
 /// This records the formatting path, not translation coverage, successful interpolation,
 /// HTML escaping, or permission to display sensitive content. Normal catalog and
@@ -20,16 +20,17 @@ use crate::{Intl, MessageDescriptor, Result};
 /// ```compile_fail
 /// let _: formatjs_intl::FormattedMessage = "request failed".into();
 /// ```
+///
+/// There is no unchecked string constructor:
+///
+/// ```compile_fail
+/// let error = std::io::Error::other("request failed");
+/// let _ = formatjs_intl::FormattedMessage::verbatim(error.to_string());
+/// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct FormattedMessage(String);
 
 impl FormattedMessage {
-    /// Explicitly accepts content that should not be translated, such as a name or path.
-    /// Applications decide which sources are appropriate; this performs no sanitization.
-    pub fn verbatim(text: impl Into<String>) -> Self {
-        Self(text.into())
-    }
-
     pub fn as_str(&self) -> &str {
         &self.0
     }
@@ -51,7 +52,62 @@ impl AsRef<str> for FormattedMessage {
     }
 }
 
-/// Checked replacements: formatted/verbatim messages, numbers, booleans, and dates.
+/// Application-owned content that may be interpolated without translation.
+///
+/// Implement this on domain types whose constructors control the text's origin,
+/// such as a selected file or a product identity. Implementations are the application's
+/// trust decision: do not implement this on generic text wrappers or diagnostic errors.
+/// There are deliberately no implementations for strings, paths, or `Display` values.
+/// Downstream crates cannot implement this foreign trait for standard-library types.
+pub trait VerbatimSource {
+    fn as_verbatim(&self) -> &str;
+}
+
+/// An interpolation-only borrow of application-approved content.
+///
+/// Raw diagnostic strings cannot be disguised as a one-placeholder message:
+///
+/// ```compile_fail
+/// # fn render(intl: &formatjs_intl::Intl) {
+/// use formatjs_intl::{Verbatim, formatted_message};
+/// let error = std::io::Error::other("request failed");
+/// formatted_message!(intl, default_message: "{detail}",
+///     values: { detail: Verbatim::new(&error.to_string()) });
+/// # }
+/// ```
+///
+/// ```compile_fail
+/// let _ = formatjs_intl::Verbatim::new("request failed");
+/// ```
+///
+/// Even an approved source cannot directly become a formatted message:
+///
+/// ```compile_fail
+/// use formatjs_intl::{FormattedMessage, Verbatim, VerbatimSource};
+/// struct Product;
+/// impl VerbatimSource for Product {
+///     fn as_verbatim(&self) -> &str { "Example" }
+/// }
+/// let _: FormattedMessage = Verbatim::new(&Product).into();
+/// ```
+#[derive(Clone, Copy)]
+pub struct Verbatim<'a>(&'a dyn VerbatimSource);
+
+impl<'a> Verbatim<'a> {
+    pub fn new(source: &'a dyn VerbatimSource) -> Self {
+        Self(source)
+    }
+}
+
+impl private::Sealed for Verbatim<'_> {}
+
+impl MessageArgument for Verbatim<'_> {
+    fn insert_into(self, values: &mut MessageValues, name: String) {
+        values.0.insert(name, self.0.as_verbatim().into());
+    }
+}
+
+/// Checked replacements: formatted messages, domain-owned verbatim arguments, numbers, booleans, and dates.
 ///
 /// ```compile_fail
 /// let mut values = formatjs_intl::MessageValues::new();
@@ -164,12 +220,16 @@ impl Intl {
 /// [`crate::format_message!`]. Inline replacement names are checked at compile time.
 ///
 /// ```
-/// # use formatjs_intl::{Intl, FormattedMessage, formatted_message};
-/// # fn render(intl: &Intl, path: &str) -> FormattedMessage {
+/// # use formatjs_intl::{Intl, FormattedMessage, Verbatim, VerbatimSource, formatted_message};
+/// struct SelectedFile { name: String }
+/// impl VerbatimSource for SelectedFile {
+///     fn as_verbatim(&self) -> &str { &self.name }
+/// }
+/// # fn render(intl: &Intl, file: &SelectedFile) -> FormattedMessage {
 /// formatted_message!(
 ///     intl,
 ///     default_message: "Open {path}?",
-///     values: { path: FormattedMessage::verbatim(path) },
+///     values: { path: Verbatim::new(file) },
 /// )
 /// # }
 /// ```
@@ -295,11 +355,24 @@ mod tests {
         .unwrap()
     }
 
+    struct SelectedFile {
+        path: String,
+    }
+
+    impl VerbatimSource for SelectedFile {
+        fn as_verbatim(&self) -> &str {
+            &self.path
+        }
+    }
+
     #[test]
     fn typed_messages_preserve_locale_pluralization_and_nested_content() {
         let intl = intl();
         let nested = formatted_message!(&intl, id: "done", default_message: "Done");
-        let path = FormattedMessage::verbatim("/tmp/{report}.txt");
+        let file = SelectedFile {
+            path: "/tmp/{report}.txt".into(),
+        };
+        let path = Verbatim::new(&file);
         for (count, expected) in [
             (0, "0 élément : Terminé (/tmp/{report}.txt)"),
             (2, "2 éléments : Terminé (/tmp/{report}.txt)"),

--- a/crates/formatjs_intl/lib.rs
+++ b/crates/formatjs_intl/lib.rs
@@ -14,7 +14,9 @@ pub use formatjs_intl_macros::{__message_descriptor, __validate_message_values};
 
 mod formatted_message;
 
-pub use formatted_message::{FormattedMessage, MessageArgument, MessageValues};
+pub use formatted_message::{
+    FormattedMessage, MessageArgument, MessageValues, Verbatim, VerbatimSource,
+};
 
 pub type Messages = HashMap<String, String>;
 pub type PrecompiledMessages = HashMap<String, Vec<MessageFormatElement>>;

--- a/docs/src/docs/rust/intl.mdx
+++ b/docs/src/docs/rust/intl.mdx
@@ -132,38 +132,60 @@ If cache infrastructure prevents formatting, it reports the error through
 Use `formatted_message!` when an interface should accept formatted text rather
 than arbitrary strings. It returns `formatjs_intl::FormattedMessage` and uses
 the same extraction, IDs, locale negotiation, fallback, and `with_on_error`
-reporting as `format_message!`.
+reporting as `format_message!`. There is no raw-string constructor.
+
+Untranslated content must come from an application-owned type implementing
+`VerbatimSource`. Implement that trait beside the domain type's controlled
+constructors, not on a generic string wrapper or diagnostic error.
 
 ```rust
-use formatjs_intl::{Intl, FormattedMessage, formatted_message};
+use formatjs_intl::{Intl, FormattedMessage, Verbatim, VerbatimSource, formatted_message};
 
-fn render(intl: &Intl, path: &str) -> FormattedMessage {
+struct SelectedFile {
+    name: String,
+}
+
+impl VerbatimSource for SelectedFile {
+    fn as_verbatim(&self) -> &str {
+        &self.name
+    }
+}
+
+fn render(intl: &Intl, file: &SelectedFile) -> FormattedMessage {
     formatted_message!(
         intl,
         default_message: "Open {path}?",
         description: "Confirmation before opening a selected file",
-        values: { path: FormattedMessage::verbatim(path) },
+        values: { path: Verbatim::new(file) },
     )
 }
 ```
 
-Replacements accept `FormattedMessage` (including borrowed messages), numbers,
-booleans, and `formatjs_icu_messageformat::DateTimeValue`. Raw `String`/`&str`
-values do not compile. Use `FormattedMessage::verbatim(...)` to explicitly
-accept content that should not be translated, such as a filename. Applications
-remain responsible for which content may be displayed.
+`Verbatim` is interpolation-only: it cannot convert directly to
+`FormattedMessage`. Strings, paths, and arbitrary `Display` values do not
+implement `VerbatimSource`, so `Verbatim::new(&error.to_string())` does not
+compile. Applications remain responsible for reviewing their domain types and
+trait implementations; this is a type-level guard, not a security sandbox.
 
+Other replacements accept nested `FormattedMessage` values (including borrowed
+messages), numbers, booleans, and `formatjs_icu_messageformat::DateTimeValue`.
 For reusable replacement maps, use `MessageValues` and pass `values: &values`.
 For static descriptors, `Intl::format_message_typed` returns
 `Result<FormattedMessage>` and `format_message_typed_or_default` also recovers
 infrastructure failures with the descriptor default. Read the result with
 `as_str()` or consume it with `into_string()` at the final presentation step.
 
-The type records an explicit formatting/verbatim path; it does not guarantee
-translation coverage, successful interpolation, HTML escaping, or sanitized
-content. It is separate from the existing low-level
-`formatjs_icu_messageformat::FormattedMessage<T>` rich-text result. Existing
-string and rich-text formatting interfaces remain unchanged.
+Migration: `FormattedMessage::verbatim(...)` has been removed. Move permitted
+untranslated sources behind domain-owned `VerbatimSource` implementations and
+interpolate them with `Verbatim::new(&source)` in an authored message. Do not
+replace the old constructor with a catch-all string wrapper or a `"{detail}"`
+message that forwards diagnostics.
+
+The type records a formatting path; it does not guarantee translation coverage,
+successful interpolation, HTML escaping, or sanitized content. It is separate
+from the existing low-level `formatjs_icu_messageformat::FormattedMessage<T>`
+rich-text result. Existing string and rich-text formatting interfaces remain
+unchanged.
 
 ## Shared cache
 

--- a/knowledge-base/003-rust-crate-dependency-hierarchy.md
+++ b/knowledge-base/003-rust-crate-dependency-hierarchy.md
@@ -178,9 +178,10 @@ the crate is not published to crates.io.
 - Defines `message_descriptor!` through a re-exported procedural macro.
 - Defines extractable `format_message!` for infallible inline string formatting.
 - Defines `formatted_message!` for opaque `FormattedMessage` output with checked
-  interpolation through `MessageValues`; raw strings require explicit
-  `FormattedMessage::verbatim`. It shares extraction, IDs, and runtime fallback
-  with the string interface.
+  interpolation through `MessageValues`; raw strings cannot construct the result.
+  Untranslated arguments use interpolation-only `Verbatim` borrows of domain
+  types implementing `VerbatimSource`. It shares extraction, IDs, and runtime
+  fallback with the string interface.
 - Accepts checked inline `values: { name: expression }`; its procedural macro
   parses the default ICU message and rejects missing, unused, or duplicate names.
 - Keeps `values: &values` for dynamically assembled or reused maps.

--- a/knowledge-base/008-package-intl-and-framework-integrations.md
+++ b/knowledge-base/008-package-intl-and-framework-integrations.md
@@ -46,11 +46,14 @@ to runtime values and checked against the default ICU message at compile time;
 callers can still pass an existing values map.
 
 `formatted_message!` is the opt-in checked-text interface. It returns the opaque
-`formatjs_intl::FormattedMessage` and accepts only formatted/explicitly verbatim
-text, numbers, booleans, and dates through sealed `MessageArgument` conversions.
-`MessageValues` provides checked reusable maps. `FormattedMessage::verbatim`
-marks intentionally untranslated content; ordinary strings cannot convert
-implicitly. Static-descriptor callers use `Intl::format_message_typed` or
+`formatjs_intl::FormattedMessage` and accepts only formatted messages,
+domain-owned verbatim arguments, numbers, booleans, and dates through sealed
+`MessageArgument` conversions. `MessageValues` provides checked reusable maps.
+There is no raw-string constructor. Applications implement `VerbatimSource` on
+domain types with controlled constructors; `Verbatim::new(&source)` borrows them
+for interpolation only. Strings, paths, and arbitrary `Display` values have no
+built-in implementation, and `Verbatim` cannot convert to `FormattedMessage`.
+Reviewing domain trait implementations remains an application responsibility. Static-descriptor callers use `Intl::format_message_typed` or
 `format_message_typed_or_default`. All paths reuse the existing formatter and
 fallback chain. The CLI extracts both inline macros with identical ID rules.
 The type does not promise translation coverage, escaping, or successful


### PR DESCRIPTION
`FormattedMessage::verbatim(error.to_string())` bypasses the checked text interface introduced in #7343. Merely moving that constructor to an interpolation type would still permit forwarding arbitrary errors through a `"{detail}"` message.

Remove the constructor. Untranslated arguments now use an interpolation-only `Verbatim` borrow of an application-owned `VerbatimSource`. There are no implementations for strings, paths, or arbitrary `Display` values, and `Verbatim` cannot convert to `FormattedMessage`. Applications must explicitly implement the trait on domain types with controlled constructors; those implementations remain a code-review trust decision.

Compile-fail coverage rejects the old constructor, raw-string interpolation through `Verbatim`, and direct promotion of an approved verbatim source to a formatted message. Existing translation, pluralization, and fallback coverage exercises the new path.

BREAKING CHANGE: replace `FormattedMessage::verbatim(...)` with domain-owned `VerbatimSource` implementations interpolated inside authored messages. Public docs include migration guidance.
