### PR TITLE
fix(deps): reconcile unpublished npm releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -77,8 +77,7 @@ jobs:
           node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON
           tools/release-please/config.test.ts
 
-      # Release Please owns version/changelog PRs, GitHub release notes, and
-      # the release-created signal used for npm publication below.
+      # Release Please owns version/changelog PRs and GitHub release notes.
       - name: Run Release Please
         id: release
         env:
@@ -91,36 +90,20 @@ jobs:
 
       - name: Collect npm release paths
         id: npm-release-paths
-        env:
-          PATHS_RELEASED: ${{ steps.release.outputs.paths_released || '[]' }}
         run: |
-          previous_manifest="$RUNNER_TEMP/release-please-manifest.previous.json"
-          if ! git show HEAD^:.release-please-manifest.json > "$previous_manifest"; then
-            echo '{}' > "$previous_manifest"
-          fi
-
-          CURRENT_MANIFEST=.release-please-manifest.json \
-          PREVIOUS_MANIFEST="$previous_manifest" \
-          node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-transform-types --input-type=module <<'JS'
+          node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --input-type=module <<'JS'
           import fs from 'node:fs'
+          import {collectNpmReleasePaths} from './tools/release-please/npm-release-paths.ts'
 
-          const {collectNpmReleasePaths} = await import(
-            './tools/release-please/npm-release-paths.ts'
-          )
           const currentManifest = JSON.parse(
-            fs.readFileSync(process.env.CURRENT_MANIFEST, 'utf8')
+            fs.readFileSync('.release-please-manifest.json', 'utf8')
           )
-          const previousManifest = JSON.parse(
-            fs.readFileSync(process.env.PREVIOUS_MANIFEST, 'utf8')
+          const packages = Object.fromEntries(
+            Object.keys(currentManifest)
+              .filter(path => path.startsWith('packages/'))
+              .map(path => [path, JSON.parse(fs.readFileSync(`${path}/package.json`, 'utf8'))])
           )
-          const pathsReleased = JSON.parse(
-            process.env.PATHS_RELEASED || '[]'
-          )
-          const npmPaths = collectNpmReleasePaths(
-            previousManifest,
-            currentManifest,
-            pathsReleased
-          )
+          const npmPaths = await collectNpmReleasePaths(currentManifest, packages)
           fs.appendFileSync(
             process.env.GITHUB_OUTPUT,
             `npm_paths=${JSON.stringify(npmPaths)}\n`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -390,39 +390,30 @@ jobs:
         env:
           NPM_RELEASE_PATHS: ${{ inputs.npm_paths }}
         run: |
-          mapfile -t package_paths < <(
-            node -e 'JSON.parse(process.env.NPM_RELEASE_PATHS || "[]").forEach(path => console.log(path))'
+          node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --input-type=module <<'JS'
+          import fs from 'node:fs'
+          import {execFileSync} from 'node:child_process'
+          import {pathToFileURL} from 'node:url'
+
+          const {publishNpmPackages} = await import(pathToFileURL(
+            `${process.env.GITHUB_WORKSPACE}/tools/release-please/npm-release-paths.ts`
+          ).href)
+          const packages = Object.fromEntries(
+            fs.readdirSync('packages', {withFileTypes: true})
+              .filter(entry => entry.isDirectory())
+              .map(entry => `packages/${entry.name}`)
+              .filter(path => fs.existsSync(`${path}/package.json`))
+              .map(path => [path, JSON.parse(fs.readFileSync(`${path}/package.json`, 'utf8'))])
           )
-
-          if [ "${#package_paths[@]}" -eq 0 ]; then
-            echo "No npm package releases to publish."
-            exit 0
-          fi
-
-          for package_path in "${package_paths[@]}"; do
-            if [ ! -d "$package_path" ]; then
-              echo "::error::Release package path does not exist in Bazel distribution: $package_path"
-              exit 1
-            fi
-
-            package_spec="$(
-              node -e 'const pkg = require(`./${process.argv[1]}/package.json`); process.stdout.write(`${pkg.name}@${pkg.version}`)' "$package_path"
-            )"
-            if npm view "$package_spec" version --json >/dev/null 2>&1; then
-              echo "Skipping already published $package_spec"
-              continue
-            fi
-
-            echo "Publishing $package_spec"
-            if (cd "$package_path" && pnpm publish --access public --no-git-checks); then
-              continue
-            fi
-
-            # A concurrent or partially completed run may have published it.
-            if npm view "$package_spec" version --json >/dev/null 2>&1; then
-              echo "Skipping concurrently published $package_spec"
-              continue
-            fi
-
-            exit 1
-          done
+          await publishNpmPackages(
+            JSON.parse(process.env.NPM_RELEASE_PATHS || '[]'),
+            packages,
+            async path => {
+              console.log(`Publishing ${packages[path].name}@${packages[path].version}`)
+              execFileSync('pnpm', ['publish', '--access', 'public', '--no-git-checks'], {
+                cwd: path,
+                stdio: 'inherit',
+              })
+            }
+          )
+          JS

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,16 +256,29 @@ jobs:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Build Distribution
+      - name: Build Release Packages
+        env:
+          NPM_RELEASE_PATHS: ${{ inputs.npm_paths }}
         run: |
+          mapfile -t package_paths < <(
+            node -e 'JSON.parse(process.env.NPM_RELEASE_PATHS).forEach(path => console.log(path))'
+          )
+          package_targets=()
+          for package_path in "${package_paths[@]}"; do
+            package_targets+=("//$package_path:pkg")
+          done
           bazel build \
             --config=ci \
             --compilation_mode=opt \
             --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
-            :dist
-          DIST_PATH=$(bazel cquery --config=ci --compilation_mode=opt --output=files :dist)
-          echo "Distribution path: $DIST_PATH"
-          cp -rf "$DIST_PATH" release/
+            :release_manifests "${package_targets[@]}"
+          manifest_path=$(bazel cquery --config=ci --compilation_mode=opt --output=files :release_manifests)
+          cp -R "$manifest_path" release/
+          chmod -R +w release/
+          for package_path in "${package_paths[@]}"; do
+            package_dir=$(bazel cquery --config=ci --compilation_mode=opt --output=files "//$package_path:pkg")
+            cp -R "$package_dir"/. "release/$package_path/"
+          done
           chmod -R +w release/
 
       - name: Download Windows Native Package

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -133,6 +133,17 @@ copy_to_directory(
     ) for pkg in DIST_PACKAGES]},
 )
 
