### PR TITLE
fix(@formatjs/icu-messageformat-parser): preserve locale hour preferences

### DIFF
--- a/crates/icu_messageformat_parser/date_time_pattern_generator.rs
+++ b/crates/icu_messageformat_parser/date_time_pattern_generator.rs
@@ -97,7 +97,9 @@ fn get_hour_symbol_from_time_data(locale: &Locale) -> char {
 
     // Try different lookup strategies
     let hour_cycles = if let Some(region) = region_tag {
-        TIME_DATA.get(region)
+        TIME_DATA
+            .get(format!("{language_tag}-{region}").as_str())
+            .or_else(|| TIME_DATA.get(region))
     } else {
         None
     }
@@ -119,6 +121,20 @@ fn get_hour_symbol_from_time_data(locale: &Locale) -> char {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_locale_hour_cycle_preferences() {
+        for (tag, expected) in [
+            ("fr-CA", "H"),
+            ("zh-TW", "ha"),
+            ("en-GB", "H"),
+            ("fr-CA-u-hc-h12", "ha"),
+            ("en-GB-u-hc-h12", "ha"),
+        ] {
+            let locale: Locale = tag.parse().unwrap();
+            assert_eq!(get_best_pattern("j", &locale), expected, "{tag}");
+        }
+    }
 
     #[test]
     fn test_get_best_pattern_simple() {

--- a/docs/src/docs/icu-messageformat-parser.mdx
+++ b/docs/src/docs/icu-messageformat-parser.mdx
@@ -57,6 +57,8 @@ ICU provides a [wide array of pattern](https://www.unicode.org/reports/tr35/tr35
 | s      | Second                        |
 | z      | Time Zone                     |
 
+With a `locale` parse option, `j` uses the locale’s preferred hour cycle. Explicit `hourCycle` options and `u-hc` extensions take precedence. The parser supports both `Intl.Locale.getHourCycles()` and the legacy `hourCycles` property.
+
 ## Benchmarks
 
 ```

--- a/docs/src/docs/tooling/rust-icu-messageformat-parser.mdx
+++ b/docs/src/docs/tooling/rust-icu-messageformat-parser.mdx
@@ -138,6 +138,8 @@ if let MessageFormatElement::Plural(plural) = &ast[1] {
 
 ### Parsing with Skeletons
 
+Locale-dependent `j` skeletons honor `u-hc` overrides and language-region hour preferences, such as the 24-hour clock in `fr-CA`.
+
 ```rust
 use formatjs_icu_messageformat_parser::{Parser, ParserOptions};
 

--- a/knowledge-base/006-package-icu-messageformat-parser.md
+++ b/knowledge-base/006-package-icu-messageformat-parser.md
@@ -53,4 +53,4 @@ syntax; the Rust fast path applies when location capture is disabled.
 ## Test Strategy
 
 - Vitest unit tests with real-world message samples
-- Integration tests comparing TypeScript and Rust parser output
+- Integration tests comparing TypeScript and Rust parser output, including locale-default hour cycles and `u-hc` overrides. Checked-in expectations are verified by both the TypeScript generation diff tests and the Rust integration runner.

--- a/knowledge-base/006-package-icu-messageformat-parser.md
+++ b/knowledge-base/006-package-icu-messageformat-parser.md
@@ -32,6 +32,8 @@ Chosen for performance — 6-10x faster than the previous PEG-based `intl-messag
 
 Delegates number/datetime skeleton parsing to `@formatjs/icu-skeleton-parser`. Skeletons are the `::` syntax in ICU MessageFormat (e.g., `{amount, number, ::currency/USD}`).
 
+Date skeleton `j` resolution prefers an explicit locale `hourCycle`, then `getHourCycles()`, then the legacy `hourCycles` property. Generated CLDR time data remains the fallback when neither API supplies a cycle.
+
 ### Rust Mirror + WASM
 
 A parallel Rust implementation exists in `crates/icu_messageformat_parser/`

--- a/knowledge-base/006-package-icu-messageformat-parser.md
+++ b/knowledge-base/006-package-icu-messageformat-parser.md
@@ -32,7 +32,7 @@ Chosen for performance — 6-10x faster than the previous PEG-based `intl-messag
 
 Delegates number/datetime skeleton parsing to `@formatjs/icu-skeleton-parser`. Skeletons are the `::` syntax in ICU MessageFormat (e.g., `{amount, number, ::currency/USD}`).
 
-Date skeleton `j` resolution prefers an explicit locale `hourCycle`, then `getHourCycles()`, then the legacy `hourCycles` property. Generated CLDR time data remains the fallback when neither API supplies a cycle.
+Date skeleton `j` resolution prefers an explicit locale `hourCycle`, then `getHourCycles()`, then the legacy `hourCycles` property. Generated CLDR time data remains the fallback when neither API supplies a cycle. Both parsers prefer language-region entries over region defaults and use only the hour symbol from CLDR patterns.
 
 ### Rust Mirror + WASM
 

--- a/packages/icu-messageformat-parser/date-time-pattern-generator.ts
+++ b/packages/icu-messageformat-parser/date-time-pattern-generator.ts
@@ -87,9 +87,10 @@ function getDefaultHourSymbolFromLocale(locale: Intl.Locale): string {
     regionTag = locale.maximize().region
   }
   const hourCycles =
+    timeData[`${languageTag}-${regionTag}`] ||
     timeData[regionTag || ''] ||
     timeData[languageTag || ''] ||
     timeData[`${languageTag}-001`] ||
     timeData['001']
-  return hourCycles[0]
+  return hourCycles[0].charAt(0)
 }

--- a/packages/icu-messageformat-parser/date-time-pattern-generator.ts
+++ b/packages/icu-messageformat-parser/date-time-pattern-generator.ts
@@ -53,17 +53,16 @@ export function getBestPattern(skeleton: string, locale: Intl.Locale): string {
  * @param locale
  */
 function getDefaultHourSymbolFromLocale(locale: Intl.Locale): string {
-  let hourCycle = locale.hourCycle
+  let hourCycle: string | undefined = locale.hourCycle
 
-  if (
-    hourCycle === undefined &&
-    // @ts-ignore hourCycle(s) is not identified yet
-    locale.hourCycles &&
-    // @ts-ignore
-    locale.hourCycles.length
-  ) {
-    // @ts-ignore
-    hourCycle = locale.hourCycles[0]
+  if (hourCycle === undefined) {
+    const localeWithHourCycles = locale as Intl.Locale & {
+      getHourCycles?: () => string[]
+      hourCycles?: string[]
+    }
+    hourCycle =
+      localeWithHourCycles.getHourCycles?.()[0] ??
+      localeWithHourCycles.hourCycles?.[0]
   }
 
   if (hourCycle) {

--- a/packages/icu-messageformat-parser/integration-tests/test_cases/date_arg_skeleton_locale_en-GB-u-hc-h12.txt
+++ b/packages/icu-messageformat-parser/integration-tests/test_cases/date_arg_skeleton_locale_en-GB-u-hc-h12.txt
@@ -1,0 +1,50 @@
+{0, date, ::j}
+---
+{
+  "locale": "en-GB-u-hc-h12",
+  "shouldParseSkeletons": true,
+  "requiresOtherClause": true
+}
+---
+{
+  "val": [
+    {
+      "type": 3,
+      "value": "0",
+      "location": {
+        "start": {
+          "offset": 0,
+          "line": 1,
+          "column": 1
+        },
+        "end": {
+          "offset": 14,
+          "line": 1,
+          "column": 15
+        }
+      },
+      "style": {
+        "type": 1,
+        "pattern": "ha",
+        "location": {
+          "start": {
+            "offset": 10,
+            "line": 1,
+            "column": 11
+          },
+          "end": {
+            "offset": 13,
+            "line": 1,
+            "column": 14
+          }
+        },
+        "parsedOptions": {
+          "hourCycle": "h12",
+          "hour": "numeric",
+          "hour12": true
+        }
+      }
+    }
+  ],
+  "err": null
+}

--- a/packages/icu-messageformat-parser/integration-tests/test_cases/date_arg_skeleton_locale_en-GB.txt
+++ b/packages/icu-messageformat-parser/integration-tests/test_cases/date_arg_skeleton_locale_en-GB.txt
@@ -1,0 +1,49 @@
+{0, date, ::j}
+---
+{
+  "locale": "en-GB",
+  "shouldParseSkeletons": true,
+  "requiresOtherClause": true
+}
+---
+{
+  "val": [
+    {
+      "type": 3,
+      "value": "0",
+      "location": {
+        "start": {
+          "offset": 0,
+          "line": 1,
+          "column": 1
+        },
+        "end": {
+          "offset": 14,
+          "line": 1,
+          "column": 15
+        }
+      },
+      "style": {
+        "type": 1,
+        "pattern": "H",
+        "location": {
+          "start": {
+            "offset": 10,
+            "line": 1,
+            "column": 11
+          },
+          "end": {
+            "offset": 13,
+            "line": 1,
+            "column": 14
+          }
+        },
+        "parsedOptions": {
+          "hourCycle": "h23",
+          "hour": "numeric"
+        }
+      }
+    }
+  ],
+  "err": null
+}

--- a/packages/icu-messageformat-parser/integration-tests/test_cases/date_arg_skeleton_locale_fr-CA-u-hc-h11.txt
+++ b/packages/icu-messageformat-parser/integration-tests/test_cases/date_arg_skeleton_locale_fr-CA-u-hc-h11.txt
@@ -1,0 +1,50 @@
+{0, date, ::j}
+---
+{
+  "locale": "fr-CA-u-hc-h11",
+  "shouldParseSkeletons": true,
+  "requiresOtherClause": true
+}
+---
+{
+  "val": [
+    {
+      "type": 3,
+      "value": "0",
+      "location": {
+        "start": {
+          "offset": 0,
+          "line": 1,
+          "column": 1
+        },
+        "end": {
+          "offset": 14,
+          "line": 1,
+          "column": 15
+        }
+      },
+      "style": {
+        "type": 1,
+        "pattern": "Ka",
+        "location": {
+          "start": {
+            "offset": 10,
+            "line": 1,
+            "column": 11
+          },
+          "end": {
+            "offset": 13,
+            "line": 1,
+            "column": 14
+          }
+        },
+        "parsedOptions": {
+          "hourCycle": "h11",
+          "hour": "numeric",
+          "hour12": true
+        }
+      }
+    }
+  ],
+  "err": null
+}

--- a/packages/icu-messageformat-parser/integration-tests/test_cases/date_arg_skeleton_locale_fr-CA-u-hc-h12.txt
+++ b/packages/icu-messageformat-parser/integration-tests/test_cases/date_arg_skeleton_locale_fr-CA-u-hc-h12.txt
@@ -1,0 +1,50 @@
+{0, date, ::j}
+---
+{
+  "locale": "fr-CA-u-hc-h12",
+  "shouldParseSkeletons": true,
+  "requiresOtherClause": true
+}
+---
+{
+  "val": [
+    {
+      "type": 3,
+      "value": "0",
+      "location": {
+        "start": {
+          "offset": 0,
+          "line": 1,
+          "column": 1
+        },
+        "end": {
+          "offset": 14,
+          "line": 1,
+          "column": 15
+        }
+      },
+      "style": {
+        "type": 1,
+        "pattern": "ha",
+        "location": {
+          "start": {
+            "offset": 10,
+            "line": 1,
+            "column": 11
+          },
+          "end": {
+            "offset": 13,
+            "line": 1,
+            "column": 14
+          }
+        },
+        "parsedOptions": {
+          "hourCycle": "h12",
+          "hour": "numeric",
+          "hour12": true
+        }
+      }
+    }
+  ],
+  "err": null
+}

--- a/packages/icu-messageformat-parser/integration-tests/test_cases/date_arg_skeleton_locale_fr-CA.txt
+++ b/packages/icu-messageformat-parser/integration-tests/test_cases/date_arg_skeleton_locale_fr-CA.txt
@@ -1,0 +1,49 @@
+{0, date, ::j}
+---
+{
+  "locale": "fr-CA",
+  "shouldParseSkeletons": true,
+  "requiresOtherClause": true
+}
+---
+{
+  "val": [
+    {
+      "type": 3,
+      "value": "0",
+      "location": {
+        "start": {
+          "offset": 0,
+          "line": 1,
+          "column": 1
+        },
+        "end": {
+          "offset": 14,
+          "line": 1,
+          "column": 15
+        }
+      },
+      "style": {
+        "type": 1,
+        "pattern": "H",
+        "location": {
+          "start": {
+            "offset": 10,
+            "line": 1,
+            "column": 11
+          },
+          "end": {
+            "offset": 13,
+            "line": 1,
+            "column": 14
+          }
+        },
+        "parsedOptions": {
+          "hourCycle": "h23",
+          "hour": "numeric"
+        }
+      }
+    }
+  ],
+  "err": null
+}

--- a/packages/icu-messageformat-parser/integration-tests/test_cases/date_arg_skeleton_locale_zh-TW-u-hc-h24.txt
+++ b/packages/icu-messageformat-parser/integration-tests/test_cases/date_arg_skeleton_locale_zh-TW-u-hc-h24.txt
@@ -1,0 +1,49 @@
+{0, date, ::j}
+---
+{
+  "locale": "zh-TW-u-hc-h24",
+  "shouldParseSkeletons": true,
+  "requiresOtherClause": true
+}
+---
+{
+  "val": [
+    {
+      "type": 3,
+      "value": "0",
+      "location": {
+        "start": {
+          "offset": 0,
+          "line": 1,
+          "column": 1
+        },
+        "end": {
+          "offset": 14,
+          "line": 1,
+          "column": 15
+        }
+      },
+      "style": {
+        "type": 1,
+        "pattern": "k",
+        "location": {
+          "start": {
+            "offset": 10,
+            "line": 1,
+            "column": 11
+          },
+          "end": {
+            "offset": 13,
+            "line": 1,
+            "column": 14
+          }
+        },
+        "parsedOptions": {
+          "hourCycle": "h24",
+          "hour": "numeric"
+        }
+      }
+    }
+  ],
+  "err": null
+}

--- a/packages/icu-messageformat-parser/integration-tests/test_cases/date_arg_skeleton_locale_zh-TW.txt
+++ b/packages/icu-messageformat-parser/integration-tests/test_cases/date_arg_skeleton_locale_zh-TW.txt
@@ -1,0 +1,50 @@
+{0, date, ::j}
+---
+{
+  "locale": "zh-TW",
+  "shouldParseSkeletons": true,
+  "requiresOtherClause": true
+}
+---
+{
+  "val": [
+    {
+      "type": 3,
+      "value": "0",
+      "location": {
+        "start": {
+          "offset": 0,
+          "line": 1,
+          "column": 1
+        },
+        "end": {
+          "offset": 14,
+          "line": 1,
+          "column": 15
+        }
+      },
+      "style": {
+        "type": 1,
+        "pattern": "ha",
+        "location": {
+          "start": {
+            "offset": 10,
+            "line": 1,
+            "column": 11
+          },
+          "end": {
+            "offset": 13,
+            "line": 1,
+            "column": 14
+          }
+        },
+        "parsedOptions": {
+          "hourCycle": "h12",
+          "hour": "numeric",
+          "hour12": true
+        }
+      }
+    }
+  ],
+  "err": null
+}

--- a/packages/icu-messageformat-parser/tests/date-time-pattern-generator.test.ts
+++ b/packages/icu-messageformat-parser/tests/date-time-pattern-generator.test.ts
@@ -153,3 +153,15 @@ it.each(['fr-CA', 'zh-TW', 'en-GB', 'fr-CA-u-hc-h12', 'en-GB-u-hc-h12'])(
     expect(formatter.format(midnight)).toBe(native.format(midnight))
   }
 )
+
+it.each([
+  ['fr-CA', 'H'],
+  ['zh-TW', 'ha'],
+])('uses locale-specific CLDR fallback for %s', (tag, expected) => {
+  const locale = new Intl.Locale(tag)
+  Object.defineProperties(locale, {
+    getHourCycles: {value: undefined},
+    hourCycles: {value: undefined},
+  })
+  expect(getBestPattern('j', locale)).toBe(expected)
+})

--- a/packages/icu-messageformat-parser/tests/date-time-pattern-generator.test.ts
+++ b/packages/icu-messageformat-parser/tests/date-time-pattern-generator.test.ts
@@ -1,3 +1,8 @@
+import {
+  parse,
+  isDateElement,
+  isDateTimeSkeleton,
+} from '#packages/icu-messageformat-parser/index.js'
 import {getBestPattern} from '#packages/icu-messageformat-parser/date-time-pattern-generator.js'
 import {describe, expect, it} from 'vitest'
 describe('date-time-pattern-generator', () => {
@@ -58,3 +63,93 @@ describe('date-time-pattern-generator', () => {
     })
   })
 })
+
+describe('locale hour cycle APIs', () => {
+  it.each([
+    ['fr-CA', 'h23', 'H'],
+    ['zh-TW', 'h12', 'ha'],
+  ])('uses getHourCycles for %s', (tag, cycle, pattern) => {
+    const locale = new Intl.Locale(tag)
+    Object.defineProperties(locale, {
+      getHourCycles: {
+        value() {
+          expect(this).toBe(locale)
+          return [cycle]
+        },
+      },
+      hourCycles: {value: undefined},
+    })
+    expect(getBestPattern('j', locale)).toBe(pattern)
+  })
+
+  it.each([
+    {modern: ['h23'], legacy: ['h12'], expected: 'H'},
+    {modern: [], legacy: ['h12'], expected: 'ha'},
+    {modern: undefined, legacy: ['h23'], expected: 'H'},
+    {modern: undefined, legacy: undefined, expected: 'ha'},
+  ])(
+    'respects API precedence and fallback: %j',
+    ({modern, legacy, expected}) => {
+      const locale = new Intl.Locale('en-US')
+      Object.defineProperties(locale, {
+        getHourCycles: {value: modern === undefined ? undefined : () => modern},
+        hourCycles: {value: legacy},
+      })
+      expect(getBestPattern('j', locale)).toBe(expected)
+    }
+  )
+
+  it.each(['fr-CA-u-hc-h12', 'en-GB-u-hc-h12'])(
+    'preserves explicit hour cycle for %s',
+    tag => {
+      const locale = new Intl.Locale(tag)
+      Object.defineProperties(locale, {
+        getHourCycles: {
+          value() {
+            throw new Error('Explicit hour cycle must win')
+          },
+        },
+        hourCycles: {
+          get() {
+            throw new Error('Explicit hour cycle must win')
+          },
+        },
+      })
+      expect(getBestPattern('j', locale)).toBe('ha')
+    }
+  )
+})
+
+it.each(['fr-CA', 'zh-TW', 'en-GB', 'fr-CA-u-hc-h12', 'en-GB-u-hc-h12'])(
+  'matches native date skeleton formatting for %s with the modern locale API',
+  tag => {
+    const locale = new Intl.Locale(tag)
+    const options: Intl.DateTimeFormatOptions = {
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      timeZoneName: 'short',
+      timeZone: 'UTC',
+    }
+    const native = new Intl.DateTimeFormat(tag, options)
+    Object.defineProperties(locale, {
+      getHourCycles: {value: () => [native.resolvedOptions().hourCycle]},
+      hourCycles: {value: undefined},
+    })
+    const [element] = parse('{value, date, ::MMMdjz}', {locale})
+    expect(isDateElement(element)).toBe(true)
+    if (
+      !isDateElement(element) ||
+      !element.style ||
+      !isDateTimeSkeleton(element.style)
+    ) {
+      throw new Error('Expected date skeleton')
+    }
+    const formatter = new Intl.DateTimeFormat(tag, {
+      ...element.style.parsedOptions,
+      timeZone: 'UTC',
+    })
+    const midnight = Date.UTC(2026, 0, 1)
+    expect(formatter.format(midnight)).toBe(native.format(midnight))
+  }
+)


### PR DESCRIPTION
Date skeletons using `j` ignored `Intl.Locale.getHourCycles()`. On runtimes exposing only that method, `fr-CA` could select a 12-hour clock and `zh-TW` could produce an unsupported day-period pattern. Rust also selected the wrong hour cycle for `fr-CA` because its CLDR lookup skipped language-region entries.

Use the modern JavaScript API before the legacy property, preserving explicit `hourCycle`/`u-hc` overrides. Both parsers prefer language-region CLDR entries over region defaults; the JavaScript fallback now extracts only the hour symbol, matching Rust.

Add regressions for modern and legacy APIs, CLDR fallback, explicit overrides, and native formatting parity. Seven shared conformance fixtures verify both parsers against fixed expectations for locale defaults and all four hour cycles. Update parser documentation.

Validation: reproduced JavaScript and Rust failures before their fixes. All 17 parser, skeleton-parser, and Rust unit-test targets pass, including TypeScript checks and package validation. All 124 shared-fixture test targets also pass.
