### PR TITLE
fix(deps): propagate Rust-only releases to npm packages

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -65,6 +65,11 @@ jobs:
             --prefix "$RUNNER_TEMP/release-please" \
             release-please@17.6.0
 
+      - name: Verify release dependency propagation
+        run: >-
+          bazel test //tools:release_please_npm_plugin_test
+          --test_env=NODE_PATH="$RUNNER_TEMP/release-please/node_modules"
+
       - name: Verify Release Please package manifest updates
         env:
           NODE_PATH: ${{ runner.temp }}/release-please/node_modules

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -177,6 +177,7 @@ ts_run_binary(
         for release_dep in pkg.get("release_deps", [])
     ],
     tool = "//tools:generate-release-please-npm-workspace-graph",
+    visibility = ["//tools:__pkg__"],
 )
 
 test_suite(

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,7 +130,10 @@ Releases are automated via GitHub Actions:
 
 1. The **Release Please** workflow runs on `main` and maintains release PRs for
    npm packages and Rust crates. Release notes use GitHub-generated changelogs
-   so entries include PR titles, PR links, and contributors.
+   so entries include PR titles, PR links, and contributors. Dependency releases
+   propagate through the Bazel-generated npm graph, including optional native
+   packages. Rust-only CLI releases also bump their native npm packages and
+   dependent CLI wrappers without requiring another npm release.
 
 2. Merge the release PR when it is ready. Release Please creates the package
    tags and GitHub releases from the merged release PR, then calls the

--- a/knowledge-base/001-repo-layout.md
+++ b/knowledge-base/001-repo-layout.md
@@ -138,7 +138,11 @@ When Release Please creates or updates release PRs,
 `//:release_please_npm_workspace_graph` from the package manifests and runs the
 local `tools/release-please/run.ts` wrapper. That wrapper registers the
 `formatjs-bazel-workspace` plugin so dependent npm packages are patch-bumped
-from the Bazel-generated dependency graph. When Release Please creates npm
+from the Bazel-generated dependency graph. Rust-only release candidates seed their
+native npm dependents before the workspace plugin runs, so propagation does
+not depend on an unrelated npm release. The release workflow tests the real
+plugin against the generated graph, including optional dependencies, manifest
+updates, and unrelated-package isolation. When Release Please creates npm
 package releases, it passes those released package paths to `release.yml`. The
 npm publish workflow builds the Bazel `:dist` output and uses npm Trusted
 Publishing, then publishes only the package paths Release Please released. Rust

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -174,3 +174,26 @@ ts_binary(
     entry_point = "generate-default-content.ts",
     visibility = ["//visibility:public"],
 )
+
+# Uses the same pinned release-please installation as the release workflow.
+js_test(
+    name = "release_please_npm_plugin_test",
+    size = "small",
+    args = [
+        "$(rootpath //:release_please_npm_workspace_graph)",
+        "$(rootpath //:release_please_config)",
+    ],
+    data = [
+        "release-please/npm-workspace-graph.ts",
+        "release-please/npm-workspace-plugin.ts",
+        "//:release_please_config",
+        "//:release_please_npm_workspace_graph",
+    ],
+    entry_point = "release-please/npm-workspace-plugin.test.ts",
+    env_inherit = ["NODE_PATH"],
+    node_options = ["--disable-warning=MODULE_TYPELESS_PACKAGE_JSON"],
+    tags = [
+        "external",
+        "manual",
+    ],
+)

--- a/tools/release-please/npm-workspace-plugin.test.ts
+++ b/tools/release-please/npm-workspace-plugin.test.ts
@@ -1,0 +1,155 @@
+import assert from 'node:assert/strict'
+import {readFileSync} from 'node:fs'
+import {createRequire} from 'node:module'
+
+import {BazelNpmWorkspace} from './npm-workspace-plugin.ts'
+import {readGraph} from './npm-workspace-graph.ts'
+
+const require = createRequire(import.meta.url)
+const {VERSION} = require('release-please')
+const {Bazel} = require('release-please/build/src/strategies/bazel')
+const {Version} = require('release-please/build/src/version')
+const {
+  PatchVersionUpdate,
+} = require('release-please/build/src/versioning-strategy')
+
+assert.equal(VERSION, '17.6.0')
+const graphPath = process.argv[2]
+const packages = readGraph(graphPath).packages
+const rawConfig = JSON.parse(readFileSync(process.argv[3], 'utf8'))
+const repositoryConfig = Object.fromEntries(
+  Object.entries(rawConfig.packages).map(([path, config]) => [
+    path,
+    {releaseType: config['release-type'] || rawConfig['release-type']},
+  ])
+)
+const logger = {debug() {}, info() {}, warn() {}, error() {}}
+const github = {
+  repository: {owner: 'formatjs', repo: 'formatjs', defaultBranch: 'main'},
+}
+
+async function run(paths: string[]) {
+  const plugin = new BazelNpmWorkspace(github, 'main', repositoryConfig, {
+    graphPath,
+    merge: false,
+    logger,
+  })
+  const strategies = Object.fromEntries(
+    packages.map(pkg => [
+      pkg.path,
+      new Bazel({
+        github,
+        targetBranch: 'main',
+        path: pkg.path,
+        component: pkg.name,
+        packageName: pkg.name,
+        versionFile: 'BUILD.bazel',
+        extraFiles: ['package.json'],
+        changelogNotes: {buildNotes: async () => '## Fixture\n\nRelease'},
+        logger,
+      }),
+    ])
+  )
+  await plugin.preconfigure(strategies, {}, {})
+  const candidates = await Promise.all(
+    paths.map(async path => {
+      const pkg = packages.find(pkg => pkg.path === path)
+      const version = pkg
+        ? new PatchVersionUpdate().bump(Version.parse(pkg.version))
+        : Version.parse('99.0.0')
+      return {
+        path,
+        config: repositoryConfig[path],
+        pullRequest: pkg
+          ? await strategies[path].buildReleasePullRequest(
+              [],
+              undefined,
+              false,
+              [],
+              {newVersion: version}
+            )
+          : {version},
+      }
+    })
+  )
+  return plugin.run(candidates)
+}
+
+const paths = candidates => candidates.map(candidate => candidate.path).sort()
+assert.deepEqual(paths(await run(['packages/editor'])), ['packages/editor'])
+assert.deepEqual(paths(await run(['packages/react-intl'])), [
+  'packages/react-intl',
+])
+const runtime = await run(['packages/intl'])
+assert(runtime.some(candidate => candidate.path === 'packages/react-intl'))
+assert(!runtime.some(candidate => candidate.path === 'packages/editor'))
+const react = runtime.find(
+  candidate => candidate.path === 'packages/react-intl'
+)
+assert.match(
+  react.pullRequest.body.releaseData[0].notes,
+  /@formatjs\/intl bumped/
+)
+
+const expectedNative = [
+  'packages/cli',
+  'packages/cli-lib',
+  'packages/cli-native-darwin-arm64',
+  'packages/cli-native-linux-arm64',
+  'packages/cli-native-linux-arm64-musl',
+  'packages/cli-native-linux-x64',
+  'packages/cli-native-linux-x64-musl',
+  'packages/cli-native-win32-x64',
+].sort()
+const rustOnly = await run(['crates/formatjs_cli'])
+assert.deepEqual(paths(rustOnly), ['crates/formatjs_cli', ...expectedNative])
+for (const candidate of rustOnly.filter(candidate =>
+  candidate.path.startsWith('packages/')
+)) {
+  const pkg = packages.find(pkg => pkg.path === candidate.path)
+  assert.equal(
+    candidate.pullRequest.version.toString(),
+    new PatchVersionUpdate().bump(Version.parse(pkg.version)).toString()
+  )
+}
+let manifest = '{}'
+for (const candidate of rustOnly) {
+  for (const update of candidate.pullRequest.updates || []) {
+    if (update.path === '.release-please-manifest.json') {
+      manifest = update.updater.updateContent(manifest)
+    }
+  }
+}
+const manifestVersions = JSON.parse(manifest)
+assert.deepEqual(Object.keys(manifestVersions).sort(), expectedNative)
+for (const candidate of rustOnly.filter(candidate =>
+  candidate.path.startsWith('packages/')
+)) {
+  assert.equal(
+    manifestVersions[candidate.path],
+    candidate.pullRequest.version.toString()
+  )
+}
+const cli = rustOnly.find(candidate => candidate.path === 'packages/cli')
+assert.match(cli.pullRequest.body.releaseData[0].notes, /optionalDependencies/)
+for (const path of expectedNative.filter(path =>
+  path.includes('/cli-native-')
+)) {
+  const pkg = packages.find(pkg => pkg.path === path)
+  assert(
+    cli.pullRequest.body.releaseData[0].notes.includes(
+      `${pkg.name} bumped to ${manifestVersions[path]}`
+    )
+  )
+}
+assert.deepEqual(
+  paths(await run(['crates/formatjs_cli', 'packages/editor'])),
+  ['crates/formatjs_cli', ...expectedNative, 'packages/editor'].sort()
+)
+assert.deepEqual(paths(await run(['crates/formatjs_intl'])), [
+  'crates/formatjs_intl',
+])
+assert.deepEqual(await run([]), [])
+console.log(
+  'Verified native-only, npm dependency, optional dependency, and unrelated releases'
+)

--- a/tools/release-please/npm-workspace-plugin.ts
+++ b/tools/release-please/npm-workspace-plugin.ts
@@ -22,6 +22,9 @@ const {
 } = require('release-please/build/src/versioning-strategy')
 const {Changelog} = require('release-please/build/src/updaters/changelog')
 const {
+  ReleasePleaseManifest,
+} = require('release-please/build/src/updaters/release-please-manifest')
+const {
   CompositeUpdater,
 } = require('release-please/build/src/updaters/composite')
 const {
@@ -119,6 +122,35 @@ export class BazelNpmWorkspace extends WorkspacePlugin {
 
   async run(candidates) {
     this.candidatePaths = new Set(candidates.map(candidate => candidate.path))
+    if (
+      candidates.length &&
+      !candidates.some(candidate => this.inScope(candidate))
+    ) {
+      // The upstream plugin exits before inspecting the graph without an npm
+      // candidate. Seed native packages so Rust-only releases propagate too.
+      const {allPackages} = await this.buildAllPackages([])
+      const graph = await this.buildGraph(allPackages)
+      const names = packageNamesWithReleaseDependencies(
+        graph,
+        this.candidatePaths
+      )
+      const seeds = []
+      const versionsMap = new Map()
+      for (const name of names) {
+        const pkg = graph.get(name).value
+        const version = this.bumpVersion(pkg)
+        seeds.push(await this.newCandidate(pkg, new Map([[name, version]])))
+        versionsMap.set(pkg.path, version)
+      }
+      if (seeds.length) {
+        seeds[0].pullRequest.updates.push({
+          path: this.manifestPath,
+          createIfMissing: false,
+          updater: new ReleasePleaseManifest({versionsMap}),
+        })
+        candidates = [...candidates, ...seeds]
+      }
+    }
     return super.run(candidates)
   }
 


### PR DESCRIPTION
Rust-only releases could skip native npm packages because the workspace plugin returned before checking release dependencies when no npm candidate existed. Seed those packages first so their versions, manifest entries, and CLI dependents advance without an unrelated npm release.

Add a regression against Release Please 17.6.0 and the Bazel-generated graph covering Rust-only and mixed releases, optional dependencies, version consistency, and unrelated-package isolation. The new regression failed before the fix; all four focused release tests and repository hooks pass. Run the integration regression in the release workflow.