+# Keep all workspace versions available without building unrelated native packages.
+copy_to_directory(
+    name = "release_manifests",
+    srcs = [
+        "package.json",
+        "pnpm-lock.yaml",
+        "pnpm-workspace.yaml",
+    ] + [pkg["package_json"] for pkg in DIST_PACKAGES] + glob(["patches/*"]),
+    out = "formatjs_release_manifests",
+)
+
 js_test(
     name = "dist_package_json_test",
     size = "small",
@@ -148,6 +159,28 @@ js_test(
     ],
     data = [
         ":dist",
+        "//:node_modules/minimist",
+        "//:node_modules/semver",
+    ] + [pkg["package_json"] for pkg in DIST_PACKAGES],
+    entry_point = "//tools:check_dist_package_json",
+    node_options = ["--experimental-transform-types"],
+)
+
+js_test(
+    name = "release_manifests_test",
+    size = "small",
+    args = [
+        "--dist",
+        "$(rootpath :release_manifests)",
+    ] + [
+        "--package=%s=$(rootpath %s)" % (
+            pkg["dirname"],
+            pkg["package_json"],
+        )
+        for pkg in DIST_PACKAGES
+    ],
+    data = [
+        ":release_manifests",
         "//:node_modules/minimist",
         "//:node_modules/semver",
     ] + [pkg["package_json"] for pkg in DIST_PACKAGES],

--- a/docs/src/docs/guides/develop.mdx
+++ b/docs/src/docs/guides/develop.mdx
@@ -131,7 +131,8 @@ it runs. Missing versions from earlier failed releases are included even when th
 latest commit did not change them. Registry errors stop recovery; only a 404 marks
 a version as missing.
 
-The release workflow publishes workspace dependencies first and verifies their
+The release workflow builds only selected package artifacts, publishes workspace
+dependencies first, and verifies their
 versions on npm before publishing dependents. Existing versions are skipped, so
 maintainers can retry `release.yml` with the affected `npm_paths` after resolving a
 publication failure.

--- a/docs/src/docs/guides/develop.mdx
+++ b/docs/src/docs/guides/develop.mdx
@@ -128,8 +128,8 @@ generated inputs.
 
 Release Please reconciles every current public package version against npm after
 it runs. Missing versions from earlier failed releases are included even when the
-latest commit did not change them. Registry errors stop recovery; only a 404 marks
-a version as missing.
+latest commit did not change them. Recovery revalidates registry metadata; absent versions are retried, while
+registry errors stop recovery.
 
 The release workflow builds only selected package artifacts, publishes workspace
 dependencies first, and verifies their

--- a/docs/src/docs/guides/develop.mdx
+++ b/docs/src/docs/guides/develop.mdx
@@ -123,3 +123,15 @@ Baseline tests invoke the generated harness binary and validate its JSON and
 exit code within the same test. Reports are test outputs; use
 `--nocache_test_results` to rerun harness execution. Realm preludes remain
 generated inputs.
+
+## npm release recovery
+
+Release Please reconciles every current public package version against npm after
+it runs. Missing versions from earlier failed releases are included even when the
+latest commit did not change them. Registry errors stop recovery; only a 404 marks
+a version as missing.
+
+The release workflow publishes workspace dependencies first and verifies their
+versions on npm before publishing dependents. Existing versions are skipped, so
+maintainers can retry `release.yml` with the affected `npm_paths` after resolving a
+publication failure.

--- a/knowledge-base/001-repo-layout.md
+++ b/knowledge-base/001-repo-layout.md
@@ -136,7 +136,7 @@ reconciliation. Checked-in package versions must match the release manifest.
 The npm publish workflow skips existing versions, orders selected packages by
 workspace dependencies, and checks internal runtime, optional, and peer dependency
 versions before each publication. It verifies each uploaded version in the registry
-before continuing, so a failed dependency cannot leave a newly published dependent
+before continuing, allowing up to three minutes for registry propagation, so a failed dependency cannot leave a newly published dependent
 uninstallable. Native CLI artifacts are built only when their package paths are
 selected. `:release_manifests` supplies all workspace manifests, while selected
 `:pkg` targets supply package contents; unrelated native binaries are not built

--- a/knowledge-base/001-repo-layout.md
+++ b/knowledge-base/001-repo-layout.md
@@ -135,9 +135,11 @@ Registry metadata is revalidated with `?write=true`; a missing version or packag
 404 means unpublished. Network errors and other HTTP failures stop reconciliation. Checked-in package versions must match the release manifest.
 The npm publish workflow skips existing versions, orders selected packages by
 workspace dependencies, and checks internal runtime, optional, and peer dependency
-versions before each publication. It verifies each uploaded version in the registry
-before continuing, allowing up to three minutes for registry propagation, so a failed dependency cannot leave a newly published dependent
-uninstallable. Native CLI artifacts are built only when their package paths are
+versions before each dependent publication. Independent uploads proceed without
+waiting for each other's registry visibility. The workflow verifies the whole batch
+before completion, allowing up to three minutes for registry propagation per
+version. A failed dependency cannot leave a newly published dependent uninstallable.
+Native CLI artifacts are built only when their package paths are
 selected. `:release_manifests` supplies all workspace manifests, while selected
 `:pkg` targets supply package contents; unrelated native binaries are not built
 for a JavaScript-only backfill. A manual backfill uses the same checks in

--- a/knowledge-base/001-repo-layout.md
+++ b/knowledge-base/001-repo-layout.md
@@ -131,8 +131,8 @@ updaters advance their Bazel wheel versions in `BUILD.bazel`.
 After Release Please runs, the workflow checks every public npm package version
 in the current release manifest against the public npm registry. Missing versions
 are dispatched even when their manifest entry did not change in the latest commit.
-Only a registry 404 means missing; network errors and other HTTP failures stop
-reconciliation. Checked-in package versions must match the release manifest.
+Registry metadata is revalidated with `?write=true`; a missing version or package
+404 means unpublished. Network errors and other HTTP failures stop reconciliation. Checked-in package versions must match the release manifest.
 The npm publish workflow skips existing versions, orders selected packages by
 workspace dependencies, and checks internal runtime, optional, and peer dependency
 versions before each publication. It verifies each uploaded version in the registry

--- a/knowledge-base/001-repo-layout.md
+++ b/knowledge-base/001-repo-layout.md
@@ -128,11 +128,17 @@ For npm packages, Release Please advances versions in both package-local Bazel
 files; `package_json_sync` keeps the rest of each generated manifest in sync.
 Python packages use the Python release strategy while generic extra-file
 updaters advance their Bazel wheel versions in `BUILD.bazel`.
-The workflow also derives npm publish paths from the release manifest diff so
-a retry still publishes packages whose GitHub releases were created before a
-partial failure. npm publishing skips versions already present in the registry,
-prepares only requested package manifests, and builds native CLI artifacts only
-when their package paths are released.
+After Release Please runs, the workflow checks every public npm package version
+in the current release manifest against the public npm registry. Missing versions
+are dispatched even when their manifest entry did not change in the latest commit.
+Only a registry 404 means missing; network errors and other HTTP failures stop
+reconciliation. Checked-in package versions must match the release manifest.
+The npm publish workflow skips existing versions, orders selected packages by
+workspace dependencies, and checks internal runtime, optional, and peer dependency
+versions before each publication. It verifies each uploaded version in the registry
+before continuing, so a failed dependency cannot leave a newly published dependent
+uninstallable. Native CLI artifacts are built only when their package paths are
+selected. A manual backfill uses the same checks in `release.yml`.
 When Release Please creates or updates release PRs,
 `.github/workflows/release-please.yml` first builds
 `//:release_please_npm_workspace_graph` from the package manifests and runs the

--- a/knowledge-base/001-repo-layout.md
+++ b/knowledge-base/001-repo-layout.md
@@ -138,7 +138,10 @@ workspace dependencies, and checks internal runtime, optional, and peer dependen
 versions before each publication. It verifies each uploaded version in the registry
 before continuing, so a failed dependency cannot leave a newly published dependent
 uninstallable. Native CLI artifacts are built only when their package paths are
-selected. A manual backfill uses the same checks in `release.yml`.
+selected. `:release_manifests` supplies all workspace manifests, while selected
+`:pkg` targets supply package contents; unrelated native binaries are not built
+for a JavaScript-only backfill. A manual backfill uses the same checks in
+`release.yml`.
 When Release Please creates or updates release PRs,
 `.github/workflows/release-please.yml` first builds
 `//:release_please_npm_workspace_graph` from the package manifests and runs the

--- a/tools/release-please/npm-release-paths.test.ts
+++ b/tools/release-please/npm-release-paths.test.ts
@@ -226,3 +226,25 @@ assert.equal(
   ),
   false
 )
