### PR TITLE
fix(deps): scope release notes to package changes

### DIFF
--- a/knowledge-base/001-repo-layout.md
+++ b/knowledge-base/001-repo-layout.md
@@ -120,9 +120,11 @@ Commit-msg hook: `commitlint` validates Conventional Commits format.
 | `verify-hooks.yml`     | PR                    | Verify lefthook hooks + commitlint                          |
 
 Release Please owns version/changelog PRs and GitHub release creation. Its
-GitHub-generated changelog notes include PR titles, PR links, and contributors.
-`.github/release.yml` excludes Renovate-authored PRs from those notes so
-dependency maintenance does not hide user-facing changes.
+package-scoped changelogs use the default Conventional Commits generator.
+The GitHub generator ignores package-filtered commits and includes unrelated
+repository PRs between package tags, so it must not be used for package releases.
+Workspace dependency bumps are listed separately by the workspace plugins.
+`.github/release.yml` only controls manually requested GitHub-generated notes.
 For npm packages, Release Please advances versions in both package-local Bazel
 `BUILD.bazel` `x-release-please-version` markers and checked-in `package.json`
 files; `package_json_sync` keeps the rest of each generated manifest in sync.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,7 @@
   "include-v-in-tag": false,
   "include-v-in-release-name": false,
   "tag-separator": "@",
-  "changelog-type": "github",
+  "changelog-type": "default",
   "bootstrap-sha": "482c8e224b2582b554e3f4b0718fe2332c4b5cff",
   "sequential-calls": true,
   "exclude-paths": ["**/tests/**", "**/*.md"],

--- a/tools/release-please/config.test.ts
+++ b/tools/release-please/config.test.ts
@@ -27,7 +27,7 @@ const logger = {
 let checked = 0
 
 assert.equal(VERSION, '17.6.0')
-assert.equal(config['changelog-type'], 'github')
+assert.equal(config['changelog-type'], 'default')
 assert.deepEqual(releaseNotesConfig.changelog.exclude.authors, [
   'renovate[bot]',
 ])

--- a/tools/release-please/npm-workspace-plugin.test.ts
+++ b/tools/release-please/npm-workspace-plugin.test.ts
@@ -10,6 +10,9 @@ const {VERSION} = require('release-please')
 const {Bazel} = require('release-please/build/src/strategies/bazel')
 const {Version} = require('release-please/build/src/version')
 const {
+  buildChangelogNotes,
+} = require('release-please/build/src/factories/changelog-notes-factory')
+const {
   PatchVersionUpdate,
 } = require('release-please/build/src/versioning-strategy')
 
@@ -26,6 +29,46 @@ const repositoryConfig = Object.fromEntries(
 const logger = {debug() {}, info() {}, warn() {}, error() {}}
 const github = {
   repository: {owner: 'formatjs', repo: 'formatjs', defaultBranch: 'main'},
+}
+
+// GitHub-generated notes ignore the package-filtered commit list.
+const notes = await buildChangelogNotes({
+  type: rawConfig['changelog-type'],
+  github: {
+    ...github,
+    generateReleaseNotes: async () =>
+      '* feat(@formatjs/editor): unrelated editor change',
+  },
+}).buildNotes(
+  [
+    {
+      sha: '1234567890abcdef1234567890abcdef12345678',
+      message:
+        'fix(@formatjs/intl-datetimeformat): preserve locale hour preferences',
+      bareMessage: 'preserve locale hour preferences',
+      type: 'fix',
+      scope: '@formatjs/intl-datetimeformat',
+      notes: [],
+      references: [],
+    },
+  ],
+  {
+    owner: 'formatjs',
+    repository: 'formatjs',
+    version: '1.0.1',
+    previousTag: '@formatjs/intl-datetimeformat@1.0.0',
+    currentTag: '@formatjs/intl-datetimeformat@1.0.1',
+    targetBranch: 'main',
+  }
+)
+assert.match(notes, /preserve locale hour preferences/)
+assert(!notes.includes('@formatjs/editor'))
+for (const [path, packageConfig] of Object.entries(rawConfig.packages)) {
+  assert.equal(
+    packageConfig['changelog-type'] ?? rawConfig['changelog-type'],
+    'default',
+    `${path} must use package-scoped changelog notes`
+  )
 }
 
 async function run(paths: string[]) {


### PR DESCRIPTION
Package release notes included unrelated repository changes because the GitHub changelog generator ignores package-filtered commits and lists every PR between package tags. This made editor changes appear in lower-level polyfill changelogs.

Use Release Please's default Conventional Commits generator for package-scoped notes. Keep workspace dependency bump notes and dependency propagation unchanged. Update configuration checks and release documentation.

Validation: a regression using the pinned Release Please version failed with the old configuration and passes with this change. All three Bazel release workspace/plugin test targets pass, including the existing check that an editor release only releases editor.

Merge before the pending release PR so Release Please regenerates its notes with the corrected configuration. Existing published changelogs are not rewritten.