+
+// Independent uploads can proceed while registry visibility catches up.
+const independent = {
+  'packages/first': {name: 'first', version: '1.0.0'},
+  'packages/second': {name: 'second', version: '1.0.0'},
+}
+const independentUploads: string[] = []
+await publishNpmPackages(
+  Object.keys(independent),
+  independent,
+  async path => {
+    independentUploads.push(path)
+  },
+  async () => independentUploads.length === 2,
+  async () => {
+    assert.fail('Independent uploads must not wait on each other')
+  }
+)
+assert.deepEqual(independentUploads, Object.keys(independent))
+console.log(
+  'Verified npm release reconciliation and dependency-safe publication'
+)

--- a/tools/release-please/npm-release-paths.test.ts
+++ b/tools/release-please/npm-release-paths.test.ts
@@ -1,31 +1,193 @@
 import assert from 'node:assert/strict'
 
-import {collectNpmReleasePaths} from './npm-release-paths.ts'
+import {
+  collectNpmReleasePaths,
+  isNpmVersionPublished,
+  orderNpmReleasePaths,
+  publishNpmPackages,
+  type NpmPackage,
+} from './npm-release-paths.ts'
 
+const packages: Record<string, NpmPackage> = {
+  'packages/duration': {
+    name: '@formatjs/duration',
+    version: '0.11.0',
+    dependencies: {'@formatjs/matcher': '0.8.14'},
+  },
+  'packages/matcher': {name: '@formatjs/matcher', version: '0.8.14'},
+  'packages/private': {name: 'private', version: '1.0.0', private: true},
+}
+const manifest = {
+  'packages/duration': '0.11.0',
+  'packages/matcher': '0.8.14',
+  'packages/private': '1.0.0',
+  'crates/parser': '1.0.0',
+}
+const published = new Set<string>(['@formatjs/duration@0.11.0'])
+const isPublished = async (name: string, version: string) =>
+  published.has(`${name}@${version}`)
+
+// Recover a dependency left behind by an older release, even with no manifest diff.
 assert.deepEqual(
-  collectNpmReleasePaths(
-    {
-      'crates/parser': '1.0.0',
-      'packages/parser': '1.0.0',
-      'packages/plugin': '2.0.0',
-    },
-    {
-      'crates/parser': '1.1.0',
-      'packages/parser': '1.1.0',
-      'packages/plugin': '2.0.0',
-    },
-    []
-  ),
-  ['packages/parser']
+  await collectNpmReleasePaths(manifest, packages, isPublished),
+  ['packages/matcher']
+)
+published.add('@formatjs/matcher@0.8.14')
+assert.deepEqual(
+  await collectNpmReleasePaths(manifest, packages, isPublished),
+  []
+)
+published.clear()
+assert.deepEqual(
+  await collectNpmReleasePaths(manifest, packages, isPublished),
+  ['packages/matcher', 'packages/duration']
+)
+await assert.rejects(
+  collectNpmReleasePaths({'packages/matcher': '0.8.15'}, packages, isPublished),
+  /Release version mismatch/
+)
+await assert.rejects(
+  collectNpmReleasePaths({'packages/missing': '1.0.0'}, packages, isPublished),
+  /Missing release package manifest/
 )
 
-assert.deepEqual(
-  collectNpmReleasePaths(
-    {'packages/parser': '1.0.0'},
-    {'packages/parser': '1.1.0', 'packages/plugin': '2.0.0'},
-    ['packages/plugin', 'crates/parser']
+const response =
+  (status: number, body: unknown): typeof fetch =>
+  async () =>
+    new Response(JSON.stringify(body), {status})
+assert.equal(
+  await isNpmVersionPublished('pkg', '1.0.0', response(404, {})),
+  false
+)
+assert.equal(
+  await isNpmVersionPublished(
+    'pkg',
+    '1.0.0',
+    response(200, {name: 'pkg', version: '1.0.0'})
   ),
-  ['packages/plugin', 'packages/parser']
+  true
+)
+for (const status of [401, 403, 429, 500]) {
+  await assert.rejects(
+    isNpmVersionPublished('pkg', '1.0.0', response(status, {})),
+    new RegExp(`registry returned ${status}`)
+  )
+}
+await assert.rejects(
+  isNpmVersionPublished(
+    'pkg',
+    '1.0.0',
+    response(200, {name: 'pkg', version: '0.9.0'})
+  ),
+  /Unexpected npm registry response/
+)
+await assert.rejects(
+  isNpmVersionPublished('pkg', '1.0.0', async () => {
+    throw new Error('DNS failure')
+  }),
+  /DNS failure/
 )
 
-console.log('Verified npm release path recovery')
+const uploads: string[] = []
+const publish = async (path: string) => {
+  uploads.push(path)
+  const pkg = packages[path]
+  published.add(`${pkg.name}@${pkg.version}`)
+}
+await publishNpmPackages(
+  ['packages/duration', 'packages/matcher'],
+  packages,
+  publish,
+  isPublished
+)
+assert.deepEqual(uploads, ['packages/matcher', 'packages/duration'])
+await publishNpmPackages(
+  ['packages/duration', 'packages/matcher'],
+  packages,
+  publish,
+  isPublished
+)
+assert.equal(uploads.length, 2)
+
+// A missing dependency outside the selected batch must block publication too.
+published.clear()
+uploads.length = 0
+await assert.rejects(
+  publishNpmPackages(['packages/duration'], packages, publish, isPublished),
+  /missing @formatjs\/matcher@0.8.14/
+)
+assert.deepEqual(uploads, [])
+
+// Failed or invisible dependency publication must never release the dependent.
+for (const fail of [true, false]) {
+  const attempted: string[] = []
+  await assert.rejects(
+    publishNpmPackages(
+      ['packages/duration', 'packages/matcher'],
+      packages,
+      async path => {
+        attempted.push(path)
+        if (fail) throw new Error('publish failed')
+      },
+      isPublished
+    ),
+    fail ? /publish failed/ : /publication not visible/
+  )
+  assert.deepEqual(attempted, ['packages/matcher'])
+}
+
+await publishNpmPackages(
+  ['packages/matcher'],
+  packages,
+  async path => {
+    await publish(path)
+    throw new Error('concurrent publication')
+  },
+  isPublished
+)
+
+for (const field of ['optionalDependencies', 'peerDependencies']) {
+  const withDependency = {
+    ...packages,
+    'packages/duration': {
+      name: '@formatjs/duration',
+      version: '0.11.0',
+      [field]: {'@formatjs/matcher': '0.8.14'},
+    },
+  }
+  assert.deepEqual(
+    orderNpmReleasePaths(
+      ['packages/duration', 'packages/matcher'],
+      withDependency
+    ),
+    ['packages/matcher', 'packages/duration']
+  )
+  published.clear()
+  await assert.rejects(
+    publishNpmPackages(
+      ['packages/duration'],
+      withDependency,
+      publish,
+      isPublished
+    ),
+    /missing @formatjs\/matcher/
+  )
+}
+assert.throws(
+  () => orderNpmReleasePaths(['packages/private'], packages),
+  /Invalid npm release package/
+)
+assert.throws(
+  () =>
+    orderNpmReleasePaths(['packages/duration', 'packages/matcher'], {
+      ...packages,
+      'packages/matcher': {
+        ...packages['packages/matcher'],
+        dependencies: {'@formatjs/duration': '0.11.0'},
+      },
+    }),
+  /Circular npm release dependency/
+)
+console.log(
+  'Verified npm release reconciliation and dependency-safe publication'
+)

--- a/tools/release-please/npm-release-paths.test.ts
+++ b/tools/release-please/npm-release-paths.test.ts
@@ -60,11 +60,13 @@ assert.equal(
   false
 )
 assert.equal(
-  await isNpmVersionPublished(
-    'pkg',
-    '1.0.0',
-    response(200, {name: 'pkg', version: '1.0.0'})
-  ),
+  await isNpmVersionPublished('pkg', '1.0.0', async url => {
+    assert.equal(String(url), 'https://registry.npmjs.org/pkg?write=true')
+    return response(200, {
+      name: 'pkg',
+      versions: {'1.0.0': {name: 'pkg', version: '1.0.0'}},
+    })(url)
+  }),
   true
 )
 for (const status of [401, 403, 429, 500]) {
@@ -77,7 +79,10 @@ await assert.rejects(
   isNpmVersionPublished(
     'pkg',
     '1.0.0',
-    response(200, {name: 'pkg', version: '0.9.0'})
+    response(200, {
+      name: 'pkg',
+      versions: {'1.0.0': {name: 'pkg', version: '0.9.0'}},
+    })
   ),
   /Unexpected npm registry response/
 )
@@ -211,4 +216,13 @@ assert.equal(waits, 2)
 
 console.log(
   'Verified npm release reconciliation and dependency-safe publication'
+)
+
+assert.equal(
+  await isNpmVersionPublished(
+    'pkg',
+    '1.0.0',
+    response(200, {name: 'pkg', versions: {}})
+  ),
+  false
 )

--- a/tools/release-please/npm-release-paths.test.ts
+++ b/tools/release-please/npm-release-paths.test.ts
@@ -129,7 +129,8 @@ for (const fail of [true, false]) {
         attempted.push(path)
         if (fail) throw new Error('publish failed')
       },
-      isPublished
+      isPublished,
+      async () => {}
     ),
     fail ? /publish failed/ : /publication not visible/
   )
@@ -188,6 +189,26 @@ assert.throws(
     }),
   /Circular npm release dependency/
 )
+console.log(
+  'Verified npm release reconciliation and dependency-safe publication'
+)
+
+// Registry propagation can lag behind a successful upload.
+published.clear()
+let polls = 0
+let waits = 0
+await publishNpmPackages(
+  ['packages/matcher'],
+  packages,
+  async () => {},
+  async () => ++polls >= 4,
+  async milliseconds => {
+    assert.equal(milliseconds, 5_000)
+    waits++
+  }
+)
+assert.equal(waits, 2)
+
 console.log(
   'Verified npm release reconciliation and dependency-safe publication'
 )

--- a/tools/release-please/npm-release-paths.test.ts
+++ b/tools/release-please/npm-release-paths.test.ts
@@ -62,10 +62,12 @@ assert.equal(
 assert.equal(
   await isNpmVersionPublished('pkg', '1.0.0', async url => {
     assert.equal(String(url), 'https://registry.npmjs.org/pkg?write=true')
-    return response(200, {
-      name: 'pkg',
-      versions: {'1.0.0': {name: 'pkg', version: '1.0.0'}},
-    })(url)
+    return new Response(
+      JSON.stringify({
+        name: 'pkg',
+        versions: {'1.0.0': {name: 'pkg', version: '1.0.0'}},
+      })
+    )
   }),
   true
 )

--- a/tools/release-please/npm-release-paths.ts
+++ b/tools/release-please/npm-release-paths.ts
@@ -125,6 +125,25 @@ export async function publishNpmPackages(
     new Promise(resolve => setTimeout(resolve, milliseconds))
 ): Promise<void> {
   const names = new Set(Object.values(packages).map(pkg => pkg.name))
+  const pending = new Map<string, string>()
+  async function verifyPublication(
+    name: string,
+    version: string,
+    publishError?: unknown
+  ) {
+    for (let attempt = 0; attempt < 36; attempt++) {
+      if (await isPublished(name, version)) {
+        return
+      }
+      if (attempt === 35) {
+        throw (
+          publishError ||
+          new Error(`npm publication not visible: ${name}@${version}`)
+        )
+      }
+      await wait(5_000)
+    }
+  }
   for (const path of orderNpmReleasePaths(paths, packages)) {
     const pkg = packages[path]
     if (await isPublished(pkg.name, pkg.version)) {
@@ -133,30 +152,25 @@ export async function publishNpmPackages(
     for (const field of dependencyFields) {
       for (const [name, version] of Object.entries(pkg[field] || {})) {
         if (names.has(name) && !(await isPublished(name, version))) {
-          throw new Error(
-            `Cannot publish ${pkg.name}@${pkg.version}: missing ${name}@${version}`
-          )
+          if (pending.get(name) === version) {
+            await verifyPublication(name, version)
+          } else {
+            throw new Error(
+              `Cannot publish ${pkg.name}@${pkg.version}: missing ${name}@${version}`
+            )
+          }
         }
       }
     }
-    let publishError: unknown
     try {
       await publish(path)
     } catch (error) {
       // Another release may have published this version concurrently.
-      publishError = error
+      await verifyPublication(pkg.name, pkg.version, error)
     }
-    for (let attempt = 0; attempt < 36; attempt++) {
-      if (await isPublished(pkg.name, pkg.version)) {
-        break
-      }
-      if (attempt === 35) {
-        throw (
-          publishError ||
-          new Error(`npm publication not visible: ${pkg.name}@${pkg.version}`)
-        )
-      }
-      await wait(5_000)
-    }
+    pending.set(pkg.name, pkg.version)
+  }
+  for (const [name, version] of pending) {
+    await verifyPublication(name, version)
   }
 }

--- a/tools/release-please/npm-release-paths.ts
+++ b/tools/release-please/npm-release-paths.ts
@@ -21,8 +21,9 @@ export async function isNpmVersionPublished(
   version: string,
   fetchRegistry: typeof fetch = fetch
 ): Promise<boolean> {
+  // npm revalidates metadata for write=true; version endpoints can cache a 404.
   const response = await fetchRegistry(
-    `https://registry.npmjs.org/${encodeURIComponent(name)}/${encodeURIComponent(version)}`,
+    `https://registry.npmjs.org/${encodeURIComponent(name)}?write=true`,
     {signal: AbortSignal.timeout(30_000), cache: 'no-store'}
   )
   if (response.status === 404) {
@@ -34,7 +35,14 @@ export async function isNpmVersionPublished(
     )
   }
   const manifest = await response.json()
-  if (manifest.name !== name || manifest.version !== version) {
+  if (manifest.name !== name || !manifest.versions) {
+    throw new Error(`Unexpected npm registry response for ${name}@${version}`)
+  }
+  const published = manifest.versions[version]
+  if (!published) {
+    return false
+  }
+  if (published.name !== name || published.version !== version) {
     throw new Error(`Unexpected npm registry response for ${name}@${version}`)
   }
   return true

--- a/tools/release-please/npm-release-paths.ts
+++ b/tools/release-please/npm-release-paths.ts
@@ -1,19 +1,144 @@
 export type ReleaseManifest = Record<string, string>
 
-export function collectNpmReleasePaths(
-  previousManifest: ReleaseManifest,
-  currentManifest: ReleaseManifest,
-  pathsReleased: string[]
-): string[] {
-  const npmPaths = new Set(
-    pathsReleased.filter(path => path.startsWith('packages/'))
-  )
+export interface NpmPackage {
+  name: string
+  version: string
+  private?: boolean
+  dependencies?: Record<string, string>
+  optionalDependencies?: Record<string, string>
+  peerDependencies?: Record<string, string>
+}
 
+type VersionPublished = (name: string, version: string) => Promise<boolean>
+const dependencyFields = [
+  'dependencies',
+  'optionalDependencies',
+  'peerDependencies',
+] as const
+
+export async function isNpmVersionPublished(
+  name: string,
+  version: string,
+  fetchRegistry: typeof fetch = fetch
+): Promise<boolean> {
+  const response = await fetchRegistry(
+    `https://registry.npmjs.org/${encodeURIComponent(name)}/${encodeURIComponent(version)}`,
+    {signal: AbortSignal.timeout(30_000)}
+  )
+  if (response.status === 404) {
+    return false
+  }
+  if (!response.ok) {
+    throw new Error(
+      `npm registry returned ${response.status} for ${name}@${version}`
+    )
+  }
+  const manifest = await response.json()
+  if (manifest.name !== name || manifest.version !== version) {
+    throw new Error(`Unexpected npm registry response for ${name}@${version}`)
+  }
+  return true
+}
+
+export async function collectNpmReleasePaths(
+  currentManifest: ReleaseManifest,
+  packages: Record<string, NpmPackage>,
+  isPublished: VersionPublished = isNpmVersionPublished
+): Promise<string[]> {
+  const missing: string[] = []
   for (const [path, version] of Object.entries(currentManifest)) {
-    if (path.startsWith('packages/') && previousManifest[path] !== version) {
-      npmPaths.add(path)
+    if (!path.startsWith('packages/')) {
+      continue
+    }
+    const pkg = packages[path]
+    if (!pkg) {
+      throw new Error(`Missing release package manifest: ${path}`)
+    }
+    if (pkg.private) {
+      continue
+    }
+    if (pkg.version !== version) {
+      throw new Error(
+        `Release version mismatch for ${path}: ${version} != ${pkg.version}`
+      )
+    }
+    if (!(await isPublished(pkg.name, version))) {
+      missing.push(path)
     }
   }
+  return orderNpmReleasePaths(missing, packages)
+}
 
-  return [...npmPaths]
+export function orderNpmReleasePaths(
+  paths: string[],
+  packages: Record<string, NpmPackage>
+): string[] {
+  const byName = new Map(
+    Object.entries(packages).map(([path, pkg]) => [pkg.name, path])
+  )
+  const selected = new Set(paths)
+  const visiting = new Set<string>()
+  const visited = new Set<string>()
+  const ordered: string[] = []
+  function visit(path: string) {
+    if (visited.has(path)) {
+      return
+    }
+    if (visiting.has(path)) {
+      throw new Error(`Circular npm release dependency: ${path}`)
+    }
+    const pkg = packages[path]
+    if (!pkg || pkg.private) {
+      throw new Error(`Invalid npm release package: ${path}`)
+    }
+    visiting.add(path)
+    for (const field of dependencyFields) {
+      for (const name of Object.keys(pkg[field] || {})) {
+        const dependencyPath = byName.get(name)
+        if (dependencyPath && selected.has(dependencyPath)) {
+          visit(dependencyPath)
+        }
+      }
+    }
+    visiting.delete(path)
+    visited.add(path)
+    ordered.push(path)
+  }
+  paths.forEach(visit)
+  return ordered
+}
+
+export async function publishNpmPackages(
+  paths: string[],
+  packages: Record<string, NpmPackage>,
+  publish: (path: string) => Promise<void>,
+  isPublished: VersionPublished = isNpmVersionPublished
+): Promise<void> {
+  const names = new Set(Object.values(packages).map(pkg => pkg.name))
+  for (const path of orderNpmReleasePaths(paths, packages)) {
+    const pkg = packages[path]
+    if (await isPublished(pkg.name, pkg.version)) {
+      continue
+    }
+    for (const field of dependencyFields) {
+      for (const [name, version] of Object.entries(pkg[field] || {})) {
+        if (names.has(name) && !(await isPublished(name, version))) {
+          throw new Error(
+            `Cannot publish ${pkg.name}@${pkg.version}: missing ${name}@${version}`
+          )
+        }
+      }
+    }
+    try {
+      await publish(path)
+    } catch (error) {
+      // Another release may have published this version concurrently.
+      if (!(await isPublished(pkg.name, pkg.version))) {
+        throw error
+      }
+    }
+    if (!(await isPublished(pkg.name, pkg.version))) {
+      throw new Error(`npm publication not visible: ${pkg.name}@${pkg.version}`)
+    }
+  }
 }

--- a/tools/release-please/npm-release-paths.ts
+++ b/tools/release-please/npm-release-paths.ts
@@ -23,7 +23,7 @@ export async function isNpmVersionPublished(
 ): Promise<boolean> {
   const response = await fetchRegistry(
     `https://registry.npmjs.org/${encodeURIComponent(name)}/${encodeURIComponent(version)}`,
-    {signal: AbortSignal.timeout(30_000)}
+    {signal: AbortSignal.timeout(30_000), cache: 'no-store'}
   )
   if (response.status === 404) {
     return false
@@ -112,7 +112,9 @@ export async function publishNpmPackages(
   paths: string[],
   packages: Record<string, NpmPackage>,
   publish: (path: string) => Promise<void>,
-  isPublished: VersionPublished = isNpmVersionPublished
+  isPublished: VersionPublished = isNpmVersionPublished,
+  wait: (milliseconds: number) => Promise<void> = milliseconds =>
+    new Promise(resolve => setTimeout(resolve, milliseconds))
 ): Promise<void> {
   const names = new Set(Object.values(packages).map(pkg => pkg.name))
   for (const path of orderNpmReleasePaths(paths, packages)) {
@@ -129,16 +131,24 @@ export async function publishNpmPackages(
         }
       }
     }
+    let publishError: unknown
     try {
       await publish(path)
     } catch (error) {
       // Another release may have published this version concurrently.
-      if (!(await isPublished(pkg.name, pkg.version))) {
-        throw error
-      }
+      publishError = error
     }
-    if (!(await isPublished(pkg.name, pkg.version))) {
-      throw new Error(`npm publication not visible: ${pkg.name}@${pkg.version}`)
+    for (let attempt = 0; attempt < 36; attempt++) {
+      if (await isPublished(pkg.name, pkg.version)) {
+        break
+      }
+      if (attempt === 35) {
+        throw (
+          publishError ||
+          new Error(`npm publication not visible: ${pkg.name}@${pkg.version}`)
+        )
+      }
+      await wait(5_000)
     }
   }
 }


### PR DESCRIPTION
A failed npm release left `@formatjs/intl-localematcher@0.8.14` unpublished. A later release published `intl-durationformat@0.11.0` against that missing version because recovery only considered the latest manifest diff.

Reconcile every current public package version with revalidated npm metadata. Publish dependencies first and require their versions to be visible before publishing dependents. Independent uploads can proceed while registry visibility catches up; verify the whole batch with bounded retries before completion. Registry errors stop recovery, and existing versions are safe to retry.

Build selected Bazel `:pkg` targets plus all workspace manifests instead of the entire distribution, so JavaScript backfills do not depend on unrelated native SDK downloads.

Validation: all 13 backfill package targets built with Bazel in opt mode; release-path, manifest staging, workspace graph, Release Please plugin, and docs sitemap tests passed. Commit hooks passed.

Backfilled all 13 missing versions through the release workflow: https://github.com/formatjs/formatjs/actions/runs/34690059819. Public npm now contains all 37 current manifest versions. A clean installation of `intl-durationformat@0.11.0` and duration formatting smoke test passed.

Fixes #7363.
